### PR TITLE
test(torghut): include tigerbeetle proof refs in packet fixtures

### DIFF
--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -57,8 +57,11 @@ def _status(
             "blocking_reasons": [],
         },
     }
-    if tigerbeetle_ledger is not None:
-        payload["tigerbeetle_ledger"] = tigerbeetle_ledger
+    payload["tigerbeetle_ledger"] = (
+        tigerbeetle_ledger
+        if tigerbeetle_ledger is not None
+        else _tigerbeetle_ledger_status()
+    )
     return payload
 
 


### PR DESCRIPTION
## Summary

- Updated the runtime proof packet test status fixture to include healthy TigerBeetle ledger reconciliation by default.
- Kept explicit override support so tests can still exercise missing or unsigned TigerBeetle ref blockers.
- Restores alignment with the production authority gate that requires reconciled signed runtime-ledger refs when proof materialization claims TigerBeetle refs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen ruff format --check tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen ruff check tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
