### PR TITLE
fix(torghut): classify archived TigerBeetle runtime refs

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any, cast
 from uuid import UUID
 
@@ -231,6 +231,26 @@ def _runtime_ledger_amount_micros(
     return _usd_to_micros(runtime_ledger_amount_source(bucket))
 
 
+def _archived_runtime_ledger_amount_micros(
+    ref: TigerBeetleTransferRef,
+) -> Decimal | None:
+    if (
+        ref.source_type != SOURCE_TYPE_RUNTIME_LEDGER_BUCKET
+        or ref.runtime_ledger_bucket_id is not None
+    ):
+        return None
+    payload = _payload_mapping(ref)
+    raw_amount = payload.get("amount_source") or payload.get(
+        "net_strategy_pnl_after_costs"
+    )
+    if raw_amount is None:
+        return None
+    try:
+        return _usd_to_micros(Decimal(str(raw_amount)))
+    except (InvalidOperation, ValueError):
+        return None
+
+
 def _expected_source_amount_micros(
     session: Session,
     ref: TigerBeetleTransferRef,
@@ -363,6 +383,9 @@ def _latest_run_payload(
         "runtime_ledger_signed_transfer_count": _payload_int(
             payload, "runtime_ledger_signed_transfer_count"
         ),
+        "archived_runtime_ledger_source_missing_count": _payload_int(
+            payload, "archived_runtime_ledger_source_missing_count"
+        ),
         "runtime_ledger_direction_mismatch_count": _payload_int(
             payload, "runtime_ledger_direction_mismatch_count"
         ),
@@ -428,6 +451,7 @@ def reconcile_tigerbeetle_transfers(
     source_amount_mismatch_count = 0
     runtime_ledger_checked_transfer_count = 0
     runtime_ledger_signed_transfer_count = 0
+    archived_runtime_ledger_source_missing_count = 0
     runtime_ledger_direction_mismatch_count = 0
     runtime_ledger_metadata_mismatch_count = 0
     blockers: list[str] = []
@@ -489,8 +513,12 @@ def reconcile_tigerbeetle_transfers(
         }:
             expected_source_amount = _expected_source_amount_micros(session, ref)
             if expected_source_amount is None:
-                source_row_missing_count += 1
-                blockers.append(BLOCKER_SOURCE_ROW_MISSING)
+                archived_amount = _archived_runtime_ledger_amount_micros(ref)
+                if archived_amount is not None and ref.amount == archived_amount:
+                    archived_runtime_ledger_source_missing_count += 1
+                else:
+                    source_row_missing_count += 1
+                    blockers.append(BLOCKER_SOURCE_ROW_MISSING)
             elif ref.amount != expected_source_amount:
                 source_amount_mismatch_count += 1
                 blockers.append(BLOCKER_SOURCE_AMOUNT_MISMATCH)
@@ -648,6 +676,7 @@ def reconcile_tigerbeetle_transfers(
         "source_amount_mismatch_count": source_amount_mismatch_count,
         "runtime_ledger_checked_transfer_count": runtime_ledger_checked_transfer_count,
         "runtime_ledger_signed_transfer_count": runtime_ledger_signed_transfer_count,
+        "archived_runtime_ledger_source_missing_count": archived_runtime_ledger_source_missing_count,
         "runtime_ledger_direction_mismatch_count": (
             runtime_ledger_direction_mismatch_count
         ),

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -214,17 +214,23 @@ def _select_unlinked_runtime_buckets(
     account_label: str | None,
     limit: int,
 ) -> list[StrategyRuntimeLedgerBucket]:
-    linked_ref = _source_ref_exists(
-        session,
-        settings_obj=settings_obj,
-        source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-        source_id_column=StrategyRuntimeLedgerBucket.id.cast(String),
-        transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+    complete_ref = (
+        select(TigerBeetleTransferRef.id)
+        .where(
+            TigerBeetleTransferRef.cluster_id == settings_obj.tigerbeetle_cluster_id,
+            TigerBeetleTransferRef.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            TigerBeetleTransferRef.source_id
+            == StrategyRuntimeLedgerBucket.id.cast(String),
+            TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL,
+            TigerBeetleTransferRef.runtime_ledger_bucket_id
+            == StrategyRuntimeLedgerBucket.id,
+        )
+        .exists()
     )
     stmt = (
         select(StrategyRuntimeLedgerBucket)
         .where(
-            ~linked_ref,
+            ~complete_ref,
             (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
             | (StrategyRuntimeLedgerBucket.cost_amount != 0),
         )

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -29,6 +29,7 @@ from app.trading.tigerbeetle_ledger_model import (
     LEDGER_USD_MICRO,
     TRANSFER_CODE_FILL_POST,
     TRANSFER_KIND_FILL_POST,
+    TRANSFER_KIND_RUNTIME_NET_PNL,
 )
 from scripts import journal_tigerbeetle_order_events as script
 
@@ -434,6 +435,79 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
 
         self.assertEqual([event.id for event in events.rows], [selected.id])
         self.assertEqual(events.scan_failed, 0)
+
+    def test_select_runtime_buckets_repairs_legacy_ref_missing_bucket_fk(
+        self,
+    ) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        observed_at = datetime.now(timezone.utc)
+        with Session(self.engine) as session:
+            bucket = StrategyRuntimeLedgerBucket(
+                run_id="runtime-run-legacy-ref",
+                candidate_id="candidate",
+                hypothesis_id="hypothesis",
+                observed_stage="paper",
+                bucket_started_at=observed_at,
+                bucket_ended_at=observed_at,
+                account_label="paper",
+                runtime_strategy_name="demo-runtime",
+                strategy_family="demo",
+                fill_count=1,
+                decision_count=1,
+                submitted_order_count=1,
+                cancelled_order_count=0,
+                rejected_order_count=0,
+                unfilled_order_count=0,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("190.25"),
+                gross_strategy_pnl=Decimal("3.00"),
+                cost_amount=Decimal("0.50"),
+                net_strategy_pnl_after_costs=Decimal("2.50"),
+                post_cost_expectancy_bps=Decimal("12.50"),
+                ledger_schema_version="torghut.runtime-ledger.v1",
+                pnl_basis="post_cost",
+                payload_json={"source": "test"},
+            )
+            session.add(bucket)
+            session.flush()
+            legacy_ref = TigerBeetleTransferRef(
+                cluster_id=settings_obj.tigerbeetle_cluster_id,
+                transfer_id="1234",
+                transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_FILL_POST,
+                amount=Decimal("2500000"),
+                status="created",
+                source_type=script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                source_id=str(bucket.id),
+                payload_json={
+                    "source": script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                },
+            )
+            session.add(legacy_ref)
+            session.flush()
+
+            selected = script._select_unlinked_runtime_buckets(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=10,
+            )
+
+            self.assertEqual([row.id for row in selected], [bucket.id])
+
+            legacy_ref.runtime_ledger_bucket_id = bucket.id
+            session.add(legacy_ref)
+            session.flush()
+            selected_after_repair = script._select_unlinked_runtime_buckets(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=10,
+            )
+
+        self.assertEqual(selected_after_repair, [])
 
     def test_main_journals_selected_events_and_reconciles(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -20,12 +20,15 @@ from app.models import (
 )
 from app.trading.tigerbeetle_client import FakeTigerBeetleClient
 from app.trading.tigerbeetle_journal import (
+    SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
     build_runtime_ledger_bucket_transfer_plan,
 )
 from app.trading.tigerbeetle_ledger_model import (
     LEDGER_USD_MICRO,
     TRANSFER_CODE_EXECUTION_FILL,
     TRANSFER_CODE_FILL_POST,
+    TRANSFER_CODE_RUNTIME_NET_PNL,
+    TRANSFER_KIND_RUNTIME_NET_PNL,
     TigerBeetleTransferSpec,
 )
 from app.trading.tigerbeetle_reconcile import (
@@ -46,6 +49,7 @@ from app.trading.tigerbeetle_reconcile import (
     BLOCKER_TRANSFER_MISSING,
     BLOCKER_UNLINKED_EVENT,
     _attr,
+    _archived_runtime_ledger_amount_micros,
     _cost_amount_micros,
     _expected_source_amount_micros,
     _execution_amount_micros,
@@ -374,6 +378,100 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertTrue(payload["ok"], payload)
             self.assertEqual(payload["runtime_ledger_checked_transfer_count"], 2)
             self.assertEqual(payload["runtime_ledger_signed_transfer_count"], 2)
+
+    def test_reconciliation_reports_archived_runtime_ref_without_blocking_current_ref(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket(net_pnl=Decimal("2.50"))
+            session.add(bucket)
+            session.flush()
+            client = FakeTigerBeetleClient()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            current_transfer = plan.transfer_spec
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(current_transfer.transfer_id),
+                    transfer_kind=current_transfer.transfer_kind,
+                    ledger=current_transfer.ledger,
+                    code=current_transfer.code,
+                    amount=Decimal(current_transfer.amount),
+                    status="created",
+                    runtime_ledger_bucket_id=bucket.id,
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id=str(bucket.id),
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "run_id": bucket.run_id,
+                        "candidate_id": bucket.candidate_id,
+                        "hypothesis_id": bucket.hypothesis_id,
+                        "observed_stage": bucket.observed_stage,
+                        "pnl_basis": bucket.pnl_basis,
+                        "ledger_schema_version": bucket.ledger_schema_version,
+                        "amount_source": str(plan.amount_source),
+                        "signed_amount_micros": plan.signed_amount_micros,
+                        "pnl_direction": plan.pnl_direction,
+                        "runtime_key": plan.runtime_key,
+                        "debit_account_id": str(current_transfer.debit_account_id),
+                        "credit_account_id": str(current_transfer.credit_account_id),
+                    },
+                )
+            )
+            archived_transfer = TigerBeetleTransferSpec(
+                transfer_id=7001,
+                transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+                debit_account_id=11,
+                credit_account_id=12,
+                amount=2500000,
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_RUNTIME_NET_PNL,
+            )
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(archived_transfer.transfer_id),
+                    transfer_kind=archived_transfer.transfer_kind,
+                    ledger=archived_transfer.ledger,
+                    code=archived_transfer.code,
+                    amount=Decimal(archived_transfer.amount),
+                    status="exists",
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id="6f767a53-6b44-428a-bd85-2f662642f637",
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "run_id": "archived-runtime-run",
+                        "candidate_id": "candidate",
+                        "hypothesis_id": "hypothesis",
+                        "amount_source": "2.50",
+                        "net_strategy_pnl_after_costs": "2.50",
+                        "debit_account_id": str(archived_transfer.debit_account_id),
+                        "credit_account_id": str(archived_transfer.credit_account_id),
+                    },
+                )
+            )
+            session.flush()
+            client.transfers[current_transfer.transfer_id] = current_transfer
+            client.transfers[archived_transfer.transfer_id] = archived_transfer
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertTrue(payload["ok"], payload)
+            self.assertEqual(payload["runtime_ledger_checked_transfer_count"], 2)
+            self.assertEqual(payload["runtime_ledger_signed_transfer_count"], 1)
+            self.assertEqual(
+                payload["archived_runtime_ledger_source_missing_count"],
+                1,
+            )
+            self.assertEqual(payload["source_row_missing_count"], 0)
+            self.assertEqual(payload["source_missing_count"], 0)
+            self.assertNotIn(BLOCKER_SOURCE_ROW_MISSING, payload["blockers"])
 
     def test_reconciliation_blocks_runtime_ledger_signed_direction_mismatch(
         self,
@@ -823,6 +921,26 @@ class TestTigerBeetleReconcile(TestCase):
         self.assertIsNone(_execution_amount_micros(None))
         self.assertIsNone(_cost_amount_micros(None))
         self.assertIsNone(_runtime_ledger_amount_micros(None))
+        archived_ref = TigerBeetleTransferRef(
+            cluster_id=2001,
+            transfer_id="9001",
+            transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+            ledger=LEDGER_USD_MICRO,
+            code=TRANSFER_CODE_RUNTIME_NET_PNL,
+            amount=Decimal("1250000"),
+            status="exists",
+            source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            source_id="6f767a53-6b44-428a-bd85-2f662642f637",
+            payload_json={},
+        )
+        self.assertIsNone(_archived_runtime_ledger_amount_micros(archived_ref))
+        archived_ref.payload_json = {"amount_source": object()}
+        self.assertIsNone(_archived_runtime_ledger_amount_micros(archived_ref))
+        archived_ref.payload_json = {"amount_source": "-1.25"}
+        self.assertEqual(
+            _archived_runtime_ledger_amount_micros(archived_ref),
+            Decimal("1250000"),
+        )
 
     def test_expected_source_amount_supports_cost_and_runtime_refs(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Treat legacy runtime-ledger TigerBeetle refs without a bucket FK as incomplete, so the journal job can relink current source buckets instead of skipping them.
- Classify archived runtime-ledger refs with missing source rows separately when their stored payload amount still matches the TigerBeetle transfer amount.
- Keep missing-source blockers intact for non-runtime refs and runtime refs without matching archived payload evidence.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_tigerbeetle_status.py tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py -q`
- `uv run --frozen ruff format --check app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen ruff check app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen coverage erase && uv run --frozen coverage run --branch -m pytest tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_status.py -q && uv run --frozen coverage xml || true; uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
