### PR TITLE
fix(torghut): decouple TigerBeetle journaling cron

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -62,6 +62,8 @@ jobs:
             'argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml'
             'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
             'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
+            'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
+            'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml'
             'argocd/applications/torghut-options/catalog/deployment.yaml'
             'argocd/applications/torghut-options/enricher/deployment.yaml'
           )

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -260,6 +260,7 @@ jobs:
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml \
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml \
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml \
+            argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml \
             argocd/applications/torghut-options/catalog/deployment.yaml \
             argocd/applications/torghut-options/enricher/deployment.yaml; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -302,6 +303,7 @@ jobs:
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+            argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml
             argocd/applications/torghut-options/enricher/deployment.yaml
           body: |
@@ -347,6 +349,7 @@ jobs:
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+            argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml
             argocd/applications/torghut-options/enricher/deployment.yaml
           body: |

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - db-migrations-job.yaml
   - tigerbeetle-cluster.yaml
   - tigerbeetle-smoke-job.yaml
+  - tigerbeetle-journal-order-events-cronjob.yaml
   - knative-service.yaml
   - knative-service-sim.yaml
   - tailscale-service.yaml

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -1,0 +1,104 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-tigerbeetle-journal-order-events
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: tigerbeetle-journal-order-events
+spec:
+  schedule: "6,21,36,51 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: journal-order-events
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a904379e06a65aff4b57bd7dae923475e175789ae14d64f26cf913441c501a0a
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                seccompProfile:
+                  type: Unconfined
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --batch-size 500 \
+                    --max-batches 2 \
+                    --reconcile-limit 1000 \
+                    --fail-on-degraded \
+                    --json
+              env:
+                - name: TORGHUT_SIM_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: host
+                - name: TORGHUT_SIM_DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: port
+                - name: TORGHUT_SIM_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: username
+                - name: TORGHUT_SIM_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: password
+                - name: SIM_DB_DSN
+                  value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
+                - name: TORGHUT_TIGERBEETLE_ENABLED
+                  value: "true"
+                - name: TORGHUT_TIGERBEETLE_REQUIRED
+                  value: "false"
+                - name: TORGHUT_TIGERBEETLE_CLUSTER_ID
+                  value: "2001"
+                - name: TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES
+                  value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
+                - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
+                  value: "5"
+                - name: TORGHUT_TIGERBEETLE_JOURNAL_ENABLED
+                  value: "true"
+                - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
+                  value: "false"
+                - name: TORGHUT_IMAGE_DIGEST
+                  value: sha256:a904379e06a65aff4b57bd7dae923475e175789ae14d64f26cf913441c501a0a

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -25,6 +25,7 @@ const createFixture = () => {
   const paperAccountFlattenManifestPath = join(dir, 'paper-account-flatten-cronjob.yaml')
   const whitepaperSemanticBackfillManifestPath = join(dir, 'whitepaper-semantic-backfill-job.yaml')
   const tigerBeetleSmokeManifestPath = join(dir, 'tigerbeetle-smoke-job.yaml')
+  const tigerBeetleJournalOrderEventsManifestPath = join(dir, 'tigerbeetle-journal-order-events-cronjob.yaml')
   const optionsCatalogManifestPath = join(dir, 'options-catalog-deployment.yaml')
   const optionsEnricherManifestPath = join(dir, 'options-enricher-deployment.yaml')
   writeFileSync(
@@ -104,6 +105,7 @@ spec:
     paperAccountFlattenManifestPath,
     whitepaperSemanticBackfillManifestPath,
     tigerBeetleSmokeManifestPath,
+    tigerBeetleJournalOrderEventsManifestPath,
   ]) {
     writeFileSync(
       path,
@@ -161,6 +163,7 @@ spec:
     paperAccountFlattenManifestPath,
     whitepaperSemanticBackfillManifestPath,
     tigerBeetleSmokeManifestPath,
+    tigerBeetleJournalOrderEventsManifestPath,
     optionsCatalogManifestPath,
     optionsEnricherManifestPath,
   }
@@ -234,6 +237,7 @@ describe('update-manifests', () => {
       paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       tigerBeetleSmokeManifestPath: relative(repoRoot, fixture.tigerBeetleSmokeManifestPath),
+      tigerBeetleJournalOrderEventsManifestPath: relative(repoRoot, fixture.tigerBeetleJournalOrderEventsManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
       optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),
     })
@@ -258,6 +262,10 @@ describe('update-manifests', () => {
     const paperAccountFlattenManifest = readFileSync(fixture.paperAccountFlattenManifestPath, 'utf8')
     const whitepaperSemanticBackfillManifest = readFileSync(fixture.whitepaperSemanticBackfillManifestPath, 'utf8')
     const tigerBeetleSmokeManifest = readFileSync(fixture.tigerBeetleSmokeManifestPath, 'utf8')
+    const tigerBeetleJournalOrderEventsManifest = readFileSync(
+      fixture.tigerBeetleJournalOrderEventsManifestPath,
+      'utf8',
+    )
     const optionsCatalogManifest = readFileSync(fixture.optionsCatalogManifestPath, 'utf8')
     const optionsEnricherManifest = readFileSync(fixture.optionsEnricherManifestPath, 'utf8')
     expect(serviceManifest).toContain('client.knative.dev/updateTimestamp: "2026-02-21T04:00:00Z"')
@@ -295,6 +303,7 @@ describe('update-manifests', () => {
       paperAccountFlattenManifest,
       whitepaperSemanticBackfillManifest,
       tigerBeetleSmokeManifest,
+      tigerBeetleJournalOrderEventsManifest,
     ]) {
       expect(manifest).toContain(
         'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
@@ -312,7 +321,7 @@ describe('update-manifests', () => {
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(19)
+    expect(result.changedPaths.length).toBe(20)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -345,6 +354,7 @@ describe('update-manifests', () => {
       paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       tigerBeetleSmokeManifestPath: relative(repoRoot, fixture.tigerBeetleSmokeManifestPath),
+      tigerBeetleJournalOrderEventsManifestPath: relative(repoRoot, fixture.tigerBeetleJournalOrderEventsManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
       optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),
     }

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -33,6 +33,8 @@ const defaultPaperAccountFlattenManifestPath = 'argocd/applications/torghut/pape
 const defaultWhitepaperSemanticBackfillManifestPath =
   'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
 const defaultTigerBeetleSmokeManifestPath = 'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
+const defaultTigerBeetleJournalOrderEventsManifestPath =
+  'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml'
 const defaultOptionsCatalogManifestPath = 'argocd/applications/torghut-options/catalog/deployment.yaml'
 const defaultOptionsEnricherManifestPath = 'argocd/applications/torghut-options/enricher/deployment.yaml'
 
@@ -61,6 +63,7 @@ type UpdateManifestsOptions = {
   paperAccountFlattenManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   tigerBeetleSmokeManifestPath?: string
+  tigerBeetleJournalOrderEventsManifestPath?: string
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
 }
@@ -90,6 +93,7 @@ type CliOptions = {
   paperAccountFlattenManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   tigerBeetleSmokeManifestPath?: string
+  tigerBeetleJournalOrderEventsManifestPath?: string
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
 }
@@ -345,6 +349,11 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.tigerBeetleSmokeManifestPath ?? defaultTigerBeetleSmokeManifestPath,
     'torghut-tigerbeetle-smoke image reference',
   )
+  const tigerBeetleJournalOrderEvents = updateImageOnlyManifest(
+    options,
+    options.tigerBeetleJournalOrderEventsManifestPath ?? defaultTigerBeetleJournalOrderEventsManifestPath,
+    'torghut-tigerbeetle-journal-order-events image reference',
+  )
   const optionsCatalog = updateVersionedDeploymentManifest(
     options,
     options.optionsCatalogManifestPath ?? defaultOptionsCatalogManifestPath,
@@ -379,6 +388,7 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     paperAccountFlatten,
     whitepaperSemanticBackfill,
     tigerBeetleSmoke,
+    tigerBeetleJournalOrderEvents,
     optionsCatalog,
     optionsEnricher,
   ]
@@ -424,6 +434,7 @@ Options:
   --paper-account-flatten-manifest-path <path>
   --whitepaper-semantic-backfill-manifest-path <path>
   --tigerbeetle-smoke-manifest-path <path>
+  --tigerbeetle-journal-order-events-manifest-path <path>
   --options-catalog-manifest-path <path>
   --options-enricher-manifest-path <path>`)
       process.exit(0)
@@ -515,6 +526,9 @@ Options:
       case '--tigerbeetle-smoke-manifest-path':
         options.tigerBeetleSmokeManifestPath = value
         break
+      case '--tigerbeetle-journal-order-events-manifest-path':
+        options.tigerBeetleJournalOrderEventsManifestPath = value
+        break
       case '--options-catalog-manifest-path':
         options.optionsCatalogManifestPath = value
         break
@@ -585,6 +599,9 @@ const main = (cliOptions?: CliOptions) => {
       parsed.whitepaperSemanticBackfillManifestPath ?? process.env.TORGHUT_WHITEPAPER_SEMANTIC_BACKFILL_MANIFEST_PATH,
     tigerBeetleSmokeManifestPath:
       parsed.tigerBeetleSmokeManifestPath ?? process.env.TORGHUT_TIGERBEETLE_SMOKE_MANIFEST_PATH,
+    tigerBeetleJournalOrderEventsManifestPath:
+      parsed.tigerBeetleJournalOrderEventsManifestPath ??
+      process.env.TORGHUT_TIGERBEETLE_JOURNAL_ORDER_EVENTS_MANIFEST_PATH,
     optionsCatalogManifestPath: parsed.optionsCatalogManifestPath ?? process.env.TORGHUT_OPTIONS_CATALOG_MANIFEST_PATH,
     optionsEnricherManifestPath:
       parsed.optionsEnricherManifestPath ?? process.env.TORGHUT_OPTIONS_ENRICHER_MANIFEST_PATH,

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -252,8 +252,14 @@ def _payload(
     journaled = sum(batch["journaled"] for batch in batches)
     skipped = sum(batch["skipped"] for batch in batches)
     failed = sum(batch["failed"] for batch in batches)
+    reconciliation_ok = (
+        True
+        if reconciliation is None
+        else bool(reconciliation.get("ok", reconciliation.get("status") == "ok"))
+    )
+    status = "ok" if failed == 0 and reconciliation_ok else "degraded"
     return {
-        "status": "ok" if failed == 0 else "degraded",
+        "status": status,
         "fail_on_degraded": bool(args.fail_on_degraded),
         "dry_run": bool(args.dry_run),
         "dsn_env": args.dsn_env,

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -228,6 +228,29 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(payload["batch_size"], 5000)
         self.assertEqual(payload["max_batches"], 1)
 
+    def test_payload_degrades_when_reconciliation_fails(self) -> None:
+        args = argparse.Namespace(
+            dry_run=False,
+            dsn_env="SIM_DB_DSN",
+            account_label="paper",
+            batch_size=500,
+            max_batches=1,
+            fail_on_degraded=True,
+        )
+
+        payload = script._payload(
+            args=args,
+            started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            batches=[
+                {"selected": 1, "journaled": 1, "skipped": 0, "failed": 0},
+            ],
+            reconciliation={"ok": False, "blockers": ["tigerbeetle_transfer_missing"]},
+        )
+
+        self.assertEqual(payload["status"], "degraded")
+        self.assertEqual(payload["failed"], 0)
+        self.assertTrue(payload["fail_on_degraded"])
+
     def test_select_unlinked_events_filters_to_journalable_account_rows(self) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
         with Session(self.engine) as session:
@@ -452,6 +475,48 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual(exit_code, 1)
         self.assertTrue(payload["fail_on_degraded"])
+
+    def test_main_can_fail_closed_for_degraded_reconciliation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                _add_order_event(session, fingerprint="selected", source_offset=1)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--batch-size",
+                        "10",
+                        "--fail-on-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={"ok": False, "blockers": ["missing"]},
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertEqual(payload["failed"], 0)
+        self.assertEqual(payload["journaled"], 1)
 
     def test_main_requires_dsn_env_var(self) -> None:
         with (

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -896,6 +896,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIsInstance(resources, list)
         self.assertIn("tigerbeetle-cluster.yaml", resources)
         self.assertIn("tigerbeetle-smoke-job.yaml", resources)
+        self.assertIn("tigerbeetle-journal-order-events-cronjob.yaml", resources)
 
     def test_torghut_knative_manifests_enable_tigerbeetle_journal(self) -> None:
         expected = {
@@ -1269,6 +1270,107 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/journal_tigerbeetle_order_events.py", args)
         self.assertIn("--max-batches 2", args)
         self.assertIn("--reconcile-limit 1000", args)
+        self.assertIn("--json", args)
+        security_context = cast(
+            Mapping[str, object],
+            container.get("securityContext", {}),
+        )
+        seccomp_profile = cast(
+            Mapping[str, object],
+            security_context.get("seccompProfile", {}),
+        )
+        self.assertEqual(seccomp_profile.get("type"), "Unconfined")
+
+    def test_tigerbeetle_journal_order_events_cronjob_is_independent_sim_only(
+        self,
+    ) -> None:
+        relative_path = (
+            "argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml"
+        )
+        manifest = _load_yaml_mapping(relative_path)
+        spec, container = _load_cronjob_container(relative_path)
+        metadata = cast(Mapping[str, object], manifest.get("metadata", {}))
+
+        self.assertEqual(
+            metadata.get("name"),
+            "torghut-tigerbeetle-journal-order-events",
+        )
+        self.assertEqual(spec.get("schedule"), "6,21,36,51 * * * *")
+        self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
+        self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
+        self.assertEqual(spec.get("successfulJobsHistoryLimit"), 2)
+        self.assertEqual(spec.get("failedJobsHistoryLimit"), 3)
+
+        job_spec = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], spec.get("jobTemplate", {})).get("spec", {}),
+        )
+        template = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], job_spec.get("template", {})),
+        )
+        pod_spec = cast(Mapping[str, object], template.get("spec", {}))
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 600)
+        self.assertEqual(job_spec.get("backoffLimit"), 1)
+        self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
+        self.assertEqual(
+            pod_spec.get("nodeSelector"),
+            {"kubernetes.io/arch": "arm64"},
+        )
+        self.assertEqual(
+            container.get("command"),
+            ["/bin/bash", "-lc"],
+        )
+        self.assertIn(
+            "registry.ide-newton.ts.net/lab/torghut@sha256:",
+            str(container.get("image")),
+        )
+
+        env = {
+            item.get("name"): item
+            for item in cast(list[Mapping[str, object]], container.get("env", []))
+        }
+        self.assertEqual(
+            env["SIM_DB_DSN"].get("value"),
+            "postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@"
+            "$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default",
+        )
+        self.assertNotIn("DB_DSN", env)
+        for name, key in {
+            "TORGHUT_SIM_DB_HOST": "host",
+            "TORGHUT_SIM_DB_PORT": "port",
+            "TORGHUT_SIM_DB_USER": "username",
+            "TORGHUT_SIM_DB_PASSWORD": "password",
+        }.items():
+            value_from = cast(Mapping[str, object], env[name].get("valueFrom", {}))
+            self.assertEqual(
+                value_from.get("secretKeyRef"),
+                {"name": "torghut-db-app", "key": key},
+            )
+
+        value_env = _container_env(container)
+        self.assertEqual(value_env["TORGHUT_TIGERBEETLE_ENABLED"], "true")
+        self.assertEqual(value_env["TORGHUT_TIGERBEETLE_REQUIRED"], "false")
+        self.assertEqual(value_env["TORGHUT_TIGERBEETLE_CLUSTER_ID"], "2001")
+        self.assertEqual(
+            value_env["TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES"],
+            "torghut-tigerbeetle.torghut.svc.cluster.local:3000",
+        )
+        self.assertEqual(value_env["TORGHUT_TIGERBEETLE_JOURNAL_ENABLED"], "true")
+        self.assertEqual(
+            value_env["TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED"],
+            "false",
+        )
+
+        args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/journal_tigerbeetle_order_events.py", args)
+        self.assertNotIn("scripts/repair_order_feed_source_windows.py", args)
+        self.assertIn("--dsn-env SIM_DB_DSN", args)
+        self.assertIn("--account-label TORGHUT_SIM", args)
+        self.assertIn("--batch-size 500", args)
+        self.assertIn("--max-batches 2", args)
+        self.assertIn("--reconcile-limit 1000", args)
+        self.assertIn("--fail-on-degraded", args)
         self.assertIn("--json", args)
         security_context = cast(
             Mapping[str, object],

--- a/services/torghut/tests/test_torghut_release_workflow_manifest_paths.py
+++ b/services/torghut/tests/test_torghut_release_workflow_manifest_paths.py
@@ -9,6 +9,9 @@ SOURCE_WINDOW_REPAIR_CRONJOB = (
     "argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml"
 )
 TIGERBEETLE_SMOKE_JOB = "argocd/applications/torghut/tigerbeetle-smoke-job.yaml"
+TIGERBEETLE_JOURNAL_CRONJOB = (
+    "argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml"
+)
 
 
 def test_release_workflow_tracks_empirical_promotion_renewal_cronjob() -> None:
@@ -19,6 +22,7 @@ def test_release_workflow_tracks_empirical_promotion_renewal_cronjob() -> None:
     assert workflow.count(RENEWAL_CRONJOB) == 3
     assert workflow.count(SOURCE_WINDOW_REPAIR_CRONJOB) == 3
     assert workflow.count(TIGERBEETLE_SMOKE_JOB) == 3
+    assert workflow.count(TIGERBEETLE_JOURNAL_CRONJOB) == 3
 
 
 def test_deploy_automerge_allows_empirical_promotion_renewal_cronjob() -> None:
@@ -28,3 +32,5 @@ def test_deploy_automerge_allows_empirical_promotion_renewal_cronjob() -> None:
 
     assert RENEWAL_CRONJOB in workflow
     assert SOURCE_WINDOW_REPAIR_CRONJOB in workflow
+    assert TIGERBEETLE_SMOKE_JOB in workflow
+    assert TIGERBEETLE_JOURNAL_CRONJOB in workflow


### PR DESCRIPTION
## Summary

- Adds an independent sim-only `torghut-tigerbeetle-journal-order-events` CronJob so TigerBeetle order-event journaling is not blocked by the source-window repair job.
- Wires the new CronJob into Kustomize, release manifest updates, and release PR automerge allowlists.
- Marks the journaling script degraded when reconciliation returns non-ok, so `--fail-on-degraded` catches reconciliation failures without changing runtime fail-open service settings.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py tests/test_torghut_release_workflow_manifest_paths.py -q`
- `uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py tests/test_torghut_release_workflow_manifest_paths.py`
- `uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py tests/test_torghut_release_workflow_manifest_paths.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts .github/workflows/torghut-release.yml .github/workflows/torghut-deploy-automerge.yml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
