### PR TITLE
fix(torghut): close paper-route proof contamination

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -2893,6 +2893,8 @@ class SimpleTradingPipeline(TradingPipeline):
             and bool(target_plan_symbols)
             and symbol in target_plan_symbols
         )
+        if target_plan_symbols and not target_source_authorized:
+            return None
         symbol_route_probe_reasons = self._proof_floor_symbol_route_probe_reasons(
             proof_floor,
             symbol,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2183,12 +2183,23 @@ def _runtime_lifecycle_ledger_row(
             "filled_price",
             "price",
         )
+        source_order_feed_delta_fill = (
+            _source_order_feed_payload_delta_fill(row, event_type=event_type)
+            if source_authority_order_event and fill_quantity_basis is None
+            else None
+        )
         if (
             source_authority_order_event
             and fill_quantity_basis in {"delta", "cumulative_to_delta"}
             and filled_qty_delta is not None
         ):
             filled_qty = filled_qty_delta
+        filled_notional_delta = _first_positive_decimal(
+            row,
+            "filled_notional_delta",
+            "fill_notional_delta",
+            "delta_filled_notional",
+        )
         filled_notional = _first_positive_decimal(
             row,
             "filled_notional_delta",
@@ -2198,7 +2209,16 @@ def _runtime_lifecycle_ledger_row(
             "notional",
             "fill_notional",
         )
-        if source_authority_order_event and fill_quantity_basis not in {
+        if source_order_feed_delta_fill is not None:
+            delta_qty, delta_price, delta_side = source_order_feed_delta_fill
+            side = side or delta_side
+            fill_quantity_basis = "delta"
+            filled_qty_delta = delta_qty
+            filled_qty = delta_qty
+            avg_fill_price = delta_price
+            filled_notional_delta = delta_qty * delta_price
+            filled_notional = filled_notional_delta
+        elif source_authority_order_event and fill_quantity_basis not in {
             "delta",
             "cumulative_to_delta",
         }:
@@ -2257,12 +2277,6 @@ def _runtime_lifecycle_ledger_row(
             ledger_row["filled_notional"] = filled_notional
         if filled_qty_delta is not None:
             ledger_row["filled_qty_delta"] = filled_qty_delta
-        filled_notional_delta = _first_positive_decimal(
-            row,
-            "filled_notional_delta",
-            "fill_notional_delta",
-            "delta_filled_notional",
-        )
         if filled_notional_delta is not None:
             ledger_row["filled_notional_delta"] = filled_notional_delta
         if fill_quantity_basis is not None:
@@ -2436,8 +2450,54 @@ def _fill_quantity_basis(row: Mapping[str, object]) -> str | None:
     return normalized or None
 
 
+def _source_order_feed_payload_delta_fill(
+    row: Mapping[str, object], *, event_type: str
+) -> tuple[Decimal, Decimal, str | None] | None:
+    if (
+        _runtime_ledger_event_type({"event_type": event_type})
+        not in _RUNTIME_LEDGER_FILL_EVENTS
+    ):
+        return None
+    raw_event = _as_mapping(row.get("raw_event"))
+    if not raw_event:
+        return None
+
+    payload_candidates: list[Mapping[str, object]] = []
+    for key in ("payload", "data"):
+        payload = _as_mapping(raw_event.get(key))
+        if payload:
+            payload_candidates.append(payload)
+    if _as_mapping(raw_event.get("order")):
+        payload_candidates.append(raw_event)
+
+    for payload in payload_candidates:
+        payload_event = _runtime_ledger_event_type(
+            {
+                "event_type": _direct_text(payload, "event", "event_type")
+                or event_type,
+                "status": _direct_text(payload, "status"),
+            }
+        )
+        if payload_event not in _RUNTIME_LEDGER_FILL_EVENTS:
+            continue
+        qty = _decimal_or_none(payload.get("qty"))
+        price = _decimal_or_none(payload.get("price"))
+        if qty is None or qty <= 0 or price is None or price <= 0:
+            continue
+        order = _as_mapping(payload.get("order"))
+        side = _direct_text(payload, "side", "order_side") or _direct_text(
+            order, "side"
+        )
+        return qty, price, side
+    return None
+
+
 def _order_feed_fill_delta_blockers(row: Mapping[str, object]) -> list[str]:
     if not _source_authority_order_event_row(row):
+        return []
+    if _source_order_feed_payload_delta_fill(
+        row, event_type=_runtime_ledger_event_type(row)
+    ):
         return []
     basis = _fill_quantity_basis(row)
     if basis not in {"delta", "cumulative_to_delta"}:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -63,6 +63,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _source_decision_mode,
     _source_decision_mode_counts,
     _source_decision_rows_profit_proof_eligible,
+    _source_order_feed_payload_delta_fill,
     _stable_payload_digest,
     _strategy_name_candidates,
     _sqlalchemy_dsn,
@@ -3899,6 +3900,140 @@ class TestImportHypothesisRuntimeWindows(TestCase):
 
         self.assertIsNone(ledger_row)
 
+    def test_source_authority_order_event_lifecycle_uses_alpaca_payload_delta(
+        self,
+    ) -> None:
+        row = {
+            "execution_order_event_id": "event-sell",
+            "source_window_id": "source-window-sell",
+            "source_offset": 22007,
+            "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+            "event_type": "partial_fill",
+            "symbol": "AMZN",
+            "account_label": "TORGHUT_SIM",
+            "strategy_id": "microbar-cross-sectional-pairs-v1",
+            "decision_hash": "decision-sell",
+            "alpaca_order_id": "order-sell",
+            "source_topic": "torghut.trade-updates.v1",
+            "qty": Decimal("41"),
+            "filled_qty": Decimal("25"),
+            "avg_fill_price": Decimal("271.75"),
+            "raw_event": {
+                "channel": "trade_updates",
+                "payload": {
+                    "event": "partial_fill",
+                    "qty": "25",
+                    "price": "271.75",
+                    "order": {
+                        "id": "order-sell",
+                        "asset_class": "us_equity",
+                        "side": "sell",
+                        "symbol": "AMZN",
+                        "status": "partially_filled",
+                        "filled_qty": "25",
+                        "filled_avg_price": "271.75",
+                    },
+                },
+            },
+            "execution_audit_json": {
+                "execution_policy_hash": "policy-sha",
+                "lineage_hash": "lineage-sha",
+            },
+        }
+
+        ledger_row = _runtime_lifecycle_ledger_row(
+            row,
+            event_type="partial_fill",
+            require_complete_fill=True,
+        )
+
+        self.assertEqual(_order_feed_fill_delta_blockers(row), [])
+        self.assertIsNotNone(ledger_row)
+        assert ledger_row is not None
+        self.assertEqual(ledger_row["side"], "sell")
+        self.assertEqual(ledger_row["filled_qty"], Decimal("25"))
+        self.assertEqual(ledger_row["filled_qty_delta"], Decimal("25"))
+        self.assertEqual(ledger_row["avg_fill_price"], Decimal("271.75"))
+        self.assertEqual(ledger_row["filled_notional"], Decimal("6793.75"))
+        self.assertEqual(ledger_row["filled_notional_delta"], Decimal("6793.75"))
+        self.assertEqual(ledger_row["fill_quantity_basis"], "delta")
+        self.assertEqual(ledger_row["cost_amount"], Decimal("0.15"))
+        self.assertEqual(
+            ledger_row["cost_basis"],
+            "alpaca_2026_equity_sec_taf_cat_fee_schedule",
+        )
+        self.assertEqual(
+            ledger_row["cost_model_hash"],
+            _alpaca_2026_equity_fee_schedule_hash(),
+        )
+
+    def test_source_order_feed_payload_delta_fill_rejects_non_delta_payloads(
+        self,
+    ) -> None:
+        self.assertIsNone(
+            _source_order_feed_payload_delta_fill(
+                {
+                    "raw_event": {
+                        "payload": {
+                            "event": "fill",
+                            "qty": "2",
+                            "price": "101.25",
+                            "order": {"side": "buy"},
+                        }
+                    }
+                },
+                event_type="new",
+            )
+        )
+        self.assertIsNone(
+            _source_order_feed_payload_delta_fill(
+                {
+                    "raw_event": {
+                        "payload": {
+                            "event": "new",
+                            "qty": "2",
+                            "price": "101.25",
+                            "order": {"side": "buy"},
+                        }
+                    }
+                },
+                event_type="fill",
+            )
+        )
+        self.assertIsNone(
+            _source_order_feed_payload_delta_fill(
+                {
+                    "raw_event": {
+                        "payload": {
+                            "event": "fill",
+                            "qty": "0",
+                            "price": "101.25",
+                            "order": {"side": "buy"},
+                        }
+                    }
+                },
+                event_type="fill",
+            )
+        )
+
+    def test_source_order_feed_payload_delta_fill_accepts_top_level_order_payload(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _source_order_feed_payload_delta_fill(
+                {
+                    "raw_event": {
+                        "event": "fill",
+                        "qty": "2",
+                        "price": "101.25",
+                        "order": {"side": "buy"},
+                    }
+                },
+                event_type="fill",
+            ),
+            (Decimal("2"), Decimal("101.25"), "buy"),
+        )
+
     def test_source_authority_order_event_lifecycle_uses_fill_delta(
         self,
     ) -> None:
@@ -4256,6 +4391,185 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "postgres:order_feed_source_windows",
             ],
         )
+        self.assertEqual(bucket["source_materialization"], "execution_order_events")
+
+    def test_source_backed_round_trip_materializes_alpaca_payload_delta_when_columns_missing(
+        self,
+    ) -> None:
+        common = {
+            "account_label": "TORGHUT_SIM",
+            "strategy_id": "microbar-cross-sectional-pairs-v1",
+            "symbol": "AAPL",
+            "lineage_hash": "lineage-sha",
+            "source_topic": "torghut.trade-updates.v1",
+            "source_partition": 0,
+            "source_window_id": "source-window",
+            "source_decision_mode": "strategy_signal_paper",
+            "profit_proof_eligible": True,
+            "execution_policy_hash": "policy-sha",
+        }
+
+        def order_row(
+            *,
+            event_id: str,
+            decision_id: str,
+            order_id: str,
+            event_ts: datetime,
+            event_type: str,
+            side: str,
+            payload_qty: str | None,
+            payload_price: str | None,
+            source_offset: int,
+        ) -> dict[str, object]:
+            raw_event_payload: dict[str, object] = {
+                "event": event_type,
+                "order": {
+                    "id": order_id,
+                    "asset_class": "us_equity",
+                    "status": "filled" if payload_qty is not None else "new",
+                    "side": side,
+                    "symbol": "AAPL",
+                },
+            }
+            if payload_qty is not None and payload_price is not None:
+                raw_event_payload.update({"qty": payload_qty, "price": payload_price})
+                cast(dict[str, object], raw_event_payload["order"]).update(
+                    {
+                        "filled_qty": payload_qty,
+                        "filled_avg_price": payload_price,
+                    }
+                )
+            return {
+                **common,
+                "execution_order_event_id": event_id,
+                "trade_decision_id": decision_id,
+                "decision_hash": decision_id,
+                "event_ts": event_ts,
+                "event_type": event_type,
+                "alpaca_order_id": order_id,
+                "source_offset": source_offset,
+                "qty": Decimal("2"),
+                "filled_qty": Decimal(payload_qty or "0"),
+                "avg_fill_price": Decimal(payload_price or "0"),
+                "raw_event": {
+                    "channel": "trade_updates",
+                    "payload": raw_event_payload,
+                },
+            }
+
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    **common,
+                    "execution_id": "execution-buy",
+                    "trade_decision_id": "decision-buy",
+                    "computed_at": datetime(2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc
+                    ),
+                    "side": "buy",
+                    "filled_qty": Decimal("0"),
+                    "avg_fill_price": Decimal("0"),
+                    "alpaca_order_id": "order-buy",
+                    "raw_order": {
+                        "side": "buy",
+                        "filled_qty": "1",
+                        "filled_avg_price": "100",
+                    },
+                },
+                {
+                    **common,
+                    "execution_id": "execution-sell",
+                    "trade_decision_id": "decision-sell",
+                    "computed_at": datetime(2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc
+                    ),
+                    "side": "sell",
+                    "filled_qty": Decimal("0"),
+                    "avg_fill_price": Decimal("0"),
+                    "alpaca_order_id": "order-sell",
+                    "raw_order": {
+                        "side": "sell",
+                        "filled_qty": "1",
+                        "filled_avg_price": "101",
+                    },
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    **common,
+                    "trade_decision_id": "decision-buy",
+                    "decision_hash": "decision-buy",
+                    "event_type": "decision",
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                },
+                {
+                    **common,
+                    "trade_decision_id": "decision-sell",
+                    "decision_hash": "decision-sell",
+                    "event_type": "decision",
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                },
+            ],
+            order_lifecycle_rows=[
+                order_row(
+                    event_id="event-new-buy",
+                    decision_id="decision-buy",
+                    order_id="order-buy",
+                    event_ts=datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    event_type="new",
+                    side="buy",
+                    payload_qty=None,
+                    payload_price=None,
+                    source_offset=1,
+                ),
+                order_row(
+                    event_id="event-fill-buy",
+                    decision_id="decision-buy",
+                    order_id="order-buy",
+                    event_ts=datetime(2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc),
+                    event_type="filled",
+                    side="buy",
+                    payload_qty="1",
+                    payload_price="100",
+                    source_offset=2,
+                ),
+                order_row(
+                    event_id="event-new-sell",
+                    decision_id="decision-sell",
+                    order_id="order-sell",
+                    event_ts=datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                    event_type="new",
+                    side="sell",
+                    payload_qty=None,
+                    payload_price=None,
+                    source_offset=3,
+                ),
+                order_row(
+                    event_id="event-fill-sell",
+                    decision_id="decision-sell",
+                    order_id="order-sell",
+                    event_ts=datetime(2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc),
+                    event_type="filled",
+                    side="sell",
+                    payload_qty="1",
+                    payload_price="101",
+                    source_offset=4,
+                ),
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["authoritative"])
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["blockers"], [])
+        self.assertEqual(bucket["filled_notional"], "201")
+        self.assertEqual(bucket["open_position_count"], 0)
+        self.assertEqual(bucket["closed_trade_count"], 1)
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
 
     def test_build_realized_strategy_pnl_rows_does_not_use_idempotency_key_as_policy_hash(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -6846,9 +6846,30 @@ class TestTradingPipeline(TestCase):
                     decision=decision,
                 )
             )
+            self.assertIsNone(
+                pipeline._paper_route_probe_context(
+                    proof_floor=proof_floor,
+                    decision=decision.model_copy(update={"symbol": "AAPL"}),
+                )
+            )
+            target_source_metadata = {
+                "mode": "paper_route_target_plan_source_decision",
+                "paper_route_probe_next_session_max_notional": "25",
+            }
             scoped_context = pipeline._paper_route_probe_context(
                 proof_floor=proof_floor,
-                decision=decision.model_copy(update={"symbol": "AAPL"}),
+                decision=decision.model_copy(
+                    update={
+                        "symbol": "AAPL",
+                        "params": {
+                            "price": "100",
+                            "paper_route_target_plan": target_source_metadata,
+                            "paper_route_target_plan_source_decision": (
+                                target_source_metadata
+                            ),
+                        },
+                    }
+                ),
             )
 
         self.assertIsNotNone(scoped_context)


### PR DESCRIPTION
## Summary

- Materialize source-backed Alpaca trade-update payload fill deltas when database delta columns are absent, while leaving cumulative-only order-feed rows fail-closed.
- Keep external paper-route target-plan symbols exclusive to target-source decisions so ambient proof-floor probes cannot contaminate a target-plan runtime window.
- Add regression coverage for payload-delta ledger materialization and target-plan probe exclusivity.
- This does not promote Torghut or weaken profitability gates; it removes two proof blockers for the next clean runtime window.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py -q`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Runtime promotion still requires a fresh clean paper-route window with closed round trips, zero open positions, source-linked execution evidence, explicit costs, and the existing alpha/TCA gates cleared.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
