### PR TITLE
fix(torghut): reuse TigerBeetle journal client

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -794,8 +794,8 @@ def _journal_tigerbeetle_order_event(
     if not settings.tigerbeetle_enabled or not settings.tigerbeetle_journal_enabled:
         return
     try:
-        with session.begin_nested():
-            TigerBeetleLedgerJournal().journal_order_event(session, row)
+        with TigerBeetleLedgerJournal() as journal, session.begin_nested():
+            journal.journal_order_event(session, row)
     except Exception as exc:
         if settings.tigerbeetle_required:
             raise

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -1624,8 +1624,8 @@ def _journal_tigerbeetle_runtime_ledger_bucket(
         return
     session.flush()
     try:
-        with session.begin_nested():
-            TigerBeetleLedgerJournal().journal_runtime_ledger_bucket(session, row)
+        with TigerBeetleLedgerJournal() as journal, session.begin_nested():
+            journal.journal_runtime_ledger_bucket(session, row)
     except Exception as exc:
         if settings.tigerbeetle_required:
             raise

--- a/services/torghut/app/trading/tca.py
+++ b/services/torghut/app/trading/tca.py
@@ -208,9 +208,8 @@ def _journal_tigerbeetle_execution_cost(
     if not settings.tigerbeetle_enabled or not settings.tigerbeetle_journal_enabled:
         return
     session.flush()
-    journal = TigerBeetleLedgerJournal()
     try:
-        with session.begin_nested():
+        with TigerBeetleLedgerJournal() as journal, session.begin_nested():
             journal.journal_execution(session, execution)
             journal.journal_execution_tca_metric(session, metric)
     except Exception as exc:

--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, cast
+from types import TracebackType
+from typing import Any, Self, cast
 
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
@@ -665,9 +666,32 @@ class TigerBeetleLedgerJournal:
     ) -> None:
         self._settings = settings_obj
         self._client = client
+        self._owns_client = client is None
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, traceback
+        self.close()
 
     def _client_for_write(self) -> TigerBeetleClientProtocol:
-        return self._client or create_tigerbeetle_client(self._settings)
+        if self._client is None:
+            self._client = create_tigerbeetle_client(self._settings)
+        return self._client
+
+    def close(self) -> None:
+        if not self._owns_client or self._client is None:
+            return
+        close = getattr(self._client, "close", None)
+        if callable(close):
+            close()
+        self._client = None
 
     def _persist_transfer(
         self,

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -328,8 +328,12 @@ def main() -> int:
     batches: list[dict[str, int | str]] = []
     reconciliation: dict[str, object] | None = None
 
-    with session_factory() as session:
-        journal = TigerBeetleLedgerJournal(settings_obj=settings_obj)
+    with (
+        session_factory() as session,
+        TigerBeetleLedgerJournal(
+            settings_obj=settings_obj,
+        ) as journal,
+    ):
         for _ in range(max_batches):
             events = _select_unlinked_events(
                 session,

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -136,7 +136,15 @@ class FakeJournal:
         self.executions: list[str] = []
         self.tca_metrics: list[str] = []
         self.runtime_buckets: list[str] = []
+        self.closed = False
         FakeJournal.instances.append(self)
+
+    def __enter__(self) -> "FakeJournal":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        del args
+        self.closed = True
 
     def journal_order_event(
         self,

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -53,6 +53,15 @@ from app.trading.tigerbeetle_ledger_model import (
 )
 
 
+class ClosableFakeTigerBeetleClient(FakeTigerBeetleClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.close_count = 0
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
 def _settings(*, enabled: bool = True, journal_enabled: bool = True) -> Settings:
     return Settings(
         TORGHUT_TIGERBEETLE_ENABLED=enabled,
@@ -232,6 +241,24 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(refs[0].amount, Decimal("190250000"))
             self.assertEqual(refs[0].ledger, LEDGER_USD_MICRO)
             self.assertEqual(len(client.transfers), 1)
+
+    def test_owned_client_is_reused_and_closed(self) -> None:
+        with Session(self.engine) as session:
+            first = _create_fill_event(session, fingerprint="client-reuse-1")
+            second = _create_fill_event(session, fingerprint="client-reuse-2")
+            client = ClosableFakeTigerBeetleClient()
+
+            with patch(
+                "app.trading.tigerbeetle_journal.create_tigerbeetle_client",
+                return_value=client,
+            ) as factory:
+                with TigerBeetleLedgerJournal(settings_obj=_settings()) as journal:
+                    self.assertIsNotNone(journal.journal_order_event(session, first))
+                    self.assertIsNotNone(journal.journal_order_event(session, second))
+
+            self.assertEqual(factory.call_count, 1)
+            self.assertEqual(client.close_count, 1)
+            self.assertEqual(len(client.transfers), 2)
 
     def test_real_fractional_notional_rounds_to_nearest_micro(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Reuses one owned TigerBeetle client per `TigerBeetleLedgerJournal` instead of creating a fresh client for every transfer write.
- Adds context-manager close handling and applies it to batch journaling plus inline order-feed, TCA, and runtime-ledger journal paths.
- Adds regression coverage proving owned clients are created once, reused across writes, and closed.
- Addresses live evidence from `torghut-tigerbeetle-journal-order-events-29671116`, which OOMKilled at 512Mi before committing refs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_window_import.py tests/test_tca_adaptive_policy.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_journal.py app/trading/order_feed.py app/trading/tca.py app/trading/runtime_window_import.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tigerbeetle_journal.py app/trading/order_feed.py app/trading/tca.py app/trading/runtime_window_import.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
