### PR TITLE
fix(torghut): persist live order-feed source authority

### DIFF
--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -44,6 +44,14 @@ spec:
                   cd /app
                   echo "stage=repair_order_feed_source_windows started_at=$(date -Iseconds)"
                   /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env DB_DSN \
+                    --account-label PA3SX7FYNUTF \
+                    --batch-size 1000 \
+                    --max-batches 5 \
+                    --backfill-execution-events \
+                    --apply \
+                    --json
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
                     --batch-size 100 \
@@ -77,5 +85,10 @@ spec:
                       key: password
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
+                - name: DB_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: uri
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Callable, Mapping, cast
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import exists, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
@@ -37,6 +38,9 @@ HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION = (
 FILL_QUANTITY_BASIS_CUMULATIVE_TO_DELTA = "cumulative_to_delta"
 FILL_QUANTITY_BASIS_CUMULATIVE_NON_INCREASING = "cumulative_non_increasing"
 _FILL_EVENT_TYPES = frozenset({"fill", "filled", "partial_fill", "partially_filled"})
+EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION = "execution_raw_order_snapshot_backfill_v1"
+EXECUTION_RAW_ORDER_SOURCE_TOPIC = "torghut.execution-raw-order.backfill.v1"
+EXECUTION_RAW_ORDER_SOURCE_PARTITION = 0
 
 
 @dataclass(frozen=True)
@@ -1194,6 +1198,88 @@ def backfill_order_feed_source_windows(
     return counters
 
 
+def backfill_order_feed_events_from_executions(
+    session: Session,
+    *,
+    account_label: str | None = None,
+    limit: int = 1000,
+) -> dict[str, int]:
+    """Materialize bounded order-feed lifecycle rows from durable executions.
+
+    This repair exists for live accounts that submitted orders before the
+    order-feed consumer was producing ``execution_order_events`` rows. It is not
+    Kafka cursor authority: generated source windows use a dedicated source
+    topic/revision and never update the consumer cursor. The rows stay
+    account-scoped and execution/trade-decision linked so runtime proof can
+    explain exactly which persisted live execution supplied the lifecycle source.
+    """
+
+    bounded_limit = max(1, min(int(limit), 5000))
+    stmt = (
+        select(Execution)
+        .where(
+            Execution.trade_decision_id.is_not(None),
+            Execution.alpaca_order_id != "",
+            ~_execution_order_event_exists_for_execution_clause(),
+        )
+        .order_by(
+            _execution_activity_timestamp().asc().nullsfirst(),
+            Execution.created_at.asc(),
+            Execution.id.asc(),
+        )
+        .limit(bounded_limit)
+    )
+    if account_label:
+        stmt = stmt.where(Execution.alpaca_account_label == account_label)
+
+    executions = session.execute(stmt).scalars().all()
+    counters = {
+        "selected": len(executions),
+        "events_created": 0,
+        "source_windows_created": 0,
+        "skipped_existing_event": 0,
+        "skipped_missing_trade_decision": 0,
+        "skipped_missing_order_identity": 0,
+        "skipped_source_offset_collision": 0,
+    }
+    for execution in executions:
+        if latest_order_event_for_execution(session, execution) is not None:
+            counters["skipped_existing_event"] += 1
+            continue
+
+        source_offset = _stable_execution_source_offset(execution.id)
+        if _source_offset_in_use(
+            session,
+            source_topic=EXECUTION_RAW_ORDER_SOURCE_TOPIC,
+            source_partition=EXECUTION_RAW_ORDER_SOURCE_PARTITION,
+            source_offset=source_offset,
+        ):
+            counters["skipped_source_offset_collision"] += 1
+            continue
+
+        event_ts = _ensure_aware_utc(
+            _execution_activity_at(execution) or datetime.now(timezone.utc)
+        )
+        source_window = _create_execution_backfill_source_window(
+            session,
+            execution=execution,
+            event_ts=event_ts,
+            source_offset=source_offset,
+        )
+        event = _execution_backfill_order_event(
+            execution=execution,
+            event_ts=event_ts,
+            source_offset=source_offset,
+            source_window_id=source_window.id,
+        )
+        session.add(event)
+        session.flush()
+        _refresh_source_window_linkage_counts(session, event)
+        counters["events_created"] += 1
+        counters["source_windows_created"] += 1
+    return counters
+
+
 def _execution_for_order_event(
     session: Session,
     event: ExecutionOrderEvent,
@@ -1224,6 +1310,42 @@ def _execution_for_order_event(
         )
         .scalars()
         .first()
+    )
+
+
+def _execution_order_event_exists_for_execution_clause() -> ColumnElement[bool]:
+    return exists().where(
+        ExecutionOrderEvent.alpaca_account_label == Execution.alpaca_account_label,
+        or_(
+            ExecutionOrderEvent.execution_id == Execution.id,
+            (
+                (Execution.alpaca_order_id != "")
+                & (ExecutionOrderEvent.alpaca_order_id == Execution.alpaca_order_id)
+            ),
+            (
+                Execution.client_order_id.is_not(None)
+                & (Execution.client_order_id != "")
+                & (ExecutionOrderEvent.client_order_id == Execution.client_order_id)
+            ),
+        ),
+    )
+
+
+def _execution_activity_timestamp() -> Any:
+    return func.coalesce(
+        Execution.order_feed_last_event_ts,
+        Execution.last_update_at,
+        Execution.updated_at,
+        Execution.created_at,
+    )
+
+
+def _execution_activity_at(row: Execution) -> datetime | None:
+    return (
+        row.order_feed_last_event_ts
+        or row.last_update_at
+        or row.updated_at
+        or row.created_at
     )
 
 
@@ -1337,11 +1459,213 @@ def _create_historical_source_window_for_event(
     return source_window
 
 
+def _create_execution_backfill_source_window(
+    session: Session,
+    *,
+    execution: Execution,
+    event_ts: datetime,
+    source_offset: int,
+) -> OrderFeedSourceWindow:
+    source_window = OrderFeedSourceWindow(
+        consumer_group=_order_feed_cursor_consumer_group(),
+        source_topic=EXECUTION_RAW_ORDER_SOURCE_TOPIC,
+        source_partition=EXECUTION_RAW_ORDER_SOURCE_PARTITION,
+        alpaca_account_label=execution.alpaca_account_label,
+        assignment_mode=settings.trading_order_feed_assignment_mode,
+        collector_identity=settings.trading_order_feed_client_id.strip() or None,
+        source_revision=EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION,
+        window_started_at=event_ts,
+        window_ended_at=event_ts,
+        start_offset=source_offset,
+        end_offset=source_offset,
+        broker_high_watermark=None,
+        consumed_count=1,
+        inserted_count=1,
+        duplicate_count=0,
+        malformed_count=0,
+        missing_payload_count=0,
+        missing_identity_count=0,
+        out_of_scope_account_count=0,
+        unlinked_execution_count=0,
+        unlinked_decision_count=0,
+        failed_unhandled_count=0,
+        dropped_count=0,
+        gap_count=0,
+        gap_ranges=None,
+        first_event_ts=event_ts,
+        last_event_ts=event_ts,
+        status="inserted",
+        status_reason="execution_raw_order_snapshot_backfill",
+        payload_json={
+            "cursor_authority": False,
+            "source": "executions.raw_order",
+            "execution_id": str(execution.id),
+            "trade_decision_id": (
+                str(execution.trade_decision_id)
+                if execution.trade_decision_id is not None
+                else None
+            ),
+        },
+    )
+    session.add(source_window)
+    session.flush()
+    return source_window
+
+
+def _execution_backfill_order_event(
+    *,
+    execution: Execution,
+    event_ts: datetime,
+    source_offset: int,
+    source_window_id: Any,
+) -> ExecutionOrderEvent:
+    event_type = _execution_backfill_event_type(execution)
+    raw_event = _execution_backfill_raw_event(execution, event_type=event_type)
+    fingerprint_input = {
+        "source_revision": EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION,
+        "execution_id": str(execution.id),
+        "trade_decision_id": (
+            str(execution.trade_decision_id)
+            if execution.trade_decision_id is not None
+            else None
+        ),
+        "alpaca_account_label": execution.alpaca_account_label,
+        "alpaca_order_id": execution.alpaca_order_id,
+        "client_order_id": execution.client_order_id,
+        "event_type": event_type,
+        "status": execution.status,
+        "event_ts": event_ts.isoformat(),
+        "filled_qty": str(execution.filled_qty),
+        "avg_fill_price": (
+            str(execution.avg_fill_price)
+            if execution.avg_fill_price is not None
+            else None
+        ),
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(fingerprint_input, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    return ExecutionOrderEvent(
+        event_fingerprint=fingerprint,
+        source_topic=EXECUTION_RAW_ORDER_SOURCE_TOPIC,
+        source_partition=EXECUTION_RAW_ORDER_SOURCE_PARTITION,
+        source_offset=source_offset,
+        alpaca_account_label=execution.alpaca_account_label,
+        feed_seq=None,
+        event_ts=event_ts,
+        symbol=execution.symbol,
+        alpaca_order_id=execution.alpaca_order_id,
+        client_order_id=execution.client_order_id,
+        event_type=event_type,
+        status=execution.status,
+        qty=execution.submitted_qty,
+        filled_qty=execution.filled_qty,
+        avg_fill_price=execution.avg_fill_price,
+        raw_event=raw_event,
+        execution_id=execution.id,
+        trade_decision_id=execution.trade_decision_id,
+        source_window_id=source_window_id,
+    )
+
+
+def _execution_backfill_event_type(execution: Execution) -> str:
+    status = (execution.status or "").strip().lower()
+    if status == "filled":
+        return "fill"
+    if status == "partially_filled":
+        return "partial_fill"
+    return status or "execution_snapshot"
+
+
+def _execution_backfill_raw_event(
+    execution: Execution,
+    *,
+    event_type: str,
+) -> dict[str, Any]:
+    raw_order = coerce_json_payload(execution.raw_order)
+    return coerce_json_payload(
+        {
+            "channel": "trade_updates",
+            "source": "execution_raw_order_snapshot_backfill",
+            "account_label": execution.alpaca_account_label,
+            "payload": {
+                "event": event_type,
+                "timestamp": _isoformat_datetime(_execution_activity_at(execution)),
+                "account_label": execution.alpaca_account_label,
+                "order": {
+                    "id": execution.alpaca_order_id,
+                    "client_order_id": execution.client_order_id,
+                    "symbol": execution.symbol,
+                    "status": execution.status,
+                    "side": execution.side,
+                    "type": execution.order_type,
+                    "time_in_force": execution.time_in_force,
+                    "qty": str(execution.submitted_qty),
+                    "filled_qty": str(execution.filled_qty),
+                    "filled_avg_price": (
+                        str(execution.avg_fill_price)
+                        if execution.avg_fill_price is not None
+                        else None
+                    ),
+                    "alpaca_account_label": execution.alpaca_account_label,
+                },
+            },
+            "execution_id": str(execution.id),
+            "trade_decision_id": (
+                str(execution.trade_decision_id)
+                if execution.trade_decision_id is not None
+                else None
+            ),
+            "raw_order": raw_order,
+        }
+    )
+
+
+def _source_offset_in_use(
+    session: Session,
+    *,
+    source_topic: str,
+    source_partition: int,
+    source_offset: int,
+) -> bool:
+    existing = session.scalar(
+        select(func.count(ExecutionOrderEvent.id)).where(
+            ExecutionOrderEvent.source_topic == source_topic,
+            ExecutionOrderEvent.source_partition == source_partition,
+            ExecutionOrderEvent.source_offset == source_offset,
+        )
+    )
+    return int(existing or 0) > 0
+
+
+def _stable_execution_source_offset(value: object) -> int:
+    try:
+        raw_int = uuid.UUID(str(value)).int
+    except (ValueError, TypeError, AttributeError):
+        raw_int = int.from_bytes(
+            hashlib.sha256(str(value).encode("utf-8")).digest()[:8],
+            "big",
+        )
+    return raw_int % ((2**63) - 1) or 1
+
+
 def _event_timestamp_for_source_window(event: ExecutionOrderEvent) -> datetime:
     event_ts = event.event_ts or event.created_at or datetime.now(timezone.utc)
     if event_ts.tzinfo is None:
         return event_ts.replace(tzinfo=timezone.utc)
     return event_ts.astimezone(timezone.utc)
+
+
+def _ensure_aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _isoformat_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return _ensure_aware_utc(value).isoformat()
 
 
 def _refresh_source_window_linkage_counts(
@@ -1689,11 +2013,13 @@ __all__ = [
     "NormalizedOrderEvent",
     "NormalizationResult",
     "OrderFeedIngestor",
+    "EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION",
     "HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION",
     "ORDER_FEED_SOURCE_REVISION",
     "normalize_order_feed_record",
     "persist_order_event",
     "apply_order_event_to_execution",
+    "backfill_order_feed_events_from_executions",
     "backfill_order_feed_source_windows",
     "link_order_events_to_execution",
     "repair_order_feed_execution_links",

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -2046,7 +2046,9 @@ def build_runtime_ledger_proof_packet(
         or _bool(tigerbeetle_status.get("required"))
         or _bool(tigerbeetle_status.get("journal_enabled"))
         or _bool(tigerbeetle_status.get("reconcile_required"))
-        or _contains_tigerbeetle_claim(runtime_import)
+        # Runtime-import TigerBeetle refs are proof artifacts; require live
+        # reconciliation status only when the status or completion gate claims
+        # TigerBeetle authority.
         or _contains_tigerbeetle_claim(live_scale_gate)
     )
     tigerbeetle_required_for_authority = (

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -13,6 +13,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from app.trading.order_feed import (
+    backfill_order_feed_events_from_executions,
     backfill_order_feed_source_windows,
     repair_order_feed_execution_links,
 )
@@ -26,6 +27,14 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--account-label", default=None)
     parser.add_argument("--batch-size", type=int, default=1000)
     parser.add_argument("--max-batches", type=int, default=1)
+    parser.add_argument(
+        "--backfill-execution-events",
+        action="store_true",
+        help=(
+            "Create non-cursor-authoritative execution_order_events/source windows "
+            "from durable executions that predate order-feed persistence."
+        ),
+    )
     parser.add_argument(
         "--apply",
         action="store_true",
@@ -65,12 +74,39 @@ def _payload(
         "execution_link_events_without_execution": sum(
             batch["execution_link_events_without_execution"] for batch in batches
         ),
+        "execution_event_backfill_candidates": sum(
+            batch["execution_event_backfill_candidates"] for batch in batches
+        ),
+        "execution_event_backfill_events_created": sum(
+            batch["execution_event_backfill_events_created"] for batch in batches
+        ),
+        "execution_event_backfill_source_windows_created": sum(
+            batch["execution_event_backfill_source_windows_created"]
+            for batch in batches
+        ),
+        "execution_event_backfill_skipped_existing_event": sum(
+            batch["execution_event_backfill_skipped_existing_event"]
+            for batch in batches
+        ),
+        "execution_event_backfill_skipped_missing_trade_decision": sum(
+            batch["execution_event_backfill_skipped_missing_trade_decision"]
+            for batch in batches
+        ),
+        "execution_event_backfill_skipped_missing_order_identity": sum(
+            batch["execution_event_backfill_skipped_missing_order_identity"]
+            for batch in batches
+        ),
+        "execution_event_backfill_skipped_source_offset_collision": sum(
+            batch["execution_event_backfill_skipped_source_offset_collision"]
+            for batch in batches
+        ),
     }
     return {
         "status": "ok",
         "apply": bool(args.apply),
         "dsn_env": args.dsn_env,
         "account_label": args.account_label,
+        "backfill_execution_events": bool(args.backfill_execution_events),
         "batch_size": max(1, min(int(args.batch_size), 5000)),
         "max_batches": max(1, int(args.max_batches)),
         "started_at": started_at.isoformat(),
@@ -127,6 +163,23 @@ def main() -> int:
                 account_label=args.account_label,
                 limit=batch_size,
             )
+            execution_event_backfill_batch = (
+                backfill_order_feed_events_from_executions(
+                    session,
+                    account_label=args.account_label,
+                    limit=batch_size,
+                )
+                if args.backfill_execution_events
+                else {
+                    "selected": 0,
+                    "events_created": 0,
+                    "source_windows_created": 0,
+                    "skipped_existing_event": 0,
+                    "skipped_missing_trade_decision": 0,
+                    "skipped_missing_order_identity": 0,
+                    "skipped_source_offset_collision": 0,
+                }
+            )
             batch = {
                 **source_window_batch,
                 "execution_link_candidates": execution_link_batch["selected"],
@@ -140,6 +193,27 @@ def main() -> int:
                 "execution_link_events_without_execution": execution_link_batch[
                     "events_without_execution"
                 ],
+                "execution_event_backfill_candidates": execution_event_backfill_batch[
+                    "selected"
+                ],
+                "execution_event_backfill_events_created": execution_event_backfill_batch[
+                    "events_created"
+                ],
+                "execution_event_backfill_source_windows_created": (
+                    execution_event_backfill_batch["source_windows_created"]
+                ),
+                "execution_event_backfill_skipped_existing_event": (
+                    execution_event_backfill_batch["skipped_existing_event"]
+                ),
+                "execution_event_backfill_skipped_missing_trade_decision": (
+                    execution_event_backfill_batch["skipped_missing_trade_decision"]
+                ),
+                "execution_event_backfill_skipped_missing_order_identity": (
+                    execution_event_backfill_batch["skipped_missing_order_identity"]
+                ),
+                "execution_event_backfill_skipped_source_offset_collision": (
+                    execution_event_backfill_batch["skipped_source_offset_collision"]
+                ),
             }
             batches.append(batch)
             if args.apply:
@@ -152,6 +226,8 @@ def main() -> int:
             if (
                 int(source_window_batch.get("selected") or 0) < batch_size
                 and int(execution_link_batch.get("selected") or 0) < batch_size
+                and int(execution_event_backfill_batch.get("selected") or 0)
+                < batch_size
             ):
                 break
 

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1208,7 +1208,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--apply", args)
         self.assertIn("--json", args)
 
-    def test_order_feed_source_window_repair_cronjob_is_bounded_sim_only(
+    def test_order_feed_source_window_repair_cronjob_is_bounded_live_and_sim(
         self,
     ) -> None:
         spec, container = _load_cronjob_container(
@@ -1263,7 +1263,12 @@ class TestLiveConfigManifestContract(TestCase):
             "postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@"
             "$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default",
         )
-        self.assertNotIn("DB_DSN", env)
+        db_dsn = cast(Mapping[str, object], env["DB_DSN"])
+        db_value_from = cast(Mapping[str, object], db_dsn.get("valueFrom", {}))
+        self.assertEqual(
+            db_value_from.get("secretKeyRef"),
+            {"name": "torghut-db-app", "key": "uri"},
+        )
         for name, key in {
             "TORGHUT_SIM_DB_HOST": "host",
             "TORGHUT_SIM_DB_PORT": "port",
@@ -1278,6 +1283,11 @@ class TestLiveConfigManifestContract(TestCase):
 
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/repair_order_feed_source_windows.py", args)
+        self.assertIn("--dsn-env DB_DSN", args)
+        self.assertIn("--account-label PA3SX7FYNUTF", args)
+        self.assertIn("--batch-size 1000", args)
+        self.assertIn("--max-batches 5", args)
+        self.assertIn("--backfill-execution-events", args)
         self.assertIn("--dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
         self.assertIn("--batch-size 100", args)

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -37,11 +37,13 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_FILL_POST,
 )
 from app.trading.order_feed import (
+    EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION,
     HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
     ORDER_FEED_SOURCE_REVISION,
     NormalizedOrderEvent,
     OrderFeedIngestor,
     apply_order_event_to_execution,
+    backfill_order_feed_events_from_executions,
     backfill_order_feed_source_windows,
     latest_order_event_for_execution,
     link_order_events_to_execution,
@@ -1455,6 +1457,215 @@ class TestOrderFeed(TestCase):
         self.assertEqual(first_result["events_linked"], 2)
         self.assertEqual(second_result["events_linked"], 2)
         self.assertEqual(linked_count, 4)
+
+    def test_backfill_order_feed_events_from_executions_links_live_account_source(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(
+                session,
+                account_label="PA3SX7FYNUTF",
+                order_id="live-order-1",
+                client_order_id="live-client-1",
+            )
+            execution.status = "filled"
+            execution.filled_qty = Decimal("1")
+            execution.avg_fill_price = Decimal("191.25")
+            execution.raw_order = {
+                "id": "live-order-1",
+                "client_order_id": "live-client-1",
+                "status": "filled",
+            }
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+            session.add(execution)
+            session.commit()
+
+            result = backfill_order_feed_events_from_executions(
+                session,
+                account_label="PA3SX7FYNUTF",
+                limit=10,
+            )
+            session.commit()
+            event = session.execute(select(ExecutionOrderEvent)).scalar_one()
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(
+            result,
+            {
+                "selected": 1,
+                "events_created": 1,
+                "source_windows_created": 1,
+                "skipped_existing_event": 0,
+                "skipped_missing_trade_decision": 0,
+                "skipped_missing_order_identity": 0,
+                "skipped_source_offset_collision": 0,
+            },
+        )
+        self.assertEqual(event.execution_id, execution_id)
+        self.assertEqual(event.trade_decision_id, trade_decision_id)
+        self.assertEqual(event.source_window_id, source_window.id)
+        self.assertEqual(event.alpaca_account_label, "PA3SX7FYNUTF")
+        self.assertEqual(event.event_type, "fill")
+        self.assertEqual(event.status, "filled")
+        self.assertEqual(event.filled_qty, Decimal("1.00000000"))
+        self.assertEqual(event.avg_fill_price, Decimal("191.25000000"))
+        self.assertIsNotNone(event.source_offset)
+        self.assertEqual(
+            source_window.source_revision,
+            EXECUTION_RAW_ORDER_SOURCE_WINDOW_REVISION,
+        )
+        self.assertEqual(source_window.status, "inserted")
+        self.assertEqual(source_window.payload_json["cursor_authority"], False)
+        self.assertEqual(source_window.payload_json["execution_id"], str(execution_id))
+        self.assertEqual(source_window.unlinked_execution_count, 0)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
+
+    def test_execution_event_backfill_filters_existing_order_feed_lifecycle(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session, account_label="PA3SX7FYNUTF")
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="existing-live-fill",
+                    source_topic="torghut.trade-updates.v2",
+                    source_partition=0,
+                    source_offset=101,
+                    alpaca_account_label="PA3SX7FYNUTF",
+                    event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                    symbol="AAPL",
+                    alpaca_order_id=execution.alpaca_order_id,
+                    client_order_id=execution.client_order_id,
+                    event_type="fill",
+                    status="filled",
+                    raw_event={"event": "fill"},
+                    execution_id=execution.id,
+                    trade_decision_id=execution.trade_decision_id,
+                )
+            )
+            session.commit()
+
+            result = backfill_order_feed_events_from_executions(
+                session,
+                account_label="PA3SX7FYNUTF",
+                limit=10,
+            )
+            event_count = session.scalar(select(func.count(ExecutionOrderEvent.id)))
+
+        self.assertEqual(result["selected"], 0)
+        self.assertEqual(result["events_created"], 0)
+        self.assertEqual(result["skipped_existing_event"], 0)
+        self.assertEqual(event_count, 1)
+
+    def test_execution_event_backfill_handles_race_and_offset_collision(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            self._seed_execution(
+                session,
+                account_label="PA3SX7FYNUTF",
+                order_id="race-order",
+                client_order_id="race-client",
+            )
+            with patch.object(
+                order_feed_module,
+                "latest_order_event_for_execution",
+                return_value=ExecutionOrderEvent(
+                    event_fingerprint="race-existing",
+                    source_topic="torghut.trade-updates.v2",
+                    alpaca_account_label="PA3SX7FYNUTF",
+                    raw_event={"event": "fill"},
+                ),
+            ):
+                race_result = backfill_order_feed_events_from_executions(
+                    session,
+                    account_label="PA3SX7FYNUTF",
+                    limit=10,
+                )
+
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="offset-collision",
+                    source_topic=order_feed_module.EXECUTION_RAW_ORDER_SOURCE_TOPIC,
+                    source_partition=order_feed_module.EXECUTION_RAW_ORDER_SOURCE_PARTITION,
+                    source_offset=77,
+                    alpaca_account_label="PA3SX7FYNUTF",
+                    event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                    symbol="MSFT",
+                    alpaca_order_id="other-order",
+                    client_order_id="other-client",
+                    event_type="fill",
+                    status="filled",
+                    raw_event={"event": "fill"},
+                )
+            )
+            session.commit()
+            with patch.object(
+                order_feed_module,
+                "_stable_execution_source_offset",
+                return_value=77,
+            ):
+                collision_result = backfill_order_feed_events_from_executions(
+                    session,
+                    account_label="PA3SX7FYNUTF",
+                    limit=10,
+                )
+
+        self.assertEqual(race_result["selected"], 1)
+        self.assertEqual(race_result["events_created"], 0)
+        self.assertEqual(race_result["skipped_existing_event"], 1)
+        self.assertEqual(collision_result["selected"], 1)
+        self.assertEqual(collision_result["events_created"], 0)
+        self.assertEqual(collision_result["skipped_source_offset_collision"], 1)
+
+    def test_execution_backfill_helper_edges_are_deterministic(self) -> None:
+        partial_execution = Execution(
+            trade_decision_id=None,
+            alpaca_account_label="PA3SX7FYNUTF",
+            alpaca_order_id="partial-order",
+            client_order_id=None,
+            symbol="AAPL",
+            side="buy",
+            order_type="limit",
+            time_in_force="day",
+            submitted_qty=Decimal("1"),
+            filled_qty=Decimal("0.5"),
+            status="partially_filled",
+        )
+        unknown_execution = Execution(
+            trade_decision_id=None,
+            alpaca_account_label="PA3SX7FYNUTF",
+            alpaca_order_id="unknown-order",
+            client_order_id=None,
+            symbol="AAPL",
+            side="buy",
+            order_type="limit",
+            time_in_force="day",
+            submitted_qty=Decimal("1"),
+            filled_qty=Decimal("0"),
+            status="",
+        )
+
+        self.assertEqual(
+            order_feed_module._execution_backfill_event_type(partial_execution),
+            "partial_fill",
+        )
+        self.assertEqual(
+            order_feed_module._execution_backfill_event_type(unknown_execution),
+            "execution_snapshot",
+        )
+        self.assertEqual(
+            order_feed_module._ensure_aware_utc(
+                datetime(2026, 2, 1, 2, 0, tzinfo=timezone(timedelta(hours=-8)))
+            ),
+            datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+        )
+        self.assertIsNone(order_feed_module._isoformat_datetime(None))
+        self.assertEqual(
+            order_feed_module._stable_execution_source_offset("not-a-uuid"),
+            order_feed_module._stable_execution_source_offset("not-a-uuid"),
+        )
 
     def test_historical_source_window_helpers_handle_missing_and_aware_offsets(
         self,

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -57,7 +57,9 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                     "3",
                 ],
             ),
-            patch.object(script, "create_engine", return_value=object()) as create_engine,
+            patch.object(
+                script, "create_engine", return_value=object()
+            ) as create_engine,
             patch.object(
                 script,
                 "sessionmaker",
@@ -84,6 +86,10 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                     "events_without_execution": 1,
                 },
             ) as repair_links,
+            patch.object(
+                script,
+                "backfill_order_feed_events_from_executions",
+            ) as backfill_execution_events,
             patch("sys.stdout", stdout),
         ):
             exit_code = script.main()
@@ -91,6 +97,7 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual(exit_code, 0)
         self.assertEqual(payload["apply"], False)
+        self.assertEqual(payload["backfill_execution_events"], False)
         self.assertEqual(payload["dsn_env"], "TEST_DSN")
         self.assertEqual(payload["batch_size"], 5000)
         self.assertEqual(payload["max_batches"], 3)
@@ -103,6 +110,9 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_link_executions_linked"], 2)
         self.assertEqual(payload["execution_link_events_linked"], 3)
         self.assertEqual(payload["execution_link_events_without_execution"], 1)
+        self.assertEqual(payload["execution_event_backfill_candidates"], 0)
+        self.assertEqual(payload["execution_event_backfill_events_created"], 0)
+        self.assertEqual(payload["execution_event_backfill_source_windows_created"], 0)
         self.assertEqual(fake_session.commits, 0)
         self.assertEqual(fake_session.rollbacks, 1)
         create_engine.assert_called_once_with(
@@ -120,6 +130,7 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             account_label=None,
             limit=5000,
         )
+        backfill_execution_events.assert_not_called()
 
     def test_main_applies_until_selection_drops_below_batch_size(self) -> None:
         fake_session = _FakeSession()
@@ -187,6 +198,10 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                     },
                 ],
             ) as repair_links,
+            patch.object(
+                script,
+                "backfill_order_feed_events_from_executions",
+            ) as backfill_execution_events,
             patch("sys.stdout", stdout),
         ):
             exit_code = script.main()
@@ -195,6 +210,7 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(payload["apply"], True)
         self.assertEqual(payload["account_label"], "TORGHUT_SIM")
+        self.assertEqual(payload["backfill_execution_events"], False)
         self.assertEqual(payload["selected"], 3)
         self.assertEqual(payload["source_windows_created"], 2)
         self.assertEqual(payload["source_windows_reused"], 1)
@@ -212,6 +228,91 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(repair_links.call_count, 2)
         self.assertEqual(repair_links.call_args.kwargs["account_label"], "TORGHUT_SIM")
         self.assertEqual(repair_links.call_args.kwargs["limit"], 2)
+        backfill_execution_events.assert_not_called()
+
+    def test_main_backfills_execution_events_when_enabled(self) -> None:
+        fake_session = _FakeSession()
+        stdout = io.StringIO()
+
+        with (
+            patch.dict(os.environ, {"LIVE_DSN": "postgresql://example/live"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "repair_order_feed_source_windows.py",
+                    "--dsn-env",
+                    "LIVE_DSN",
+                    "--account-label",
+                    "PA3SX7FYNUTF",
+                    "--batch-size",
+                    "100",
+                    "--max-batches",
+                    "1",
+                    "--backfill-execution-events",
+                    "--apply",
+                    "--json",
+                ],
+            ),
+            patch.object(script, "create_engine", return_value=object()),
+            patch.object(
+                script,
+                "sessionmaker",
+                return_value=_FakeSessionFactory(fake_session),
+            ),
+            patch.object(
+                script,
+                "backfill_order_feed_source_windows",
+                return_value={
+                    "selected": 0,
+                    "source_windows_created": 0,
+                    "source_windows_reused": 0,
+                    "events_linked": 0,
+                },
+            ),
+            patch.object(
+                script,
+                "repair_order_feed_execution_links",
+                return_value={
+                    "selected": 0,
+                    "executions_matched": 0,
+                    "executions_linked": 0,
+                    "events_linked": 0,
+                    "events_without_execution": 0,
+                },
+            ),
+            patch.object(
+                script,
+                "backfill_order_feed_events_from_executions",
+                return_value={
+                    "selected": 7,
+                    "events_created": 6,
+                    "source_windows_created": 6,
+                    "skipped_existing_event": 1,
+                    "skipped_missing_trade_decision": 0,
+                    "skipped_missing_order_identity": 0,
+                    "skipped_source_offset_collision": 0,
+                },
+            ) as backfill_execution_events,
+            patch("sys.stdout", stdout),
+        ):
+            exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["apply"], True)
+        self.assertEqual(payload["backfill_execution_events"], True)
+        self.assertEqual(payload["account_label"], "PA3SX7FYNUTF")
+        self.assertEqual(payload["execution_event_backfill_candidates"], 7)
+        self.assertEqual(payload["execution_event_backfill_events_created"], 6)
+        self.assertEqual(payload["execution_event_backfill_source_windows_created"], 6)
+        self.assertEqual(payload["execution_event_backfill_skipped_existing_event"], 1)
+        self.assertEqual(fake_session.commits, 1)
+        backfill_execution_events.assert_called_once_with(
+            fake_session,
+            account_label="PA3SX7FYNUTF",
+            limit=100,
+        )
 
     def test_main_requires_configured_dsn_env(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- Adds a bounded live repair path that materializes non-cursor-authoritative `execution_order_events` and `order_feed_source_windows` from durable executions that predate order-feed persistence.
- Extends `repair_order_feed_source_windows.py` with `--backfill-execution-events` counters while preserving dry-run-by-default behavior.
- Wires the Torghut GitOps repair CronJob to backfill the live `PA3SX7FYNUTF` DB before the existing `TORGHUT_SIM` repair.
- Adds regression coverage for execution-event backfill, script output, live repair manifest contract, and keeps proof-packet TigerBeetle ref artifacts non-blocking without live ledger status claims.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev` (pass after installing the missing system C compiler in this workspace)
- `uv run --frozen ruff format scripts/assemble_runtime_ledger_proof_packet.py app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_live_config_manifest_contract.py tests/test_assemble_runtime_ledger_proof_packet.py` (pass)
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_live_config_manifest_contract.py tests/test_assemble_runtime_ledger_proof_packet.py` (pass)
- `uv run --frozen pytest tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_live_config_manifest_contract.py -q` (pass: 145 passed, 1 warning)
- `uv run --frozen pyright --project pyrightconfig.json` (pass)
- `uv run --frozen pyright --project pyrightconfig.alpha.json` (pass)
- `uv run --frozen pyright --project pyrightconfig.scripts.json` (pass)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.


