### PR TITLE
fix(torghut): stop rollback PR spam

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -413,6 +413,36 @@ jobs:
 
           echo "should_rollback=true" >> "$GITHUB_OUTPUT"
 
+      - name: Close older failed-promotion rollback pull requests
+        if: failure() && steps.rollback.outputs.should_rollback == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          FAILED_SHA: ${{ github.sha }}
+          FAILED_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          current_branch="codex/torghut-rollback-${{ github.run_id }}-${{ github.run_attempt }}"
+          mapfile -t rollback_pr_numbers < <(
+            gh pr list -R "${GH_REPO}" --state open --base main --limit 200 \
+              --json number,title,headRefName \
+              --jq ".[] | select(.headRefName | startswith(\"codex/torghut-rollback-\")) | select(.headRefName != \"${current_branch}\") | select(.title | startswith(\"revert(torghut): rollback failed promotion \")) | .number"
+          )
+
+          if [ "${#rollback_pr_numbers[@]}" -eq 0 ]; then
+            echo "No older Torghut rollback pull requests to close"
+            exit 0
+          fi
+
+          for pr_number in "${rollback_pr_numbers[@]}"; do
+            printf -v comment "Closing this older automatic Torghut rollback PR because a newer failed promotion rollback is being opened for %s.\n\nNew failed run: %s\n" \
+              "${FAILED_SHA}" \
+              "${FAILED_RUN_URL}"
+            gh pr close "${pr_number}" -R "${GH_REPO}" --delete-branch --comment "${comment}"
+          done
+
       - name: Open rollback pull request
         if: failure() && steps.rollback.outputs.should_rollback == 'true'
         uses: peter-evans/create-pull-request@v7

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -93,7 +93,7 @@ describe('torghut post-deploy verifier workflow', () => {
   })
 
   it('rotates the options TA Kafka transactional client prefix with the restart nonce', () => {
-    expect(optionsTaFlinkDeployment).toContain('restartNonce: 8')
+    expect(optionsTaFlinkDeployment).toContain('restartNonce: 9')
     expect(optionsTaConfigmap).toContain('TA_KAFKA_TRANSACTION_TIMEOUT_MS: "120000"')
     expect(optionsTaConfigmap).toContain('TA_CLIENT_ID: "torghut-options-ta-r8"')
     expect(optionsTaConfigmap).toContain('TA_GROUP_ID: "torghut-options-ta-2026-03-08"')
@@ -106,5 +106,13 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('codex/torghut-rollback-')
     expect(workflow).toContain('revert(torghut): rollback failed promotion ')
     expect(workflow).toContain('gh pr close "${pr_number}" -R "${GH_REPO}" --delete-branch --comment "${comment}"')
+  })
+
+  it('closes older automatic rollback pull requests before opening a new failed-promotion rollback', () => {
+    expect(workflow).toContain('Close older failed-promotion rollback pull requests')
+    expect(workflow).toContain("failure() && steps.rollback.outputs.should_rollback == 'true'")
+    expect(workflow).toContain('current_branch="codex/torghut-rollback-${{ github.run_id }}-${{ github.run_attempt }}"')
+    expect(workflow).toContain('select(.headRefName != \\"${current_branch}\\")')
+    expect(workflow).toContain('because a newer failed promotion rollback is being opened')
   })
 })

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4600,6 +4600,7 @@ def trading_paper_route_evidence(
         live_submission_gate,
         simple_lane_status=simple_lane_status,
         state=scheduler.state,
+        session=session,
     )
     if route_reacquisition_book is None:
         proof_floor = _build_profitability_proof_floor_payload(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -8315,6 +8315,121 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
+    def test_trading_paper_route_evidence_resolves_target_plan_strategy_universe(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        settings.trading_paper_route_target_plan_url = ""
+        strategy_symbols = [
+            "NVDA",
+            "AAPL",
+            "AMZN",
+            "GOOGL",
+            "AVGO",
+            "AMD",
+            "ORCL",
+            "INTC",
+        ]
+        target = {
+            "hypothesis_id": "H-TSMOM-LIQ-01",
+            "candidate_id": "ca4e6e3c7d639e3363dc5860",
+            "observed_stage": "paper",
+            "strategy_family": "intraday_tsmom",
+            "strategy_name": "intraday-tsmom-profit-v3",
+            "runtime_strategy_name": "intraday-tsmom-profit-v3",
+            "strategy_lookup_names": [
+                "intraday-tsmom-profit-v3",
+                "intraday-tsmom-v2",
+            ],
+            "account_label": "TORGHUT_REPLAY",
+            "source_kind": "runtime_ledger_paper_probation_candidates",
+            "source_manifest_ref": (
+                "config/trading/hypotheses/h-tsmom-liq-01.json"
+            ),
+            "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+            "window_start": "2026-05-22T13:30:00+00:00",
+            "window_end": "2026-05-22T20:00:00+00:00",
+            "paper_route_probe_next_session_max_notional": "75000",
+            "paper_probation_authorized": True,
+            "source_collection_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "max_notional": "0",
+        }
+        live_gate = {
+            "allowed": False,
+            "reason": "simple_submit_disabled",
+            "blocked_reasons": ["simple_submit_disabled"],
+            "promotion_eligible_total": 0,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "skipped_target_count": 0,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [target],
+            },
+        }
+        with self.session_local() as session:
+            session.add(
+                Strategy(
+                    name="intraday-tsmom-profit-v3",
+                    description="tsmom runtime strategy",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=strategy_symbols,
+                )
+            )
+            session.commit()
+        try:
+            if hasattr(app.state, "trading_scheduler"):
+                del app.state.trading_scheduler
+            with (
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value=live_gate,
+                ),
+                patch(
+                    "app.main._build_simple_lane_status_payload",
+                    return_value={
+                        "paper_route_probe_enabled": True,
+                        "paper_route_probe_max_notional": "75000",
+                    },
+                ),
+                patch(
+                    "app.main._build_profitability_proof_floor_payload",
+                    side_effect=AssertionError(
+                        "target-plan strategy universe should avoid proof-floor fallback"
+                    ),
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-evidence")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(
+                payload["paper_route_probe"]["eligible_symbols"], strategy_symbols
+            )
+            next_target = payload["next_paper_route_runtime_window_targets"][
+                "targets"
+            ][0]
+            self.assertEqual(next_target["paper_route_probe_symbols"], strategy_symbols)
+            self.assertEqual(
+                next_target["paper_route_probe_strategy_universe_symbols"],
+                strategy_symbols,
+            )
+            self.assertEqual(
+                next_target["paper_route_probe_missing_strategy_universe_symbols"], []
+            )
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
     def test_paper_route_target_plan_from_payload_prefers_next_window_targets(
         self,
     ) -> None:


### PR DESCRIPTION
﻿## Summary

- Fixes `/trading/paper-route-evidence` so it passes the request DB session into target-plan probe-book resolution, matching `/trading/paper-route-target-plan` and preserving strategy-universe symbol scope.
- Adds a failure-path cleanup step in `torghut-post-deploy-verify` that closes older automatic `revert(torghut): rollback failed promotion ...` PRs before opening a newer rollback PR.
- Adds regression coverage for the evidence endpoint strategy-universe path and the workflow rollback PR dedupe guard.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_api.py -q -k "paper_route_evidence_resolves_target_plan_strategy_universe or paper_route_evidence_uses_external_plan_when_url_configured or paper_route_target_plan" -o faulthandler_timeout=60`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
