### PR TITLE
fix(torghut): keep paper route source audits fail closed

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -7,6 +7,7 @@ of mutating any live submission gate.
 
 from __future__ import annotations
 
+import logging
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from datetime import date, datetime, time, timedelta, timezone
@@ -15,6 +16,7 @@ from typing import Any, cast
 from zoneinfo import ZoneInfo
 
 from sqlalchemy import func, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ..models import (
@@ -79,6 +81,7 @@ RUNTIME_LEDGER_SUMMARY_ROW_LIMIT = 50
 US_EQUITIES_TIMEZONE = "America/New_York"
 US_EQUITIES_OPEN = time(hour=9, minute=30)
 US_EQUITIES_CLOSE = time(hour=16, minute=0)
+logger = logging.getLogger(__name__)
 PROMOTION_ONLY_READINESS_BLOCKERS = frozenset(
     {
         "paper_probation_evidence_collection_only",
@@ -1817,6 +1820,70 @@ def _next_paper_route_runtime_window_targets(
     }
 
 
+def _rollback_after_source_activity_error(
+    session: Session,
+    *,
+    source: str,
+    exc: SQLAlchemyError,
+) -> None:
+    logger.warning(
+        "Paper route source activity query unavailable source=%s error=%s",
+        source,
+        exc,
+    )
+    try:
+        session.rollback()
+    except SQLAlchemyError as rollback_exc:
+        logger.warning(
+            "Failed to rollback paper route source activity session source=%s error=%s",
+            source,
+            rollback_exc,
+        )
+
+
+def _unavailable_source_activity(
+    *,
+    strategy_name: str | None,
+    strategy_lookup_names: Sequence[str],
+    account_label: str | None,
+    symbols: Sequence[str],
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+    require_source_lineage: bool,
+    source: str,
+    missing_reason: str,
+    raw_decision_count: int = 0,
+    lineage_matched_decision_count: int = 0,
+) -> dict[str, object]:
+    return {
+        "strategy_name": strategy_name,
+        "strategy_lookup_names": list(strategy_lookup_names),
+        "account_label": account_label,
+        "symbols": list(symbols),
+        "lineage_required": require_source_lineage,
+        "expected_candidate_id": candidate_id,
+        "expected_hypothesis_id": hypothesis_id,
+        "raw_decision_count": raw_decision_count,
+        "lineage_matched_decision_count": lineage_matched_decision_count,
+        "lineage_blockers": [],
+        "decision_count": lineage_matched_decision_count,
+        "execution_count": 0,
+        "filled_execution_count": 0,
+        "order_event_count": 0,
+        "fill_order_event_count": 0,
+        "complete_fill_order_event_count": 0,
+        "tca_sample_count": 0,
+        "last_decision_at": None,
+        "last_execution_at": None,
+        "last_order_event_at": None,
+        "last_tca_at": None,
+        "missing": True,
+        "missing_reasons": [missing_reason],
+        "query_unavailable": True,
+        "unavailable_source": source,
+    }
+
+
 def _strategy_source_activity(
     session: Session,
     *,
@@ -1876,11 +1943,29 @@ def _strategy_source_activity(
         decision_stmt = decision_stmt.where(
             func.upper(TradeDecision.symbol).in_(symbol_filters)
         )
-    decision_rows = list(
-        session.execute(
-            decision_stmt.order_by(TradeDecision.created_at.desc()).limit(500)
-        ).scalars()
-    )
+    try:
+        decision_rows = list(
+            session.execute(
+                decision_stmt.order_by(TradeDecision.created_at.desc()).limit(500)
+            ).scalars()
+        )
+    except SQLAlchemyError as exc:
+        _rollback_after_source_activity_error(
+            session,
+            source="trade_decisions",
+            exc=exc,
+        )
+        return _unavailable_source_activity(
+            strategy_name=strategy_name,
+            strategy_lookup_names=strategy_filters,
+            account_label=account_label,
+            symbols=symbol_filters,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            require_source_lineage=require_source_lineage,
+            source="trade_decisions",
+            missing_reason="source_decisions_unavailable",
+        )
     raw_decision_count = len(decision_rows)
     lineage_blockers = (
         _source_lineage_blockers(
@@ -1919,11 +2004,31 @@ def _strategy_source_activity(
             execution_stmt = execution_stmt.where(
                 func.upper(Execution.symbol).in_(symbol_filters)
             )
-        execution_rows = list(
-            session.execute(
-                execution_stmt.order_by(execution_activity_ts.desc()).limit(500)
-            ).scalars()
-        )
+        try:
+            execution_rows = list(
+                session.execute(
+                    execution_stmt.order_by(execution_activity_ts.desc()).limit(500)
+                ).scalars()
+            )
+        except SQLAlchemyError as exc:
+            _rollback_after_source_activity_error(
+                session,
+                source="executions",
+                exc=exc,
+            )
+            return _unavailable_source_activity(
+                strategy_name=strategy_name,
+                strategy_lookup_names=strategy_filters,
+                account_label=account_label,
+                symbols=symbol_filters,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                require_source_lineage=require_source_lineage,
+                source="executions",
+                missing_reason="source_executions_unavailable",
+                raw_decision_count=raw_decision_count,
+                lineage_matched_decision_count=len(decision_rows),
+            )
     order_event_rows: list[ExecutionOrderEvent] = []
     if decision_ids:
         order_event_activity_ts = _order_event_activity_timestamp()
@@ -1941,11 +2046,31 @@ def _strategy_source_activity(
             order_event_stmt = order_event_stmt.where(
                 func.upper(ExecutionOrderEvent.symbol).in_(symbol_filters)
             )
-        order_event_rows = list(
-            session.execute(
-                order_event_stmt.order_by(order_event_activity_ts.desc()).limit(500)
-            ).scalars()
-        )
+        try:
+            order_event_rows = list(
+                session.execute(
+                    order_event_stmt.order_by(order_event_activity_ts.desc()).limit(500)
+                ).scalars()
+            )
+        except SQLAlchemyError as exc:
+            _rollback_after_source_activity_error(
+                session,
+                source="execution_order_events",
+                exc=exc,
+            )
+            return _unavailable_source_activity(
+                strategy_name=strategy_name,
+                strategy_lookup_names=strategy_filters,
+                account_label=account_label,
+                symbols=symbol_filters,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                require_source_lineage=require_source_lineage,
+                source="execution_order_events",
+                missing_reason="source_order_events_unavailable",
+                raw_decision_count=raw_decision_count,
+                lineage_matched_decision_count=len(decision_rows),
+            )
     tca_rows: list[ExecutionTCAMetric] = []
     if decision_ids:
         tca_stmt = (
@@ -1966,11 +2091,31 @@ def _strategy_source_activity(
             tca_stmt = tca_stmt.where(
                 func.upper(ExecutionTCAMetric.symbol).in_(symbol_filters)
             )
-        tca_rows = list(
-            session.execute(
-                tca_stmt.order_by(ExecutionTCAMetric.computed_at.desc()).limit(500)
-            ).scalars()
-        )
+        try:
+            tca_rows = list(
+                session.execute(
+                    tca_stmt.order_by(ExecutionTCAMetric.computed_at.desc()).limit(500)
+                ).scalars()
+            )
+        except SQLAlchemyError as exc:
+            _rollback_after_source_activity_error(
+                session,
+                source="execution_tca_metrics",
+                exc=exc,
+            )
+            return _unavailable_source_activity(
+                strategy_name=strategy_name,
+                strategy_lookup_names=strategy_filters,
+                account_label=account_label,
+                symbols=symbol_filters,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                require_source_lineage=require_source_lineage,
+                source="execution_tca_metrics",
+                missing_reason="source_tca_unavailable",
+                raw_decision_count=raw_decision_count,
+                lineage_matched_decision_count=len(decision_rows),
+            )
     decision_count = len(decision_rows)
     execution_count = len(execution_rows)
     tca_sample_count = len(tca_rows)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
@@ -31,6 +32,7 @@ from app.trading.paper_route_evidence import (
     _runtime_ledger_bucket_evidence_grade,
     _runtime_ledger_non_evidence_diagnostic_summary,
     _runtime_ledger_row_diagnostic_expectancy_bps,
+    _strategy_source_activity,
     _strategy_source_decision_readiness,
     build_paper_route_evidence_audit,
     build_paper_route_target_plan_payload,
@@ -92,6 +94,184 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "authority_class": "runtime_order_feed_execution_source",
             "source_decision_mode_counts": {"strategy_signal_paper": 1},
         }
+
+    def test_source_activity_query_timeout_fails_closed(self) -> None:
+        window_start = datetime(2026, 5, 13, 17, tzinfo=timezone.utc)
+        window_end = window_start + timedelta(minutes=30)
+        with Session(self.engine) as session:
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=SQLAlchemyError("statement timeout"),
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                activity = _strategy_source_activity(
+                    session,
+                    strategy_name="microbar-cross-sectional-pairs-v1",
+                    account_label="TORGHUT_REPLAY",
+                    symbols=["AAPL", "INTC"],
+                    window_start=window_start,
+                    window_end=window_end,
+                    candidate_id="candidate-timeout",
+                    hypothesis_id="hypothesis-timeout",
+                    require_source_lineage=True,
+                )
+
+        rollback.assert_called_once()
+        self.assertTrue(activity["missing"])
+        self.assertTrue(activity["query_unavailable"])
+        self.assertEqual(activity["unavailable_source"], "trade_decisions")
+        self.assertEqual(activity["missing_reasons"], ["source_decisions_unavailable"])
+        self.assertEqual(activity["raw_decision_count"], 0)
+        self.assertEqual(activity["lineage_matched_decision_count"], 0)
+
+    def test_source_activity_timeout_suppresses_rollback_failure(self) -> None:
+        window_start = datetime(2026, 5, 13, 17, tzinfo=timezone.utc)
+        window_end = window_start + timedelta(minutes=30)
+        with Session(self.engine) as session:
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=SQLAlchemyError("statement timeout"),
+                ),
+                patch.object(
+                    session,
+                    "rollback",
+                    side_effect=SQLAlchemyError("rollback failed"),
+                ) as rollback,
+            ):
+                activity = _strategy_source_activity(
+                    session,
+                    strategy_name="microbar-cross-sectional-pairs-v1",
+                    account_label="TORGHUT_REPLAY",
+                    symbols=["AAPL", "INTC"],
+                    window_start=window_start,
+                    window_end=window_end,
+                )
+
+        rollback.assert_called_once()
+        self.assertTrue(activity["query_unavailable"])
+        self.assertEqual(activity["missing_reasons"], ["source_decisions_unavailable"])
+
+    def _seed_source_activity_decision(
+        self,
+        session: Session,
+        *,
+        window_start: datetime,
+    ) -> None:
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="paper route source timeout fixture",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL", "INTC"],
+            created_at=window_start,
+            updated_at=window_start,
+        )
+        session.add(strategy)
+        session.flush()
+        session.add(
+            TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_REPLAY",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-timeout",
+                    "hypothesis_id": "hypothesis-timeout",
+                },
+                rationale="paper route source timeout fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=5),
+                executed_at=window_start + timedelta(minutes=6),
+            )
+        )
+        session.flush()
+
+    def _source_activity_with_failing_query(
+        self,
+        *,
+        failure_call: int,
+    ) -> tuple[dict[str, object], int]:
+        window_start = datetime(2026, 5, 13, 17, tzinfo=timezone.utc)
+        window_end = window_start + timedelta(minutes=30)
+        with Session(self.engine) as session:
+            self._seed_source_activity_decision(session, window_start=window_start)
+            original_execute = session.execute
+            call_count = 0
+
+            def execute_or_fail(*args: object, **kwargs: object) -> object:
+                nonlocal call_count
+                call_count += 1
+                if call_count == failure_call:
+                    raise SQLAlchemyError("statement timeout")
+                return original_execute(*args, **kwargs)
+
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=execute_or_fail,
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                activity = _strategy_source_activity(
+                    session,
+                    strategy_name="microbar-cross-sectional-pairs-v1",
+                    account_label="TORGHUT_REPLAY",
+                    symbols=["AAPL", "INTC"],
+                    window_start=window_start,
+                    window_end=window_end,
+                    candidate_id="candidate-timeout",
+                    hypothesis_id="hypothesis-timeout",
+                    require_source_lineage=True,
+                )
+                rollback_count = rollback.call_count
+        return activity, rollback_count
+
+    def test_source_activity_execution_query_timeout_fails_closed(self) -> None:
+        activity, rollback_count = self._source_activity_with_failing_query(
+            failure_call=2
+        )
+
+        self.assertEqual(rollback_count, 1)
+        self.assertTrue(activity["query_unavailable"])
+        self.assertEqual(activity["unavailable_source"], "executions")
+        self.assertEqual(activity["missing_reasons"], ["source_executions_unavailable"])
+        self.assertEqual(activity["raw_decision_count"], 1)
+        self.assertEqual(activity["lineage_matched_decision_count"], 1)
+
+    def test_source_activity_order_event_query_timeout_fails_closed(self) -> None:
+        activity, rollback_count = self._source_activity_with_failing_query(
+            failure_call=3
+        )
+
+        self.assertEqual(rollback_count, 1)
+        self.assertTrue(activity["query_unavailable"])
+        self.assertEqual(activity["unavailable_source"], "execution_order_events")
+        self.assertEqual(
+            activity["missing_reasons"], ["source_order_events_unavailable"]
+        )
+        self.assertEqual(activity["raw_decision_count"], 1)
+        self.assertEqual(activity["lineage_matched_decision_count"], 1)
+
+    def test_source_activity_tca_query_timeout_fails_closed(self) -> None:
+        activity, rollback_count = self._source_activity_with_failing_query(
+            failure_call=4
+        )
+
+        self.assertEqual(rollback_count, 1)
+        self.assertTrue(activity["query_unavailable"])
+        self.assertEqual(activity["unavailable_source"], "execution_tca_metrics")
+        self.assertEqual(activity["missing_reasons"], ["source_tca_unavailable"])
+        self.assertEqual(activity["raw_decision_count"], 1)
+        self.assertEqual(activity["lineage_matched_decision_count"], 1)
 
     def _add_flat_account_start_snapshot(
         self,


### PR DESCRIPTION
## Summary

- Keep paper-route source-activity evidence collection fail closed when database reads time out.
- Roll back the read session after source audit SQLAlchemy failures so later audit components do not inherit an aborted transaction.
- Add regression coverage for timeout handling across `trade_decisions`, executions, order events, TCA metrics, and rollback failure.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'source_activity_query_timeout_fails_closed'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'source_activity'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
