### PR TITLE
chore(agents): promote images 65b3200e

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 594b1582
-  digest: sha256:e7a33972ce382fb274a57c3b46b814983710772d02c56610b6651928a475c777
+  tag: 65b3200e
+  digest: sha256:250ce377be3b305ccb7fcb5599f06bc948eedd10e5a6a17ff7d5a3dfde0d23c4
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 594b1582
-    digest: sha256:34ae2c25f70d272a866a824381a73a1b9261839c0706c5ee865f3237be6ac3f0
+    tag: 65b3200e
+    digest: sha256:1c9ce8d362bd78879142646b5efeb937c1f97f2657bb65cc8775d3a50895ddc4
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 594b1582d245716c2ef7f468ced93110f20e4b86
-      AGENTS_GITOPS_REVISION: 594b1582d245716c2ef7f468ced93110f20e4b86
-      AGENTS_SOURCE_CI_RUN_ID: "26674265454"
+      AGENTS_SOURCE_HEAD_SHA: 65b3200ea6fc50b22b995adede4b842d426a39a8
+      AGENTS_GITOPS_REVISION: 65b3200ea6fc50b22b995adede4b842d426a39a8
+      AGENTS_SOURCE_CI_RUN_ID: "26730067587"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:34ae2c25f70d272a866a824381a73a1b9261839c0706c5ee865f3237be6ac3f0
-      AGENTS_SERVING_BUILD_COMMIT: 594b1582d245716c2ef7f468ced93110f20e4b86
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:34ae2c25f70d272a866a824381a73a1b9261839c0706c5ee865f3237be6ac3f0
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:1c9ce8d362bd78879142646b5efeb937c1f97f2657bb65cc8775d3a50895ddc4
+      AGENTS_SERVING_BUILD_COMMIT: 65b3200ea6fc50b22b995adede4b842d426a39a8
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:1c9ce8d362bd78879142646b5efeb937c1f97f2657bb65cc8775d3a50895ddc4
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 594b1582
-    digest: sha256:2cb3d417bf880a008ff072e32dc13eedb79ae8698dc6dda514556a2653c765e3
+    tag: 65b3200e
+    digest: sha256:df3b0a8babfef495d726feffe913e7e5bcdb4577f741033af561f65404572080
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 594b1582
-    digest: sha256:e7a33972ce382fb274a57c3b46b814983710772d02c56610b6651928a475c777
+    tag: 65b3200e
+    digest: sha256:250ce377be3b305ccb7fcb5599f06bc948eedd10e5a6a17ff7d5a3dfde0d23c4
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
﻿## Summary

- Promote Agents controller and control-plane images built from 65b3200ea6fc50b22b995adede4b842d426a39a8.
- Promote the matching codex runner image digest from agents-build-push run 26730067587.
- Preserve runtime debris cleanup GitOps settings with delete mode, 86400 second orphan pod retention, and max 25 deletes per namespace.

## Related Issues

None

## Testing

- Verified the promotion artifact diff only changes Agents image tags, digests, and release metadata from 594b1582 to 65b3200e.
- `git diff --check -- argocd/applications/agents/values.yaml`
- Rendered `argocd/applications/agents` with Helm v3 through `kubectl kustomize --enable-helm` and confirmed the 65b3200e controller image and runtime debris cleanup env render.
- `kubectl apply --dry-run=server -f $env:TEMP\agents-release-rendered.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
