### PR TITLE
docs(agents): tighten mcp server docs

### DIFF
--- a/docs/agents/codex-mcp-agents.md
+++ b/docs/agents/codex-mcp-agents.md
@@ -1,6 +1,6 @@
 # Codex Agents MCP setup
 
-Status: draft
+Status: Current (2026-05-31)
 
 Docs index: [README](README.md)
 
@@ -38,8 +38,10 @@ The MCP handshake should expose server `agents-control-plane`.
 
 ## Required tools
 
-`tools/list` must include these AgentRun tools:
+`tools/list` must include these tools:
 
+- `persist_memory`
+- `retrieve_memory`
 - `create_agent_run`
 - `list_agent_runs`
 - `get_agent_run`
@@ -49,7 +51,70 @@ The MCP handshake should expose server `agents-control-plane`.
 - `ack_agent_run_terminal_event`
 - `rerun_agent_run`
 
-The memory tools `persist_memory` and `retrieve_memory` should remain available.
+Some clients may expose a filtered subset of these tools as first-class client
+tools. When debugging availability, check the MCP server directly with
+`tools/list` before assuming the server is missing a tool.
+
+## Create payload shape
+
+`create_agent_run` accepts the same top-level payload as `POST
+/v1/agent-runs`, plus the required MCP `deliveryId`. For inline runs, pass the
+inline implementation body directly as `payload.implementation`; the API wraps
+that object as `spec.implementation.inline`.
+
+Correct MCP shape:
+
+```json
+{
+  "deliveryId": "mcp-smoke-20260531",
+  "payload": {
+    "agentRef": { "name": "codex-spark-agent" },
+    "implementation": {
+      "text": "Verify the Agents MCP create path without making source changes."
+    },
+    "goal": {
+      "objective": "Verify the Agents MCP create path."
+    },
+    "runtime": { "type": "workflow" },
+    "vcsPolicy": { "required": false, "mode": "none" },
+    "workflow": {
+      "steps": [
+        {
+          "name": "verify",
+          "parameters": { "stage": "verify" },
+          "timeoutSeconds": 300
+        }
+      ]
+    },
+    "ttlSecondsAfterFinished": 600,
+    "parameters": {
+      "stage": "verification"
+    }
+  }
+}
+```
+
+Do not send Kubernetes-manifest shape inside the MCP payload, such as
+`payload.implementation.inline.text`; that nests incorrectly as
+`spec.implementation.inline.inline`.
+
+Do not set `payload.parameters.prompt`. The MCP server rejects prompt
+parameters before calling the AgentRun API. Use `payload.implementation.text`
+or `payload.implementationSpecRef.name`.
+
+If a run requests `payload.secrets`, `payload.vcsRef`, or a VCS policy that
+needs credentials, also pass `secretBindingRef` or set
+`payload.policy.secretBindingRef`. VCS runs must set
+`payload.parameters.repository`.
+
+## Dry run behavior
+
+`create_agent_run` has an optional `dryRun` parameter that is forwarded to the
+Agents API. Do not assume it is side-effect free until the API behavior is
+verified in the target environment; a 2026-05-31 live check with
+`dryRun: true` returned success while still materializing an AgentRun resource.
+Use a short TTL and delete any verification resource explicitly when testing
+create behavior.
 
 ## Smoke sequence
 
@@ -58,7 +123,8 @@ The memory tools `persist_memory` and `retrieve_memory` should remain available.
    should have no token budget.
 2. Call `get_agent_run` with the returned projection id.
 3. Call `list_agent_runs` with `statuses: ["Pending", "Running", "Succeeded",
-   "Failed"]` and a small `limit`.
+   "Failed"]` or `agentName`, plus a small `limit`. The backing API requires at
+   least one of `statuses` or `agentName`; `limit` alone is not enough.
 4. Call `get_agent_run_logs` with the live AgentRun resource name and
    `tailLines: 5`.
 5. Call `list_agent_run_terminal_events` with a stable consumer name.


### PR DESCRIPTION
## Summary

- Marked the Codex Agents MCP setup guide current and made the direct `tools/list` contract explicit.
- Added the MCP-specific `create_agent_run` payload shape, including inline implementation wrapping, prompt rejection, secret binding, and VCS repository requirements.
- Documented live smoke-test caveats for `dryRun` behavior and `list_agent_runs` filter requirements.

## Related Issues

None

## Testing

- `git diff --check`
- Scaffold scan on `docs/agents/codex-mcp-agents.md`: no template comments or unchecked checklist items found.
- `Invoke-RestMethod -Method Post -Uri 'http://agents.ide-newton.ts.net/mcp' -ContentType 'application/json' -Body '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
