### PR TITLE
fix(torghut): accept TigerBeetle exists status

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -57,10 +57,18 @@ SOURCE_TYPE_RUNTIME_LEDGER_BUCKET = "strategy_runtime_ledger_bucket"
 
 
 def _result_status(result: object) -> str:
+    def normalize(value: object) -> str:
+        text = str(value).split(".")[-1].lower()
+        if text == "4294967295":
+            return "created"
+        if text == "46":
+            return "exists"
+        return text
+
     if isinstance(result, Mapping):
         result_mapping = cast(Mapping[str, object], result)
-        return str(result_mapping.get("status") or "").split(".")[-1].lower()
-    return str(getattr(result, "status", "")).split(".")[-1].lower()
+        return normalize(result_mapping.get("status") or "")
+    return normalize(getattr(result, "status", ""))
 
 
 def _transfer_attr(transfer: object, name: str) -> Any:

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -242,13 +242,15 @@ def _journal_source_batch(
     source: str,
     rows: list[Any],
     journal_one: Any,
-) -> dict[str, int | str]:
-    batch: dict[str, int | str] = {
+) -> dict[str, Any]:
+    batch: dict[str, Any] = {
         "source": source,
         "selected": len(rows),
         "journaled": 0,
         "skipped": 0,
         "failed": 0,
+        "error_counts": {},
+        "sample_errors": [],
     }
     for row in rows:
         try:
@@ -261,16 +263,36 @@ def _journal_source_batch(
                 batch["skipped"] = int(batch["skipped"]) + 1
             else:
                 batch["journaled"] = int(batch["journaled"]) + 1
-        except Exception:
+        except Exception as exc:
             batch["failed"] = int(batch["failed"]) + 1
+            error_counts = batch["error_counts"]
+            if isinstance(error_counts, dict):
+                error_key = _error_summary(exc)
+                error_counts[error_key] = int(error_counts.get(error_key, 0)) + 1
+            sample_errors = batch["sample_errors"]
+            if isinstance(sample_errors, list) and len(sample_errors) < 5:
+                sample_errors.append(
+                    {
+                        "row_id": str(getattr(row, "id", "unknown")),
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    }
+                )
     return batch
+
+
+def _error_summary(exc: Exception) -> str:
+    message = str(exc).strip()
+    if len(message) > 160:
+        message = f"{message[:157]}..."
+    return f"{type(exc).__name__}:{message}"
 
 
 def _payload(
     *,
     args: argparse.Namespace,
     started_at: datetime,
-    batches: list[dict[str, int | str]],
+    batches: list[dict[str, Any]],
     reconciliation: dict[str, object] | None,
 ) -> dict[str, Any]:
     selected = sum(int(batch["selected"]) for batch in batches)
@@ -325,7 +347,7 @@ def main() -> int:
         expire_on_commit=False,
         future=True,
     )
-    batches: list[dict[str, int | str]] = []
+    batches: list[dict[str, Any]] = []
     reconciliation: dict[str, object] | None = None
 
     with (

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -622,6 +622,15 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(payload["status"], "degraded")
         self.assertEqual(payload["skipped"], 1)
         self.assertEqual(payload["failed"], 1)
+        self.assertEqual(
+            payload["batches"][0]["error_counts"],
+            {"RuntimeError:journal failed": 1},
+        )
+        sample_errors = payload["batches"][0]["sample_errors"]
+        self.assertEqual(len(sample_errors), 1)
+        self.assertTrue(sample_errors[0]["row_id"])
+        self.assertEqual(sample_errors[0]["error_type"], "RuntimeError")
+        self.assertEqual(sample_errors[0]["error"], "journal failed")
 
     def test_main_can_fail_closed_for_degraded_batch(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -905,3 +905,29 @@ class TestTigerBeetleLedgerJournal(TestCase):
                     settings_obj=_settings(),
                     client=ErrorTransferClient(),
                 ).journal_order_event(session, event)
+
+    def test_journal_accepts_official_numeric_exists_status(self) -> None:
+        class NumericExistsTransferClient(FakeTigerBeetleClient):
+            def create_transfers(self, transfers: list[object]) -> list[object]:
+                for transfer in transfers:
+                    transfer_id = int(getattr(transfer, "transfer_id"))
+                    self.transfers[transfer_id] = transfer
+                return [SimpleNamespace(status=46)]
+
+        with Session(self.engine) as session:
+            event = _create_fill_event(session, fingerprint="fingerprint-exists-status")
+            client = NumericExistsTransferClient()
+
+            ref = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            ).journal_order_event(session, event)
+
+            self.assertIsNotNone(ref)
+            assert ref is not None
+            self.assertEqual(ref.status, "exists")
+            self.assertEqual(_result_status(SimpleNamespace(status=46)), "exists")
+            self.assertEqual(
+                _result_status(SimpleNamespace(status=4294967295)),
+                "created",
+            )


### PR DESCRIPTION
## Summary

- Normalize official TigerBeetle numeric transfer statuses so `CreateTransferStatus.EXISTS` (`46`) is treated as idempotent success.
- Add bounded per-source `error_counts` and `sample_errors` to the journal script payload so degraded journal runs expose concrete row-level causes.
- Cover the numeric `exists` path and degraded batch error summaries with regression tests.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py -q`
- `uv run --frozen ruff format --check app/trading/tigerbeetle_journal.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen ruff check app/trading/tigerbeetle_journal.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Live diagnostic on promoted image `sha256:a6c9d5fd7fb3530daa371215815305992dc4faa887c54fc06e92b2087b224d44`: first selected journal rows failed with `tigerbeetle_create_transfer_failed:46`, confirming the numeric `EXISTS` handling gap.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
