### PR TITLE
fix(torghut): require order-feed fill deltas

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -359,8 +359,17 @@ class ExecutionOrderEvent(Base, CreatedAtMixin):
     status: Mapped[Optional[str]] = mapped_column(String(length=32), nullable=True)
     qty: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
     filled_qty: Mapped[Optional[Decimal]] = mapped_column(Numeric(20, 8), nullable=True)
+    filled_qty_delta: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
     avg_fill_price: Mapped[Optional[Decimal]] = mapped_column(
         Numeric(20, 8), nullable=True
+    )
+    filled_notional_delta: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    fill_quantity_basis: Mapped[Optional[str]] = mapped_column(
+        String(length=32), nullable=True
     )
     raw_event: Mapped[Any] = mapped_column(JSONType, nullable=False)
     execution_id: Mapped[Optional[uuid.UUID]] = mapped_column(

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Callable, Mapping, cast
 
@@ -34,6 +34,9 @@ ORDER_FEED_SOURCE_REVISION = "alpaca_trade_updates_v1"
 HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION = (
     "execution_order_events_existing_source_offsets_v1"
 )
+FILL_QUANTITY_BASIS_CUMULATIVE_TO_DELTA = "cumulative_to_delta"
+FILL_QUANTITY_BASIS_CUMULATIVE_NON_INCREASING = "cumulative_non_increasing"
+_FILL_EVENT_TYPES = frozenset({"fill", "filled", "partial_fill", "partially_filled"})
 
 
 @dataclass(frozen=True)
@@ -54,7 +57,10 @@ class NormalizedOrderEvent:
     status: str | None
     qty: Decimal | None
     filled_qty: Decimal | None
+    filled_qty_delta: Decimal | None
     avg_fill_price: Decimal | None
+    filled_notional_delta: Decimal | None
+    fill_quantity_basis: str | None
     raw_event: dict[str, Any]
 
 
@@ -701,7 +707,10 @@ def normalize_order_feed_record(
         status=status,
         qty=qty,
         filled_qty=filled_qty,
+        filled_qty_delta=None,
         avg_fill_price=avg_fill_price,
+        filled_notional_delta=None,
+        fill_quantity_basis=None,
         raw_event=coerce_json_payload(payload),
     )
     return NormalizationResult(event=event, drop_reason=None)
@@ -724,9 +733,13 @@ def persist_order_event(
         if existing.source_window_id is None and source_window_id is not None:
             existing.source_window_id = source_window_id
             session.add(existing)
+            _refresh_source_window_linkage_counts(session, existing)
         _journal_tigerbeetle_order_event(session, existing)
         return existing, True
 
+    filled_qty_delta, filled_notional_delta, fill_quantity_basis = _fill_delta_fields(
+        session, event
+    )
     execution = _resolve_execution(session, event)
     trade_decision_id = None
     if execution is not None:
@@ -756,7 +769,10 @@ def persist_order_event(
         status=event.status,
         qty=event.qty,
         filled_qty=event.filled_qty,
+        filled_qty_delta=filled_qty_delta,
         avg_fill_price=event.avg_fill_price,
+        filled_notional_delta=filled_notional_delta,
+        fill_quantity_basis=fill_quantity_basis,
         raw_event=event.raw_event,
         execution_id=execution.id if execution is not None else None,
         trade_decision_id=trade_decision_id,
@@ -779,6 +795,7 @@ def persist_order_event(
         if existing.source_window_id is None and source_window_id is not None:
             existing.source_window_id = source_window_id
             session.add(existing)
+            _refresh_source_window_linkage_counts(session, existing)
         _journal_tigerbeetle_order_event(session, existing)
         return existing, True
 
@@ -849,6 +866,59 @@ def apply_order_event_to_execution(
         update_key="_order_feed_last_event",
     )
     return updated, False
+
+
+def _fill_delta_fields(
+    session: Session,
+    event: NormalizedOrderEvent,
+) -> tuple[Decimal | None, Decimal | None, str | None]:
+    if not _is_fill_event(event.event_type, event.status) or event.filled_qty is None:
+        return None, None, None
+
+    identity_clauses: list[ColumnElement[bool]] = []
+    if event.alpaca_order_id:
+        identity_clauses.append(
+            ExecutionOrderEvent.alpaca_order_id == event.alpaca_order_id
+        )
+    if event.client_order_id:
+        identity_clauses.append(
+            ExecutionOrderEvent.client_order_id == event.client_order_id
+        )
+    if not identity_clauses:
+        return None, None, FILL_QUANTITY_BASIS_CUMULATIVE_NON_INCREASING
+
+    previous_filled_qty = session.scalar(
+        select(func.max(ExecutionOrderEvent.filled_qty)).where(
+            ExecutionOrderEvent.alpaca_account_label == event.alpaca_account_label,
+            or_(*identity_clauses),
+            ExecutionOrderEvent.filled_qty.is_not(None),
+        )
+    )
+    previous_qty = (
+        Decimal("0")
+        if previous_filled_qty is None
+        else Decimal(str(previous_filled_qty))
+    )
+    filled_qty_delta = Decimal(str(event.filled_qty)) - previous_qty
+    if filled_qty_delta <= 0:
+        return None, None, FILL_QUANTITY_BASIS_CUMULATIVE_NON_INCREASING
+
+    filled_notional_delta = (
+        filled_qty_delta * Decimal(str(event.avg_fill_price))
+        if event.avg_fill_price is not None
+        else None
+    )
+    return (
+        filled_qty_delta,
+        filled_notional_delta,
+        FILL_QUANTITY_BASIS_CUMULATIVE_TO_DELTA,
+    )
+
+
+def _is_fill_event(event_type: str | None, status: str | None) -> bool:
+    return (event_type or "").strip().lower() in _FILL_EVENT_TYPES or (
+        status or ""
+    ).strip().lower() in _FILL_EVENT_TYPES
 
 
 def merge_execution_raw_order_update(
@@ -1224,7 +1294,7 @@ def _create_historical_source_window_for_event(
         collector_identity=settings.trading_order_feed_client_id.strip() or None,
         source_revision=HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
         window_started_at=event_ts,
-        window_ended_at=event_ts,
+        window_ended_at=event_ts + timedelta(microseconds=1),
         start_offset=event.source_offset,
         end_offset=event.source_offset,
         broker_high_watermark=None,

--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -52,6 +52,8 @@ _DIAGNOSTIC_EXPECTANCY_SUPPRESSING_BLOCKERS = frozenset(
         "closed_round_trip_missing",
         "filled_notional_missing",
         "filled_qty_missing_or_non_positive",
+        "fill_quantity_delta_basis_missing",
+        "fill_quantity_delta_missing",
         "fill_price_missing",
         "side_missing_or_invalid",
         "explicit_cost_missing",
@@ -71,6 +73,9 @@ class RuntimeLedgerFill:
     filled_qty: Decimal
     avg_fill_price: Decimal | None = None
     filled_notional: Decimal | None = None
+    filled_qty_delta: Decimal | None = None
+    filled_notional_delta: Decimal | None = None
+    fill_quantity_basis: str | None = None
     cost_amount: Decimal | None = None
     cost_basis: str | None = None
     account_label: str | None = None
@@ -139,6 +144,9 @@ class _NormalizedFill:
     lineage_hash: str | None
     replay_data_hash: str | None
     blockers: tuple[str, ...]
+    filled_qty_delta: Decimal | None = None
+    filled_notional_delta: Decimal | None = None
+    fill_quantity_basis: str | None = None
 
     @property
     def is_usable_fill(self) -> bool:
@@ -628,6 +636,32 @@ def _normalize_fill_row(
     filled_notional = _positive_decimal(
         _row_value(row, "filled_notional", "notional", "fill_notional")
     )
+    filled_qty_delta = _positive_decimal(
+        _row_value(row, "filled_qty_delta", "fill_qty_delta", "delta_filled_qty")
+    )
+    filled_notional_delta = _positive_decimal(
+        _row_value(
+            row,
+            "filled_notional_delta",
+            "fill_notional_delta",
+            "delta_filled_notional",
+        )
+    )
+    fill_quantity_basis = _coerce_fill_quantity_basis(
+        _row_value(row, "fill_quantity_basis", "quantity_basis")
+    )
+    order_feed_source_fill = _is_order_feed_source_fill(row)
+    if event_type in _FILL_EVENTS and order_feed_source_fill:
+        if fill_quantity_basis in {"delta", "cumulative_to_delta"}:
+            if filled_qty_delta is not None:
+                filled_qty = filled_qty_delta
+                if filled_notional_delta is not None:
+                    filled_notional = filled_notional_delta
+                elif avg_fill_price is not None:
+                    filled_notional = filled_qty_delta * avg_fill_price
+        else:
+            filled_qty = None
+            filled_notional = None
     if (
         filled_notional is None
         and filled_qty is not None
@@ -699,6 +733,17 @@ def _normalize_fill_row(
             blockers.append("side_missing_or_invalid")
         if filled_qty is None:
             blockers.append("filled_qty_missing_or_non_positive")
+        if order_feed_source_fill and fill_quantity_basis not in {
+            "delta",
+            "cumulative_to_delta",
+        }:
+            blockers.append("fill_quantity_delta_basis_missing")
+        elif (
+            order_feed_source_fill
+            and fill_quantity_basis in {"delta", "cumulative_to_delta"}
+            and filled_qty_delta is None
+        ):
+            blockers.append("fill_quantity_delta_missing")
         if avg_fill_price is None:
             blockers.append("fill_price_missing")
         if filled_notional is None:
@@ -720,6 +765,9 @@ def _normalize_fill_row(
         filled_qty=filled_qty,
         avg_fill_price=avg_fill_price,
         filled_notional=filled_notional,
+        filled_qty_delta=filled_qty_delta,
+        filled_notional_delta=filled_notional_delta,
+        fill_quantity_basis=fill_quantity_basis,
         cost_amount=cost_amount,
         cost_basis=cost_basis,
         event_type=event_type,
@@ -793,6 +841,51 @@ def _row_value(
         if value is not None:
             return value
     return None
+
+
+def _coerce_fill_quantity_basis(value: object | None) -> str | None:
+    text = _coerce_text(value)
+    if text is None:
+        return None
+    normalized = text.lower().replace("-", "_").replace(" ", "_")
+    if normalized in {"delta", "fill_delta", "filled_delta"}:
+        return "delta"
+    if normalized in {"cumulative_to_delta", "cumulative_delta", "cum_to_delta"}:
+        return "cumulative_to_delta"
+    if normalized in {"cumulative", "cum"}:
+        return "cumulative"
+    if normalized in {"unknown", "cumulative_non_increasing"}:
+        return normalized
+    return normalized or None
+
+
+def _is_order_feed_source_fill(row: RuntimeLedgerFill | Mapping[str, object]) -> bool:
+    source = _coerce_text(
+        _row_value(row, "source", "pnl_derivation", "source_materialization")
+    )
+    authority_class = _coerce_text(_row_value(row, "authority_class"))
+    if source in {
+        "execution_order_event",
+        "execution_order_events",
+        "execution_order_events_runtime_ledger",
+        "runtime_order_feed_execution_source",
+        "source_execution_lifecycle",
+    }:
+        return True
+    if authority_class in {
+        "runtime_order_feed_execution_source",
+        "source_execution_lifecycle_materialized_runtime_ledger",
+    }:
+        return True
+    return any(
+        _row_value(row, key) is not None
+        for key in (
+            "execution_order_event_id",
+            "event_fingerprint",
+            "source_window_id",
+            "source_offset",
+        )
+    )
 
 
 def _has_tca_pnl_shortcut(row: RuntimeLedgerFill | Mapping[str, object]) -> bool:

--- a/services/torghut/migrations/versions/0040_order_feed_fill_delta_basis.py
+++ b/services/torghut/migrations/versions/0040_order_feed_fill_delta_basis.py
@@ -1,0 +1,60 @@
+"""Add order-feed fill delta basis fields."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0040_order_feed_fill_delta_basis"
+down_revision = "0039_tigerbeetle_real_flow_refs"
+branch_labels = None
+depends_on = None
+
+
+def _column_names(table_name: str) -> set[str]:
+    inspector = inspect(op.get_bind())
+    if not inspector.has_table(table_name):
+        return set()
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    columns = _column_names("execution_order_events")
+    if not columns:
+        return
+
+    if "filled_qty_delta" not in columns:
+        op.add_column(
+            "execution_order_events",
+            sa.Column("filled_qty_delta", sa.Numeric(20, 8), nullable=True),
+        )
+    if "filled_notional_delta" not in columns:
+        op.add_column(
+            "execution_order_events",
+            sa.Column("filled_notional_delta", sa.Numeric(20, 8), nullable=True),
+        )
+    if "fill_quantity_basis" not in columns:
+        op.add_column(
+            "execution_order_events",
+            sa.Column("fill_quantity_basis", sa.String(length=32), nullable=True),
+        )
+
+    op.execute(
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.execution_order_events TO torghut_app;"
+    )
+
+
+def downgrade() -> None:
+    columns = _column_names("execution_order_events")
+    if not columns:
+        return
+
+    for column_name in (
+        "fill_quantity_basis",
+        "filled_notional_delta",
+        "filled_qty_delta",
+    ):
+        if column_name in columns:
+            op.drop_column("execution_order_events", column_name)

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -94,6 +94,8 @@ ORDER_FEED_FILL_LIFECYCLE_ORDER_ID_MISSING_BLOCKER = (
 ORDER_FEED_UNLINKED_FILL_LIFECYCLE_PRESENT_BLOCKER = (
     "order_feed_unlinked_fill_lifecycle_present"
 )
+ORDER_FEED_FILL_DELTA_BASIS_MISSING_BLOCKER = "order_feed_fill_delta_basis_missing"
+ORDER_FEED_FILL_DELTA_MISSING_BLOCKER = "order_feed_fill_delta_missing"
 _RUNTIME_LIFECYCLE_IDENTIFIER_KEYS = (
     "execution_id",
     "trade_decision_id",
@@ -1296,6 +1298,37 @@ def _execution_query_row_has_time(row: Sequence[object]) -> bool:
 
 
 def _order_lifecycle_query_row(row: Sequence[object]) -> dict[str, object]:
+    if len(row) >= 28:
+        return {
+            "execution_order_event_id": str(row[0]),
+            "trade_decision_id": str(row[1]),
+            "execution_id": str(row[2]) if row[2] is not None else None,
+            "event_ts": row[3],
+            "symbol": row[4],
+            "account_label": row[5],
+            "strategy_id": row[6],
+            "decision_hash": row[7],
+            "decision_json": row[8],
+            "alpaca_order_id": row[9],
+            "client_order_id": row[10],
+            "event_type": row[11],
+            "order_status": row[12],
+            "side": row[13],
+            "qty": row[14],
+            "filled_qty": row[15],
+            "filled_qty_delta": row[16],
+            "avg_fill_price": row[17],
+            "filled_notional_delta": row[18],
+            "fill_quantity_basis": row[19],
+            "event_fingerprint": row[20],
+            "source_topic": row[21],
+            "source_partition": row[22],
+            "source_offset": row[23],
+            "source_window_id": str(row[24]) if row[24] is not None else None,
+            "raw_event": row[25],
+            "execution_audit_json": row[26],
+            "raw_order": row[27],
+        }
     if len(row) >= 25:
         return {
             "execution_order_event_id": str(row[0]),
@@ -2125,6 +2158,14 @@ def _runtime_lifecycle_ledger_row(
     }
     if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
         side = _first_text(row, "side", "action", "order_side")
+        source_authority_order_event = _source_authority_order_event_row(row)
+        fill_quantity_basis = _fill_quantity_basis(row)
+        filled_qty_delta = _first_positive_decimal(
+            row,
+            "filled_qty_delta",
+            "fill_qty_delta",
+            "delta_filled_qty",
+        )
         filled_qty = _first_positive_decimal(
             row,
             "filled_qty",
@@ -2142,12 +2183,34 @@ def _runtime_lifecycle_ledger_row(
             "filled_price",
             "price",
         )
+        if (
+            source_authority_order_event
+            and fill_quantity_basis in {"delta", "cumulative_to_delta"}
+            and filled_qty_delta is not None
+        ):
+            filled_qty = filled_qty_delta
         filled_notional = _first_positive_decimal(
             row,
+            "filled_notional_delta",
+            "fill_notional_delta",
+            "delta_filled_notional",
             "filled_notional",
             "notional",
             "fill_notional",
         )
+        if source_authority_order_event and fill_quantity_basis not in {
+            "delta",
+            "cumulative_to_delta",
+        }:
+            filled_qty = None
+            filled_notional = None
+        elif (
+            source_authority_order_event
+            and fill_quantity_basis in {"delta", "cumulative_to_delta"}
+            and filled_qty_delta is None
+        ):
+            filled_qty = None
+            filled_notional = None
         if (
             filled_notional is None
             and filled_qty is not None
@@ -2192,6 +2255,18 @@ def _runtime_lifecycle_ledger_row(
             ledger_row["avg_fill_price"] = avg_fill_price
         if filled_notional is not None:
             ledger_row["filled_notional"] = filled_notional
+        if filled_qty_delta is not None:
+            ledger_row["filled_qty_delta"] = filled_qty_delta
+        filled_notional_delta = _first_positive_decimal(
+            row,
+            "filled_notional_delta",
+            "fill_notional_delta",
+            "delta_filled_notional",
+        )
+        if filled_notional_delta is not None:
+            ledger_row["filled_notional_delta"] = filled_notional_delta
+        if fill_quantity_basis is not None:
+            ledger_row["fill_quantity_basis"] = fill_quantity_basis
         if cost_amount is not None:
             ledger_row["cost_amount"] = cost_amount
         if cost_basis is not None:
@@ -2309,9 +2384,8 @@ def _order_feed_fill_lifecycle_blockers(
 
     observed_fill_order_ids: set[str] = set()
     for row in order_lifecycle_rows or []:
-        event_type = _runtime_ledger_event_type(
-            {str(key): value for key, value in row.items()}
-        )
+        normalized = {str(key): value for key, value in row.items()}
+        event_type = _runtime_ledger_event_type(normalized)
         if event_type not in _RUNTIME_LEDGER_FILL_EVENTS:
             continue
         order_id = _runtime_order_id(row)
@@ -2333,6 +2407,52 @@ def _order_feed_fill_lifecycle_blockers(
     elif expected_order_ids - observed_fill_order_ids:
         blockers.append(ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER)
     return blockers
+
+
+def _source_authority_order_event_row(row: Mapping[str, object]) -> bool:
+    return any(
+        row.get(key) is not None
+        for key in (
+            "execution_order_event_id",
+            "source_window_id",
+            "source_offset",
+        )
+    )
+
+
+def _fill_quantity_basis(row: Mapping[str, object]) -> str | None:
+    raw = _first_text(row, "fill_quantity_basis", "quantity_basis")
+    if raw is None:
+        return None
+    normalized = raw.strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized in {"delta", "fill_delta", "filled_delta"}:
+        return "delta"
+    if normalized in {"cumulative_to_delta", "cumulative_delta", "cum_to_delta"}:
+        return "cumulative_to_delta"
+    if normalized in {"cumulative", "cum"}:
+        return "cumulative"
+    if normalized in {"unknown", "cumulative_non_increasing"}:
+        return normalized
+    return normalized or None
+
+
+def _order_feed_fill_delta_blockers(row: Mapping[str, object]) -> list[str]:
+    if not _source_authority_order_event_row(row):
+        return []
+    basis = _fill_quantity_basis(row)
+    if basis not in {"delta", "cumulative_to_delta"}:
+        return [ORDER_FEED_FILL_DELTA_BASIS_MISSING_BLOCKER]
+    if (
+        _first_positive_decimal(
+            row,
+            "filled_qty_delta",
+            "fill_qty_delta",
+            "delta_filled_qty",
+        )
+        is None
+    ):
+        return [ORDER_FEED_FILL_DELTA_MISSING_BLOCKER]
+    return []
 
 
 def _runtime_source_row_symbol(row: Mapping[str, object]) -> str | None:
@@ -4355,7 +4475,10 @@ def _query_timestamps(
                     e.side,
                     oe.qty,
                     oe.filled_qty,
+                    oe.filled_qty_delta,
                     oe.avg_fill_price,
+                    oe.filled_notional_delta,
+                    oe.fill_quantity_basis,
                     oe.event_fingerprint,
                     oe.source_topic,
                     oe.source_partition,
@@ -4650,7 +4773,10 @@ def _query_timestamps(
                         e.side,
                         oe.qty,
                         oe.filled_qty,
+                        oe.filled_qty_delta,
                         oe.avg_fill_price,
+                        oe.filled_notional_delta,
+                        oe.fill_quantity_basis,
                         oe.event_fingerprint,
                         oe.source_topic,
                         oe.source_partition,
@@ -4785,7 +4911,10 @@ def _query_timestamps(
                         e.side,
                         oe.qty,
                         oe.filled_qty,
+                        oe.filled_qty_delta,
                         oe.avg_fill_price,
+                        oe.filled_notional_delta,
+                        oe.fill_quantity_basis,
                         oe.event_fingerprint,
                         oe.source_topic,
                         oe.source_partition,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -25,10 +25,12 @@ from scripts.import_hypothesis_runtime_windows import (
     _alpaca_2026_equity_fee_schedule_hash,
     _build_realized_strategy_pnl_rows,
     _execution_signed_qty,
+    _fill_quantity_basis,
     _first_bool,
     _first_lineage_digest,
     _load_json_artifact,
     _load_report_post_cost_expectancy_bps,
+    _order_feed_fill_delta_blockers,
     _nonnegative_int,
     _order_lifecycle_query_row,
     _parse_args,
@@ -1964,7 +1966,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "symbol": "AAPL",
                     "side": "buy",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
+                    "filled_notional_delta": Decimal("100"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.20"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-buy",
@@ -1976,7 +1981,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "symbol": "AAPL",
                     "side": "sell",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("101"),
+                    "filled_notional_delta": Decimal("101"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.10"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-sell",
@@ -2023,7 +2031,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "symbol": "AAPL",
                     "side": "buy",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
+                    "filled_notional_delta": Decimal("100"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.20"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-buy",
@@ -2037,7 +2048,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "symbol": "AAPL",
                     "side": "sell",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("101"),
+                    "filled_notional_delta": Decimal("101"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.10"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-sell",
@@ -2119,7 +2133,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "symbol": "AAPL",
                     "side": "buy",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
+                    "filled_notional_delta": Decimal("100"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.20"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
@@ -2143,7 +2160,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "symbol": "AAPL",
                     "side": "sell",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("101"),
+                    "filled_notional_delta": Decimal("101"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.10"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
@@ -2374,7 +2394,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "symbol": "AAPL",
                     "side": "buy",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
+                    "filled_notional_delta": Decimal("100"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.20"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
@@ -3225,7 +3248,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "symbol": "AAPL",
                     "side": "buy",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
+                    "filled_notional_delta": Decimal("100"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.20"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
@@ -3249,7 +3275,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "symbol": "AAPL",
                     "side": "sell",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("101"),
+                    "filled_notional_delta": Decimal("101"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.10"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
@@ -3837,6 +3866,80 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(ledger_row["filled_qty"], Decimal("1"))
         self.assertEqual(ledger_row["cost_amount"], Decimal("0.20"))
 
+    def test_source_authority_order_event_lifecycle_requires_fill_delta_basis(
+        self,
+    ) -> None:
+        row = {
+            "execution_order_event_id": "event-buy",
+            "source_window_id": "source-window-buy",
+            "source_offset": 10,
+            "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+            "event_type": "filled",
+            "symbol": "AAPL",
+            "account_label": "TORGHUT_SIM",
+            "strategy_id": "microbar-cross-sectional-pairs-v1",
+            "decision_hash": "decision-buy",
+            "alpaca_order_id": "order-buy",
+            "filled_qty": Decimal("2"),
+            "avg_fill_price": Decimal("100"),
+            "raw_order": {
+                "side": "buy",
+                "runtime_ledger_cost": {
+                    "cost_amount": "0.20",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                },
+            },
+        }
+
+        ledger_row = _runtime_lifecycle_ledger_row(
+            row,
+            event_type="filled",
+            require_complete_fill=True,
+        )
+
+        self.assertIsNone(ledger_row)
+
+    def test_source_authority_order_event_lifecycle_uses_fill_delta(
+        self,
+    ) -> None:
+        row = {
+            "execution_order_event_id": "event-buy",
+            "source_window_id": "source-window-buy",
+            "source_offset": 10,
+            "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+            "event_type": "filled",
+            "symbol": "AAPL",
+            "account_label": "TORGHUT_SIM",
+            "strategy_id": "microbar-cross-sectional-pairs-v1",
+            "decision_hash": "decision-buy",
+            "alpaca_order_id": "order-buy",
+            "filled_qty": Decimal("2"),
+            "filled_qty_delta": Decimal("1"),
+            "filled_notional_delta": Decimal("100"),
+            "fill_quantity_basis": "cumulative_to_delta",
+            "avg_fill_price": Decimal("100"),
+            "raw_order": {
+                "side": "buy",
+                "runtime_ledger_cost": {
+                    "cost_amount": "0.20",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                },
+            },
+        }
+
+        ledger_row = _runtime_lifecycle_ledger_row(
+            row,
+            event_type="filled",
+            require_complete_fill=True,
+        )
+
+        self.assertIsNotNone(ledger_row)
+        assert ledger_row is not None
+        self.assertEqual(ledger_row["filled_qty"], Decimal("1"))
+        self.assertEqual(ledger_row["filled_notional"], Decimal("100"))
+        self.assertEqual(ledger_row["filled_qty_delta"], Decimal("1"))
+        self.assertEqual(ledger_row["fill_quantity_basis"], "cumulative_to_delta")
+
     def test_order_event_lifecycle_materializes_alpaca_fee_schedule_costs(self) -> None:
         row = {
             "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
@@ -3913,7 +4016,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             "sell",
             Decimal("10"),
             Decimal("10"),
+            Decimal("10"),
             Decimal("100"),
+            Decimal("1000"),
+            "cumulative_to_delta",
             "fingerprint-1",
             "torghut.trade-updates.v1",
             2,
@@ -3995,7 +4101,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                         "filled_avg_price": nested_avg_price,
                     }
                 )
-            return {
+            row: dict[str, object] = {
                 **common,
                 "execution_order_event_id": event_id,
                 "trade_decision_id": decision_id,
@@ -4012,6 +4118,16 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "raw_event": {"event": event_type, "order": raw_event_order},
                 "raw_order": raw_order,
             }
+            if nested_filled_qty is not None and nested_avg_price is not None:
+                row.update(
+                    {
+                        "filled_qty_delta": Decimal(nested_filled_qty),
+                        "filled_notional_delta": Decimal(nested_filled_qty)
+                        * Decimal(nested_avg_price),
+                        "fill_quantity_basis": "cumulative_to_delta",
+                    }
+                )
+            return row
 
         rows = _build_realized_strategy_pnl_rows(
             [
@@ -4771,18 +4887,22 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "source_decision_mode": mode,
             }
             if event_type in {"fill", "filled", "partial_fill"}:
+                avg_fill_price = Decimal(
+                    {
+                        "route-buy": "100",
+                        "route-sell": "101",
+                        "signal-buy": "110",
+                        "signal-sell": "112",
+                    }[decision_id]
+                )
                 row.update(
                     {
                         "side": "sell" if "sell" in decision_id else "buy",
                         "filled_qty": Decimal("1"),
-                        "avg_fill_price": Decimal(
-                            {
-                                "route-buy": "100",
-                                "route-sell": "101",
-                                "signal-buy": "110",
-                                "signal-sell": "112",
-                            }[decision_id]
-                        ),
+                        "filled_qty_delta": Decimal("1"),
+                        "avg_fill_price": avg_fill_price,
+                        "filled_notional_delta": avg_fill_price,
+                        "fill_quantity_basis": "cumulative_to_delta",
                         "cost_amount": Decimal("0.10"),
                         "cost_basis": "broker_reported_commission_and_fees",
                     }
@@ -5268,7 +5388,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "event_type": "fill",
                     "side": "buy",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
+                    "filled_notional_delta": Decimal("100"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.20"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "source_topic": "alpaca-trade-updates",
@@ -5313,7 +5436,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "event_type": "fill",
                     "side": "sell",
                     "filled_qty": Decimal("1"),
+                    "filled_qty_delta": Decimal("1"),
                     "avg_fill_price": Decimal("101"),
+                    "filled_notional_delta": Decimal("101"),
+                    "fill_quantity_basis": "cumulative_to_delta",
                     "cost_amount": Decimal("0.10"),
                     "cost_basis": "broker_reported_commission_and_fees",
                     "source_topic": "alpaca-trade-updates",
@@ -5407,6 +5533,100 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             _runtime_ledger_bucket_profit_proof_blockers(
                 cast(Mapping[str, object], row["runtime_ledger_bucket"])
             ),
+        )
+
+    def test_runtime_lifecycle_row_requires_delta_when_source_backed(self) -> None:
+        row = _runtime_lifecycle_ledger_row(
+            {
+                "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                "symbol": "AAPL",
+                "side": "buy",
+                "filled_qty": Decimal("3"),
+                "avg_fill_price": Decimal("100"),
+                "cost_amount": Decimal("0"),
+                "cost_basis": "broker_reported_zero_cost",
+                "source_offset": 14,
+                "fill_quantity_basis": "delta",
+            },
+            event_type="fill",
+        )
+
+        self.assertIsNotNone(row)
+        assert row is not None
+        self.assertNotIn("filled_qty", row)
+        self.assertNotIn("filled_notional", row)
+        self.assertEqual(row["fill_quantity_basis"], "delta")
+
+    def test_order_feed_fill_delta_blockers_name_missing_basis_and_delta(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _order_feed_fill_delta_blockers(
+                {
+                    "symbol": "AAPL",
+                    "source_offset": 14,
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                }
+            ),
+            ["order_feed_fill_delta_basis_missing"],
+        )
+        self.assertEqual(
+            _order_feed_fill_delta_blockers(
+                {
+                    "symbol": "AAPL",
+                    "source_offset": 14,
+                    "fill_quantity_basis": "delta",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                }
+            ),
+            ["order_feed_fill_delta_missing"],
+        )
+        self.assertEqual(
+            _order_feed_fill_delta_blockers(
+                {
+                    "symbol": "AAPL",
+                    "fill_quantity_basis": "delta",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                }
+            ),
+            [],
+        )
+        self.assertEqual(
+            _order_feed_fill_delta_blockers(
+                {
+                    "symbol": "AAPL",
+                    "source_offset": 14,
+                    "fill_quantity_basis": "delta",
+                    "filled_qty_delta": Decimal("1"),
+                    "filled_qty": Decimal("2"),
+                    "avg_fill_price": Decimal("100"),
+                }
+            ),
+            [],
+        )
+
+    def test_fill_quantity_basis_aliases_are_normalized_for_import(self) -> None:
+        self.assertEqual(
+            _fill_quantity_basis({"fill_quantity_basis": "filled-delta"}), "delta"
+        )
+        self.assertEqual(
+            _fill_quantity_basis({"fill_quantity_basis": "cum"}),
+            "cumulative",
+        )
+        self.assertEqual(
+            _fill_quantity_basis({"fill_quantity_basis": "unknown"}),
+            "unknown",
+        )
+        self.assertEqual(
+            _fill_quantity_basis({"fill_quantity_basis": "cumulative-non-increasing"}),
+            "cumulative_non_increasing",
+        )
+        self.assertEqual(
+            _fill_quantity_basis({"fill_quantity_basis": "broker custom"}),
+            "broker_custom",
         )
 
     def test_build_realized_strategy_pnl_rows_rejects_shortfall_only_costs(

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -39,6 +39,7 @@ from app.trading.tigerbeetle_ledger_model import (
 from app.trading.order_feed import (
     HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
     ORDER_FEED_SOURCE_REVISION,
+    NormalizedOrderEvent,
     OrderFeedIngestor,
     apply_order_event_to_execution,
     backfill_order_feed_source_windows,
@@ -1124,6 +1125,10 @@ class TestOrderFeed(TestCase):
             HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
         )
         self.assertEqual(source_window.status, "inserted")
+        self.assertGreater(
+            source_window.window_ended_at,
+            source_window.window_started_at,
+        )
         self.assertEqual(
             source_window.status_reason, "historical_execution_order_event_backfill"
         )
@@ -1319,6 +1324,10 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.status, "inserted")
         self.assertEqual(source_window.start_offset, 188)
         self.assertEqual(source_window.end_offset, 188)
+        self.assertGreater(
+            source_window.window_ended_at,
+            source_window.window_started_at,
+        )
         self.assertEqual(source_window.inserted_count, 1)
         self.assertEqual(source_window.unlinked_execution_count, 0)
         self.assertEqual(source_window.unlinked_decision_count, 0)
@@ -1734,6 +1743,15 @@ class TestOrderFeed(TestCase):
             self._seed_execution(session)
             counters = ingestor.ingest_once(session)
             cursor = session.execute(select(OrderFeedConsumerCursor)).scalar_one()
+            events = (
+                session.execute(
+                    select(ExecutionOrderEvent).order_by(
+                        ExecutionOrderEvent.source_offset.asc()
+                    )
+                )
+                .scalars()
+                .all()
+            )
 
         self.assertEqual(counters["events_persisted_total"], 2)
         self.assertEqual(counters["cursor_updates_total"], 2)
@@ -1744,6 +1762,162 @@ class TestOrderFeed(TestCase):
             cursor.last_event_ts,
             datetime(2026, 2, 1, 10, 0, 5),
         )
+        self.assertEqual(
+            [event.filled_qty for event in events], [Decimal("1"), Decimal("2")]
+        )
+        self.assertEqual(
+            [event.filled_qty_delta for event in events],
+            [Decimal("1"), Decimal("1")],
+        )
+        self.assertEqual(
+            [event.fill_quantity_basis for event in events],
+            ["cumulative_to_delta", "cumulative_to_delta"],
+        )
+        self.assertEqual(
+            [event.filled_notional_delta for event in events],
+            [Decimal("190.20000000"), Decimal("190.40000000")],
+        )
+
+    def test_fill_delta_fields_rejects_fill_without_order_identity(self) -> None:
+        event = NormalizedOrderEvent(
+            event_fingerprint="fill-no-order-id",
+            source_topic="torghut.trade-updates.v1",
+            source_partition=0,
+            source_offset=12,
+            alpaca_account_label="paper",
+            feed_seq=12,
+            event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+            symbol="AAPL",
+            alpaca_order_id=None,
+            client_order_id=None,
+            event_type="fill",
+            status="filled",
+            qty=Decimal("1"),
+            filled_qty=Decimal("1"),
+            filled_qty_delta=None,
+            avg_fill_price=Decimal("190.2"),
+            filled_notional_delta=None,
+            fill_quantity_basis=None,
+            raw_event={},
+        )
+
+        with Session(self.engine) as session:
+            qty_delta, notional_delta, basis = order_feed_module._fill_delta_fields(
+                session,
+                event,
+            )
+
+        self.assertIsNone(qty_delta)
+        self.assertIsNone(notional_delta)
+        self.assertEqual(basis, "cumulative_non_increasing")
+
+    def test_fill_delta_fields_rejects_non_increasing_cumulative_fill(self) -> None:
+        first = FakeRecord(
+            value=(
+                b'{"channel":"trade_updates","payload":{"event":"partial_fill",'
+                b'"timestamp":"2026-02-01T10:00:00Z",'
+                b'"order":{"id":"order-1","client_order_id":"client-1","symbol":"AAPL","status":"partially_filled",'
+                b'"qty":"2","filled_qty":"1","filled_avg_price":"190.2"}},"seq":10}'
+            ),
+            offset=7,
+        )
+        stale_repeat = NormalizedOrderEvent(
+            event_fingerprint="fill-non-increasing",
+            source_topic="torghut.trade-updates.v1",
+            source_partition=0,
+            source_offset=13,
+            alpaca_account_label="paper",
+            feed_seq=13,
+            event_ts=datetime(2026, 2, 1, 10, 1, tzinfo=timezone.utc),
+            symbol="AAPL",
+            alpaca_order_id="order-1",
+            client_order_id="client-1",
+            event_type="fill",
+            status="filled",
+            qty=Decimal("2"),
+            filled_qty=Decimal("1"),
+            filled_qty_delta=None,
+            avg_fill_price=Decimal("190.3"),
+            filled_notional_delta=None,
+            fill_quantity_basis=None,
+            raw_event={},
+        )
+
+        with Session(self.engine) as session:
+            self._seed_execution(session)
+            normalized = normalize_order_feed_record(
+                first,
+                default_topic="torghut.trade-updates.v1",
+                default_account_label="paper",
+            )
+            assert normalized.event is not None
+            persist_order_event(session, normalized.event)
+
+            qty_delta, notional_delta, basis = order_feed_module._fill_delta_fields(
+                session,
+                stale_repeat,
+            )
+
+        self.assertIsNone(qty_delta)
+        self.assertIsNone(notional_delta)
+        self.assertEqual(basis, "cumulative_non_increasing")
+
+    def test_duplicate_event_source_window_attach_refreshes_linkage_counts(
+        self,
+    ) -> None:
+        payload = (
+            b'{"channel":"trade_updates","payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+            b'"order":{"id":"order-1","client_order_id":"client-1","symbol":"AAPL","status":"filled",'
+            b'"qty":"1","filled_qty":"1","filled_avg_price":"190.2"}},"seq":10}'
+        )
+        record = FakeRecord(value=payload, offset=11)
+
+        with Session(self.engine) as session:
+            self._seed_execution(session)
+            normalized = normalize_order_feed_record(
+                record,
+                default_topic="torghut.trade-updates.v1",
+                default_account_label="paper",
+            )
+            assert normalized.event is not None
+            persisted, duplicate = persist_order_event(session, normalized.event)
+            self.assertFalse(duplicate)
+            persisted_id = persisted.id
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed-v1",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                alpaca_account_label="paper",
+                assignment_mode="manual",
+                source_revision=ORDER_FEED_SOURCE_REVISION,
+                window_started_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                window_ended_at=datetime(2026, 2, 1, 10, 1, tzinfo=timezone.utc),
+                start_offset=11,
+                end_offset=11,
+                consumed_count=1,
+                inserted_count=1,
+                unlinked_execution_count=1,
+                unlinked_decision_count=1,
+                status="inserted",
+            )
+            session.add(source_window)
+            session.flush()
+            persisted.source_window_id = None
+            session.flush()
+
+            persisted_again, duplicate_again = persist_order_event(
+                session,
+                normalized.event,
+                source_window_id=source_window.id,
+            )
+            persisted_again_id = persisted_again.id
+            session.commit()
+            session.refresh(source_window)
+
+        self.assertTrue(duplicate_again)
+        self.assertEqual(persisted_again_id, persisted_id)
+        self.assertEqual(source_window.unlinked_execution_count, 0)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
 
     def test_duplicate_event_advances_cursor_accounting_and_commits(self) -> None:
         record = FakeRecord(

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -9,6 +9,7 @@ from app.trading.runtime_ledger import (
     EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
     RuntimeLedgerFill,
     _build_bucket,
+    _coerce_fill_quantity_basis,
     _NormalizedFill,
     build_runtime_ledger_buckets,
 )
@@ -709,6 +710,162 @@ def test_invalid_runtime_fill_fields_fail_closed() -> None:
     assert "filled_notional_missing" in bucket.blockers
     assert "explicit_cost_missing" in bucket.blockers
     assert "runtime_fills_missing" in bucket.blockers
+
+
+def test_order_feed_source_fill_requires_delta_basis() -> None:
+    bucket = _bucket(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(1),
+                "source": "execution_order_event",
+                "execution_order_event_id": "event-1",
+                "source_window_id": "window-1",
+                "source_offset": 7,
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "1",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            }
+        ]
+    )
+
+    assert bucket.fill_count == 0
+    assert "fill_quantity_delta_basis_missing" in bucket.blockers
+    assert "runtime_fills_missing" in bucket.blockers
+
+
+def test_order_feed_source_fill_requires_positive_delta_quantity() -> None:
+    bucket = _bucket(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(1),
+                "source": "execution_order_event",
+                "execution_order_event_id": "event-1",
+                "source_window_id": "window-1",
+                "source_offset": 7,
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "1",
+                "fill_quantity_basis": "delta",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            }
+        ]
+    )
+
+    assert bucket.fill_count == 0
+    assert "fill_quantity_delta_missing" in bucket.blockers
+    assert "runtime_fills_missing" in bucket.blockers
+
+
+def test_order_feed_source_fill_uses_delta_not_cumulative_quantity() -> None:
+    bucket = _bucket(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(1),
+                "source": "execution_order_event",
+                "execution_order_event_id": "event-buy",
+                "source_window_id": "window-buy",
+                "source_offset": 7,
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "2",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(2),
+                "source": "execution_order_event",
+                "execution_order_event_id": "event-sell",
+                "source_window_id": "window-sell",
+                "source_offset": 8,
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "2",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "101",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+        ]
+    )
+
+    assert bucket.fill_count == 2
+    assert bucket.closed_trade_count == 1
+    assert bucket.open_position_count == 0
+    assert bucket.filled_notional == Decimal("201")
+    assert bucket.gross_strategy_pnl == Decimal("1")
+
+
+def test_order_feed_source_fill_accepts_authority_class_marker() -> None:
+    bucket = _bucket(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(1),
+                "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "2",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(2),
+                "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "2",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "101",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+        ]
+    )
+
+    assert bucket.fill_count == 2
+    assert bucket.closed_trade_count == 1
+    assert bucket.filled_notional == Decimal("201")
+
+
+def test_fill_quantity_basis_aliases_are_normalized() -> None:
+    assert _coerce_fill_quantity_basis("fill-delta") == "delta"
+    assert _coerce_fill_quantity_basis("cum") == "cumulative"
+    assert _coerce_fill_quantity_basis("unknown") == "unknown"
+    assert (
+        _coerce_fill_quantity_basis("cumulative-non-increasing")
+        == "cumulative_non_increasing"
+    )
+    assert _coerce_fill_quantity_basis("broker custom") == "broker_custom"
 
 
 def test_exact_replay_ledger_requires_order_lifecycle_and_hash_lineage() -> None:


### PR DESCRIPTION
## Summary

- Add nullable order-feed fill delta and fill quantity basis fields to `execution_order_events`.
- Persist cumulative-to-delta fill quantities during order-feed ingestion and refresh source-window linkage on duplicate attaches.
- Require source-backed order-event fill economics to prove delta basis before runtime-ledger/import authority can count them.
- Add regression coverage for duplicate source-window linkage, cumulative fill handling, and source-authority delta blockers.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check app/models/entities.py app/trading/order_feed.py app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py migrations/versions/0040_order_feed_fill_delta_basis.py`
- `cd services/torghut && uv run --frozen ruff format --check app/models/entities.py app/trading/order_feed.py app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py migrations/versions/0040_order_feed_fill_delta_basis.py`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py -q` (270 passed, 1 existing warning)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds nullable Alembic-managed columns to `execution_order_events`: `filled_qty_delta`, `filled_notional_delta`, and `fill_quantity_basis`. No API break expected.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
