### PR TITLE
fix(torghut): require runtime proof row refs

### DIFF
--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -101,7 +101,7 @@ def _positive_mapping_value_count(value: object) -> int:
 
 def _source_ref_present(value: object) -> bool:
     if isinstance(value, Mapping):
-        return len(cast(Mapping[object, object], value)) > 0
+        return _source_ref_count({"refs": cast(object, value)}, "refs") > 0
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return bool(_string_list(cast(Sequence[object], value)))
     return bool(_string_list(value) or _text(value) is not None)
@@ -117,8 +117,10 @@ def _source_ref_count(bucket: Mapping[str, object], *keys: str) -> int:
         value = bucket.get(key)
         if isinstance(value, Mapping):
             for ref_key, ref_value in cast(Mapping[object, object], value).items():
+                if ref_value is None or ref_value is False:
+                    continue
                 ref_text = _text(ref_value)
-                if ref_text is None or ref_text in {"True", "False"}:
+                if ref_value is True or ref_text is None:
                     ref_text = _text(ref_key)
                 if ref_text is not None:
                     refs.add(ref_text)
@@ -190,7 +192,9 @@ def _source_offset_count(bucket: Mapping[str, object]) -> int:
 
     source_offsets = bucket.get("source_offsets")
     if isinstance(source_offsets, Mapping):
-        return int(has_source_offset_triplet(cast(Mapping[object, object], source_offsets)))
+        return int(
+            has_source_offset_triplet(cast(Mapping[object, object], source_offsets))
+        )
     if isinstance(source_offsets, Sequence) and not isinstance(
         source_offsets, (str, bytes, bytearray)
     ):

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -934,14 +934,34 @@ def _runtime_import_target_surface_blockers(
     blockers = _text_list(target.get("materialization_blockers"))
     if _int(target.get("metric_window_count")) <= 0:
         blockers.append("runtime_window_import_metric_window_missing")
+    elif not _text_list(target.get("metric_window_ids")):
+        blockers.append("runtime_window_import_metric_window_refs_missing")
     if _int(target.get("promotion_decision_count")) <= 0:
         blockers.append("runtime_window_import_promotion_decision_missing")
+    elif not _text(target.get("promotion_decision_id")):
+        blockers.append("runtime_window_import_promotion_decision_ref_missing")
     if profit_proof_count > 0:
-        if _int(target.get("runtime_ledger_bucket_count")) <= 0:
+        runtime_ledger_bucket_count = _int(target.get("runtime_ledger_bucket_count"))
+        evidence_grade_runtime_ledger_bucket_count = _int(
+            target.get("evidence_grade_runtime_ledger_bucket_count")
+        )
+        if runtime_ledger_bucket_count <= 0:
             blockers.append("runtime_window_import_runtime_ledger_bucket_missing")
-        if _int(target.get("evidence_grade_runtime_ledger_bucket_count")) <= 0:
+        elif (
+            len(_text_list(target.get("runtime_ledger_bucket_ids")))
+            < runtime_ledger_bucket_count
+        ):
+            blockers.append("runtime_window_import_runtime_ledger_bucket_refs_missing")
+        if evidence_grade_runtime_ledger_bucket_count <= 0:
             blockers.append(
                 "runtime_window_import_evidence_grade_runtime_ledger_bucket_missing"
+            )
+        elif (
+            len(_text_list(target.get("evidence_grade_runtime_ledger_bucket_ids")))
+            < evidence_grade_runtime_ledger_bucket_count
+        ):
+            blockers.append(
+                "runtime_window_import_evidence_grade_runtime_ledger_bucket_refs_missing"
             )
     if target.get("materialized") is False:
         blockers.extend(

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -40,10 +40,15 @@ class _FakeObjectStoreClient:
         }
 
 
+_DEFAULT_TIGERBEETLE_LEDGER = object()
+
+
 def _status(
     *,
     blockers: list[str] | None = None,
-    tigerbeetle_ledger: dict[str, object] | None = None,
+    tigerbeetle_ledger: dict[str, object] | None | object = (
+        _DEFAULT_TIGERBEETLE_LEDGER
+    ),
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "mode": "paper",
@@ -57,7 +62,9 @@ def _status(
             "blocking_reasons": [],
         },
     }
-    if tigerbeetle_ledger is not None:
+    if tigerbeetle_ledger is _DEFAULT_TIGERBEETLE_LEDGER:
+        payload["tigerbeetle_ledger"] = _tigerbeetle_ledger_status()
+    elif tigerbeetle_ledger is not None:
         payload["tigerbeetle_ledger"] = tigerbeetle_ledger
     return payload
 
@@ -2065,6 +2072,53 @@ class TestRuntimeLedgerProofPacket(TestCase):
             target_blockers,
         )
         self.assertIn("source_runtime_ledger_missing", target_blockers)
+
+    def test_packet_blocks_count_only_runtime_import_materialization(self) -> None:
+        runtime_import = _runtime_import()
+        first_import = runtime_import["imports"][0]
+        assert isinstance(first_import, dict)
+        first_summary = first_import["summary"]
+        assert isinstance(first_summary, dict)
+        target = first_summary["runtime_materialization_target"]
+        assert isinstance(target, dict)
+        target["metric_window_ids"] = []
+        target["promotion_decision_id"] = None
+        target["runtime_ledger_bucket_ids"] = []
+        target["evidence_grade_runtime_ledger_bucket_ids"] = []
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        target_blockers = materialization["unmaterialized_targets"][0]["blockers"]
+        self.assertIn(
+            "runtime_window_import_metric_window_refs_missing", target_blockers
+        )
+        self.assertIn(
+            "runtime_window_import_promotion_decision_ref_missing",
+            target_blockers,
+        )
+        self.assertIn(
+            "runtime_window_import_runtime_ledger_bucket_refs_missing",
+            target_blockers,
+        )
+        self.assertIn(
+            "runtime_window_import_evidence_grade_runtime_ledger_bucket_refs_missing",
+            target_blockers,
+        )
+        self.assertIn(
+            "runtime_window_import_runtime_ledger_bucket_refs_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
 
     def test_packet_waits_on_target_level_settlement_blocker(self) -> None:
         paper = _paper_route_evidence()

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -188,6 +188,42 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
 
         self.assertEqual(blockers, [])
 
+    def test_promotion_source_authority_rejects_false_mapping_refs(
+        self,
+    ) -> None:
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 1,
+                    "executions": 1,
+                    "execution_order_events": 1,
+                    "order_feed_source_windows": 1,
+                },
+                "trade_decision_ids": {"decision-1": False},
+                "execution_ids": {"execution-1": False},
+                "execution_order_event_ids": {"event-1": False},
+                "source_window_ids": {"source-window-1": False},
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+            }
+        )
+
+        self.assertIn("runtime_ledger_trade_decision_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_order_event_refs_missing", blockers)
+        self.assertIn("runtime_ledger_source_window_ids_missing", blockers)
+
     def test_promotion_source_authority_rejects_duplicate_refs_and_offsets(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Require mapping-style runtime-ledger source refs to be truthy before they count toward promotion-grade source authority.
- Block runtime-window proof packets when materialization declares row counts without persisted metric-window, promotion-decision, runtime-ledger, and evidence-grade bucket refs.
- Refresh proof-packet tests so authority-mode happy paths include reconciled signed TigerBeetle runtime-ledger status, while broken TigerBeetle coverage stays explicit.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_source_authority.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_completion_trace.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_source_authority.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_ledger_source_authority.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger_source_authority.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_ledger_source_authority.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
