### PR TITLE
test(torghut): seed proof packet TigerBeetle fixtures

### DIFF
--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -57,8 +57,11 @@ def _status(
             "blocking_reasons": [],
         },
     }
-    if tigerbeetle_ledger is not None:
-        payload["tigerbeetle_ledger"] = tigerbeetle_ledger
+    payload["tigerbeetle_ledger"] = (
+        tigerbeetle_ledger
+        if tigerbeetle_ledger is not None
+        else _tigerbeetle_ledger_status()
+    )
     return payload
 
 


### PR DESCRIPTION
## Summary

- Seeds the runtime-ledger proof packet test status fixture with reconciled TigerBeetle ledger status by default.
- Keeps the explicit unsigned-ref blocker test override intact, so authority packets still fail without signed refs.
- Restores CI coverage for authority-mode proof packets after the stricter TigerBeetle runtime-ledger ref gate landed on main.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_order_feed.py -q`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py::TestImportHypothesisRuntimeWindows::test_source_authority_order_event_lifecycle_uses_fill_delta tests/test_order_feed.py::TestOrderFeed::test_fill_delta_fields_rejects_non_increasing_cumulative_fill -q`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
