### PR TITLE
fix(torghut): keep proof packet jobs fail closed

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Protocol, cast
+from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin
 from urllib.request import urlopen
 
@@ -218,11 +219,78 @@ def _load_json_object(path: Path) -> dict[str, Any]:
 
 
 def _load_json_url(url: str, *, timeout_seconds: float) -> dict[str, Any]:
-    with urlopen(url, timeout=timeout_seconds) as response:
-        payload = json.loads(response.read().decode("utf-8"))
+    try:
+        with urlopen(url, timeout=timeout_seconds) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        body = exc.read()
+        if body:
+            try:
+                payload = json.loads(body.decode("utf-8"))
+            except json.JSONDecodeError:
+                raise exc from None
+            if isinstance(payload, Mapping):
+                result = {
+                    str(key): value
+                    for key, value in cast(Mapping[str, Any], payload).items()
+                }
+                result["source_load"] = {
+                    "source_url": url,
+                    "http_status": exc.code,
+                    "http_reason": str(exc.reason),
+                    "http_error": True,
+                }
+                return result
+        raise
     if not isinstance(payload, Mapping):
         raise ValueError(f"json_object_required:{url}")
     return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+
+
+def _source_fetch_error_payload(
+    *,
+    source_name: str,
+    url: str,
+    error: BaseException,
+) -> dict[str, Any]:
+    blocker = f"{source_name}_fetch_failed"
+    http_status = getattr(error, "code", None)
+    reason = getattr(error, "reason", None)
+    error_payload: dict[str, Any] = {
+        "source_url": url,
+        "blocker": blocker,
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+    if http_status is not None:
+        error_payload["http_status"] = http_status
+    if reason is not None:
+        error_payload["http_reason"] = str(reason)
+    return {
+        "schema_version": f"torghut.{source_name}.unavailable.v1",
+        "status": "unavailable",
+        "summary": {
+            "status": "unavailable",
+            "blockers": [blocker],
+        },
+        "runtime_window_import_audit": {
+            "state": blocker,
+            "next_action": f"retry_{source_name}_fetch",
+            "import_ready": False,
+            "blockers": [blocker],
+            "target_blockers": [blocker],
+            "counts": {},
+        },
+        "gates": [
+            {
+                "gate_id": DOC29_LIVE_SCALE_GATE,
+                "status": "blocked",
+                "blocking_reasons": [blocker],
+                "blocked_reason": blocker,
+            }
+        ],
+        "source_load_error": error_payload,
+    }
 
 
 def _ceph_client_from_env() -> tuple[_ObjectStoreClient | None, str]:
@@ -378,11 +446,21 @@ def _load_optional_json_object(
     path: Path | None,
     url: str | None,
     timeout_seconds: float,
+    unavailable_source_name: str | None = None,
 ) -> dict[str, Any] | None:
     if path is not None:
         return _load_json_object(path)
     if url:
-        return _load_json_url(url, timeout_seconds=timeout_seconds)
+        try:
+            return _load_json_url(url, timeout_seconds=timeout_seconds)
+        except (HTTPError, URLError, TimeoutError) as exc:
+            if unavailable_source_name is None:
+                raise
+            return _source_fetch_error_payload(
+                source_name=unavailable_source_name,
+                url=url,
+                error=exc,
+            )
     return None
 
 
@@ -2419,9 +2497,10 @@ def _parser() -> argparse.ArgumentParser:
         "--allow-blocked-exit-zero",
         action="store_true",
         help=(
-            "Exit 0 after writing a blocked/waiting packet. Source load and "
-            "schema errors still fail; this is for scheduled evidence collection "
-            "where a blocked verdict is expected proof state, not job failure."
+            "Exit 0 after writing a blocked/waiting packet. Required source "
+            "schema errors still fail; degraded paper-route/completion service "
+            "fetches are recorded as proof blockers so scheduled evidence "
+            "collection still uploads an honest packet."
         ),
     )
     return parser
@@ -2485,6 +2564,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         path=args.paper_route_evidence_file,
         url=args.paper_route_evidence_url,
         timeout_seconds=args.timeout_seconds,
+        unavailable_source_name="paper_route_evidence",
     )
     runtime_window_import = _load_optional_json_object(
         path=args.runtime_window_import_file,
@@ -2495,6 +2575,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         path=args.completion_file,
         url=args.completion_url,
         timeout_seconds=args.timeout_seconds,
+        unavailable_source_name="completion",
     )
     assert status is not None
     packet = build_runtime_ledger_proof_packet(

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import tempfile
@@ -7,6 +8,7 @@ from argparse import Namespace
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, cast
+from urllib.error import HTTPError
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -2516,6 +2518,78 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 },
             )
 
+    def test_cli_records_degraded_paper_route_fetch_as_blocked_packet(self) -> None:
+        class _Response:
+            def __init__(self, body: object) -> None:
+                self.body = body
+
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(self.body).encode("utf-8")
+
+        def open_url(url: str, *, timeout: float) -> _Response:
+            self.assertEqual(timeout, 10.0)
+            if url == "http://torghut-live.local/trading/status":
+                return _Response(_status())
+            if url == "http://torghut-sim.local/trading/paper-route-evidence":
+                raise HTTPError(
+                    url=url,
+                    code=503,
+                    msg="Service Unavailable",
+                    hdrs={},
+                    fp=io.BytesIO(b"Service Unavailable"),
+                )
+            if url == "http://torghut-live.local/trading/completion/doc29":
+                return _Response(_completion())
+            raise AssertionError(f"unexpected URL: {url}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            import_path = tmp_path / "import.json"
+            output_path = tmp_path / "packet.json"
+            import_path.write_text(json.dumps(_runtime_import()), encoding="utf-8")
+
+            with patch.object(packet, "urlopen", side_effect=open_url):
+                exit_code = packet.main(
+                    [
+                        "--status-service-base-url",
+                        "http://torghut-live.local/",
+                        "--paper-route-service-base-url",
+                        "http://torghut-sim.local/",
+                        "--completion-service-base-url",
+                        "http://torghut-live.local/",
+                        "--runtime-window-import-file",
+                        str(import_path),
+                        "--proof-mode",
+                        "authority",
+                        "--output-file",
+                        str(output_path),
+                        "--allow-blocked-exit-zero",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertFalse(payload["ok"])
+            self.assertEqual(payload["verdict"], "blocked")
+            self.assertIn(
+                "paper_route_evidence_fetch_failed",
+                payload["evidence"]["paper_route_runtime_window_import_audit"][
+                    "blockers"
+                ],
+            )
+            self.assertIn(
+                "paper_route_evidence_fetch_failed",
+                payload["checks"]["paper_route_runtime_window_import_audit"][
+                    "observed"
+                ]["blockers"],
+            )
+
     def test_cli_rejects_missing_duplicate_and_invalid_sources(self) -> None:
         with self.assertRaisesRegex(SystemExit, "exactly_one_status_source_required"):
             packet.main([])
@@ -2599,5 +2673,58 @@ class TestRuntimeLedgerProofPacket(TestCase):
             with self.assertRaisesRegex(ValueError, "json_object_required"):
                 packet._load_json_url(
                     "http://example.invalid/status.json",
+                    timeout_seconds=1,
+                )
+        http_error_url = "http://example.invalid/degraded.json"
+        with patch.object(
+            packet,
+            "urlopen",
+            side_effect=HTTPError(
+                url=http_error_url,
+                code=503,
+                msg="Service Unavailable",
+                hdrs={},
+                fp=io.BytesIO(json.dumps({"ok": False}).encode("utf-8")),
+            ),
+        ):
+            payload = packet._load_json_url(http_error_url, timeout_seconds=1)
+            self.assertEqual(payload["ok"], False)
+            self.assertEqual(
+                payload["source_load"],
+                {
+                    "source_url": http_error_url,
+                    "http_status": 503,
+                    "http_reason": "Service Unavailable",
+                    "http_error": True,
+                },
+            )
+        with patch.object(
+            packet,
+            "urlopen",
+            side_effect=HTTPError(
+                url=http_error_url,
+                code=503,
+                msg="Service Unavailable",
+                hdrs={},
+                fp=io.BytesIO(json.dumps(["bad"]).encode("utf-8")),
+            ),
+        ):
+            with self.assertRaises(HTTPError):
+                packet._load_json_url(http_error_url, timeout_seconds=1)
+        with patch.object(
+            packet,
+            "_load_json_url",
+            side_effect=HTTPError(
+                url=http_error_url,
+                code=503,
+                msg="Service Unavailable",
+                hdrs={},
+                fp=io.BytesIO(b"Service Unavailable"),
+            ),
+        ):
+            with self.assertRaises(HTTPError):
+                packet._load_optional_json_object(
+                    path=None,
+                    url=http_error_url,
                     timeout_seconds=1,
                 )


### PR DESCRIPTION
## Summary

- Records degraded optional paper-route evidence and completion service fetches as fail-closed proof packet blockers instead of aborting scheduled blocked-proof uploads.
- Preserves strict behavior for required status/runtime-import sources and required schema errors.
- Adds regression coverage for HTTP error JSON bodies, non-object HTTP error bodies, strict optional-source re-raise behavior, and the CLI blocked-packet path.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen coverage erase`
- `uv run --frozen coverage run -m pytest tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen coverage xml -o coverage.xml --fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check origin/main..HEAD`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
