### PR TITLE
fix(torghut): surface TigerBeetle refs in proof packets

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -1616,6 +1616,83 @@ def _ledger_payload_with_tigerbeetle_refs(
     }
 
 
+def _runtime_ledger_tigerbeetle_proof_refs(
+    rows: Sequence[StrategyRuntimeLedgerBucket],
+) -> dict[str, Any]:
+    if not rows:
+        return {}
+    account_ids: list[str] = []
+    account_keys: list[str] = []
+    transfer_ids: list[str] = []
+    source_refs: list[str] = []
+    missing_account_ids: list[str] = []
+    buckets: list[dict[str, Any]] = []
+    cluster_ids: set[int] = set()
+
+    def extend_unique(target: list[str], values: Sequence[str]) -> None:
+        for value in values:
+            if value not in target:
+                target.append(value)
+
+    for row in rows:
+        payload = _mapping(row.payload_json)
+        refs = _mapping(payload.get("tigerbeetle"))
+        row_account_ids = _string_list(
+            refs.get("account_ids") or payload.get("tigerbeetle_account_ids")
+        )
+        row_account_keys = _string_list(
+            refs.get("account_keys") or payload.get("tigerbeetle_account_keys")
+        )
+        row_transfer_ids = _string_list(
+            refs.get("transfer_ids") or payload.get("tigerbeetle_transfer_ids")
+        )
+        row_missing_account_ids = _string_list(refs.get("missing_account_ids"))
+        row_source_refs = _string_list(payload.get("source_refs"))
+        if not row_account_ids and not row_account_keys and not row_transfer_ids:
+            continue
+        raw_cluster_ids = refs.get("cluster_ids")
+        cluster_items: Sequence[object] = (
+            cast(Sequence[object], raw_cluster_ids)
+            if isinstance(raw_cluster_ids, Sequence)
+            and not isinstance(raw_cluster_ids, (str, bytes, bytearray))
+            else ()
+        )
+        cluster_ids.update(
+            value
+            for value in (_observation_int(item) for item in cluster_items)
+            if value > 0
+        )
+        extend_unique(account_ids, row_account_ids)
+        extend_unique(account_keys, row_account_keys)
+        extend_unique(transfer_ids, row_transfer_ids)
+        extend_unique(missing_account_ids, row_missing_account_ids)
+        extend_unique(source_refs, row_source_refs)
+        buckets.append(
+            {
+                "runtime_ledger_bucket_id": str(row.id),
+                "account_ids": row_account_ids,
+                "account_keys": row_account_keys,
+                "transfer_ids": row_transfer_ids,
+                "missing_account_ids": row_missing_account_ids,
+            }
+        )
+
+    if not account_ids and not account_keys and not transfer_ids:
+        return {}
+    return {
+        "schema_version": "torghut.tigerbeetle-runtime-ledger-proof-refs.v1",
+        "cluster_ids": sorted(cluster_ids),
+        "account_count": len(account_ids),
+        "transfer_count": len(transfer_ids),
+        "account_ids": account_ids,
+        "account_keys": account_keys,
+        "transfer_ids": transfer_ids,
+        "missing_account_ids": missing_account_ids,
+        "source_refs": source_refs,
+        "runtime_ledger_buckets": buckets,
+    }
+
+
 def _journal_tigerbeetle_runtime_ledger_bucket(
     session: Session,
     row: StrategyRuntimeLedgerBucket,
@@ -2337,6 +2414,7 @@ def persist_observed_runtime_windows(
                 }
             )
     proof_status = "blocked" if proof_blockers else "ok"
+    tigerbeetle_proof_refs = _runtime_ledger_tigerbeetle_proof_refs(runtime_ledger_rows)
     runtime_materialization_target.update(
         {
             "proof_status": proof_status,
@@ -2350,6 +2428,11 @@ def persist_observed_runtime_windows(
             "evidence_grade_runtime_ledger_bucket_ids": [
                 str(row.id) for row in evidence_grade_runtime_ledger_rows
             ],
+            **(
+                {"tigerbeetle": tigerbeetle_proof_refs}
+                if tigerbeetle_proof_refs
+                else {}
+            ),
             "replaced_runtime_ledger_bucket_count": (
                 replaced_runtime_ledger_bucket_count
             ),

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -778,6 +778,12 @@ def _runtime_import_target_materialization_ref(
                     return value
         return ""
 
+    tigerbeetle_refs = _runtime_import_tigerbeetle_refs(
+        item,
+        summary,
+        materialization_target,
+        observation,
+    )
     ref: dict[str, Any] = {
         "materialized": materialized,
         "candidate_id": first_text("candidate_id"),
@@ -822,7 +828,60 @@ def _runtime_import_target_materialization_ref(
         ),
         "blockers": list(blockers),
     }
+    if tigerbeetle_refs:
+        ref["tigerbeetle"] = tigerbeetle_refs
     return {key: value for key, value in ref.items() if value not in ("", [], None)}
+
+
+def _runtime_import_tigerbeetle_refs(
+    *sources: Mapping[str, Any],
+) -> dict[str, Any]:
+    account_ids: list[str] = []
+    account_keys: list[str] = []
+    transfer_ids: list[str] = []
+    source_refs: list[str] = []
+    missing_account_ids: list[str] = []
+    cluster_ids: list[str] = []
+    bucket_refs: list[Mapping[str, Any]] = []
+
+    def extend_unique(target: list[str], values: Sequence[str]) -> None:
+        for value in values:
+            if value and value not in target:
+                target.append(value)
+
+    for source in sources:
+        refs = _mapping(source.get("tigerbeetle"))
+        extend_unique(account_ids, _text_list(source.get("tigerbeetle_account_ids")))
+        extend_unique(account_keys, _text_list(source.get("tigerbeetle_account_keys")))
+        extend_unique(transfer_ids, _text_list(source.get("tigerbeetle_transfer_ids")))
+        if refs:
+            extend_unique(cluster_ids, _text_list(refs.get("cluster_ids")))
+            extend_unique(account_ids, _text_list(refs.get("account_ids")))
+            extend_unique(account_keys, _text_list(refs.get("account_keys")))
+            extend_unique(transfer_ids, _text_list(refs.get("transfer_ids")))
+            extend_unique(source_refs, _text_list(refs.get("source_refs")))
+            extend_unique(
+                missing_account_ids, _text_list(refs.get("missing_account_ids"))
+            )
+            for bucket_ref in _sequence(refs.get("runtime_ledger_buckets")):
+                bucket_mapping = _mapping(bucket_ref)
+                if bucket_mapping:
+                    bucket_refs.append(bucket_mapping)
+
+    if not account_ids and not account_keys and not transfer_ids:
+        return {}
+    return {
+        "schema_version": "torghut.tigerbeetle-runtime-ledger-proof-refs.v1",
+        "cluster_ids": cluster_ids,
+        "account_count": len(account_ids),
+        "transfer_count": len(transfer_ids),
+        "account_ids": account_ids,
+        "account_keys": account_keys,
+        "transfer_ids": transfer_ids,
+        "missing_account_ids": missing_account_ids,
+        "source_refs": source_refs,
+        "runtime_ledger_buckets": bucket_refs,
+    }
 
 
 def _runtime_import_target_blocker_codes(value: object) -> list[str]:

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -179,6 +179,27 @@ def _runtime_import(
         "proof_blockers": blocker_payloads,
         "materialized": authoritative and proof_status == "ok" and not blocker_payloads,
     }
+    if authoritative:
+        target_payload["tigerbeetle"] = {
+            "schema_version": "torghut.tigerbeetle-runtime-ledger-proof-refs.v1",
+            "cluster_ids": [2001],
+            "account_count": 2,
+            "transfer_count": 1,
+            "account_ids": ["100100100100100100100100100100100101"],
+            "account_keys": ["TORGHUT_SIM:cash", "TORGHUT_SIM:AAPL:position"],
+            "transfer_ids": ["340282366920938463463374607431768211"],
+            "missing_account_ids": [],
+            "source_refs": [
+                "postgres:tigerbeetle_account_refs",
+                "postgres:tigerbeetle_transfer_refs",
+            ],
+            "runtime_ledger_buckets": [
+                {
+                    "runtime_ledger_bucket_id": "runtime-ledger-bucket-1",
+                    "transfer_ids": ["340282366920938463463374607431768211"],
+                }
+            ],
+        }
     summary: dict[str, object] = {
         "promotion_allowed": authoritative,
         "runtime_observation": {
@@ -464,6 +485,21 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(result["proof_mode"], "authority")
         self.assertTrue(result["final_authority_ok"])
         self.assertFalse(result["evidence_collection_only"])
+        tigerbeetle_refs = result["evidence"]["runtime_window_import"][
+            "materialization"
+        ]["materialized_targets"][0]["tigerbeetle"]
+        self.assertEqual(
+            tigerbeetle_refs["schema_version"],
+            "torghut.tigerbeetle-runtime-ledger-proof-refs.v1",
+        )
+        self.assertEqual(tigerbeetle_refs["transfer_count"], 1)
+        self.assertEqual(
+            tigerbeetle_refs["source_refs"],
+            [
+                "postgres:tigerbeetle_account_refs",
+                "postgres:tigerbeetle_transfer_refs",
+            ],
+        )
 
     def test_packet_prefers_importable_paper_route_plan_over_next_session_plan(
         self,

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -949,6 +949,36 @@ class TestRuntimeWindowImport(TestCase):
             payload.get("source_row_counts", {}).get("tigerbeetle_transfer_refs"),
             1,
         )
+        target_tigerbeetle_refs = summary["runtime_materialization_target"].get(
+            "tigerbeetle"
+        )
+        self.assertIsInstance(target_tigerbeetle_refs, dict)
+        self.assertEqual(
+            target_tigerbeetle_refs.get("schema_version"),
+            "torghut.tigerbeetle-runtime-ledger-proof-refs.v1",
+        )
+        self.assertEqual(target_tigerbeetle_refs.get("account_count"), 2)
+        self.assertEqual(target_tigerbeetle_refs.get("transfer_count"), 1)
+        self.assertEqual(
+            target_tigerbeetle_refs.get("account_ids"),
+            tigerbeetle_refs.get("account_ids"),
+        )
+        self.assertEqual(
+            target_tigerbeetle_refs.get("transfer_ids"),
+            tigerbeetle_refs.get("transfer_ids"),
+        )
+        self.assertEqual(
+            target_tigerbeetle_refs.get("runtime_ledger_buckets"),
+            [
+                {
+                    "runtime_ledger_bucket_id": str(ledger_buckets[0].id),
+                    "account_ids": tigerbeetle_refs.get("account_ids"),
+                    "account_keys": tigerbeetle_refs.get("account_keys"),
+                    "transfer_ids": tigerbeetle_refs.get("transfer_ids"),
+                    "missing_account_ids": [],
+                }
+            ],
+        )
         self.assertEqual(datasets[0].candidate_id, "cand-1")
         self.assertEqual(datasets[0].artifact_ref, "torghut-runtime-window-cand-1")
         self.assertEqual(datasets[0].source, "live_runtime_observed")


### PR DESCRIPTION
## Summary

- Surface TigerBeetle account and transfer refs from persisted runtime-ledger bucket payloads into the runtime-window import materialization target.
- Carry those TigerBeetle refs into assembled runtime-ledger proof packet materialization evidence.
- Add regression coverage proving proof-facing payloads cite TigerBeetle refs where available.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen ruff check app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff format --check app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Targeted changed-line coverage: `71/71` changed source lines covered, 100 percent.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
