### PR TITLE
fix(torghut): bound paper target plan endpoint

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4636,30 +4636,32 @@ def trading_paper_route_target_plan(
         scheduler = TradingScheduler()
         app.state.trading_scheduler = scheduler
 
-    empirical_jobs = _empirical_jobs_status()
-    quant_evidence = load_quant_evidence_status(
-        account_label=settings.trading_account_label,
-    )
-    tca_summary = _load_tca_summary(session, scheduler=scheduler)
-    market_context_status = scheduler.market_context_status()
-    hypothesis_payload, _hypothesis_summary, _dependency_quorum = (
-        _build_hypothesis_runtime_payload(
-            scheduler,
-            tca_summary=tca_summary,
-            market_context_status=market_context_status,
+    live_submission_gate = _paper_route_cached_live_submission_gate(scheduler)
+    if live_submission_gate is None:
+        empirical_jobs = _empirical_jobs_status()
+        quant_evidence = load_quant_evidence_status(
+            account_label=settings.trading_account_label,
         )
-    )
-    live_submission_gate = _build_live_submission_gate_payload(
-        scheduler.state,
-        session=session,
-        hypothesis_summary=hypothesis_payload,
-        empirical_jobs_status=empirical_jobs,
-        dspy_runtime_status=cast(
-            dict[str, object],
-            scheduler.llm_status().get("dspy_runtime", {}),
-        ),
-        quant_health_status=quant_evidence,
-    )
+        tca_summary = _load_tca_summary(session, scheduler=scheduler)
+        market_context_status = scheduler.market_context_status()
+        hypothesis_payload, _hypothesis_summary, _dependency_quorum = (
+            _build_hypothesis_runtime_payload(
+                scheduler,
+                tca_summary=tca_summary,
+                market_context_status=market_context_status,
+            )
+        )
+        live_submission_gate = _build_live_submission_gate_payload(
+            scheduler.state,
+            session=session,
+            hypothesis_summary=hypothesis_payload,
+            empirical_jobs_status=empirical_jobs,
+            dspy_runtime_status=cast(
+                dict[str, object],
+                scheduler.llm_status().get("dspy_runtime", {}),
+            ),
+            quant_health_status=quant_evidence,
+        )
     live_submission_gate = _merge_external_paper_route_target_plan(
         cast(Mapping[str, Any], live_submission_gate)
     )
@@ -4668,23 +4670,10 @@ def trading_paper_route_target_plan(
         live_submission_gate,
         simple_lane_status=simple_lane_status,
         state=scheduler.state,
+        session=session,
     )
     if route_reacquisition_book is None:
-        proof_floor = _build_profitability_proof_floor_payload(
-            state=scheduler.state,
-            torghut_revision=BUILD_VERSION,
-            live_submission_gate=live_submission_gate,
-            hypothesis_payload=hypothesis_payload,
-            empirical_jobs_status=empirical_jobs,
-            quant_evidence=quant_evidence,
-            market_context_status=market_context_status,
-            tca_summary=tca_summary,
-            simple_lane_status=simple_lane_status,
-        )
-        route_reacquisition_book = cast(
-            Mapping[str, Any],
-            proof_floor.get("route_reacquisition_book") or {},
-        )
+        route_reacquisition_book = cast(Mapping[str, Any], {})
     payload = build_paper_route_target_plan_payload(
         session,
         live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
@@ -4743,17 +4732,101 @@ def _paper_route_target_plan_probe_notional(
     return _decimal_to_string(max(positive_values))
 
 
+def _paper_route_cached_live_submission_gate(
+    scheduler: object,
+) -> dict[str, object] | None:
+    cached_gate = getattr(scheduler, "_last_live_submission_gate", None)
+    if not isinstance(cached_gate, Mapping):
+        return None
+    gate = dict(cast(Mapping[str, object], cached_gate))
+    if not _paper_route_target_plan_targets(
+        _paper_route_target_plan_from_payload(gate)
+    ):
+        return None
+    gate.setdefault("paper_route_target_plan_source", "cached_live_submission_gate")
+    return gate
+
+
+def _paper_route_target_strategy_lookup_names(
+    target: Mapping[str, Any],
+) -> list[str]:
+    names: list[str] = []
+    for raw_value in (
+        target.get("strategy_lookup_names"),
+        target.get("runtime_strategy_name"),
+        target.get("strategy_name"),
+    ):
+        values: Sequence[object]
+        if isinstance(raw_value, Sequence) and not isinstance(
+            raw_value,
+            (str, bytes, bytearray),
+        ):
+            values = cast(Sequence[object], raw_value)
+        else:
+            values = (raw_value,)
+        for value in values:
+            if value is None:
+                continue
+            name = str(value).strip()
+            if name and name not in names:
+                names.append(name)
+    return names
+
+
+def _paper_route_probe_symbols_from_target_plan_strategies(
+    session: Session,
+    targets: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    lookup_names: list[str] = []
+    for target in targets:
+        for name in _paper_route_target_strategy_lookup_names(target):
+            if name not in lookup_names:
+                lookup_names.append(name)
+    if not lookup_names:
+        return []
+
+    rows = session.execute(
+        select(Strategy.name, Strategy.universe_symbols).where(
+            Strategy.name.in_(lookup_names)
+        )
+    ).all()
+    universe_by_name = {
+        str(name): universe_symbols for name, universe_symbols in rows if name
+    }
+    symbols: list[str] = []
+    for name in lookup_names:
+        raw_symbols = universe_by_name.get(name)
+        if isinstance(raw_symbols, Sequence) and not isinstance(
+            raw_symbols,
+            (str, bytes, bytearray),
+        ):
+            values = cast(Sequence[object], raw_symbols)
+        else:
+            values = ()
+        for raw_symbol in values:
+            symbol = str(raw_symbol).strip().upper()
+            if symbol and symbol not in symbols:
+                symbols.append(symbol)
+    return symbols
+
+
 def _paper_route_probe_book_from_target_plan(
     live_submission_gate: Mapping[str, Any],
     *,
     simple_lane_status: Mapping[str, Any],
     state: object,
+    session: Session | None = None,
 ) -> Mapping[str, Any] | None:
     plan = _paper_route_target_plan_from_payload(live_submission_gate)
     targets = _paper_route_target_plan_targets(plan)
     if not targets:
         return None
     eligible_symbols = _paper_route_target_plan_probe_symbols(plan)
+    if not eligible_symbols and session is not None:
+        eligible_symbols = _paper_route_probe_symbols_from_target_plan_strategies(
+            session,
+            targets,
+        )
     if not eligible_symbols:
         return None
     next_session_max_notional = _paper_route_target_plan_probe_notional(

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -790,12 +790,75 @@ def _target_allows_strategy_universe_probe_fallback(
     )
 
 
+def _strategy_lookup_names_for_target(target: Mapping[str, Any]) -> list[str]:
+    strategy_name = _safe_text(target.get("strategy_name"))
+    strategy_id = _safe_text(target.get("strategy_id"))
+    runtime_strategy_name = (
+        explicit_runtime_strategy_name_or_family_harness(
+            runtime_strategy_name=target.get("runtime_strategy_name"),
+            strategy_name=strategy_name,
+            strategy_id=strategy_id,
+        )
+        or strategy_name
+    )
+    return _strategy_lookup_names(
+        target.get("strategy_lookup_names"),
+        runtime_strategy_name,
+        strategy_name,
+        strategy_names_from_strategy_id(strategy_id),
+        derived_strategy_name_from_strategy_id(strategy_id),
+    )
+
+
+def _strategy_rows_by_name_for_targets(
+    session: Session,
+    targets: Sequence[Mapping[str, Any]],
+) -> dict[str, dict[str, object]]:
+    lookup_names: list[str] = []
+    for target in targets:
+        for name in _strategy_lookup_names_for_target(target):
+            if name and name not in lookup_names:
+                lookup_names.append(name)
+    if not lookup_names:
+        return {}
+    rows = session.execute(
+        select(
+            Strategy.id.label("id"),
+            Strategy.name.label("name"),
+            Strategy.enabled.label("enabled"),
+            Strategy.base_timeframe.label("base_timeframe"),
+            Strategy.universe_symbols.label("universe_symbols"),
+            Strategy.max_notional_per_trade.label("max_notional_per_trade"),
+        ).where(Strategy.name.in_(lookup_names))
+    ).mappings()
+    return {str(row.get("name")): dict(row) for row in rows if row.get("name")}
+
+
+def _strategy_universe_symbols_from_row(row: Mapping[str, object]) -> list[str]:
+    symbols: list[str] = []
+    for item in _as_sequence(row.get("universe_symbols")):
+        symbol = str(item).strip().upper()
+        if symbol and symbol not in symbols:
+            symbols.append(symbol)
+    return symbols
+
+
 def _strategy_universe_symbols(
     session: Session,
     *,
     strategy_lookup_names: Sequence[str],
+    strategy_rows_by_name: Mapping[str, Mapping[str, object]] | None = None,
 ) -> list[str]:
     if not strategy_lookup_names:
+        return []
+    if strategy_rows_by_name is not None:
+        for strategy_name in strategy_lookup_names:
+            row = strategy_rows_by_name.get(strategy_name)
+            if row is None:
+                continue
+            symbols = _strategy_universe_symbols_from_row(row)
+            if symbols:
+                return symbols
         return []
     rows = session.execute(
         select(Strategy.name, Strategy.universe_symbols).where(
@@ -823,26 +886,34 @@ def _strategy_source_decision_readiness(
     strategy_lookup_names: Sequence[str],
     raw_probe_symbols: Sequence[str],
     scoped_probe_symbols: Sequence[str],
+    strategy_rows_by_name: Mapping[str, Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
     lookup_names = [name for name in strategy_lookup_names if name]
     blockers: list[str] = []
     matched: dict[str, object] | None = None
     if lookup_names:
-        rows = [
-            dict(row)
-            for row in session.execute(
-                select(
-                    Strategy.id.label("id"),
-                    Strategy.name.label("name"),
-                    Strategy.enabled.label("enabled"),
-                    Strategy.base_timeframe.label("base_timeframe"),
-                    Strategy.universe_symbols.label("universe_symbols"),
-                    Strategy.max_notional_per_trade.label("max_notional_per_trade"),
-                ).where(Strategy.name.in_(lookup_names))
-            )
-            .mappings()
-            .all()
-        ]
+        if strategy_rows_by_name is None:
+            rows = [
+                dict(row)
+                for row in session.execute(
+                    select(
+                        Strategy.id.label("id"),
+                        Strategy.name.label("name"),
+                        Strategy.enabled.label("enabled"),
+                        Strategy.base_timeframe.label("base_timeframe"),
+                        Strategy.universe_symbols.label("universe_symbols"),
+                        Strategy.max_notional_per_trade.label("max_notional_per_trade"),
+                    ).where(Strategy.name.in_(lookup_names))
+                )
+                .mappings()
+                .all()
+            ]
+        else:
+            rows = [
+                dict(row)
+                for name in lookup_names
+                if (row := strategy_rows_by_name.get(name)) is not None
+            ]
         rows_by_name = {str(row.get("name")): row for row in rows if row.get("name")}
         for lookup_name in lookup_names:
             row = rows_by_name.get(lookup_name)
@@ -1231,6 +1302,7 @@ def _next_paper_route_runtime_window_targets(
         "final_promotion_authorized": False,
         "promotion_gate": "runtime_ledger_live_or_live_paper_required",
     }
+    strategy_rows_by_name = _strategy_rows_by_name_for_targets(session, targets)
     planned_targets: list[dict[str, object]] = []
     skipped_targets: list[dict[str, object]] = []
     planned_keys: set[tuple[object, ...]] = set()
@@ -1263,6 +1335,7 @@ def _next_paper_route_runtime_window_targets(
         strategy_universe_symbols = _strategy_universe_symbols(
             session,
             strategy_lookup_names=strategy_lookup_names,
+            strategy_rows_by_name=strategy_rows_by_name,
         )
         target_probe_symbols = raw_target_probe_symbols
         source_readiness_raw_probe_symbols = raw_target_probe_symbols
@@ -1290,6 +1363,7 @@ def _next_paper_route_runtime_window_targets(
             strategy_lookup_names=strategy_lookup_names,
             raw_probe_symbols=source_readiness_raw_probe_symbols,
             scoped_probe_symbols=target_probe_symbols,
+            strategy_rows_by_name=strategy_rows_by_name,
         )
         matched_strategy = _as_mapping(
             source_decision_readiness.get("matched_strategy")

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -31,6 +31,7 @@ from app.trading.paper_route_evidence import (
     _runtime_ledger_bucket_evidence_grade,
     _runtime_ledger_non_evidence_diagnostic_summary,
     _runtime_ledger_row_diagnostic_expectancy_bps,
+    _strategy_source_decision_readiness,
     build_paper_route_evidence_audit,
     build_paper_route_target_plan_payload,
 )
@@ -1470,6 +1471,49 @@ class TestPaperRouteEvidenceAudit(TestCase):
             summary_target["source_decision_mode"], "route_acquisition_probe"
         )
         self.assertFalse(summary_target["profit_proof_eligible"])
+
+    def test_strategy_source_decision_readiness_queries_session_without_prefetch(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="session-source-strategy",
+                description="source decision session lookup fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "MSFT"],
+                max_notional_per_trade=Decimal("25000"),
+            )
+            session.add(strategy)
+            session.commit()
+            strategy_id = str(strategy.id)
+
+            readiness = _strategy_source_decision_readiness(
+                session,
+                strategy_lookup_names=["session-source-strategy"],
+                raw_probe_symbols=["AAPL", "GOOG"],
+                scoped_probe_symbols=["AAPL"],
+            )
+
+        self.assertTrue(readiness["ready"])
+        self.assertEqual(readiness["blockers"], [])
+        self.assertEqual(
+            readiness["matched_strategy"],
+            {
+                "strategy_id": strategy_id,
+                "strategy_name": "session-source-strategy",
+                "enabled": True,
+                "base_timeframe": "1Min",
+                "universe_symbols": ["AAPL", "MSFT"],
+                "max_notional_per_trade": "25000",
+            },
+        )
+        self.assertEqual(
+            readiness["strategy_lookup_names"], ["session-source-strategy"]
+        )
+        self.assertEqual(readiness["raw_probe_symbols"], ["AAPL", "GOOG"])
+        self.assertEqual(readiness["scoped_probe_symbols"], ["AAPL"])
 
     def test_next_paper_route_targets_use_family_runtime_harness_from_strategy_id(
         self,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7525,22 +7525,6 @@ class TestTradingApi(TestCase):
                 "targets": [target],
             },
         }
-        proof_floor = {
-            "route_reacquisition_book": {
-                "schema_version": "torghut.route-reacquisition-book.v1",
-                "state": "repair_only",
-                "paper_route_probe": {
-                    "configured_enabled": True,
-                    "active": False,
-                    "effective_max_notional": "0",
-                    "next_session_max_notional": "63180",
-                    "eligible_symbol_count": 1,
-                    "eligible_symbols": ["AAPL"],
-                    "active_symbols": [],
-                    "blocking_reasons": ["market_session_closed"],
-                },
-            }
-        }
         try:
             if hasattr(app.state, "trading_scheduler"):
                 del app.state.trading_scheduler
@@ -7551,7 +7535,14 @@ class TestTradingApi(TestCase):
                 ),
                 patch(
                     "app.main._build_profitability_proof_floor_payload",
-                    return_value=proof_floor,
+                    side_effect=AssertionError("proof floor should not run"),
+                ),
+                patch(
+                    "app.main._build_simple_lane_status_payload",
+                    return_value={
+                        "paper_route_probe_enabled": True,
+                        "paper_route_probe_max_notional": "63180",
+                    },
                 ),
                 patch(
                     "app.main.build_paper_route_evidence_audit",
@@ -7604,6 +7595,308 @@ class TestTradingApi(TestCase):
             )
             self.assertFalse(payload["targets"][0]["promotion_allowed"])
             self.assertFalse(payload["targets"][0]["final_promotion_allowed"])
+        finally:
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
+    def test_trading_paper_route_target_plan_uses_cached_gate_fast_path(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "account_label": "TORGHUT_SIM",
+            "source_kind": "runtime_ledger_paper_probation_candidates",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+            "window_start": "2026-05-22T13:30:00+00:00",
+            "window_end": "2026-05-22T20:00:00+00:00",
+            "paper_route_probe_symbols": ["AAPL"],
+            "paper_probation_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "max_notional": "0",
+        }
+        cached_gate = {
+            "allowed": False,
+            "reason": "simple_submit_disabled",
+            "blocked_reasons": [
+                "alpha_readiness_not_promotion_eligible",
+                "simple_submit_disabled",
+            ],
+            "promotion_eligible_total": 0,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "skipped_target_count": 0,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [target],
+            },
+        }
+        fake_scheduler = SimpleNamespace(
+            state=SimpleNamespace(market_session_open=False),
+            _last_live_submission_gate=cached_gate,
+        )
+        try:
+            app.state.trading_scheduler = fake_scheduler
+            with (
+                patch(
+                    "app.main._empirical_jobs_status",
+                    side_effect=AssertionError("empirical jobs should not load"),
+                ),
+                patch(
+                    "app.main.load_quant_evidence_status",
+                    side_effect=AssertionError("quant evidence should not load"),
+                ),
+                patch(
+                    "app.main._load_tca_summary",
+                    side_effect=AssertionError("TCA summary should not load"),
+                ),
+                patch(
+                    "app.main._build_hypothesis_runtime_payload",
+                    side_effect=AssertionError("hypothesis payload should not load"),
+                ),
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    side_effect=AssertionError("live gate should use cache"),
+                ),
+                patch(
+                    "app.main._build_profitability_proof_floor_payload",
+                    side_effect=AssertionError("proof floor should not run"),
+                ),
+                patch(
+                    "app.main._build_simple_lane_status_payload",
+                    return_value={
+                        "paper_route_probe_enabled": True,
+                        "paper_route_probe_max_notional": "75000",
+                    },
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-target-plan")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["target_count"], 1)
+            self.assertEqual(
+                payload["targets"][0]["candidate_id"], "c88421d619759b2cfaa6f4d0"
+            )
+            self.assertEqual(
+                payload["live_submission_gate"]["paper_route_target_plan_source"],
+                "cached_live_submission_gate",
+            )
+            self.assertFalse(payload["summary"]["promotion_authority"]["allowed"])
+        finally:
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
+    def test_paper_route_cached_gate_requires_target_plan(self) -> None:
+        self.assertIsNone(
+            main_module._paper_route_cached_live_submission_gate(
+                SimpleNamespace(_last_live_submission_gate=None)
+            )
+        )
+        self.assertIsNone(
+            main_module._paper_route_cached_live_submission_gate(
+                SimpleNamespace(_last_live_submission_gate={"allowed": False})
+            )
+        )
+
+    def test_paper_route_target_strategy_lookup_names_skip_missing_values(
+        self,
+    ) -> None:
+        names = main_module._paper_route_target_strategy_lookup_names(
+            {
+                "strategy_lookup_names": [
+                    " source-strategy ",
+                    "source-strategy",
+                    12,
+                ],
+                "runtime_strategy_name": "runtime-strategy",
+                "strategy_name": "source-strategy",
+            }
+        )
+
+        self.assertEqual(
+            names,
+            ["source-strategy", "12", "runtime-strategy"],
+        )
+        self.assertEqual(
+            main_module._paper_route_target_strategy_lookup_names({}),
+            [],
+        )
+
+    def test_paper_route_probe_symbols_resolve_target_strategy_universe(
+        self,
+    ) -> None:
+        with self.session_local() as session:
+            session.add_all(
+                [
+                    Strategy(
+                        name="route-target-source",
+                        description="route target source",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols=[" msft ", "", "AAPL", "MSFT"],
+                    ),
+                    Strategy(
+                        name="route-target-string-universe",
+                        description="route target string universe",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols="TSLA",
+                    ),
+                ]
+            )
+            session.commit()
+
+            self.assertEqual(
+                main_module._paper_route_probe_symbols_from_target_plan_strategies(
+                    session,
+                    [{}],
+                ),
+                [],
+            )
+            symbols = (
+                main_module._paper_route_probe_symbols_from_target_plan_strategies(
+                    session,
+                    [
+                        {
+                            "strategy_lookup_names": [
+                                "route-target-source",
+                                "route-target-string-universe",
+                                "route-target-source",
+                            ],
+                            "runtime_strategy_name": "route-target-source",
+                            "strategy_name": "route-target-string-universe",
+                        }
+                    ],
+                )
+            )
+
+        self.assertEqual(symbols, ["MSFT", "AAPL"])
+
+    def test_paper_route_probe_book_uses_strategy_universe_when_symbols_missing(
+        self,
+    ) -> None:
+        with self.session_local() as session:
+            session.add(
+                Strategy(
+                    name="route-book-source",
+                    description="route book source",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["aapl", "MSFT"],
+                )
+            )
+            session.commit()
+
+            book = main_module._paper_route_probe_book_from_target_plan(
+                {
+                    "paper_route_target_plan_source": "cached_live_submission_gate",
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": (
+                            "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                        ),
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "candidate_id": "candidate-strategy-universe",
+                                "strategy_lookup_names": ["route-book-source"],
+                                "paper_route_probe_next_session_max_notional": "25000",
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_allowed": False,
+                            }
+                        ],
+                    },
+                },
+                simple_lane_status={"paper_route_probe_enabled": True},
+                state=SimpleNamespace(market_session_open=True),
+                session=session,
+            )
+
+        self.assertIsNotNone(book)
+        assert book is not None
+        self.assertEqual(
+            book["summary"]["paper_route_probe_eligible_symbols"], ["AAPL", "MSFT"]
+        )
+        self.assertEqual(book["paper_route_probe"]["active_symbols"], ["AAPL", "MSFT"])
+        self.assertEqual(book["paper_route_probe"]["effective_max_notional"], "25000")
+        self.assertEqual(book["source_refs"]["target_plan_target_count"], 1)
+        self.assertEqual(
+            book["source_refs"]["target_plan_source"], "cached_live_submission_gate"
+        )
+
+    def test_trading_paper_route_target_plan_uses_empty_route_book_when_unavailable(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        cached_gate = {
+            "allowed": False,
+            "reason": "simple_submit_disabled",
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "targets": [
+                    {
+                        "candidate_id": "candidate-empty-book",
+                        "strategy_name": "route-book-missing",
+                        "paper_probation_authorized": True,
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ],
+            },
+        }
+
+        def _assert_empty_route_book(
+            *args: object, **kwargs: object
+        ) -> dict[str, object]:
+            self.assertEqual(kwargs["route_reacquisition_book"], {})
+            self.assertFalse(kwargs["include_runtime_window_import_audit"])
+            return {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "target_count": 1,
+                "targets": [{"candidate_id": "candidate-empty-book"}],
+            }
+
+        try:
+            app.state.trading_scheduler = SimpleNamespace(
+                state=SimpleNamespace(market_session_open=False),
+                _last_live_submission_gate=cached_gate,
+            )
+            with (
+                patch(
+                    "app.main._paper_route_probe_book_from_target_plan",
+                    return_value=None,
+                ),
+                patch(
+                    "app.main.build_paper_route_target_plan_payload",
+                    side_effect=_assert_empty_route_book,
+                ),
+                patch(
+                    "app.main._build_simple_lane_status_payload",
+                    return_value={"paper_route_probe_enabled": True},
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-target-plan")
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["target_count"], 1)
         finally:
             if original_scheduler is None:
                 if hasattr(app.state, "trading_scheduler"):


### PR DESCRIPTION
## Summary

- Makes `/trading/paper-route-target-plan` prefer the scheduler's cached live submission gate instead of rebuilding the full status/gate stack on every handoff request.
- Resolves paper-route probe symbols from target strategy universes without falling back to the full profitability proof floor, while skipping missing strategy lookup values instead of treating them as names.
- Batches strategy lookups while building paper-route target plans so each target window no longer repeats the same strategy queries per target.
- Adds regression coverage for the cached-gate guard, no-route-book fallback, strategy-universe probe fallback, and direct source-decision session lookup path.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan_returns_lightweight_plan or paper_route_target_plan_uses_cached_gate_fast_path or paper_route_target_plan_skips_full_proof_floor_when_target_plan_ready'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -k 'paper_route_target_plan or paper_route_evidence_uses_external_plan'`
- `uv run --frozen pytest tests/test_trading_api.py tests/test_paper_route_evidence.py -k 'paper_route_cached_gate_requires_target_plan or paper_route_target_strategy_lookup_names_skip_missing_values or paper_route_probe_symbols_resolve_target_strategy_universe or paper_route_probe_book_uses_strategy_universe_when_symbols_missing or trading_paper_route_target_plan_uses_empty_route_book_when_unavailable or strategy_source_decision_readiness_queries_session_without_prefetch'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app/main.py app/trading/paper_route_evidence.py tests/test_trading_api.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/main.py app/trading/paper_route_evidence.py tests/test_trading_api.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A (backend endpoint change)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
