### PR TITLE
fix(torghut): extend source-window repair deadline

### DIFF
--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 300
+      activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: Never

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1227,7 +1227,7 @@ class TestLiveConfigManifestContract(TestCase):
             cast(Mapping[str, object], job_spec.get("template", {})),
         )
         pod_spec = cast(Mapping[str, object], template.get("spec", {}))
-        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 300)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 900)
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
         self.assertEqual(
             pod_spec.get("nodeSelector"),


### PR DESCRIPTION
## Summary

- Extends the Torghut order-feed source-window repair CronJob deadline from 300s to 900s.
- Keeps the repair job bounded with the existing batch limits and `Forbid` concurrency.
- Updates the live manifest contract test to match the production deadline.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k order_feed_source_window_repair -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
