### PR TITLE
fix(torghut): round TigerBeetle ledger notionals

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -44,7 +44,7 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_SUBMITTED_PENDING,
     TigerBeetleAccountSpec,
     TigerBeetleTransferSpec,
-    decimal_usd_to_micros,
+    decimal_usd_to_nearest_micros,
     transfer_code_for_kind,
     transfer_kind_for_event,
 )
@@ -537,7 +537,9 @@ def build_order_event_transfer_plan(
         else None
     )
     amount_usd = _event_amount_usd(event, transfer_kind, session=session)
-    amount = decimal_usd_to_micros(amount_usd) if amount_usd is not None else None
+    amount = (
+        decimal_usd_to_nearest_micros(amount_usd) if amount_usd is not None else None
+    )
     if amount is None and pending_ref is not None:
         amount = int(pending_ref.amount)
     if amount is None or amount <= 0:
@@ -650,7 +652,7 @@ def _execution_notional_usd(execution: Execution) -> Decimal | None:
 def _amount_to_micros(value: Decimal | None) -> int | None:
     if value is None:
         return None
-    amount = decimal_usd_to_micros(abs(Decimal(str(value))))
+    amount = decimal_usd_to_nearest_micros(abs(Decimal(str(value))))
     return amount if amount > 0 else None
 
 

--- a/services/torghut/app/trading/tigerbeetle_ledger_model.py
+++ b/services/torghut/app/trading/tigerbeetle_ledger_model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 
 
 LEDGER_USD_MICRO = 840001
@@ -85,6 +85,13 @@ def decimal_usd_to_micros(value: Decimal) -> int:
     if scaled < 0:
         raise ValueError("usd_amount_negative")
     return int(scaled)
+
+
+def decimal_usd_to_nearest_micros(value: Decimal) -> int:
+    scaled = value * USD_MICRO_SCALE
+    if scaled < 0:
+        raise ValueError("usd_amount_negative")
+    return int(scaled.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
 
 def transfer_kind_for_event(event_type: str | None, status: str | None) -> str | None:

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -36,6 +36,7 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_EXECUTION_COST,
     TRANSFER_KIND_EXECUTION_FILL,
     TRANSFER_KIND_RUNTIME_NET_PNL,
+    decimal_usd_to_nearest_micros,
 )
 
 
@@ -54,7 +55,6 @@ BLOCKER_UNLINKED_RUNTIME_LEDGER = "tigerbeetle_unlinked_runtime_ledger"
 BLOCKER_SOURCE_ROW_MISSING = "tigerbeetle_source_row_missing"
 BLOCKER_SOURCE_AMOUNT_MISMATCH = "tigerbeetle_source_amount_mismatch"
 BLOCKER_CLIENT_UNAVAILABLE = "tigerbeetle_client_unavailable"
-USD_MICRO_SCALE = Decimal("1000000")
 
 
 def _attr(value: object, name: str) -> Any:
@@ -132,10 +132,10 @@ def _uuid_or_none(value: str | None) -> UUID | None:
 def _usd_to_micros(value: Decimal | None) -> Decimal | None:
     if value is None:
         return None
-    scaled = abs(Decimal(str(value))) * USD_MICRO_SCALE
-    if scaled != scaled.to_integral_value() or scaled <= 0:
+    scaled = Decimal(decimal_usd_to_nearest_micros(abs(Decimal(str(value)))))
+    if scaled <= 0:
         return None
-    return Decimal(int(scaled))
+    return scaled
 
 
 def _execution_amount_micros(execution: Execution | None) -> Decimal | None:

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -42,6 +42,7 @@ def _add_order_event(
     status: str = "filled",
     source_offset: int = 1,
     has_amount: bool = True,
+    avg_fill_price: Decimal = Decimal("190.25"),
 ) -> ExecutionOrderEvent:
     event = ExecutionOrderEvent(
         event_fingerprint=fingerprint,
@@ -57,7 +58,7 @@ def _add_order_event(
         status=status,
         qty=Decimal("1") if has_amount else None,
         filled_qty=Decimal("1") if has_amount else None,
-        avg_fill_price=Decimal("190.25") if has_amount else None,
+        avg_fill_price=avg_fill_price if has_amount else None,
         raw_event={"event": event_type},
     )
     session.add(event)
@@ -309,23 +310,23 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual([event.id for event in events.rows], [selected.id])
         self.assertEqual(events.scan_failed, 0)
 
-    def test_select_unlinked_events_degrades_bad_amount_rows(self) -> None:
+    def test_select_unlinked_events_rounds_high_precision_amount_rows(self) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
         with Session(self.engine) as session:
-            bad = _add_order_event(
+            rounded = _add_order_event(
                 session,
-                fingerprint="bad-precision",
+                fingerprint="rounded-precision",
                 account_label="paper",
                 source_offset=1,
             )
-            bad.avg_fill_price = Decimal("190.2500001")
+            rounded.avg_fill_price = Decimal("190.2500001")
             selected = _add_order_event(
                 session,
                 fingerprint="selected",
                 account_label="paper",
                 source_offset=2,
             )
-            session.add_all([bad, selected])
+            session.add_all([rounded, selected])
             session.flush()
 
             events = script._select_unlinked_events(
@@ -337,27 +338,28 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             )
 
         self.assertEqual(
-            [event.event_fingerprint for event in events.rows], ["selected"]
+            [event.event_fingerprint for event in events.rows],
+            ["rounded-precision", "selected"],
         )
-        self.assertEqual(events.scan_failed, 1)
+        self.assertEqual(events.scan_failed, 0)
 
     def test_select_unlinked_events_honors_scan_limit(self) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
         with Session(self.engine) as session:
-            bad = _add_order_event(
+            rounded = _add_order_event(
                 session,
-                fingerprint="bad-precision",
+                fingerprint="rounded-precision",
                 account_label="paper",
                 source_offset=1,
             )
-            bad.avg_fill_price = Decimal("190.2500001")
+            rounded.avg_fill_price = Decimal("190.2500001")
             _add_order_event(
                 session,
                 fingerprint="selected",
                 account_label="paper",
                 source_offset=2,
             )
-            session.add(bad)
+            session.add(rounded)
             session.flush()
 
             events = script._select_unlinked_events(
@@ -368,8 +370,10 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 event_scan_limit=1,
             )
 
-        self.assertEqual(events.rows, [])
-        self.assertEqual(events.scan_failed, 1)
+        self.assertEqual(
+            [event.event_fingerprint for event in events.rows], ["rounded-precision"]
+        )
+        self.assertEqual(events.scan_failed, 0)
 
     def test_select_unlinked_events_stops_after_limit(self) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
@@ -397,6 +401,26 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             )
 
         self.assertEqual([event.id for event in events.rows], [first.id])
+        self.assertEqual(events.scan_failed, 0)
+
+    def test_select_unlinked_events_accepts_sub_micro_notional_rows(self) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        with Session(self.engine) as session:
+            selected = _add_order_event(
+                session,
+                fingerprint="sub-micro-notional",
+                account_label="paper",
+                avg_fill_price=Decimal("1.0000005"),
+            )
+
+            events = script._select_unlinked_events(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=10,
+            )
+
+        self.assertEqual([event.id for event in events.rows], [selected.id])
         self.assertEqual(events.scan_failed, 0)
 
     def test_main_journals_selected_events_and_reconciles(self) -> None:
@@ -500,6 +524,18 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 _add_order_event(session, fingerprint="selected", source_offset=2)
                 session.commit()
 
+            real_build_plan = script.build_order_event_transfer_plan
+
+            def build_plan_with_failure(
+                session: Session,
+                event: ExecutionOrderEvent,
+                *,
+                settings_obj: Settings,
+            ) -> object:
+                if event.event_fingerprint == "bad":
+                    raise RuntimeError("scan failed")
+                return real_build_plan(session, event, settings_obj=settings_obj)
+
             stdout = io.StringIO()
             with (
                 patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
@@ -520,6 +556,11 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                     script,
                     "reconcile_tigerbeetle_transfers",
                     return_value={"ok": True},
+                ),
+                patch.object(
+                    script,
+                    "build_order_event_transfer_plan",
+                    side_effect=build_plan_with_failure,
                 ),
                 redirect_stdout(stdout),
             ):

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -233,6 +233,24 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(refs[0].ledger, LEDGER_USD_MICRO)
             self.assertEqual(len(client.transfers), 1)
 
+    def test_real_fractional_notional_rounds_to_nearest_micro(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(session, fingerprint="fractional-notional")
+            event.filled_qty = Decimal("1")
+            event.qty = Decimal("1")
+            event.avg_fill_price = Decimal("1.0000005")
+            client = FakeTigerBeetleClient()
+
+            ref = TigerBeetleLedgerJournal(
+                settings_obj=_settings(), client=client
+            ).journal_order_event(session, event)
+
+            self.assertIsNotNone(ref)
+            assert ref is not None
+            self.assertEqual(ref.amount, Decimal("1000001"))
+            transfer = client.transfers[int(ref.transfer_id)]
+            self.assertEqual(getattr(transfer, "amount"), 1000001)
+
     def test_fill_without_pending_ref_uses_standalone_transfer(self) -> None:
         with Session(self.engine) as session:
             event = _create_fill_event(session, fingerprint="fingerprint-standalone")

--- a/services/torghut/tests/test_tigerbeetle_ledger_model.py
+++ b/services/torghut/tests/test_tigerbeetle_ledger_model.py
@@ -20,6 +20,7 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_REJECT_VOID,
     TRANSFER_KIND_SUBMITTED_PENDING,
     decimal_usd_to_micros,
+    decimal_usd_to_nearest_micros,
     transfer_code_for_kind,
     transfer_kind_for_event,
 )
@@ -35,6 +36,13 @@ class TestTigerBeetleLedgerModel(TestCase):
             decimal_usd_to_micros(Decimal("1.0000001"))
         with self.assertRaisesRegex(ValueError, "usd_amount_negative"):
             decimal_usd_to_micros(Decimal("-0.01"))
+
+    def test_decimal_usd_to_nearest_micros_rounds_real_broker_notional(self) -> None:
+        self.assertEqual(decimal_usd_to_nearest_micros(Decimal("1.0000004")), 1000000)
+        self.assertEqual(decimal_usd_to_nearest_micros(Decimal("1.0000005")), 1000001)
+        self.assertEqual(decimal_usd_to_nearest_micros(Decimal("1.234567")), 1234567)
+        with self.assertRaisesRegex(ValueError, "usd_amount_negative"):
+            decimal_usd_to_nearest_micros(Decimal("-0.01"))
 
     def test_account_and_transfer_codes_do_not_overlap(self) -> None:
         account_codes = {

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -145,6 +145,10 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertFalse(payload["ok"])
             self.assertIn(BLOCKER_AMOUNT_MISMATCH, payload["blockers"])
 
+    def test_source_amount_micros_rounds_real_broker_notional(self) -> None:
+        self.assertEqual(_usd_to_micros(Decimal("1.0000004")), Decimal("1000000"))
+        self.assertEqual(_usd_to_micros(Decimal("1.0000005")), Decimal("1000001"))
+
     def test_reconciliation_blocks_source_amount_mismatch(self) -> None:
         with Session(self.engine) as session:
             execution = Execution(


### PR DESCRIPTION
## Summary

- Round real broker/order notional amounts deterministically to USD micros before TigerBeetle journaling.
- Use the same rounded micros conversion during reconciliation source-amount checks.
- Preserve scan-failure accounting while treating high-precision fractional-share notionals as valid journalable evidence.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py -q`
- `uv run --frozen ruff check app/trading/tigerbeetle_ledger_model.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen ruff format --check app/trading/tigerbeetle_ledger_model.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
