### PR TITLE
fix(torghut): fail closed on promotion count timeouts

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -141,6 +141,47 @@ def _rollback_runtime_ledger_status_session(session: Session) -> None:
         logger.warning("Failed to roll back runtime-ledger status session")
 
 
+def _empty_profit_promotion_table_counts(
+    *,
+    count_errors: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "research_candidates": 0,
+        "research_promotions": 0,
+        "strategy_promotion_decisions": 0,
+        "vnext_promotion_decisions": 0,
+        "autoresearch_epochs": 0,
+        "autoresearch_candidate_specs": 0,
+        "autoresearch_proposal_scores": 0,
+        "autoresearch_portfolio_candidates": 0,
+        "autoresearch_portfolio_ready": 0,
+        "autoresearch_portfolio_blocked": 0,
+        "autoresearch_portfolio_ready_refs": [],
+        "count_errors": sorted(set(count_errors or ())),
+    }
+
+
+def _load_profit_promotion_scalar_count(
+    session: Session,
+    *,
+    table_name: str,
+    statement: Any,
+    count_errors: list[str],
+) -> int:
+    try:
+        _maybe_set_runtime_ledger_status_statement_timeout(session)
+        return int(session.execute(statement).scalar_one())
+    except SQLAlchemyError as exc:
+        logger.warning(
+            "Failed to load profit promotion table count table=%s error=%s",
+            table_name,
+            exc,
+        )
+        count_errors.append(table_name)
+        _rollback_runtime_ledger_status_session(session)
+        return 0
+
+
 def _runtime_window_import_continuity_signal(state: object) -> tuple[str, str, str]:
     state_text = _safe_attr_text(state, "last_signal_continuity_state")
     reason = _safe_attr_text(state, "last_signal_continuity_reason")
@@ -2982,9 +3023,22 @@ def _attach_lineage_refs(
 
 
 def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
-    portfolio_rows = list(
-        session.execute(select(AutoresearchPortfolioCandidate)).scalars()
-    )
+    count_errors: list[str] = []
+    try:
+        _maybe_set_runtime_ledger_status_statement_timeout(session)
+        portfolio_rows = list(
+            session.execute(select(AutoresearchPortfolioCandidate)).scalars()
+        )
+    except SQLAlchemyError as exc:
+        logger.warning(
+            "Failed to load profit promotion portfolio rows error=%s",
+            exc,
+        )
+        _rollback_runtime_ledger_status_session(session)
+        return _empty_profit_promotion_table_counts(
+            count_errors=["autoresearch_portfolio_candidates"]
+        )
+
     current_oracle_ready = 0
     current_policy_blocked = 0
     ready_refs: set[str] = set()
@@ -3016,53 +3070,79 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
             current_policy_blocked += 1
 
     if ready_source_candidate_ids:
-        spec_rows = session.execute(
-            select(AutoresearchCandidateSpec).where(
-                AutoresearchCandidateSpec.candidate_spec_id.in_(
-                    sorted(ready_source_candidate_ids)
+        try:
+            _maybe_set_runtime_ledger_status_statement_timeout(session)
+            spec_rows = session.execute(
+                select(AutoresearchCandidateSpec).where(
+                    AutoresearchCandidateSpec.candidate_spec_id.in_(
+                        sorted(ready_source_candidate_ids)
+                    )
                 )
+            ).scalars()
+            for spec_row in spec_rows:
+                if hypothesis_id := _safe_text(spec_row.hypothesis_id):
+                    ready_refs.add(f"hypothesis_id:{hypothesis_id}")
+        except SQLAlchemyError as exc:
+            logger.warning(
+                "Failed to load profit promotion ready spec refs error=%s",
+                exc,
             )
-        ).scalars()
-        for spec_row in spec_rows:
-            if hypothesis_id := _safe_text(spec_row.hypothesis_id):
-                ready_refs.add(f"hypothesis_id:{hypothesis_id}")
+            count_errors.append("autoresearch_candidate_specs")
+            _rollback_runtime_ledger_status_session(session)
 
     return {
-        "research_candidates": int(
-            session.execute(select(func.count(ResearchCandidate.id))).scalar_one()
+        "research_candidates": _load_profit_promotion_scalar_count(
+            session,
+            table_name="research_candidates",
+            statement=select(func.count(ResearchCandidate.id)),
+            count_errors=count_errors,
         ),
-        "research_promotions": int(
-            session.execute(select(func.count(ResearchPromotion.id))).scalar_one()
+        "research_promotions": _load_profit_promotion_scalar_count(
+            session,
+            table_name="research_promotions",
+            statement=select(func.count(ResearchPromotion.id)),
+            count_errors=count_errors,
         ),
-        "strategy_promotion_decisions": int(
-            session.execute(
-                select(func.count(StrategyPromotionDecision.id))
-            ).scalar_one()
+        "strategy_promotion_decisions": _load_profit_promotion_scalar_count(
+            session,
+            table_name="strategy_promotion_decisions",
+            statement=select(func.count(StrategyPromotionDecision.id)),
+            count_errors=count_errors,
         ),
-        "vnext_promotion_decisions": int(
-            session.execute(select(func.count(VNextPromotionDecision.id))).scalar_one()
+        "vnext_promotion_decisions": _load_profit_promotion_scalar_count(
+            session,
+            table_name="vnext_promotion_decisions",
+            statement=select(func.count(VNextPromotionDecision.id)),
+            count_errors=count_errors,
         ),
-        "autoresearch_epochs": int(
-            session.execute(select(func.count(AutoresearchEpoch.id))).scalar_one()
+        "autoresearch_epochs": _load_profit_promotion_scalar_count(
+            session,
+            table_name="autoresearch_epochs",
+            statement=select(func.count(AutoresearchEpoch.id)),
+            count_errors=count_errors,
         ),
-        "autoresearch_candidate_specs": int(
-            session.execute(
-                select(func.count(AutoresearchCandidateSpec.id))
-            ).scalar_one()
+        "autoresearch_candidate_specs": _load_profit_promotion_scalar_count(
+            session,
+            table_name="autoresearch_candidate_specs",
+            statement=select(func.count(AutoresearchCandidateSpec.id)),
+            count_errors=count_errors,
         ),
-        "autoresearch_proposal_scores": int(
-            session.execute(
-                select(func.count(AutoresearchProposalScore.id))
-            ).scalar_one()
+        "autoresearch_proposal_scores": _load_profit_promotion_scalar_count(
+            session,
+            table_name="autoresearch_proposal_scores",
+            statement=select(func.count(AutoresearchProposalScore.id)),
+            count_errors=count_errors,
         ),
-        "autoresearch_portfolio_candidates": int(
-            session.execute(
-                select(func.count(AutoresearchPortfolioCandidate.id))
-            ).scalar_one()
+        "autoresearch_portfolio_candidates": _load_profit_promotion_scalar_count(
+            session,
+            table_name="autoresearch_portfolio_candidates",
+            statement=select(func.count(AutoresearchPortfolioCandidate.id)),
+            count_errors=count_errors,
         ),
         "autoresearch_portfolio_ready": current_oracle_ready,
         "autoresearch_portfolio_blocked": current_policy_blocked,
         "autoresearch_portfolio_ready_refs": sorted(ready_refs),
+        "count_errors": sorted(set(count_errors)),
     }
 
 

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -3570,6 +3570,181 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(counts["autoresearch_portfolio_candidates"], 1)
         self.assertEqual(counts["autoresearch_portfolio_blocked"], 1)
         self.assertEqual(counts["autoresearch_portfolio_ready"], 0)
+        self.assertEqual(counts["count_errors"], [])
+
+    def test_load_profit_promotion_counts_fail_closed_for_timed_out_count(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            session.add(
+                AutoresearchEpoch(
+                    epoch_id="epoch-1",
+                    status="no_profit_target_candidate",
+                    target_net_pnl_per_day=Decimal("500"),
+                    paper_run_ids_json=[],
+                    snapshot_manifest_json={},
+                    runner_config_json={},
+                    summary_json={},
+                    started_at=datetime.now(timezone.utc),
+                    completed_at=datetime.now(timezone.utc),
+                )
+            )
+            session.add(
+                AutoresearchCandidateSpec(
+                    candidate_spec_id="spec-1",
+                    epoch_id="epoch-1",
+                    hypothesis_id="H-CONT-01",
+                    candidate_kind="sleeve",
+                    family_template_id="microbar_cross_sectional_pairs_v1",
+                    payload_json={"candidate_spec_id": "spec-1"},
+                    payload_hash="hash",
+                    status="eligible",
+                    blockers_json=[],
+                )
+            )
+            session.add(
+                AutoresearchProposalScore(
+                    epoch_id="epoch-1",
+                    candidate_spec_id="spec-1",
+                    model_id="model-1",
+                    backend="numpy-fallback",
+                    proposal_score=Decimal("12.5"),
+                    rank=1,
+                    selection_reason="exploitation",
+                    feature_hash="feature-hash",
+                    payload_json={},
+                )
+            )
+            session.commit()
+
+            execute = session.execute
+
+            def fail_proposal_score_count(
+                statement: object, *args: object, **kwargs: object
+            ) -> object:
+                if "count(autoresearch_proposal_scores.id)" in str(statement):
+                    raise SQLAlchemyError("statement timeout")
+                return execute(statement, *args, **kwargs)
+
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=fail_proposal_score_count,
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                counts = _load_profit_promotion_table_counts(session)
+
+        self.assertEqual(counts["autoresearch_epochs"], 1)
+        self.assertEqual(counts["autoresearch_candidate_specs"], 1)
+        self.assertEqual(counts["autoresearch_proposal_scores"], 0)
+        self.assertEqual(counts["count_errors"], ["autoresearch_proposal_scores"])
+        self.assertEqual(rollback.call_count, 1)
+
+    def test_load_profit_promotion_counts_fail_closed_for_portfolio_timeout(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=SQLAlchemyError("statement timeout"),
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                counts = _load_profit_promotion_table_counts(session)
+
+        self.assertEqual(counts["research_candidates"], 0)
+        self.assertEqual(counts["autoresearch_portfolio_candidates"], 0)
+        self.assertEqual(counts["autoresearch_portfolio_ready_refs"], [])
+        self.assertEqual(counts["count_errors"], ["autoresearch_portfolio_candidates"])
+        self.assertEqual(rollback.call_count, 1)
+
+    def test_load_profit_promotion_counts_keeps_ready_refs_when_spec_ref_times_out(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            session.add(
+                AutoresearchPortfolioCandidate(
+                    portfolio_candidate_id="portfolio-1",
+                    epoch_id="epoch-1",
+                    source_candidate_ids_json=["spec-1"],
+                    target_net_pnl_per_day=Decimal("500"),
+                    objective_scorecard_json={},
+                    optimizer_report_json={"selected_count": 1},
+                    payload_json={"portfolio_candidate_id": "portfolio-1"},
+                    status="target_met",
+                )
+            )
+            session.commit()
+
+            execute = session.execute
+
+            def fail_ready_spec_ref(
+                statement: object, *args: object, **kwargs: object
+            ) -> object:
+                statement_text = str(statement)
+                if (
+                    "FROM autoresearch_candidate_specs" in statement_text
+                    and "WHERE autoresearch_candidate_specs.candidate_spec_id IN"
+                    in statement_text
+                ):
+                    raise SQLAlchemyError("statement timeout")
+                return execute(statement, *args, **kwargs)
+
+            with (
+                patch(
+                    "app.trading.submission_council._autoresearch_portfolio_current_oracle_passed",
+                    return_value=True,
+                ),
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=fail_ready_spec_ref,
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                counts = _load_profit_promotion_table_counts(session)
+
+        self.assertEqual(counts["autoresearch_portfolio_candidates"], 1)
+        self.assertEqual(counts["autoresearch_portfolio_ready"], 1)
+        self.assertEqual(counts["autoresearch_portfolio_blocked"], 0)
+        self.assertEqual(
+            counts["autoresearch_portfolio_ready_refs"],
+            [
+                "candidate_spec_id:spec-1",
+                "portfolio_candidate_id:portfolio-1",
+                "source_candidate_id:spec-1",
+            ],
+        )
+        self.assertEqual(counts["count_errors"], ["autoresearch_candidate_specs"])
+        self.assertEqual(rollback.call_count, 1)
 
     def test_load_profit_promotion_counts_rejudges_ready_autoresearch_portfolios(
         self,


### PR DESCRIPTION
## Summary

- Bounds profit-promotion count reads behind the status payload with the existing status statement timeout.
- Makes each count fail closed to zero with `count_errors` instead of raising through `/trading/status`.
- Keeps ready portfolio refs usable when only the hypothesis/spec ref lookup times out.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py::TestSubmissionCouncil::test_load_profit_promotion_counts_includes_autoresearch_ledgers tests/test_submission_council.py::TestSubmissionCouncil::test_load_profit_promotion_counts_fail_closed_for_timed_out_count tests/test_submission_council.py::TestSubmissionCouncil::test_load_profit_promotion_counts_rejudges_ready_autoresearch_portfolios -q`
- `uv run --frozen pytest tests/test_submission_council.py::TestSubmissionCouncil::test_load_profit_promotion_counts_fail_closed_for_timed_out_count tests/test_submission_council.py::TestSubmissionCouncil::test_load_profit_promotion_counts_fail_closed_for_portfolio_timeout tests/test_submission_council.py::TestSubmissionCouncil::test_load_profit_promotion_counts_keeps_ready_refs_when_spec_ref_times_out -q`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_runtime_ledger_status_index_migration.py -q`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_runtime_ledger_status_index_migration.py --cov --cov-branch --cov-fail-under=0 --cov-report=xml:coverage.xml -q && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py && uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
