### PR TITLE
fix(torghut): run ready paper route source audits

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4678,7 +4678,7 @@ def trading_paper_route_target_plan(
         session,
         live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
         route_reacquisition_book=route_reacquisition_book,
-        include_runtime_window_import_audit=False,
+        include_runtime_window_import_audit=None,
     )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -407,6 +407,33 @@ class TestPaperRouteEvidenceAudit(TestCase):
             1,
         )
 
+    def test_target_plan_auto_runs_full_runtime_window_audit_when_import_ready(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 26, 22, 30, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            payload = self._build_basic_paper_route_target_plan(
+                session,
+                generated_at=generated_at,
+                include_runtime_window_import_audit=None,
+            )
+
+        self.assertEqual(payload["runtime_window_import_audit_mode"], "full")
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertNotIn(
+            "runtime_window_import_audit_deferred_until_import_ready",
+            import_audit["blockers"],
+        )
+        self.assertEqual(import_audit["import_ready"], True)
+        self.assertEqual(
+            import_audit["diagnostics"]["source_activity_missing_reasons"],
+            [
+                "source_decisions_missing",
+                "source_executions_missing",
+                "source_tca_missing",
+            ],
+        )
+
     def test_evidence_audit_records_target_db_timeout_as_fail_closed_blocker(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7491,7 +7491,7 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
-    def test_trading_paper_route_target_plan_returns_lightweight_plan(self) -> None:
+    def test_trading_paper_route_target_plan_uses_auto_import_audit_mode(self) -> None:
         original_scheduler = getattr(app.state, "trading_scheduler", None)
         target = {
             "hypothesis_id": "H-PAIRS-01",
@@ -7528,6 +7528,60 @@ class TestTradingApi(TestCase):
         try:
             if hasattr(app.state, "trading_scheduler"):
                 del app.state.trading_scheduler
+
+            def _assert_auto_audit_mode(
+                *args: object, **kwargs: object
+            ) -> dict[str, object]:
+                self.assertEqual(
+                    kwargs["live_submission_gate"][
+                        "runtime_ledger_paper_probation_import_plan"
+                    ],
+                    live_gate["runtime_ledger_paper_probation_import_plan"],
+                )
+                self.assertIsNone(kwargs["include_runtime_window_import_audit"])
+                self.assertTrue(kwargs["route_reacquisition_book"])
+                return {
+                    "schema_version": "torghut.paper-route-target-plan.v1",
+                    "target_count": 1,
+                    "skipped_target_count": 0,
+                    "runtime_window_import_audit_mode": "deferred_until_import_ready",
+                    "runtime_window_import_plan": {
+                        "target_count": 1,
+                        "runtime_window_import_handoff": {
+                            "target_plan_endpoint": "/trading/paper-route-target-plan"
+                        },
+                        "targets": [
+                            {
+                                "candidate_id": target["candidate_id"],
+                                "paper_route_probe_symbols": ["AAPL"],
+                                "promotion_allowed": False,
+                                "final_promotion_allowed": False,
+                            }
+                        ],
+                    },
+                    "next_paper_route_runtime_window_targets": {
+                        "purpose": "next_session_paper_route_runtime_window_evidence_collection",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "candidate_id": target["candidate_id"],
+                                "paper_route_probe_symbols": ["AAPL"],
+                                "window_start": "2026-05-26T13:30:00+00:00",
+                            }
+                        ],
+                    },
+                    "purpose": "next_session_paper_route_runtime_window_evidence_collection",
+                    "targets": [
+                        {
+                            "candidate_id": target["candidate_id"],
+                            "paper_route_probe_symbols": ["AAPL"],
+                            "window_start": "2026-05-26T13:30:00+00:00",
+                            "promotion_allowed": False,
+                            "final_promotion_allowed": False,
+                        }
+                    ],
+                }
+
             with (
                 patch(
                     "app.main._build_live_submission_gate_payload",
@@ -7545,14 +7599,8 @@ class TestTradingApi(TestCase):
                     },
                 ),
                 patch(
-                    "app.main.build_paper_route_evidence_audit",
-                    side_effect=AssertionError("full audit should not run"),
-                ),
-                patch(
-                    "app.trading.paper_route_evidence._target_audit",
-                    side_effect=AssertionError(
-                        "target-plan endpoint should not run per-target audits"
-                    ),
+                    "app.main.build_paper_route_target_plan_payload",
+                    side_effect=_assert_auto_audit_mode,
                 ),
             ):
                 response = self.client.get("/trading/paper-route-target-plan")
@@ -7867,7 +7915,7 @@ class TestTradingApi(TestCase):
             *args: object, **kwargs: object
         ) -> dict[str, object]:
             self.assertEqual(kwargs["route_reacquisition_book"], {})
-            self.assertFalse(kwargs["include_runtime_window_import_audit"])
+            self.assertIsNone(kwargs["include_runtime_window_import_audit"])
             return {
                 "schema_version": "torghut.paper-route-target-plan.v1",
                 "target_count": 1,


### PR DESCRIPTION
## Summary

- Switched `/trading/paper-route-target-plan` to auto-select runtime-window import audit mode instead of forcing the lightweight/deferred path.
- Keeps pre-import windows cheap, but runs the full source-activity audit once a closed paper-route window is import-ready.
- Added regression coverage for both the API handoff and the import-ready full-audit behavior.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_target_plan_can_defer_full_runtime_window_audit tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_target_plan_auto_runs_full_runtime_window_audit_when_import_ready tests/test_trading_api.py::TestTradingApi::test_trading_paper_route_target_plan_uses_auto_import_audit_mode tests/test_trading_api.py::TestTradingApi::test_trading_paper_route_target_plan_uses_empty_route_book_when_unavailable -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
