### PR TITLE
fix(agents): handle pod Date timestamps in debris cleanup

### DIFF
--- a/services/agents/src/server/agents-controller/runtime-debris.test.ts
+++ b/services/agents/src/server/agents-controller/runtime-debris.test.ts
@@ -9,7 +9,7 @@ const nowMs = Date.parse('2026-06-01T00:00:00.000Z')
 const buildPod = (
   name: string,
   overrides: {
-    createdAt?: string
+    createdAt?: Date | string
     deletionTimestamp?: string
     labels?: Record<string, string>
     ownerReferences?: Array<Record<string, unknown>>
@@ -73,6 +73,27 @@ describe('runtime debris cleanup', () => {
     expect(kube.delete).not.toHaveBeenCalled()
     expect(summary).toMatchObject({
       deletedPods: 0,
+      mode: 'audit',
+      orphanTerminalPods: 1,
+      scannedPods: 1,
+    })
+  })
+
+  it('treats Kubernetes client Date creation timestamps as stale candidates', async () => {
+    const kube = buildKube([buildPod('orphan-old-date', { createdAt: new Date(staleCreatedAt) })])
+
+    const summary = await reconcileRuntimeDebris({
+      config: {
+        maxDeletesPerNamespace: 25,
+        mode: 'audit',
+        orphanPodRetentionSeconds: 3600,
+      },
+      kube: kube as never,
+      namespace: 'agents',
+      nowMs,
+    })
+
+    expect(summary).toMatchObject({
       mode: 'audit',
       orphanTerminalPods: 1,
       scannedPods: 1,

--- a/services/agents/src/server/agents-controller/runtime-debris.ts
+++ b/services/agents/src/server/agents-controller/runtime-debris.ts
@@ -40,9 +40,11 @@ const getPodName = (pod: unknown) => asString(readNested(pod, ['metadata', 'name
 const getPodPhase = (pod: unknown) => asString(readNested(pod, ['status', 'phase']))?.trim() ?? null
 
 const getCreationTimestampMs = (pod: unknown) => {
-  const raw = asString(readNested(pod, ['metadata', 'creationTimestamp']))
-  if (!raw) return null
-  const parsed = Date.parse(raw)
+  const raw = readNested(pod, ['metadata', 'creationTimestamp'])
+  if (raw instanceof Date) return raw.getTime()
+  const timestamp = asString(raw)
+  if (!timestamp) return null
+  const parsed = Date.parse(timestamp)
   return Number.isNaN(parsed) ? null : parsed
 }
 


### PR DESCRIPTION
﻿## Summary

- Fix runtime debris cleanup to treat Kubernetes client `Date` creation timestamps as valid pod ages.
- Add a regression test covering stale terminal orphan pods with `Date` timestamps.
- Keeps cleanup selection behavior unchanged for string timestamps, terminal phases, owner checks, and rate limiting.

## Related Issues

None

## Testing

- Confirmed the new regression test failed before the fix with `orphanTerminalPods: 0`.
- `bun run --cwd services/agents test src/server/agents-controller/runtime-debris.test.ts src/server/agents-controller/runtime-config.test.ts src/server/agents-controller/index.integration.test.ts src/server/metrics.test.ts`
- `bun run --cwd services/agents tsc`
- `bunx oxfmt --check services/agents/src/server/agents-controller/runtime-debris.ts services/agents/src/server/agents-controller/runtime-debris.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
