### PR TITLE
fix(torghut): preserve hpairs short runtime proof

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1945,13 +1945,13 @@ def _strategy_name_candidates(*values: str | None) -> list[str]:
 
 
 def _execution_signed_qty(*, side: Any, qty: Any) -> Decimal:
-    normalized_side = str(side or "").strip().lower()
+    normalized_side = str(side or "").strip().lower().replace("-", "_")
     quantity = _decimal_or_none(qty)
     if quantity is None or quantity <= 0:
         return Decimal("0")
-    if normalized_side == "buy":
+    if normalized_side in {"buy", "buy_to_cover", "cover"}:
         return quantity
-    if normalized_side == "sell":
+    if normalized_side in {"sell", "sell_short", "short"}:
         return -quantity
     return Decimal("0")
 

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -24,6 +24,7 @@ from scripts.import_hypothesis_runtime_windows import (
     POST_COST_BASIS_TCA_PROXY,
     _alpaca_2026_equity_fee_schedule_hash,
     _build_realized_strategy_pnl_rows,
+    _execution_signed_qty,
     _first_bool,
     _first_lineage_digest,
     _load_json_artifact,
@@ -1865,6 +1866,24 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             _stable_payload_digest(lineage_payload),
         )
 
+    def test_execution_signed_qty_accepts_short_and_cover_sides(self) -> None:
+        self.assertEqual(
+            _execution_signed_qty(side="sell_short", qty=Decimal("3")),
+            Decimal("-3"),
+        )
+        self.assertEqual(
+            _execution_signed_qty(side="SELL-SHORT", qty=Decimal("3")),
+            Decimal("-3"),
+        )
+        self.assertEqual(
+            _execution_signed_qty(side="buy_to_cover", qty=Decimal("3")),
+            Decimal("3"),
+        )
+        self.assertEqual(
+            _execution_signed_qty(side="BUY-TO-COVER", qty=Decimal("3")),
+            Decimal("3"),
+        )
+
     def test_build_realized_strategy_pnl_rows_requires_costed_round_trip(
         self,
     ) -> None:
@@ -2403,6 +2422,190 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "trade_decisions": 2,
             },
         )
+        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+    def test_build_realized_strategy_pnl_rows_authorizes_source_backed_short_round_trip(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "execution_id": "execution-short",
+                    "trade_decision_id": "decision-short-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AMZN",
+                    "side": "sell_short",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-short",
+                    "alpaca_order_id": "order-short",
+                    "execution_policy_hash": "policy-short",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "source_topic": "alpaca.trade_updates",
+                    "asset_class": "us_equity",
+                },
+                {
+                    "execution_id": "execution-cover",
+                    "trade_decision_id": "decision-cover-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AMZN",
+                    "side": "buy_to_cover",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-cover",
+                    "alpaca_order_id": "order-cover",
+                    "execution_policy_hash": "policy-cover",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "source_topic": "alpaca.trade_updates",
+                    "asset_class": "us_equity",
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    "trade_decision_id": "decision-short-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 34, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AMZN",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-short",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "trade_decision_id": "decision-cover-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AMZN",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-cover",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            order_lifecycle_rows=[
+                {
+                    "execution_order_event_id": "event-new-short",
+                    "trade_decision_id": "decision-short-id",
+                    "event_ts": datetime(2026, 3, 6, 14, 34, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AMZN",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-short",
+                    "alpaca_order_id": "order-short",
+                    "execution_policy_hash": "policy-short",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 300,
+                    "source_window_id": "source-window-new-short",
+                },
+                {
+                    "execution_order_event_id": "event-new-cover",
+                    "trade_decision_id": "decision-cover-id",
+                    "event_ts": datetime(2026, 3, 6, 14, 39, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AMZN",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-cover",
+                    "alpaca_order_id": "order-cover",
+                    "execution_policy_hash": "policy-cover",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 301,
+                    "source_window_id": "source-window-new-cover",
+                },
+                {
+                    "execution_order_event_id": "event-fill-short",
+                    "trade_decision_id": "decision-short-id",
+                    "execution_id": "execution-short",
+                    "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AMZN",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-short",
+                    "alpaca_order_id": "order-short",
+                    "execution_policy_hash": "policy-short",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 302,
+                    "source_window_id": "source-window-fill-short",
+                },
+                {
+                    "execution_order_event_id": "event-fill-cover",
+                    "trade_decision_id": "decision-cover-id",
+                    "execution_id": "execution-cover",
+                    "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AMZN",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-cover",
+                    "alpaca_order_id": "order-cover",
+                    "execution_policy_hash": "policy-cover",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 303,
+                    "source_window_id": "source-window-fill-cover",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["post_cost_promotion_eligible"])
+        self.assertTrue(rows[0]["authoritative"])
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["blockers"], [])
+        self.assertEqual(bucket["closed_trade_count"], 1)
+        self.assertEqual(bucket["open_position_count"], 0)
+        self.assertEqual(bucket["filled_notional"], "201")
+        self.assertEqual(bucket["gross_strategy_pnl"], "1")
+        self.assertEqual(bucket["cost_amount"], "0.02")
+        self.assertEqual(bucket["net_strategy_pnl_after_costs"], "0.98")
+        self.assertEqual(
+            bucket["cost_basis_counts"],
+            {
+                "alpaca_2026_equity_sec_taf_cat_fee_schedule": 1,
+                "alpaca_2026_equity_zero_commission_and_cat_fee_schedule": 1,
+            },
+        )
+        self.assertEqual(
+            bucket["cost_model_hash_counts"],
+            {_alpaca_2026_equity_fee_schedule_hash(): 2},
+        )
+        self.assertEqual(
+            bucket["source_decision_mode_counts"],
+            {"strategy_signal_paper": 4},
+        )
+        self.assertEqual(bucket["source_materialization"], "source_execution_lifecycle")
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_runtime_carry_in_source_filters_reject_wrong_symbol_and_decision(


### PR DESCRIPTION
## Summary

- Fixed the Torghut runtime-window importer so execution-side proof rows preserve short-sale and cover-side signs (`sell_short`/`short` negative, `buy_to_cover`/`cover` positive) instead of dropping those fills.
- Added regression coverage for a source-backed H-PAIRS-style short round trip where order-feed lifecycle proves source lineage and execution rows supply broker-schedule costs.
- Preserved fail-closed promotion proof semantics: reconstructed rows still stay non-authoritative unless source refs, lifecycle, explicit/schedule costs, hashes, closed-trip state, and profit-proof decision modes are complete.

## Related Issues

None. H-PAIRS-01 cleanup for candidate `c88421d619759b2cfaa6f4d0`.

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no documentation or release-note change is needed for this focused importer bug fix.
