### PR TITLE
fix(torghut): repair order-feed decision lineage

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -1054,9 +1054,14 @@ def link_order_events_to_execution(
         if event.execution_id is None:
             event.execution_id = execution.id
             changed = True
-        if event.trade_decision_id is None and execution.trade_decision_id is not None:
-            event.trade_decision_id = execution.trade_decision_id
-            changed = True
+        if event.trade_decision_id is None:
+            trade_decision_id = execution.trade_decision_id
+            if trade_decision_id is None:
+                decision = _trade_decision_for_order_event(session, event)
+                trade_decision_id = decision.id if decision is not None else None
+            if trade_decision_id is not None:
+                event.trade_decision_id = trade_decision_id
+                changed = True
         if not changed:
             continue
         _ensure_source_window_for_event(session, event)
@@ -1118,14 +1123,31 @@ def repair_order_feed_execution_links(
         "selected": len(events),
         "executions_matched": 0,
         "executions_linked": 0,
+        "decisions_matched": 0,
         "events_linked": 0,
+        "decision_events_linked": 0,
         "events_without_execution": 0,
+        "events_without_decision": 0,
     }
+    processed_decision_ids: set[object] = set()
     for event in events:
         if counters["events_linked"] >= bounded_limit:
             break
         execution = _execution_for_order_event(session, event)
         if execution is None:
+            if event.trade_decision_id is None:
+                decision = _trade_decision_for_order_event(session, event)
+                if decision is None:
+                    counters["events_without_decision"] += 1
+                else:
+                    event.trade_decision_id = decision.id
+                    if decision.id not in processed_decision_ids:
+                        processed_decision_ids.add(decision.id)
+                        counters["decisions_matched"] += 1
+                    _ensure_source_window_for_event(session, event)
+                    session.add(event)
+                    _refresh_source_window_linkage_counts(session, event)
+                    counters["decision_events_linked"] += 1
             counters["events_without_execution"] += 1
             continue
         if execution.id in processed_execution_ids:
@@ -1404,6 +1426,23 @@ def _execution_for_order_event(
         .scalars()
         .first()
     )
+
+
+def _trade_decision_for_order_event(
+    session: Session,
+    event: ExecutionOrderEvent,
+) -> TradeDecision | None:
+    if not event.client_order_id:
+        return None
+    return session.execute(
+        select(TradeDecision)
+        .where(
+            TradeDecision.decision_hash == event.client_order_id,
+            TradeDecision.alpaca_account_label == event.alpaca_account_label,
+        )
+        .order_by(TradeDecision.created_at.desc())
+        .limit(1)
+    ).scalar_one_or_none()
 
 
 def _execution_order_event_exists_for_execution_clause() -> ColumnElement[bool]:

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -69,11 +69,20 @@ def _payload(
         "execution_link_executions_linked": sum(
             batch["execution_link_executions_linked"] for batch in batches
         ),
+        "execution_link_decisions_matched": sum(
+            batch["execution_link_decisions_matched"] for batch in batches
+        ),
         "execution_link_events_linked": sum(
             batch["execution_link_events_linked"] for batch in batches
         ),
+        "execution_link_decision_events_linked": sum(
+            batch["execution_link_decision_events_linked"] for batch in batches
+        ),
         "execution_link_events_without_execution": sum(
             batch["execution_link_events_without_execution"] for batch in batches
+        ),
+        "execution_link_events_without_decision": sum(
+            batch["execution_link_events_without_decision"] for batch in batches
         ),
         "execution_event_backfill_candidates": sum(
             batch["execution_event_backfill_candidates"] for batch in batches
@@ -207,10 +216,19 @@ def main() -> int:
                 "execution_link_executions_linked": execution_link_batch[
                     "executions_linked"
                 ],
+                "execution_link_decisions_matched": execution_link_batch.get(
+                    "decisions_matched", 0
+                ),
                 "execution_link_events_linked": execution_link_batch["events_linked"],
+                "execution_link_decision_events_linked": execution_link_batch.get(
+                    "decision_events_linked", 0
+                ),
                 "execution_link_events_without_execution": execution_link_batch[
                     "events_without_execution"
                 ],
+                "execution_link_events_without_decision": execution_link_batch.get(
+                    "events_without_decision", 0
+                ),
                 "execution_event_backfill_candidates": execution_event_backfill_batch[
                     "selected"
                 ],

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -1335,6 +1335,43 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.unlinked_execution_count, 0)
         self.assertEqual(source_window.unlinked_decision_count, 0)
 
+    def test_linking_event_uses_client_order_decision_when_execution_is_unlinked(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            execution_id = execution.id
+            decision_id = execution.trade_decision_id
+            execution.trade_decision_id = None
+            session.add(execution)
+            session.flush()
+            event = ExecutionOrderEvent(
+                event_fingerprint="legacy-fill-execution-missing-decision",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=238,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+            )
+            session.add(event)
+            session.commit()
+
+            linked = link_order_events_to_execution(session, execution)
+            session.commit()
+            session.refresh(event)
+
+        self.assertEqual(linked, 1)
+        self.assertEqual(event.execution_id, execution_id)
+        self.assertEqual(event.trade_decision_id, decision_id)
+
     def test_repair_order_feed_execution_links_links_matching_lifecycle_rows(
         self,
     ) -> None:
@@ -1395,8 +1432,11 @@ class TestOrderFeed(TestCase):
                 "selected": 2,
                 "executions_matched": 1,
                 "executions_linked": 1,
+                "decisions_matched": 0,
                 "events_linked": 1,
+                "decision_events_linked": 0,
                 "events_without_execution": 1,
+                "events_without_decision": 1,
             },
         )
         self.assertEqual(linkable_event.execution_id, execution_id)
@@ -1409,6 +1449,113 @@ class TestOrderFeed(TestCase):
         self.assertEqual(tca_metric.execution_id, execution_id)
         self.assertEqual(source_window.unlinked_execution_count, 0)
         self.assertEqual(source_window.unlinked_decision_count, 0)
+
+    def test_repair_order_feed_execution_links_links_matching_decision_without_execution(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="decision-only-demo",
+                description="decision-only-demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="symbols_list",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"side": "buy"},
+                decision_hash="decision-only-client-1",
+                status="submitted",
+            )
+            session.add(decision)
+            session.flush()
+            decision_id = decision.id
+            event = ExecutionOrderEvent(
+                event_fingerprint="repair-decision-only-fill",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=388,
+                alpaca_account_label="TORGHUT_SIM",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id="missing-execution-order",
+                client_order_id="decision-only-client-1",
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+            )
+            session.add(event)
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="TORGHUT_SIM",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(event)
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(
+            result,
+            {
+                "selected": 1,
+                "executions_matched": 0,
+                "executions_linked": 0,
+                "decisions_matched": 1,
+                "events_linked": 0,
+                "decision_events_linked": 1,
+                "events_without_execution": 1,
+                "events_without_decision": 0,
+            },
+        )
+        self.assertIsNone(event.execution_id)
+        self.assertEqual(event.trade_decision_id, decision_id)
+        self.assertEqual(event.source_window_id, source_window.id)
+        self.assertEqual(source_window.unlinked_execution_count, 1)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
+
+    def test_repair_order_feed_execution_links_counts_missing_decision_identity(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            event = ExecutionOrderEvent(
+                event_fingerprint="repair-missing-decision-identity",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=389,
+                alpaca_account_label="TORGHUT_SIM",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id="missing-execution-order-no-client",
+                client_order_id=None,
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+            )
+            session.add(event)
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="TORGHUT_SIM",
+                limit=10,
+            )
+
+        self.assertEqual(result["selected"], 1)
+        self.assertEqual(result["decision_events_linked"], 0)
+        self.assertEqual(result["events_without_execution"], 1)
+        self.assertEqual(result["events_without_decision"], 1)
 
     def test_repair_order_feed_execution_links_limits_matching_execution_fanout(
         self,

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -82,8 +82,11 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                     "selected": 4,
                     "executions_matched": 3,
                     "executions_linked": 2,
+                    "decisions_matched": 1,
                     "events_linked": 3,
+                    "decision_events_linked": 1,
                     "events_without_execution": 1,
+                    "events_without_decision": 0,
                 },
             ) as repair_links,
             patch.object(
@@ -118,8 +121,11 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_link_candidates"], 4)
         self.assertEqual(payload["execution_link_executions_matched"], 3)
         self.assertEqual(payload["execution_link_executions_linked"], 2)
+        self.assertEqual(payload["execution_link_decisions_matched"], 1)
         self.assertEqual(payload["execution_link_events_linked"], 3)
+        self.assertEqual(payload["execution_link_decision_events_linked"], 1)
         self.assertEqual(payload["execution_link_events_without_execution"], 1)
+        self.assertEqual(payload["execution_link_events_without_decision"], 0)
         self.assertEqual(payload["execution_event_backfill_candidates"], 0)
         self.assertEqual(payload["execution_event_backfill_events_created"], 0)
         self.assertEqual(payload["execution_event_backfill_source_windows_created"], 0)
@@ -205,15 +211,21 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                         "selected": 2,
                         "executions_matched": 2,
                         "executions_linked": 1,
+                        "decisions_matched": 0,
                         "events_linked": 2,
+                        "decision_events_linked": 0,
                         "events_without_execution": 0,
+                        "events_without_decision": 0,
                     },
                     {
                         "selected": 0,
                         "executions_matched": 0,
                         "executions_linked": 0,
+                        "decisions_matched": 0,
                         "events_linked": 0,
+                        "decision_events_linked": 0,
                         "events_without_execution": 0,
+                        "events_without_decision": 0,
                     },
                 ],
             ) as repair_links,
@@ -255,8 +267,11 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_link_candidates"], 2)
         self.assertEqual(payload["execution_link_executions_matched"], 2)
         self.assertEqual(payload["execution_link_executions_linked"], 1)
+        self.assertEqual(payload["execution_link_decisions_matched"], 0)
         self.assertEqual(payload["execution_link_events_linked"], 2)
+        self.assertEqual(payload["execution_link_decision_events_linked"], 0)
         self.assertEqual(payload["execution_link_events_without_execution"], 0)
+        self.assertEqual(payload["execution_link_events_without_decision"], 0)
         self.assertEqual(payload["fill_delta_candidates"], 3)
         self.assertEqual(payload["fill_delta_events_repaired"], 2)
         self.assertEqual(payload["fill_delta_non_increasing_events_marked"], 1)


### PR DESCRIPTION
## Summary

- Repair legacy order-feed rows that match a TradeDecision by client_order_id even when no Execution row exists yet.
- Preserve fail-closed execution semantics: missing executions remain counted as `events_without_execution`, while newly repaired decision lineage is reported separately.
- Expose decision-link repair counters in the source-window repair script JSON output.
- Add regression coverage for TORGHUT_SIM-style decision-only order-feed repair and script counter aggregation.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py -k 'repair_order_feed_execution_links or linking_legacy_offset_event or linking_one_event or client_order_decision' tests/test_repair_order_feed_source_windows_script.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.