### PR TITLE
fix(torghut): normalize TigerBeetle numeric statuses

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -56,19 +56,40 @@ SOURCE_TYPE_EXECUTION_TCA_METRIC = "execution_tca_metric"
 SOURCE_TYPE_RUNTIME_LEDGER_BUCKET = "strategy_runtime_ledger_bucket"
 
 
-def _result_status(result: object) -> str:
-    def normalize(value: object) -> str:
-        text = str(value).split(".")[-1].lower()
-        if text == "4294967295":
-            return "created"
-        if text == "46":
-            return "exists"
-        return text
+def _official_status_name(value: object) -> str | None:
+    if not isinstance(value, int):
+        return None
+    fallback_statuses = {46: "exists", 4294967295: "created"}
+    try:
+        import tigerbeetle as tb
+    except Exception:
+        return fallback_statuses.get(value)
 
+    for status_type_name in ("CreateTransferStatus", "CreateAccountStatus"):
+        status_type = getattr(tb, status_type_name, None)
+        if status_type is None:
+            continue
+        for name in dir(status_type):
+            if name.startswith("_"):
+                continue
+            status_value = getattr(status_type, name)
+            if isinstance(status_value, int) and status_value == value:
+                return name.lower()
+    return fallback_statuses.get(value)
+
+
+def _normalize_result_status(value: object) -> str:
+    official_name = _official_status_name(value)
+    if official_name is not None:
+        return official_name
+    return str(value or "").split(".")[-1].lower()
+
+
+def _result_status(result: object) -> str:
     if isinstance(result, Mapping):
         result_mapping = cast(Mapping[str, object], result)
-        return normalize(result_mapping.get("status") or "")
-    return normalize(getattr(result, "status", ""))
+        return _normalize_result_status(result_mapping.get("status"))
+    return _normalize_result_status(getattr(result, "status", ""))
 
 
 def _transfer_attr(transfer: object, name: str) -> Any:

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 import sys
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -60,6 +61,12 @@ class ClosableFakeTigerBeetleClient(FakeTigerBeetleClient):
 
     def close(self) -> None:
         self.close_count += 1
+
+
+class NumericExistsFakeTigerBeetleClient(FakeTigerBeetleClient):
+    def create_transfers(self, transfers: Sequence[object]) -> list[SimpleNamespace]:
+        del transfers
+        return [SimpleNamespace(status=46)]
 
 
 def _settings(*, enabled: bool = True, journal_enabled: bool = True) -> Settings:
@@ -565,6 +572,40 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(ref.status, "exists")
             self.assertEqual(ref.transfer_id, str(expected.transfer_id))
 
+    def test_numeric_duplicate_transfer_exists_is_verified_before_ref_persist(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(
+                session,
+                fingerprint="fingerprint-numeric-exists",
+            )
+            client = NumericExistsFakeTigerBeetleClient()
+            amount = decimal_usd_to_micros(
+                _event_amount_usd(event, TRANSFER_KIND_FILL_POST) or Decimal("0")
+            )
+            accounts = {spec.account_key: spec for spec in _account_specs(event)}
+            expected = _transfer_spec(
+                event,
+                transfer_kind=TRANSFER_KIND_FILL_POST,
+                amount=amount,
+                accounts=accounts,
+                use_pending_transfer=False,
+            )
+            client.transfers[expected.transfer_id] = expected
+
+            ref = TigerBeetleLedgerJournal(
+                settings_obj=_settings(), client=client
+            ).journal_order_event(
+                session,
+                event,
+            )
+
+            self.assertIsNotNone(ref)
+            assert ref is not None
+            self.assertEqual(ref.status, "exists")
+            self.assertEqual(ref.transfer_id, str(expected.transfer_id))
+
     def test_duplicate_transfer_conflict_fails_hard(self) -> None:
         with Session(self.engine) as session:
             event = _create_fill_event(session, fingerprint="fingerprint-conflict")
@@ -594,6 +635,28 @@ class TestTigerBeetleLedgerJournal(TestCase):
         self.assertEqual(
             _result_status(SimpleNamespace(status="Result.CREATED")), "created"
         )
+        self.assertEqual(_result_status(SimpleNamespace(status=46)), "exists")
+        self.assertEqual(_result_status(SimpleNamespace(status=4294967295)), "created")
+        with patch.dict(sys.modules, {"tigerbeetle": None}):
+            self.assertEqual(_result_status(SimpleNamespace(status=46)), "exists")
+        with patch.dict(sys.modules, {"tigerbeetle": SimpleNamespace()}):
+            self.assertEqual(_result_status(SimpleNamespace(status=1234)), "1234")
+
+        class FakeTransferStatuses:
+            _IGNORED = 1
+            EXISTS = 46
+
+        with patch.dict(
+            sys.modules,
+            {
+                "tigerbeetle": SimpleNamespace(
+                    CreateTransferStatus=FakeTransferStatuses,
+                    CreateAccountStatus=None,
+                )
+            },
+        ):
+            self.assertEqual(_result_status(SimpleNamespace(status=46)), "exists")
+            self.assertEqual(_result_status(SimpleNamespace(status=1)), "1")
         self.assertEqual(_transfer_attr({"transfer_id": 123}, "id"), 123)
         self.assertEqual(_transfer_attr(SimpleNamespace(transfer_id=456), "id"), 456)
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
## Summary

- Normalizes official TigerBeetle numeric create statuses to stable names before journal status checks.
- Treats numeric `CreateTransferStatus.EXISTS` as `exists`, verifies the existing transfer, and persists the missing SQL ref.
- Adds regression coverage for the live `EXISTS == 46` failure mode that caused `0/237` journaled rows after the OOM fix.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_journal.py tests/test_tigerbeetle_journal.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tigerbeetle_journal.py tests/test_tigerbeetle_journal.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
