### PR TITLE
fix(torghut): promote ta manifests together

### DIFF
--- a/.github/workflows/torghut-ta-release.yml
+++ b/.github/workflows/torghut-ta-release.yml
@@ -175,7 +175,7 @@ jobs:
 
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      - name: Update torghut-options ta manifest
+      - name: Update torghut ta manifests
         if: steps.meta.outputs.promote == 'true'
         shell: bash
         env:
@@ -188,7 +188,8 @@ jobs:
             --tag "${TORGHUT_TA_IMAGE_TAG}" \
             --digest "${TORGHUT_TA_IMAGE_DIGEST}" \
             --commit "${TORGHUT_TA_COMMIT}" \
-            --version "${TORGHUT_TA_IMAGE_TAG}"
+            --version "${TORGHUT_TA_IMAGE_TAG}" \
+            --bump-restart-nonce
 
       - name: Check for manifest changes
         if: steps.meta.outputs.promote == 'true'
@@ -196,7 +197,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if git diff --quiet -- argocd/applications/torghut-options/ta/flinkdeployment.yaml; then
+          if git diff --quiet -- \
+            argocd/applications/torghut/ta/flinkdeployment.yaml \
+            argocd/applications/torghut/ta-sim/flinkdeployment.yaml \
+            argocd/applications/torghut-options/ta/flinkdeployment.yaml; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -211,24 +215,27 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
-          branch: codex/torghut-options-ta-release-${{ steps.meta.outputs.tag }}
+          branch: codex/torghut-ta-release-${{ steps.meta.outputs.tag }}
           base: main
-          title: 'chore(torghut-options): promote ta image ${{ steps.meta.outputs.tag }}'
-          commit-message: 'chore(torghut-options): promote ta image ${{ steps.meta.outputs.tag }}'
+          title: 'chore(torghut): promote ta image ${{ steps.meta.outputs.tag }}'
+          commit-message: 'chore(torghut): promote ta image ${{ steps.meta.outputs.tag }}'
           delete-branch: true
           add-paths: |
+            argocd/applications/torghut/ta/flinkdeployment.yaml
+            argocd/applications/torghut/ta-sim/flinkdeployment.yaml
             argocd/applications/torghut-options/ta/flinkdeployment.yaml
           body: |
             ## Summary
-            Promote the Torghut options TA image into GitOps manifests.
+            Promote the Torghut TA image into GitOps manifests.
 
             - Source commit: `${{ steps.meta.outputs.source_sha }}`
             - Image tag: `${{ steps.meta.outputs.tag }}`
             - Image digest: `${{ steps.digest.outputs.digest }}`
+            - Manifests: live TA, sim TA, options TA
 
       - name: No manifest changes detected
         if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed != 'true'
-        run: echo 'No torghut-options ta manifest changes detected.'
+        run: echo 'No torghut ta manifest changes detected.'
 
       - name: Promotion skipped (stale workflow_run)
         if: steps.meta.outputs.promote != 'true'

--- a/packages/scripts/src/torghut/__tests__/update-ta-manifest.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-ta-manifest.test.ts
@@ -7,15 +7,14 @@ import { repoRoot } from '../../shared/cli'
 import { __private } from '../update-ta-manifest'
 
 describe('update-ta-manifest', () => {
-  it('updates the options ta image and version metadata', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'torghut-ta-manifest-test-'))
-    const manifestPath = join(dir, 'flinkdeployment.yaml')
+  const writeManifest = (manifestPath: string, restartNonce: number) => {
     writeFileSync(
       manifestPath,
       `apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:1111111111111111111111111111111111111111111111111111111111111111
+  restartNonce: ${restartNonce}
   podTemplate:
     spec:
       containers:
@@ -28,6 +27,12 @@ spec:
 `,
       'utf8',
     )
+  }
+
+  it('updates the ta image and version metadata', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'torghut-ta-manifest-test-'))
+    const manifestPath = join(dir, 'flinkdeployment.yaml')
+    writeManifest(manifestPath, 8)
 
     const result = __private.updateTaManifest(
       'registry.ide-newton.ts.net/lab/torghut-ta',
@@ -43,8 +48,55 @@ spec:
     )
     expect(updated).toContain('value: v0.600.0')
     expect(updated).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    expect(updated).toContain('restartNonce: 8')
     expect(result.changed).toBe(true)
 
     rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('updates multiple ta manifests and bumps restart nonces when requested', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'torghut-ta-manifest-test-'))
+    const manifestPaths = ['ta.yaml', 'ta-sim.yaml', 'options-ta.yaml'].map((name, index) => {
+      const manifestPath = join(dir, name)
+      writeManifest(manifestPath, 7 + index)
+      return manifestPath
+    })
+
+    const results = __private.updateTaManifests(
+      'registry.ide-newton.ts.net/lab/torghut-ta',
+      'sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+      '186840e5',
+      '186840e512c0490414e253497bbebaaf5d9de29d',
+      manifestPaths.map((manifestPath) => relative(repoRoot, manifestPath)),
+      { bumpRestartNonce: true },
+    )
+
+    expect(results.every((result) => result.changed)).toBe(true)
+    for (const [index, manifestPath] of manifestPaths.entries()) {
+      const updated = readFileSync(manifestPath, 'utf8')
+      expect(updated).toContain(
+        'image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+      )
+      expect(updated).toContain('value: 186840e5')
+      expect(updated).toContain('value: 186840e512c0490414e253497bbebaaf5d9de29d')
+      expect(updated).toContain(`restartNonce: ${8 + index}`)
+    }
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('parses repeated manifest paths and restart nonce flag', () => {
+    const options = __private.parseArgs([
+      '--manifest-path',
+      'argocd/applications/torghut/ta/flinkdeployment.yaml',
+      '--manifest-path=argocd/applications/torghut/ta-sim/flinkdeployment.yaml',
+      '--bump-restart-nonce',
+    ])
+
+    expect(options.manifestPaths).toEqual([
+      'argocd/applications/torghut/ta/flinkdeployment.yaml',
+      'argocd/applications/torghut/ta-sim/flinkdeployment.yaml',
+    ])
+    expect(options.bumpRestartNonce).toBe(true)
   })
 })

--- a/packages/scripts/src/torghut/update-ta-manifest.ts
+++ b/packages/scripts/src/torghut/update-ta-manifest.ts
@@ -10,7 +10,11 @@ import { execGit } from '../shared/git'
 
 const defaultRegistry = 'registry.ide-newton.ts.net'
 const defaultRepository = 'lab/torghut-ta'
-const defaultManifestPath = 'argocd/applications/torghut-options/ta/flinkdeployment.yaml'
+const defaultManifestPaths = [
+  'argocd/applications/torghut/ta/flinkdeployment.yaml',
+  'argocd/applications/torghut/ta-sim/flinkdeployment.yaml',
+  'argocd/applications/torghut-options/ta/flinkdeployment.yaml',
+]
 const digestPattern = /^sha256:[0-9a-f]{64}$/i
 
 type CliOptions = {
@@ -20,7 +24,12 @@ type CliOptions = {
   digest?: string
   version?: string
   commit?: string
-  manifestPath?: string
+  manifestPaths?: string[]
+  bumpRestartNonce?: boolean
+}
+
+type UpdateOptions = {
+  bumpRestartNonce?: boolean
 }
 
 const resolvePath = (path: string) => resolve(repoRoot, path)
@@ -40,12 +49,24 @@ const replaceSingle = (source: string, pattern: RegExp, replacement: string, lab
   return source.replace(pattern, replacement)
 }
 
+const bumpRestartNonce = (source: string): string => {
+  const pattern = /^(\s*restartNonce:\s*)(\d+)(\s*)$/m
+  if (!pattern.test(source)) {
+    throw new Error('Unable to locate restartNonce in torghut ta manifest')
+  }
+  return source.replace(
+    pattern,
+    (_match, prefix: string, nonce: string, suffix: string) => `${prefix}${Number.parseInt(nonce, 10) + 1}${suffix}`,
+  )
+}
+
 const updateTaManifest = (
   imageName: string,
   digest: string,
   version: string,
   commit: string,
   manifestPathValue: string,
+  options: UpdateOptions = {},
 ) => {
   const manifestPath = resolvePath(manifestPathValue)
   const source = readFileSync(manifestPath, 'utf8')
@@ -64,6 +85,9 @@ const updateTaManifest = (
     `$1${commit}`,
     'TORGHUT_TA_COMMIT',
   )
+  if (options.bumpRestartNonce) {
+    updated = bumpRestartNonce(updated)
+  }
 
   if (updated !== source) {
     writeFileSync(manifestPath, updated, 'utf8')
@@ -75,6 +99,21 @@ const updateTaManifest = (
     changed: updated !== source,
   }
 }
+
+const updateTaManifests = (
+  imageName: string,
+  digest: string,
+  version: string,
+  commit: string,
+  manifestPaths: string[],
+  options: UpdateOptions = {},
+) => manifestPaths.map((manifestPath) => updateTaManifest(imageName, digest, version, commit, manifestPath, options))
+
+const parseManifestPathList = (value: string): string[] =>
+  value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
 
 const parseArgs = (argv: string[]): CliOptions => {
   const options: CliOptions = {}
@@ -91,8 +130,14 @@ Options:
   --digest <sha256:...>
   --version <value>
   --commit <sha40>
-  --manifest-path <path>`)
+  --manifest-path <path>  May be repeated. Defaults to live, sim, and options TA manifests.
+  --bump-restart-nonce`)
       process.exit(0)
+    }
+
+    if (arg === '--bump-restart-nonce') {
+      options.bumpRestartNonce = true
+      continue
     }
 
     if (!arg.startsWith('--')) {
@@ -128,7 +173,8 @@ Options:
         options.commit = value
         break
       case '--manifest-path':
-        options.manifestPath = value
+        options.manifestPaths ??= []
+        options.manifestPaths.push(value)
         break
       default:
         throw new Error(`Unknown option: ${flag}`)
@@ -136,6 +182,16 @@ Options:
   }
 
   return options
+}
+
+const envManifestPaths = (): string[] | undefined => {
+  if (process.env.TORGHUT_TA_MANIFEST_PATHS) {
+    return parseManifestPathList(process.env.TORGHUT_TA_MANIFEST_PATHS)
+  }
+  if (process.env.TORGHUT_TA_MANIFEST_PATH) {
+    return [process.env.TORGHUT_TA_MANIFEST_PATH]
+  }
+  return undefined
 }
 
 const main = (cliOptions?: CliOptions) => {
@@ -154,13 +210,18 @@ const main = (cliOptions?: CliOptions) => {
 
   const version = parsed.version ?? process.env.TORGHUT_TA_VERSION ?? execGit(['describe', '--tags', '--always'])
   const commit = parsed.commit ?? process.env.TORGHUT_TA_COMMIT ?? execGit(['rev-parse', 'HEAD'])
-  const manifestPath = parsed.manifestPath ?? process.env.TORGHUT_TA_MANIFEST_PATH ?? defaultManifestPath
+  const manifestPaths = parsed.manifestPaths ?? envManifestPaths() ?? defaultManifestPaths
+  const bumpRestartNonceValue = parsed.bumpRestartNonce ?? process.env.TORGHUT_TA_BUMP_RESTART_NONCE === 'true'
 
-  const result = updateTaManifest(imageName, digest, version, commit, manifestPath)
-  if (result.changed) {
-    console.log(`Updated ${result.manifestPath} with ${result.imageRef}`)
-  } else {
-    console.log(`No manifest changes required for ${result.imageRef}`)
+  const results = updateTaManifests(imageName, digest, version, commit, manifestPaths, {
+    bumpRestartNonce: bumpRestartNonceValue,
+  })
+  for (const result of results) {
+    if (result.changed) {
+      console.log(`Updated ${result.manifestPath} with ${result.imageRef}`)
+    } else {
+      console.log(`No manifest changes required for ${result.imageRef} in ${result.manifestPath}`)
+    }
   }
 }
 
@@ -173,8 +234,12 @@ if (import.meta.main) {
 }
 
 export const __private = {
+  bumpRestartNonce,
+  envManifestPaths,
   normalizeDigest,
   parseArgs,
+  parseManifestPathList,
   replaceSingle,
   updateTaManifest,
+  updateTaManifests,
 }


### PR DESCRIPTION
## Summary

- Expand Torghut TA release automation to update live TA, sim TA, and options TA manifests together.
- Add multi-manifest support to `update-ta-manifest` with an explicit `restartNonce` bump for schema-affecting rollouts.
- Cover multi-manifest updates, restart nonce bumps, and CLI parsing with focused Bun tests.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-ta-manifest.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/torghut/update-ta-manifest.ts packages/scripts/src/torghut/__tests__/update-ta-manifest.test.ts`
- `bun x oxfmt --check packages/scripts/src/torghut/update-ta-manifest.ts packages/scripts/src/torghut/__tests__/update-ta-manifest.test.ts .github/workflows/torghut-ta-release.yml`
- Copied the three real TA FlinkDeployment manifests to a temp directory and ran `bun run packages/scripts/src/torghut/update-ta-manifest.ts` with a fixed test digest, temp manifest paths, and `--bump-restart-nonce`; confirmed updated image refs, `TORGHUT_TA_VERSION`, and incremented `restartNonce` values for live TA, sim TA, and options TA copies.
- `git diff --check`
- `bunx tsc --noEmit --pretty false -p packages/scripts/tsconfig.json` still has package-wide pre-existing unrelated errors; confirmed there are no `update-ta-manifest` type errors.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
