### PR TITLE
fix(torghut): publish paper route target plan targets

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -3769,10 +3769,40 @@ def build_paper_route_target_plan_payload(
         target_audits=source_target_audits,
         next_target_audits=runtime_window_import_target_audits,
     )
+    effective_target_plan: Mapping[str, Any] = {}
+    for candidate_plan in (
+        next_targets,
+        source_targets,
+        runtime_window_import_plan,
+        plan,
+    ):
+        if _as_mapping_items(candidate_plan.get("targets")):
+            effective_target_plan = candidate_plan
+            break
+    effective_targets = _as_mapping_items(effective_target_plan.get("targets"))
+    effective_skipped_targets = _as_mapping_items(
+        effective_target_plan.get("skipped_targets")
+    )
+    effective_target_count = max(
+        _safe_int(effective_target_plan.get("target_count")),
+        len(effective_targets),
+    )
+    effective_skipped_target_count = max(
+        _safe_int(effective_target_plan.get("skipped_target_count")),
+        len(effective_skipped_targets),
+    )
     return {
         "schema_version": PAPER_ROUTE_TARGET_PLAN_PAYLOAD_SCHEMA_VERSION,
         "generated_at": _isoformat(resolved_generated_at),
         "source": "paper_route_target_plan_endpoint",
+        "purpose": _safe_text(effective_target_plan.get("purpose"))
+        or "next_session_paper_route_runtime_window_evidence_collection",
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "target_count": effective_target_count,
+        "skipped_target_count": effective_skipped_target_count,
+        "targets": effective_targets,
+        "skipped_targets": effective_skipped_targets,
         "live_submission_gate": {
             "allowed": bool(live_submission_gate.get("allowed")),
             "reason": _safe_text(live_submission_gate.get("reason")),

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7508,6 +7508,8 @@ class TestTradingApi(TestCase):
             self.assertEqual(
                 payload["next_paper_route_runtime_window_targets"]["target_count"], 1
             )
+            self.assertEqual(payload["target_count"], 1)
+            self.assertEqual(payload["skipped_target_count"], 0)
             self.assertEqual(
                 plan["runtime_window_import_handoff"]["target_plan_endpoint"],
                 "/trading/paper-route-target-plan",
@@ -7516,6 +7518,20 @@ class TestTradingApi(TestCase):
             self.assertEqual(plan["targets"][0]["paper_route_probe_symbols"], ["AAPL"])
             self.assertFalse(plan["targets"][0]["promotion_allowed"])
             self.assertFalse(plan["targets"][0]["final_promotion_allowed"])
+            next_plan = payload["next_paper_route_runtime_window_targets"]
+            next_target = next_plan["targets"][0]
+            self.assertEqual(payload["purpose"], next_plan["purpose"])
+            self.assertEqual(
+                payload["targets"][0]["candidate_id"], target["candidate_id"]
+            )
+            self.assertEqual(
+                payload["targets"][0]["paper_route_probe_symbols"], ["AAPL"]
+            )
+            self.assertEqual(
+                payload["targets"][0]["window_start"], next_target["window_start"]
+            )
+            self.assertFalse(payload["targets"][0]["promotion_allowed"])
+            self.assertFalse(payload["targets"][0]["final_promotion_allowed"])
         finally:
             if original_scheduler is None:
                 if hasattr(app.state, "trading_scheduler"):
@@ -7587,6 +7603,10 @@ class TestTradingApi(TestCase):
             )
             self.assertEqual(
                 payload["paper_route_probe"]["next_session_max_notional"], "75000"
+            )
+            self.assertEqual(payload["target_count"], 1)
+            self.assertEqual(
+                payload["targets"][0]["paper_route_probe_symbols"], ["AAPL", "AMZN"]
             )
             self.assertFalse(payload["summary"]["promotion_authority"]["allowed"])
         finally:


### PR DESCRIPTION
## Summary

- Publishes the effective paper-route target plan at the top level of `/trading/paper-route-target-plan`.
- Keeps the endpoint promotion-blocked while preserving nested next-window, source-window, runtime-import, and audit payloads.
- Adds API regressions so the lightweight target-plan endpoint must expose consumable top-level targets.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k "paper_route_target_plan_returns_lightweight_plan or paper_route_target_plan_skips_full_proof_floor_when_target_plan_ready or paper_route_target_plan_payload_prefers_next_window_over_closed_import" -q`
- `uv run --frozen pytest tests/test_trading_api.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_trading_api.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
