### PR TITLE
fix(torghut): include tigerbeetle account refs in runtime proof

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -21,6 +21,7 @@ from ..models import (
     StrategyHypothesisVersion,
     StrategyPromotionDecision,
     StrategyRuntimeLedgerBucket,
+    TigerBeetleAccountRef,
     TigerBeetleTransferRef,
     VNextDatasetSnapshot,
 )
@@ -1439,6 +1440,41 @@ def _uuid_values(values: Sequence[str]) -> list[UUID]:
     return uuids
 
 
+def _tigerbeetle_transfer_account_ids(row: TigerBeetleTransferRef) -> list[str]:
+    payload = _mapping(row.payload_json)
+    account_ids: list[str] = []
+    for key in ("debit_account_id", "credit_account_id"):
+        account_id = _text(payload.get(key))
+        if account_id is not None:
+            account_ids.append(account_id)
+    return account_ids
+
+
+def _tigerbeetle_account_refs_for_ids(
+    *,
+    session: Session,
+    cluster_ids: Sequence[int],
+    account_ids: Sequence[str],
+) -> list[TigerBeetleAccountRef]:
+    if not cluster_ids or not account_ids:
+        return []
+    return list(
+        session.execute(
+            select(TigerBeetleAccountRef)
+            .where(
+                TigerBeetleAccountRef.cluster_id.in_(cluster_ids),
+                TigerBeetleAccountRef.account_id.in_(account_ids),
+            )
+            .order_by(
+                TigerBeetleAccountRef.cluster_id.asc(),
+                TigerBeetleAccountRef.account_key.asc(),
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
 def _tigerbeetle_refs_for_ledger_payload(
     session: Session,
     ledger_payload: Mapping[str, Any],
@@ -1484,9 +1520,47 @@ def _tigerbeetle_refs_for_ledger_payload(
     )
     if not rows:
         return {}
+    account_ids = sorted(
+        {
+            account_id
+            for row in rows
+            for account_id in _tigerbeetle_transfer_account_ids(row)
+        }
+    )
+    account_rows = _tigerbeetle_account_refs_for_ids(
+        session=session,
+        cluster_ids=sorted({row.cluster_id for row in rows}),
+        account_ids=account_ids,
+    )
+    account_ref_keys = {(row.cluster_id, row.account_id) for row in account_rows}
+    missing_account_ids = sorted(
+        {
+            account_id
+            for row in rows
+            for account_id in _tigerbeetle_transfer_account_ids(row)
+            if (row.cluster_id, account_id) not in account_ref_keys
+        }
+    )
     return {
         "schema_version": "torghut.tigerbeetle-ledger-refs.v1",
         "cluster_ids": sorted({row.cluster_id for row in rows}),
+        "account_count": len(account_rows),
+        "account_ids": sorted({row.account_id for row in account_rows}),
+        "account_keys": sorted({row.account_key for row in account_rows}),
+        "accounts": [
+            {
+                "cluster_id": row.cluster_id,
+                "account_id": row.account_id,
+                "account_key": row.account_key,
+                "ledger": row.ledger,
+                "code": row.code,
+                "account_label": row.account_label,
+                "symbol": row.symbol,
+                "strategy_id": row.strategy_id,
+            }
+            for row in account_rows
+        ],
+        "missing_account_ids": missing_account_ids,
         "transfer_count": len(rows),
         "transfer_ids": sorted({row.transfer_id for row in rows}),
         "transfers": [
@@ -1520,11 +1594,19 @@ def _ledger_payload_with_tigerbeetle_refs(
         source_refs.append("postgres:tigerbeetle_transfer_refs")
     source_row_counts = _mapping(ledger_payload.get("source_row_counts"))
     source_row_counts["tigerbeetle_transfer_refs"] = tigerbeetle_refs["transfer_count"]
+    if tigerbeetle_refs.get("account_count"):
+        if "postgres:tigerbeetle_account_refs" not in source_refs:
+            source_refs.append("postgres:tigerbeetle_account_refs")
+        source_row_counts["tigerbeetle_account_refs"] = tigerbeetle_refs[
+            "account_count"
+        ]
     return {
         **ledger_payload,
         "source_refs": source_refs,
         "source_row_counts": source_row_counts,
         "tigerbeetle": tigerbeetle_refs,
+        "tigerbeetle_account_ids": tigerbeetle_refs["account_ids"],
+        "tigerbeetle_account_keys": tigerbeetle_refs["account_keys"],
         "tigerbeetle_transfer_ids": tigerbeetle_refs["transfer_ids"],
     }
 

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -17,6 +17,7 @@ from app.models import (
     StrategyHypothesisVersion,
     StrategyPromotionDecision,
     StrategyRuntimeLedgerBucket,
+    TigerBeetleAccountRef,
     TigerBeetleTransferRef,
     VNextDatasetSnapshot,
 )
@@ -732,6 +733,27 @@ class TestRuntimeWindowImport(TestCase):
         )
 
         with self.session_local() as session:
+            session.add_all(
+                [
+                    TigerBeetleAccountRef(
+                        cluster_id=2001,
+                        account_id="100100100100100100100100100100100101",
+                        account_key="TORGHUT_SIM:cash",
+                        ledger=840001,
+                        code=1001,
+                        account_label="paper",
+                    ),
+                    TigerBeetleAccountRef(
+                        cluster_id=2001,
+                        account_id="100100100100100100100100100100100102",
+                        account_key="TORGHUT_SIM:AAPL:position",
+                        ledger=840001,
+                        code=1002,
+                        account_label="paper",
+                        symbol="AAPL",
+                    ),
+                ]
+            )
             session.add(
                 TigerBeetleTransferRef(
                     cluster_id=2001,
@@ -743,6 +765,10 @@ class TestRuntimeWindowImport(TestCase):
                     status="created",
                     execution_order_event_id=event_id,
                     event_fingerprint="runtime-fill-event",
+                    payload_json={
+                        "debit_account_id": "100100100100100100100100100100100101",
+                        "credit_account_id": "100100100100100100100100100100100102",
+                    },
                 )
             )
             session.flush()
@@ -802,14 +828,39 @@ class TestRuntimeWindowImport(TestCase):
         tigerbeetle_refs = payload.get("tigerbeetle")
         self.assertIsInstance(tigerbeetle_refs, dict)
         self.assertEqual(
+            tigerbeetle_refs.get("account_ids"),
+            [
+                "100100100100100100100100100100100101",
+                "100100100100100100100100100100100102",
+            ],
+        )
+        self.assertEqual(
+            tigerbeetle_refs.get("account_keys"),
+            ["TORGHUT_SIM:AAPL:position", "TORGHUT_SIM:cash"],
+        )
+        self.assertEqual(tigerbeetle_refs.get("missing_account_ids"), [])
+        self.assertEqual(
             tigerbeetle_refs.get("transfer_ids"),
             ["340282366920938463463374607431768211"],
+        )
+        self.assertEqual(
+            payload.get("tigerbeetle_account_ids"),
+            tigerbeetle_refs.get("account_ids"),
+        )
+        self.assertEqual(
+            payload.get("tigerbeetle_account_keys"),
+            tigerbeetle_refs.get("account_keys"),
         )
         self.assertEqual(
             payload.get("tigerbeetle_transfer_ids"),
             tigerbeetle_refs.get("transfer_ids"),
         )
+        self.assertIn("postgres:tigerbeetle_account_refs", payload.get("source_refs"))
         self.assertIn("postgres:tigerbeetle_transfer_refs", payload.get("source_refs"))
+        self.assertEqual(
+            payload.get("source_row_counts", {}).get("tigerbeetle_account_refs"),
+            2,
+        )
         self.assertEqual(
             payload.get("source_row_counts", {}).get("tigerbeetle_transfer_refs"),
             1,


### PR DESCRIPTION
## Summary

- Adds deterministic TigerBeetle account refs to persisted runtime-ledger bucket payloads when matching transfer refs are present.
- Includes account IDs, account keys, detailed account rows, and missing-account diagnostics in the `tigerbeetle` proof payload.
- Extends source refs and source row counts so proof packets can cite both `tigerbeetle_transfer_refs` and `tigerbeetle_account_refs`.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev pytest tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_persist_observed_runtime_windows_creates_governance_rows -q`
- `uv run --frozen ruff format services/torghut/app/trading/runtime_window_import.py services/torghut/tests/test_runtime_window_import.py`
- `uv run --frozen ruff check services/torghut/app/trading/runtime_window_import.py services/torghut/tests/test_runtime_window_import.py`
- `uv run --frozen ruff format --check services/torghut/app/trading/runtime_window_import.py services/torghut/tests/test_runtime_window_import.py`
- `uv run --frozen coverage erase`
- `uv run --frozen --extra dev coverage run -m pytest tests/test_runtime_window_import.py -q`
- `uv run --frozen coverage xml --fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
