### PR TITLE
fix(torghut): journal tigerbeetle ledger refs

### DIFF
--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -49,6 +49,16 @@ spec:
                     --max-batches 1 \
                     --apply \
                     --json
+                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --batch-size 500 \
+                    --max-batches 2 \
+                    --reconcile-limit 1000 \
+                    --json
+              securityContext:
+                seccompProfile:
+                  type: Unconfined
               env:
                 - name: TORGHUT_SIM_DB_HOST
                   valueFrom:

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -26,6 +26,7 @@ from ..models import (
 )
 from .tca import upsert_execution_tca_metric
 from .tigerbeetle_journal import TigerBeetleLedgerJournal
+from .tigerbeetle_reconcile import reconcile_tigerbeetle_transfers
 
 logger = logging.getLogger(__name__)
 
@@ -119,10 +120,23 @@ class OrderFeedIngestor:
                 break
 
         if durable_any:
+            self._reconcile_tigerbeetle_if_enabled(session)
             session.commit()
         if durable_any and commit_allowed:
             _commit_consumer(consumer)
         return counters
+
+    def _reconcile_tigerbeetle_if_enabled(self, session: Session) -> None:
+        if not settings.tigerbeetle_enabled or not settings.tigerbeetle_journal_enabled:
+            return
+        try:
+            reconcile_tigerbeetle_transfers(session)
+        except Exception as exc:
+            if settings.tigerbeetle_reconcile_required:
+                raise
+            logger.warning(
+                "TigerBeetle reconciliation failed after order-feed ingest: %s", exc
+            )
 
     @staticmethod
     def _new_counters() -> dict[str, int]:

--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, cast
 
@@ -114,6 +115,14 @@ def _account_id(account_key: str) -> int:
     return stable_u128("torghut.tigerbeetle.account", account_key)
 
 
+@dataclass(frozen=True)
+class TigerBeetleOrderEventTransferPlan:
+    account_specs: tuple[TigerBeetleAccountSpec, ...]
+    transfer_spec: TigerBeetleTransferSpec
+    transfer_kind: str
+    pending_mode: str
+
+
 def _submitted_pending_key(event: ExecutionOrderEvent) -> str:
     source_id = (
         str(event.execution_id)
@@ -222,6 +231,7 @@ def _transfer_spec(
     transfer_kind: str,
     amount: int,
     accounts: Mapping[str, TigerBeetleAccountSpec],
+    use_pending_transfer: bool = True,
 ) -> TigerBeetleTransferSpec:
     cash = accounts[f"cash:{event.alpaca_account_label}:usd"]
     order_identity = (
@@ -247,6 +257,8 @@ def _transfer_spec(
             timeout=0,
         )
     if transfer_kind in {TRANSFER_KIND_CANCEL_VOID, TRANSFER_KIND_REJECT_VOID}:
+        if not use_pending_transfer:
+            raise ValueError("tigerbeetle_pending_transfer_required_for_void")
         return TigerBeetleTransferSpec(
             transfer_id=transfer_id,
             transfer_kind=transfer_kind,
@@ -257,6 +269,16 @@ def _transfer_spec(
             ledger=LEDGER_USD_MICRO,
             code=code,
             flags=_transfer_flag("VOID_PENDING_TRANSFER"),
+        )
+    if transfer_kind == TRANSFER_KIND_FILL_POST and not use_pending_transfer:
+        return TigerBeetleTransferSpec(
+            transfer_id=transfer_id,
+            transfer_kind=transfer_kind,
+            debit_account_id=cash.account_id,
+            credit_account_id=fill_notional.account_id,
+            amount=amount,
+            ledger=LEDGER_USD_MICRO,
+            code=code,
         )
     return TigerBeetleTransferSpec(
         transfer_id=transfer_id,
@@ -272,6 +294,86 @@ def _transfer_spec(
         flags=_transfer_flag("POST_PENDING_TRANSFER")
         if transfer_kind == TRANSFER_KIND_FILL_POST
         else 0,
+    )
+
+
+def _pending_transfer_ref_for_event(
+    session: Session,
+    event: ExecutionOrderEvent,
+    *,
+    cluster_id: int,
+) -> TigerBeetleTransferRef | None:
+    return session.execute(
+        select(TigerBeetleTransferRef).where(
+            TigerBeetleTransferRef.cluster_id == cluster_id,
+            TigerBeetleTransferRef.transfer_id
+            == u128_decimal(submitted_pending_transfer_id(event)),
+            TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_SUBMITTED_PENDING,
+        )
+    ).scalar_one_or_none()
+
+
+def build_order_event_transfer_plan(
+    session: Session,
+    event: ExecutionOrderEvent,
+    *,
+    settings_obj: Settings = settings,
+) -> TigerBeetleOrderEventTransferPlan | None:
+    transfer_kind = transfer_kind_for_event(event.event_type, event.status)
+    if transfer_kind is None:
+        return None
+
+    pending_ref = (
+        _pending_transfer_ref_for_event(
+            session,
+            event,
+            cluster_id=settings_obj.tigerbeetle_cluster_id,
+        )
+        if transfer_kind
+        in {
+            TRANSFER_KIND_FILL_POST,
+            TRANSFER_KIND_CANCEL_VOID,
+            TRANSFER_KIND_REJECT_VOID,
+        }
+        else None
+    )
+    amount_usd = _event_amount_usd(event, transfer_kind)
+    amount = decimal_usd_to_micros(amount_usd) if amount_usd is not None else None
+    if amount is None and pending_ref is not None:
+        amount = int(pending_ref.amount)
+    if amount is None or amount <= 0:
+        return None
+    if (
+        transfer_kind in {TRANSFER_KIND_CANCEL_VOID, TRANSFER_KIND_REJECT_VOID}
+        and pending_ref is None
+    ):
+        return None
+
+    account_specs = tuple(_account_specs(event))
+    account_by_key = {spec.account_key: spec for spec in account_specs}
+    use_pending_transfer = pending_ref is not None or transfer_kind in {
+        TRANSFER_KIND_SUBMITTED_PENDING,
+        TRANSFER_KIND_CANCEL_VOID,
+        TRANSFER_KIND_REJECT_VOID,
+    }
+    transfer_spec = _transfer_spec(
+        event,
+        transfer_kind=transfer_kind,
+        amount=amount,
+        accounts=account_by_key,
+        use_pending_transfer=use_pending_transfer,
+    )
+    return TigerBeetleOrderEventTransferPlan(
+        account_specs=account_specs,
+        transfer_spec=transfer_spec,
+        transfer_kind=transfer_kind,
+        pending_mode=(
+            "pending_transfer_ref"
+            if pending_ref is not None
+            else "standalone_fill"
+            if transfer_kind == TRANSFER_KIND_FILL_POST
+            else "pending_transfer"
+        ),
     )
 
 
@@ -341,24 +443,16 @@ class TigerBeetleLedgerJournal:
             or not self._settings.tigerbeetle_journal_enabled
         ):
             return None
-        transfer_kind = transfer_kind_for_event(event.event_type, event.status)
-        if transfer_kind is None:
-            return None
-        amount_usd = _event_amount_usd(event, transfer_kind)
-        if amount_usd is None:
-            return None
-        amount = decimal_usd_to_micros(amount_usd)
-        if amount <= 0:
+        plan = build_order_event_transfer_plan(
+            session,
+            event,
+            settings_obj=self._settings,
+        )
+        if plan is None:
             return None
 
-        account_specs = _account_specs(event)
-        account_by_key = {spec.account_key: spec for spec in account_specs}
-        transfer_spec = _transfer_spec(
-            event,
-            transfer_kind=transfer_kind,
-            amount=amount,
-            accounts=account_by_key,
-        )
+        account_specs = plan.account_specs
+        transfer_spec = plan.transfer_spec
         transfer_id_text = u128_decimal(transfer_spec.transfer_id)
         existing = session.execute(
             select(TigerBeetleTransferRef).where(
@@ -369,7 +463,7 @@ class TigerBeetleLedgerJournal:
         ).scalar_one_or_none()
         if existing is not None:
             if (
-                existing.amount == Decimal(amount)
+                existing.amount == Decimal(transfer_spec.amount)
                 and existing.code == transfer_spec.code
                 and existing.ledger == transfer_spec.ledger
             ):
@@ -399,10 +493,10 @@ class TigerBeetleLedgerJournal:
         ref = TigerBeetleTransferRef(
             cluster_id=self._settings.tigerbeetle_cluster_id,
             transfer_id=transfer_id_text,
-            transfer_kind=transfer_kind,
+            transfer_kind=plan.transfer_kind,
             ledger=transfer_spec.ledger,
             code=transfer_spec.code,
-            amount=Decimal(amount),
+            amount=Decimal(transfer_spec.amount),
             status=status,
             result_code=status,
             trade_decision_id=event.trade_decision_id,
@@ -416,6 +510,7 @@ class TigerBeetleLedgerJournal:
                     "pending_id": u128_decimal(transfer_spec.pending_id)
                     if transfer_spec.pending_id
                     else None,
+                    "pending_mode": plan.pending_mode,
                     "source": "execution_order_event",
                 }
             ),

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -21,7 +21,7 @@ from app.trading.tigerbeetle_client import (
     TigerBeetleClientProtocol,
     create_tigerbeetle_client,
 )
-from app.trading.tigerbeetle_ledger_model import transfer_kind_for_event
+from app.trading.tigerbeetle_journal import build_order_event_transfer_plan
 
 
 SCHEMA_VERSION = "torghut.tigerbeetle-reconciliation.v1"
@@ -29,6 +29,9 @@ BLOCKER_TRANSFER_MISSING = "tigerbeetle_transfer_missing"
 BLOCKER_AMOUNT_MISMATCH = "tigerbeetle_transfer_amount_mismatch"
 BLOCKER_CODE_MISMATCH = "tigerbeetle_transfer_code_mismatch"
 BLOCKER_LEDGER_MISMATCH = "tigerbeetle_transfer_ledger_mismatch"
+BLOCKER_DEBIT_ACCOUNT_MISMATCH = "tigerbeetle_transfer_debit_account_mismatch"
+BLOCKER_CREDIT_ACCOUNT_MISMATCH = "tigerbeetle_transfer_credit_account_mismatch"
+BLOCKER_POSTGRES_REF_MISMATCH = "tigerbeetle_postgres_ref_mismatch"
 BLOCKER_UNLINKED_EVENT = "tigerbeetle_unlinked_order_event"
 BLOCKER_CLIENT_UNAVAILABLE = "tigerbeetle_client_unavailable"
 
@@ -45,6 +48,45 @@ def _attr(value: object, name: str) -> Any:
     if name == "id" and hasattr(value, "transfer_id"):
         return getattr(value, "transfer_id")
     raise AttributeError(name)
+
+
+def _payload_value(row: TigerBeetleTransferRef, key: str) -> str | None:
+    raw_payload = cast(object, row.payload_json)
+    payload: Mapping[str, object] = (
+        cast(Mapping[str, object], raw_payload)
+        if isinstance(raw_payload, Mapping)
+        else cast(Mapping[str, object], {})
+    )
+    value: object | None = payload.get(key)
+    return None if value is None else str(value)
+
+
+def _ref_matches_expected_event(
+    session: Session,
+    ref: TigerBeetleTransferRef,
+    *,
+    settings_obj: Settings,
+) -> bool:
+    event = (
+        session.get(ExecutionOrderEvent, ref.execution_order_event_id)
+        if ref.execution_order_event_id is not None
+        else None
+    )
+    if event is None:
+        return True
+    plan = build_order_event_transfer_plan(session, event, settings_obj=settings_obj)
+    if plan is None:
+        return False
+    expected = plan.transfer_spec
+    return (
+        ref.transfer_id == str(expected.transfer_id)
+        and ref.transfer_kind == plan.transfer_kind
+        and ref.amount == Decimal(expected.amount)
+        and ref.ledger == expected.ledger
+        and ref.code == expected.code
+        and _payload_value(ref, "debit_account_id") == str(expected.debit_account_id)
+        and _payload_value(ref, "credit_account_id") == str(expected.credit_account_id)
+    )
 
 
 def _latest_run_payload(
@@ -149,6 +191,23 @@ def reconcile_tigerbeetle_transfers(
         if int(_attr(actual, "ledger")) != ref.ledger:
             mismatched_transfer_count += 1
             blockers.append(BLOCKER_LEDGER_MISMATCH)
+        if _payload_value(ref, "debit_account_id") is not None and int(
+            _attr(actual, "debit_account_id")
+        ) != int(_payload_value(ref, "debit_account_id") or "0"):
+            mismatched_transfer_count += 1
+            blockers.append(BLOCKER_DEBIT_ACCOUNT_MISMATCH)
+        if _payload_value(ref, "credit_account_id") is not None and int(
+            _attr(actual, "credit_account_id")
+        ) != int(_payload_value(ref, "credit_account_id") or "0"):
+            mismatched_transfer_count += 1
+            blockers.append(BLOCKER_CREDIT_ACCOUNT_MISMATCH)
+        if not _ref_matches_expected_event(
+            session,
+            ref,
+            settings_obj=settings_obj,
+        ):
+            mismatched_transfer_count += 1
+            blockers.append(BLOCKER_POSTGRES_REF_MISMATCH)
 
     event_ids_with_refs = {
         item
@@ -174,7 +233,12 @@ def reconcile_tigerbeetle_transfers(
         1
         for event in recent_events
         if event.id not in event_ids_with_refs
-        and transfer_kind_for_event(event.event_type, event.status) is not None
+        and build_order_event_transfer_plan(
+            session,
+            event,
+            settings_obj=settings_obj,
+        )
+        is not None
     )
     if unlinked_event_count:
         blockers.append(BLOCKER_UNLINKED_EVENT)

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Journal existing order-feed events into TigerBeetle and persist reconciliation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.config import Settings
+from app.models import ExecutionOrderEvent, TigerBeetleTransferRef
+from app.trading.tigerbeetle_journal import (
+    TigerBeetleLedgerJournal,
+    build_order_event_transfer_plan,
+)
+from app.trading.tigerbeetle_reconcile import reconcile_tigerbeetle_transfers
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Journal unlinked Torghut order-feed lifecycle events into TigerBeetle.",
+    )
+    parser.add_argument("--dsn-env", default="DB_DSN")
+    parser.add_argument("--account-label", default=None)
+    parser.add_argument("--batch-size", type=int, default=500)
+    parser.add_argument("--max-batches", type=int, default=1)
+    parser.add_argument("--reconcile-limit", type=int, default=1000)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
+
+
+def _select_unlinked_events(
+    session: Any,
+    *,
+    settings_obj: Settings,
+    account_label: str | None,
+    limit: int,
+) -> list[ExecutionOrderEvent]:
+    linked_ref = (
+        select(TigerBeetleTransferRef.id)
+        .where(
+            TigerBeetleTransferRef.cluster_id == settings_obj.tigerbeetle_cluster_id,
+            TigerBeetleTransferRef.execution_order_event_id == ExecutionOrderEvent.id,
+        )
+        .exists()
+    )
+    stmt = (
+        select(ExecutionOrderEvent)
+        .where(~linked_ref)
+        .order_by(
+            ExecutionOrderEvent.event_ts.asc().nullsfirst(),
+            ExecutionOrderEvent.feed_seq.asc().nullsfirst(),
+            ExecutionOrderEvent.created_at.asc(),
+        )
+    )
+    if account_label:
+        stmt = stmt.where(ExecutionOrderEvent.alpaca_account_label == account_label)
+    scan_limit = max(limit, min(limit * 20, 10000))
+    candidates = session.execute(stmt.limit(scan_limit)).scalars().all()
+    return [
+        event
+        for event in candidates
+        if build_order_event_transfer_plan(
+            session,
+            event,
+            settings_obj=settings_obj,
+        )
+        is not None
+    ][:limit]
+
+
+def _payload(
+    *,
+    args: argparse.Namespace,
+    started_at: datetime,
+    batches: list[dict[str, int]],
+    reconciliation: dict[str, object] | None,
+) -> dict[str, Any]:
+    selected = sum(batch["selected"] for batch in batches)
+    journaled = sum(batch["journaled"] for batch in batches)
+    skipped = sum(batch["skipped"] for batch in batches)
+    failed = sum(batch["failed"] for batch in batches)
+    return {
+        "status": "ok" if failed == 0 else "degraded",
+        "dry_run": bool(args.dry_run),
+        "dsn_env": args.dsn_env,
+        "account_label": args.account_label,
+        "batch_size": max(1, min(int(args.batch_size), 5000)),
+        "max_batches": max(1, int(args.max_batches)),
+        "started_at": started_at.isoformat(),
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "selected": selected,
+        "journaled": journaled,
+        "skipped": skipped,
+        "failed": failed,
+        "batches": batches,
+        "reconciliation": reconciliation,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    dsn = os.environ.get(str(args.dsn_env).strip())
+    if not dsn:
+        raise SystemExit(f"missing DSN env var: {args.dsn_env}")
+
+    started_at = datetime.now(timezone.utc)
+    batch_size = max(1, min(int(args.batch_size), 5000))
+    max_batches = max(1, int(args.max_batches))
+    settings_obj = Settings(
+        DB_DSN=dsn,
+        TORGHUT_TIGERBEETLE_ENABLED=True,
+        TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
+    )
+    engine = create_engine(_sqlalchemy_dsn(dsn), pool_pre_ping=True, future=True)
+    session_factory = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    batches: list[dict[str, int]] = []
+    reconciliation: dict[str, object] | None = None
+
+    with session_factory() as session:
+        journal = TigerBeetleLedgerJournal(settings_obj=settings_obj)
+        for _ in range(max_batches):
+            events = _select_unlinked_events(
+                session,
+                settings_obj=settings_obj,
+                account_label=args.account_label,
+                limit=batch_size,
+            )
+            batch = {"selected": len(events), "journaled": 0, "skipped": 0, "failed": 0}
+            for event in events:
+                try:
+                    if args.dry_run:
+                        batch["journaled"] += 1
+                        continue
+                    with session.begin_nested():
+                        ref = journal.journal_order_event(session, event)
+                    if ref is None and not args.dry_run:
+                        batch["skipped"] += 1
+                    else:
+                        batch["journaled"] += 1
+                except Exception:
+                    batch["failed"] += 1
+            batches.append(batch)
+            if args.dry_run:
+                session.rollback()
+                break
+            session.commit()
+            if len(events) < batch_size:
+                break
+
+        if not args.dry_run:
+            reconciliation = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=settings_obj,
+                limit=max(1, int(args.reconcile_limit)),
+                persist=True,
+            )
+            session.commit()
+
+    payload = _payload(
+        args=args,
+        started_at=started_at,
+        batches=batches,
+        reconciliation=reconciliation,
+    )
+    print(
+        json.dumps(payload, separators=(",", ":"))
+        if args.json
+        else json.dumps(payload, indent=2)
+    )
+    return 0 if payload["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.config import Settings
+from app.models import Base, ExecutionOrderEvent, TigerBeetleTransferRef
+from app.trading.tigerbeetle_ledger_model import (
+    LEDGER_USD_MICRO,
+    TRANSFER_CODE_FILL_POST,
+    TRANSFER_KIND_FILL_POST,
+)
+from scripts import journal_tigerbeetle_order_events as script
+
+
+def _add_order_event(
+    session: Session,
+    *,
+    fingerprint: str,
+    account_label: str = "paper",
+    event_type: str = "fill",
+    status: str = "filled",
+    source_offset: int = 1,
+    has_amount: bool = True,
+) -> ExecutionOrderEvent:
+    event = ExecutionOrderEvent(
+        event_fingerprint=fingerprint,
+        source_topic="torghut.trade-updates.v1",
+        source_partition=0,
+        source_offset=source_offset,
+        alpaca_account_label=account_label,
+        event_ts=datetime.now(timezone.utc),
+        symbol="AAPL",
+        alpaca_order_id=f"order-{fingerprint}",
+        client_order_id=f"client-{fingerprint}",
+        event_type=event_type,
+        status=status,
+        qty=Decimal("1") if has_amount else None,
+        filled_qty=Decimal("1") if has_amount else None,
+        avg_fill_price=Decimal("190.25") if has_amount else None,
+        raw_event={"event": event_type},
+    )
+    session.add(event)
+    session.flush()
+    return event
+
+
+class FakeJournal:
+    instances: list["FakeJournal"] = []
+
+    def __init__(self, *, settings_obj: Settings) -> None:
+        self.settings_obj = settings_obj
+        self.events: list[str] = []
+        FakeJournal.instances.append(self)
+
+    def journal_order_event(
+        self,
+        session: Session,
+        event: ExecutionOrderEvent,
+    ) -> object | None:
+        del session
+        self.events.append(event.event_fingerprint)
+        if event.event_fingerprint == "skip":
+            return None
+        if event.event_fingerprint == "fail":
+            raise RuntimeError("journal failed")
+        return SimpleNamespace(transfer_id="1")
+
+
+class TestJournalTigerBeetleOrderEventsScript(TestCase):
+    def setUp(self) -> None:
+        FakeJournal.instances = []
+        self.engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        Base.metadata.create_all(self.engine)
+
+    def test_sqlalchemy_dsn_normalizes_postgres_urls(self) -> None:
+        self.assertEqual(
+            script._sqlalchemy_dsn("postgres://user:pass@host/db"),
+            "postgresql+psycopg://user:pass@host/db",
+        )
+        self.assertEqual(
+            script._sqlalchemy_dsn("postgresql://user:pass@host/db"),
+            "postgresql+psycopg://user:pass@host/db",
+        )
+        self.assertEqual(
+            script._sqlalchemy_dsn("postgresql+psycopg://user:pass@host/db"),
+            "postgresql+psycopg://user:pass@host/db",
+        )
+        self.assertEqual(
+            script._sqlalchemy_dsn("sqlite+pysqlite:///:memory:"),
+            "sqlite+pysqlite:///:memory:",
+        )
+
+    def test_payload_summarizes_batches(self) -> None:
+        args = argparse.Namespace(
+            dry_run=True,
+            dsn_env="SIM_DB_DSN",
+            account_label="paper",
+            batch_size=10000,
+            max_batches=0,
+        )
+
+        payload = script._payload(
+            args=args,
+            started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            batches=[
+                {"selected": 2, "journaled": 1, "skipped": 0, "failed": 1},
+                {"selected": 1, "journaled": 0, "skipped": 1, "failed": 0},
+            ],
+            reconciliation={"ok": True},
+        )
+
+        self.assertEqual(payload["status"], "degraded")
+        self.assertEqual(payload["selected"], 3)
+        self.assertEqual(payload["journaled"], 1)
+        self.assertEqual(payload["skipped"], 1)
+        self.assertEqual(payload["failed"], 1)
+        self.assertEqual(payload["batch_size"], 5000)
+        self.assertEqual(payload["max_batches"], 1)
+
+    def test_select_unlinked_events_filters_to_journalable_account_rows(self) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        with Session(self.engine) as session:
+            selected = _add_order_event(
+                session,
+                fingerprint="selected",
+                account_label="paper",
+                source_offset=1,
+            )
+            _add_order_event(
+                session,
+                fingerprint="accepted-no-amount",
+                account_label="paper",
+                event_type="accepted",
+                status="accepted",
+                source_offset=2,
+                has_amount=False,
+            )
+            _add_order_event(
+                session,
+                fingerprint="wrong-account",
+                account_label="live",
+                source_offset=3,
+            )
+            linked = _add_order_event(
+                session,
+                fingerprint="linked",
+                account_label="paper",
+                source_offset=4,
+            )
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=settings_obj.tigerbeetle_cluster_id,
+                    transfer_id="99",
+                    transfer_kind=TRANSFER_KIND_FILL_POST,
+                    ledger=LEDGER_USD_MICRO,
+                    code=TRANSFER_CODE_FILL_POST,
+                    amount=Decimal("190250000"),
+                    status="created",
+                    execution_order_event_id=linked.id,
+                    event_fingerprint=linked.event_fingerprint,
+                )
+            )
+            session.flush()
+
+            events = script._select_unlinked_events(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=10,
+            )
+
+        self.assertEqual([event.id for event in events], [selected.id])
+
+    def test_main_journals_selected_events_and_reconciles(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                _add_order_event(session, fingerprint="selected", source_offset=1)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--batch-size",
+                        "10",
+                        "--max-batches",
+                        "2",
+                        "--reconcile-limit",
+                        "12",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={"ok": True},
+                ) as reconcile,
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["journaled"], 1)
+        self.assertEqual(payload["failed"], 0)
+        self.assertEqual(FakeJournal.instances[0].events, ["selected"])
+        reconcile.assert_called_once()
+
+    def test_main_dry_run_rolls_back_without_reconcile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                _add_order_event(session, fingerprint="selected", source_offset=1)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--dry-run",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script, "reconcile_tigerbeetle_transfers") as reconcile,
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["journaled"], 1)
+        reconcile.assert_not_called()
+
+    def test_main_reports_degraded_for_failed_batch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                _add_order_event(session, fingerprint="skip", source_offset=1)
+                _add_order_event(session, fingerprint="fail", source_offset=2)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--batch-size",
+                        "10",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={"ok": False},
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertEqual(payload["skipped"], 1)
+        self.assertEqual(payload["failed"], 1)
+
+    def test_main_requires_dsn_env_var(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(
+                sys,
+                "argv",
+                ["journal_tigerbeetle_order_events.py", "--dsn-env", "MISSING_DSN"],
+            ),
+            self.assertRaisesRegex(SystemExit, "missing DSN env var: MISSING_DSN"),
+        ):
+            script.main()

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1265,7 +1265,19 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--batch-size 500", args)
         self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
+        self.assertIn("scripts/journal_tigerbeetle_order_events.py", args)
+        self.assertIn("--max-batches 2", args)
+        self.assertIn("--reconcile-limit 1000", args)
         self.assertIn("--json", args)
+        security_context = cast(
+            Mapping[str, object],
+            container.get("securityContext", {}),
+        )
+        seccomp_profile = cast(
+            Mapping[str, object],
+            security_context.get("seccompProfile", {}),
+        )
+        self.assertEqual(seccomp_profile.get("type"), "Unconfined")
 
     def test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db(
         self,

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -133,6 +133,9 @@ class TestOrderFeed(TestCase):
         self._orig_tigerbeetle_enabled = settings.tigerbeetle_enabled
         self._orig_tigerbeetle_journal_enabled = settings.tigerbeetle_journal_enabled
         self._orig_tigerbeetle_required = settings.tigerbeetle_required
+        self._orig_tigerbeetle_reconcile_required = (
+            settings.tigerbeetle_reconcile_required
+        )
         settings.trading_order_feed_enabled = True
         settings.trading_order_feed_bootstrap_servers = "localhost:9092"
         settings.trading_order_feed_topic = "torghut.trade-updates.v1"
@@ -142,6 +145,7 @@ class TestOrderFeed(TestCase):
         settings.tigerbeetle_enabled = False
         settings.tigerbeetle_journal_enabled = False
         settings.tigerbeetle_required = False
+        settings.tigerbeetle_reconcile_required = False
 
     def tearDown(self) -> None:
         settings.trading_order_feed_enabled = self._orig_feed_enabled
@@ -155,6 +159,9 @@ class TestOrderFeed(TestCase):
         settings.tigerbeetle_enabled = self._orig_tigerbeetle_enabled
         settings.tigerbeetle_journal_enabled = self._orig_tigerbeetle_journal_enabled
         settings.tigerbeetle_required = self._orig_tigerbeetle_required
+        settings.tigerbeetle_reconcile_required = (
+            self._orig_tigerbeetle_reconcile_required
+        )
 
     def _seed_execution(
         self,
@@ -419,6 +426,26 @@ class TestOrderFeed(TestCase):
             runs = session.execute(select(TigerBeetleReconciliationRun)).scalars().all()
             self.assertEqual(len(runs), 1)
             self.assertEqual(runs[0].status, "ok")
+
+    def test_order_feed_reconciliation_failure_respects_required_flag(self) -> None:
+        settings.tigerbeetle_enabled = True
+        settings.tigerbeetle_journal_enabled = True
+
+        with Session(self.engine) as session:
+            ingestor = OrderFeedIngestor(
+                consumer_factory=lambda: FakeConsumer([]),
+                default_account_label="paper",
+            )
+            with patch(
+                "app.trading.order_feed.reconcile_tigerbeetle_transfers",
+                side_effect=RuntimeError("reconcile failed"),
+            ):
+                with self.assertLogs(order_feed_module.logger, level="WARNING"):
+                    ingestor._reconcile_tigerbeetle_if_enabled(session)
+
+                settings.tigerbeetle_reconcile_required = True
+                with self.assertRaisesRegex(RuntimeError, "reconcile failed"):
+                    ingestor._reconcile_tigerbeetle_if_enabled(session)
 
     def test_optional_tigerbeetle_journal_failure_does_not_drop_order_event(
         self,

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -22,6 +22,7 @@ from app.models import (
     OrderFeedSourceWindow,
     RejectedSignalOutcomeEvent,
     Strategy,
+    TigerBeetleReconciliationRun,
     TigerBeetleTransferRef,
     TradeDecision,
 )
@@ -381,6 +382,43 @@ class TestOrderFeed(TestCase):
             self.assertEqual(len(refs), 1)
             self.assertEqual(refs[0].execution_order_event_id, persisted.id)
             self.assertEqual(refs[0].amount, Decimal("190250000"))
+
+    def test_order_feed_ingest_persists_tigerbeetle_reconciliation(self) -> None:
+        payload = (
+            b'{"channel":"trade_updates","payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+            b'"order":{"id":"order-1","client_order_id":"client-1","symbol":"AAPL","status":"filled",'
+            b'"qty":"1","filled_qty":"1","filled_avg_price":"190.25"}},"seq":10}'
+        )
+        record = FakeRecord(value=payload, offset=22)
+        client = FakeTigerBeetleClient()
+        settings.tigerbeetle_enabled = True
+        settings.tigerbeetle_journal_enabled = True
+
+        with Session(self.engine) as session:
+            self._seed_execution(session)
+            ingestor = OrderFeedIngestor(
+                consumer_factory=lambda: FakeConsumer([record]),
+                default_account_label="paper",
+            )
+
+            with (
+                patch(
+                    "app.trading.tigerbeetle_journal.create_tigerbeetle_client",
+                    return_value=client,
+                ),
+                patch(
+                    "app.trading.tigerbeetle_reconcile.create_tigerbeetle_client",
+                    return_value=client,
+                ),
+            ):
+                counters = ingestor.ingest_once(session)
+
+            self.assertEqual(counters["events_persisted_total"], 1)
+            refs = session.execute(select(TigerBeetleTransferRef)).scalars().all()
+            self.assertEqual(len(refs), 1)
+            runs = session.execute(select(TigerBeetleReconciliationRun)).scalars().all()
+            self.assertEqual(len(runs), 1)
+            self.assertEqual(runs[0].status, "ok")
 
     def test_optional_tigerbeetle_journal_failure_does_not_drop_order_event(
         self,

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -16,6 +16,7 @@ from app.models import (
     Execution,
     ExecutionOrderEvent,
     Strategy,
+    TigerBeetleAccountRef,
     TigerBeetleTransferRef,
     TradeDecision,
 )
@@ -29,6 +30,7 @@ from app.trading.tigerbeetle_journal import (
     _transfer_attr,
     _transfer_flag,
     _transfer_spec,
+    submitted_pending_transfer_id,
     event_transfer_id,
 )
 from app.trading.tigerbeetle_ledger_model import (
@@ -152,6 +154,66 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(refs[0].ledger, LEDGER_USD_MICRO)
             self.assertEqual(len(client.transfers), 1)
 
+    def test_fill_without_pending_ref_uses_standalone_transfer(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(session, fingerprint="fingerprint-standalone")
+            client = FakeTigerBeetleClient()
+
+            ref = TigerBeetleLedgerJournal(
+                settings_obj=_settings(), client=client
+            ).journal_order_event(
+                session,
+                event,
+            )
+
+            self.assertIsNotNone(ref)
+            assert ref is not None
+            self.assertIsNone(ref.payload_json["pending_id"])
+            self.assertEqual(ref.payload_json["pending_mode"], "standalone_fill")
+            transfer = client.transfers[int(ref.transfer_id)]
+            self.assertEqual(getattr(transfer, "pending_id"), 0)
+            self.assertEqual(getattr(transfer, "flags"), 0)
+
+    def test_fill_with_pending_ref_uses_post_pending_transfer(self) -> None:
+        with Session(self.engine) as session:
+            fill = _create_fill_event(session, fingerprint="fingerprint-post-pending")
+            submitted = ExecutionOrderEvent(
+                event_fingerprint="fingerprint-post-pending-submitted",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=10,
+                alpaca_account_label=fill.alpaca_account_label,
+                event_ts=datetime.now(timezone.utc),
+                symbol=fill.symbol,
+                alpaca_order_id=fill.alpaca_order_id,
+                client_order_id=fill.client_order_id,
+                event_type="new",
+                status="new",
+                qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                raw_event={"event": "new", "price": "190.25"},
+                execution_id=fill.execution_id,
+                trade_decision_id=fill.trade_decision_id,
+            )
+            session.add(submitted)
+            session.flush()
+            client = FakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(settings_obj=_settings(), client=client)
+
+            pending_ref = journal.journal_order_event(session, submitted)
+            fill_ref = journal.journal_order_event(session, fill)
+
+            self.assertIsNotNone(pending_ref)
+            self.assertIsNotNone(fill_ref)
+            assert fill_ref is not None
+            self.assertEqual(
+                fill_ref.payload_json["pending_id"],
+                str(submitted_pending_transfer_id(fill)),
+            )
+            self.assertEqual(
+                fill_ref.payload_json["pending_mode"], "pending_transfer_ref"
+            )
+
     def test_duplicate_transfer_exists_is_verified_before_ref_persist(self) -> None:
         with Session(self.engine) as session:
             event = _create_fill_event(session, fingerprint="fingerprint-exists")
@@ -165,6 +227,7 @@ class TestTigerBeetleLedgerJournal(TestCase):
                 transfer_kind=TRANSFER_KIND_FILL_POST,
                 amount=amount,
                 accounts=accounts,
+                use_pending_transfer=False,
             )
             client.transfers[expected.transfer_id] = expected
 
@@ -328,6 +391,10 @@ class TestTigerBeetleLedgerJournal(TestCase):
                 if getattr(ref, "account_key", "") == "cash:paper:usd"
             ]
             self.assertEqual(len(cash_refs), 1)
+            account_refs = (
+                session.execute(select(TigerBeetleAccountRef)).scalars().all()
+            )
+            self.assertGreaterEqual(len(account_refs), 5)
 
     def test_journal_ignores_non_transfer_and_missing_amount_events(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -30,6 +30,7 @@ from app.trading.tigerbeetle_journal import (
     _transfer_attr,
     _transfer_flag,
     _transfer_spec,
+    build_order_event_transfer_plan,
     submitted_pending_transfer_id,
     event_transfer_id,
 )
@@ -367,6 +368,70 @@ class TestTigerBeetleLedgerJournal(TestCase):
         self.assertEqual(submitted.transfer_kind, TRANSFER_KIND_SUBMITTED_PENDING)
         self.assertEqual(canceled.transfer_kind, TRANSFER_KIND_CANCEL_VOID)
         self.assertNotEqual(canceled.pending_id, 0)
+
+    def test_void_transfer_requires_pending_mode(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(session, fingerprint="fingerprint-void-required")
+            accounts = {spec.account_key: spec for spec in _account_specs(event)}
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "tigerbeetle_pending_transfer_required_for_void",
+            ):
+                _transfer_spec(
+                    event,
+                    transfer_kind=TRANSFER_KIND_CANCEL_VOID,
+                    amount=100,
+                    accounts=accounts,
+                    use_pending_transfer=False,
+                )
+
+    def test_transfer_plan_derives_void_amount_from_pending_ref(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(session, fingerprint="fingerprint-void-amount")
+            event.event_type = "canceled"
+            event.status = "canceled"
+            event.qty = None
+            event.filled_qty = None
+            event.avg_fill_price = None
+            event.raw_event = {"event": "canceled"}
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=_settings().tigerbeetle_cluster_id,
+                    transfer_id=str(submitted_pending_transfer_id(event)),
+                    transfer_kind=TRANSFER_KIND_SUBMITTED_PENDING,
+                    ledger=LEDGER_USD_MICRO,
+                    code=2000,
+                    amount=Decimal("123000000"),
+                    status="created",
+                    event_fingerprint="fingerprint-void-amount-submitted",
+                )
+            )
+            session.flush()
+
+            plan = build_order_event_transfer_plan(
+                session,
+                event,
+                settings_obj=_settings(),
+            )
+
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            self.assertEqual(plan.transfer_spec.amount, 123000000)
+
+    def test_transfer_plan_skips_void_without_pending_ref(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(session, fingerprint="fingerprint-void-skip")
+            event.event_type = "canceled"
+            event.status = "canceled"
+
+            self.assertIsNone(
+                build_order_event_transfer_plan(
+                    session,
+                    event,
+                    settings_obj=_settings(),
+                )
+            )
 
     def test_transfer_flag_handles_missing_module_and_missing_flags(self) -> None:
         with patch.dict(sys.modules, {"tigerbeetle": None}):

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -27,6 +27,7 @@ from app.trading.tigerbeetle_reconcile import (
     BLOCKER_CREDIT_ACCOUNT_MISMATCH,
     BLOCKER_DEBIT_ACCOUNT_MISMATCH,
     BLOCKER_LEDGER_MISMATCH,
+    BLOCKER_POSTGRES_REF_MISMATCH,
     BLOCKER_TRANSFER_MISSING,
     BLOCKER_UNLINKED_EVENT,
     _attr,
@@ -172,6 +173,54 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertFalse(payload["ok"])
             self.assertIn(BLOCKER_DEBIT_ACCOUNT_MISMATCH, payload["blockers"])
             self.assertIn(BLOCKER_CREDIT_ACCOUNT_MISMATCH, payload["blockers"])
+
+    def test_reconciliation_blocks_postgres_ref_that_no_longer_matches_event(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            event = ExecutionOrderEvent(
+                event_fingerprint="linked-unjournalable-event",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=1,
+                alpaca_account_label="paper",
+                event_ts=datetime.now(timezone.utc),
+                symbol="AAPL",
+                event_type="accepted",
+                status="accepted",
+                raw_event={"event": "accepted"},
+            )
+            session.add(event)
+            session.flush()
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id="1001",
+                    transfer_kind="fill_post",
+                    ledger=LEDGER_USD_MICRO,
+                    code=TRANSFER_CODE_FILL_POST,
+                    amount=Decimal("190250000"),
+                    status="created",
+                    event_fingerprint=event.event_fingerprint,
+                    execution_order_event_id=event.id,
+                    payload_json={
+                        "debit_account_id": "11",
+                        "credit_account_id": "12",
+                    },
+                )
+            )
+            session.flush()
+            client = FakeTigerBeetleClient()
+            client.transfers[1001] = _transfer()
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertFalse(payload["ok"])
+            self.assertIn(BLOCKER_POSTGRES_REF_MISMATCH, payload["blockers"])
 
     def test_reconciliation_blocks_unlinked_order_event(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -24,6 +24,8 @@ from app.trading.tigerbeetle_reconcile import (
     BLOCKER_AMOUNT_MISMATCH,
     BLOCKER_CODE_MISMATCH,
     BLOCKER_CLIENT_UNAVAILABLE,
+    BLOCKER_CREDIT_ACCOUNT_MISMATCH,
+    BLOCKER_DEBIT_ACCOUNT_MISMATCH,
     BLOCKER_LEDGER_MISMATCH,
     BLOCKER_TRANSFER_MISSING,
     BLOCKER_UNLINKED_EVENT,
@@ -47,6 +49,7 @@ def _add_ref(
     *,
     transfer_id: str = "1001",
     amount: Decimal = Decimal("190250000"),
+    payload_json: dict[str, object] | None = None,
 ) -> None:
     session.add(
         TigerBeetleTransferRef(
@@ -58,6 +61,7 @@ def _add_ref(
             amount=amount,
             status="created",
             event_fingerprint=f"fingerprint-{transfer_id}",
+            payload_json=payload_json,
         )
     )
     session.flush()
@@ -144,6 +148,31 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertIn(BLOCKER_CODE_MISMATCH, payload["blockers"])
             self.assertIn(BLOCKER_LEDGER_MISMATCH, payload["blockers"])
 
+    def test_reconciliation_blocks_account_mismatch(self) -> None:
+        with Session(self.engine) as session:
+            _add_ref(
+                session,
+                payload_json={"debit_account_id": "11", "credit_account_id": "12"},
+            )
+            client = FakeTigerBeetleClient()
+            client.transfers[1001] = TigerBeetleTransferSpec(
+                transfer_id=1001,
+                transfer_kind="fill_post",
+                debit_account_id=99,
+                credit_account_id=98,
+                amount=190250000,
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_FILL_POST,
+            )
+
+            payload = reconcile_tigerbeetle_transfers(
+                session, settings_obj=_settings(), client=client
+            )
+
+            self.assertFalse(payload["ok"])
+            self.assertIn(BLOCKER_DEBIT_ACCOUNT_MISMATCH, payload["blockers"])
+            self.assertIn(BLOCKER_CREDIT_ACCOUNT_MISMATCH, payload["blockers"])
+
     def test_reconciliation_blocks_unlinked_order_event(self) -> None:
         with Session(self.engine) as session:
             session.add(
@@ -173,6 +202,34 @@ class TestTigerBeetleReconcile(TestCase):
 
             self.assertFalse(payload["ok"])
             self.assertIn(BLOCKER_UNLINKED_EVENT, payload["blockers"])
+
+    def test_reconciliation_ignores_unjournalable_lifecycle_event(self) -> None:
+        with Session(self.engine) as session:
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="accepted-without-price",
+                    source_topic="torghut.trade-updates.v1",
+                    source_partition=0,
+                    source_offset=1,
+                    alpaca_account_label="paper",
+                    event_ts=datetime.now(timezone.utc),
+                    symbol="AAPL",
+                    event_type="accepted",
+                    status="accepted",
+                    qty=Decimal("1"),
+                    raw_event={"event": "accepted"},
+                )
+            )
+            session.flush()
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=FakeTigerBeetleClient(),
+            )
+
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["unlinked_event_count"], 0)
 
     def test_reconciliation_blocks_client_unavailable(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Allows TigerBeetle fill refs to journal as standalone double-entry transfers when no submitted pending transfer exists, while preserving post-pending behavior when a pending ref is present.
- Persists TigerBeetle reconciliation after durable order-feed ingestion and tightens reconciliation checks for debit and credit account mismatches.
- Adds a GitOps-managed sim DB backfill/reconciliation path through the existing bounded source-window repair CronJob.
- Adds regression coverage for standalone fills, pending fills, reconciliation blockers, automatic reconciliation persistence, the backfill script, and the CronJob contract.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen --extra dev pytest tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_order_feed.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen coverage erase`
- `uv run --frozen --extra dev coverage run -m pytest tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_order_feed.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen coverage xml --fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py app/trading/order_feed.py tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_order_feed.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py app/trading/order_feed.py tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_order_feed.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut` rendered successfully; searched the render for `journal_tigerbeetle_order_events`, `seccompProfile`, and `torghut-tigerbeetle`.
- `gh pr checks 9195 --watch -R proompteng/lab`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This keeps TigerBeetle fail-open in the runtime services; the sim backfill/reconciliation CronJob may report degraded status if ledger writes or lookups fail.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
