### PR TITLE
fix(olden): restore responsive wiki hierarchy

### DIFF
--- a/apps/olden/app/(home)/page.tsx
+++ b/apps/olden/app/(home)/page.tsx
@@ -44,10 +44,12 @@ export default function HomePage() {
   return (
     <main className="flex flex-1 flex-col">
       <section className="border-b border-zinc-200 bg-zinc-950 text-zinc-50 dark:border-zinc-800">
-        <div className="mx-auto grid min-h-[68vh] w-full max-w-6xl items-center gap-10 px-6 py-16 sm:px-8 lg:grid-cols-[1.05fr_0.95fr] lg:px-12">
+        <div className="olden-lg-grid-home olden-lg-px-12 mx-auto grid min-h-[68vh] w-full max-w-6xl items-center gap-10 px-6 py-16 sm:px-8 lg:grid-cols-[1.05fr_0.95fr] lg:px-12">
           <div className="flex flex-col gap-6">
             <div className="flex flex-col gap-4">
-              <h1 className="max-w-3xl text-balance text-4xl font-semibold sm:text-5xl lg:text-6xl">Olden Era Wiki</h1>
+              <h1 className="olden-lg-text-6xl max-w-3xl text-balance text-4xl font-semibold sm:text-5xl lg:text-6xl">
+                Olden Era Wiki
+              </h1>
               <p className="max-w-2xl text-base leading-7 text-zinc-300 sm:text-lg">
                 An unofficial player wiki for Heroes of Might and Magic: Olden Era, focused on the practical knowledge
                 needed to route the map, build towns, preserve armies, and understand every faction.
@@ -97,7 +99,7 @@ export default function HomePage() {
           </div>
         </div>
       </section>
-      <section className="mx-auto grid w-full max-w-6xl gap-4 px-6 py-12 sm:px-8 md:grid-cols-2 lg:grid-cols-3 lg:px-12">
+      <section className="olden-md-grid-cols-2 olden-lg-grid-cols-3 olden-lg-px-12 mx-auto grid w-full max-w-6xl gap-4 px-6 py-12 sm:px-8 md:grid-cols-2 lg:grid-cols-3 lg:px-12">
         {entryPoints.map((item) => (
           <Link
             key={item.href}

--- a/apps/olden/app/global.css
+++ b/apps/olden/app/global.css
@@ -2,6 +2,91 @@
 @import 'fumadocs-ui/css/preset.css';
 @import '@proompteng/design/globals.css';
 
+@theme inline {
+  --breakpoint-md: 48rem;
+  --breakpoint-lg: 64rem;
+  --breakpoint-xl: 80rem;
+  --breakpoint-2xl: 96rem;
+}
+
+@layer utilities {
+  @media (min-width: 48rem) {
+    .olden-md-flex-row {
+      flex-direction: row;
+    }
+
+    .olden-md-items-start {
+      align-items: flex-start;
+    }
+
+    .olden-md-justify-between {
+      justify-content: space-between;
+    }
+
+    .olden-md-grid-cols-2 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .olden-md-grid-cols-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .olden-md-col-span-2 {
+      grid-column: span 2 / span 2;
+    }
+
+    .olden-md-border-r {
+      border-right-width: 1px;
+    }
+
+    .olden-md-border-t-0 {
+      border-top-width: 0;
+    }
+  }
+
+  @media (min-width: 64rem) {
+    .olden-lg-grid-cols-2 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .olden-lg-grid-cols-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .olden-lg-grid-artifact-set {
+      grid-template-columns: 1fr 1.15fr;
+    }
+
+    .olden-lg-grid-town {
+      grid-template-columns: 1fr 1.4fr;
+    }
+
+    .olden-lg-grid-home {
+      grid-template-columns: 1.05fr 0.95fr;
+    }
+
+    .olden-lg-px-12 {
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+
+    .olden-lg-text-6xl {
+      font-size: 3.75rem;
+      line-height: 1;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .olden-xl-grid-cols-2 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .olden-xl-grid-cols-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+}
+
 @source "./**/*.{js,jsx,ts,tsx,mdx}";
 @source "../content/**/*.{md,mdx}";
 @source not "../../node_modules";

--- a/apps/olden/content/docs/mechanics.mdx
+++ b/apps/olden/content/docs/mechanics.mdx
@@ -12,8 +12,6 @@ import {
   spellEntries,
 } from '@/src/data/olden/encyclopedia'
 
-# Mechanics
-
 Mechanics need to be framed as decision rules. The point is not to list terms; the point is to tell a player what to check before ending a turn, taking a fight, building a town, or committing the main hero.
 
 <WikiVisual

--- a/apps/olden/src/components/wiki/__tests__/content-integrity.test.ts
+++ b/apps/olden/src/components/wiki/__tests__/content-integrity.test.ts
@@ -163,6 +163,29 @@ describe('Olden Era wiki data', () => {
 })
 
 describe('Olden Era wiki components', () => {
+  it('keeps the mechanics page structured with visible hierarchy', () => {
+    const mechanicsPage = readFileSync(join(contentRoot, 'mechanics.mdx'), 'utf8')
+    const globalCss = readFileSync(join(import.meta.dir, '../../../../app/global.css'), 'utf8')
+    const formulaComponent = readFileSync(join(import.meta.dir, '../mechanics-formula-reference.tsx'), 'utf8')
+    const matrixComponent = readFileSync(join(import.meta.dir, '../mechanics-matrix.tsx'), 'utf8')
+
+    expect(globalCss).toContain('--breakpoint-md: 48rem')
+    expect(globalCss).toContain('--breakpoint-lg: 64rem')
+    expect(globalCss).toContain('--breakpoint-xl: 80rem')
+    expect(globalCss).toContain('.olden-md-grid-cols-3')
+    expect(globalCss).toContain('.olden-lg-grid-cols-3')
+    expect(globalCss).toContain('.olden-xl-grid-cols-2')
+    expect(mechanicsPage).not.toMatch(/^# Mechanics$/m)
+    expect(formulaComponent).toContain('Rules that change play')
+    expect(formulaComponent).toContain('Source-backed rule')
+    expect(formulaComponent).toContain('Decision check')
+    expect(formulaComponent).toContain('How it shows up')
+    expect(formulaComponent).toContain('space-y-10')
+    expect(matrixComponent).toContain('What to check before spending a turn')
+    expect(matrixComponent).toContain('Check before acting')
+    expect(matrixComponent).toContain('Avoid')
+  })
+
   it('keeps source notes compact and readable on the dark docs surface', () => {
     expect(sourceNoteClassNames.aside).toContain('px-3')
     expect(sourceNoteClassNames.aside).toContain('py-2')

--- a/apps/olden/src/components/wiki/artifact-set-reference.tsx
+++ b/apps/olden/src/components/wiki/artifact-set-reference.tsx
@@ -14,7 +14,7 @@ export function ArtifactSetReference() {
         </p>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-2">
+      <div className="olden-xl-grid-cols-2 grid gap-4 xl:grid-cols-2">
         {artifactSetEntries.map((set) => (
           <section key={set.id} className="rounded-lg border border-fd-border bg-fd-card p-4">
             <div className="grid gap-4 sm:grid-cols-[80px_1fr]">
@@ -42,7 +42,7 @@ export function ArtifactSetReference() {
               </div>
             </div>
 
-            <div className="mt-4 grid gap-3 lg:grid-cols-[1fr_1.15fr]">
+            <div className="olden-lg-grid-artifact-set mt-4 grid gap-3 lg:grid-cols-[1fr_1.15fr]">
               <div>
                 <p className="text-xs font-semibold uppercase text-fd-muted-foreground">Threshold effects</p>
                 <ul className="mt-2 space-y-2 text-sm text-fd-foreground">

--- a/apps/olden/src/components/wiki/encyclopedia-entry-table.tsx
+++ b/apps/olden/src/components/wiki/encyclopedia-entry-table.tsx
@@ -56,14 +56,23 @@ export function EncyclopediaEntryTable({
   const visibleGroups = groups.length > 0 ? groups : [['All entries', entries] as const]
 
   return (
-    <div className="not-prose space-y-4">
-      <div className="rounded-lg border border-fd-border bg-fd-card p-4">
-        <p className="text-sm font-semibold text-fd-foreground">{title}</p>
-        <p className="mt-1 text-sm text-fd-muted-foreground">{description}</p>
-        <p className="mt-2 text-xs text-fd-muted-foreground">
-          {entries.length} visible entries. Each row links back to the public source page used for the current snapshot.
+    <div className="not-prose my-10 space-y-6">
+      <section className="rounded-lg border border-fd-border bg-fd-card px-5 py-6 sm:px-6">
+        <div className="olden-md-flex-row olden-md-items-start olden-md-justify-between flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="max-w-3xl">
+            <p className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">Reference index</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-normal text-fd-foreground">{title}</h2>
+            <p className="mt-3 text-base leading-7 text-fd-muted-foreground">{description}</p>
+          </div>
+          <div className="shrink-0 border-l-2 border-fd-primary/70 bg-fd-muted/30 px-4 py-3">
+            <p className="text-2xl font-semibold text-fd-foreground">{entries.length}</p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">visible entries</p>
+          </div>
+        </div>
+        <p className="mt-5 border-t border-fd-border pt-4 text-sm leading-6 text-fd-muted-foreground">
+          Every row links back to the public source page used for the current snapshot.
         </p>
-      </div>
+      </section>
 
       {visibleGroups.map(([groupName, rows], index) => (
         <details
@@ -71,23 +80,28 @@ export function EncyclopediaEntryTable({
           className="rounded-lg border border-fd-border bg-fd-card"
           open={index < defaultOpenGroups}
         >
-          <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-fd-foreground">
-            {groupName} ({rows.length})
+          <summary className="cursor-pointer px-5 py-4 text-sm font-semibold text-fd-foreground">
+            <span className="inline-flex w-full items-center justify-between gap-4">
+              <span>{groupName}</span>
+              <span className="rounded border border-fd-border bg-fd-muted px-2 py-1 text-xs text-fd-muted-foreground">
+                {rows.length}
+              </span>
+            </span>
           </summary>
           <div className="overflow-x-auto border-t border-fd-border">
-            <table className="min-w-[1080px] text-left text-xs">
+            <table className="min-w-[1080px] text-left text-sm">
               <thead className="bg-fd-muted/40 text-fd-foreground">
                 <tr>
-                  <th className="px-3 py-2 font-semibold">Entry</th>
-                  <th className="px-3 py-2 font-semibold">Properties</th>
-                  <th className="px-3 py-2 font-semibold">Information</th>
-                  <th className="px-3 py-2 font-semibold">Source</th>
+                  <th className="px-4 py-3 font-semibold">Entry</th>
+                  <th className="px-4 py-3 font-semibold">Properties</th>
+                  <th className="px-4 py-3 font-semibold">Information</th>
+                  <th className="px-4 py-3 font-semibold">Source</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-fd-border text-fd-muted-foreground">
                 {rows.map((entry) => (
                   <tr key={entry.id}>
-                    <td className="w-[260px] px-3 py-3 align-top">
+                    <td className="w-[260px] px-4 py-4 align-top">
                       <div className="flex items-center gap-3">
                         {entry.image ? (
                           <img
@@ -103,7 +117,7 @@ export function EncyclopediaEntryTable({
                         <span className="font-medium text-fd-foreground">{entry.name}</span>
                       </div>
                     </td>
-                    <td className="w-[300px] px-3 py-3 align-top">
+                    <td className="w-[300px] px-4 py-4 align-top">
                       <div className="flex flex-wrap gap-1.5">
                         {propertyEntries(entry).map(([key, value]) => (
                           <span key={key} className="rounded border border-fd-border bg-fd-muted/40 px-2 py-1">
@@ -113,8 +127,10 @@ export function EncyclopediaEntryTable({
                         ))}
                       </div>
                     </td>
-                    <td className="max-w-[460px] px-3 py-3 align-top">{shortDescription(entry.description)}</td>
-                    <td className="w-[160px] px-3 py-3 align-top">
+                    <td className="max-w-[460px] px-4 py-4 align-top leading-6">
+                      {shortDescription(entry.description)}
+                    </td>
+                    <td className="w-[160px] px-4 py-4 align-top">
                       <a
                         className="font-medium text-fd-foreground underline decoration-fd-muted-foreground/60 underline-offset-2"
                         href={entry.url}

--- a/apps/olden/src/components/wiki/encyclopedia-overview.tsx
+++ b/apps/olden/src/components/wiki/encyclopedia-overview.tsx
@@ -70,7 +70,7 @@ export function EncyclopediaOverview() {
 
   return (
     <div className="not-prose my-8 space-y-5">
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      <div className="olden-xl-grid-cols-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
         {cards.map((card) => (
           <a
             key={card.href}

--- a/apps/olden/src/components/wiki/faction-grid.tsx
+++ b/apps/olden/src/components/wiki/faction-grid.tsx
@@ -5,7 +5,7 @@ import { FreshnessBadge } from './freshness-badge'
 
 export function FactionGrid() {
   return (
-    <div className="not-prose grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="olden-lg-grid-cols-3 not-prose grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {factions.map((faction) => (
         <Link
           key={faction.id}

--- a/apps/olden/src/components/wiki/game-mode-list.tsx
+++ b/apps/olden/src/components/wiki/game-mode-list.tsx
@@ -2,7 +2,7 @@ import { gameModes } from '@/src/data/olden/game-modes'
 
 export function GameModeList() {
   return (
-    <div className="not-prose grid gap-4 lg:grid-cols-2">
+    <div className="olden-lg-grid-cols-2 not-prose grid gap-4 lg:grid-cols-2">
       {gameModes.map((mode) => (
         <section key={mode.id} className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
           <h2 className="text-base font-semibold text-zinc-950 dark:text-zinc-50">{mode.name}</h2>

--- a/apps/olden/src/components/wiki/mechanics-formula-reference.tsx
+++ b/apps/olden/src/components/wiki/mechanics-formula-reference.tsx
@@ -1,28 +1,67 @@
 import { mechanicsFormulaEntries } from '@/src/data/olden/assets'
 
+const focusLabels = ['Combat math', 'Chance caps', 'Terrain tempo', 'Build gates', 'Magic access', 'Law economy']
+
 export function MechanicsFormulaReference() {
   return (
-    <div className="not-prose my-8 space-y-4">
-      <div className="rounded-lg border border-fd-border bg-fd-card p-4">
-        <p className="text-sm font-semibold text-fd-foreground">Concrete mechanics and combinations</p>
-        <p className="mt-1 text-sm text-fd-muted-foreground">
-          These are the source-backed rules that affect actual decisions: damage breakpoints, morale/luck caps, native
-          terrain, skill synergies, spell access, law-point economy, and artifact-set thresholds.
-        </p>
-      </div>
-      <div className="grid gap-3">
-        {mechanicsFormulaEntries.map((entry) => (
-          <section key={entry.id} className="rounded-lg border border-fd-border bg-fd-card p-4">
-            <h3 className="text-base font-semibold text-fd-foreground">{entry.title}</h3>
-            <p className="mt-2 text-sm text-fd-muted-foreground">{entry.rule}</p>
-            <p className="mt-3 text-sm font-medium text-fd-foreground">{entry.check}</p>
-            <ul className="mt-3 grid gap-2 md:grid-cols-2">
-              {entry.examples.map((example) => (
-                <li key={example} className="rounded border border-fd-border bg-fd-muted/30 px-3 py-2 text-sm">
-                  {example}
-                </li>
-              ))}
-            </ul>
+    <div className="not-prose my-14 space-y-10">
+      <section className="rounded-lg border border-fd-border bg-fd-card px-5 py-6 sm:px-6">
+        <div className="max-w-4xl">
+          <p className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+            Rules that change play
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-normal text-fd-foreground">
+            Concrete mechanics and combinations
+          </h2>
+          <p className="mt-3 text-base leading-7 text-fd-muted-foreground">
+            Source-backed rules are grouped by the decision they change: fight breakpoints, morale/luck caps, native
+            terrain, hero skill synergies, spell access, law-point economy, and set thresholds.
+          </p>
+        </div>
+
+        <div className="olden-lg-grid-cols-3 mt-6 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {focusLabels.map((label) => (
+            <div key={label} className="border-l-2 border-fd-primary/70 bg-fd-muted/30 px-3 py-2">
+              <p className="text-sm font-medium text-fd-foreground">{label}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <div className="space-y-8">
+        {mechanicsFormulaEntries.map((entry, index) => (
+          <section key={entry.id} className="rounded-lg border border-fd-border bg-fd-card">
+            <div className="olden-md-grid-cols-3 grid gap-6 border-b border-fd-border px-5 py-6 md:grid-cols-3 sm:px-6">
+              <div className="olden-md-col-span-2 md:col-span-2">
+                <div className="flex flex-wrap items-center gap-3">
+                  <span className="rounded border border-fd-border bg-fd-muted px-2 py-1 text-xs font-semibold text-fd-muted-foreground">
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+                    Source-backed rule
+                  </p>
+                </div>
+                <h3 className="mt-4 text-2xl font-semibold tracking-normal text-fd-foreground">{entry.title}</h3>
+                <p className="mt-3 text-base leading-7 text-fd-muted-foreground">{entry.rule}</p>
+              </div>
+
+              <aside className="border-l-2 border-fd-primary/70 bg-fd-muted/25 px-4 py-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">Decision check</p>
+                <p className="mt-2 text-sm font-medium leading-6 text-fd-foreground">{entry.check}</p>
+              </aside>
+            </div>
+
+            <div className="px-5 py-6 sm:px-6">
+              <p className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">How it shows up</p>
+              <ul className="olden-md-grid-cols-2 mt-3 grid gap-3 md:grid-cols-2">
+                {entry.examples.map((example) => (
+                  <li key={example} className="flex gap-3 text-sm leading-6 text-fd-foreground">
+                    <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-fd-primary" />
+                    <span>{example}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </section>
         ))}
       </div>

--- a/apps/olden/src/components/wiki/mechanics-matrix.tsx
+++ b/apps/olden/src/components/wiki/mechanics-matrix.tsx
@@ -2,31 +2,61 @@ import { mechanics } from '@/src/data/olden/mechanics'
 
 export function MechanicsMatrix() {
   return (
-    <div className="not-prose grid gap-3 md:grid-cols-2">
-      {mechanics.map((mechanic) => (
-        <section key={mechanic.name} className="rounded-lg border border-fd-border bg-fd-card p-4">
-          <h3 className="text-base font-semibold text-fd-foreground">{mechanic.name}</h3>
-          <p className="mt-2 text-sm text-fd-muted-foreground">{mechanic.whyItMatters}</p>
-          <div className="mt-4 grid gap-3 lg:grid-cols-2">
-            <div>
-              <p className="text-xs font-semibold uppercase text-fd-muted-foreground">Decision checks</p>
-              <ul className="mt-2 space-y-1 text-sm text-fd-foreground">
-                {mechanic.decisions.map((decision) => (
-                  <li key={decision}>{decision}</li>
-                ))}
-              </ul>
+    <div className="not-prose my-12 space-y-6">
+      <section className="rounded-lg border border-fd-border bg-fd-card px-5 py-6 sm:px-6">
+        <p className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">Decision matrix</p>
+        <h2 className="mt-2 text-2xl font-semibold tracking-normal text-fd-foreground">
+          What to check before spending a turn
+        </h2>
+        <p className="mt-3 max-w-4xl text-base leading-7 text-fd-muted-foreground">
+          These cards separate the useful question from the common mistake. Use them while planning a route, fight,
+          build order, or hero commitment.
+        </p>
+      </section>
+
+      <div className="olden-md-grid-cols-2 grid gap-5 md:grid-cols-2">
+        {mechanics.map((mechanic, index) => (
+          <section key={mechanic.name} className="rounded-lg border border-fd-border bg-fd-card">
+            <div className="border-b border-fd-border px-5 py-5">
+              <div className="flex items-center gap-3">
+                <span className="rounded border border-fd-border bg-fd-muted px-2 py-1 text-xs font-semibold text-fd-muted-foreground">
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <h3 className="text-lg font-semibold tracking-normal text-fd-foreground">{mechanic.name}</h3>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-fd-muted-foreground">{mechanic.whyItMatters}</p>
             </div>
-            <div>
-              <p className="text-xs font-semibold uppercase text-fd-muted-foreground">Common failures</p>
-              <ul className="mt-2 space-y-1 text-sm text-fd-foreground">
-                {mechanic.mistakes.map((mistake) => (
-                  <li key={mistake}>{mistake}</li>
-                ))}
-              </ul>
+
+            <div className="olden-md-grid-cols-2 grid gap-0 md:grid-cols-2">
+              <div className="olden-md-border-r px-5 py-4 md:border-r md:border-fd-border">
+                <p className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+                  Check before acting
+                </p>
+                <ul className="mt-3 space-y-3 text-sm leading-6 text-fd-foreground">
+                  {mechanic.decisions.map((decision) => (
+                    <li key={decision} className="flex gap-3">
+                      <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-fd-primary" />
+                      <span>{decision}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="olden-md-border-t-0 border-t border-fd-border px-5 py-4 md:border-t-0">
+                <p className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">Avoid</p>
+                <ul className="mt-3 space-y-3 text-sm leading-6 text-fd-muted-foreground">
+                  {mechanic.mistakes.map((mistake) => (
+                    <li key={mistake} className="flex gap-3">
+                      <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-fd-muted-foreground" />
+                      <span>{mistake}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
-          </div>
-        </section>
-      ))}
+          </section>
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/olden/src/components/wiki/source-site-index.tsx
+++ b/apps/olden/src/components/wiki/source-site-index.tsx
@@ -10,7 +10,7 @@ export function SourceSiteIndex() {
           laws, spells, heroes, classes, factions, objects, resources, and buildings.
         </p>
       </div>
-      <div className="grid gap-3 md:grid-cols-2">
+      <div className="olden-md-grid-cols-2 grid gap-3 md:grid-cols-2">
         {sourceSiteNavEntries.map((entry) => (
           <article key={entry.id} className="rounded-lg border border-fd-border bg-fd-card p-4">
             <div className="flex items-start justify-between gap-3">

--- a/apps/olden/src/components/wiki/town-build-tree.tsx
+++ b/apps/olden/src/components/wiki/town-build-tree.tsx
@@ -35,7 +35,7 @@ export function TownBuildTree() {
               <h3 className="text-base font-semibold text-fd-foreground">{branch.faction}</h3>
               <p className="mt-1 text-sm text-fd-muted-foreground">{branch.identity}</p>
             </div>
-            <div className="grid gap-4 p-4 lg:grid-cols-[1fr_1.4fr]">
+            <div className="olden-lg-grid-town grid gap-4 p-4 lg:grid-cols-[1fr_1.4fr]">
               <div className="space-y-3">
                 <div>
                   <p className="text-xs font-semibold uppercase text-fd-muted-foreground">Opening priorities</p>

--- a/apps/olden/src/components/wiki/wiki-visual.tsx
+++ b/apps/olden/src/components/wiki/wiki-visual.tsx
@@ -6,9 +6,9 @@ type WikiVisualProps = {
 
 export function WikiVisual({ src, alt, caption }: WikiVisualProps) {
   return (
-    <figure className="not-prose my-8 overflow-hidden rounded-lg border border-fd-border bg-fd-card shadow-xl">
+    <figure className="not-prose my-10 overflow-hidden rounded-lg border border-fd-border bg-fd-card shadow-xl">
       <img className="aspect-video w-full object-cover" src={src} alt={alt} loading="eager" />
-      <figcaption className="border-t border-fd-border px-4 py-3 text-xs text-fd-muted-foreground">
+      <figcaption className="border-t border-fd-border px-5 py-4 text-sm leading-6 text-fd-muted-foreground">
         {caption}
       </figcaption>
     </figure>


### PR DESCRIPTION
## Summary

- Restores Olden wiki responsive layout utilities so desktop encyclopedia pages render with real multi-column hierarchy.
- Reworks the mechanics page into source-backed rule sections with clear overview, decision checks, and applied examples.
- Removes the duplicate Mechanics heading and improves reference table, visual, faction, town, item set, and home-page layout spacing.

## Related Issues

None

## Testing

- `bun run --filter olden format`
- `bun run test:olden`
- `bun run lint:olden`
- `bun run --cwd apps/olden lint:oxlint`
- `bun run --cwd apps/olden lint:oxlint:type`
- `bun run build:olden`
- `git diff --check`
- Local route check: all 68 `/docs` routes returned HTTP 200.
- Local Playwright check: `/docs`, `/docs/mechanics`, `/docs/items`, and `/docs/source-database` rendered without page errors.
- Local mechanics layout proof: one Mechanics heading, three-column rule header grid, two-column mechanics matrix, and desktop side rail visible.

## Screenshots (if applicable)

Local proof screenshots saved in the rollout workspace:

- `/tmp/olden-ui-hierarchy-proof-desktop.png`
- `/tmp/olden-ui-hierarchy-proof-mobile.png`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
