### PR TITLE
fix(torghut): audit latest closed paper route import evidence

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -4077,11 +4077,19 @@ def _runtime_ledger_proof_packet_handoff(
         or runtime_import_handoff.get("import_ready")
         or runtime_window_import_audit.get("import_ready")
     )
-    import_blockers = _unique_text_items(session_readiness.get("import_blockers")) + [
+    session_import_blockers = _unique_text_items(
+        session_readiness.get("import_blockers")
+    )
+    import_blockers = session_import_blockers + [
         blocker
         for blocker in _unique_text_items(runtime_import_handoff.get("import_blockers"))
-        if blocker not in _unique_text_items(session_readiness.get("import_blockers"))
+        if blocker not in session_import_blockers
     ]
+    import_blockers.extend(
+        blocker
+        for blocker in _unique_text_items(runtime_window_import_audit.get("blockers"))
+        if blocker not in import_blockers
+    )
     smoke_targets = proof_policy.target_payload("smoke")
     authority_targets = proof_policy.target_payload("authority")
     smoke_threshold_args = [
@@ -4323,9 +4331,15 @@ def build_paper_route_target_plan_payload(
     latest_closed_readiness = _as_mapping(
         latest_closed_targets.get("session_readiness")
     )
+    targets_have_explicit_window_bounds = any(
+        _parse_datetime(target.get("window_start")) is not None
+        and _parse_datetime(target.get("window_end")) is not None
+        for target in targets
+    )
     runtime_window_import_plan = (
         latest_closed_targets
-        if bool(latest_closed_readiness.get("import_ready"))
+        if not targets_have_explicit_window_bounds
+        and bool(latest_closed_readiness.get("import_ready"))
         and _safe_int(latest_closed_targets.get("target_count")) > 0
         else next_targets
     )
@@ -4530,6 +4544,35 @@ def build_paper_route_evidence_audit(
         live_submission_gate=live_submission_gate,
         generated_at=resolved_generated_at,
     )
+    closed_window_start, closed_window_end = (
+        _latest_closed_regular_equities_session_window(resolved_generated_at)
+    )
+    latest_closed_targets = _next_paper_route_runtime_window_targets(
+        session=session,
+        targets=targets,
+        probe=probe,
+        live_submission_gate=live_submission_gate,
+        generated_at=resolved_generated_at,
+        require_clean_pre_session=False,
+        window_start=closed_window_start,
+        window_end=closed_window_end,
+        purpose="latest_closed_session_paper_route_runtime_window_import",
+    )
+    latest_closed_readiness = _as_mapping(
+        latest_closed_targets.get("session_readiness")
+    )
+    targets_have_explicit_window_bounds = any(
+        _parse_datetime(target.get("window_start")) is not None
+        and _parse_datetime(target.get("window_end")) is not None
+        for target in targets
+    )
+    runtime_window_import_plan = (
+        latest_closed_targets
+        if not targets_have_explicit_window_bounds
+        and bool(latest_closed_readiness.get("import_ready"))
+        and _safe_int(latest_closed_targets.get("target_count")) > 0
+        else next_targets
+    )
     next_target_audits = [
         _target_audit_fail_closed(
             session,
@@ -4541,14 +4584,28 @@ def build_paper_route_evidence_audit(
         )
         for target in _as_mapping_items(next_targets.get("targets"))
     ]
+    runtime_window_import_target_audits = [
+        _target_audit_fail_closed(
+            session,
+            raw_target=target,
+            probe=probe,
+            generated_at=resolved_generated_at,
+            lookback_hours=lookback_hours,
+            error_source="paper_route_runtime_window_import_target_audit",
+        )
+        for target in _as_mapping_items(runtime_window_import_plan.get("targets"))
+    ]
     runtime_window_import_audit = _runtime_window_import_audit(
-        next_targets=next_targets,
+        next_targets=runtime_window_import_plan,
         target_audits=target_audits,
-        next_target_audits=next_target_audits,
+        next_target_audits=runtime_window_import_target_audits,
     )
     next_target_counts = _runtime_window_target_counts(next_target_audits)
+    runtime_window_import_target_counts = _runtime_window_target_counts(
+        runtime_window_import_target_audits
+    )
     proof_packet_handoff = _runtime_ledger_proof_packet_handoff(
-        next_targets=next_targets,
+        next_targets=runtime_window_import_plan,
         runtime_window_import_audit=runtime_window_import_audit,
     )
     summary_blockers = sorted(
@@ -4601,7 +4658,10 @@ def build_paper_route_evidence_audit(
         },
         "paper_route_probe": probe,
         "next_paper_route_runtime_window_targets": next_targets,
+        "latest_closed_paper_route_runtime_window_targets": latest_closed_targets,
+        "runtime_window_import_plan": runtime_window_import_plan,
         "next_runtime_window_target_audits": next_target_audits,
+        "runtime_window_import_target_audits": runtime_window_import_target_audits,
         "runtime_window_import_audit": runtime_window_import_audit,
         "runtime_ledger_proof_packet_handoff": proof_packet_handoff,
         "summary": {
@@ -4710,6 +4770,27 @@ def build_paper_route_evidence_audit(
             ),
             "next_runtime_window_target_with_promotion_decision_count": (
                 next_target_counts["promotion_decision"]
+            ),
+            "runtime_window_import_target_count": _safe_int(
+                runtime_window_import_plan.get("target_count")
+            ),
+            "runtime_window_import_selected_target_count": len(
+                runtime_window_import_target_audits
+            ),
+            "runtime_window_import_target_with_source_activity_count": (
+                runtime_window_import_target_counts["source_activity"]
+            ),
+            "runtime_window_import_target_with_rejected_signal_activity_count": (
+                runtime_window_import_target_counts["rejected_signal_activity"]
+            ),
+            "runtime_window_import_target_with_runtime_ledger_count": (
+                runtime_window_import_target_counts["runtime_ledger"]
+            ),
+            "runtime_window_import_target_with_evidence_grade_runtime_ledger_count": (
+                runtime_window_import_target_counts["evidence_grade_runtime_ledger"]
+            ),
+            "runtime_window_import_target_with_promotion_decision_count": (
+                runtime_window_import_target_counts["promotion_decision"]
             ),
             "next_runtime_window_import_next_action": runtime_window_import_audit[
                 "next_action"

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -948,6 +948,142 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "latest_closed_session_paper_route_runtime_window_import",
         )
 
+    def test_evidence_import_audit_uses_latest_closed_window_before_next_open(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 6, 1, 5, tzinfo=timezone.utc)
+        closed_start = datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc)
+        closed_end = datetime(2026, 5, 29, 20, tzinfo=timezone.utc)
+        strategy_name = "closed-window-paper-route"
+        with Session(self.engine) as session:
+            session.add(
+                StrategyRuntimeLedgerBucket(
+                    run_id="closed-window-paper-route-run",
+                    candidate_id="candidate-closed-window",
+                    hypothesis_id="H-CLOSED-WINDOW",
+                    observed_stage="paper",
+                    bucket_started_at=closed_start + timedelta(minutes=30),
+                    bucket_ended_at=closed_start + timedelta(minutes=60),
+                    account_label="TORGHUT_SIM",
+                    runtime_strategy_name=strategy_name,
+                    strategy_family="microbar_pairs",
+                    fill_count=2,
+                    decision_count=1,
+                    submitted_order_count=1,
+                    closed_trade_count=1,
+                    open_position_count=0,
+                    filled_notional=Decimal("200"),
+                    gross_strategy_pnl=Decimal("12"),
+                    cost_amount=Decimal("2"),
+                    net_strategy_pnl_after_costs=Decimal("10"),
+                    post_cost_expectancy_bps=Decimal("500"),
+                    ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                    pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                    execution_policy_hash_counts={"policy-a": 1},
+                    cost_model_hash_counts={"cost-a": 1},
+                    lineage_hash_counts={"lineage-a": 1},
+                    blockers_json=[],
+                    payload_json=self._runtime_ledger_source_authority_payload(
+                        window_start=closed_start,
+                        window_end=closed_end,
+                        suffix="closed-window",
+                    ),
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 1,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-CLOSED-WINDOW",
+                                "candidate_id": "candidate-closed-window",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": "config/trading/hypotheses/h-closed-window.json",
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=generated_at,
+            )
+
+        next_plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(
+            next_plan["session_window"],
+            {
+                "start": "2026-06-01T13:30:00+00:00",
+                "end": "2026-06-01T20:00:00+00:00",
+            },
+        )
+        import_plan = payload["runtime_window_import_plan"]
+        self.assertEqual(
+            import_plan["purpose"],
+            "latest_closed_session_paper_route_runtime_window_import",
+        )
+        self.assertEqual(
+            import_plan["session_window"],
+            {
+                "start": "2026-05-29T13:30:00+00:00",
+                "end": "2026-05-29T20:00:00+00:00",
+            },
+        )
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["session_window"], import_plan["session_window"])
+        self.assertTrue(import_audit["import_ready"])
+        self.assertEqual(import_audit["counts"]["targets_with_runtime_ledger"], 1)
+        self.assertEqual(
+            import_audit["counts"]["targets_with_evidence_grade_runtime_ledger"],
+            1,
+        )
+        self.assertEqual(
+            payload["summary"][
+                "runtime_window_import_target_with_runtime_ledger_count"
+            ],
+            1,
+        )
+        self.assertEqual(
+            payload["summary"][
+                "runtime_window_import_target_with_evidence_grade_runtime_ledger_count"
+            ],
+            1,
+        )
+        self.assertEqual(
+            payload["summary"]["next_runtime_window_target_with_runtime_ledger_count"],
+            0,
+        )
+        runtime_import_audit = payload["runtime_window_import_target_audits"][0]
+        self.assertEqual(runtime_import_audit["window"], import_plan["session_window"])
+        self.assertEqual(runtime_import_audit["runtime_ledger"]["bucket_count"], 1)
+
     def test_source_runtime_window_import_plan_keeps_next_session_window(
         self,
     ) -> None:
@@ -1524,12 +1660,19 @@ class TestPaperRouteEvidenceAudit(TestCase):
             import_audit["schema_version"],
             "torghut.paper-route-runtime-window-import-audit.v1",
         )
-        self.assertEqual(import_audit["state"], "waiting_for_session_open")
-        self.assertEqual(import_audit["next_action"], "wait_for_regular_session_open")
-        self.assertFalse(import_audit["import_ready"])
         self.assertEqual(
+            payload["runtime_window_import_plan"]["purpose"],
+            "latest_closed_session_paper_route_runtime_window_import",
+        )
+        self.assertEqual(import_audit["state"], "import_due_account_state_not_clean")
+        self.assertEqual(
+            import_audit["next_action"],
+            "reset_paper_account_or_discard_contaminated_window",
+        )
+        self.assertTrue(import_audit["import_ready"])
+        self.assertIn(
+            "paper_route_account_window_start_snapshot_missing",
             import_audit["blockers"],
-            ["paper_route_session_window_not_open"],
         )
         self.assertEqual(import_audit["counts"]["source_plan_target_count"], 2)
         self.assertEqual(import_audit["counts"]["selected_target_count"], 1)
@@ -1547,7 +1690,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             summary["next_runtime_window_import_next_action"],
-            "wait_for_regular_session_open",
+            "reset_paper_account_or_discard_contaminated_window",
         )
         self.assertEqual(len(summary["next_paper_route_targets"]), 1)
         summary_target = summary["next_paper_route_targets"][0]
@@ -1634,11 +1777,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             proof_handoff["runtime_window"]["import_audit_state"],
-            "waiting_for_session_open",
+            "import_due_account_state_not_clean",
         )
-        self.assertEqual(
+        self.assertIn(
+            "paper_route_account_window_start_snapshot_missing",
             proof_handoff["runtime_window"]["import_blockers"],
-            ["paper_route_session_window_not_open"],
         )
         self.assertEqual(
             proof_handoff["runtime_window"]["health_gate"]["ready_target_count"],


### PR DESCRIPTION
## Summary

- Align `/trading/paper-route-evidence` with the target-plan endpoint by auditing the latest closed settled paper-route import window before the next session opens.
- Keep next-session targets visible separately while adding runtime-window import plan/audit fields for the closed import path.
- Carry runtime-window import audit blockers into the proof-packet handoff so blocked states do not lose their actionable reasons.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -k paper_route_evidence -q`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
