### PR TITLE
fix(torghut): sign tigerbeetle runtime pnl refs

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -37,6 +37,8 @@ from app.trading.tigerbeetle_ledger_model import (
     ACCOUNT_CODE_REALIZED_PNL,
     ACCOUNT_CODE_RUNTIME_LEDGER_EVIDENCE,
     LEDGER_USD_MICRO,
+    PNL_DIRECTION_LOSS,
+    PNL_DIRECTION_PROFIT,
     TRANSFER_KIND_CANCEL_VOID,
     TRANSFER_KIND_EXECUTION_COST,
     TRANSFER_KIND_EXECUTION_FILL,
@@ -276,6 +278,16 @@ class TigerBeetleOrderEventTransferPlan:
     pending_mode: str
 
 
+@dataclass(frozen=True)
+class TigerBeetleRuntimeLedgerTransferPlan:
+    account_specs: tuple[TigerBeetleAccountSpec, ...]
+    transfer_spec: TigerBeetleTransferSpec
+    amount_source: Decimal
+    signed_amount_micros: int
+    pnl_direction: str
+    runtime_key: str
+
+
 def _submitted_pending_key(event: ExecutionOrderEvent) -> str:
     source_id = (
         str(event.execution_id)
@@ -311,6 +323,14 @@ def execution_cost_transfer_id(metric: ExecutionTCAMetric) -> int:
 
 def runtime_ledger_transfer_id(bucket: StrategyRuntimeLedgerBucket) -> int:
     return stable_u128("torghut.tigerbeetle.runtime_ledger", str(bucket.id))
+
+
+def runtime_ledger_amount_source(bucket: StrategyRuntimeLedgerBucket) -> Decimal:
+    if bucket.net_strategy_pnl_after_costs != Decimal("0"):
+        return Decimal(str(bucket.net_strategy_pnl_after_costs))
+    if bucket.cost_amount != Decimal("0"):
+        return -abs(Decimal(str(bucket.cost_amount)))
+    return Decimal("0")
 
 
 def _account_specs(event: ExecutionOrderEvent) -> list[TigerBeetleAccountSpec]:
@@ -720,6 +740,47 @@ def _amount_to_micros(value: Decimal | None) -> int | None:
     return amount if amount > 0 else None
 
 
+def build_runtime_ledger_bucket_transfer_plan(
+    bucket: StrategyRuntimeLedgerBucket,
+) -> TigerBeetleRuntimeLedgerTransferPlan | None:
+    amount_source = runtime_ledger_amount_source(bucket)
+    amount = _amount_to_micros(amount_source)
+    if amount is None:
+        return None
+    runtime_key = (
+        f"{bucket.hypothesis_id}:{bucket.run_id}:{bucket.bucket_started_at.isoformat()}"
+    )
+    account_specs = tuple(
+        _evidence_account_specs(
+            account_label=bucket.account_label,
+            symbol=None,
+            strategy_id=bucket.hypothesis_id,
+            runtime_key=runtime_key,
+        )
+    )
+    account_label = bucket.account_label or "unknown"
+    accounts = {spec.account_key: spec for spec in account_specs}
+    control = accounts[f"evidence_control:{account_label}:usd"]
+    runtime_account = accounts[f"runtime_ledger:{account_label}:{runtime_key}"]
+    pnl_direction = PNL_DIRECTION_PROFIT if amount_source > 0 else PNL_DIRECTION_LOSS
+    debit = control if pnl_direction == PNL_DIRECTION_PROFIT else runtime_account
+    credit = runtime_account if pnl_direction == PNL_DIRECTION_PROFIT else control
+    return TigerBeetleRuntimeLedgerTransferPlan(
+        account_specs=account_specs,
+        transfer_spec=_source_transfer_spec(
+            transfer_id=runtime_ledger_transfer_id(bucket),
+            transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+            amount=amount,
+            debit=debit,
+            credit=credit,
+        ),
+        amount_source=amount_source,
+        signed_amount_micros=amount if amount_source > 0 else -amount,
+        pnl_direction=pnl_direction,
+        runtime_key=runtime_key,
+    )
+
+
 class TigerBeetleLedgerJournal:
     def __init__(
         self,
@@ -1027,35 +1088,13 @@ class TigerBeetleLedgerJournal:
             or not self._settings.tigerbeetle_journal_enabled
         ):
             return None
-        amount_source = (
-            bucket.net_strategy_pnl_after_costs
-            if bucket.net_strategy_pnl_after_costs != Decimal("0")
-            else bucket.cost_amount
-        )
-        amount = _amount_to_micros(amount_source)
-        if amount is None:
+        plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+        if plan is None:
             return None
-        runtime_key = f"{bucket.hypothesis_id}:{bucket.run_id}:{bucket.bucket_started_at.isoformat()}"
-        account_specs = _evidence_account_specs(
-            account_label=bucket.account_label,
-            symbol=None,
-            strategy_id=bucket.hypothesis_id,
-            runtime_key=runtime_key,
-        )
-        account_label = bucket.account_label or "unknown"
-        accounts = {spec.account_key: spec for spec in account_specs}
-        control = accounts[f"evidence_control:{account_label}:usd"]
-        runtime_account = accounts[f"runtime_ledger:{account_label}:{runtime_key}"]
-        transfer_spec = _source_transfer_spec(
-            transfer_id=runtime_ledger_transfer_id(bucket),
-            transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
-            amount=amount,
-            debit=control,
-            credit=runtime_account,
-        )
+        transfer_spec = plan.transfer_spec
         return self._persist_transfer(
             session,
-            account_specs=account_specs,
+            account_specs=plan.account_specs,
             transfer_spec=transfer_spec,
             runtime_ledger_bucket_id=bucket.id,
             source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
@@ -1074,8 +1113,11 @@ class TigerBeetleLedgerJournal:
                 "net_strategy_pnl_after_costs": str(
                     bucket.net_strategy_pnl_after_costs
                 ),
-                "amount_source": str(amount_source),
-                "amount_micros": amount,
+                "amount_source": str(plan.amount_source),
+                "amount_micros": transfer_spec.amount,
+                "signed_amount_micros": plan.signed_amount_micros,
+                "pnl_direction": plan.pnl_direction,
+                "runtime_key": plan.runtime_key,
                 "debit_account_id": u128_decimal(transfer_spec.debit_account_id),
                 "credit_account_id": u128_decimal(transfer_spec.credit_account_id),
             },

--- a/services/torghut/app/trading/tigerbeetle_ledger_model.py
+++ b/services/torghut/app/trading/tigerbeetle_ledger_model.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 from decimal import Decimal, ROUND_HALF_UP
 
 
+PNL_DIRECTION_PROFIT = "profit"
+PNL_DIRECTION_LOSS = "loss"
+
 LEDGER_USD_MICRO = 840001
 USD_MICRO_SCALE = Decimal("1000000")
 

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -31,6 +31,8 @@ from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
     build_order_event_transfer_plan,
+    build_runtime_ledger_bucket_transfer_plan,
+    runtime_ledger_amount_source,
 )
 from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_EXECUTION_COST,
@@ -54,6 +56,12 @@ BLOCKER_UNLINKED_COST = "tigerbeetle_unlinked_execution_cost"
 BLOCKER_UNLINKED_RUNTIME_LEDGER = "tigerbeetle_unlinked_runtime_ledger"
 BLOCKER_SOURCE_ROW_MISSING = "tigerbeetle_source_row_missing"
 BLOCKER_SOURCE_AMOUNT_MISMATCH = "tigerbeetle_source_amount_mismatch"
+BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH = (
+    "tigerbeetle_runtime_ledger_direction_mismatch"
+)
+BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH = (
+    "tigerbeetle_runtime_ledger_metadata_mismatch"
+)
 BLOCKER_CLIENT_UNAVAILABLE = "tigerbeetle_client_unavailable"
 
 
@@ -80,6 +88,13 @@ def _payload_value(row: TigerBeetleTransferRef, key: str) -> str | None:
     )
     value: object | None = payload.get(key)
     return None if value is None else str(value)
+
+
+def _payload_mapping(row: TigerBeetleTransferRef) -> Mapping[str, object]:
+    raw_payload = cast(object, row.payload_json)
+    if isinstance(raw_payload, Mapping):
+        return cast(Mapping[str, object], raw_payload)
+    return {}
 
 
 def _ref_matches_expected_event(
@@ -157,12 +172,7 @@ def _runtime_ledger_amount_micros(
 ) -> Decimal | None:
     if bucket is None:
         return None
-    amount_source = (
-        bucket.net_strategy_pnl_after_costs
-        if bucket.net_strategy_pnl_after_costs != Decimal("0")
-        else bucket.cost_amount
-    )
-    return _usd_to_micros(amount_source)
+    return _usd_to_micros(runtime_ledger_amount_source(bucket))
 
 
 def _expected_source_amount_micros(
@@ -181,6 +191,51 @@ def _expected_source_amount_micros(
             session.get(StrategyRuntimeLedgerBucket, source_uuid)
         )
     return None
+
+
+def _runtime_ledger_ref_matches_expected_bucket(
+    ref: TigerBeetleTransferRef,
+    actual: object,
+    bucket: StrategyRuntimeLedgerBucket,
+) -> tuple[bool, bool]:
+    plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+    if plan is None:
+        return False, False
+    expected = plan.transfer_spec
+    payload = _payload_mapping(ref)
+    direction_matches = (
+        ref.transfer_id == str(expected.transfer_id)
+        and ref.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL
+        and ref.amount == Decimal(expected.amount)
+        and ref.ledger == expected.ledger
+        and ref.code == expected.code
+        and int(_attr(actual, "amount")) == expected.amount
+        and int(_attr(actual, "ledger")) == expected.ledger
+        and int(_attr(actual, "code")) == expected.code
+        and int(_attr(actual, "debit_account_id")) == expected.debit_account_id
+        and int(_attr(actual, "credit_account_id")) == expected.credit_account_id
+        and str(payload.get("debit_account_id")) == str(expected.debit_account_id)
+        and str(payload.get("credit_account_id")) == str(expected.credit_account_id)
+        and str(payload.get("signed_amount_micros")) == str(plan.signed_amount_micros)
+        and str(payload.get("pnl_direction")) == plan.pnl_direction
+    )
+    expected_metadata = {
+        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+        "run_id": bucket.run_id,
+        "candidate_id": bucket.candidate_id,
+        "hypothesis_id": bucket.hypothesis_id,
+        "observed_stage": bucket.observed_stage,
+        "pnl_basis": bucket.pnl_basis,
+        "ledger_schema_version": bucket.ledger_schema_version,
+        "amount_source": str(plan.amount_source),
+        "runtime_key": plan.runtime_key,
+    }
+    metadata_matches = all(
+        str(payload.get(key)) == str(value)
+        for key, value in expected_metadata.items()
+        if value is not None
+    )
+    return direction_matches, metadata_matches
 
 
 def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, object]:
@@ -246,6 +301,18 @@ def _latest_run_payload(
         "source_amount_mismatch_count": _payload_int(
             payload, "source_amount_mismatch_count"
         ),
+        "runtime_ledger_checked_transfer_count": _payload_int(
+            payload, "runtime_ledger_checked_transfer_count"
+        ),
+        "runtime_ledger_signed_transfer_count": _payload_int(
+            payload, "runtime_ledger_signed_transfer_count"
+        ),
+        "runtime_ledger_direction_mismatch_count": _payload_int(
+            payload, "runtime_ledger_direction_mismatch_count"
+        ),
+        "runtime_ledger_metadata_mismatch_count": _payload_int(
+            payload, "runtime_ledger_metadata_mismatch_count"
+        ),
         "unlinked_event_count": _payload_int(payload, "unlinked_event_count"),
         "unlinked_execution_count": _payload_int(payload, "unlinked_execution_count"),
         "unlinked_cost_count": _payload_int(payload, "unlinked_cost_count"),
@@ -303,6 +370,10 @@ def reconcile_tigerbeetle_transfers(
     mismatched_transfer_count = 0
     source_row_missing_count = 0
     source_amount_mismatch_count = 0
+    runtime_ledger_checked_transfer_count = 0
+    runtime_ledger_signed_transfer_count = 0
+    runtime_ledger_direction_mismatch_count = 0
+    runtime_ledger_metadata_mismatch_count = 0
     blockers: list[str] = []
 
     transfer_lookup: dict[str, object] = {}
@@ -367,6 +438,28 @@ def reconcile_tigerbeetle_transfers(
             elif ref.amount != expected_source_amount:
                 source_amount_mismatch_count += 1
                 blockers.append(BLOCKER_SOURCE_AMOUNT_MISMATCH)
+        if ref.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET:
+            runtime_ledger_checked_transfer_count += 1
+            source_uuid = _uuid_or_none(ref.source_id)
+            bucket = (
+                session.get(StrategyRuntimeLedgerBucket, source_uuid)
+                if source_uuid is not None
+                else None
+            )
+            if bucket is not None:
+                direction_matches, metadata_matches = (
+                    _runtime_ledger_ref_matches_expected_bucket(ref, actual, bucket)
+                )
+                if direction_matches:
+                    runtime_ledger_signed_transfer_count += 1
+                else:
+                    runtime_ledger_direction_mismatch_count += 1
+                    mismatched_transfer_count += 1
+                    blockers.append(BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH)
+                if not metadata_matches:
+                    runtime_ledger_metadata_mismatch_count += 1
+                    mismatched_transfer_count += 1
+                    blockers.append(BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH)
 
     event_ids_with_refs = {
         item
@@ -527,6 +620,14 @@ def reconcile_tigerbeetle_transfers(
         "source_missing_count": source_missing_count,
         "source_row_missing_count": source_row_missing_count,
         "source_amount_mismatch_count": source_amount_mismatch_count,
+        "runtime_ledger_checked_transfer_count": runtime_ledger_checked_transfer_count,
+        "runtime_ledger_signed_transfer_count": runtime_ledger_signed_transfer_count,
+        "runtime_ledger_direction_mismatch_count": (
+            runtime_ledger_direction_mismatch_count
+        ),
+        "runtime_ledger_metadata_mismatch_count": (
+            runtime_ledger_metadata_mismatch_count
+        ),
         "unlinked_event_count": unlinked_event_count,
         "unlinked_execution_count": unlinked_execution_count,
         "unlinked_cost_count": unlinked_cost_count,

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -173,6 +173,21 @@ def _mapping(value: object) -> Mapping[str, Any]:
     return {}
 
 
+def _contains_tigerbeetle_claim(value: object) -> bool:
+    if isinstance(value, Mapping):
+        for raw_key, raw_value in cast(Mapping[object, object], value).items():
+            key = str(raw_key).lower()
+            if key == "tigerbeetle" and _mapping(raw_value):
+                return True
+            if key.startswith("tigerbeetle_") and bool(raw_value):
+                return True
+            if _contains_tigerbeetle_claim(raw_value):
+                return True
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return any(_contains_tigerbeetle_claim(item) for item in value)
+    return False
+
+
 def _sequence(value: object) -> Sequence[object]:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return cast(Sequence[object], value)
@@ -1936,6 +1951,93 @@ def build_runtime_ledger_proof_packet(
         status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     _extend_unique(blockers, risk_blockers)
+
+    tigerbeetle_status = _mapping(
+        status.get("tigerbeetle_ledger") or status.get("tigerbeetle")
+    )
+    latest_tigerbeetle_reconciliation = _mapping(
+        tigerbeetle_status.get("latest_reconciliation")
+    )
+    tigerbeetle_ref_counts = _mapping(
+        tigerbeetle_status.get("ref_counts")
+        or latest_tigerbeetle_reconciliation.get("ref_counts")
+    )
+    tigerbeetle_claimed = (
+        _bool(tigerbeetle_status.get("enabled"))
+        or _bool(tigerbeetle_status.get("required"))
+        or _bool(tigerbeetle_status.get("journal_enabled"))
+        or _bool(tigerbeetle_status.get("reconcile_required"))
+        or _contains_tigerbeetle_claim(runtime_import)
+        or _contains_tigerbeetle_claim(live_scale_gate)
+    )
+    tigerbeetle_required_for_authority = (
+        final_authority_mode and tigerbeetle_claimed and runtime_import_due
+    )
+    tigerbeetle_blockers = _text_list(tigerbeetle_status.get("blockers"))
+    if tigerbeetle_required_for_authority:
+        if not latest_tigerbeetle_reconciliation:
+            _extend_unique(tigerbeetle_blockers, ["tigerbeetle_reconciliation_missing"])
+        elif not _bool(latest_tigerbeetle_reconciliation.get("ok")):
+            _extend_unique(tigerbeetle_blockers, ["tigerbeetle_reconciliation_not_ok"])
+        _extend_unique(
+            tigerbeetle_blockers,
+            _text_list(latest_tigerbeetle_reconciliation.get("blockers")),
+        )
+        required_runtime_ref_count = max(1, len(ledger_refs))
+        runtime_ref_count = _int(tigerbeetle_ref_counts.get("runtime_ledger_ref_count"))
+        signed_ref_count = _int(
+            latest_tigerbeetle_reconciliation.get(
+                "runtime_ledger_signed_transfer_count"
+            )
+        )
+        if runtime_ref_count < required_runtime_ref_count:
+            _extend_unique(
+                tigerbeetle_blockers, ["tigerbeetle_runtime_ledger_refs_missing"]
+            )
+        if signed_ref_count < required_runtime_ref_count:
+            _extend_unique(
+                tigerbeetle_blockers,
+                ["tigerbeetle_runtime_ledger_signed_refs_missing"],
+            )
+    else:
+        required_runtime_ref_count = 0
+        runtime_ref_count = _int(tigerbeetle_ref_counts.get("runtime_ledger_ref_count"))
+        signed_ref_count = _int(
+            latest_tigerbeetle_reconciliation.get(
+                "runtime_ledger_signed_transfer_count"
+            )
+        )
+    _check(
+        checks,
+        "tigerbeetle_runtime_pnl_authority_refs",
+        passed=not tigerbeetle_required_for_authority or not tigerbeetle_blockers,
+        observed={
+            "claimed": tigerbeetle_claimed,
+            "required_for_authority": tigerbeetle_required_for_authority,
+            "runtime_import_due": runtime_import_due,
+            "enabled": tigerbeetle_status.get("enabled"),
+            "required": tigerbeetle_status.get("required"),
+            "journal_enabled": tigerbeetle_status.get("journal_enabled"),
+            "reconcile_required": tigerbeetle_status.get("reconcile_required"),
+            "status_ok": tigerbeetle_status.get("ok"),
+            "reconciliation_ok": tigerbeetle_status.get("reconciliation_ok"),
+            "required_runtime_ledger_ref_count": required_runtime_ref_count,
+            "runtime_ledger_ref_count": runtime_ref_count,
+            "runtime_ledger_signed_transfer_count": signed_ref_count,
+            "latest_reconciliation": dict(latest_tigerbeetle_reconciliation),
+            "blockers": tigerbeetle_blockers,
+        },
+        expected=(
+            "authority packets require reconciled signed TigerBeetle runtime-ledger "
+            "PnL refs when TigerBeetle is enabled or claimed"
+        ),
+        blockers=tigerbeetle_blockers,
+        status=None
+        if tigerbeetle_required_for_authority
+        else "not_claimed_not_due_or_not_authority_mode",
+    )
+    if tigerbeetle_required_for_authority:
+        _extend_unique(blockers, tigerbeetle_blockers)
 
     failed_checks = [key for key, value in checks.items() if not value["passed"]]
     post_cost_proof_satisfied = not failed_checks

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -40,8 +40,12 @@ class _FakeObjectStoreClient:
         }
 
 
-def _status(*, blockers: list[str] | None = None) -> dict[str, object]:
-    return {
+def _status(
+    *,
+    blockers: list[str] | None = None,
+    tigerbeetle_ledger: dict[str, object] | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
         "mode": "paper",
         "running": True,
         "live_submission_gate": {
@@ -52,6 +56,42 @@ def _status(*, blockers: list[str] | None = None) -> dict[str, object]:
         "proof_floor": {
             "blocking_reasons": [],
         },
+    }
+    if tigerbeetle_ledger is not None:
+        payload["tigerbeetle_ledger"] = tigerbeetle_ledger
+    return payload
+
+
+def _tigerbeetle_ledger_status(
+    *,
+    ok: bool = True,
+    runtime_ledger_ref_count: int = 1,
+    signed_ref_count: int = 1,
+    blockers: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.tigerbeetle-ledger-status.v1",
+        "enabled": True,
+        "journal_enabled": True,
+        "required": False,
+        "reconcile_required": True,
+        "ok": ok and not blockers,
+        "protocol_ok": True,
+        "reconciliation_ok": ok and not blockers,
+        "ref_counts": {
+            "runtime_ledger_ref_count": runtime_ledger_ref_count,
+        },
+        "latest_reconciliation": {
+            "schema_version": "torghut.tigerbeetle-reconciliation.v1",
+            "ok": ok and not blockers,
+            "runtime_ledger_checked_transfer_count": runtime_ledger_ref_count,
+            "runtime_ledger_signed_transfer_count": signed_ref_count,
+            "ref_counts": {
+                "runtime_ledger_ref_count": runtime_ledger_ref_count,
+            },
+            "blockers": blockers or [],
+        },
+        "blockers": blockers or [],
     }
 
 
@@ -532,6 +572,57 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(
             result["candidate"]["candidate_id"],
             "c88421d619759b2cfaa6f4d0",
+        )
+
+    def test_authority_packet_allows_reconciled_tigerbeetle_runtime_refs(
+        self,
+    ) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(tigerbeetle_ledger=_tigerbeetle_ledger_status()),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertTrue(result["ok"], result)
+        self.assertTrue(result["promotion_authority"]["allowed"], result)
+        check = result["checks"]["tigerbeetle_runtime_pnl_authority_refs"]
+        self.assertTrue(check["passed"], check)
+        self.assertTrue(check["observed"]["required_for_authority"])
+        self.assertEqual(check["observed"]["runtime_ledger_signed_transfer_count"], 1)
+
+    def test_authority_packet_blocks_claimed_tigerbeetle_without_signed_refs(
+        self,
+    ) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(
+                tigerbeetle_ledger=_tigerbeetle_ledger_status(
+                    runtime_ledger_ref_count=1,
+                    signed_ref_count=0,
+                )
+            ),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertFalse(result["promotion_authority"]["allowed"])
+        self.assertIn(
+            "tigerbeetle_runtime_ledger_signed_refs_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "tigerbeetle_runtime_pnl_authority_refs",
+            result["promotion_authority"]["failed_checks"],
         )
 
     def test_authority_packet_requires_daily_distribution_and_scale(self) -> None:

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -504,6 +504,58 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(ref.transfer_kind, TRANSFER_KIND_RUNTIME_NET_PNL)
             self.assertEqual(ref.transfer_id, str(runtime_ledger_transfer_id(bucket)))
             self.assertEqual(ref.amount, Decimal("2500000"))
+            self.assertEqual(ref.payload_json["pnl_direction"], "profit")
+            self.assertEqual(ref.payload_json["signed_amount_micros"], 2500000)
+            transfer = client.transfers[int(ref.transfer_id)]
+            self.assertEqual(
+                ref.payload_json["debit_account_id"],
+                str(getattr(transfer, "debit_account_id")),
+            )
+            self.assertEqual(
+                ref.payload_json["credit_account_id"],
+                str(getattr(transfer, "credit_account_id")),
+            )
+
+    def test_negative_runtime_bucket_reverses_transfer_direction(self) -> None:
+        with Session(self.engine) as session:
+            winning_bucket = _runtime_bucket()
+            losing_bucket = _runtime_bucket()
+            losing_bucket.run_id = "runtime-run-loss"
+            losing_bucket.gross_strategy_pnl = Decimal("-3.00")
+            losing_bucket.cost_amount = Decimal("0.50")
+            losing_bucket.net_strategy_pnl_after_costs = Decimal("-3.50")
+            session.add_all([winning_bucket, losing_bucket])
+            session.flush()
+            client = FakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            winning_ref = journal.journal_runtime_ledger_bucket(session, winning_bucket)
+            losing_ref = journal.journal_runtime_ledger_bucket(session, losing_bucket)
+
+            self.assertIsNotNone(winning_ref)
+            self.assertIsNotNone(losing_ref)
+            assert winning_ref is not None
+            assert losing_ref is not None
+            self.assertEqual(winning_ref.payload_json["pnl_direction"], "profit")
+            self.assertEqual(losing_ref.payload_json["pnl_direction"], "loss")
+            self.assertEqual(losing_ref.payload_json["signed_amount_micros"], -3500000)
+            winning_transfer = client.transfers[int(winning_ref.transfer_id)]
+            losing_transfer = client.transfers[int(losing_ref.transfer_id)]
+            self.assertEqual(
+                getattr(winning_transfer, "debit_account_id"),
+                getattr(losing_transfer, "credit_account_id"),
+            )
+            self.assertNotEqual(
+                getattr(losing_transfer, "debit_account_id"),
+                getattr(losing_transfer, "credit_account_id"),
+            )
+            self.assertNotEqual(
+                getattr(winning_transfer, "debit_account_id"),
+                getattr(losing_transfer, "debit_account_id"),
+            )
 
     def test_source_journals_noop_when_disabled_or_amount_missing(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -19,6 +19,9 @@ from app.models import (
     TigerBeetleTransferRef,
 )
 from app.trading.tigerbeetle_client import FakeTigerBeetleClient
+from app.trading.tigerbeetle_journal import (
+    build_runtime_ledger_bucket_transfer_plan,
+)
 from app.trading.tigerbeetle_ledger_model import (
     LEDGER_USD_MICRO,
     TRANSFER_CODE_EXECUTION_FILL,
@@ -33,6 +36,8 @@ from app.trading.tigerbeetle_reconcile import (
     BLOCKER_DEBIT_ACCOUNT_MISMATCH,
     BLOCKER_LEDGER_MISMATCH,
     BLOCKER_POSTGRES_REF_MISMATCH,
+    BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH,
+    BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH,
     BLOCKER_SOURCE_ROW_MISSING,
     BLOCKER_UNLINKED_COST,
     BLOCKER_UNLINKED_EXECUTION,
@@ -107,6 +112,39 @@ def _transfer(
         amount=amount,
         ledger=LEDGER_USD_MICRO,
         code=TRANSFER_CODE_FILL_POST,
+    )
+
+
+def _runtime_bucket(
+    *, net_pnl: Decimal = Decimal("2.50")
+) -> StrategyRuntimeLedgerBucket:
+    observed_at = datetime.now(timezone.utc)
+    return StrategyRuntimeLedgerBucket(
+        run_id=f"runtime-run-{net_pnl}",
+        candidate_id="candidate",
+        hypothesis_id="hypothesis",
+        observed_stage="paper",
+        bucket_started_at=observed_at,
+        bucket_ended_at=observed_at,
+        account_label="paper",
+        runtime_strategy_name="demo",
+        strategy_family="demo",
+        fill_count=1,
+        decision_count=1,
+        submitted_order_count=1,
+        cancelled_order_count=0,
+        rejected_order_count=0,
+        unfilled_order_count=0,
+        closed_trade_count=1,
+        open_position_count=0,
+        filled_notional=Decimal("190.25"),
+        gross_strategy_pnl=net_pnl + Decimal("0.50"),
+        cost_amount=Decimal("0.50"),
+        net_strategy_pnl_after_costs=net_pnl,
+        post_cost_expectancy_bps=Decimal("12.50"),
+        ledger_schema_version="torghut.runtime-ledger.v1",
+        pnl_basis="post_cost",
+        payload_json={"source": "representative-runtime-ledger"},
     )
 
 
@@ -280,6 +318,130 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertIn(BLOCKER_SOURCE_ROW_MISSING, payload["blockers"])
             self.assertEqual(payload["source_row_missing_count"], 1)
             self.assertEqual(payload["source_missing_count"], 1)
+
+    def test_reconciliation_accepts_signed_runtime_ledger_profit_and_loss_refs(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            profit_bucket = _runtime_bucket(net_pnl=Decimal("2.50"))
+            loss_bucket = _runtime_bucket(net_pnl=Decimal("-3.50"))
+            session.add_all([profit_bucket, loss_bucket])
+            session.flush()
+            client = FakeTigerBeetleClient()
+            for bucket in (profit_bucket, loss_bucket):
+                plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+                self.assertIsNotNone(plan)
+                assert plan is not None
+                transfer = plan.transfer_spec
+                session.add(
+                    TigerBeetleTransferRef(
+                        cluster_id=2001,
+                        transfer_id=str(transfer.transfer_id),
+                        transfer_kind=transfer.transfer_kind,
+                        ledger=transfer.ledger,
+                        code=transfer.code,
+                        amount=Decimal(transfer.amount),
+                        status="created",
+                        runtime_ledger_bucket_id=bucket.id,
+                        source_type="strategy_runtime_ledger_bucket",
+                        source_id=str(bucket.id),
+                        payload_json={
+                            "source": "strategy_runtime_ledger_bucket",
+                            "run_id": bucket.run_id,
+                            "candidate_id": bucket.candidate_id,
+                            "hypothesis_id": bucket.hypothesis_id,
+                            "observed_stage": bucket.observed_stage,
+                            "pnl_basis": bucket.pnl_basis,
+                            "ledger_schema_version": bucket.ledger_schema_version,
+                            "amount_source": str(plan.amount_source),
+                            "signed_amount_micros": plan.signed_amount_micros,
+                            "pnl_direction": plan.pnl_direction,
+                            "runtime_key": plan.runtime_key,
+                            "debit_account_id": str(transfer.debit_account_id),
+                            "credit_account_id": str(transfer.credit_account_id),
+                        },
+                    )
+                )
+                client.transfers[transfer.transfer_id] = transfer
+            session.flush()
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertTrue(payload["ok"], payload)
+            self.assertEqual(payload["runtime_ledger_checked_transfer_count"], 2)
+            self.assertEqual(payload["runtime_ledger_signed_transfer_count"], 2)
+
+    def test_reconciliation_blocks_runtime_ledger_signed_direction_mismatch(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket(net_pnl=Decimal("-3.50"))
+            session.add(bucket)
+            session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            expected = plan.transfer_spec
+            wrong_transfer = TigerBeetleTransferSpec(
+                transfer_id=expected.transfer_id,
+                transfer_kind=expected.transfer_kind,
+                debit_account_id=expected.credit_account_id,
+                credit_account_id=expected.debit_account_id,
+                amount=expected.amount,
+                ledger=expected.ledger,
+                code=expected.code,
+            )
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(expected.transfer_id),
+                    transfer_kind=expected.transfer_kind,
+                    ledger=expected.ledger,
+                    code=expected.code,
+                    amount=Decimal(expected.amount),
+                    status="created",
+                    runtime_ledger_bucket_id=bucket.id,
+                    source_type="strategy_runtime_ledger_bucket",
+                    source_id=str(bucket.id),
+                    payload_json={
+                        "source": "strategy_runtime_ledger_bucket",
+                        "run_id": bucket.run_id,
+                        "candidate_id": "wrong-candidate",
+                        "hypothesis_id": bucket.hypothesis_id,
+                        "observed_stage": bucket.observed_stage,
+                        "pnl_basis": bucket.pnl_basis,
+                        "ledger_schema_version": bucket.ledger_schema_version,
+                        "amount_source": str(plan.amount_source),
+                        "signed_amount_micros": abs(plan.signed_amount_micros),
+                        "pnl_direction": "profit",
+                        "runtime_key": plan.runtime_key,
+                        "debit_account_id": str(wrong_transfer.debit_account_id),
+                        "credit_account_id": str(wrong_transfer.credit_account_id),
+                    },
+                )
+            )
+            session.flush()
+            client = FakeTigerBeetleClient()
+            client.transfers[expected.transfer_id] = wrong_transfer
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertFalse(payload["ok"])
+            self.assertIn(
+                BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH, payload["blockers"]
+            )
+            self.assertIn(BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH, payload["blockers"])
+            self.assertEqual(payload["runtime_ledger_signed_transfer_count"], 0)
+            self.assertEqual(payload["runtime_ledger_direction_mismatch_count"], 1)
+            self.assertEqual(payload["runtime_ledger_metadata_mismatch_count"], 1)
 
     def test_reconciliation_blocks_code_and_ledger_mismatch(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Signs TigerBeetle runtime-net-PnL refs by reversing transfer direction for loss buckets instead of storing sign only in JSON.
- Adds reconciliation enforcement for runtime-ledger bucket refs, signed amount/direction, ledger/code/account ids, and runtime metadata agreement.
- Requires reconciled signed TigerBeetle runtime-ledger refs in authority proof packets when TigerBeetle is enabled or explicitly claimed, without making TigerBeetle mandatory when absent or before runtime import is due.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_ledger_model.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tigerbeetle_ledger_model.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A — backend proof plumbing only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
