### PR TITLE
fix(torghut): materialize nested fill economics

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -335,6 +335,15 @@ def _first_decimal(row: Mapping[str, object], *keys: str) -> Decimal | None:
     return None
 
 
+def _first_positive_decimal(row: Mapping[str, object], *keys: str) -> Decimal | None:
+    for payload in _row_payloads(row):
+        for key in keys:
+            value = payload.get(key)
+            if (parsed := _decimal_or_none(value)) is not None and parsed > 0:
+                return parsed
+    return None
+
+
 def _first_text(row: Mapping[str, object], *keys: str) -> str | None:
     for payload in _row_payloads(row):
         for key in keys:
@@ -1652,7 +1661,9 @@ def _runtime_window_import_proof_hygiene_blockers(
         source_kind.strip().lower().replace("-", "_")
         == "runtime_ledger_source_collection_candidate"
     ):
-        blockers.extend(_source_collection_target_authorization_blockers(target_metadata))
+        blockers.extend(
+            _source_collection_target_authorization_blockers(target_metadata)
+        )
     if not dependency_quorum_decision.strip():
         blockers.append("dependency_quorum_decision_missing")
     if not continuity_ok.strip():
@@ -2114,14 +2125,14 @@ def _runtime_lifecycle_ledger_row(
     }
     if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
         side = _first_text(row, "side", "action", "order_side")
-        filled_qty = _first_decimal(
+        filled_qty = _first_positive_decimal(
             row,
             "filled_qty",
             "filled_quantity",
             "qty",
             "quantity",
         )
-        avg_fill_price = _first_decimal(
+        avg_fill_price = _first_positive_decimal(
             row,
             "avg_fill_price",
             "filled_avg_price",
@@ -2131,7 +2142,7 @@ def _runtime_lifecycle_ledger_row(
             "filled_price",
             "price",
         )
-        filled_notional = _first_decimal(
+        filled_notional = _first_positive_decimal(
             row,
             "filled_notional",
             "notional",
@@ -2202,14 +2213,14 @@ def _runtime_order_id(row: Mapping[str, object]) -> str | None:
 
 
 def _execution_row_has_fill(row: Mapping[str, object]) -> bool:
-    filled_qty = _first_decimal(
+    filled_qty = _first_positive_decimal(
         row,
         "filled_qty",
         "filled_quantity",
         "qty",
         "quantity",
     )
-    avg_fill_price = _first_decimal(
+    avg_fill_price = _first_positive_decimal(
         row,
         "avg_fill_price",
         "filled_avg_price",
@@ -2536,11 +2547,11 @@ def _execution_fill_economics_order_ids(
         order_id = _runtime_order_id(row)
         if order_id is None:
             continue
-        filled_notional = _first_decimal(
+        filled_notional = _first_positive_decimal(
             row, "filled_notional", "notional", "turnover_notional"
         ) or Decimal("0")
         if filled_notional <= 0:
-            price = _first_decimal(
+            price = _first_positive_decimal(
                 row,
                 "avg_fill_price",
                 "filled_avg_price",
@@ -2549,7 +2560,7 @@ def _execution_fill_economics_order_ids(
                 "fill_price",
                 "filled_price",
             )
-            qty = _first_decimal(
+            qty = _first_positive_decimal(
                 row, "filled_qty", "filled_quantity", "qty", "quantity"
             )
             if price is None or qty is None or price <= 0 or qty <= 0:
@@ -2560,7 +2571,9 @@ def _execution_fill_economics_order_ids(
             filled_notional=filled_notional,
             side=_first_text(row, "side", "order_side") or "",
             filled_qty=(
-                _first_decimal(row, "filled_qty", "filled_quantity", "qty", "quantity")
+                _first_positive_decimal(
+                    row, "filled_qty", "filled_quantity", "qty", "quantity"
+                )
                 or Decimal("0")
             ),
         )
@@ -2569,7 +2582,9 @@ def _execution_fill_economics_order_ids(
             cost_amount=cost_amount,
             side=_first_text(row, "side", "order_side") or "",
             filled_qty=(
-                _first_decimal(row, "filled_qty", "filled_quantity", "qty", "quantity")
+                _first_positive_decimal(
+                    row, "filled_qty", "filled_quantity", "qty", "quantity"
+                )
                 or Decimal("0")
             ),
             filled_notional=filled_notional,
@@ -2686,8 +2701,8 @@ def _runtime_source_context_for_bucket(
     for row in bucket_order_rows:
         if (order_id := _runtime_order_id(row)) is not None:
             expected_execution_fill_order_ids.add(order_id)
-    source_backed_fill_lifecycle_order_ids = (
-        _source_backed_fill_lifecycle_order_ids(source_backed_fill_lifecycle_rows)
+    source_backed_fill_lifecycle_order_ids = _source_backed_fill_lifecycle_order_ids(
+        source_backed_fill_lifecycle_rows
     )
     event_sourced_fill_order_ids = _event_sourced_fill_economics_order_ids(
         source_backed_fill_lifecycle_rows
@@ -2719,8 +2734,7 @@ def _runtime_source_context_for_bucket(
             source_materialization = "execution_order_events"
             authority_class = "runtime_order_feed_execution_source"
         elif (
-            execution_fill_economics_complete
-            and source_backed_fill_lifecycle_complete
+            execution_fill_economics_complete and source_backed_fill_lifecycle_complete
         ):
             source_materialization = "source_execution_lifecycle"
             authority_class = "source_execution_lifecycle_materialized_runtime_ledger"
@@ -2889,7 +2903,7 @@ def _runtime_execution_ledger_fill_from_row(
     ledger_computed_at = (
         fill_event_at if isinstance(fill_event_at, datetime) else computed_at
     )
-    price = _first_decimal(
+    price = _first_positive_decimal(
         row,
         "avg_fill_price",
         "filled_avg_price",
@@ -2901,7 +2915,7 @@ def _runtime_execution_ledger_fill_from_row(
     side = _first_text(row, "side", "order_side") or ""
     signed_qty = _execution_signed_qty(
         side=side,
-        qty=_first_decimal(
+        qty=_first_positive_decimal(
             row,
             "filled_qty",
             "filled_quantity",

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1569,7 +1569,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "source_collection_authorized": True,
                     "source_collection_authorization_scope": (
                         "source_window_evidence_collection_only"
-                    )
+                    ),
                 },
             )
         )
@@ -3505,7 +3505,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
 
         self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["execution_order_event_id"], "source-backed-fill-event")
+        self.assertEqual(
+            rows[0]["execution_order_event_id"], "source-backed-fill-event"
+        )
 
     def test_build_realized_strategy_pnl_rows_accepts_execution_economics_with_order_feed_lifecycle(
         self,
@@ -3731,6 +3733,60 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(ledger_row["cost_model_hash"], "cost-sha")
         self.assertEqual(ledger_row["lineage_hash"], "lineage-sha")
 
+    def test_order_event_lifecycle_uses_nested_positive_fill_economics_over_zero_placeholders(
+        self,
+    ) -> None:
+        row = {
+            "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+            "event_type": "filled",
+            "symbol": "AAPL",
+            "account_label": "TORGHUT_SIM",
+            "strategy_id": "microbar-cross-sectional-pairs-v1",
+            "decision_hash": "decision-buy",
+            "alpaca_order_id": "order-buy",
+            "filled_qty": Decimal("0"),
+            "avg_fill_price": Decimal("0"),
+            "filled_notional": Decimal("0"),
+            "raw_event": {
+                "event": "fill",
+                "order": {
+                    "id": "order-buy",
+                    "status": "filled",
+                    "side": "buy",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                },
+            },
+            "execution_audit_json": {
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+            },
+            "raw_order": {
+                "runtime_ledger_cost": {
+                    "cost_amount": "0.20",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                },
+            },
+        }
+
+        ledger_row = _runtime_lifecycle_ledger_row(
+            row,
+            event_type="filled",
+            require_complete_fill=True,
+        )
+
+        self.assertIsNotNone(ledger_row)
+        assert ledger_row is not None
+        self.assertEqual(ledger_row["side"], "buy")
+        self.assertEqual(ledger_row["filled_qty"], Decimal("1"))
+        self.assertEqual(ledger_row["avg_fill_price"], Decimal("100"))
+        self.assertEqual(ledger_row["filled_notional"], Decimal("100"))
+        self.assertEqual(ledger_row["cost_amount"], Decimal("0.20"))
+        self.assertEqual(
+            ledger_row["cost_basis"], "broker_reported_commission_and_fees"
+        )
+
     def test_order_event_lifecycle_does_not_hash_raw_event_as_policy_or_cost(
         self,
     ) -> None:
@@ -3892,6 +3948,199 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(ledger_row["filled_notional"], Decimal("1000"))
         self.assertEqual(ledger_row["cost_amount"], Decimal("0.04"))
         self.assertEqual(ledger_row["source"], "execution_order_event")
+
+    def test_source_backed_round_trip_materializes_nested_fill_economics_over_zero_placeholders(
+        self,
+    ) -> None:
+        common = {
+            "account_label": "TORGHUT_SIM",
+            "strategy_id": "microbar-cross-sectional-pairs-v1",
+            "symbol": "AAPL",
+            "lineage_hash": "lineage-sha",
+            "source_topic": "alpaca.trade_updates",
+            "source_partition": 0,
+            "source_window_id": "source-window",
+            "source_decision_mode": "strategy_signal_paper",
+            "profit_proof_eligible": True,
+        }
+
+        def order_row(
+            *,
+            event_id: str,
+            decision_id: str,
+            order_id: str,
+            event_ts: datetime,
+            event_type: str,
+            side: str,
+            nested_filled_qty: str | None = None,
+            nested_avg_price: str | None = None,
+            source_offset: int,
+        ) -> dict[str, object]:
+            raw_order: dict[str, object] = {
+                "side": side,
+                "runtime_ledger_cost": {
+                    "cost_amount": "0.10",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                },
+            }
+            raw_event_order: dict[str, object] = {
+                "id": order_id,
+                "status": "filled" if nested_filled_qty is not None else "new",
+                "side": side,
+            }
+            if nested_filled_qty is not None:
+                raw_event_order.update(
+                    {
+                        "filled_qty": nested_filled_qty,
+                        "filled_avg_price": nested_avg_price,
+                    }
+                )
+            return {
+                **common,
+                "execution_order_event_id": event_id,
+                "trade_decision_id": decision_id,
+                "decision_hash": decision_id,
+                "event_ts": event_ts,
+                "event_type": event_type,
+                "alpaca_order_id": order_id,
+                "execution_policy_hash": f"policy-{side}",
+                "cost_model_hash": "cost-sha",
+                "source_offset": source_offset,
+                "filled_qty": Decimal("0"),
+                "avg_fill_price": Decimal("0"),
+                "filled_notional": Decimal("0"),
+                "raw_event": {"event": event_type, "order": raw_event_order},
+                "raw_order": raw_order,
+            }
+
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    **common,
+                    "execution_id": "execution-buy",
+                    "trade_decision_id": "decision-buy",
+                    "computed_at": datetime(2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc
+                    ),
+                    "side": "buy",
+                    "filled_qty": Decimal("0"),
+                    "avg_fill_price": Decimal("0"),
+                    "alpaca_order_id": "order-buy",
+                    "raw_order": {
+                        "side": "buy",
+                        "filled_qty": "1",
+                        "filled_avg_price": "100",
+                        "runtime_ledger_cost": {
+                            "cost_amount": "0.10",
+                            "cost_basis": "broker_reported_commission_and_fees",
+                        },
+                    },
+                },
+                {
+                    **common,
+                    "execution_id": "execution-sell",
+                    "trade_decision_id": "decision-sell",
+                    "computed_at": datetime(2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc
+                    ),
+                    "side": "sell",
+                    "filled_qty": Decimal("0"),
+                    "avg_fill_price": Decimal("0"),
+                    "alpaca_order_id": "order-sell",
+                    "raw_order": {
+                        "side": "sell",
+                        "filled_qty": "1",
+                        "filled_avg_price": "101",
+                        "runtime_ledger_cost": {
+                            "cost_amount": "0.10",
+                            "cost_basis": "broker_reported_commission_and_fees",
+                        },
+                    },
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    **common,
+                    "trade_decision_id": "decision-buy",
+                    "decision_hash": "decision-buy",
+                    "event_type": "decision",
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                },
+                {
+                    **common,
+                    "trade_decision_id": "decision-sell",
+                    "decision_hash": "decision-sell",
+                    "event_type": "decision",
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                },
+            ],
+            order_lifecycle_rows=[
+                order_row(
+                    event_id="event-new-buy",
+                    decision_id="decision-buy",
+                    order_id="order-buy",
+                    event_ts=datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    event_type="new",
+                    side="buy",
+                    source_offset=1,
+                ),
+                order_row(
+                    event_id="event-fill-buy",
+                    decision_id="decision-buy",
+                    order_id="order-buy",
+                    event_ts=datetime(2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc),
+                    event_type="filled",
+                    side="buy",
+                    nested_filled_qty="1",
+                    nested_avg_price="100",
+                    source_offset=2,
+                ),
+                order_row(
+                    event_id="event-new-sell",
+                    decision_id="decision-sell",
+                    order_id="order-sell",
+                    event_ts=datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                    event_type="new",
+                    side="sell",
+                    source_offset=3,
+                ),
+                order_row(
+                    event_id="event-fill-sell",
+                    decision_id="decision-sell",
+                    order_id="order-sell",
+                    event_ts=datetime(2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc),
+                    event_type="filled",
+                    side="sell",
+                    nested_filled_qty="1",
+                    nested_avg_price="101",
+                    source_offset=4,
+                ),
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["authoritative"])
+        self.assertTrue(rows[0]["post_cost_promotion_eligible"])
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["blockers"], [])
+        self.assertEqual(bucket["filled_notional"], "201")
+        self.assertEqual(bucket["open_position_count"], 0)
+        self.assertEqual(bucket["closed_trade_count"], 1)
+        self.assertEqual(
+            bucket["source_refs"],
+            [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+        )
+        self.assertEqual(bucket["source_materialization"], "execution_order_events")
 
     def test_build_realized_strategy_pnl_rows_does_not_use_idempotency_key_as_policy_hash(
         self,


### PR DESCRIPTION
## Summary

- Materializes runtime-ledger fill economics from nested broker raw_event/raw_order payloads when top-level DB fields contain zero placeholders.
- Keeps H-PAIRS source-backed runtime-ledger buckets fail-closed while preserving real filled notional, explicit costs, source refs, closed_trade_count, and open_position_count semantics.
- Adds regressions for nested fill economics and a source-backed round trip that stays separated from final promotion authority.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- PASS: `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_decisions.py tests/test_strategy_runtime.py -q`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A - backend/runtime-ledger importer change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
