### PR TITLE
fix(agents): clean up orphan runtime pods

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -120,6 +120,10 @@ controller:
   agentRunRetentionSeconds: 604800
   jobTtlSeconds: 86400
   jobTtlSecondsAfterFinished: 86400
+  runtimeDebrisCleanup:
+    mode: delete
+    orphanPodRetentionSeconds: 86400
+    maxDeletesPerNamespace: 25
   logRetentionSeconds: 604800
   authSecret:
     name: codex-auth

--- a/charts/agents/templates/deployment-controllers.yaml
+++ b/charts/agents/templates/deployment-controllers.yaml
@@ -323,6 +323,13 @@ spec:
               value: {{ .Values.controller.rate.cluster | default 600 | quote }}
             - name: AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
               value: {{ .Values.controller.agentRunRetentionSeconds | default 2592000 | quote }}
+            {{- $runtimeDebrisCleanup := .Values.controller.runtimeDebrisCleanup | default dict }}
+            - name: AGENTS_CONTROLLER_RUNTIME_DEBRIS_CLEANUP_MODE
+              value: {{ $runtimeDebrisCleanup.mode | default "disabled" | quote }}
+            - name: AGENTS_CONTROLLER_ORPHAN_POD_RETENTION_SECONDS
+              value: {{ $runtimeDebrisCleanup.orphanPodRetentionSeconds | default 86400 | quote }}
+            - name: AGENTS_CONTROLLER_RUNTIME_DEBRIS_MAX_DELETES_PER_NAMESPACE
+              value: {{ $runtimeDebrisCleanup.maxDeletesPerNamespace | default 25 | quote }}
             {{- if and .Values.controller.admissionPolicy.labels.required (gt (len .Values.controller.admissionPolicy.labels.required) 0) }}
             - name: AGENTS_CONTROLLER_LABELS_REQUIRED
               value: {{ .Values.controller.admissionPolicy.labels.required | toJson | quote }}

--- a/charts/agents/templates/rbac.yaml
+++ b/charts/agents/templates/rbac.yaml
@@ -293,6 +293,13 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups: [""]
+    resources:
       - pods/log
     verbs:
       - get

--- a/charts/agents/values.schema.json
+++ b/charts/agents/values.schema.json
@@ -835,6 +835,15 @@
         "logRetentionSeconds": { "type": "integer", "minimum": 0 },
         "jobTtlSeconds": { "type": "integer", "minimum": 0 },
         "jobTtlSecondsAfterFinished": { "type": "integer", "minimum": 0 },
+        "runtimeDebrisCleanup": {
+          "type": "object",
+          "properties": {
+            "mode": { "type": "string", "enum": ["disabled", "audit", "delete"] },
+            "orphanPodRetentionSeconds": { "type": "integer", "minimum": 0 },
+            "maxDeletesPerNamespace": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": false
+        },
         "authSecret": {
           "type": "object",
           "properties": {

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -316,6 +316,10 @@ controller:
   logRetentionSeconds: 604800
   jobTtlSeconds: 600
   jobTtlSecondsAfterFinished: 600
+  runtimeDebrisCleanup:
+    mode: disabled
+    orphanPodRetentionSeconds: 86400
+    maxDeletesPerNamespace: 25
   authSecret:
     name: ''
     key: auth.json

--- a/services/agents/src/server/agents-controller/index.integration.test.ts
+++ b/services/agents/src/server/agents-controller/index.integration.test.ts
@@ -8,6 +8,9 @@ const metricsMocks = vi.hoisted(() => ({
   recordAgentRunResyncAdoptions: vi.fn(),
   recordAgentRunUntouchedBacklog: vi.fn(),
   recordAgentRunUntouchedOldestAgeSeconds: vi.fn(),
+  recordRuntimeDebrisDeletedPods: vi.fn(),
+  recordRuntimeDebrisDeleteErrors: vi.fn(),
+  recordRuntimeDebrisOrphanPods: vi.fn(),
   recordAgentConcurrency: vi.fn(),
   recordAgentQueueDepth: vi.fn(),
   recordAgentRateLimitRejection: vi.fn(),
@@ -389,6 +392,55 @@ describe('agents controller startup', () => {
     expect(kube.patch).not.toHaveBeenCalled()
     expect(kube.applyStatus).not.toHaveBeenCalled()
     expect(__test.getRuntimeMutableState().agentRunIngestionState.get('agents')?.untouchedRunCount).toBe(0)
+  })
+
+  it('cleans stale terminal runtime Pods during controller resync', async () => {
+    stopAgentsController()
+    const previousMode = process.env.AGENTS_CONTROLLER_RUNTIME_DEBRIS_CLEANUP_MODE
+    const previousRetention = process.env.AGENTS_CONTROLLER_ORPHAN_POD_RETENTION_SECONDS
+    const previousMaxDeletes = process.env.AGENTS_CONTROLLER_RUNTIME_DEBRIS_MAX_DELETES_PER_NAMESPACE
+    process.env.AGENTS_CONTROLLER_RUNTIME_DEBRIS_CLEANUP_MODE = 'delete'
+    process.env.AGENTS_CONTROLLER_ORPHAN_POD_RETENTION_SECONDS = '1'
+    process.env.AGENTS_CONTROLLER_RUNTIME_DEBRIS_MAX_DELETES_PER_NAMESPACE = '10'
+
+    try {
+      const state = { namespaces: new Map() }
+      const deleteMock = vi.fn(async () => ({}))
+      const kube = buildKube({
+        delete: deleteMock,
+        list: vi.fn(async (resource: string) => {
+          if (resource === RESOURCE_MAP.AgentRun) return { items: [] }
+          if (resource === 'pods') {
+            return {
+              items: [
+                {
+                  metadata: {
+                    name: 'run-1-step-1-attempt-1-abcd',
+                    creationTimestamp: '2026-01-20T00:00:00.000Z',
+                    labels: { 'agents.proompteng.ai/agent-run': 'run-1' },
+                  },
+                  status: { phase: 'Succeeded' },
+                },
+              ],
+            }
+          }
+          if (resource === 'jobs') return { items: [] }
+          return { items: [] }
+        }),
+      })
+
+      await __test.resyncAgentRunsForNamespace(kube as never, 'agents', state as never, defaultConcurrency, 'manual')
+
+      expect(deleteMock).toHaveBeenCalledWith('pod', 'run-1-step-1-attempt-1-abcd', 'agents', { wait: false })
+    } finally {
+      if (previousMode === undefined) delete process.env.AGENTS_CONTROLLER_RUNTIME_DEBRIS_CLEANUP_MODE
+      else process.env.AGENTS_CONTROLLER_RUNTIME_DEBRIS_CLEANUP_MODE = previousMode
+      if (previousRetention === undefined) delete process.env.AGENTS_CONTROLLER_ORPHAN_POD_RETENTION_SECONDS
+      else process.env.AGENTS_CONTROLLER_ORPHAN_POD_RETENTION_SECONDS = previousRetention
+      if (previousMaxDeletes === undefined)
+        delete process.env.AGENTS_CONTROLLER_RUNTIME_DEBRIS_MAX_DELETES_PER_NAMESPACE
+      else process.env.AGENTS_CONTROLLER_RUNTIME_DEBRIS_MAX_DELETES_PER_NAMESPACE = previousMaxDeletes
+    }
   })
 
   it('adopts missed AgentRuns on watch restart resync', async () => {

--- a/services/agents/src/server/agents-controller/index.ts
+++ b/services/agents/src/server/agents-controller/index.ts
@@ -61,7 +61,12 @@ import {
 import { buildInFlightCounts } from './queue-state'
 import { resetControllerRateState as resetControllerRateStateMaps } from './rate-limits'
 import { createResourceReconcilers } from './resource-reconcilers'
-import { resolveAgentRunnerDefaultsConfig, resolveAgentsControllerBehaviorConfig } from './runtime-config'
+import {
+  resolveAgentRunnerDefaultsConfig,
+  resolveAgentsControllerBehaviorConfig,
+  resolveRuntimeDebrisCleanupConfig,
+} from './runtime-config'
+import { reconcileRuntimeDebris } from './runtime-debris'
 import { resolveParam, resolveParameters } from './run-utils'
 import { createTemporalRuntimeTools } from './temporal-runtime'
 import { resolveVcsAuthMethod, validateVcsAuthConfig } from './vcs-auth'
@@ -742,6 +747,23 @@ const resyncAgentRunsForNamespace = async (
 
   if (candidateRuns.length > 0) {
     recordAgentRunResyncAdoptions(candidateRuns.length, { namespace, reason })
+  }
+
+  const runtimeDebrisConfig = resolveRuntimeDebrisCleanupConfig()
+  if (runtimeDebrisConfig.mode !== 'disabled') {
+    try {
+      await reconcileRuntimeDebris({
+        config: runtimeDebrisConfig,
+        kube,
+        namespace,
+      })
+    } catch (error) {
+      logAgentsControllerWarn('runtime_debris_reconcile_failed', {
+        namespace,
+        reason,
+        ...toLogError(error),
+      })
+    }
   }
 
   const resyncSummarySignature = [

--- a/services/agents/src/server/agents-controller/runtime-config.test.ts
+++ b/services/agents/src/server/agents-controller/runtime-config.test.ts
@@ -4,6 +4,7 @@ import {
   resolveAgentRunnerDefaultsConfig,
   resolveAgentsControllerAuthSecretConfig,
   resolveAgentsControllerBehaviorConfig,
+  resolveRuntimeDebrisCleanupConfig,
   resolveImplementationSourceWebhookConfig,
 } from './runtime-config'
 
@@ -53,6 +54,26 @@ describe('Agents controller runtime config', () => {
       retryBaseDelaySeconds: null,
       retryMaxDelaySeconds: null,
       retryMaxAttempts: null,
+    })
+  })
+
+  it('reads runtime debris cleanup env with safe defaults', () => {
+    expect(resolveRuntimeDebrisCleanupConfig({})).toEqual({
+      maxDeletesPerNamespace: 25,
+      mode: 'disabled',
+      orphanPodRetentionSeconds: 86400,
+    })
+
+    expect(
+      resolveRuntimeDebrisCleanupConfig({
+        AGENTS_CONTROLLER_RUNTIME_DEBRIS_CLEANUP_MODE: 'delete',
+        AGENTS_CONTROLLER_ORPHAN_POD_RETENTION_SECONDS: '3600',
+        AGENTS_CONTROLLER_RUNTIME_DEBRIS_MAX_DELETES_PER_NAMESPACE: '7',
+      }),
+    ).toEqual({
+      maxDeletesPerNamespace: 7,
+      mode: 'delete',
+      orphanPodRetentionSeconds: 3600,
     })
   })
 })

--- a/services/agents/src/server/agents-controller/runtime-config.ts
+++ b/services/agents/src/server/agents-controller/runtime-config.ts
@@ -9,6 +9,8 @@ const DEFAULT_AGENTRUN_UNTOUCHED_WARN_AFTER_SECONDS = 120
 const DEFAULT_AGENTRUN_IDEMPOTENCY_RETENTION_DAYS = 30
 const DEFAULT_RUNNER_JOB_TTL_SECONDS = 600
 const DEFAULT_RUNNER_LOG_RETENTION_SECONDS = 7 * 24 * 60 * 60
+const DEFAULT_RUNTIME_DEBRIS_ORPHAN_POD_RETENTION_SECONDS = 24 * 60 * 60
+const DEFAULT_RUNTIME_DEBRIS_MAX_DELETES_PER_NAMESPACE = 25
 
 const normalizeNonEmpty = (value: string | undefined | null) => {
   const normalized = value?.trim()
@@ -29,6 +31,12 @@ const parsePositiveInt = (value: string | undefined, fallback: number) => {
   const parsed = Number.parseInt(normalized, 10)
   if (!Number.isFinite(parsed) || parsed < 0) return fallback
   return Math.floor(parsed)
+}
+
+const parseCleanupMode = (value: string | undefined): RuntimeDebrisCleanupMode => {
+  const normalized = normalizeNonEmpty(value)?.toLowerCase()
+  if (normalized === 'audit' || normalized === 'delete') return normalized
+  return 'disabled'
 }
 
 const parseJson = (value: string | undefined) => {
@@ -57,6 +65,14 @@ export type AgentsControllerBehaviorConfig = {
   agentRunRetentionSeconds: number | null
   artifactsMaxEntries: number
   artifactsStrict: boolean
+}
+
+export type RuntimeDebrisCleanupMode = 'disabled' | 'audit' | 'delete'
+
+export type RuntimeDebrisCleanupConfig = {
+  maxDeletesPerNamespace: number
+  mode: RuntimeDebrisCleanupMode
+  orphanPodRetentionSeconds: number
 }
 
 export type AgentsControllerAuthSecretConfig = {
@@ -144,6 +160,24 @@ export const resolveAgentsControllerAuthSecretConfig = (
       DEFAULT_AUTH_SECRET_MOUNT_PATH,
   }
 }
+
+export const resolveRuntimeDebrisCleanupConfig = (env: EnvSource = process.env): RuntimeDebrisCleanupConfig => ({
+  maxDeletesPerNamespace: Math.max(
+    0,
+    parsePositiveInt(
+      readAgentsEnv(env, 'AGENTS_CONTROLLER_RUNTIME_DEBRIS_MAX_DELETES_PER_NAMESPACE'),
+      DEFAULT_RUNTIME_DEBRIS_MAX_DELETES_PER_NAMESPACE,
+    ),
+  ),
+  mode: parseCleanupMode(readAgentsEnv(env, 'AGENTS_CONTROLLER_RUNTIME_DEBRIS_CLEANUP_MODE')),
+  orphanPodRetentionSeconds: Math.max(
+    0,
+    parsePositiveInt(
+      readAgentsEnv(env, 'AGENTS_CONTROLLER_ORPHAN_POD_RETENTION_SECONDS'),
+      DEFAULT_RUNTIME_DEBRIS_ORPHAN_POD_RETENTION_SECONDS,
+    ),
+  ),
+})
 
 export const resolveAgentRunnerDefaultsConfig = (env: EnvSource = process.env): AgentRunnerDefaultsConfig => {
   const nodeSelector = asRecord(parseJson(readAgentsEnv(env, 'AGENTS_AGENT_RUNNER_NODE_SELECTOR')))

--- a/services/agents/src/server/agents-controller/runtime-debris.test.ts
+++ b/services/agents/src/server/agents-controller/runtime-debris.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { reconcileRuntimeDebris } from './runtime-debris'
+
+const staleCreatedAt = '2026-05-31T00:00:00.000Z'
+const freshCreatedAt = '2026-05-31T23:45:00.000Z'
+const nowMs = Date.parse('2026-06-01T00:00:00.000Z')
+
+const buildPod = (
+  name: string,
+  overrides: {
+    createdAt?: string
+    deletionTimestamp?: string
+    labels?: Record<string, string>
+    ownerReferences?: Array<Record<string, unknown>>
+    phase?: string
+  } = {},
+) => ({
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: {
+    name,
+    namespace: 'agents',
+    creationTimestamp: overrides.createdAt ?? staleCreatedAt,
+    ...(overrides.deletionTimestamp ? { deletionTimestamp: overrides.deletionTimestamp } : {}),
+    labels: {
+      'agents.proompteng.ai/agent-run': 'run-1',
+      ...overrides.labels,
+    },
+    ...(overrides.ownerReferences ? { ownerReferences: overrides.ownerReferences } : {}),
+  },
+  status: {
+    phase: overrides.phase ?? 'Succeeded',
+  },
+})
+
+const buildJob = (name: string) => ({
+  apiVersion: 'batch/v1',
+  kind: 'Job',
+  metadata: {
+    name,
+    namespace: 'agents',
+    labels: {
+      'agents.proompteng.ai/agent-run': 'run-1',
+    },
+  },
+})
+
+const buildKube = (pods: Record<string, unknown>[], jobs: Record<string, unknown>[] = []) => ({
+  list: vi.fn(async (resource: string) => {
+    if (resource === 'pods') return { items: pods }
+    if (resource === 'jobs') return { items: jobs }
+    return { items: [] }
+  }),
+  delete: vi.fn(async () => ({})),
+})
+
+describe('runtime debris cleanup', () => {
+  it('audits stale terminal orphan Pods without deleting them', async () => {
+    const kube = buildKube([buildPod('orphan-old')])
+
+    const summary = await reconcileRuntimeDebris({
+      config: {
+        maxDeletesPerNamespace: 25,
+        mode: 'audit',
+        orphanPodRetentionSeconds: 3600,
+      },
+      kube: kube as never,
+      namespace: 'agents',
+      nowMs,
+    })
+
+    expect(kube.delete).not.toHaveBeenCalled()
+    expect(summary).toMatchObject({
+      deletedPods: 0,
+      mode: 'audit',
+      orphanTerminalPods: 1,
+      scannedPods: 1,
+    })
+  })
+
+  it('deletes only stale terminal Pods without a valid Job owner', async () => {
+    const pods = [
+      buildPod('orphan-old'),
+      buildPod('fresh-terminal', { createdAt: freshCreatedAt }),
+      buildPod('running-orphan', { phase: 'Running' }),
+      buildPod('terminating-orphan', { deletionTimestamp: '2026-05-31T23:59:00.000Z' }),
+      buildPod('owned-by-existing-job', {
+        ownerReferences: [{ apiVersion: 'batch/v1', kind: 'Job', name: 'job-owned', uid: 'job-owned-uid' }],
+      }),
+      buildPod('owned-by-missing-job', {
+        ownerReferences: [{ apiVersion: 'batch/v1', kind: 'Job', name: 'job-missing', uid: 'job-missing-uid' }],
+      }),
+    ]
+    const kube = buildKube(pods, [buildJob('job-owned')])
+
+    const summary = await reconcileRuntimeDebris({
+      config: {
+        maxDeletesPerNamespace: 25,
+        mode: 'delete',
+        orphanPodRetentionSeconds: 3600,
+      },
+      kube: kube as never,
+      namespace: 'agents',
+      nowMs,
+    })
+
+    expect(kube.delete).toHaveBeenCalledTimes(2)
+    expect(kube.delete).toHaveBeenNthCalledWith(1, 'pod', 'orphan-old', 'agents', { wait: false })
+    expect(kube.delete).toHaveBeenNthCalledWith(2, 'pod', 'owned-by-missing-job', 'agents', { wait: false })
+    expect(summary).toMatchObject({
+      deletedPods: 2,
+      mode: 'delete',
+      orphanTerminalPods: 2,
+      scannedPods: 6,
+    })
+  })
+
+  it('rate limits deletes per namespace while reporting all candidates', async () => {
+    const kube = buildKube([buildPod('orphan-1'), buildPod('orphan-2'), buildPod('orphan-3')])
+
+    const summary = await reconcileRuntimeDebris({
+      config: {
+        maxDeletesPerNamespace: 2,
+        mode: 'delete',
+        orphanPodRetentionSeconds: 3600,
+      },
+      kube: kube as never,
+      namespace: 'agents',
+      nowMs,
+    })
+
+    expect(kube.delete).toHaveBeenCalledTimes(2)
+    expect(kube.delete).toHaveBeenNthCalledWith(1, 'pod', 'orphan-1', 'agents', { wait: false })
+    expect(kube.delete).toHaveBeenNthCalledWith(2, 'pod', 'orphan-2', 'agents', { wait: false })
+    expect(summary).toMatchObject({
+      deletedPods: 2,
+      orphanTerminalPods: 3,
+      rateLimitedPods: 1,
+    })
+  })
+})

--- a/services/agents/src/server/agents-controller/runtime-debris.ts
+++ b/services/agents/src/server/agents-controller/runtime-debris.ts
@@ -1,0 +1,157 @@
+import { asRecord, asString, readNested } from '../primitives'
+import type { createKubernetesClient } from '../kube-types'
+import {
+  recordRuntimeDebrisDeletedPods,
+  recordRuntimeDebrisDeleteErrors,
+  recordRuntimeDebrisOrphanPods,
+} from '../metrics'
+
+import { logAgentsControllerInfo } from './operational-logging'
+import type { RuntimeDebrisCleanupConfig, RuntimeDebrisCleanupMode } from './runtime-config'
+import { resolveRuntimeDebrisCleanupConfig } from './runtime-config'
+
+const AGENT_RUN_LABEL = 'agents.proompteng.ai/agent-run'
+const RUNTIME_LABEL_SELECTOR = AGENT_RUN_LABEL
+const TERMINAL_POD_PHASES = new Set(['Succeeded', 'Failed'])
+
+type KubeClient = ReturnType<typeof createKubernetesClient>
+
+type RuntimeDebrisCandidate = {
+  name: string
+  reason: 'missing_job_owner' | 'no_owner_reference'
+}
+
+export type RuntimeDebrisCleanupSummary = {
+  deletedPods: number
+  deleteErrors: number
+  mode: RuntimeDebrisCleanupMode
+  namespace: string
+  orphanTerminalPods: number
+  rateLimitedPods: number
+  scannedPods: number
+}
+
+const listItems = (payload: Record<string, unknown>) => (Array.isArray(payload.items) ? payload.items : [])
+
+const getMetadata = (resource: unknown) => asRecord(readNested(resource, ['metadata'])) ?? {}
+
+const getPodName = (pod: unknown) => asString(readNested(pod, ['metadata', 'name']))?.trim() ?? null
+
+const getPodPhase = (pod: unknown) => asString(readNested(pod, ['status', 'phase']))?.trim() ?? null
+
+const getCreationTimestampMs = (pod: unknown) => {
+  const raw = asString(readNested(pod, ['metadata', 'creationTimestamp']))
+  if (!raw) return null
+  const parsed = Date.parse(raw)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+const getOwnerReferences = (pod: unknown) => {
+  const ownerReferences = getMetadata(pod).ownerReferences
+  return Array.isArray(ownerReferences) ? ownerReferences.map((entry) => asRecord(entry)).filter(Boolean) : []
+}
+
+const isDeleting = (pod: unknown) => Boolean(asString(readNested(pod, ['metadata', 'deletionTimestamp'])))
+
+const getExistingJobNames = (jobs: unknown[]) =>
+  new Set(
+    jobs
+      .map((job) => asString(readNested(job, ['metadata', 'name']))?.trim())
+      .filter((name): name is string => Boolean(name)),
+  )
+
+const isStaleEnough = (pod: unknown, nowMs: number, retentionSeconds: number) => {
+  const createdAtMs = getCreationTimestampMs(pod)
+  if (createdAtMs === null) return false
+  return nowMs - createdAtMs >= retentionSeconds * 1000
+}
+
+const selectRuntimeDebrisCandidate = (
+  pod: unknown,
+  existingJobNames: Set<string>,
+  nowMs: number,
+  retentionSeconds: number,
+): RuntimeDebrisCandidate | null => {
+  const name = getPodName(pod)
+  if (!name) return null
+  if (isDeleting(pod)) return null
+  if (!TERMINAL_POD_PHASES.has(getPodPhase(pod) ?? '')) return null
+  if (!isStaleEnough(pod, nowMs, retentionSeconds)) return null
+
+  const ownerReferences = getOwnerReferences(pod)
+  if (ownerReferences.length === 0) return { name, reason: 'no_owner_reference' }
+
+  const jobOwners = ownerReferences.filter((owner) => asString(owner?.kind) === 'Job')
+  if (jobOwners.some((owner) => existingJobNames.has(asString(owner?.name) ?? ''))) return null
+  if (jobOwners.length > 0) return { name, reason: 'missing_job_owner' }
+
+  return null
+}
+
+const recordRuntimeDebrisSummary = (summary: RuntimeDebrisCleanupSummary) => {
+  const metricAttributes = { mode: summary.mode, namespace: summary.namespace }
+  recordRuntimeDebrisOrphanPods(summary.orphanTerminalPods, metricAttributes)
+  recordRuntimeDebrisDeletedPods(summary.deletedPods, metricAttributes)
+  recordRuntimeDebrisDeleteErrors(summary.deleteErrors, metricAttributes)
+
+  if (summary.orphanTerminalPods > 0 || summary.deletedPods > 0 || summary.deleteErrors > 0) {
+    logAgentsControllerInfo('runtime_debris_reconcile_completed', {
+      ...summary,
+    })
+  }
+}
+
+export const reconcileRuntimeDebris = async (input: {
+  config?: RuntimeDebrisCleanupConfig
+  kube: Pick<KubeClient, 'delete' | 'list'>
+  namespace: string
+  nowMs?: number
+}): Promise<RuntimeDebrisCleanupSummary> => {
+  const config = input.config ?? resolveRuntimeDebrisCleanupConfig()
+  const summary: RuntimeDebrisCleanupSummary = {
+    deletedPods: 0,
+    deleteErrors: 0,
+    mode: config.mode,
+    namespace: input.namespace,
+    orphanTerminalPods: 0,
+    rateLimitedPods: 0,
+    scannedPods: 0,
+  }
+
+  if (config.mode === 'disabled') return summary
+
+  const [podList, jobList] = await Promise.all([
+    input.kube.list('pods', input.namespace, RUNTIME_LABEL_SELECTOR),
+    input.kube.list('jobs', input.namespace, RUNTIME_LABEL_SELECTOR),
+  ])
+  const pods = listItems(podList)
+  const existingJobNames = getExistingJobNames(listItems(jobList))
+  const nowMs = input.nowMs ?? Date.now()
+
+  summary.scannedPods = pods.length
+  const candidates = pods
+    .map((pod) => selectRuntimeDebrisCandidate(pod, existingJobNames, nowMs, config.orphanPodRetentionSeconds))
+    .filter((candidate): candidate is RuntimeDebrisCandidate => candidate !== null)
+
+  summary.orphanTerminalPods = candidates.length
+  if (config.mode !== 'delete') {
+    recordRuntimeDebrisSummary(summary)
+    return summary
+  }
+
+  const selected = candidates.slice(0, config.maxDeletesPerNamespace)
+  summary.rateLimitedPods = Math.max(0, candidates.length - selected.length)
+
+  for (const candidate of selected) {
+    try {
+      await input.kube.delete('pod', candidate.name, input.namespace, { wait: false })
+      summary.deletedPods += 1
+    } catch {
+      summary.deleteErrors += 1
+    }
+  }
+
+  recordRuntimeDebrisSummary(summary)
+
+  return summary
+}

--- a/services/agents/src/server/metrics.ts
+++ b/services/agents/src/server/metrics.ts
@@ -8,6 +8,9 @@ export type AgentsMetricsSink = {
   recordAgentRunResyncAdoptions?: (count: number, attributes?: MetricsAttributes) => void
   recordAgentRunUntouchedBacklog?: (count: number, attributes?: MetricsAttributes) => void
   recordAgentRunUntouchedOldestAgeSeconds?: (ageSeconds: number, attributes?: MetricsAttributes) => void
+  recordRuntimeDebrisDeletedPods?: (count: number, attributes?: MetricsAttributes) => void
+  recordRuntimeDebrisDeleteErrors?: (count: number, attributes?: MetricsAttributes) => void
+  recordRuntimeDebrisOrphanPods?: (count: number, attributes?: MetricsAttributes) => void
   recordAgentCommsBatch?: (count: number, durationMs: number, attributes?: MetricsAttributes) => void
   recordAgentCommsError?: (stage: string, attributes?: MetricsAttributes) => void
   recordReconcileDurationMs?: (durationMs: number, attributes?: MetricsAttributes) => void
@@ -64,6 +67,18 @@ const METRICS = {
   agentRunUntouchedOldestAgeSeconds: {
     name: 'agents_agentrun_untouched_oldest_age_seconds',
     help: 'Observed age in seconds of the oldest untouched AgentRun.',
+  },
+  runtimeDebrisDeletedPods: {
+    name: 'agents_runtime_debris_deleted_pods_total',
+    help: 'Count of stale terminal runtime Pods deleted by the Agents controller.',
+  },
+  runtimeDebrisDeleteErrors: {
+    name: 'agents_runtime_debris_delete_errors_total',
+    help: 'Count of stale terminal runtime Pod deletion errors observed by the Agents controller.',
+  },
+  runtimeDebrisOrphanPods: {
+    name: 'agents_runtime_debris_orphan_pods',
+    help: 'Observed count of stale terminal runtime Pods eligible for cleanup.',
   },
   agentCommsInserted: {
     name: 'agents_agent_comms_inserted_total',
@@ -194,6 +209,23 @@ export const recordAgentRunUntouchedBacklog = (count: number, attributes?: Metri
 export const recordAgentRunUntouchedOldestAgeSeconds = (ageSeconds: number, attributes?: MetricsAttributes) => {
   recordHistogram(METRICS.agentRunUntouchedOldestAgeSeconds, ageSeconds, attributes)
   externalMetricsSink.recordAgentRunUntouchedOldestAgeSeconds?.(ageSeconds, attributes)
+}
+
+export const recordRuntimeDebrisDeletedPods = (count: number, attributes?: MetricsAttributes) => {
+  if (count <= 0) return
+  recordCounter(METRICS.runtimeDebrisDeletedPods, count, attributes)
+  externalMetricsSink.recordRuntimeDebrisDeletedPods?.(count, attributes)
+}
+
+export const recordRuntimeDebrisDeleteErrors = (count: number, attributes?: MetricsAttributes) => {
+  if (count <= 0) return
+  recordCounter(METRICS.runtimeDebrisDeleteErrors, count, attributes)
+  externalMetricsSink.recordRuntimeDebrisDeleteErrors?.(count, attributes)
+}
+
+export const recordRuntimeDebrisOrphanPods = (count: number, attributes?: MetricsAttributes) => {
+  recordHistogram(METRICS.runtimeDebrisOrphanPods, count, attributes)
+  externalMetricsSink.recordRuntimeDebrisOrphanPods?.(count, attributes)
 }
 
 export const recordAgentCommsBatch = (count: number, durationMs: number, attributes?: MetricsAttributes) => {


### PR DESCRIPTION
﻿## Summary

- Adds a controller runtime debris reconciler for stale terminal Agent runtime Pods that no longer have a valid Job owner.
- Keeps cleanup gated by mode, age retention, and per-namespace delete limits, with Prometheus metrics and controller logs.
- Adds Helm values/RBAC for safe production rollout and enables delete mode in the live Agents GitOps values with a 24 hour retention window.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test src/server/metrics.test.ts src/server/agents-controller/runtime-debris.test.ts src/server/agents-controller/runtime-config.test.ts src/server/agents-controller/index.integration.test.ts`
- `bun run --cwd services/agents tsc`
- `bunx oxfmt --check services/agents/src/server/agents-controller/runtime-debris.ts services/agents/src/server/agents-controller/runtime-debris.test.ts services/agents/src/server/agents-controller/runtime-config.ts services/agents/src/server/agents-controller/runtime-config.test.ts services/agents/src/server/agents-controller/index.ts services/agents/src/server/agents-controller/index.integration.test.ts services/agents/src/server/metrics.ts charts/agents/values.schema.json`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `node -e "JSON.parse(require('fs').readFileSync('charts/agents/values.schema.json','utf8')); console.log('values.schema.json parse ok')"`
- `kubectl kustomize argocd/applications/agents --enable-helm`
- `kubectl apply --dry-run=server -f %TEMP%/agents-rendered.yaml`
- `bun run --cwd services/agents test` was also run on Windows; cleanup-related tests passed, but the full suite still has three pre-existing Windows host-sensitive failures around executable-bit checks/fake Codex app-server execution.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
