### PR TITLE
chore(symphony): promote image 84300aed

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-31T08:27:57Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-01T03:49:03Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cae13b67"
-    digest: sha256:bf2cba0ab474779f22ee86a7b34b1092910c8ebc03beca372f0bd59b8e2b4a4e
+    newTag: "84300aed"
+    digest: sha256:b3d2fad832cdaa24bf1fbeee9d555b32c4714127ad20b96ca4d3caa27605f037

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-31T08:27:57Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-01T03:49:03Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cae13b67"
-    digest: sha256:bf2cba0ab474779f22ee86a7b34b1092910c8ebc03beca372f0bd59b8e2b4a4e
+    newTag: "84300aed"
+    digest: sha256:b3d2fad832cdaa24bf1fbeee9d555b32c4714127ad20b96ca4d3caa27605f037

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-31T08:27:57Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-01T03:49:03Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cae13b67"
-    digest: sha256:bf2cba0ab474779f22ee86a7b34b1092910c8ebc03beca372f0bd59b8e2b4a4e
+    newTag: "84300aed"
+    digest: sha256:b3d2fad832cdaa24bf1fbeee9d555b32c4714127ad20b96ca4d3caa27605f037


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `84300aed90d32b77ae01a28d9a070d194b72c59a`
- Image tag: `84300aed`
- Image digest: `sha256:b3d2fad832cdaa24bf1fbeee9d555b32c4714127ad20b96ca4d3caa27605f037`