### PR TITLE
feat(torghut): add whitepaper frontier replay harness

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -15,8 +15,16 @@ from app.trading.discovery.candidate_specs import CandidateSpec
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v1"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v2"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v2"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v3"
+FAST_REPLAY_PROOF_SEMANTICS_LABEL = "preview_ranking_only_exact_replay_and_runtime_ledger_required"
+FAST_REPLAY_WHITEPAPER_MECHANISMS = (
+    "cluster_lob_event_clustering_proxy",
+    "ofi_horizon_decay_regime_screen",
+    "macro_news_ofi_stress_veto_if_present",
+    "square_root_impact_capacity_prefilter",
+    "conformal_tail_risk_prefilter",
+)
 
 
 @dataclass(frozen=True)
@@ -40,6 +48,15 @@ class FastReplayPreviewRow:
     spread_tail_bps: Decimal
     return_tail_abs_bps: Decimal
     impact_liquidity_penalty_bps: Decimal
+    cluster_lob_activity_score: Decimal
+    ofi_decay_alignment_score: Decimal
+    liquidity_regime_score: Decimal
+    macro_stress_veto_score: Decimal
+    conformal_tail_risk_penalty_bps: Decimal
+    square_root_impact_capacity_penalty_bps: Decimal
+    exploration_score: Decimal
+    frontier_bucket: str
+    proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -62,9 +79,20 @@ class FastReplayPreviewRow:
             "microprice_bias_bps": str(self.microprice_bias_bps),
             "spread_tail_bps": str(self.spread_tail_bps),
             "return_tail_abs_bps": str(self.return_tail_abs_bps),
-            "impact_liquidity_penalty_bps": str(
-                self.impact_liquidity_penalty_bps
+            "impact_liquidity_penalty_bps": str(self.impact_liquidity_penalty_bps),
+            "cluster_lob_activity_score": str(self.cluster_lob_activity_score),
+            "ofi_decay_alignment_score": str(self.ofi_decay_alignment_score),
+            "liquidity_regime_score": str(self.liquidity_regime_score),
+            "macro_stress_veto_score": str(self.macro_stress_veto_score),
+            "conformal_tail_risk_penalty_bps": str(self.conformal_tail_risk_penalty_bps),
+            "square_root_impact_capacity_penalty_bps": str(
+                self.square_root_impact_capacity_penalty_bps
             ),
+            "exploration_score": str(self.exploration_score),
+            "frontier_bucket": self.frontier_bucket,
+            "proof_semantics_label": self.proof_semantics_label,
+            "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
+            "promotion_proof": False,
         }
 
 
@@ -76,18 +104,35 @@ class FastReplayPreviewResult:
     input_candidate_count: int
     replay_tape_manifest: ReplayTapeManifest
     selected_row_count: int
+    exploitation_candidate_count: int
+    exploration_candidate_count: int
+    exact_replay_candidate_cap: int
 
     def to_manifest_payload(self) -> dict[str, Any]:
         return {
             "schema_version": FAST_REPLAY_PREVIEW_SCHEMA_VERSION,
             "status": "preview_only",
             "promotion_proof": False,
+            "authority": "not_promotion_proof",
+            "proof_semantics_label": FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+            "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
+            "implemented_mechanisms": {
+                "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
+                "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
+                "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
+                "square_root_impact_capacity": "sqrt(notional / tape dollar-volume proxy) capacity prefilter",
+                "conformal_tail_risk": "distribution-free lower-tail signed-return penalty used only for ranking",
+            },
             "blockers": [
                 "preview_only_not_promotion_proof",
                 "exact_replay_required",
-                "runtime_ledger_proof_required",
+                "source_backed_runtime_ledger_proof_required",
+                "live_paper_runtime_evidence_required_for_final_promotion",
             ],
             "requested_top_k": self.requested_top_k,
+            "exact_replay_candidate_cap": self.exact_replay_candidate_cap,
+            "exploitation_candidate_count": self.exploitation_candidate_count,
+            "exploration_candidate_count": self.exploration_candidate_count,
             "input_candidate_count": self.input_candidate_count,
             "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
             "selected_candidate_spec_count": len(self.selected_candidate_spec_ids),
@@ -95,6 +140,7 @@ class FastReplayPreviewResult:
             "replay_tape": {
                 "dataset_snapshot_ref": self.replay_tape_manifest.dataset_snapshot_ref,
                 "content_sha256": self.replay_tape_manifest.content_sha256,
+                "replay_cache_key": self.replay_tape_manifest.replay_cache_key,
                 "row_count": self.replay_tape_manifest.row_count,
                 "trading_day_count": self.replay_tape_manifest.trading_day_count,
                 "start_date": self.replay_tape_manifest.start_date.isoformat(),
@@ -110,12 +156,18 @@ class _SymbolTapeStats:
     row_count: int
     trading_day_count: int
     returns_bps: NDArray[np.float64]
+    ofi_values: NDArray[np.float64]
     median_spread_bps: float
     spread_tail_bps: float
     ofi_pressure_score: float
+    ofi_decay_score: float
     microprice_bias_bps: float
     median_volume: float
+    median_price: float
     return_tail_abs_bps: float
+    cluster_lob_activity_score: float
+    liquidity_regime_score: float
+    macro_stress_veto_score: float
 
 
 def build_fast_replay_preview(
@@ -125,6 +177,9 @@ def build_fast_replay_preview(
     replay_tape_manifest: ReplayTapeManifest,
     top_k: int,
     min_rows_per_candidate: int = 2,
+    exploitation_count: int | None = None,
+    exploration_count: int = 0,
+    exact_replay_candidate_cap: int | None = None,
 ) -> FastReplayPreviewResult:
     """Rank candidate specs with cheap tape-derived features only.
 
@@ -133,6 +188,17 @@ def build_fast_replay_preview(
     """
 
     bounded_top_k = max(1, min(len(specs) or 1, int(top_k)))
+    if exact_replay_candidate_cap is not None:
+        bounded_top_k = max(1, min(bounded_top_k, int(exact_replay_candidate_cap)))
+    bounded_exploitation_count = (
+        bounded_top_k
+        if exploitation_count is None
+        else max(0, min(bounded_top_k, int(exploitation_count)))
+    )
+    bounded_exploration_count = max(
+        0,
+        min(bounded_top_k - bounded_exploitation_count, int(exploration_count)),
+    )
     symbol_stats = _build_symbol_stats(rows)
     scored_rows: list[FastReplayPreviewRow] = []
     for spec in specs:
@@ -144,42 +210,18 @@ def build_fast_replay_preview(
             )
         )
 
-    ranked_rows = sorted(
-        scored_rows,
-        key=lambda row: (
-            row.selection_reason == "insufficient_replay_tape_rows",
-            -float(row.preview_score),
-            row.candidate_spec_id,
-        ),
+    ranked_rows = sorted(scored_rows, key=_preview_rank_key)
+    selected_bucket_by_id = _select_frontier_buckets(
+        ranked_rows=ranked_rows,
+        exploitation_count=bounded_exploitation_count,
+        exploration_count=bounded_exploration_count,
+        exact_replay_candidate_cap=bounded_top_k,
     )
-    selected_ids = {
-        row.candidate_spec_id for row in ranked_rows[:bounded_top_k] if scored_rows
-    }
     final_rows = tuple(
-        FastReplayPreviewRow(
-            candidate_spec_id=row.candidate_spec_id,
+        _row_with_rank_and_selection(
+            row=row,
             rank=index,
-            preview_score=row.preview_score,
-            selected=row.candidate_spec_id in selected_ids,
-            selection_reason=(
-                "fast_replay_preview_selected"
-                if row.candidate_spec_id in selected_ids
-                else row.selection_reason
-            ),
-            matched_row_count=row.matched_row_count,
-            matched_symbol_count=row.matched_symbol_count,
-            requested_symbol_count=row.requested_symbol_count,
-            trading_day_count=row.trading_day_count,
-            signed_return_bps=row.signed_return_bps,
-            avg_abs_return_bps=row.avg_abs_return_bps,
-            median_spread_bps=row.median_spread_bps,
-            activity_score=row.activity_score,
-            coverage_score=row.coverage_score,
-            ofi_pressure_score=row.ofi_pressure_score,
-            microprice_bias_bps=row.microprice_bias_bps,
-            spread_tail_bps=row.spread_tail_bps,
-            return_tail_abs_bps=row.return_tail_abs_bps,
-            impact_liquidity_penalty_bps=row.impact_liquidity_penalty_bps,
+            frontier_bucket=selected_bucket_by_id.get(row.candidate_spec_id, "not_selected"),
         )
         for index, row in enumerate(ranked_rows, start=1)
     )
@@ -192,12 +234,17 @@ def build_fast_replay_preview(
         input_candidate_count=len(specs),
         replay_tape_manifest=replay_tape_manifest,
         selected_row_count=len(rows),
+        exploitation_candidate_count=sum(
+            1 for row in final_rows if row.frontier_bucket == "exploitation"
+        ),
+        exploration_candidate_count=sum(
+            1 for row in final_rows if row.frontier_bucket == "exploration"
+        ),
+        exact_replay_candidate_cap=bounded_top_k,
     )
 
 
-def _build_symbol_stats(
-    rows: Sequence[SignalEnvelope],
-) -> dict[str, _SymbolTapeStats]:
+def _build_symbol_stats(rows: Sequence[SignalEnvelope]) -> dict[str, _SymbolTapeStats]:
     rows_by_symbol: dict[str, list[SignalEnvelope]] = {}
     for row in rows:
         symbol = row.symbol.strip().upper()
@@ -226,6 +273,7 @@ def _build_symbol_stats(
         ofi_values = [
             ofi for row in ordered if (ofi := _extract_ofi_pressure(row)) is not None
         ]
+        ofi_array = np.asarray(ofi_values, dtype=np.float64)
         microprice_bias_values = [
             bias
             for row in ordered
@@ -242,20 +290,30 @@ def _build_symbol_stats(
                 {row.event_ts.astimezone(timezone.utc).date() for row in ordered}
             ),
             returns_bps=returns,
+            ofi_values=ofi_array,
             median_spread_bps=float(np.median(spread_values)) if spread_values else 0.0,
             spread_tail_bps=float(np.percentile(spread_values, 95))
             if spread_values
             else 0.0,
             ofi_pressure_score=float(np.mean(ofi_values)) if ofi_values else 0.0,
+            ofi_decay_score=_ofi_decay_score(ofi_array),
             microprice_bias_bps=(
                 float(np.mean(microprice_bias_values))
                 if microprice_bias_values
                 else 0.0
             ),
             median_volume=float(np.median(volume_values)) if volume_values else 0.0,
+            median_price=float(np.median(price_array)) if price_array.size else 0.0,
             return_tail_abs_bps=(
                 float(np.percentile(abs_returns, 95)) if abs_returns.size else 0.0
             ),
+            cluster_lob_activity_score=_cluster_lob_activity_score(ordered, ofi_array),
+            liquidity_regime_score=_liquidity_regime_score(
+                spread_values=spread_values,
+                volume_values=volume_values,
+                row_count=len(ordered),
+            ),
+            macro_stress_veto_score=_macro_stress_veto_score(ordered),
         )
     return stats
 
@@ -267,9 +325,7 @@ def _score_candidate_spec(
     min_rows_per_candidate: int,
 ) -> FastReplayPreviewRow:
     requested_symbols = _candidate_symbols(spec)
-    matched = [
-        stat for symbol in requested_symbols if (stat := symbol_stats.get(symbol))
-    ]
+    matched = [stat for symbol in requested_symbols if (stat := symbol_stats.get(symbol))]
     matched_row_count = sum(stat.row_count for stat in matched)
     requested_symbol_count = len(requested_symbols)
     matched_symbol_count = len(matched)
@@ -283,9 +339,7 @@ def _score_candidate_spec(
             matched_row_count=matched_row_count,
             matched_symbol_count=matched_symbol_count,
             requested_symbol_count=requested_symbol_count,
-            trading_day_count=max(
-                (stat.trading_day_count for stat in matched), default=0
-            ),
+            trading_day_count=max((stat.trading_day_count for stat in matched), default=0),
             signed_return_bps=Decimal("0"),
             avg_abs_return_bps=Decimal("0"),
             median_spread_bps=Decimal("0"),
@@ -296,47 +350,85 @@ def _score_candidate_spec(
             spread_tail_bps=Decimal("0"),
             return_tail_abs_bps=Decimal("0"),
             impact_liquidity_penalty_bps=Decimal("0"),
+            cluster_lob_activity_score=Decimal("0"),
+            ofi_decay_alignment_score=Decimal("0"),
+            liquidity_regime_score=Decimal("0"),
+            macro_stress_veto_score=Decimal("0"),
+            conformal_tail_risk_penalty_bps=Decimal("0"),
+            square_root_impact_capacity_penalty_bps=Decimal("0"),
+            exploration_score=Decimal("0"),
+            frontier_bucket="not_selected",
         )
 
     return_vectors = [stat.returns_bps for stat in matched if stat.returns_bps.size]
-    returns = (
-        np.concatenate(return_vectors)
-        if return_vectors
-        else np.asarray([], dtype=np.float64)
-    )
+    returns = np.concatenate(return_vectors) if return_vectors else np.asarray([], dtype=np.float64)
     direction = _candidate_direction(spec)
-    signed_return_bps = float(np.mean(returns)) * direction if returns.size else 0.0
+    signed_returns = returns * direction if returns.size else np.asarray([], dtype=np.float64)
+    signed_return_bps = float(np.mean(signed_returns)) if signed_returns.size else 0.0
     avg_abs_return_bps = float(np.mean(np.abs(returns))) if returns.size else 0.0
     median_spread_bps = float(np.median([stat.median_spread_bps for stat in matched]))
     spread_tail_bps = float(np.median([stat.spread_tail_bps for stat in matched]))
     ofi_pressure_score = _weighted_average(
         [(stat.ofi_pressure_score, stat.row_count) for stat in matched]
     )
+    ofi_decay_alignment_score = direction * _weighted_average(
+        [(stat.ofi_decay_score, stat.row_count) for stat in matched]
+    )
     microprice_bias_bps = _weighted_average(
         [(stat.microprice_bias_bps, stat.row_count) for stat in matched]
     )
-    return_tail_abs_bps = float(
-        np.median([stat.return_tail_abs_bps for stat in matched])
-    )
+    return_tail_abs_bps = float(np.median([stat.return_tail_abs_bps for stat in matched]))
     median_volume = float(np.median([stat.median_volume for stat in matched]))
+    median_price = float(np.median([stat.median_price for stat in matched]))
     activity_score = float(np.log1p(matched_row_count))
     coverage_score = matched_symbol_count / max(1, requested_symbol_count)
+    cluster_lob_activity_score = _weighted_average(
+        [(stat.cluster_lob_activity_score, stat.row_count) for stat in matched]
+    )
+    liquidity_regime_score = _weighted_average(
+        [(stat.liquidity_regime_score, stat.row_count) for stat in matched]
+    )
+    macro_stress_veto_score = _weighted_average(
+        [(stat.macro_stress_veto_score, stat.row_count) for stat in matched]
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
         median_volume=median_volume,
     )
+    square_root_impact_capacity_penalty_bps = _square_root_impact_capacity_penalty_bps(
+        spec=spec,
+        median_price=median_price,
+        median_volume=median_volume,
+        median_spread_bps=median_spread_bps,
+    )
+    conformal_tail_risk_penalty_bps = _conformal_tail_risk_penalty_bps(signed_returns)
     preview_score = (
         signed_return_bps
-        + avg_abs_return_bps * 0.15
-        + direction * ofi_pressure_score * 8.0
-        + direction * microprice_bias_bps * 0.35
+        + avg_abs_return_bps * 0.12
+        + direction * ofi_pressure_score * 6.0
+        + ofi_decay_alignment_score * 8.0
+        + direction * microprice_bias_bps * 0.32
+        + cluster_lob_activity_score * 5.0
+        + liquidity_regime_score * 4.0
         + activity_score
         + coverage_score * 25.0
         - median_spread_bps * 0.05
         - spread_tail_bps * 0.03
         - return_tail_abs_bps * 0.02
-        - impact_liquidity_penalty_bps * 0.20
+        - impact_liquidity_penalty_bps * 0.18
+        - square_root_impact_capacity_penalty_bps * 0.22
+        - conformal_tail_risk_penalty_bps * 0.12
+        - macro_stress_veto_score * 18.0
+    )
+    exploration_score = (
+        cluster_lob_activity_score * 4.0
+        + abs(ofi_decay_alignment_score) * 5.0
+        + liquidity_regime_score * 2.0
+        + coverage_score * 6.0
+        - macro_stress_veto_score * 8.0
+        - conformal_tail_risk_penalty_bps * 0.04
+        - square_root_impact_capacity_penalty_bps * 0.08
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -357,10 +449,225 @@ def _score_candidate_spec(
         microprice_bias_bps=_decimal_from_float(microprice_bias_bps),
         spread_tail_bps=_decimal_from_float(spread_tail_bps),
         return_tail_abs_bps=_decimal_from_float(return_tail_abs_bps),
-        impact_liquidity_penalty_bps=_decimal_from_float(
-            impact_liquidity_penalty_bps
+        impact_liquidity_penalty_bps=_decimal_from_float(impact_liquidity_penalty_bps),
+        cluster_lob_activity_score=_decimal_from_float(cluster_lob_activity_score),
+        ofi_decay_alignment_score=_decimal_from_float(ofi_decay_alignment_score),
+        liquidity_regime_score=_decimal_from_float(liquidity_regime_score),
+        macro_stress_veto_score=_decimal_from_float(macro_stress_veto_score),
+        conformal_tail_risk_penalty_bps=_decimal_from_float(conformal_tail_risk_penalty_bps),
+        square_root_impact_capacity_penalty_bps=_decimal_from_float(
+            square_root_impact_capacity_penalty_bps
         ),
+        exploration_score=_decimal_from_float(exploration_score),
+        frontier_bucket="not_selected",
     )
+
+
+def _preview_rank_key(row: FastReplayPreviewRow) -> tuple[bool, float, str]:
+    return (
+        row.selection_reason == "insufficient_replay_tape_rows",
+        -float(row.preview_score),
+        row.candidate_spec_id,
+    )
+
+
+def _select_frontier_buckets(
+    *,
+    ranked_rows: Sequence[FastReplayPreviewRow],
+    exploitation_count: int,
+    exploration_count: int,
+    exact_replay_candidate_cap: int,
+) -> dict[str, str]:
+    eligible = [row for row in ranked_rows if row.selection_reason != "insufficient_replay_tape_rows"]
+    selected: dict[str, str] = {}
+    for row in eligible[:exploitation_count]:
+        if len(selected) >= exact_replay_candidate_cap:
+            break
+        selected[row.candidate_spec_id] = "exploitation"
+    exploration_pool = sorted(
+        (row for row in eligible if row.candidate_spec_id not in selected),
+        key=lambda row: (-float(row.exploration_score), row.candidate_spec_id),
+    )
+    for row in exploration_pool[:exploration_count]:
+        if len(selected) >= exact_replay_candidate_cap:
+            break
+        selected[row.candidate_spec_id] = "exploration"
+    for row in eligible:
+        if len(selected) >= exact_replay_candidate_cap:
+            break
+        selected.setdefault(row.candidate_spec_id, "exploitation_backfill")
+    if not selected and ranked_rows:
+        selected[ranked_rows[0].candidate_spec_id] = "exploitation_backfill"
+    return selected
+
+
+def _row_with_rank_and_selection(
+    *, row: FastReplayPreviewRow, rank: int, frontier_bucket: str
+) -> FastReplayPreviewRow:
+    selected = frontier_bucket != "not_selected"
+    selection_reason = row.selection_reason
+    if selected:
+        selection_reason = f"fast_replay_frontier_{frontier_bucket}_selected"
+    return FastReplayPreviewRow(
+        candidate_spec_id=row.candidate_spec_id,
+        rank=rank,
+        preview_score=row.preview_score,
+        selected=selected,
+        selection_reason=selection_reason,
+        matched_row_count=row.matched_row_count,
+        matched_symbol_count=row.matched_symbol_count,
+        requested_symbol_count=row.requested_symbol_count,
+        trading_day_count=row.trading_day_count,
+        signed_return_bps=row.signed_return_bps,
+        avg_abs_return_bps=row.avg_abs_return_bps,
+        median_spread_bps=row.median_spread_bps,
+        activity_score=row.activity_score,
+        coverage_score=row.coverage_score,
+        ofi_pressure_score=row.ofi_pressure_score,
+        microprice_bias_bps=row.microprice_bias_bps,
+        spread_tail_bps=row.spread_tail_bps,
+        return_tail_abs_bps=row.return_tail_abs_bps,
+        impact_liquidity_penalty_bps=row.impact_liquidity_penalty_bps,
+        cluster_lob_activity_score=row.cluster_lob_activity_score,
+        ofi_decay_alignment_score=row.ofi_decay_alignment_score,
+        liquidity_regime_score=row.liquidity_regime_score,
+        macro_stress_veto_score=row.macro_stress_veto_score,
+        conformal_tail_risk_penalty_bps=row.conformal_tail_risk_penalty_bps,
+        square_root_impact_capacity_penalty_bps=row.square_root_impact_capacity_penalty_bps,
+        exploration_score=row.exploration_score,
+        frontier_bucket=frontier_bucket,
+        proof_semantics_label=row.proof_semantics_label,
+    )
+
+
+def _ofi_decay_score(values: NDArray[np.float64]) -> float:
+    if values.size == 0:
+        return 0.0
+    short = _ewma_last(values, half_life=3.0)
+    long = _ewma_last(values, half_life=12.0)
+    return float(np.clip(0.65 * short + 0.35 * long, -1.0, 1.0))
+
+
+def _ewma_last(values: NDArray[np.float64], *, half_life: float) -> float:
+    if values.size == 0:
+        return 0.0
+    decay = np.log(2.0) / max(1.0, half_life)
+    distances = np.arange(values.size - 1, -1, -1, dtype=np.float64)
+    weights = np.exp(-decay * distances)
+    total = float(np.sum(weights))
+    if total <= 0.0:
+        return 0.0
+    return float(np.sum(values * weights) / total)
+
+
+def _cluster_lob_activity_score(rows: Sequence[SignalEnvelope], ofi_values: NDArray[np.float64]) -> float:
+    event_labels = [_event_label(row) for row in rows]
+    label_entropy = _normalized_entropy(event_labels)
+    pressure = float(np.mean(np.abs(ofi_values))) if ofi_values.size else 0.0
+    if ofi_values.size >= 3:
+        changes = np.abs(np.diff(ofi_values))
+        burstiness = float(np.clip(np.percentile(changes, 75), 0.0, 1.0))
+    else:
+        burstiness = 0.0
+    return float(np.clip(0.35 * label_entropy + 0.45 * pressure + 0.20 * burstiness, 0.0, 1.0))
+
+
+def _event_label(signal: SignalEnvelope) -> str:
+    payload = signal.payload
+    for key in ("cluster_lob_label", "order_cluster", "event_type", "order_event_type", "side", "liquidity_side"):
+        value = str(payload.get(key) or "").strip().lower()
+        if value:
+            return value
+    return "unknown"
+
+
+def _normalized_entropy(labels: Sequence[str]) -> float:
+    if not labels:
+        return 0.0
+    counts: dict[str, int] = {}
+    for label in labels:
+        counts[label] = counts.get(label, 0) + 1
+    if len(counts) <= 1:
+        return 0.0
+    probabilities = np.asarray([count / len(labels) for count in counts.values()], dtype=np.float64)
+    entropy = -float(np.sum(probabilities * np.log(probabilities)))
+    return float(np.clip(entropy / np.log(len(counts)), 0.0, 1.0))
+
+
+def _liquidity_regime_score(
+    *, spread_values: Sequence[float], volume_values: Sequence[float], row_count: int
+) -> float:
+    if row_count <= 0:
+        return 0.0
+    median_spread = float(np.median(spread_values)) if spread_values else 0.0
+    median_volume = float(np.median(volume_values)) if volume_values else 0.0
+    tight_spread_score = 1.0 / (1.0 + max(0.0, median_spread) / 10.0)
+    volume_score = float(np.clip(np.log1p(max(0.0, median_volume)) / 12.0, 0.0, 1.0))
+    coverage_score = float(np.clip(np.log1p(row_count) / 8.0, 0.0, 1.0))
+    return float(np.clip(0.45 * tight_spread_score + 0.35 * volume_score + 0.20 * coverage_score, 0.0, 1.0))
+
+
+def _macro_stress_veto_score(rows: Sequence[SignalEnvelope]) -> float:
+    if not rows:
+        return 0.0
+    stress_values = [_extract_macro_stress(row) for row in rows]
+    supported = [value for value in stress_values if value is not None]
+    if not supported:
+        return 0.0
+    return float(np.clip(np.mean(supported), 0.0, 1.0))
+
+
+def _extract_macro_stress(signal: SignalEnvelope) -> float | None:
+    payload = signal.payload
+    for key in (
+        "macro_news_stress_score",
+        "macro_stress_score",
+        "news_stress_score",
+        "macro_event_window",
+        "macro_announcement_window",
+        "news_event_window",
+        "stress_veto_window",
+    ):
+        if key not in payload:
+            continue
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return 1.0 if value else 0.0
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return float(np.clip(parsed, 0.0, 1.0))
+        text = str(value).strip().lower()
+        if text in {"yes", "true", "macro", "news", "event", "stress"}:
+            return 1.0
+        if text in {"no", "false", "none", "normal"}:
+            return 0.0
+    return None
+
+
+def _conformal_tail_risk_penalty_bps(signed_returns_bps: NDArray[np.float64]) -> float:
+    if signed_returns_bps.size < 2:
+        return 0.0
+    lower_tail = float(np.percentile(signed_returns_bps, 10))
+    mean_return = float(np.mean(signed_returns_bps))
+    sample_error = float(np.std(signed_returns_bps) / np.sqrt(signed_returns_bps.size))
+    return max(0.0, -lower_tail) + max(0.0, sample_error - max(0.0, mean_return))
+
+
+def _square_root_impact_capacity_penalty_bps(
+    *, spec: CandidateSpec, median_price: float, median_volume: float, median_spread_bps: float
+) -> float:
+    notional = _candidate_notional(spec)
+    if notional <= 0.0:
+        return 0.0
+    dollar_volume = max(0.0, median_price) * max(0.0, median_volume)
+    if dollar_volume <= 0.0:
+        return 25.0 + median_spread_bps
+    participation = notional / dollar_volume
+    return float(np.clip(np.sqrt(max(0.0, participation)) * 100.0 + median_spread_bps * 0.25, 0.0, 500.0))
+
+
+def _candidate_notional(spec: CandidateSpec) -> float:
+    return _float_or_none(spec.strategy_overrides.get("max_notional_per_trade")) or 0.0
 
 
 def _candidate_symbols(spec: CandidateSpec) -> tuple[str, ...]:
@@ -368,9 +675,7 @@ def _candidate_symbols(spec: CandidateSpec) -> tuple[str, ...]:
     if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
         raw_symbols = cast(Sequence[Any], raw)
         symbols = tuple(
-            sorted(
-                {_string(item).upper() for item in raw_symbols if _string(item).strip()}
-            )
+            sorted({_string(item).upper() for item in raw_symbols if _string(item).strip()})
         )
         if symbols:
             return symbols
@@ -390,9 +695,7 @@ def _candidate_direction(spec: CandidateSpec) -> float:
         )
         if item
     ).lower()
-    if any(
-        token in text for token in ("reversal", "rebound", "washout", "mean_revert")
-    ):
+    if any(token in text for token in ("reversal", "rebound", "washout", "mean_revert")):
         return -1.0
     return 1.0
 
@@ -450,25 +753,11 @@ def _extract_quote_depth_imbalance(signal: SignalEnvelope) -> float | None:
     payload = signal.payload
     bid_size = _first_float(
         payload,
-        (
-            "bid_size",
-            "bid_qty",
-            "best_bid_size",
-            "best_bid_qty",
-            "bid_depth",
-            "bid_volume",
-        ),
+        ("bid_size", "bid_qty", "best_bid_size", "best_bid_qty", "bid_depth", "bid_volume"),
     )
     ask_size = _first_float(
         payload,
-        (
-            "ask_size",
-            "ask_qty",
-            "best_ask_size",
-            "best_ask_qty",
-            "ask_depth",
-            "ask_volume",
-        ),
+        ("ask_size", "ask_qty", "best_ask_size", "best_ask_qty", "ask_depth", "ask_volume"),
     )
     if (
         bid_size is None
@@ -490,12 +779,8 @@ def _extract_microprice_bias_bps(signal: SignalEnvelope) -> float | None:
     if explicit_microprice is not None and price is not None and price > 0.0:
         return (explicit_microprice - price) / price * 10_000.0
 
-    bid_size = _first_float(
-        payload, ("bid_size", "bid_qty", "best_bid_size", "best_bid_qty")
-    )
-    ask_size = _first_float(
-        payload, ("ask_size", "ask_qty", "best_ask_size", "best_ask_qty")
-    )
+    bid_size = _first_float(payload, ("bid_size", "bid_qty", "best_bid_size", "best_bid_qty"))
+    ask_size = _first_float(payload, ("ask_size", "ask_qty", "best_ask_size", "best_ask_qty"))
     if (
         bid is None
         or ask is None
@@ -518,14 +803,7 @@ def _extract_volume(signal: SignalEnvelope) -> float | None:
     payload = signal.payload
     return _first_float(
         payload,
-        (
-            "microbar_volume",
-            "bar_volume",
-            "trade_volume",
-            "volume",
-            "qty",
-            "size",
-        ),
+        ("microbar_volume", "bar_volume", "trade_volume", "volume", "qty", "size"),
         positive=True,
     )
 
@@ -585,6 +863,8 @@ def _string(value: Any) -> str:
 __all__ = [
     "FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION",
     "FAST_REPLAY_PREVIEW_SCHEMA_VERSION",
+    "FAST_REPLAY_PROOF_SEMANTICS_LABEL",
+    "FAST_REPLAY_WHITEPAPER_MECHANISMS",
     "FastReplayPreviewResult",
     "FastReplayPreviewRow",
     "build_fast_replay_preview",

--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -58,6 +58,7 @@ class ReplayTapeManifest:
     artifact_refs: Mapping[str, str]
     source_table_versions: Mapping[str, str]
     created_at: datetime
+    replay_cache_key: str = ""
     requested_trading_days: tuple[date, ...] = ()
     observed_trading_days: tuple[date, ...] = ()
     missing_trading_days: tuple[date, ...] = ()
@@ -89,6 +90,7 @@ class ReplayTapeManifest:
             "row_count": self.row_count,
             "source_query_digest": self.source_query_digest,
             "content_sha256": self.content_sha256,
+            "replay_cache_key": self.replay_cache_key,
             "artifact_refs": dict(self.artifact_refs),
             "source_table_versions": dict(self.source_table_versions),
             "created_at": self.created_at.isoformat(),
@@ -141,6 +143,7 @@ class ReplayTapeManifest:
             row_count=int(payload.get("row_count") or 0),
             source_query_digest=str(payload.get("source_query_digest") or ""),
             content_sha256=str(payload.get("content_sha256") or ""),
+            replay_cache_key=str(payload.get("replay_cache_key") or ""),
             artifact_refs=_string_mapping(payload.get("artifact_refs")),
             source_table_versions=_string_mapping(payload.get("source_table_versions")),
             created_at=_parse_datetime(str(payload["created_at"])),
@@ -176,6 +179,30 @@ def build_source_query_digest(payload: Mapping[str, Any]) -> str:
         separators=(",", ":"),
     )
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_replay_tape_cache_key(
+    *,
+    dataset_snapshot_ref: str,
+    symbols: Sequence[str],
+    start_date: date,
+    end_date: date,
+    source_query_digest: str,
+    source_table_versions: Mapping[str, str] | None = None,
+) -> str:
+    """Build a stable cache key for a manifest-verified replay tape input set."""
+
+    return build_source_query_digest(
+        {
+            "schema_version": "torghut.replay-tape-cache-key.v1",
+            "dataset_snapshot_ref": dataset_snapshot_ref,
+            "symbols": _normalize_symbols(symbols),
+            "start_date": start_date,
+            "end_date": end_date,
+            "source_query_digest": source_query_digest,
+            "source_table_versions": dict(source_table_versions or {}),
+        }
+    )
 
 
 def materialize_signal_tape(
@@ -250,6 +277,14 @@ def materialize_signal_tape(
         "tape_path": str(tape_path),
         **dict(artifact_refs or {}),
     }
+    replay_cache_key = build_replay_tape_cache_key(
+        dataset_snapshot_ref=dataset_snapshot_ref,
+        symbols=normalized_symbols,
+        start_date=start_date,
+        end_date=end_date,
+        source_query_digest=source_query_digest,
+        source_table_versions=source_table_versions,
+    )
     manifest = ReplayTapeManifest(
         schema_version=REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
         dataset_snapshot_ref=dataset_snapshot_ref,
@@ -265,6 +300,7 @@ def materialize_signal_tape(
         row_count=len(ordered_rows),
         source_query_digest=source_query_digest,
         content_sha256=content_hash.hexdigest(),
+        replay_cache_key=replay_cache_key,
         artifact_refs=resolved_artifact_refs,
         source_table_versions=dict(source_table_versions or {}),
         created_at=created_at or datetime.now(timezone.utc),
@@ -737,6 +773,7 @@ __all__ = [
     "ReplayTape",
     "ReplayTapeCoverageError",
     "ReplayTapeManifest",
+    "build_replay_tape_cache_key",
     "build_source_query_digest",
     "default_manifest_path",
     "load_replay_tape",

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -56,7 +56,11 @@ from app.trading.discovery.evidence_bundles import (
 from app.trading.discovery.factor_acceptance import (
     build_factor_acceptance_artifact_from_scorecard,
 )
-from app.trading.discovery.fast_replay import build_fast_replay_preview
+from app.trading.discovery.fast_replay import (
+    FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+    FAST_REPLAY_WHITEPAPER_MECHANISMS,
+    build_fast_replay_preview,
+)
 from app.trading.discovery.hypothesis_cards import HypothesisCard
 from app.trading.discovery.mlx_snapshot import build_mlx_snapshot_manifest
 from app.trading.discovery.mlx_snapshot import MlxSnapshotManifest
@@ -136,6 +140,9 @@ _CANDIDATE_BOARD_RUNTIME_SESSION_OPEN = time(hour=9, minute=30)
 _CANDIDATE_BOARD_RUNTIME_SESSION_CLOSE = time(hour=16, minute=0)
 _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC = 8
 _DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES = 16
+_DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP = 6
+_DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS = 4
+_DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS = 2
 _DEFAULT_CLICKHOUSE_HTTP_URL = (
     "http://torghut-clickhouse.torghut.svc.cluster.local:8123"
 )
@@ -576,6 +583,27 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=2,
         help="Minimum manifest-verified tape rows required to score a candidate in preview narrowing.",
+    )
+    parser.add_argument(
+        "--replay-tape-exact-candidate-cap",
+        type=int,
+        default=_DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
+        help=(
+            "Maximum candidate specs forwarded from preview ranking to exact replay. "
+            "Defaults to a bounded 4 exploitation + 2 exploration frontier."
+        ),
+    )
+    parser.add_argument(
+        "--replay-tape-frontier-exploitation-slots",
+        type=int,
+        default=_DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS,
+        help="Preview frontier exploitation slots forwarded to exact replay.",
+    )
+    parser.add_argument(
+        "--replay-tape-frontier-exploration-slots",
+        type=int,
+        default=_DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS,
+        help="Preview frontier exploration slots forwarded to exact replay.",
     )
     parser.add_argument(
         "--materialize-replay-tape",
@@ -6303,6 +6331,42 @@ def _apply_fast_replay_preview_narrowing(
     tape_path = getattr(args, "replay_tape_path", None)
     if tape_path is None:
         raise ValueError("fast_replay_preview_requires_replay_tape_path")
+    exact_replay_candidate_cap = max(
+        1,
+        min(
+            preview_top_k,
+            int(
+                getattr(
+                    args,
+                    "replay_tape_exact_candidate_cap",
+                    _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
+                )
+                or _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP
+            ),
+        ),
+    )
+    exploitation_slots = max(
+        0,
+        int(
+            getattr(
+                args,
+                "replay_tape_frontier_exploitation_slots",
+                _DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS,
+            )
+            or 0
+        ),
+    )
+    exploration_slots = max(
+        0,
+        int(
+            getattr(
+                args,
+                "replay_tape_frontier_exploration_slots",
+                _DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS,
+            )
+            or 0
+        ),
+    )
 
     start_date = _fast_replay_preview_date_arg(args, "full_window_start_date")
     end_date = _fast_replay_preview_date_arg(args, "full_window_end_date")
@@ -6337,6 +6401,9 @@ def _apply_fast_replay_preview_narrowing(
         min_rows_per_candidate=max(
             1, int(getattr(args, "replay_tape_preview_min_rows", 2) or 2)
         ),
+        exploitation_count=exploitation_slots,
+        exploration_count=exploration_slots,
+        exact_replay_candidate_cap=exact_replay_candidate_cap,
     )
     preview_scores_path = output_dir / "replay-tape-preview-scores.jsonl"
     preview_manifest_path = output_dir / "replay-tape-preview-manifest.json"
@@ -6344,6 +6411,7 @@ def _apply_fast_replay_preview_narrowing(
     preview_manifest = {
         **preview.to_manifest_payload(),
         "validation": validation,
+        "proof_semantics": _fast_replay_preview_proof_semantics(),
         "artifacts": {
             "scores_jsonl": str(preview_scores_path),
             "manifest_json": str(preview_manifest_path),
@@ -6399,6 +6467,10 @@ def _apply_fast_replay_preview_narrowing(
             updated["fast_replay_preview_impact_liquidity_penalty_bps"] = preview_row[
                 "impact_liquidity_penalty_bps"
             ]
+            updated["fast_replay_frontier_bucket"] = preview_row["frontier_bucket"]
+            updated["fast_replay_proof_semantics_label"] = preview_row[
+                "proof_semantics_label"
+            ]
         if candidate_spec_id in original_selected_ids:
             updated["pre_fast_replay_preview_selected_for_replay"] = bool(
                 row.get("selected_for_replay")
@@ -6415,6 +6487,9 @@ def _apply_fast_replay_preview_narrowing(
             **_mapping(candidate_selection.get("budget")),
             "fast_replay_preview_enabled": True,
             "fast_replay_preview_requested_top_k": preview_top_k,
+            "fast_replay_exact_replay_candidate_cap": exact_replay_candidate_cap,
+            "fast_replay_frontier_exploitation_slots": exploitation_slots,
+            "fast_replay_frontier_exploration_slots": exploration_slots,
             "fast_replay_preview_selected_count": len(narrowed_specs),
             "pre_fast_replay_preview_selected_count": len(specs),
             "selected_count": len(narrowed_specs),
@@ -6428,8 +6503,74 @@ def _apply_fast_replay_preview_narrowing(
             "scores_artifact": str(preview_scores_path),
             "manifest_artifact": str(preview_manifest_path),
         },
+        "bounded_sim_target_queue": _bounded_sim_target_queue_metadata(
+            preview_rows=[row.to_payload() for row in preview.rows],
+            exact_replay_candidate_cap=exact_replay_candidate_cap,
+            exploitation_slots=exploitation_slots,
+            exploration_slots=exploration_slots,
+        ),
     }
     return narrowed_specs, updated_selection
+
+
+def _fast_replay_preview_proof_semantics() -> dict[str, Any]:
+    return {
+        "schema_version": "torghut.fast-replay-proof-semantics.v1",
+        "label": FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+        "promotion_proof": False,
+        "authority": "preview_prefilter_only",
+        "final_promotion_requires": [
+            "exact_replay_evidence",
+            "source_backed_runtime_ledger",
+            "live_paper_runtime_evidence",
+            "unchanged_promotion_gates",
+        ],
+        "whitepaper_gpu_fast_replay_policy": (
+            "whitepaper-derived fast/GPU preview signals rank candidates only and cannot unlock final promotion"
+        ),
+    }
+
+
+def _bounded_sim_target_queue_metadata(
+    *,
+    preview_rows: Sequence[Mapping[str, Any]],
+    exact_replay_candidate_cap: int,
+    exploitation_slots: int,
+    exploration_slots: int,
+) -> dict[str, Any]:
+    selected_rows = [
+        dict(row)
+        for row in preview_rows
+        if bool(row.get("selected"))
+    ][:exact_replay_candidate_cap]
+    entries: list[dict[str, Any]] = []
+    for index, row in enumerate(selected_rows, start=1):
+        entries.append(
+            {
+                "queue_priority": index,
+                "candidate_spec_id": _string(row.get("candidate_spec_id")),
+                "frontier_bucket": _string(row.get("frontier_bucket")),
+                "preview_rank": row.get("rank"),
+                "preview_score": row.get("preview_score"),
+                "proof_semantics_label": row.get("proof_semantics_label"),
+                "promotion_proof": False,
+            }
+        )
+    return {
+        "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v1",
+        "status": "metadata_only_preview_to_exact_replay_queue",
+        "authority": "not_promotion_proof",
+        "promotion_proof": False,
+        "proof_semantics": _fast_replay_preview_proof_semantics(),
+        "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
+        "queue_policy": "top_exploitation_plus_exploration_exact_replay_cap",
+        "exact_replay_candidate_cap": exact_replay_candidate_cap,
+        "exploitation_slots": exploitation_slots,
+        "exploration_slots": exploration_slots,
+        "exact_replay_candidate_count": len(entries),
+        "candidate_spec_ids": [entry["candidate_spec_id"] for entry in entries],
+        "entries": entries,
+    }
 
 
 def _maybe_materialize_epoch_replay_tape(

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from app.trading.discovery.candidate_specs import CANDIDATE_SPEC_SCHEMA_VERSION, CandidateSpec
+from app.trading.discovery.fast_replay import (
+    FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+    build_fast_replay_preview,
+)
+from app.trading.discovery.replay_tape import build_source_query_digest, materialize_signal_tape
+from app.trading.models import SignalEnvelope
+
+
+class TestFastReplayPreview(TestCase):
+    def _spec(
+        self,
+        candidate_spec_id: str,
+        *,
+        symbols: list[str],
+        selection_mode: str = "continuation",
+        max_notional_per_trade: str = "2500",
+    ) -> CandidateSpec:
+        return CandidateSpec(
+            schema_version=CANDIDATE_SPEC_SCHEMA_VERSION,
+            candidate_spec_id=candidate_spec_id,
+            hypothesis_id=f"hyp-{candidate_spec_id}",
+            family_template_id="microbar_cross_sectional_pairs_v1",
+            candidate_kind="sleeve",
+            runtime_family="microbar_cross_sectional_pairs",
+            runtime_strategy_name="microbar-cross-sectional-pairs-v1",
+            feature_contract={"mechanism": "test hpairs", "required_features": ["ofi"]},
+            parameter_space={},
+            strategy_overrides={
+                "max_notional_per_trade": max_notional_per_trade,
+                "params": {
+                    "selection_mode": selection_mode,
+                    "signal_motif": "ofi_lob_response_continuation",
+                    "rank_feature": "cross_section_session_open_rank",
+                },
+                "universe_symbols": symbols,
+            },
+            objective={"target_net_pnl_per_day": "500"},
+            hard_vetoes={},
+            expected_failure_modes=(),
+            promotion_contract={"promotion_policy": "research_only"},
+        )
+
+    def _signal(
+        self,
+        *,
+        symbol: str,
+        offset: int,
+        price: str,
+        ofi: str,
+        volume: str = "100000",
+        stress: bool = False,
+        event_type: str = "trade",
+    ) -> SignalEnvelope:
+        return SignalEnvelope(
+            event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc) + timedelta(minutes=offset),
+            symbol=symbol,
+            timeframe="1Min",
+            seq=offset,
+            source="test",
+            payload={
+                "price": Decimal(price),
+                "spread_bps": Decimal("2"),
+                "ofi": Decimal(ofi),
+                "microbar_volume": Decimal(volume),
+                "event_type": event_type,
+                "bid_size": Decimal("700"),
+                "ask_size": Decimal("300"),
+                "macro_event_window": stress,
+            },
+            ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
+        )
+
+    def test_whitepaper_features_rank_and_label_preview_only(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            rows = [
+                self._signal(symbol="AAA", offset=1, price="100", ofi="0.65", event_type="add"),
+                self._signal(symbol="AAA", offset=2, price="101", ofi="0.80", event_type="trade"),
+                self._signal(symbol="AAA", offset=3, price="102", ofi="0.85", event_type="cancel"),
+                self._signal(symbol="BBB", offset=1, price="100", ofi="-0.10", stress=True),
+                self._signal(symbol="BBB", offset=2, price="99", ofi="-0.20", stress=True),
+                self._signal(symbol="BBB", offset=3, price="98", ofi="-0.20", stress=True),
+            ]
+            manifest = materialize_signal_tape(
+                rows=rows,
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-fast",
+                symbols=("AAA", "BBB"),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest({"window": "fast"}),
+            )
+
+        preview = build_fast_replay_preview(
+            specs=(
+                self._spec("spec-good", symbols=["AAA"]),
+                self._spec("spec-stress", symbols=["BBB"]),
+            ),
+            rows=rows,
+            replay_tape_manifest=manifest,
+            top_k=2,
+            min_rows_per_candidate=2,
+            exploitation_count=1,
+            exploration_count=1,
+            exact_replay_candidate_cap=2,
+        )
+
+        self.assertEqual(preview.selected_candidate_spec_ids, ("spec-good", "spec-stress"))
+        good, stress = preview.rows
+        self.assertEqual(good.candidate_spec_id, "spec-good")
+        self.assertGreater(good.cluster_lob_activity_score, Decimal("0"))
+        self.assertGreater(good.ofi_decay_alignment_score, Decimal("0"))
+        self.assertEqual(good.frontier_bucket, "exploitation")
+        self.assertEqual(stress.frontier_bucket, "exploration")
+        self.assertGreater(stress.macro_stress_veto_score, Decimal("0"))
+        payload = preview.to_manifest_payload()
+        self.assertFalse(payload["promotion_proof"])
+        self.assertEqual(payload["proof_semantics_label"], FAST_REPLAY_PROOF_SEMANTICS_LABEL)
+        self.assertIn("source_backed_runtime_ledger_proof_required", payload["blockers"])
+        self.assertIn("conformal_tail_risk", payload["implemented_mechanisms"])
+
+    def test_frontier_selection_caps_exact_replay_with_exploration_slots(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            rows = [
+                self._signal(symbol="AAA", offset=index, price=str(100 + index), ofi="0.50")
+                for index in range(1, 8)
+            ]
+            manifest = materialize_signal_tape(
+                rows=rows,
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-cap",
+                symbols=("AAA",),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest({"window": "cap"}),
+            )
+        specs = tuple(self._spec(f"spec-{index}", symbols=["AAA"]) for index in range(8))
+
+        preview = build_fast_replay_preview(
+            specs=specs,
+            rows=rows,
+            replay_tape_manifest=manifest,
+            top_k=8,
+            min_rows_per_candidate=2,
+            exploitation_count=4,
+            exploration_count=2,
+            exact_replay_candidate_cap=6,
+        )
+
+        self.assertEqual(len(preview.selected_candidate_spec_ids), 6)
+        self.assertEqual(preview.exploitation_candidate_count, 4)
+        self.assertEqual(preview.exploration_candidate_count, 2)
+        self.assertEqual(preview.exact_replay_candidate_cap, 6)
+        self.assertEqual(
+            [row.frontier_bucket for row in preview.rows if row.selected],
+            ["exploitation", "exploitation", "exploitation", "exploitation", "exploration", "exploration"],
+        )

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -16,6 +16,7 @@ from app.trading.discovery.replay_tape import (
     REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
     ReplayTapeCoverageError,
     ReplayTapeManifest,
+    build_replay_tape_cache_key,
     build_source_query_digest,
     default_manifest_path,
     load_replay_tape,
@@ -181,6 +182,51 @@ class TestReplayTape(TestCase):
         self.assertNotEqual(
             first_manifest.content_sha256, second_manifest.content_sha256
         )
+
+    def test_replay_tape_cache_key_is_stable_for_same_query_inputs(self) -> None:
+        first_digest = build_source_query_digest({"window": "a", "symbols": ["NVDA"]})
+        first_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("NVDA", "AAPL"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=first_digest,
+            source_table_versions={"signals": "v1"},
+        )
+        reordered_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("aapl", "nvda"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=first_digest,
+            source_table_versions={"signals": "v1"},
+        )
+        changed_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("AAPL", "NVDA"),
+            start_date=date(2026, 3, 28),
+            end_date=date(2026, 3, 28),
+            source_query_digest=first_digest,
+            source_table_versions={"signals": "v1"},
+        )
+
+        self.assertEqual(first_key, reordered_key)
+        self.assertNotEqual(first_key, changed_key)
+
+        with TemporaryDirectory() as tmpdir:
+            manifest = materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, symbol="NVDA")],
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-a",
+                symbols=("NVDA", "AAPL"),
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=first_digest,
+                source_table_versions={"signals": "v1"},
+            )
+
+        self.assertEqual(manifest.replay_cache_key, first_key)
+        self.assertEqual(manifest.to_payload()["replay_cache_key"], first_key)
 
     def test_materialize_manifest_session_window_follows_new_york_dst(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -284,6 +284,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             replay_tape_manifest=None,
             replay_tape_preview_top_k=0,
             replay_tape_preview_min_rows=2,
+            replay_tape_exact_candidate_cap=runner._DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
+            replay_tape_frontier_exploitation_slots=runner._DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS,
+            replay_tape_frontier_exploration_slots=runner._DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS,
             materialize_replay_tape=False,
             min_daily_net_pnl=None,
             persist_results=False,
@@ -4603,6 +4606,99 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertFalse(aapl_row["selected_for_replay"])
         self.assertEqual(aapl_row["selection_reason"], "fast_replay_preview_filtered")
 
+    def test_fast_replay_preview_builds_bounded_sim_target_queue_and_caps_exact_replay(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            output_dir.mkdir()
+            tape_path = Path(tmpdir) / "tape.jsonl"
+            rows = [
+                SignalEnvelope(
+                    event_ts=datetime(
+                        2026, 2, 23, 14, 30 + index, tzinfo=timezone.utc
+                    ),
+                    symbol=symbol,
+                    timeframe="1Min",
+                    seq=index,
+                    source="ta",
+                    payload={
+                        "price": Decimal(str(100 + index)),
+                        "spread_bps": Decimal("2"),
+                        "ofi": Decimal("0.35"),
+                        "microbar_volume": Decimal("100000"),
+                        "event_type": "trade",
+                    },
+                )
+                for index, symbol in enumerate(["NVDA", "AAPL", "INTC"] * 3)
+            ]
+            materialize_signal_tape(
+                rows=rows,
+                tape_path=tape_path,
+                dataset_snapshot_ref="frontier-preview",
+                symbols=("NVDA", "AAPL", "INTC"),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest({"window": "frontier"}),
+            )
+            specs = [
+                self._candidate_spec(f"spec-frontier-{index}") for index in range(8)
+            ]
+            args = self._args(output_dir)
+            args.replay_mode = "real"
+            args.full_window_start_date = "2026-02-23"
+            args.full_window_end_date = "2026-02-23"
+            args.symbols = "NVDA,AAPL,INTC"
+            args.replay_tape_path = tape_path
+            args.replay_tape_preview_top_k = 8
+            candidate_selection = {
+                "schema_version": "torghut.whitepaper-autoresearch-selection.v1",
+                "budget": {"selected_count": len(specs)},
+                "selected_candidate_spec_ids": [
+                    spec.candidate_spec_id for spec in specs
+                ],
+                "rows": [
+                    {
+                        "candidate_spec_id": spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                        "selection_reason": "test",
+                    }
+                    for spec in specs
+                ],
+            }
+
+            narrowed_specs, updated_selection = (
+                runner._apply_fast_replay_preview_narrowing(
+                    args=args,
+                    output_dir=output_dir,
+                    specs=specs,
+                    candidate_selection=candidate_selection,
+                )
+            )
+
+        self.assertEqual(len(narrowed_specs), 6)
+        self.assertEqual(
+            updated_selection["budget"]["fast_replay_exact_replay_candidate_cap"], 6
+        )
+        queue_payload = updated_selection["bounded_sim_target_queue"]
+        self.assertEqual(queue_payload["exact_replay_candidate_count"], 6)
+        self.assertFalse(queue_payload["promotion_proof"])
+        self.assertEqual(
+            queue_payload["proof_semantics"]["label"],
+            fast_replay.FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+        )
+        self.assertEqual(
+            [entry["frontier_bucket"] for entry in queue_payload["entries"]],
+            [
+                "exploitation",
+                "exploitation",
+                "exploitation",
+                "exploitation",
+                "exploration",
+                "exploration",
+            ],
+        )
+
     def test_fast_replay_preview_scores_microstructure_diagnostics_preview_only(
         self,
     ) -> None:
@@ -4691,10 +4787,15 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         manifest_payload = preview.to_manifest_payload()
 
         self.assertEqual(
-            row_payload["schema_version"], "torghut.fast-replay-preview-row.v2"
+            row_payload["schema_version"], "torghut.fast-replay-preview-row.v3"
         )
         self.assertEqual(manifest_payload["status"], "preview_only")
         self.assertFalse(manifest_payload["promotion_proof"])
+        self.assertEqual(
+            row_payload["proof_semantics_label"],
+            fast_replay.FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+        )
+        self.assertFalse(row_payload["promotion_proof"])
         self.assertIn("exact_replay_required", manifest_payload["blockers"])
         self.assertGreater(Decimal(row_payload["ofi_pressure_score"]), Decimal("0"))
         self.assertGreater(Decimal(row_payload["microprice_bias_bps"]), Decimal("0"))
@@ -4702,6 +4803,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertGreater(
             Decimal(row_payload["impact_liquidity_penalty_bps"]), Decimal("0")
         )
+        self.assertIn("conformal_tail_risk", manifest_payload["implemented_mechanisms"])
 
     def test_materialize_replay_tape_writes_run_artifacts_and_updates_args(
         self,


### PR DESCRIPTION
## Summary

- Adds a preview-only Torghut fast replay frontier harness that converts recent 2025-2026 microstructure research into manifest-backed H-PAIRS candidate ranking signals without changing final proof gates.
- Implements replay tape cache keys and preview feature extraction for ClusterLOB-style event clustering proxies, OFI horizon/decay/regime alignment, macro/news stress-veto fields when present, square-root impact capacity, and conformal tail-risk ranking penalties.
- Adds a bounded frontier path from many previewed specs to a default 6-candidate exact replay queue: 4 exploitation plus 2 exploration candidates, with bounded SIM target queue metadata.
- Labels every fast/GPU/whitepaper-derived artifact as preview-only and not promotion proof; exact replay, source-backed runtime ledger, and live-paper runtime evidence remain required.

## Related Issues

None

## Research Sources and Actualized Mechanisms

- https://arxiv.org/abs/2504.20349 - ClusterLOB order-event clustering inspired the tape-local event-mix plus OFI burstiness proxy used only for candidate ranking.
- https://arxiv.org/abs/2508.06788 - Intraday OFI and macro-news dynamics motivated OFI EWMA horizon/decay alignment, liquidity regime scoring, and optional macro/news stress-veto penalties when tape rows already carry those fields.
- https://arxiv.org/abs/2601.23172 - Order-flow, market-impact, and volatility power-law lineage motivated the square-root notional versus tape dollar-volume capacity penalty.
- https://arxiv.org/abs/2602.03903 - Regime-weighted conformal VaR motivated the distribution-free lower-tail signed-return penalty as a prefilter only.

## Testing

- PASS: `uv sync --frozen --extra dev`
- PASS: `uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` with 201 passed and 1 existing warning
- PASS: `uv run --frozen ruff check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- PASS: `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- NOTE: The exact default-heap `uv run --frozen pyright --project pyrightconfig.json` command exhausted Node heap in this aarch64 workspace; rerunning with increased Node heap passed with 0 errors.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Rollout

No live rollout performed from this worktree. This change is a Torghut research/harness code path only; it does not edit Kubernetes, Argo CD, DB migrations, order feeds, runtime ledger authority, or live/paper submit flags. Normal CI/CD image publication after merge is sufficient if the Torghut image includes this service code.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
