### PR TITLE
fix(torghut): harden source-window TigerBeetle journaling

### DIFF
--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -18,7 +18,7 @@ spec:
       activeDeadlineSeconds: 180
       template:
         spec:
-          restartPolicy: OnFailure
+          restartPolicy: Never
           serviceAccountName: torghut-runtime
           nodeSelector:
             kubernetes.io/arch: arm64
@@ -42,6 +42,7 @@ spec:
                 - |
                   set -euo pipefail
                   cd /app
+                  echo "stage=repair_order_feed_source_windows started_at=$(date -Iseconds)"
                   /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
@@ -49,13 +50,16 @@ spec:
                     --max-batches 1 \
                     --apply \
                     --json
+                  echo "stage=journal_tigerbeetle_order_events started_at=$(date -Iseconds)"
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
                     --batch-size 500 \
                     --max-batches 2 \
+                    --event-scan-limit 1000 \
                     --reconcile-limit 1000 \
                     --json
+                  echo "stage=order_feed_source_window_repair completed_at=$(date -Iseconds)"
               securityContext:
                 seccompProfile:
                   type: Unconfined
@@ -82,3 +86,5 @@ spec:
                       key: password
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
+                - name: PYTHONUNBUFFERED
+                  value: "1"

--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, cast
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 from app.config import Settings, settings
@@ -94,7 +94,60 @@ def _nested_mapping(value: object) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
 
 
-def _event_amount_usd(event: ExecutionOrderEvent, transfer_kind: str) -> Decimal | None:
+FILL_POST_EVENT_TYPES = {"fill", "filled", "partial_fill", "partially_filled"}
+
+
+def _event_amount_usd(
+    event: ExecutionOrderEvent,
+    transfer_kind: str,
+    *,
+    session: Session | None = None,
+) -> Decimal | None:
+    explicit_delta = _explicit_fill_delta_notional_usd(event)
+    if transfer_kind == TRANSFER_KIND_FILL_POST and explicit_delta is not None:
+        return explicit_delta
+
+    amount = _event_cumulative_amount_usd(event, transfer_kind)
+    if transfer_kind != TRANSFER_KIND_FILL_POST or amount is None or session is None:
+        return amount
+
+    prior_amount = _prior_cumulative_fill_notional_usd(session, event)
+    if prior_amount is None:
+        return amount
+    delta = amount - prior_amount
+    if delta <= 0:
+        return None
+    return abs(delta)
+
+
+def _explicit_fill_delta_notional_usd(event: ExecutionOrderEvent) -> Decimal | None:
+    raw_event = _nested_mapping(event.raw_event)
+    nested_order = _nested_mapping(raw_event.get("order"))
+    value = _lookup_payload_decimal(
+        raw_event,
+        (
+            "fill_notional",
+            "last_fill_notional",
+            "filled_notional_delta",
+            "execution_notional",
+        ),
+    )
+    if value is None:
+        value = _lookup_payload_decimal(
+            nested_order,
+            (
+                "fill_notional",
+                "last_fill_notional",
+                "filled_notional_delta",
+                "execution_notional",
+            ),
+        )
+    return abs(value) if value is not None else None
+
+
+def _event_cumulative_amount_usd(
+    event: ExecutionOrderEvent, transfer_kind: str
+) -> Decimal | None:
     raw_event = _nested_mapping(event.raw_event)
     nested_order = _nested_mapping(raw_event.get("order"))
     notional = _lookup_payload_decimal(raw_event, ("notional", "filled_notional"))
@@ -123,6 +176,61 @@ def _event_amount_usd(event: ExecutionOrderEvent, transfer_kind: str) -> Decimal
         return None
     amount = Decimal(str(qty)) * Decimal(str(price))
     return abs(amount)
+
+
+def _prior_cumulative_fill_notional_usd(
+    session: Session, event: ExecutionOrderEvent
+) -> Decimal | None:
+    clauses: list[Any] = []
+    if event.alpaca_order_id:
+        clauses.append(ExecutionOrderEvent.alpaca_order_id == event.alpaca_order_id)
+    if event.client_order_id:
+        clauses.append(ExecutionOrderEvent.client_order_id == event.client_order_id)
+    if not clauses:
+        return None
+
+    candidates = (
+        session.execute(
+            select(ExecutionOrderEvent).where(
+                ExecutionOrderEvent.id != event.id,
+                ExecutionOrderEvent.alpaca_account_label == event.alpaca_account_label,
+                or_(*clauses),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    prior_amounts = [
+        _event_cumulative_amount_usd(candidate, TRANSFER_KIND_FILL_POST)
+        for candidate in candidates
+        if _is_fill_post_event(candidate) and _order_event_precedes(candidate, event)
+    ]
+    usable_amounts = [amount for amount in prior_amounts if amount is not None]
+    if not usable_amounts:
+        return None
+    return max(usable_amounts)
+
+
+def _is_fill_post_event(event: ExecutionOrderEvent) -> bool:
+    normalized = (event.event_type or event.status or "").strip().lower()
+    return normalized in FILL_POST_EVENT_TYPES
+
+
+def _order_event_precedes(
+    candidate: ExecutionOrderEvent, event: ExecutionOrderEvent
+) -> bool:
+    if (
+        candidate.source_topic == event.source_topic
+        and candidate.source_partition == event.source_partition
+        and candidate.source_offset is not None
+        and event.source_offset is not None
+    ):
+        return candidate.source_offset < event.source_offset
+    if candidate.feed_seq is not None and event.feed_seq is not None:
+        return candidate.feed_seq < event.feed_seq
+    if candidate.event_ts is not None and event.event_ts is not None:
+        return candidate.event_ts < event.event_ts
+    return candidate.created_at < event.created_at
 
 
 def _account_id(account_key: str) -> int:
@@ -428,7 +536,7 @@ def build_order_event_transfer_plan(
         }
         else None
     )
-    amount_usd = _event_amount_usd(event, transfer_kind)
+    amount_usd = _event_amount_usd(event, transfer_kind, session=session)
     amount = decimal_usd_to_micros(amount_usd) if amount_usd is not None else None
     if amount is None and pending_ref is not None:
         amount = int(pending_ref.amount)

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -36,6 +37,12 @@ from app.trading.tigerbeetle_ledger_model import (
 from app.trading.tigerbeetle_reconcile import reconcile_tigerbeetle_transfers
 
 
+@dataclass(frozen=True)
+class OrderEventSelection:
+    rows: list[ExecutionOrderEvent]
+    scan_failed: int
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Journal unlinked Torghut order-feed lifecycle events into TigerBeetle.",
@@ -44,6 +51,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--account-label", default=None)
     parser.add_argument("--batch-size", type=int, default=500)
     parser.add_argument("--max-batches", type=int, default=1)
+    parser.add_argument(
+        "--event-scan-limit",
+        type=int,
+        default=None,
+        help="Maximum candidate order-feed events to inspect when looking for journalable lifecycle rows.",
+    )
     parser.add_argument("--reconcile-limit", type=int, default=1000)
     parser.add_argument(
         "--fail-on-degraded",
@@ -72,7 +85,8 @@ def _select_unlinked_events(
     settings_obj: Settings,
     account_label: str | None,
     limit: int,
-) -> list[ExecutionOrderEvent]:
+    event_scan_limit: int | None = None,
+) -> OrderEventSelection:
     linked_ref = (
         select(TigerBeetleTransferRef.id)
         .where(
@@ -92,18 +106,29 @@ def _select_unlinked_events(
     )
     if account_label:
         stmt = stmt.where(ExecutionOrderEvent.alpaca_account_label == account_label)
-    scan_limit = max(limit, min(limit * 20, 10000))
+    if event_scan_limit is None:
+        scan_limit = max(limit, min(limit * 20, 10000))
+    else:
+        scan_limit = max(limit, min(int(event_scan_limit), 10000))
     candidates = session.execute(stmt.limit(scan_limit)).scalars().all()
-    return [
-        event
-        for event in candidates
-        if build_order_event_transfer_plan(
-            session,
-            event,
-            settings_obj=settings_obj,
-        )
-        is not None
-    ][:limit]
+    events: list[ExecutionOrderEvent] = []
+    scan_failed = 0
+    for event in candidates:
+        try:
+            plan = build_order_event_transfer_plan(
+                session,
+                event,
+                settings_obj=settings_obj,
+            )
+        except Exception:
+            scan_failed += 1
+            continue
+        if plan is None:
+            continue
+        events.append(event)
+        if len(events) >= limit:
+            break
+    return OrderEventSelection(rows=events, scan_failed=scan_failed)
 
 
 def _source_ref_exists(
@@ -245,13 +270,13 @@ def _payload(
     *,
     args: argparse.Namespace,
     started_at: datetime,
-    batches: list[dict[str, int]],
+    batches: list[dict[str, int | str]],
     reconciliation: dict[str, object] | None,
 ) -> dict[str, Any]:
-    selected = sum(batch["selected"] for batch in batches)
-    journaled = sum(batch["journaled"] for batch in batches)
-    skipped = sum(batch["skipped"] for batch in batches)
-    failed = sum(batch["failed"] for batch in batches)
+    selected = sum(int(batch["selected"]) for batch in batches)
+    journaled = sum(int(batch["journaled"]) for batch in batches)
+    skipped = sum(int(batch["skipped"]) for batch in batches)
+    failed = sum(int(batch["failed"]) for batch in batches)
     reconciliation_ok = (
         True
         if reconciliation is None
@@ -266,6 +291,7 @@ def _payload(
         "account_label": args.account_label,
         "batch_size": max(1, min(int(args.batch_size), 5000)),
         "max_batches": max(1, int(args.max_batches)),
+        "event_scan_limit": getattr(args, "event_scan_limit", None),
         "started_at": started_at.isoformat(),
         "completed_at": datetime.now(timezone.utc).isoformat(),
         "selected": selected,
@@ -299,7 +325,7 @@ def main() -> int:
         expire_on_commit=False,
         future=True,
     )
-    batches: list[dict[str, int]] = []
+    batches: list[dict[str, int | str]] = []
     reconciliation: dict[str, object] | None = None
 
     with session_factory() as session:
@@ -310,6 +336,7 @@ def main() -> int:
                 settings_obj=settings_obj,
                 account_label=args.account_label,
                 limit=batch_size,
+                event_scan_limit=args.event_scan_limit,
             )
             executions = _select_unlinked_executions(
                 session,
@@ -329,18 +356,22 @@ def main() -> int:
                 account_label=args.account_label,
                 limit=batch_size,
             )
+            event_batch = _journal_source_batch(
+                session,
+                args=args,
+                source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                rows=events.rows,
+                journal_one=lambda event: journal.journal_order_event(
+                    session,
+                    event,
+                ),
+            )
+            if events.scan_failed:
+                event_batch["failed"] = int(event_batch["failed"]) + events.scan_failed
+                event_batch["scan_failed"] = events.scan_failed
             batches.extend(
                 [
-                    _journal_source_batch(
-                        session,
-                        args=args,
-                        source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
-                        rows=events,
-                        journal_one=lambda event: journal.journal_order_event(
-                            session,
-                            event,
-                        ),
-                    ),
+                    event_batch,
                     _journal_source_batch(
                         session,
                         args=args,
@@ -381,7 +412,7 @@ def main() -> int:
             session.commit()
             if all(
                 len(rows) < batch_size
-                for rows in (events, executions, tca_metrics, runtime_buckets)
+                for rows in (events.rows, executions, tca_metrics, runtime_buckets)
             ):
                 break
 

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -207,6 +207,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             account_label="paper",
             batch_size=10000,
             max_batches=0,
+            event_scan_limit=1000,
             fail_on_degraded=False,
         )
 
@@ -227,6 +228,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(payload["failed"], 1)
         self.assertEqual(payload["batch_size"], 5000)
         self.assertEqual(payload["max_batches"], 1)
+        self.assertEqual(payload["event_scan_limit"], 1000)
 
     def test_payload_degrades_when_reconciliation_fails(self) -> None:
         args = argparse.Namespace(
@@ -301,9 +303,101 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 settings_obj=settings_obj,
                 account_label="paper",
                 limit=10,
+                event_scan_limit=10,
             )
 
-        self.assertEqual([event.id for event in events], [selected.id])
+        self.assertEqual([event.id for event in events.rows], [selected.id])
+        self.assertEqual(events.scan_failed, 0)
+
+    def test_select_unlinked_events_degrades_bad_amount_rows(self) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        with Session(self.engine) as session:
+            bad = _add_order_event(
+                session,
+                fingerprint="bad-precision",
+                account_label="paper",
+                source_offset=1,
+            )
+            bad.avg_fill_price = Decimal("190.2500001")
+            selected = _add_order_event(
+                session,
+                fingerprint="selected",
+                account_label="paper",
+                source_offset=2,
+            )
+            session.add_all([bad, selected])
+            session.flush()
+
+            events = script._select_unlinked_events(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=10,
+                event_scan_limit=10,
+            )
+
+        self.assertEqual(
+            [event.event_fingerprint for event in events.rows], ["selected"]
+        )
+        self.assertEqual(events.scan_failed, 1)
+
+    def test_select_unlinked_events_honors_scan_limit(self) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        with Session(self.engine) as session:
+            bad = _add_order_event(
+                session,
+                fingerprint="bad-precision",
+                account_label="paper",
+                source_offset=1,
+            )
+            bad.avg_fill_price = Decimal("190.2500001")
+            _add_order_event(
+                session,
+                fingerprint="selected",
+                account_label="paper",
+                source_offset=2,
+            )
+            session.add(bad)
+            session.flush()
+
+            events = script._select_unlinked_events(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=1,
+                event_scan_limit=1,
+            )
+
+        self.assertEqual(events.rows, [])
+        self.assertEqual(events.scan_failed, 1)
+
+    def test_select_unlinked_events_stops_after_limit(self) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        with Session(self.engine) as session:
+            first = _add_order_event(
+                session,
+                fingerprint="selected-1",
+                account_label="paper",
+                source_offset=1,
+            )
+            _add_order_event(
+                session,
+                fingerprint="selected-2",
+                account_label="paper",
+                source_offset=2,
+            )
+            session.commit()
+
+            events = script._select_unlinked_events(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=1,
+                event_scan_limit=10,
+            )
+
+        self.assertEqual([event.id for event in events.rows], [first.id])
+        self.assertEqual(events.scan_failed, 0)
 
     def test_main_journals_selected_events_and_reconciles(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -393,6 +487,50 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertTrue(payload["dry_run"])
         self.assertEqual(payload["journaled"], 1)
         reconcile.assert_not_called()
+
+    def test_main_reports_scan_failed_rows_as_degraded_event_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                bad = _add_order_event(session, fingerprint="bad", source_offset=1)
+                bad.avg_fill_price = Decimal("190.2500001")
+                _add_order_event(session, fingerprint="selected", source_offset=2)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--batch-size",
+                        "10",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={"ok": True},
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertEqual(payload["journaled"], 1)
+        self.assertEqual(payload["failed"], 1)
+        self.assertEqual(payload["batches"][0]["scan_failed"], 1)
 
     def test_main_reports_degraded_for_failed_batch(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -28,6 +28,7 @@ from app.trading.tigerbeetle_journal import (
     _account_specs,
     _event_amount_usd,
     _lookup_payload_decimal,
+    _order_event_precedes,
     _result_status,
     _transfer_attr,
     _transfer_flag,
@@ -557,6 +558,23 @@ class TestTigerBeetleLedgerJournal(TestCase):
             Decimal("20"),
         )
 
+        explicit_delta_event = ExecutionOrderEvent(
+            event_fingerprint="amount-explicit-delta",
+            source_topic="torghut.trade-updates.v1",
+            source_partition=0,
+            source_offset=1,
+            alpaca_account_label="paper",
+            event_ts=datetime.now(timezone.utc),
+            symbol="AAPL",
+            event_type="fill",
+            status="filled",
+            raw_event={"fill_notional": "7.25", "notional": "100"},
+        )
+        self.assertEqual(
+            _event_amount_usd(explicit_delta_event, TRANSFER_KIND_FILL_POST),
+            Decimal("7.25"),
+        )
+
         nested_payload_event = ExecutionOrderEvent(
             event_fingerprint="amount-nested",
             source_topic="torghut.trade-updates.v1",
@@ -590,6 +608,103 @@ class TestTigerBeetleLedgerJournal(TestCase):
         self.assertIsNone(
             _event_amount_usd(missing_payload_event, TRANSFER_KIND_FILL_POST)
         )
+
+    def test_fill_event_amount_uses_incremental_notional_delta(self) -> None:
+        with Session(self.engine) as session:
+            first = _create_fill_event(session, fingerprint="partial-fill-delta-1")
+            first.alpaca_order_id = "shared-order"
+            first.client_order_id = "shared-client"
+            first.event_type = "partial_fill"
+            first.status = "partially_filled"
+            first.qty = Decimal("2")
+            first.filled_qty = Decimal("1")
+            first.avg_fill_price = Decimal("190.20")
+            first.source_offset = 10
+
+            second = _create_fill_event(session, fingerprint="partial-fill-delta-2")
+            second.alpaca_order_id = "shared-order"
+            second.client_order_id = "shared-client"
+            second.event_type = "fill"
+            second.status = "filled"
+            second.qty = Decimal("2")
+            second.filled_qty = Decimal("2")
+            second.avg_fill_price = Decimal("190.40")
+            second.source_offset = 11
+            duplicate_cumulative = _create_fill_event(
+                session, fingerprint="partial-fill-delta-3"
+            )
+            duplicate_cumulative.alpaca_order_id = "shared-order"
+            duplicate_cumulative.client_order_id = "shared-client"
+            duplicate_cumulative.event_type = "fill"
+            duplicate_cumulative.status = "filled"
+            duplicate_cumulative.qty = Decimal("2")
+            duplicate_cumulative.filled_qty = Decimal("2")
+            duplicate_cumulative.avg_fill_price = Decimal("190.40")
+            duplicate_cumulative.source_offset = 12
+            session.add_all([first, second])
+            session.flush()
+
+            first_plan = build_order_event_transfer_plan(
+                session,
+                first,
+                settings_obj=_settings(),
+            )
+            second_plan = build_order_event_transfer_plan(
+                session,
+                second,
+                settings_obj=_settings(),
+            )
+            duplicate_cumulative_plan = build_order_event_transfer_plan(
+                session,
+                duplicate_cumulative,
+                settings_obj=_settings(),
+            )
+
+        self.assertIsNotNone(first_plan)
+        self.assertIsNotNone(second_plan)
+        assert first_plan is not None
+        assert second_plan is not None
+        self.assertEqual(first_plan.transfer_spec.amount, 190200000)
+        self.assertEqual(second_plan.transfer_spec.amount, 190600000)
+        self.assertIsNone(duplicate_cumulative_plan)
+
+    def test_order_event_precedence_falls_back_deterministically(self) -> None:
+        older = ExecutionOrderEvent(
+            event_fingerprint="older",
+            source_topic="torghut.trade-updates.v1",
+            source_partition=0,
+            source_offset=None,
+            alpaca_account_label="paper",
+            symbol="AAPL",
+            event_type="fill",
+            status="filled",
+            feed_seq=10,
+            event_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            created_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        newer = ExecutionOrderEvent(
+            event_fingerprint="newer",
+            source_topic="torghut.trade-updates.v1",
+            source_partition=0,
+            source_offset=None,
+            alpaca_account_label="paper",
+            symbol="AAPL",
+            event_type="fill",
+            status="filled",
+            feed_seq=11,
+            event_ts=datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+            created_at=datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+        )
+
+        self.assertTrue(_order_event_precedes(older, newer))
+
+        older.feed_seq = None
+        newer.feed_seq = None
+        self.assertTrue(_order_event_precedes(older, newer))
+
+        older.event_ts = None
+        newer.event_ts = None
+        self.assertTrue(_order_event_precedes(older, newer))
 
     def test_transfer_specs_cover_pending_and_void_paths(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Fix TigerBeetle order-event selection so bad/unrepresentable order-feed amounts degrade the bounded journal run instead of crashing the source-window repair CronJob.
- Journal fill lifecycle events with incremental fill notional derived from cumulative filled quantity and average price, avoiding double-counted partial/final fill transfers.
- Add a bounded event scan cap and better CronJob stage logging while preserving GitOps rollout and proof-blocking semantics for unjournaled rows.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_journal.py scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py`
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_order_feed.py tests/test_tigerbeetle_reconcile.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
