### PR TITLE
fix(torghut): repair legacy fill delta proof

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -1145,6 +1145,99 @@ def repair_order_feed_execution_links(
     return counters
 
 
+def repair_order_feed_fill_deltas(
+    session: Session,
+    *,
+    account_label: str | None = None,
+    limit: int = 1000,
+) -> dict[str, int]:
+    """Backfill fill-delta proof fields for already-persisted cumulative fills.
+
+    Alpaca order-feed fill events carry cumulative filled quantity. Runtime-ledger
+    source authority needs per-event deltas so a repeated lifecycle event cannot
+    be counted as a fresh fill. This repair is bounded and fail-closed: rows that
+    cannot prove a positive cumulative increase are marked non-increasing instead
+    of receiving a synthetic delta.
+    """
+
+    bounded_limit = max(1, min(int(limit), 5000))
+    stmt = (
+        select(ExecutionOrderEvent)
+        .where(
+            ExecutionOrderEvent.fill_quantity_basis.is_(None),
+            ExecutionOrderEvent.filled_qty.is_not(None),
+            or_(
+                ExecutionOrderEvent.event_type.in_(tuple(_FILL_EVENT_TYPES)),
+                ExecutionOrderEvent.status.in_(tuple(_FILL_EVENT_TYPES)),
+            ),
+        )
+        .order_by(
+            ExecutionOrderEvent.alpaca_account_label.asc(),
+            ExecutionOrderEvent.alpaca_order_id.asc().nullsfirst(),
+            ExecutionOrderEvent.client_order_id.asc().nullsfirst(),
+            ExecutionOrderEvent.event_ts.asc().nullsfirst(),
+            ExecutionOrderEvent.feed_seq.asc().nullsfirst(),
+            ExecutionOrderEvent.source_topic.asc(),
+            ExecutionOrderEvent.source_partition.asc().nullsfirst(),
+            ExecutionOrderEvent.source_offset.asc().nullsfirst(),
+            ExecutionOrderEvent.created_at.asc(),
+        )
+        .limit(bounded_limit)
+    )
+    if account_label:
+        stmt = stmt.where(ExecutionOrderEvent.alpaca_account_label == account_label)
+
+    events = session.execute(stmt).scalars().all()
+    counters = {
+        "selected": len(events),
+        "delta_events_repaired": 0,
+        "non_increasing_events_marked": 0,
+        "missing_identity_events_marked": 0,
+    }
+    for event in events:
+        if event.filled_qty is None:
+            continue
+        identity_clauses = _order_event_identity_clauses(event)
+        if not identity_clauses:
+            event.fill_quantity_basis = FILL_QUANTITY_BASIS_CUMULATIVE_NON_INCREASING
+            counters["missing_identity_events_marked"] += 1
+            session.add(event)
+            continue
+
+        previous_filled_qty = session.scalar(
+            select(func.max(ExecutionOrderEvent.filled_qty)).where(
+                ExecutionOrderEvent.id != event.id,
+                ExecutionOrderEvent.alpaca_account_label == event.alpaca_account_label,
+                or_(*identity_clauses),
+                ExecutionOrderEvent.filled_qty.is_not(None),
+                _event_precedes_order_event(event),
+            )
+        )
+        previous_qty = (
+            Decimal("0")
+            if previous_filled_qty is None
+            else Decimal(str(previous_filled_qty))
+        )
+        filled_qty = Decimal(str(event.filled_qty))
+        filled_qty_delta = filled_qty - previous_qty
+        if filled_qty_delta <= 0:
+            event.fill_quantity_basis = FILL_QUANTITY_BASIS_CUMULATIVE_NON_INCREASING
+            counters["non_increasing_events_marked"] += 1
+            session.add(event)
+            continue
+
+        event.filled_qty_delta = filled_qty_delta
+        event.filled_notional_delta = (
+            filled_qty_delta * Decimal(str(event.avg_fill_price))
+            if event.avg_fill_price is not None
+            else None
+        )
+        event.fill_quantity_basis = FILL_QUANTITY_BASIS_CUMULATIVE_TO_DELTA
+        counters["delta_events_repaired"] += 1
+        session.add(event)
+    return counters
+
+
 def backfill_order_feed_source_windows(
     session: Session,
     *,
@@ -1347,6 +1440,48 @@ def _execution_activity_at(row: Execution) -> datetime | None:
         or row.updated_at
         or row.created_at
     )
+
+
+def _order_event_identity_clauses(
+    event: ExecutionOrderEvent,
+) -> list[ColumnElement[bool]]:
+    clauses: list[ColumnElement[bool]] = []
+    if event.alpaca_order_id:
+        clauses.append(ExecutionOrderEvent.alpaca_order_id == event.alpaca_order_id)
+    if event.client_order_id:
+        clauses.append(ExecutionOrderEvent.client_order_id == event.client_order_id)
+    return clauses
+
+
+def _event_precedes_order_event(event: ExecutionOrderEvent) -> ColumnElement[bool]:
+    created_at = event.created_at
+    clauses: list[ColumnElement[bool]] = []
+    if event.event_ts is not None:
+        clauses.append(ExecutionOrderEvent.event_ts < event.event_ts)
+        same_event_ts = ExecutionOrderEvent.event_ts == event.event_ts
+        if event.feed_seq is not None:
+            clauses.append(
+                same_event_ts
+                & ExecutionOrderEvent.feed_seq.is_not(None)
+                & (ExecutionOrderEvent.feed_seq < event.feed_seq)
+            )
+        clauses.append(same_event_ts & (ExecutionOrderEvent.created_at < created_at))
+    if (
+        event.source_topic
+        and event.source_partition is not None
+        and event.source_offset is not None
+    ):
+        clauses.append(
+            (ExecutionOrderEvent.source_topic == event.source_topic)
+            & (ExecutionOrderEvent.source_partition == event.source_partition)
+            & ExecutionOrderEvent.source_offset.is_not(None)
+            & (ExecutionOrderEvent.source_offset < event.source_offset)
+        )
+    else:
+        clauses.append(ExecutionOrderEvent.created_at < created_at)
+    if not clauses:
+        return ExecutionOrderEvent.id != event.id
+    return or_(*clauses)
 
 
 def _ensure_source_window_for_event(
@@ -2023,5 +2158,6 @@ __all__ = [
     "backfill_order_feed_source_windows",
     "link_order_events_to_execution",
     "repair_order_feed_execution_links",
+    "repair_order_feed_fill_deltas",
     "latest_order_event_for_execution",
 ]

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -16,6 +16,7 @@ from app.trading.order_feed import (
     backfill_order_feed_events_from_executions,
     backfill_order_feed_source_windows,
     repair_order_feed_execution_links,
+    repair_order_feed_fill_deltas,
 )
 
 
@@ -100,6 +101,18 @@ def _payload(
             batch["execution_event_backfill_skipped_source_offset_collision"]
             for batch in batches
         ),
+        "fill_delta_candidates": sum(
+            batch["fill_delta_candidates"] for batch in batches
+        ),
+        "fill_delta_events_repaired": sum(
+            batch["fill_delta_events_repaired"] for batch in batches
+        ),
+        "fill_delta_non_increasing_events_marked": sum(
+            batch["fill_delta_non_increasing_events_marked"] for batch in batches
+        ),
+        "fill_delta_missing_identity_events_marked": sum(
+            batch["fill_delta_missing_identity_events_marked"] for batch in batches
+        ),
     }
     return {
         "status": "ok",
@@ -180,6 +193,11 @@ def main() -> int:
                     "skipped_source_offset_collision": 0,
                 }
             )
+            fill_delta_batch = repair_order_feed_fill_deltas(
+                session,
+                account_label=args.account_label,
+                limit=batch_size,
+            )
             batch = {
                 **source_window_batch,
                 "execution_link_candidates": execution_link_batch["selected"],
@@ -214,6 +232,14 @@ def main() -> int:
                 "execution_event_backfill_skipped_source_offset_collision": (
                     execution_event_backfill_batch["skipped_source_offset_collision"]
                 ),
+                "fill_delta_candidates": fill_delta_batch["selected"],
+                "fill_delta_events_repaired": fill_delta_batch["delta_events_repaired"],
+                "fill_delta_non_increasing_events_marked": fill_delta_batch[
+                    "non_increasing_events_marked"
+                ],
+                "fill_delta_missing_identity_events_marked": fill_delta_batch[
+                    "missing_identity_events_marked"
+                ],
             }
             batches.append(batch)
             if args.apply:
@@ -228,6 +254,7 @@ def main() -> int:
                 and int(execution_link_batch.get("selected") or 0) < batch_size
                 and int(execution_event_backfill_batch.get("selected") or 0)
                 < batch_size
+                and int(fill_delta_batch.get("selected") or 0) < batch_size
             ):
                 break
 

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -51,6 +51,7 @@ from app.trading.order_feed import (
     normalize_order_feed_record,
     persist_order_event,
     repair_order_feed_execution_links,
+    repair_order_feed_fill_deltas,
 )
 
 
@@ -2121,6 +2122,216 @@ class TestOrderFeed(TestCase):
         self.assertIsNone(qty_delta)
         self.assertIsNone(notional_delta)
         self.assertEqual(basis, "cumulative_non_increasing")
+
+    def test_repair_order_feed_fill_deltas_converts_legacy_cumulative_fills(
+        self,
+    ) -> None:
+        base_ts = datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            self._seed_execution(session)
+            session.add_all(
+                [
+                    ExecutionOrderEvent(
+                        event_fingerprint="legacy-fill-1",
+                        source_topic="torghut.trade-updates.v1",
+                        source_partition=0,
+                        source_offset=101,
+                        alpaca_account_label="paper",
+                        feed_seq=10,
+                        event_ts=base_ts,
+                        symbol="AAPL",
+                        alpaca_order_id="order-1",
+                        client_order_id="client-1",
+                        event_type="partial_fill",
+                        status="partially_filled",
+                        qty=Decimal("2"),
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("190.20"),
+                        raw_event={},
+                    ),
+                    ExecutionOrderEvent(
+                        event_fingerprint="legacy-fill-2",
+                        source_topic="torghut.trade-updates.v1",
+                        source_partition=0,
+                        source_offset=102,
+                        alpaca_account_label="paper",
+                        feed_seq=11,
+                        event_ts=base_ts + timedelta(seconds=1),
+                        symbol="AAPL",
+                        alpaca_order_id="order-1",
+                        client_order_id="client-1",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("2"),
+                        filled_qty=Decimal("2"),
+                        avg_fill_price=Decimal("190.40"),
+                        raw_event={},
+                    ),
+                    ExecutionOrderEvent(
+                        event_fingerprint="legacy-fill-repeat",
+                        source_topic="torghut.trade-updates.v1",
+                        source_partition=0,
+                        source_offset=103,
+                        alpaca_account_label="paper",
+                        feed_seq=12,
+                        event_ts=base_ts + timedelta(seconds=2),
+                        symbol="AAPL",
+                        alpaca_order_id="order-1",
+                        client_order_id="client-1",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("2"),
+                        filled_qty=Decimal("2"),
+                        avg_fill_price=Decimal("190.50"),
+                        raw_event={},
+                    ),
+                ]
+            )
+            session.commit()
+
+            counters = repair_order_feed_fill_deltas(
+                session,
+                account_label="paper",
+                limit=10,
+            )
+            session.commit()
+            events = (
+                session.execute(
+                    select(ExecutionOrderEvent).order_by(
+                        ExecutionOrderEvent.feed_seq.asc()
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        self.assertEqual(counters["selected"], 3)
+        self.assertEqual(counters["delta_events_repaired"], 2)
+        self.assertEqual(counters["non_increasing_events_marked"], 1)
+        self.assertEqual(counters["missing_identity_events_marked"], 0)
+        self.assertEqual(
+            [event.filled_qty_delta for event in events],
+            [Decimal("1.00000000"), Decimal("1.00000000"), None],
+        )
+        self.assertEqual(
+            [event.filled_notional_delta for event in events],
+            [Decimal("190.20000000"), Decimal("190.40000000"), None],
+        )
+        self.assertEqual(
+            [event.fill_quantity_basis for event in events],
+            [
+                "cumulative_to_delta",
+                "cumulative_to_delta",
+                "cumulative_non_increasing",
+            ],
+        )
+
+    def test_repair_order_feed_fill_deltas_rejects_missing_order_identity(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="legacy-fill-no-identity",
+                    source_topic="torghut.trade-updates.v1",
+                    source_partition=0,
+                    source_offset=201,
+                    alpaca_account_label="paper",
+                    feed_seq=20,
+                    event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                    symbol="AAPL",
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("190.20"),
+                    raw_event={},
+                )
+            )
+            session.commit()
+
+            counters = repair_order_feed_fill_deltas(
+                session,
+                account_label="paper",
+                limit=10,
+            )
+            session.commit()
+            event = session.execute(select(ExecutionOrderEvent)).scalar_one()
+
+        self.assertEqual(counters["selected"], 1)
+        self.assertEqual(counters["delta_events_repaired"], 0)
+        self.assertEqual(counters["missing_identity_events_marked"], 1)
+        self.assertIsNone(event.filled_qty_delta)
+        self.assertIsNone(event.filled_notional_delta)
+        self.assertEqual(event.fill_quantity_basis, "cumulative_non_increasing")
+
+    def test_repair_order_feed_fill_deltas_orders_by_source_offset_without_event_ts(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            session.add_all(
+                [
+                    ExecutionOrderEvent(
+                        event_fingerprint="legacy-fill-offset-1",
+                        source_topic="torghut.trade-updates.v1",
+                        source_partition=0,
+                        source_offset=301,
+                        alpaca_account_label="paper",
+                        symbol="AAPL",
+                        alpaca_order_id="order-offset",
+                        event_type="partial_fill",
+                        status="partially_filled",
+                        qty=Decimal("2"),
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("190"),
+                        raw_event={},
+                    ),
+                    ExecutionOrderEvent(
+                        event_fingerprint="legacy-fill-offset-2",
+                        source_topic="torghut.trade-updates.v1",
+                        source_partition=0,
+                        source_offset=302,
+                        alpaca_account_label="paper",
+                        symbol="AAPL",
+                        alpaca_order_id="order-offset",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("2"),
+                        filled_qty=Decimal("2"),
+                        avg_fill_price=Decimal("191"),
+                        raw_event={},
+                    ),
+                ]
+            )
+            session.commit()
+
+            counters = repair_order_feed_fill_deltas(
+                session,
+                account_label="paper",
+                limit=10,
+            )
+            session.commit()
+            events = (
+                session.execute(
+                    select(ExecutionOrderEvent).order_by(
+                        ExecutionOrderEvent.source_offset.asc()
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        self.assertEqual(counters["selected"], 2)
+        self.assertEqual(counters["delta_events_repaired"], 2)
+        self.assertEqual(
+            [event.filled_qty_delta for event in events],
+            [Decimal("1.00000000"), Decimal("1.00000000")],
+        )
+        self.assertEqual(
+            [event.filled_notional_delta for event in events],
+            [Decimal("190.00000000"), Decimal("191.00000000")],
+        )
 
     def test_duplicate_event_source_window_attach_refreshes_linkage_counts(
         self,

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -90,6 +90,16 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                 script,
                 "backfill_order_feed_events_from_executions",
             ) as backfill_execution_events,
+            patch.object(
+                script,
+                "repair_order_feed_fill_deltas",
+                return_value={
+                    "selected": 6,
+                    "delta_events_repaired": 5,
+                    "non_increasing_events_marked": 1,
+                    "missing_identity_events_marked": 0,
+                },
+            ) as repair_deltas,
             patch("sys.stdout", stdout),
         ):
             exit_code = script.main()
@@ -113,6 +123,10 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_event_backfill_candidates"], 0)
         self.assertEqual(payload["execution_event_backfill_events_created"], 0)
         self.assertEqual(payload["execution_event_backfill_source_windows_created"], 0)
+        self.assertEqual(payload["fill_delta_candidates"], 6)
+        self.assertEqual(payload["fill_delta_events_repaired"], 5)
+        self.assertEqual(payload["fill_delta_non_increasing_events_marked"], 1)
+        self.assertEqual(payload["fill_delta_missing_identity_events_marked"], 0)
         self.assertEqual(fake_session.commits, 0)
         self.assertEqual(fake_session.rollbacks, 1)
         create_engine.assert_called_once_with(
@@ -131,6 +145,11 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             limit=5000,
         )
         backfill_execution_events.assert_not_called()
+        repair_deltas.assert_called_once_with(
+            fake_session,
+            account_label=None,
+            limit=5000,
+        )
 
     def test_main_applies_until_selection_drops_below_batch_size(self) -> None:
         fake_session = _FakeSession()
@@ -202,6 +221,24 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                 script,
                 "backfill_order_feed_events_from_executions",
             ) as backfill_execution_events,
+            patch.object(
+                script,
+                "repair_order_feed_fill_deltas",
+                side_effect=[
+                    {
+                        "selected": 2,
+                        "delta_events_repaired": 2,
+                        "non_increasing_events_marked": 0,
+                        "missing_identity_events_marked": 0,
+                    },
+                    {
+                        "selected": 1,
+                        "delta_events_repaired": 0,
+                        "non_increasing_events_marked": 1,
+                        "missing_identity_events_marked": 0,
+                    },
+                ],
+            ) as repair_deltas,
             patch("sys.stdout", stdout),
         ):
             exit_code = script.main()
@@ -220,6 +257,10 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_link_executions_linked"], 1)
         self.assertEqual(payload["execution_link_events_linked"], 2)
         self.assertEqual(payload["execution_link_events_without_execution"], 0)
+        self.assertEqual(payload["fill_delta_candidates"], 3)
+        self.assertEqual(payload["fill_delta_events_repaired"], 2)
+        self.assertEqual(payload["fill_delta_non_increasing_events_marked"], 1)
+        self.assertEqual(payload["fill_delta_missing_identity_events_marked"], 0)
         self.assertEqual(fake_session.commits, 2)
         self.assertEqual(fake_session.rollbacks, 0)
         self.assertEqual(backfill.call_count, 2)
@@ -229,6 +270,9 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(repair_links.call_args.kwargs["account_label"], "TORGHUT_SIM")
         self.assertEqual(repair_links.call_args.kwargs["limit"], 2)
         backfill_execution_events.assert_not_called()
+        self.assertEqual(repair_deltas.call_count, 2)
+        self.assertEqual(repair_deltas.call_args.kwargs["account_label"], "TORGHUT_SIM")
+        self.assertEqual(repair_deltas.call_args.kwargs["limit"], 2)
 
     def test_main_backfills_execution_events_when_enabled(self) -> None:
         fake_session = _FakeSession()
@@ -294,6 +338,16 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                     "skipped_source_offset_collision": 0,
                 },
             ) as backfill_execution_events,
+            patch.object(
+                script,
+                "repair_order_feed_fill_deltas",
+                return_value={
+                    "selected": 0,
+                    "delta_events_repaired": 0,
+                    "non_increasing_events_marked": 0,
+                    "missing_identity_events_marked": 0,
+                },
+            ) as repair_deltas,
             patch("sys.stdout", stdout),
         ):
             exit_code = script.main()
@@ -307,8 +361,15 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_event_backfill_events_created"], 6)
         self.assertEqual(payload["execution_event_backfill_source_windows_created"], 6)
         self.assertEqual(payload["execution_event_backfill_skipped_existing_event"], 1)
+        self.assertEqual(payload["fill_delta_candidates"], 0)
+        self.assertEqual(payload["fill_delta_events_repaired"], 0)
         self.assertEqual(fake_session.commits, 1)
         backfill_execution_events.assert_called_once_with(
+            fake_session,
+            account_label="PA3SX7FYNUTF",
+            limit=100,
+        )
+        repair_deltas.assert_called_once_with(
             fake_session,
             account_label="PA3SX7FYNUTF",
             limit=100,


### PR DESCRIPTION
## Summary

- Adds a bounded order-feed repair that converts legacy cumulative fill events into per-event fill deltas only when source ordering proves a positive cumulative increase.
- Marks missing-identity or non-increasing legacy fill rows as `cumulative_non_increasing` instead of inventing synthetic deltas.
- Wires the existing source-window repair script to run fill-delta repair after source-window, execution-link, and execution-snapshot repairs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
