### PR TITLE
fix(torghut): split source-window repair from journaling

### DIFF
--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -50,15 +50,6 @@ spec:
                     --max-batches 1 \
                     --apply \
                     --json
-                  echo "stage=journal_tigerbeetle_order_events started_at=$(date -Iseconds)"
-                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
-                    --dsn-env SIM_DB_DSN \
-                    --account-label TORGHUT_SIM \
-                    --batch-size 500 \
-                    --max-batches 2 \
-                    --event-scan-limit 1000 \
-                    --reconcile-limit 1000 \
-                    --json
                   echo "stage=order_feed_source_window_repair completed_at=$(date -Iseconds)"
               securityContext:
                 seccompProfile:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -60,6 +60,7 @@ spec:
                     --account-label TORGHUT_SIM \
                     --batch-size 500 \
                     --max-batches 2 \
+                    --event-scan-limit 1000 \
                     --reconcile-limit 1000 \
                     --fail-on-degraded \
                     --json

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1267,9 +1267,8 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--batch-size 500", args)
         self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
-        self.assertIn("scripts/journal_tigerbeetle_order_events.py", args)
-        self.assertIn("--max-batches 2", args)
-        self.assertIn("--reconcile-limit 1000", args)
+        self.assertNotIn("scripts/journal_tigerbeetle_order_events.py", args)
+        self.assertNotIn("--reconcile-limit 1000", args)
         self.assertIn("--json", args)
         security_context = cast(
             Mapping[str, object],
@@ -1369,6 +1368,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--account-label TORGHUT_SIM", args)
         self.assertIn("--batch-size 500", args)
         self.assertIn("--max-batches 2", args)
+        self.assertIn("--event-scan-limit 1000", args)
         self.assertIn("--reconcile-limit 1000", args)
         self.assertIn("--fail-on-degraded", args)
         self.assertIn("--json", args)


### PR DESCRIPTION
## Summary

- Removes TigerBeetle journaling from the source-window repair CronJob so the repair run owns only source-window lineage repair.
- Keeps TigerBeetle journaling in the dedicated CronJob and adds the bounded `--event-scan-limit 1000` cap there.
- Updates the live manifest contract test so the split ownership is enforced.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check tests/test_live_config_manifest_contract.py tests/test_torghut_release_workflow_manifest_paths.py`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py tests/test_torghut_release_workflow_manifest_paths.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
