### PR TITLE
fix(torghut): keep paper target plan handoff lightweight

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4689,6 +4689,7 @@ def trading_paper_route_target_plan(
         session,
         live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
         route_reacquisition_book=route_reacquisition_book,
+        include_runtime_window_import_audit=False,
     )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1624,8 +1624,7 @@ def _next_paper_route_runtime_window_targets(
     account_pre_session_clean_count = sum(
         1
         for item in account_pre_session_items
-        if item.get("state") == "clean"
-        and not _unique_text_items(item.get("blockers"))
+        if item.get("state") == "clean" and not _unique_text_items(item.get("blockers"))
     )
     account_pre_session_blocked_count = sum(
         1
@@ -2473,7 +2472,9 @@ def _runtime_ledger_bucket_diagnostic_blockers(
         if str(item).strip()
     ]
     blockers.extend(
-        runtime_ledger_promotion_source_authority_blockers(_as_mapping(row.payload_json))
+        runtime_ledger_promotion_source_authority_blockers(
+            _as_mapping(row.payload_json)
+        )
     )
     return list(dict.fromkeys(blockers))
 
@@ -2626,7 +2627,9 @@ def _runtime_ledger_non_evidence_diagnostic_summary(
             else Decimal("0")
         ),
         "blocker_counts": dict(sorted(blocker_counts.items())),
-        "source_decision_mode_counts": dict(sorted(source_decision_mode_counts.items())),
+        "source_decision_mode_counts": dict(
+            sorted(source_decision_mode_counts.items())
+        ),
         "source_decision_mode_bucket_counts": dict(
             sorted(source_decision_mode_bucket_counts.items())
         ),
@@ -3698,6 +3701,44 @@ def _runtime_ledger_proof_packet_handoff(
     }
 
 
+def _deferred_runtime_window_target_audits(
+    targets: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    audits: list[dict[str, object]] = []
+    for target in targets:
+        audits.append(
+            {
+                "target": dict(target),
+                "source_activity": {
+                    "missing": True,
+                    "missing_reasons": [
+                        "runtime_window_import_audit_deferred_until_import_ready"
+                    ],
+                },
+                "rejected_signal_activity": {
+                    "event_count": 0,
+                    "blocking_reasons": [],
+                },
+                "account_contamination": {
+                    "contaminated": False,
+                    "blockers": [],
+                },
+                "account_state": {
+                    "blockers": [],
+                },
+                "runtime_ledger": {
+                    "bucket_count": 0,
+                    "evidence_grade_bucket_count": 0,
+                    "blockers": [],
+                },
+                "promotion_decisions": {
+                    "decision_count": 0,
+                },
+            }
+        )
+    return audits
+
+
 def build_paper_route_target_plan_payload(
     session: Session,
     *,
@@ -3705,6 +3746,7 @@ def build_paper_route_target_plan_payload(
     route_reacquisition_book: Mapping[str, Any],
     generated_at: datetime | None = None,
     target_limit: int = DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+    include_runtime_window_import_audit: bool | None = True,
 ) -> dict[str, object]:
     """Build the lightweight runtime-window target-plan payload."""
 
@@ -3762,26 +3804,50 @@ def build_paper_route_target_plan_payload(
         and _safe_int(latest_closed_targets.get("target_count")) > 0
         else next_targets
     )
-    source_target_audits = [
-        _target_audit(
-            session,
-            raw_target=target,
-            probe=probe,
-            generated_at=resolved_generated_at,
-            lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+    runtime_import_readiness = _as_mapping(
+        runtime_window_import_plan.get("session_readiness")
+    )
+    runtime_import_handoff = _as_mapping(
+        runtime_window_import_plan.get("runtime_window_import_handoff")
+    )
+    runtime_import_ready = bool(
+        runtime_import_readiness.get("import_ready")
+        or runtime_import_handoff.get("import_ready")
+    )
+    run_full_runtime_import_audit = (
+        runtime_import_ready
+        if include_runtime_window_import_audit is None
+        else include_runtime_window_import_audit
+    )
+    runtime_window_import_audit_mode = (
+        "full" if run_full_runtime_import_audit else "deferred_until_import_ready"
+    )
+    if run_full_runtime_import_audit:
+        source_target_audits = [
+            _target_audit(
+                session,
+                raw_target=target,
+                probe=probe,
+                generated_at=resolved_generated_at,
+                lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+            )
+            for target in targets
+        ]
+        runtime_window_import_target_audits = [
+            _target_audit(
+                session,
+                raw_target=target,
+                probe=probe,
+                generated_at=resolved_generated_at,
+                lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+            )
+            for target in _as_mapping_items(runtime_window_import_plan.get("targets"))
+        ]
+    else:
+        source_target_audits = _deferred_runtime_window_target_audits(targets)
+        runtime_window_import_target_audits = _deferred_runtime_window_target_audits(
+            _as_mapping_items(runtime_window_import_plan.get("targets"))
         )
-        for target in targets
-    ]
-    runtime_window_import_target_audits = [
-        _target_audit(
-            session,
-            raw_target=target,
-            probe=probe,
-            generated_at=resolved_generated_at,
-            lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
-        )
-        for target in _as_mapping_items(runtime_window_import_plan.get("targets"))
-    ]
     runtime_window_import_audit = _runtime_window_import_audit(
         next_targets=runtime_window_import_plan,
         target_audits=source_target_audits,
@@ -3821,6 +3887,7 @@ def build_paper_route_target_plan_payload(
         "skipped_target_count": effective_skipped_target_count,
         "targets": effective_targets,
         "skipped_targets": effective_skipped_targets,
+        "runtime_window_import_audit_mode": runtime_window_import_audit_mode,
         "live_submission_gate": {
             "allowed": bool(live_submission_gate.get("allowed")),
             "reason": _safe_text(live_submission_gate.get("reason")),
@@ -3877,6 +3944,7 @@ def build_paper_route_target_plan_payload(
             "runtime_window_import_audit_state": _safe_text(
                 runtime_window_import_audit.get("state")
             ),
+            "runtime_window_import_audit_mode": runtime_window_import_audit_mode,
             "runtime_window_import_audit_blockers": _unique_text_items(
                 runtime_window_import_audit.get("blockers")
             ),

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from unittest import TestCase
+from unittest.mock import patch
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -133,6 +134,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         session: Session,
         *,
         generated_at: datetime,
+        include_runtime_window_import_audit: bool | None = True,
     ) -> dict[str, object]:
         return build_paper_route_target_plan_payload(
             session,
@@ -185,6 +187,43 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 },
             },
             generated_at=generated_at,
+            include_runtime_window_import_audit=include_runtime_window_import_audit,
+        )
+
+    def test_target_plan_can_defer_full_runtime_window_audit(self) -> None:
+        generated_at = datetime(2026, 5, 26, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            with patch(
+                "app.trading.paper_route_evidence._target_audit",
+                side_effect=AssertionError("full runtime-window audit should defer"),
+            ):
+                payload = self._build_basic_paper_route_target_plan(
+                    session,
+                    generated_at=generated_at,
+                    include_runtime_window_import_audit=False,
+                )
+
+        self.assertEqual(
+            payload["runtime_window_import_audit_mode"],
+            "deferred_until_import_ready",
+        )
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["state"], "import_due_source_activity_missing")
+        self.assertEqual(
+            import_audit["next_action"],
+            "inspect_paper_route_source_activity_before_import",
+        )
+        self.assertIn(
+            "runtime_window_import_audit_deferred_until_import_ready",
+            import_audit["blockers"],
+        )
+        self.assertEqual(
+            import_audit["counts"]["source_plan_target_count"],
+            1,
+        )
+        self.assertEqual(
+            import_audit["counts"]["selected_target_count"],
+            1,
         )
 
     def test_normalized_open_positions_handles_flat_short_and_implicit_market_value(
@@ -368,12 +407,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
             audit["readiness"]["evidence_collection_blockers"],
         )
         import_audit = payload["runtime_window_import_audit"]
-        self.assertNotEqual(
-            import_audit["state"], "import_due_account_state_not_clean"
-        )
-        self.assertEqual(
-            import_audit["diagnostics"]["account_state_blockers"], []
-        )
+        self.assertNotEqual(import_audit["state"], "import_due_account_state_not_clean")
+        self.assertEqual(import_audit["diagnostics"]["account_state_blockers"], [])
 
     def test_pre_session_dirty_account_skips_next_paper_route_target(self) -> None:
         generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
@@ -707,7 +742,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
             cost_model_hash_counts={"cost-a": 1},
             lineage_hash_counts={"lineage-a": 1},
             blockers_json=["unclosed_position"],
-            payload_json={"source_decision_mode_counts": {"route_acquisition_probe": 10}},
+            payload_json={
+                "source_decision_mode_counts": {"route_acquisition_probe": 10}
+            },
         )
 
         summary = _runtime_ledger_non_evidence_diagnostic_summary(
@@ -723,9 +760,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             {"route_acquisition_probe": 1, "strategy_signal_paper": 1},
         )
         self.assertEqual(
-            summary["profit_proof_eligible_diagnostic"][
-                "net_strategy_pnl_after_costs"
-            ],
+            summary["profit_proof_eligible_diagnostic"]["net_strategy_pnl_after_costs"],
             "19",
         )
         self.assertEqual(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7495,6 +7495,12 @@ class TestTradingApi(TestCase):
                     "app.main.build_paper_route_evidence_audit",
                     side_effect=AssertionError("full audit should not run"),
                 ),
+                patch(
+                    "app.trading.paper_route_evidence._target_audit",
+                    side_effect=AssertionError(
+                        "target-plan endpoint should not run per-target audits"
+                    ),
+                ),
             ):
                 response = self.client.get("/trading/paper-route-target-plan")
             self.assertEqual(response.status_code, 200)
@@ -7503,6 +7509,10 @@ class TestTradingApi(TestCase):
                 payload["schema_version"], "torghut.paper-route-target-plan.v1"
             )
             self.assertNotIn("next_runtime_window_target_audits", payload)
+            self.assertEqual(
+                payload["runtime_window_import_audit_mode"],
+                "deferred_until_import_ready",
+            )
             plan = payload["runtime_window_import_plan"]
             self.assertEqual(plan["target_count"], 1)
             self.assertEqual(


### PR DESCRIPTION
## Summary

- Keeps `/trading/paper-route-target-plan` lightweight by deferring per-target runtime-window audits in the endpoint response.
- Preserves fail-closed metadata by returning deferred audit state, blockers, counts, and `runtime_window_import_audit_mode`.
- Leaves full runtime-window audits available for evidence/proof paths while preventing the target-plan handoff from timing out before the session.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k target_plan_can_defer_full_runtime_window_audit`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan_returns_lightweight_plan or paper_route_target_plan_skips_full_proof_floor_when_target_plan_ready'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -k 'paper_route_target_plan or paper_route_evidence_uses_external_plan'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py app/main.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/main.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
