### PR TITLE
fix(torghut): bound runtime ledger status scans

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
@@ -12,7 +13,8 @@ from typing import Any, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ..config import settings
@@ -64,6 +66,9 @@ from .runtime_strategy_resolution import (
 )
 from .tca import build_tca_gate_inputs
 
+
+logger = logging.getLogger(__name__)
+
 _CAPITAL_STAGE_ORDER = (
     "shadow",
     "0.10x canary",
@@ -102,12 +107,38 @@ _AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
 )
 _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT = 256
 _RUNTIME_LEDGER_REPAIR_CANDIDATE_LIMIT = 8
+_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS = 750
 _RUNTIME_WINDOW_IMPORT_CONTINUITY_READY_STATES = frozenset(
     {
         "signals_present",
         "expected_market_closed_staleness",
     }
 )
+
+
+def _maybe_set_runtime_ledger_status_statement_timeout(session: Session) -> None:
+    get_bind = getattr(session, "get_bind", None)
+    if callable(get_bind):
+        try:
+            bind = get_bind()
+            dialect = getattr(getattr(bind, "dialect", None), "name", "")
+            if dialect != "postgresql":
+                return
+        except Exception:
+            pass
+    session.execute(
+        text(f"SET LOCAL statement_timeout = {_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS}")
+    )
+
+
+def _rollback_runtime_ledger_status_session(session: Session) -> None:
+    rollback = getattr(session, "rollback", None)
+    if not callable(rollback):
+        return
+    try:
+        rollback()
+    except SQLAlchemyError:
+        logger.warning("Failed to roll back runtime-ledger status session")
 
 
 def _runtime_window_import_continuity_signal(state: object) -> tuple[str, str, str]:
@@ -1064,29 +1095,36 @@ def _load_latest_runtime_ledger_summary(
 
     rows_by_hypothesis: dict[str, int] = {}
     retained_rows: list[dict[str, object]] = []
-    rows = session.execute(
-        select(StrategyRuntimeLedgerBucket)
-        .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(normalized_ids))
-        .order_by(
-            StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
-            StrategyRuntimeLedgerBucket.created_at.desc(),
-        )
-    ).scalars()
-    for row in rows:
-        payload = _runtime_ledger_bucket_payload(row)
-        retained_count = rows_by_hypothesis.get(row.hypothesis_id, 0)
-        if retained_count < 8:
-            retained_rows.append(payload)
-            rows_by_hypothesis[row.hypothesis_id] = retained_count + 1
+    try:
+        _maybe_set_runtime_ledger_status_statement_timeout(session)
+        rows = session.execute(
+            select(StrategyRuntimeLedgerBucket)
+            .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(normalized_ids))
+            .order_by(
+                StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+                StrategyRuntimeLedgerBucket.created_at.desc(),
+            )
+            .limit(_RUNTIME_LEDGER_REPAIR_SCAN_LIMIT)
+        ).scalars()
+        for row in rows:
+            payload = _runtime_ledger_bucket_payload(row)
+            retained_count = rows_by_hypothesis.get(row.hypothesis_id, 0)
+            if retained_count < 8:
+                retained_rows.append(payload)
+                rows_by_hypothesis[row.hypothesis_id] = retained_count + 1
 
-        current = by_hypothesis.get(row.hypothesis_id)
-        if current is None:
-            by_hypothesis[row.hypothesis_id] = payload
-            continue
-        current_is_live = str(current.get("observed_stage") or "").strip() == "live"
-        row_is_live = str(payload.get("observed_stage") or "").strip() == "live"
-        if row_is_live and not current_is_live:
-            by_hypothesis[row.hypothesis_id] = payload
+            current = by_hypothesis.get(row.hypothesis_id)
+            if current is None:
+                by_hypothesis[row.hypothesis_id] = payload
+                continue
+            current_is_live = str(current.get("observed_stage") or "").strip() == "live"
+            row_is_live = str(payload.get("observed_stage") or "").strip() == "live"
+            if row_is_live and not current_is_live:
+                by_hypothesis[row.hypothesis_id] = payload
+    except SQLAlchemyError as exc:
+        logger.warning("Runtime ledger latest summary unavailable: %s", exc)
+        _rollback_runtime_ledger_status_session(session)
+        return {"by_hypothesis": by_hypothesis, "runtime_ledger_buckets": []}
     return {"by_hypothesis": by_hypothesis, "runtime_ledger_buckets": retained_rows}
 
 
@@ -1721,19 +1759,25 @@ def _load_runtime_ledger_repair_candidates(
     if not hypothesis_ids or limit <= 0:
         return []
 
-    rows = (
-        session.execute(
-            select(StrategyRuntimeLedgerBucket)
-            .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(hypothesis_ids))
-            .order_by(
-                StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
-                StrategyRuntimeLedgerBucket.created_at.desc(),
+    try:
+        _maybe_set_runtime_ledger_status_statement_timeout(session)
+        rows = (
+            session.execute(
+                select(StrategyRuntimeLedgerBucket)
+                .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(hypothesis_ids))
+                .order_by(
+                    StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+                    StrategyRuntimeLedgerBucket.created_at.desc(),
+                )
+                .limit(_RUNTIME_LEDGER_REPAIR_SCAN_LIMIT)
             )
-            .limit(_RUNTIME_LEDGER_REPAIR_SCAN_LIMIT)
+            .scalars()
+            .all()
         )
-        .scalars()
-        .all()
-    )
+    except SQLAlchemyError as exc:
+        logger.warning("Runtime ledger repair candidates unavailable: %s", exc)
+        _rollback_runtime_ledger_status_session(session)
+        return []
 
     candidates: list[dict[str, object]] = []
     seen: set[tuple[str, str, str, str, str]] = set()
@@ -2042,16 +2086,23 @@ def _load_latest_certificate_evidence(
         latest_promotions.setdefault(row.hypothesis_id, []).append(row)
 
     latest_runtime_ledgers: dict[str, list[StrategyRuntimeLedgerBucket]] = {}
-    runtime_ledger_rows = session.execute(
-        select(StrategyRuntimeLedgerBucket)
-        .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(normalized_ids))
-        .order_by(
-            StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
-            StrategyRuntimeLedgerBucket.created_at.desc(),
-        )
-    ).scalars()
-    for row in runtime_ledger_rows:
-        latest_runtime_ledgers.setdefault(row.hypothesis_id, []).append(row)
+    try:
+        _maybe_set_runtime_ledger_status_statement_timeout(session)
+        runtime_ledger_rows = session.execute(
+            select(StrategyRuntimeLedgerBucket)
+            .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(normalized_ids))
+            .order_by(
+                StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+                StrategyRuntimeLedgerBucket.created_at.desc(),
+            )
+            .limit(_RUNTIME_LEDGER_REPAIR_SCAN_LIMIT)
+        ).scalars()
+        for row in runtime_ledger_rows:
+            latest_runtime_ledgers.setdefault(row.hypothesis_id, []).append(row)
+    except SQLAlchemyError as exc:
+        logger.warning("Runtime ledger certificate evidence unavailable: %s", exc)
+        _rollback_runtime_ledger_status_session(session)
+        latest_runtime_ledgers = {}
 
     evidence: list[dict[str, object]] = []
     for hypothesis_id in normalized_ids:

--- a/services/torghut/migrations/versions/0041_runtime_ledger_status_index.py
+++ b/services/torghut/migrations/versions/0041_runtime_ledger_status_index.py
@@ -1,0 +1,30 @@
+"""Add runtime-ledger status lookup index."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0041_runtime_ledger_status_index"
+down_revision = "0040_order_feed_fill_delta_basis"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_strategy_runtime_ledger_buckets_hypothesis_ended_created"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+CREATE INDEX IF NOT EXISTS {INDEX_NAME}
+ON strategy_runtime_ledger_buckets (
+    hypothesis_id,
+    bucket_ended_at DESC,
+    created_at DESC
+)
+"""
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP INDEX IF EXISTS {INDEX_NAME}")

--- a/services/torghut/tests/test_portfolio_sizing.py
+++ b/services/torghut/tests/test_portfolio_sizing.py
@@ -501,9 +501,7 @@ class TestPortfolioSizing(TestCase):
 
         self.assertEqual(len(results), 1)
         self.assertFalse(results[0].approved)
-        self.assertIn(
-            ALLOCATOR_STRATEGY_FACTORY_OBSERVE_ONLY, results[0].reason_codes
-        )
+        self.assertIn(ALLOCATOR_STRATEGY_FACTORY_OBSERVE_ONLY, results[0].reason_codes)
 
     def test_allocator_blocks_strategy_factory_baseline_fail_candidates(self) -> None:
         allocator = PortfolioAllocator(
@@ -557,9 +555,7 @@ class TestPortfolioSizing(TestCase):
 
         self.assertEqual(len(results), 1)
         self.assertFalse(results[0].approved)
-        self.assertIn(
-            ALLOCATOR_STRATEGY_FACTORY_BASELINE_FAIL, results[0].reason_codes
-        )
+        self.assertIn(ALLOCATOR_STRATEGY_FACTORY_BASELINE_FAIL, results[0].reason_codes)
 
     def test_allocator_clips_by_strategy_budget(self) -> None:
         allocator = PortfolioAllocator(
@@ -1028,6 +1024,7 @@ class TestPortfolioSizing(TestCase):
     def test_sell_inventory_clip_below_one_share_reports_inventory_reason(self) -> None:
         original_allow_shorts = config.settings.trading_allow_shorts
         config.settings.trading_allow_shorts = False
+        config.settings.trading_fractional_equities_enabled = False
         try:
             sizer = PortfolioSizer(
                 PortfolioSizingConfig(

--- a/services/torghut/tests/test_runtime_ledger_status_index_migration.py
+++ b/services/torghut/tests/test_runtime_ledger_status_index_migration.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest import TestCase
+from unittest.mock import patch
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0041_runtime_ledger_status_index.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0041", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0041")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestRuntimeLedgerStatusIndexMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(module.revision, "0041_runtime_ledger_status_index")
+        self.assertEqual(module.down_revision, "0040_order_feed_fill_delta_basis")
+
+    def test_upgrade_adds_hypothesis_ordering_index(self) -> None:
+        module = _load_migration_module()
+
+        with patch.object(module.op, "execute") as execute:
+            module.upgrade()
+
+        execute.assert_called_once()
+        sql = str(execute.call_args.args[0])
+        self.assertIn("CREATE INDEX IF NOT EXISTS", sql)
+        self.assertIn(
+            "ix_strategy_runtime_ledger_buckets_hypothesis_ended_created",
+            sql,
+        )
+        self.assertIn("hypothesis_id", sql)
+        self.assertIn("bucket_ended_at DESC", sql)
+        self.assertIn("created_at DESC", sql)
+
+    def test_downgrade_drops_index(self) -> None:
+        module = _load_migration_module()
+
+        with patch.object(module.op, "execute") as execute:
+            module.downgrade()
+
+        execute.assert_called_once()
+        self.assertIn("DROP INDEX IF EXISTS", str(execute.call_args.args[0]))

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -8,6 +8,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -34,8 +35,11 @@ from app.trading.submission_council import (
     _load_latest_certificate_evidence,
     _load_latest_runtime_ledger_summary,
     _load_profit_promotion_table_counts,
+    _load_runtime_ledger_repair_candidates,
     _merge_runtime_certificate_evidence,
+    _maybe_set_runtime_ledger_status_statement_timeout,
     _metric_window_activity_reason_codes,
+    _rollback_runtime_ledger_status_session,
     _runtime_ledger_repair_reason_codes,
     _refresh_runtime_summary_totals,
     _runtime_ledger_paper_probation_import_plan,
@@ -60,6 +64,42 @@ class _FakeQuantHealthResponse:
 
     def read(self) -> bytes:
         return json.dumps(self._payload).encode("utf-8")
+
+
+class _FailingRuntimeLedgerStatusSession:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.rollback_count = 0
+
+    def execute(self, statement: object) -> object:
+        self.calls.append(str(statement))
+        raise SQLAlchemyError("statement timeout")
+
+    def rollback(self) -> None:
+        self.rollback_count += 1
+
+
+class _RaisingBindRuntimeLedgerStatusSession:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def get_bind(self) -> object:
+        raise RuntimeError("fake bind unavailable")
+
+    def execute(self, statement: object) -> object:
+        self.calls.append(str(statement))
+        return object()
+
+
+class _NoRollbackRuntimeLedgerStatusSession:
+    def execute(self, statement: object) -> object:
+        raise SQLAlchemyError(f"statement timeout: {statement}")
+
+
+class _RollbackFailingRuntimeLedgerStatusSession(_FailingRuntimeLedgerStatusSession):
+    def rollback(self) -> None:
+        self.rollback_count += 1
+        raise SQLAlchemyError("rollback failed")
 
 
 class TestSubmissionCouncil(TestCase):
@@ -543,6 +583,72 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(cont["execution_policy_hash_counts"], {"new-policy": 1})
         self.assertIsNone(rev["post_cost_expectancy_bps"])
         self.assertGreaterEqual(len(summary["runtime_ledger_buckets"]), 4)
+
+    def test_load_latest_runtime_ledger_summary_fails_closed_on_query_timeout(
+        self,
+    ) -> None:
+        fake_session = _FailingRuntimeLedgerStatusSession()
+
+        summary = _load_latest_runtime_ledger_summary(
+            fake_session,  # type: ignore[arg-type]
+            hypothesis_ids=["H-PAIRS-01"],
+        )
+
+        self.assertEqual(summary, {"by_hypothesis": {}, "runtime_ledger_buckets": []})
+        self.assertEqual(fake_session.rollback_count, 1)
+
+    def test_runtime_ledger_status_timeout_helper_applies_timeout_when_bind_lookup_fails(
+        self,
+    ) -> None:
+        fake_session = _RaisingBindRuntimeLedgerStatusSession()
+
+        _maybe_set_runtime_ledger_status_statement_timeout(
+            fake_session,  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(
+            fake_session.calls,
+            ["SET LOCAL statement_timeout = 750"],
+        )
+
+    def test_runtime_ledger_status_rollback_helper_ignores_missing_rollback(
+        self,
+    ) -> None:
+        _rollback_runtime_ledger_status_session(
+            _NoRollbackRuntimeLedgerStatusSession(),  # type: ignore[arg-type]
+        )
+
+    def test_load_latest_runtime_ledger_summary_fails_closed_when_rollback_fails(
+        self,
+    ) -> None:
+        fake_session = _RollbackFailingRuntimeLedgerStatusSession()
+
+        summary = _load_latest_runtime_ledger_summary(
+            fake_session,  # type: ignore[arg-type]
+            hypothesis_ids=["H-PAIRS-01"],
+        )
+
+        self.assertEqual(summary, {"by_hypothesis": {}, "runtime_ledger_buckets": []})
+        self.assertEqual(fake_session.rollback_count, 1)
+
+    def test_load_runtime_ledger_repair_candidates_fails_closed_on_query_timeout(
+        self,
+    ) -> None:
+        fake_session = _FailingRuntimeLedgerStatusSession()
+
+        candidates = _load_runtime_ledger_repair_candidates(
+            fake_session,  # type: ignore[arg-type]
+            registry_items=[
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "candidate",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                }
+            ],
+        )
+
+        self.assertEqual(candidates, [])
+        self.assertEqual(fake_session.rollback_count, 1)
 
     def test_build_live_submission_gate_payload_surfaces_runtime_ledger_repair_candidates(
         self,
@@ -2710,6 +2816,82 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(
             runtime_ledger_bucket["strategy_family"], "intraday_continuation"
         )
+
+    def test_load_latest_certificate_evidence_fails_closed_when_runtime_ledger_scan_times_out(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+
+        with session_local() as session:
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="live",
+                    window_started_at=now,
+                    window_ended_at=now,
+                    market_session_count=3,
+                    decision_count=42,
+                    trade_count=42,
+                    order_count=42,
+                    avg_abs_slippage_bps="4.2",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="8.5",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="0.10x canary",
+                    payload_json={
+                        "post_cost_promotion_sample_count": 42,
+                        "post_cost_basis_counts": {
+                            "realized_strategy_pnl_after_explicit_costs": 42
+                        },
+                        "post_cost_expectancy_aggregation": "runtime_ledger_notional_weighted",
+                        "runtime_ledger_notional_weighted_sample_count": 42,
+                    },
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="live",
+                    state="0.10x canary",
+                    allowed=True,
+                    reason_summary="runtime_evidence_thresholds_satisfied",
+                )
+            )
+            session.add(
+                self._runtime_ledger_bucket_row(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    bucket_at=now,
+                )
+            )
+            session.commit()
+
+            with patch(
+                "app.trading.submission_council._maybe_set_runtime_ledger_status_statement_timeout",
+                side_effect=SQLAlchemyError("statement timeout"),
+            ):
+                evidence = _load_latest_certificate_evidence(
+                    session,
+                    hypothesis_ids=["H-CONT-01"],
+                )
+
+        self.assertEqual(len(evidence), 1)
+        self.assertIsNone(evidence[0]["runtime_ledger_bucket"])
 
     def test_hypothesis_runtime_summary_counts_allowed_paper_runtime_readiness_without_capital_promotion(
         self,


### PR DESCRIPTION
## Summary

- Bound runtime-ledger status scans used by live submission/status payloads with a Postgres statement timeout and fail-closed empty diagnostics on timeout.
- Add a composite index for `strategy_runtime_ledger_buckets` lookups by hypothesis and newest bucket ordering.
- Add regression coverage for timeout-safe runtime-ledger status fallbacks and the new migration.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py -k "runtime_ledger_summary or runtime_ledger_repair_candidates" -q`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_status_index_migration.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py tests/test_runtime_ledger_status_index_migration.py migrations/versions/0041_runtime_ledger_status_index.py`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_runtime_ledger_status_index_migration.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k "options_catalog_freshness" -q`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py tests/test_runtime_ledger_status_index_migration.py migrations/versions/0041_runtime_ledger_status_index.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
