### PR TITLE
fix(torghut): keep TigerBeetle journal cron bounded

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -14,11 +14,11 @@ spec:
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
-      backoffLimit: 1
+      backoffLimit: 0
       activeDeadlineSeconds: 600
       template:
         spec:
-          restartPolicy: OnFailure
+          restartPolicy: Never
           serviceAccountName: torghut-runtime
           nodeSelector:
             kubernetes.io/arch: arm64
@@ -62,7 +62,6 @@ spec:
                     --max-batches 2 \
                     --event-scan-limit 1000 \
                     --reconcile-limit 1000 \
-                    --fail-on-degraded \
                     --json
               env:
                 - name: TORGHUT_SIM_DB_HOST
@@ -103,3 +102,5 @@ spec:
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:cc3fc1095b90378a3b1e0655309b128935eaa02bc555fa61f6ee058046362d61
+                - name: PYTHONUNBUFFERED
+                  value: "1"

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1310,7 +1310,8 @@ class TestLiveConfigManifestContract(TestCase):
         )
         pod_spec = cast(Mapping[str, object], template.get("spec", {}))
         self.assertEqual(job_spec.get("activeDeadlineSeconds"), 600)
-        self.assertEqual(job_spec.get("backoffLimit"), 1)
+        self.assertEqual(job_spec.get("backoffLimit"), 0)
+        self.assertEqual(pod_spec.get("restartPolicy"), "Never")
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
         self.assertEqual(
             pod_spec.get("nodeSelector"),
@@ -1360,6 +1361,7 @@ class TestLiveConfigManifestContract(TestCase):
             value_env["TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED"],
             "false",
         )
+        self.assertEqual(value_env["PYTHONUNBUFFERED"], "1")
 
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/journal_tigerbeetle_order_events.py", args)
@@ -1370,7 +1372,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--max-batches 2", args)
         self.assertIn("--event-scan-limit 1000", args)
         self.assertIn("--reconcile-limit 1000", args)
-        self.assertIn("--fail-on-degraded", args)
+        self.assertNotIn("--fail-on-degraded", args)
         self.assertIn("--json", args)
         security_context = cast(
             Mapping[str, object],


### PR DESCRIPTION
## Summary

- Changes the TigerBeetle journal CronJob to `restartPolicy: Never` with `backoffLimit: 0` so a failing run does not retry-loop or delete the useful failed pod state.
- Removes `--fail-on-degraded` from the scheduled journal run; degraded rows stay visible in JSON output and remain blocked from promotion by runtime-ledger gates.
- Adds unbuffered Python output and updates the live manifest contract test for the bounded CronJob semantics.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
