### PR TITLE
fix(torghut): bound proof cron reconciliation

### DIFF
--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -25,6 +25,15 @@ spec:
             - name: refresh-execution-tca
               image: registry.ide-newton.ts.net/lab/torghut@sha256:904c43b5c4a659e8f3d3c86f965afed95b65ed6387b670a509d08f3b7c4225d2
               imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 1Gi
+                  ephemeral-storage: 512Mi
               env:
                 - name: DB_DSN
                   valueFrom:
@@ -40,7 +49,7 @@ spec:
                   cd /app
                   /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
                     --older-than-seconds 900 \
-                    --batch-size 250 \
-                    --max-batches 1 \
+                    --batch-size 100 \
+                    --max-batches 3 \
                     --apply \
                     --json

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 180
+      activeDeadlineSeconds: 300
       template:
         spec:
           restartPolicy: Never
@@ -28,12 +28,12 @@ spec:
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
-                  cpu: 50m
-                  memory: 128Mi
+                  cpu: 100m
+                  memory: 256Mi
                   ephemeral-storage: 128Mi
                 limits:
-                  cpu: 250m
-                  memory: 512Mi
+                  cpu: 500m
+                  memory: 1Gi
                   ephemeral-storage: 512Mi
               command:
                 - /bin/bash
@@ -46,8 +46,8 @@ spec:
                   /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
-                    --batch-size 250 \
-                    --max-batches 1 \
+                    --batch-size 100 \
+                    --max-batches 4 \
                     --apply \
                     --json
                   echo "stage=order_feed_source_window_repair completed_at=$(date -Iseconds)"

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 600
+      activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: Never
@@ -41,12 +41,12 @@ spec:
                     - ALL
               resources:
                 requests:
-                  cpu: 100m
-                  memory: 256Mi
+                  cpu: 250m
+                  memory: 512Mi
                   ephemeral-storage: 128Mi
                 limits:
-                  cpu: 500m
-                  memory: 1Gi
+                  cpu: "1"
+                  memory: 2Gi
                   ephemeral-storage: 512Mi
               command:
                 - /bin/bash
@@ -58,9 +58,9 @@ spec:
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
-                    --batch-size 100 \
-                    --max-batches 1 \
-                    --event-scan-limit 250 \
+                    --batch-size 75 \
+                    --max-batches 4 \
+                    --event-scan-limit 300 \
                     --reconcile-limit 250 \
                     --json
               env:

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -924,7 +924,12 @@ def latest_order_event_for_execution(
     return session.execute(stmt).scalar_one_or_none()
 
 
-def link_order_events_to_execution(session: Session, execution: Execution) -> int:
+def link_order_events_to_execution(
+    session: Session,
+    execution: Execution,
+    *,
+    limit: int | None = None,
+) -> int:
     """Attach previously ingested order-feed events once their Execution exists."""
 
     clauses: list[ColumnElement[bool]] = []
@@ -947,25 +952,24 @@ def link_order_events_to_execution(session: Session, execution: Execution) -> in
     if not clauses:
         return 0
 
-    events = (
-        session.execute(
-            select(ExecutionOrderEvent)
-            .where(
-                or_(*clauses),
-                (
-                    (ExecutionOrderEvent.execution_id.is_(None))
-                    | (ExecutionOrderEvent.trade_decision_id.is_(None))
-                ),
-            )
-            .order_by(
-                ExecutionOrderEvent.event_ts.asc().nullsfirst(),
-                ExecutionOrderEvent.feed_seq.asc().nullsfirst(),
-                ExecutionOrderEvent.created_at.asc(),
-            )
+    stmt = (
+        select(ExecutionOrderEvent)
+        .where(
+            or_(*clauses),
+            (
+                (ExecutionOrderEvent.execution_id.is_(None))
+                | (ExecutionOrderEvent.trade_decision_id.is_(None))
+            ),
         )
-        .scalars()
-        .all()
+        .order_by(
+            ExecutionOrderEvent.event_ts.asc().nullsfirst(),
+            ExecutionOrderEvent.feed_seq.asc().nullsfirst(),
+            ExecutionOrderEvent.created_at.asc(),
+        )
     )
+    if limit is not None:
+        stmt = stmt.limit(max(1, min(int(limit), 5000)))
+    events = session.execute(stmt).scalars().all()
     if not events:
         return 0
 
@@ -1044,6 +1048,8 @@ def repair_order_feed_execution_links(
         "events_without_execution": 0,
     }
     for event in events:
+        if counters["events_linked"] >= bounded_limit:
+            break
         execution = _execution_for_order_event(session, event)
         if execution is None:
             counters["events_without_execution"] += 1
@@ -1052,7 +1058,12 @@ def repair_order_feed_execution_links(
             continue
         processed_execution_ids.add(execution.id)
         counters["executions_matched"] += 1
-        linked = link_order_events_to_execution(session, execution)
+        remaining_event_budget = max(1, bounded_limit - counters["events_linked"])
+        linked = link_order_events_to_execution(
+            session,
+            execution,
+            limit=remaining_event_budget,
+        )
         if linked <= 0:
             continue
         counters["executions_linked"] += 1

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.config import Settings, settings
@@ -107,6 +107,62 @@ def _ref_matches_expected_event(
         and ref.code == expected.code
         and _payload_value(ref, "debit_account_id") == str(expected.debit_account_id)
         and _payload_value(ref, "credit_account_id") == str(expected.credit_account_id)
+    )
+
+
+def _order_event_ref_exists(
+    session: Session,
+    event: ExecutionOrderEvent,
+    *,
+    settings_obj: Settings,
+) -> bool:
+    clauses = [
+        TigerBeetleTransferRef.execution_order_event_id == event.id,
+        (
+            (TigerBeetleTransferRef.source_type == SOURCE_TYPE_EXECUTION_ORDER_EVENT)
+            & (TigerBeetleTransferRef.source_id == str(event.id))
+        ),
+    ]
+    if event.event_fingerprint:
+        clauses.append(
+            (TigerBeetleTransferRef.source_type == SOURCE_TYPE_EXECUTION_ORDER_EVENT)
+            & (TigerBeetleTransferRef.event_fingerprint == event.event_fingerprint)
+        )
+    return (
+        session.scalar(
+            select(TigerBeetleTransferRef.id)
+            .where(
+                TigerBeetleTransferRef.cluster_id
+                == settings_obj.tigerbeetle_cluster_id,
+                or_(*clauses),
+            )
+            .limit(1)
+        )
+        is not None
+    )
+
+
+def _source_ref_exists(
+    session: Session,
+    *,
+    settings_obj: Settings,
+    source_type: str,
+    source_id: str,
+    transfer_kind: str,
+) -> bool:
+    return (
+        session.scalar(
+            select(TigerBeetleTransferRef.id)
+            .where(
+                TigerBeetleTransferRef.cluster_id
+                == settings_obj.tigerbeetle_cluster_id,
+                TigerBeetleTransferRef.source_type == source_type,
+                TigerBeetleTransferRef.source_id == source_id,
+                TigerBeetleTransferRef.transfer_kind == transfer_kind,
+            )
+            .limit(1)
+        )
+        is not None
     )
 
 
@@ -368,17 +424,6 @@ def reconcile_tigerbeetle_transfers(
                 source_amount_mismatch_count += 1
                 blockers.append(BLOCKER_SOURCE_AMOUNT_MISMATCH)
 
-    event_ids_with_refs = {
-        item
-        for item in session.execute(
-            select(TigerBeetleTransferRef.execution_order_event_id).where(
-                TigerBeetleTransferRef.cluster_id
-                == settings_obj.tigerbeetle_cluster_id,
-                TigerBeetleTransferRef.execution_order_event_id.is_not(None),
-            )
-        ).scalars()
-        if item is not None
-    }
     recent_events = (
         session.execute(
             select(ExecutionOrderEvent)
@@ -391,7 +436,7 @@ def reconcile_tigerbeetle_transfers(
     unlinked_event_count = sum(
         1
         for event in recent_events
-        if event.id not in event_ids_with_refs
+        if not _order_event_ref_exists(session, event, settings_obj=settings_obj)
         and build_order_event_transfer_plan(
             session,
             event,
@@ -402,19 +447,6 @@ def reconcile_tigerbeetle_transfers(
     if unlinked_event_count:
         blockers.append(BLOCKER_UNLINKED_EVENT)
 
-    execution_ids_with_refs = {
-        str(item)
-        for item in session.execute(
-            select(TigerBeetleTransferRef.source_id).where(
-                TigerBeetleTransferRef.cluster_id
-                == settings_obj.tigerbeetle_cluster_id,
-                TigerBeetleTransferRef.source_type == SOURCE_TYPE_EXECUTION,
-                TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_EXECUTION_FILL,
-                TigerBeetleTransferRef.source_id.is_not(None),
-            )
-        ).scalars()
-        if item is not None
-    }
     recent_executions = (
         session.execute(
             select(Execution)
@@ -431,24 +463,17 @@ def reconcile_tigerbeetle_transfers(
     unlinked_execution_count = sum(
         1
         for execution in recent_executions
-        if str(execution.id) not in execution_ids_with_refs
+        if not _source_ref_exists(
+            session,
+            settings_obj=settings_obj,
+            source_type=SOURCE_TYPE_EXECUTION,
+            source_id=str(execution.id),
+            transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+        )
     )
     if unlinked_execution_count:
         blockers.append(BLOCKER_UNLINKED_EXECUTION)
 
-    cost_ids_with_refs = {
-        str(item)
-        for item in session.execute(
-            select(TigerBeetleTransferRef.source_id).where(
-                TigerBeetleTransferRef.cluster_id
-                == settings_obj.tigerbeetle_cluster_id,
-                TigerBeetleTransferRef.source_type == SOURCE_TYPE_EXECUTION_TCA_METRIC,
-                TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_EXECUTION_COST,
-                TigerBeetleTransferRef.source_id.is_not(None),
-            )
-        ).scalars()
-        if item is not None
-    }
     recent_cost_metrics = (
         session.execute(
             select(ExecutionTCAMetric)
@@ -463,24 +488,19 @@ def reconcile_tigerbeetle_transfers(
         .all()
     )
     unlinked_cost_count = sum(
-        1 for metric in recent_cost_metrics if str(metric.id) not in cost_ids_with_refs
+        1
+        for metric in recent_cost_metrics
+        if not _source_ref_exists(
+            session,
+            settings_obj=settings_obj,
+            source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
+            source_id=str(metric.id),
+            transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+        )
     )
     if unlinked_cost_count:
         blockers.append(BLOCKER_UNLINKED_COST)
 
-    runtime_ids_with_refs = {
-        str(item)
-        for item in session.execute(
-            select(TigerBeetleTransferRef.source_id).where(
-                TigerBeetleTransferRef.cluster_id
-                == settings_obj.tigerbeetle_cluster_id,
-                TigerBeetleTransferRef.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-                TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL,
-                TigerBeetleTransferRef.source_id.is_not(None),
-            )
-        ).scalars()
-        if item is not None
-    }
     recent_runtime_buckets = (
         session.execute(
             select(StrategyRuntimeLedgerBucket)
@@ -497,7 +517,13 @@ def reconcile_tigerbeetle_transfers(
     unlinked_runtime_ledger_count = sum(
         1
         for bucket in recent_runtime_buckets
-        if str(bucket.id) not in runtime_ids_with_refs
+        if not _source_ref_exists(
+            session,
+            settings_obj=settings_obj,
+            source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            source_id=str(bucket.id),
+            transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+        )
     )
     if unlinked_runtime_ledger_count:
         blockers.append(BLOCKER_UNLINKED_RUNTIME_LEDGER)

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -288,6 +288,12 @@ def _error_summary(exc: Exception) -> str:
     return f"{type(exc).__name__}:{message}"
 
 
+def _reset_session_identity_map(session: Any) -> None:
+    expunge_all = getattr(session, "expunge_all", None)
+    if callable(expunge_all):
+        expunge_all()
+
+
 def _payload(
     *,
     args: argparse.Namespace,
@@ -434,8 +440,10 @@ def main() -> int:
             )
             if args.dry_run:
                 session.rollback()
+                _reset_session_identity_map(session)
                 break
             session.commit()
+            _reset_session_identity_map(session)
             if all(
                 len(rows) < batch_size
                 for rows in (events.rows, executions, tca_metrics, runtime_buckets)

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -46,7 +46,9 @@ def _payload(
         "source_windows_created": sum(
             batch["source_windows_created"] for batch in batches
         ),
-        "source_windows_reused": sum(batch["source_windows_reused"] for batch in batches),
+        "source_windows_reused": sum(
+            batch["source_windows_reused"] for batch in batches
+        ),
         "events_linked": sum(batch["events_linked"] for batch in batches),
         "execution_link_candidates": sum(
             batch["execution_link_candidates"] for batch in batches
@@ -87,6 +89,12 @@ def _sqlalchemy_dsn(dsn: str) -> str:
     if text.startswith("postgresql://"):
         return text.replace("postgresql://", "postgresql+psycopg://", 1)
     return text
+
+
+def _reset_session_identity_map(session: Any) -> None:
+    expunge_all = getattr(session, "expunge_all", None)
+    if callable(expunge_all):
+        expunge_all()
 
 
 def main() -> int:
@@ -136,8 +144,10 @@ def main() -> int:
             batches.append(batch)
             if args.apply:
                 session.commit()
+                _reset_session_identity_map(session)
             else:
                 session.rollback()
+                _reset_session_identity_map(session)
                 break
             if (
                 int(source_window_batch.get("selected") or 0) < batch_size

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1101,6 +1101,22 @@ class TestLiveConfigManifestContract(TestCase):
             "registry.ide-newton.ts.net/lab/torghut@sha256:",
             str(container.get("image")),
         )
+        resources = cast(Mapping[str, object], container.get("resources", {}))
+        self.assertEqual(
+            resources,
+            {
+                "requests": {
+                    "cpu": "100m",
+                    "memory": "256Mi",
+                    "ephemeral-storage": "128Mi",
+                },
+                "limits": {
+                    "cpu": "500m",
+                    "memory": "1Gi",
+                    "ephemeral-storage": "512Mi",
+                },
+            },
+        )
         env = {
             item.get("name"): item
             for item in cast(list[Mapping[str, object]], container.get("env", []))
@@ -1115,8 +1131,8 @@ class TestLiveConfigManifestContract(TestCase):
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/refresh_execution_tca_metrics.py", args)
         self.assertIn("--older-than-seconds 900", args)
-        self.assertIn("--batch-size 250", args)
-        self.assertIn("--max-batches 1", args)
+        self.assertIn("--batch-size 100", args)
+        self.assertIn("--max-batches 3", args)
         self.assertIn("--apply", args)
 
     def test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account(
@@ -1211,7 +1227,7 @@ class TestLiveConfigManifestContract(TestCase):
             cast(Mapping[str, object], job_spec.get("template", {})),
         )
         pod_spec = cast(Mapping[str, object], template.get("spec", {}))
-        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 180)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 300)
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
         self.assertEqual(
             pod_spec.get("nodeSelector"),
@@ -1222,13 +1238,13 @@ class TestLiveConfigManifestContract(TestCase):
             resources,
             {
                 "requests": {
-                    "cpu": "50m",
-                    "memory": "128Mi",
+                    "cpu": "100m",
+                    "memory": "256Mi",
                     "ephemeral-storage": "128Mi",
                 },
                 "limits": {
-                    "cpu": "250m",
-                    "memory": "512Mi",
+                    "cpu": "500m",
+                    "memory": "1Gi",
                     "ephemeral-storage": "512Mi",
                 },
             },
@@ -1264,8 +1280,8 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/repair_order_feed_source_windows.py", args)
         self.assertIn("--dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
-        self.assertIn("--batch-size 250", args)
-        self.assertIn("--max-batches 1", args)
+        self.assertIn("--batch-size 100", args)
+        self.assertIn("--max-batches 4", args)
         self.assertIn("--apply", args)
         self.assertNotIn("scripts/journal_tigerbeetle_order_events.py", args)
         self.assertNotIn("--reconcile-limit 1000", args)
@@ -1309,7 +1325,7 @@ class TestLiveConfigManifestContract(TestCase):
             cast(Mapping[str, object], job_spec.get("template", {})),
         )
         pod_spec = cast(Mapping[str, object], template.get("spec", {}))
-        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 600)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 900)
         self.assertEqual(job_spec.get("backoffLimit"), 0)
         self.assertEqual(pod_spec.get("restartPolicy"), "Never")
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
@@ -1324,6 +1340,22 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn(
             "registry.ide-newton.ts.net/lab/torghut@sha256:",
             str(container.get("image")),
+        )
+        resources = cast(Mapping[str, object], container.get("resources", {}))
+        self.assertEqual(
+            resources,
+            {
+                "requests": {
+                    "cpu": "250m",
+                    "memory": "512Mi",
+                    "ephemeral-storage": "128Mi",
+                },
+                "limits": {
+                    "cpu": "1",
+                    "memory": "2Gi",
+                    "ephemeral-storage": "512Mi",
+                },
+            },
         )
 
         env = {
@@ -1368,9 +1400,9 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("scripts/repair_order_feed_source_windows.py", args)
         self.assertIn("--dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
-        self.assertIn("--batch-size 100", args)
-        self.assertIn("--max-batches 1", args)
-        self.assertIn("--event-scan-limit 250", args)
+        self.assertIn("--batch-size 75", args)
+        self.assertIn("--max-batches 4", args)
+        self.assertIn("--event-scan-limit 300", args)
         self.assertIn("--reconcile-limit 250", args)
         self.assertNotIn("--fail-on-degraded", args)
         self.assertIn("--json", args)

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, func, select
 from sqlalchemy.orm import Session
 from unittest import TestCase
 from unittest.mock import patch
@@ -1397,6 +1397,55 @@ class TestOrderFeed(TestCase):
         self.assertEqual(tca_metric.execution_id, execution_id)
         self.assertEqual(source_window.unlinked_execution_count, 0)
         self.assertEqual(source_window.unlinked_decision_count, 0)
+
+    def test_repair_order_feed_execution_links_limits_matching_execution_fanout(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            events = [
+                ExecutionOrderEvent(
+                    event_fingerprint=f"repair-fanout-fill-{index}",
+                    source_topic="torghut.trade-updates.v1",
+                    source_partition=0,
+                    source_offset=400 + index,
+                    alpaca_account_label="paper",
+                    event_ts=datetime(2026, 2, 1, 10, index, tzinfo=timezone.utc),
+                    symbol="AAPL",
+                    alpaca_order_id=execution.alpaca_order_id,
+                    client_order_id=execution.client_order_id,
+                    event_type="fill",
+                    status="filled",
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("191.25"),
+                    raw_event={"event": "fill"},
+                )
+                for index in range(5)
+            ]
+            session.add_all(events)
+            session.commit()
+
+            first_result = repair_order_feed_execution_links(
+                session,
+                account_label="paper",
+                limit=2,
+            )
+            session.commit()
+            second_result = repair_order_feed_execution_links(
+                session,
+                account_label="paper",
+                limit=2,
+            )
+            session.commit()
+            linked_count = session.scalar(
+                select(func.count(ExecutionOrderEvent.id)).where(
+                    ExecutionOrderEvent.execution_id == execution.id
+                )
+            )
+
+        self.assertEqual(first_result["events_linked"], 2)
+        self.assertEqual(second_result["events_linked"], 2)
+        self.assertEqual(linked_count, 4)
 
     def test_historical_source_window_helpers_handle_missing_and_aware_offsets(
         self,

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -407,6 +407,53 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertIn(BLOCKER_UNLINKED_EVENT, payload["blockers"])
             self.assertEqual(payload["source_missing_count"], 1)
 
+    def test_reconciliation_treats_source_id_order_event_ref_as_linked(self) -> None:
+        with Session(self.engine) as session:
+            event = ExecutionOrderEvent(
+                event_fingerprint="source-id-linked-fill",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=1,
+                alpaca_account_label="paper",
+                event_ts=datetime.now(timezone.utc),
+                symbol="AAPL",
+                event_type="fill",
+                status="filled",
+                qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                raw_event={"event": "fill"},
+            )
+            session.add(event)
+            session.flush()
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id="1001",
+                    transfer_kind="fill_post",
+                    ledger=LEDGER_USD_MICRO,
+                    code=TRANSFER_CODE_FILL_POST,
+                    amount=Decimal("190250000"),
+                    status="created",
+                    source_type="execution_order_event",
+                    source_id=str(event.id),
+                    event_fingerprint=event.event_fingerprint,
+                )
+            )
+            session.flush()
+            client = FakeTigerBeetleClient()
+            client.transfers[1001] = _transfer()
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["unlinked_event_count"], 0)
+            self.assertNotIn(BLOCKER_UNLINKED_EVENT, payload["blockers"])
+
     def test_reconciliation_blocks_unlinked_execution_ref(self) -> None:
         with Session(self.engine) as session:
             session.add(


### PR DESCRIPTION
## Summary

- Bounded order-feed execution-link repair fanout so one execution with many lifecycle rows cannot overrun a repair batch.
- Reset SQLAlchemy identity maps between repair/journal batches to avoid batch-to-batch memory growth in CronJob runs.
- Reworked TigerBeetle reconciliation to avoid unbounded transfer-ref ID sets and to treat source-id/event-fingerprint order-event refs as linked.
- Hardened GitOps CronJob resources/batch settings for source-window repair, TigerBeetle journaling, and execution TCA refresh.
- Added focused regressions for idempotent repair batching, reconciliation classification, and CronJob manifest contracts.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev` (pass)
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_repair_order_feed_source_windows_script.py tests/test_tigerbeetle_reconcile.py tests/test_order_feed.py -k 'tigerbeetle or repair_order_feed_execution_links or source_window or journal'` (pass: 53 selected)
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'execution_tca_refresh or source_window_repair or tigerbeetle_journal'` (pass: 4 selected)
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_repair_order_feed_source_windows_script.py tests/test_tigerbeetle_reconcile.py tests/test_order_feed.py tests/test_live_config_manifest_contract.py` (pass: 124)
- `uv run --frozen ruff check app/trading/order_feed.py app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py scripts/repair_order_feed_source_windows.py tests/test_tigerbeetle_reconcile.py tests/test_order_feed.py tests/test_live_config_manifest_contract.py` (pass)
- `uv run --frozen pyright --project pyrightconfig.json` (pass: 0 errors)
- `uv run --frozen pyright --project pyrightconfig.alpha.json` (pass: 0 errors)
- `uv run --frozen pyright --project pyrightconfig.scripts.json` (pass: 0 errors)
- `kubectl kustomize --enable-helm argocd/applications/torghut >/tmp/torghut-render.yaml` (pass: rendered 8180 lines)
- `scripts/kubeconform.sh argocd/applications/torghut` (pass: 106 resources, 0 invalid, 0 errors)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
