### PR TITLE
revert(torghut): rollback failed promotion 3b5ee4737df92b55dedd31f58e2bea2280efe85e

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f94248fb3b6f6e75ef349e1afd460938a6e1e6a6931040fc41ee234518dc8198
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
   imagePullPolicy: IfNotPresent
-  restartNonce: 9
+  restartNonce: 8
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: cb8f0010
+              value: 0333e762
             - name: TORGHUT_TA_COMMIT
-              value: cb8f00100f4a7fa8d80e37b16acda33e28426caf
+              value: 0333e762a68aff7c13028d7f16582aee2877d83e
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta-sim
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f94248fb3b6f6e75ef349e1afd460938a6e1e6a6931040fc41ee234518dc8198
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
   imagePullPolicy: IfNotPresent
-  restartNonce: 14
+  restartNonce: 13
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: cb8f0010
+              value: v0.560.0-20-ga2660f64
             - name: TORGHUT_TA_COMMIT
-              value: cb8f00100f4a7fa8d80e37b16acda33e28426caf
+              value: a2660f64dfb913cc8cfcb1483508d79eef6b7f58
           ports:
             - containerPort: 9249
               name: metrics

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     app: torghut-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f94248fb3b6f6e75ef349e1afd460938a6e1e6a6931040fc41ee234518dc8198
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
   imagePullPolicy: IfNotPresent
-  restartNonce: 8
+  restartNonce: 7
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:
@@ -157,9 +157,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: cb8f0010
+              value: 3300ed68
             - name: TORGHUT_TA_COMMIT
-              value: cb8f00100f4a7fa8d80e37b16acda33e28426caf
+              value: 3300ed68d642b2178bcedeef58a66bf9adc82526
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `3b5ee4737df92b55dedd31f58e2bea2280efe85e`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/26734882656`
- Rollback source: `HEAD^` manifests from the failed run checkout