### PR TITLE
fix(torghut): bound proof ledger cron resources

### DIFF
--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: order-feed-source-window-repair
 spec:
-  schedule: "13,28,43,58 * * * *"
+  schedule: "13,43 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 2
@@ -33,7 +33,7 @@ spec:
                   ephemeral-storage: 128Mi
                 limits:
                   cpu: 250m
-                  memory: 256Mi
+                  memory: 512Mi
                   ephemeral-storage: 512Mi
               command:
                 - /bin/bash
@@ -46,7 +46,7 @@ spec:
                   /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
-                    --batch-size 500 \
+                    --batch-size 250 \
                     --max-batches 1 \
                     --apply \
                     --json

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: tigerbeetle-journal-order-events
 spec:
-  schedule: "6,21,36,51 * * * *"
+  schedule: "6,36 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
@@ -46,7 +46,7 @@ spec:
                   ephemeral-storage: 128Mi
                 limits:
                   cpu: 500m
-                  memory: 512Mi
+                  memory: 1Gi
                   ephemeral-storage: 512Mi
               command:
                 - /bin/bash
@@ -58,10 +58,10 @@ spec:
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
-                    --batch-size 500 \
-                    --max-batches 2 \
-                    --event-scan-limit 1000 \
-                    --reconcile-limit 1000 \
+                    --batch-size 100 \
+                    --max-batches 1 \
+                    --event-scan-limit 250 \
+                    --reconcile-limit 250 \
                     --json
               env:
                 - name: TORGHUT_SIM_DB_HOST

--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -685,6 +685,14 @@ class TigerBeetleLedgerJournal:
             self._client = create_tigerbeetle_client(self._settings)
         return self._client
 
+    def client_for_reconciliation(self) -> TigerBeetleClientProtocol | None:
+        if (
+            not self._settings.tigerbeetle_enabled
+            or not self._settings.tigerbeetle_journal_enabled
+        ):
+            return None
+        return self._client_for_write()
+
     def close(self) -> None:
         if not self._owns_client or self._client is None:
             return

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -306,6 +306,8 @@ def reconcile_tigerbeetle_transfers(
     blockers: list[str] = []
 
     transfer_lookup: dict[str, object] = {}
+    owned_client = client is None
+    tb_client: TigerBeetleClientProtocol | None = None
     try:
         if refs:
             tb_client = client or create_tigerbeetle_client(settings_obj)
@@ -315,6 +317,11 @@ def reconcile_tigerbeetle_transfers(
             transfer_lookup = {str(_attr(item, "id")): item for item in looked_up}
     except Exception:
         blockers.append(BLOCKER_CLIENT_UNAVAILABLE)
+    finally:
+        if owned_client and tb_client is not None:
+            close = getattr(tb_client, "close", None)
+            if callable(close):
+                close()
 
     for ref in refs:
         actual = transfer_lookup.get(ref.transfer_id)

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -424,6 +424,7 @@ def main() -> int:
             reconciliation = reconcile_tigerbeetle_transfers(
                 session,
                 settings_obj=settings_obj,
+                client=journal.client_for_reconciliation(),
                 limit=max(1, int(args.reconcile_limit)),
                 persist=True,
             )

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -136,6 +136,7 @@ class FakeJournal:
         self.executions: list[str] = []
         self.tca_metrics: list[str] = []
         self.runtime_buckets: list[str] = []
+        self.reconciliation_client = SimpleNamespace(name="shared-tigerbeetle-client")
         self.closed = False
         FakeJournal.instances.append(self)
 
@@ -183,6 +184,9 @@ class FakeJournal:
         del session
         self.runtime_buckets.append(bucket.run_id)
         return SimpleNamespace(transfer_id="4")
+
+    def client_for_reconciliation(self) -> object:
+        return self.reconciliation_client
 
 
 class TestJournalTigerBeetleOrderEventsScript(TestCase):
@@ -483,6 +487,10 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             ["runtime-run-source"],
         )
         reconcile.assert_called_once()
+        self.assertIs(
+            reconcile.call_args.kwargs["client"],
+            FakeJournal.instances[0].reconciliation_client,
+        )
 
     def test_main_dry_run_rolls_back_without_reconcile(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1199,7 +1199,7 @@ class TestLiveConfigManifestContract(TestCase):
             "argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml"
         )
 
-        self.assertEqual(spec.get("schedule"), "13,28,43,58 * * * *")
+        self.assertEqual(spec.get("schedule"), "13,43 * * * *")
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
         self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
         job_spec = cast(
@@ -1228,7 +1228,7 @@ class TestLiveConfigManifestContract(TestCase):
                 },
                 "limits": {
                     "cpu": "250m",
-                    "memory": "256Mi",
+                    "memory": "512Mi",
                     "ephemeral-storage": "512Mi",
                 },
             },
@@ -1264,7 +1264,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/repair_order_feed_source_windows.py", args)
         self.assertIn("--dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
-        self.assertIn("--batch-size 500", args)
+        self.assertIn("--batch-size 250", args)
         self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
         self.assertNotIn("scripts/journal_tigerbeetle_order_events.py", args)
@@ -1294,7 +1294,7 @@ class TestLiveConfigManifestContract(TestCase):
             metadata.get("name"),
             "torghut-tigerbeetle-journal-order-events",
         )
-        self.assertEqual(spec.get("schedule"), "6,21,36,51 * * * *")
+        self.assertEqual(spec.get("schedule"), "6,36 * * * *")
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
         self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
         self.assertEqual(spec.get("successfulJobsHistoryLimit"), 2)
@@ -1368,10 +1368,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("scripts/repair_order_feed_source_windows.py", args)
         self.assertIn("--dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
-        self.assertIn("--batch-size 500", args)
-        self.assertIn("--max-batches 2", args)
-        self.assertIn("--event-scan-limit 1000", args)
-        self.assertIn("--reconcile-limit 1000", args)
+        self.assertIn("--batch-size 100", args)
+        self.assertIn("--max-batches 1", args)
+        self.assertIn("--event-scan-limit 250", args)
+        self.assertIn("--reconcile-limit 250", args)
         self.assertNotIn("--fail-on-degraded", args)
         self.assertIn("--json", args)
         security_context = cast(

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -260,6 +260,38 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(client.close_count, 1)
             self.assertEqual(len(client.transfers), 2)
 
+    def test_reconciliation_client_is_disabled_when_journal_is_disabled(
+        self,
+    ) -> None:
+        client = FakeTigerBeetleClient()
+
+        self.assertIsNone(
+            TigerBeetleLedgerJournal(
+                settings_obj=_settings(enabled=False),
+                client=client,
+            ).client_for_reconciliation()
+        )
+        self.assertIsNone(
+            TigerBeetleLedgerJournal(
+                settings_obj=_settings(journal_enabled=False),
+                client=client,
+            ).client_for_reconciliation()
+        )
+
+    def test_reconciliation_client_reuses_owned_journal_client(self) -> None:
+        client = ClosableFakeTigerBeetleClient()
+
+        with patch(
+            "app.trading.tigerbeetle_journal.create_tigerbeetle_client",
+            return_value=client,
+        ) as factory:
+            with TigerBeetleLedgerJournal(settings_obj=_settings()) as journal:
+                self.assertIs(journal.client_for_reconciliation(), client)
+                self.assertIs(journal.client_for_reconciliation(), client)
+
+        self.assertEqual(factory.call_count, 1)
+        self.assertEqual(client.close_count, 1)
+
     def test_real_fractional_notional_rounds_to_nearest_micro(self) -> None:
         with Session(self.engine) as session:
             event = _create_fill_event(session, fingerprint="fractional-notional")

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from decimal import Decimal
 from unittest import TestCase
+from unittest.mock import patch
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -55,6 +56,15 @@ from app.trading.tigerbeetle_reconcile import (
 class FailingLookupClient(FakeTigerBeetleClient):
     def lookup_transfers(self, ids: list[int]) -> list[object]:
         raise RuntimeError("lookup failed")
+
+
+class CloseTrackingClient(FakeTigerBeetleClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def _settings() -> Settings:
@@ -118,6 +128,39 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertTrue(payload["ok"])
             self.assertEqual(payload["blockers"], [])
             self.assertEqual(payload["checked_transfer_count"], 1)
+
+    def test_reconciliation_closes_owned_tigerbeetle_client(self) -> None:
+        with Session(self.engine) as session:
+            _add_ref(session)
+            client = CloseTrackingClient()
+            client.transfers[1001] = _transfer()
+
+            with patch(
+                "app.trading.tigerbeetle_reconcile.create_tigerbeetle_client",
+                return_value=client,
+            ):
+                payload = reconcile_tigerbeetle_transfers(
+                    session,
+                    settings_obj=_settings(),
+                )
+
+            self.assertTrue(payload["ok"])
+            self.assertTrue(client.closed)
+
+    def test_reconciliation_does_not_close_injected_tigerbeetle_client(self) -> None:
+        with Session(self.engine) as session:
+            _add_ref(session)
+            client = CloseTrackingClient()
+            client.transfers[1001] = _transfer()
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertTrue(payload["ok"])
+            self.assertFalse(client.closed)
 
     def test_reconciliation_blocks_missing_tigerbeetle_transfer(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Reuse the TigerBeetle journal client for reconciliation so the proof cron does not open an extra client during the same run.
- Close reconciliation-owned TigerBeetle clients after lookup to avoid leaking client resources in other callers.
- Bound the source-window repair and TigerBeetle journal cron jobs with lower run frequency, smaller batches, and safer memory limits.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_order_feed_source_window_repair_cronjob_is_bounded_sim_only tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_tigerbeetle_journal_order_events_cronjob_is_independent_sim_only -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_live_config_manifest_contract.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
