### PR TITLE
fix(torghut): retry deploy evidence warmup

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -271,11 +271,38 @@ jobs:
             local label="$3"
             local status
 
-            status="$(fetch_json "${url}" "${output_path}" "${label}")"
-            if ! [[ "${status}" =~ ^2[0-9][0-9]$ ]]; then
-              echo "${label} returned HTTP ${status}; expected 2xx" >&2
-              return 1
-            fi
+            for attempt in $(seq 1 18); do
+              status="$(
+                curl -sS --connect-timeout 10 --max-time 90 \
+                  -o "${output_path}" -w '%{http_code}' "${url}" || true
+              )"
+              if [[ "${status}" =~ ^2[0-9][0-9]$ ]] &&
+                python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
+                return 0
+              fi
+
+              if [ "${attempt}" -eq 18 ]; then
+                if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
+                  [ "${status}" != '000' ] &&
+                  python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
+                  echo "${label} returned HTTP ${status}; expected 2xx" >&2
+                else
+                  echo "${label} did not return a parseable JSON HTTP 2xx response; status=${status:-empty}" >&2
+                fi
+                head -c 1000 "${output_path}" >&2 || true
+                echo >&2
+                return 1
+              fi
+
+              if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
+                [ "${status}" != '000' ] &&
+                python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
+                echo "Attempt ${attempt}: ${label} returned HTTP ${status}; expected 2xx; retrying" >&2
+              else
+                echo "Attempt ${attempt}: ${label} status=${status:-empty} not usable JSON 2xx yet; retrying" >&2
+              fi
+              sleep 5
+            done
           }
 
           TORGHUT_READYZ_HTTP_STATUS="$(

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -62,6 +62,12 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).not.toContain('curl -fsS http://torghut.torghut.svc.cluster.local/trading/status')
   })
 
+  it('retries parseable non-2xx deploy evidence before failing', () => {
+    expect(workflow).toContain('Attempt ${attempt}: ${label} returned HTTP ${status}; expected 2xx; retrying')
+    expect(workflow).toContain('did not return a parseable JSON HTTP 2xx response')
+    expect(workflow).not.toContain('status="$(fetch_json "${url}" "${output_path}" "${label}")"')
+  })
+
   it('verifies torghut-sim paper-route target mirroring after deploy', () => {
     expect(workflow).toContain('Knative Service torghut-sim is not Ready')
     expect(workflow).toContain('http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence')


### PR DESCRIPTION
## Summary

- Retries Torghut post-deploy evidence endpoints until they return parseable 2xx JSON instead of failing immediately on a transient JSON 503.
- Keeps `/readyz` handling unchanged so degraded readiness still flows into the evidence validator.
- Adds workflow-contract coverage for parseable non-2xx deploy evidence retries.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check .github/workflows/torghut-post-deploy-verify.yml packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
