### PR TITLE
fix(torghut): diversify autoresearch portfolio readiness

### DIFF
--- a/services/torghut/app/trading/autonomy/evidence.py
+++ b/services/torghut/app/trading/autonomy/evidence.py
@@ -33,6 +33,7 @@ _AUTORESEARCH_PORTFOLIO_READY_STATUSES = {
     "promotion_ready",
     "ready_for_promotion",
     "ready_for_promotion_review",
+    "target_met",
     "accepted",
     "promoted",
 }
@@ -84,7 +85,9 @@ def _autoresearch_continuity_counts(session: Session) -> dict[str, int] | None:
             ).scalar_one()
         ),
         "autoresearch_proposal_scores": int(
-            session.execute(select(func.count(AutoresearchProposalScore.id))).scalar_one()
+            session.execute(
+                select(func.count(AutoresearchProposalScore.id))
+            ).scalar_one()
         ),
         "autoresearch_portfolio_candidates": len(portfolio_rows),
         "autoresearch_portfolio_ready": 0,
@@ -362,9 +365,7 @@ def evaluate_evidence_continuity(
                 )
                 .join(
                     ResearchCostCalibration,
-                    (
-                        ResearchCostCalibration.scope_type == 'candidate_family'
-                    )
+                    (ResearchCostCalibration.scope_type == "candidate_family")
                     & (
                         ResearchCostCalibration.scope_id
                         == ResearchCandidate.candidate_family
@@ -408,8 +409,8 @@ def evaluate_evidence_continuity(
         economic_validity_count = int(
             candidate_economic_validity_counts.get(run_id, 0) or 0
         )
-        discovery_mode = str(run.discovery_mode or '').strip()
-        require_strategy_factory_chain = discovery_mode.startswith('strategy_factory')
+        discovery_mode = str(run.discovery_mode or "").strip()
+        require_strategy_factory_chain = discovery_mode.startswith("strategy_factory")
         missing: list[str] = []
         use_autoresearch_continuity = (
             autoresearch_counts is not None

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -104,6 +104,71 @@ def _scorecard_universe_symbols(bundle: CandidateEvidenceBundle) -> list[str]:
     ]
 
 
+def _scorecard_primary_symbol(bundle: CandidateEvidenceBundle) -> str:
+    raw_symbol_shares = _scorecard(bundle).get("symbol_contribution_shares")
+    if isinstance(raw_symbol_shares, Mapping):
+        rows = cast(Mapping[Any, Any], raw_symbol_shares)
+        symbols = [
+            (_string(symbol).upper(), _decimal(share))
+            for symbol, share in rows.items()
+            if _string(symbol)
+        ]
+        if symbols:
+            symbols.sort(key=lambda item: (item[1], item[0]), reverse=True)
+            return symbols[0][0]
+    symbol = _string(_scorecard(bundle).get("symbol")).upper()
+    if symbol:
+        return symbol
+    universe_symbols = _scorecard_universe_symbols(bundle)
+    if universe_symbols:
+        return universe_symbols[0]
+    return "UNKNOWN"
+
+
+def _diversified_candidate_order(
+    candidates: Sequence[CandidateEvidenceBundle],
+) -> list[CandidateEvidenceBundle]:
+    """Interleave sleeves by primary symbol before the bounded beam search.
+
+    Autoresearch proposal scores can produce a long prefix of high raw-PnL sleeves
+    from a single symbol or concentration cluster. The optimizer's beam is bounded,
+    so that prefix can evict the empty/partial states before lower-scoring but
+    diversifying sleeves are ever considered. Interleaving preserves each symbol's
+    internal quality order while ensuring risk-diversifying sleeves enter the beam
+    early enough to prove (or disprove) an oracle-passing portfolio.
+    """
+
+    buckets: dict[str, list[CandidateEvidenceBundle]] = {}
+    for candidate in candidates:
+        buckets.setdefault(_scorecard_primary_symbol(candidate), []).append(candidate)
+    ordered_buckets = sorted(
+        buckets.values(),
+        key=lambda bucket: (
+            _sleeve_score(bucket[0]),
+            _net_per_day(bucket[0]),
+            bucket[0].candidate_id,
+        ),
+        reverse=True,
+    )
+    diversified: list[CandidateEvidenceBundle] = []
+    while ordered_buckets:
+        next_buckets: list[list[CandidateEvidenceBundle]] = []
+        for bucket in ordered_buckets:
+            diversified.append(bucket.pop(0))
+            if bucket:
+                next_buckets.append(bucket)
+        ordered_buckets = sorted(
+            next_buckets,
+            key=lambda bucket: (
+                _sleeve_score(bucket[0]),
+                _net_per_day(bucket[0]),
+                bucket[0].candidate_id,
+            ),
+            reverse=True,
+        )
+    return diversified
+
+
 def _scorecard_sleeve_runtime_limits(bundle: CandidateEvidenceBundle) -> dict[str, str]:
     limits: dict[str, str] = {}
     scorecard = _scorecard(bundle)
@@ -2123,10 +2188,16 @@ def optimize_portfolio_candidate(
         for bundle in evidence_bundles
         if _candidate_passes_minimums(bundle, oracle_policy=oracle_policy)
     ]
-    ordered = sorted(
-        eligible,
-        key=lambda item: (_sleeve_score(item), _net_per_day(item), item.candidate_id),
-        reverse=True,
+    ordered = _diversified_candidate_order(
+        sorted(
+            eligible,
+            key=lambda item: (
+                _sleeve_score(item),
+                _net_per_day(item),
+                item.candidate_id,
+            ),
+            reverse=True,
+        )
     )
     rejected: list[dict[str, Any]] = [
         *invalid_evidence_rejections,

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -96,6 +96,7 @@ _AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
     "promotion_ready",
     "ready_for_promotion",
     "ready_for_promotion_review",
+    "target_met",
     "accepted",
     "promoted",
 )

--- a/services/torghut/tests/test_autonomy_evidence.py
+++ b/services/torghut/tests/test_autonomy_evidence.py
@@ -428,7 +428,7 @@ class TestEvidenceContinuity(TestCase):
                     objective_scorecard_json=_passing_autoresearch_scorecard(),
                     optimizer_report_json={"selected_count": 1},
                     payload_json={"portfolio_candidate_id": "portfolio-ready"},
-                    status="promotion_ready",
+                    status="target_met",
                 )
             )
             session.commit()

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -2565,6 +2565,113 @@ class TestPortfolioOptimizer(TestCase):
         )
         self.assertGreater(portfolio.optimizer_report["finalist_state_count"], 1)
 
+    def test_optimizer_interleaves_large_concentrated_prefix_before_beam_prunes_diversifiers(
+        self,
+    ) -> None:
+        def bundle(
+            *,
+            candidate_id: str,
+            net_pnl_per_day: str,
+            symbol: str,
+            cluster: str,
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": net_pnl_per_day,
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "350000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": cluster,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": net_pnl_per_day,
+                            "2026-02-24": net_pnl_per_day,
+                            "2026-02-25": net_pnl_per_day,
+                            "2026-02-26": net_pnl_per_day,
+                            "2026-02-27": net_pnl_per_day,
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "350000",
+                            "2026-02-24": "350000",
+                            "2026-02-25": "350000",
+                            "2026-02-26": "350000",
+                            "2026-02-27": "350000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-concentrated-prefix",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        concentrated_prefix = [
+            bundle(
+                candidate_id=f"cand-nvda-prefix-{index:03d}",
+                net_pnl_per_day="1000",
+                symbol="NVDA",
+                cluster=f"nvda-prefix-{index:03d}",
+            )
+            for index in range(
+                portfolio_optimizer_module.PORTFOLIO_SEARCH_BEAM_WIDTH + 20
+            )
+        ]
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                *concentrated_prefix,
+                bundle(
+                    candidate_id="cand-ready-aapl",
+                    net_pnl_per_day="450",
+                    symbol="AAPL",
+                    cluster="ready-aapl",
+                ),
+                bundle(
+                    candidate_id="cand-ready-amzn",
+                    net_pnl_per_day="450",
+                    symbol="AMZN",
+                    cluster="ready-amzn",
+                ),
+                bundle(
+                    candidate_id="cand-ready-googl",
+                    net_pnl_per_day="450",
+                    symbol="GOOGL",
+                    cluster="ready-googl",
+                ),
+            ],
+            target_net_pnl_per_day=Decimal("300"),
+            oracle_policy=ProfitTargetOraclePolicy(min_observed_trading_days=5),
+            portfolio_size_min=3,
+            portfolio_size_max=3,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertCountEqual(
+            portfolio.source_candidate_ids,
+            ("cand-ready-aapl", "cand-ready-amzn", "cand-ready-googl"),
+        )
+        self.assertTrue(portfolio.objective_scorecard["target_met"])
+        self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
+        self.assertLessEqual(
+            Decimal(
+                portfolio.objective_scorecard["max_single_symbol_contribution_share"]
+            ),
+            Decimal("0.35"),
+        )
+
     def test_optimizer_prefers_nearest_promotion_candidate_over_raw_target_met(
         self,
     ) -> None:

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -3549,7 +3549,7 @@ class TestSubmissionCouncil(TestCase):
                     },
                     optimizer_report_json={"method": "current_optimizer"},
                     payload_json={"portfolio_candidate_id": "portfolio-current-ready"},
-                    status="promotion_ready",
+                    status="target_met",
                 )
             )
             session.add(
@@ -3838,7 +3838,7 @@ class TestSubmissionCouncil(TestCase):
                         payload_json={
                             "portfolio_candidate_id": "portfolio-current-ready"
                         },
-                        status="promotion_ready",
+                        status="target_met",
                     ),
                 ]
             )


### PR DESCRIPTION
## Summary

- Interleaves autoresearch portfolio optimizer inputs by primary symbol before the bounded beam search so large concentrated high-PnL prefixes cannot prune lower-scoring diversifiers that satisfy oracle risk constraints.
- Treats `target_met` autoresearch portfolio rows as portfolio-ready only after the current profit target oracle rejudges them as passing, preserving runtime/risk proof gates.
- Adds regression coverage for target-met versus oracle-passed behavior, concentration-safe beam search, and ready portfolio ledger materialization.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py::TestPortfolioOptimizer::test_optimizer_interleaves_large_concentrated_prefix_before_beam_prunes_diversifiers tests/test_portfolio_optimizer.py::TestPortfolioOptimizer::test_optimizer_searches_past_concentrated_greedy_sleeve tests/test_autonomy_evidence.py::TestEvidenceContinuity::test_current_oracle_ready_autoresearch_portfolio_passes_without_legacy_rows tests/test_submission_council.py::TestSubmissionCouncil::test_load_profit_promotion_counts_rejudges_ready_autoresearch_portfolios -q`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py -q`
- `uv run --frozen pytest tests/test_autonomy_evidence.py tests/test_submission_council.py tests/test_profit_leases.py -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "portfolio_candidate or ready or profit_target" -q`
- `uv run --frozen ruff format --check app/trading/discovery/portfolio_optimizer.py app/trading/autonomy/evidence.py app/trading/submission_council.py tests/test_portfolio_optimizer.py tests/test_autonomy_evidence.py tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py app/trading/autonomy/evidence.py app/trading/submission_council.py tests/test_portfolio_optimizer.py tests/test_autonomy_evidence.py tests/test_submission_council.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
