### PR TITLE
fix(torghut): bound options freshness status fallback

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5799,6 +5799,15 @@ def _decimal_or_none(value: object) -> Decimal | None:
         return None
 
 
+def _sqlalchemy_error_indicates_statement_timeout(exc: SQLAlchemyError) -> bool:
+    message = str(exc).lower()
+    return (
+        "statement timeout" in message
+        or "querycanceled" in message
+        or "query canceled" in message
+    )
+
+
 def _load_bounded_options_catalog_freshness_summary(
     session: Session,
     scoped_symbols: tuple[str, ...],
@@ -5823,6 +5832,7 @@ LIMIT 1
 """
     )
     try:
+        session.execute(text("SET LOCAL statement_timeout = 500"))
         for symbol in scoped_symbols:
             row = (
                 session.execute(
@@ -6041,6 +6051,18 @@ WHERE status = 'active'
                 rollback()
             except SQLAlchemyError:
                 logger.warning("Failed to roll back options catalog freshness session")
+        reason_codes = ["options_catalog_freshness_summary_unavailable"]
+        if _sqlalchemy_error_indicates_statement_timeout(exc):
+            reason_codes.append("options_catalog_freshness_query_timeout")
+            return _store_options_catalog_freshness_summary(
+                scoped_symbols,
+                {
+                    "status": "unavailable",
+                    "scope": "route_symbols" if scoped_symbols else "global",
+                    "route_symbols": list(scoped_symbols),
+                    "reason_codes": reason_codes,
+                },
+            )
         bounded_payload = _load_bounded_options_catalog_freshness_summary(
             session,
             scoped_symbols,
@@ -6057,7 +6079,7 @@ WHERE status = 'active'
                 "status": "unavailable",
                 "scope": "route_symbols" if scoped_symbols else "global",
                 "route_symbols": list(scoped_symbols),
-                "reason_codes": ["options_catalog_freshness_summary_unavailable"],
+                "reason_codes": reason_codes,
             },
         )
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -257,6 +257,38 @@ class _FailingOptionsFreshnessSession:
         raise SQLAlchemyError("statement timeout")
 
 
+class _TimedOutAggregateOptionsFreshnessSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object | None]] = []
+
+    def execute(
+        self, statement: object, params: object | None = None
+    ) -> _ExecuteResult:
+        statement_text = str(statement)
+        self.calls.append((statement_text, params))
+        if statement_text.startswith("SET LOCAL"):
+            return _ExecuteResult([])
+        if "GROUP BY underlying_symbol" in statement_text:
+            raise SQLAlchemyError(
+                "QueryCanceled: canceling statement due to statement timeout"
+            )
+        if "LIMIT 1" in statement_text:
+            return _ExecuteResult(
+                [
+                    {
+                        "underlying_symbol": "AAPL",
+                        "last_seen_ts": datetime(2026, 5, 12, tzinfo=timezone.utc),
+                        "provider_updated_ts": datetime(
+                            2026, 5, 12, tzinfo=timezone.utc
+                        ),
+                        "close_price": Decimal("182.10"),
+                        "open_interest": Decimal("100"),
+                    }
+                ]
+            )
+        return _ExecuteResult([])
+
+
 class _FallbackOptionsFreshnessSession:
     def __init__(self) -> None:
         self.calls: list[tuple[str, object | None]] = []
@@ -269,7 +301,7 @@ class _FallbackOptionsFreshnessSession:
         if statement_text.startswith("SET LOCAL"):
             return _ExecuteResult([])
         if "GROUP BY underlying_symbol" in statement_text:
-            raise SQLAlchemyError("statement timeout")
+            raise SQLAlchemyError("catalog aggregate unavailable")
         if "LIMIT 1" in statement_text:
             symbol = None
             if isinstance(params, dict):
@@ -307,7 +339,7 @@ class _FallbackOptionsFreshnessRequiresRollbackSession:
             return _ExecuteResult([])
         if "GROUP BY underlying_symbol" in statement_text:
             self._transaction_failed = True
-            raise SQLAlchemyError("statement timeout")
+            raise SQLAlchemyError("catalog aggregate unavailable")
         if "LIMIT 1" in statement_text:
             if self._transaction_failed:
                 raise SQLAlchemyError("current transaction is aborted")
@@ -344,7 +376,7 @@ class _FallbackOptionsFreshnessBlankSymbolSession:
         if statement_text.startswith("SET LOCAL"):
             return _ExecuteResult([])
         if "GROUP BY underlying_symbol" in statement_text:
-            raise SQLAlchemyError("statement timeout")
+            raise SQLAlchemyError("catalog aggregate unavailable")
         if "LIMIT 1" in statement_text:
             symbol = None
             if isinstance(params, dict):
@@ -654,7 +686,11 @@ class TestTradingApi(TestCase):
         self.assertEqual(second["status"], "unavailable")
         self.assertEqual(first["route_symbols"], ["AAPL"])
         self.assertEqual(second["route_symbols"], ["AAPL"])
-        self.assertEqual(len(fake_session.calls), 2)
+        self.assertEqual(len(fake_session.calls), 1)
+        self.assertIn(
+            "options_catalog_freshness_query_timeout",
+            first["reason_codes"],
+        )
         first_cache = first.get("cache")
         second_cache = second.get("cache")
         self.assertIsInstance(first_cache, dict)
@@ -663,6 +699,32 @@ class TestTradingApi(TestCase):
         assert isinstance(second_cache, dict)
         self.assertEqual(first_cache["hit"], False)
         self.assertEqual(second_cache["hit"], True)
+
+    def test_options_catalog_freshness_summary_skips_bounded_fallback_on_timeout(
+        self,
+    ) -> None:
+        fake_session = _TimedOutAggregateOptionsFreshnessSession()
+
+        payload = _load_options_catalog_freshness_summary(
+            fake_session,  # type: ignore[arg-type]
+            route_symbols=["AAPL", "MSFT"],
+        )
+
+        self.assertEqual(payload["status"], "unavailable")
+        self.assertEqual(payload["scope"], "route_symbols")
+        self.assertEqual(payload["route_symbols"], ["AAPL", "MSFT"])
+        self.assertIn(
+            "options_catalog_freshness_summary_unavailable",
+            payload["reason_codes"],
+        )
+        self.assertIn(
+            "options_catalog_freshness_query_timeout",
+            payload["reason_codes"],
+        )
+        self.assertEqual(
+            sum("LIMIT 1" in sql for sql, _params in fake_session.calls),
+            0,
+        )
 
     def test_options_catalog_freshness_summary_expires_cached_route_scope(
         self,


### PR DESCRIPTION
## Summary

- Bound options catalog freshness fallback behavior so statement timeouts return cached unavailable status instead of doing more synchronous catalog reads inside health/status endpoints.
- Keep the bounded per-symbol fallback for non-timeout aggregate failures and apply the same local statement timeout before fallback reads.
- Add regression coverage for timeout short-circuiting and preserved non-timeout bounded fallback behavior.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k "options_catalog_freshness" -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
