### PR TITLE
fix(torghut): add final paper flatten preopen run

### DIFF
--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: paper-account-flatten
 spec:
-  schedule: "5,20 9 * * 1-5"
+  schedule: "5,20,25 9 * * 1-5"
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1125,7 +1125,7 @@ class TestLiveConfigManifestContract(TestCase):
             "argocd/applications/torghut/paper-account-flatten-cronjob.yaml"
         )
 
-        self.assertEqual(spec.get("schedule"), "5,20 9 * * 1-5")
+        self.assertEqual(spec.get("schedule"), "5,20,25 9 * * 1-5")
         self.assertEqual(spec.get("timeZone"), "America/New_York")
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
         job_spec = cast(


### PR DESCRIPTION
## Summary

- Adds a final guarded `torghut-paper-account-flatten` CronJob run at 9:25 ET before the 9:30 ET proof window.
- Keeps the job paper-only, account-label guarded, bounded, and GitOps-managed.
- Updates the Torghut live manifest contract test to lock the pre-open schedule.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
