### PR TITLE
fix(torghut): close paper route target probes

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -214,6 +214,26 @@ def _target_probe_action(target: Mapping[str, Any]) -> Literal["buy", "sell"]:
     return "buy"
 
 
+def _target_probe_exit_minute_after_open(
+    target: Mapping[str, Any],
+) -> tuple[int | None, bool]:
+    for key in ("exit_minute_after_open", "paper_route_probe_exit_minute_after_open"):
+        exit_minute = SimpleTradingPipeline._paper_route_probe_exit_minute_value(
+            target.get(key)
+        )
+        if exit_minute is not None:
+            return exit_minute, False
+    if _safe_text(
+        target.get("source_kind")
+    ) == "paper_route_probe_runtime_observed" and (
+        _target_truthy(target.get("bounded_evidence_collection_authorized"))
+        or _target_truthy(target.get("paper_probation_authorized"))
+        or _target_truthy(target.get("source_collection_authorized"))
+    ):
+        return _REGULAR_SESSION_MINUTES, True
+    return None, False
+
+
 def _target_truthy(value: object) -> bool:
     if isinstance(value, bool):
         return value
@@ -819,6 +839,26 @@ class SimpleTradingPipeline(TradingPipeline):
                 metadata_exit_minute = (
                     SimpleTradingPipeline._paper_route_probe_exit_minute_value(
                         probe_mapping.get(key)
+                    )
+                )
+                if metadata_exit_minute is not None:
+                    return metadata_exit_minute
+        for params_key in (
+            "paper_route_target_plan_source_decision",
+            "paper_route_target_plan",
+            "strategy_signal_paper",
+        ):
+            target_metadata = decision.params.get(params_key)
+            if not isinstance(target_metadata, Mapping):
+                continue
+            target_mapping = cast(Mapping[str, object], target_metadata)
+            for key in (
+                "exit_minute_after_open",
+                "effective_exit_minute_after_open",
+            ):
+                metadata_exit_minute = (
+                    SimpleTradingPipeline._paper_route_probe_exit_minute_value(
+                        target_mapping.get(key)
                     )
                 )
                 if metadata_exit_minute is not None:
@@ -2340,10 +2380,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "final_promotion_allowed": False,
             **lineage,
         }
-        exit_minute = SimpleTradingPipeline._paper_route_probe_exit_minute_value(
-            target.get("exit_minute_after_open")
-            or target.get("paper_route_probe_exit_minute_after_open")
-        )
+        exit_minute, exit_defaulted = _target_probe_exit_minute_after_open(target)
         if exit_minute is not None:
             effective_exit_minute = min(exit_minute, _REGULAR_SESSION_MINUTES - 1)
             metadata["exit_minute_after_open"] = exit_minute
@@ -2351,6 +2388,11 @@ class SimpleTradingPipeline(TradingPipeline):
             metadata["exit_due_at"] = (
                 window_start + timedelta(minutes=effective_exit_minute)
             ).isoformat()
+            if exit_defaulted:
+                metadata["paper_route_probe_exit_defaulted"] = True
+                metadata["paper_route_probe_exit_default_reason"] = (
+                    "target_plan_evidence_collection_session_close"
+                )
         for key in (
             "candidate_id",
             "hypothesis_id",
@@ -2784,6 +2826,19 @@ class SimpleTradingPipeline(TradingPipeline):
             window_start, window_end = window
             metadata["paper_route_probe_window_start"] = window_start.isoformat()
             metadata["paper_route_probe_window_end"] = window_end.isoformat()
+            exit_minute, exit_defaulted = _target_probe_exit_minute_after_open(target)
+            if exit_minute is not None:
+                effective_exit_minute = min(exit_minute, _REGULAR_SESSION_MINUTES - 1)
+                metadata["exit_minute_after_open"] = exit_minute
+                metadata["effective_exit_minute_after_open"] = effective_exit_minute
+                metadata["exit_due_at"] = (
+                    window_start + timedelta(minutes=effective_exit_minute)
+                ).isoformat()
+                if exit_defaulted:
+                    metadata["paper_route_probe_exit_defaulted"] = True
+                    metadata["paper_route_probe_exit_default_reason"] = (
+                        "target_plan_evidence_collection_session_close"
+                    )
         return metadata
 
     def _with_paper_route_target_lineage(
@@ -2821,6 +2876,11 @@ class SimpleTradingPipeline(TradingPipeline):
             params.setdefault("promotion_allowed", False)
             params.setdefault("final_promotion_authorized", False)
             params.setdefault("final_promotion_allowed", False)
+            if "exit_minute_after_open" in metadata:
+                params.setdefault(
+                    "exit_minute_after_open",
+                    metadata["exit_minute_after_open"],
+                )
             target_plan = params.get("paper_route_target_plan")
             if isinstance(target_plan, Mapping):
                 merged_target_plan = dict(cast(Mapping[str, Any], target_plan))

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3634,6 +3634,77 @@ class TestTradingPipeline(TestCase):
             ),
             120,
         )
+        window_end = datetime(2026, 3, 26, 20, 0, tzinfo=timezone.utc)
+        strategy = Strategy(
+            name="paper-route-candidate-v1",
+            description="paper route candidate without explicit exit",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+        )
+        target = {
+            "candidate_id": "cand-paper-route",
+            "hypothesis_id": "H-PAPER-ROUTE",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "paper_route_probe_symbols": ["AAPL"],
+            "paper_route_probe_window_start": event_ts.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+            "paper_probation_authorized": True,
+            "bounded_evidence_collection_authorized": True,
+        }
+        source_decision_metadata = (
+            SimpleTradingPipeline._paper_route_target_source_decision_metadata(
+                target=target,
+                strategy=strategy,
+                symbol="AAPL",
+                window_start=event_ts,
+                window_end=window_end,
+                max_notional=Decimal("250"),
+            )
+        )
+        self.assertEqual(source_decision_metadata["exit_minute_after_open"], 390)
+        self.assertEqual(
+            source_decision_metadata["effective_exit_minute_after_open"], 389
+        )
+        self.assertEqual(
+            source_decision_metadata["exit_due_at"],
+            "2026-03-26T19:59:00+00:00",
+        )
+        self.assertTrue(source_decision_metadata["paper_route_probe_exit_defaulted"])
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_after_open(
+                decision=decision.model_copy(
+                    update={
+                        "params": {
+                            "paper_route_target_plan_source_decision": (
+                                source_decision_metadata
+                            )
+                        }
+                    }
+                )
+            ),
+            390,
+        )
+        strategy_signal_metadata = (
+            SimpleTradingPipeline._strategy_signal_paper_metadata(
+                decision=decision,
+                target=target,
+                strategy=strategy,
+            )
+        )
+        self.assertEqual(strategy_signal_metadata["exit_minute_after_open"], 390)
+        self.assertTrue(strategy_signal_metadata["paper_route_probe_exit_defaulted"])
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_after_open(
+                decision=decision.model_copy(
+                    update={
+                        "params": {"strategy_signal_paper": strategy_signal_metadata}
+                    }
+                )
+            ),
+            390,
+        )
         old_row = TradeDecision(
             strategy_id=strategy_id,
             alpaca_account_label="paper",


### PR DESCRIPTION
## Summary

- Default bounded paper-route target-plan evidence probes to a session-close exit when the target plan omits explicit exit timing.
- Teach the probe-exit scanner to read exit timing from target-plan source-decision, target-plan lineage, and strategy-signal authority metadata.
- Add regression coverage for default close metadata and exit-minute recovery from target-plan authority payloads.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'retry_helpers_filter_invalid_rows_and_limits or target_plan_source_decision' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
