### PR TITLE
fix(torghut): constrain runtime ledger source windows

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2642,9 +2642,12 @@ def _runtime_source_context_for_bucket(
         bucket_order_ids=bucket_order_ids,
     )
     source_rows = [*bucket_execution_rows, *bucket_decision_rows, *bucket_order_rows]
-    source_row_times = [
+    source_backed_fill_lifecycle_rows = _source_backed_fill_lifecycle_rows(
+        bucket_order_rows
+    )
+    source_backed_fill_lifecycle_times = [
         event_time
-        for row in source_rows
+        for row in source_backed_fill_lifecycle_rows
         if (
             event_time := _runtime_ledger_row_time(
                 {str(key): value for key, value in row.items()}
@@ -2652,9 +2655,6 @@ def _runtime_source_context_for_bucket(
         )
         is not None
     ]
-    source_backed_fill_lifecycle_rows = _source_backed_fill_lifecycle_rows(
-        bucket_order_rows
-    )
     source_window_ids = _source_identifier_values(
         source_backed_fill_lifecycle_rows,
         "source_window_id",
@@ -2732,11 +2732,13 @@ def _runtime_source_context_for_bucket(
         "source_rows": source_rows,
         "source_window_ids": source_window_ids,
         "source_window_start": (
-            min(source_row_times) if source_row_times else bucket.bucket_started_at
+            min(source_backed_fill_lifecycle_times)
+            if source_backed_fill_lifecycle_times
+            else bucket.bucket_started_at
         ),
         "source_window_end": (
-            max(source_row_times) + timedelta(microseconds=1)
-            if source_row_times
+            max(source_backed_fill_lifecycle_times) + timedelta(microseconds=1)
+            if source_backed_fill_lifecycle_times
             else bucket.bucket_ended_at
         ),
         "source_row_counts": source_row_counts,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -2189,7 +2189,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
         self.assertEqual(bucket["account_equity"], "10000")
         self.assertEqual(bucket["account_equity_source"], "equity")
-        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:34:00+00:00")
+        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:35:01+00:00")
         self.assertEqual(
             bucket["source_window_end"], "2026-03-06T14:40:01.000001+00:00"
         )
@@ -2405,7 +2405,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["net_strategy_pnl_after_costs"], "0.70")
         self.assertEqual(bucket["open_position_count"], 0)
         self.assertEqual(bucket["closed_trade_count"], 1)
-        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:34:00+00:00")
+        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:35:01+00:00")
+        self.assertEqual(
+            bucket["source_window_end"], "2026-03-06T14:40:01.000001+00:00"
+        )
         self.assertEqual(
             bucket["source_window_ids"],
             [
@@ -3662,6 +3665,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         assert isinstance(bucket, dict)
         self.assertEqual(bucket["blockers"], [])
         self.assertEqual(bucket["source_materialization"], "source_execution_lifecycle")
+        self.assertEqual(
+            bucket["source_window_start"],
+            "2026-03-06T14:31:01+00:00",
+        )
+        self.assertEqual(
+            bucket["source_window_end"],
+            "2026-03-06T14:32:01.000001+00:00",
+        )
+        self.assertEqual(
+            bucket["source_window_ids"],
+            ["source-window-fill-buy", "source-window-fill-sell"],
+        )
         self.assertEqual(
             bucket["cost_basis_counts"],
             {"broker_reported_commission_and_fees": 2},
@@ -5838,7 +5853,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         assert isinstance(bucket, dict)
         self.assertEqual(bucket["closed_trade_count"], 1)
         self.assertEqual(bucket["open_position_count"], 0)
-        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:34:00+00:00")
+        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:35:00+00:00")
+        self.assertEqual(
+            bucket["source_window_end"], "2026-03-06T14:40:00.000001+00:00"
+        )
 
     def test_source_activity_diagnostic_blockers_classify_materialization_gap(
         self,


### PR DESCRIPTION
## Summary

- Constrains runtime-ledger source window start/end to source-backed fill lifecycle events.
- Prevents decision or non-fill order lifecycle rows from widening the authority window attached to promotion-grade runtime-ledger buckets.
- Updates runtime-window import regressions for event-sourced, source-backed carry-in, and query materialization paths.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check HEAD~1..HEAD`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
