### PR TITLE
fix(torghut): defer future account state blockers

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -2101,21 +2101,26 @@ def _account_window_start_snapshot_audit(
     account_label: str | None,
     symbols: Sequence[str],
     window_start: datetime,
+    generated_at: datetime | None = None,
 ) -> dict[str, object]:
     symbol_filters = {
         str(item).strip().upper() for item in symbols if str(item).strip()
     }
+    required = generated_at is None or generated_at >= window_start
     base_payload: dict[str, object] = {
         "schema_version": "torghut.paper-route-account-window-start-snapshot-audit.v1",
         "scope": "account_position_snapshot_at_runtime_window_start",
         "account_label": account_label,
         "symbols": sorted(symbol_filters),
+        "generated_at": _isoformat(generated_at) if generated_at is not None else None,
         "window_start": _isoformat(window_start),
+        "required": required,
+        "state": "required" if required else "pending_until_window_start",
         "snapshot_id": None,
         "snapshot_as_of": None,
         "snapshot_source": None,
         "snapshot_offset_seconds": None,
-        "flat": False,
+        "flat": False if required else None,
         "position_count": 0,
         "target_symbol_position_count": 0,
         "non_target_symbol_position_count": 0,
@@ -2126,8 +2131,12 @@ def _account_window_start_snapshot_audit(
     if account_label is None:
         return {
             **base_payload,
+            "required": False,
+            "state": "not_applicable",
             "flat": True,
         }
+    if not required:
+        return base_payload
 
     before_snapshot = session.execute(
         select(PositionSnapshot)
@@ -2202,6 +2211,7 @@ def _account_window_start_snapshot_audit(
             else "first_after_window_start"
         ),
         "snapshot_offset_seconds": offset_seconds,
+        "state": "blocked" if blockers else "clean",
         "flat": not positions and not blockers,
         "position_count": len(positions),
         "target_symbol_position_count": target_position_count,
@@ -2985,6 +2995,7 @@ def _target_audit(
         account_label=cast(str | None, target.get("account_label")),
         symbols=_target_probe_symbols(target, probe),
         window_start=window_start,
+        generated_at=generated_at,
     )
     rejected_signal_activity = _rejected_signal_activity(
         session,
@@ -3370,7 +3381,14 @@ def _runtime_window_target_blockers(
                     ),
                 },
                 "account_state": {
-                    "flat": bool(account_state.get("flat")),
+                    "state": _safe_text(account_state.get("state")),
+                    "required": bool(account_state.get("required")),
+                    "flat": (
+                        account_state.get("flat")
+                        if isinstance(account_state.get("flat"), bool)
+                        else None
+                    ),
+                    "generated_at": _safe_text(account_state.get("generated_at")),
                     "snapshot_id": _safe_text(account_state.get("snapshot_id")),
                     "snapshot_as_of": _safe_text(account_state.get("snapshot_as_of")),
                     "snapshot_source": _safe_text(account_state.get("snapshot_source")),

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -254,6 +254,127 @@ class TestPaperRouteEvidenceAudit(TestCase):
             ["paper_route_account_window_start_snapshot_stale"],
         )
 
+    def test_account_window_start_snapshot_audit_defers_future_window(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        generated_at = window_start - timedelta(hours=1)
+        with Session(self.engine) as session:
+            self._add_account_position_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                as_of=generated_at - timedelta(seconds=30),
+                positions=[
+                    {
+                        "symbol": "AAPL",
+                        "qty": "1",
+                        "side": "long",
+                        "market_value": "200",
+                    }
+                ],
+            )
+            session.commit()
+
+            audit = _account_window_start_snapshot_audit(
+                session,
+                account_label="TORGHUT_SIM",
+                symbols=["AAPL"],
+                window_start=window_start,
+                generated_at=generated_at,
+            )
+
+        self.assertEqual(audit["state"], "pending_until_window_start")
+        self.assertFalse(audit["required"])
+        self.assertIsNone(audit["flat"])
+        self.assertEqual(audit["position_count"], 0)
+        self.assertEqual(audit["sample_positions"], [])
+        self.assertEqual(audit["blockers"], [])
+
+    def test_future_runtime_window_defers_stale_account_state_blockers(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        generated_at = window_start - timedelta(hours=1)
+        with Session(self.engine) as session:
+            self._add_account_position_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                as_of=generated_at - timedelta(seconds=30),
+                positions=[
+                    {
+                        "symbol": "AAPL",
+                        "qty": "1",
+                        "side": "long",
+                        "market_value": "200",
+                    }
+                ],
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-FUTURE-ACCOUNT",
+                                "candidate_id": "candidate-future-account",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "future-account-state-strategy",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": "config/trading/hypotheses/h-future-account.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": [],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=generated_at,
+            )
+
+        audit = payload["next_runtime_window_target_audits"][0]
+        self.assertEqual(audit["account_state"]["state"], "pending_until_window_start")
+        self.assertEqual(audit["account_state"]["blockers"], [])
+        self.assertNotIn(
+            "paper_route_account_window_start_not_flat",
+            audit["readiness"]["blockers"],
+        )
+        self.assertNotIn(
+            "paper_route_account_window_start_positions_present",
+            audit["readiness"]["evidence_collection_blockers"],
+        )
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertNotEqual(
+            import_audit["state"], "import_due_account_state_not_clean"
+        )
+        self.assertEqual(
+            import_audit["diagnostics"]["account_state_blockers"], []
+        )
+
     def test_pre_session_dirty_account_skips_next_paper_route_target(self) -> None:
         generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Defer paper-route account-window-start snapshot checks until the runtime window has actually started.
- Keep pre-session readiness and at/after-window dirty-account checks fail-closed.
- Add helper and endpoint regression coverage so stale future-window snapshots do not become premature evidence-collection blockers.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'account_window_start_snapshot_audit or future_runtime_window_defers_stale_account_state_blockers or import_blocks_dirty_account_state' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
