### PR TITLE
fix(torghut): stabilize closed paper route proof handoff

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -265,6 +265,53 @@ jobs:
             done
           }
 
+          fetch_readyz_json() {
+            local url="$1"
+            local output_path="$2"
+            local label="$3"
+            local status
+
+            for attempt in $(seq 1 18); do
+              status="$(
+                curl -sS --connect-timeout 10 --max-time 90 \
+                  -o "${output_path}" -w '%{http_code}' "${url}" || true
+              )"
+              if [[ "${status}" =~ ^2[0-9][0-9]$ ]] &&
+                python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
+                printf '%s' "${status}"
+                return 0
+              fi
+              if [ "${status}" = '503' ] &&
+                python3 -m json.tool "${output_path}" >/dev/null 2>&1 &&
+                python3 -c 'import json, sys; payload = json.load(open(sys.argv[1], encoding="utf-8")); sys.exit(0 if payload.get("status") == "degraded" else 1)' "${output_path}"; then
+                printf '%s' "${status}"
+                return 0
+              fi
+
+              if [ "${attempt}" -eq 18 ]; then
+                if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
+                  [ "${status}" != '000' ] &&
+                  python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
+                  echo "${label} returned HTTP ${status} without an acceptable readyz contract" >&2
+                else
+                  echo "${label} did not return a parseable JSON HTTP response; status=${status:-empty}" >&2
+                fi
+                head -c 1000 "${output_path}" >&2 || true
+                echo >&2
+                return 1
+              fi
+
+              if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
+                [ "${status}" != '000' ] &&
+                python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
+                echo "Attempt ${attempt}: ${label} returned HTTP ${status} without an acceptable readyz contract; retrying" >&2
+              else
+                echo "Attempt ${attempt}: ${label} status=${status:-empty} not usable JSON yet; retrying" >&2
+              fi
+              sleep 5
+            done
+          }
+
           fetch_json_2xx() {
             local url="$1"
             local output_path="$2"
@@ -306,7 +353,7 @@ jobs:
           }
 
           TORGHUT_READYZ_HTTP_STATUS="$(
-            fetch_json \
+            fetch_readyz_json \
               http://torghut.torghut.svc.cluster.local/readyz \
               "${EVIDENCE_DIR}/torghut-readyz.json" \
               "Torghut /readyz"

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -53,6 +53,13 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).not.toContain('Torghut /readyz returned HTTP')
   })
 
+  it('retries transient readyz 503 payloads until they match the repair-only contract', () => {
+    expect(workflow).toContain('fetch_readyz_json()')
+    expect(workflow).toContain('payload.get("status") == "degraded"')
+    expect(workflow).toContain('without an acceptable readyz contract; retrying')
+    expect(workflow).toContain('fetch_readyz_json \\')
+  })
+
   it('retries Knative service JSON evidence capture before invoking the validator', () => {
     expect(workflow).toContain('fetch_json()')
     expect(workflow).toContain('python3 -m json.tool "${output_path}"')

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -4058,6 +4058,22 @@ def _runtime_window_target_counts(
     }
 
 
+def _target_audits_have_material_runtime_window_evidence(
+    target_audits: Sequence[Mapping[str, object]],
+) -> bool:
+    counts = _runtime_window_target_counts(target_audits)
+    return any(
+        counts[key] > 0
+        for key in (
+            "source_activity",
+            "rejected_signal_activity",
+            "runtime_ledger",
+            "evidence_grade_runtime_ledger",
+            "promotion_decision",
+        )
+    )
+
+
 def _next_paper_route_target_summaries(
     targets: Sequence[Mapping[str, object]],
 ) -> list[dict[str, object]]:
@@ -4340,6 +4356,32 @@ def _deferred_runtime_window_target_audits(
     return audits
 
 
+def _runtime_window_import_plan_for_audit(
+    *,
+    latest_closed_targets: Mapping[str, Any],
+    next_targets: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    latest_closed_readiness = _as_mapping(
+        latest_closed_targets.get("session_readiness")
+    )
+    if (
+        bool(latest_closed_readiness.get("import_ready"))
+        and _safe_int(latest_closed_targets.get("target_count")) > 0
+    ):
+        return latest_closed_targets
+    return next_targets
+
+
+def _targets_have_explicit_window_bounds(
+    targets: Sequence[Mapping[str, object]],
+) -> bool:
+    return any(
+        _parse_datetime(target.get("window_start")) is not None
+        and _parse_datetime(target.get("window_end")) is not None
+        for target in targets
+    )
+
+
 def build_paper_route_target_plan_payload(
     session: Session,
     *,
@@ -4396,20 +4438,9 @@ def build_paper_route_target_plan_payload(
         generated_at=resolved_generated_at,
         require_clean_pre_session=False,
     )
-    latest_closed_readiness = _as_mapping(
-        latest_closed_targets.get("session_readiness")
-    )
-    targets_have_explicit_window_bounds = any(
-        _parse_datetime(target.get("window_start")) is not None
-        and _parse_datetime(target.get("window_end")) is not None
-        for target in targets
-    )
-    runtime_window_import_plan = (
-        latest_closed_targets
-        if not targets_have_explicit_window_bounds
-        and bool(latest_closed_readiness.get("import_ready"))
-        and _safe_int(latest_closed_targets.get("target_count")) > 0
-        else next_targets
+    runtime_window_import_plan = _runtime_window_import_plan_for_audit(
+        latest_closed_targets=latest_closed_targets,
+        next_targets=next_targets,
     )
     runtime_import_readiness = _as_mapping(
         runtime_window_import_plan.get("session_readiness")
@@ -4626,21 +4657,6 @@ def build_paper_route_evidence_audit(
         window_end=closed_window_end,
         purpose="latest_closed_session_paper_route_runtime_window_import",
     )
-    latest_closed_readiness = _as_mapping(
-        latest_closed_targets.get("session_readiness")
-    )
-    targets_have_explicit_window_bounds = any(
-        _parse_datetime(target.get("window_start")) is not None
-        and _parse_datetime(target.get("window_end")) is not None
-        for target in targets
-    )
-    runtime_window_import_plan = (
-        latest_closed_targets
-        if not targets_have_explicit_window_bounds
-        and bool(latest_closed_readiness.get("import_ready"))
-        and _safe_int(latest_closed_targets.get("target_count")) > 0
-        else next_targets
-    )
     next_target_audits = [
         _target_audit_fail_closed(
             session,
@@ -4652,17 +4668,35 @@ def build_paper_route_evidence_audit(
         )
         for target in _as_mapping_items(next_targets.get("targets"))
     ]
-    runtime_window_import_target_audits = [
-        _target_audit_fail_closed(
-            session,
-            raw_target=target,
-            probe=probe,
-            generated_at=resolved_generated_at,
-            lookback_hours=lookback_hours,
-            error_source="paper_route_runtime_window_import_target_audit",
+    runtime_window_import_plan = next_targets
+    runtime_window_import_target_audits = next_target_audits
+    latest_closed_runtime_window_import_plan = _runtime_window_import_plan_for_audit(
+        latest_closed_targets=latest_closed_targets,
+        next_targets=next_targets,
+    )
+    if latest_closed_runtime_window_import_plan is latest_closed_targets:
+        targets_have_explicit_window_bounds = _targets_have_explicit_window_bounds(
+            targets
         )
-        for target in _as_mapping_items(runtime_window_import_plan.get("targets"))
-    ]
+        latest_closed_target_audits = [
+            _target_audit_fail_closed(
+                session,
+                raw_target=target,
+                probe=probe,
+                generated_at=resolved_generated_at,
+                lookback_hours=lookback_hours,
+                error_source="paper_route_runtime_window_import_target_audit",
+            )
+            for target in _as_mapping_items(latest_closed_targets.get("targets"))
+        ]
+        if (
+            not targets_have_explicit_window_bounds
+            or _target_audits_have_material_runtime_window_evidence(
+                latest_closed_target_audits
+            )
+        ):
+            runtime_window_import_plan = latest_closed_targets
+            runtime_window_import_target_audits = latest_closed_target_audits
     runtime_window_import_audit = _runtime_window_import_audit(
         next_targets=runtime_window_import_plan,
         target_audits=target_audits,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1012,6 +1012,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "account_label": "TORGHUT_SIM",
                                 "source_kind": "paper_route_probe_runtime_observed",
                                 "source_manifest_ref": "config/trading/hypotheses/h-closed-window.json",
+                                "window_start": "2026-06-01T13:30:00+00:00",
+                                "window_end": "2026-06-01T20:00:00+00:00",
                                 "paper_probation_authorized": True,
                                 "promotion_allowed": False,
                                 "final_promotion_authorized": False,


### PR DESCRIPTION
## Summary

- Prefer the latest closed paper-route runtime window in the target-plan import handoff whenever it is import-ready.
- Keep evidence audits on explicit future/next-session windows unless the latest closed-window audit has material source, rejected-signal, runtime-ledger, or promotion-decision evidence.
- Add regression coverage where explicit next-session target bounds no longer prevent surfacing material latest-closed runtime ledger evidence.
- Retry transient `/readyz` 503 payloads in the post-deploy verifier until they become either 2xx JSON or the accepted degraded repair-only contract, instead of triggering rollback on `{"detail":"database unavailable"}`.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -q -k paper_route_evidence`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `git diff --check`
- Live check: promoted image `812167e1b4ea131516e60cdcfeac7f9065057250` is running at digest `sha256:b61b9f68415b3d3e3f271f84700ea6fe0ca99c294872f1e13a9a6b26ff6fb8b4`; `/trading/paper-route-evidence` still keeps `runtime_window_import_plan` on `2026-06-01` while `latest_closed_paper_route_runtime_window_targets` exposes `2026-05-29`, confirming this PR addresses the current live blocker.
- Live failure evidence: post-deploy run `26737662528` uploaded `/readyz` as `{"detail":"database unavailable"}` with HTTP 503 before the current live pod recovered to a degraded repair-only payload, confirming the verifier retry gap.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
