### PR TITLE
fix(torghut): fail closed on readiness diagnostic timeouts

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -141,6 +141,15 @@ def _rollback_runtime_ledger_status_session(session: Session) -> None:
         logger.warning("Failed to roll back runtime-ledger status session")
 
 
+def _sqlalchemy_error_indicates_statement_timeout(exc: SQLAlchemyError) -> bool:
+    message = str(exc).lower()
+    return (
+        "statement timeout" in message
+        or "querycanceled" in message
+        or "query canceled" in message
+    )
+
+
 def _empty_profit_promotion_table_counts(
     *,
     count_errors: Sequence[str] | None = None,
@@ -2922,41 +2931,66 @@ def _attach_lineage_refs(
     )
 
     dataset_snapshots_by_candidate: dict[str, list[VNextDatasetSnapshot]] = {}
-    if candidate_ids:
-        dataset_rows = (
-            session.execute(
-                select(VNextDatasetSnapshot)
-                .where(VNextDatasetSnapshot.candidate_id.in_(candidate_ids))
-                .order_by(VNextDatasetSnapshot.created_at.desc())
-            )
-            .scalars()
-            .all()
-        )
-        for row in dataset_rows:
-            candidate_id = _safe_text(row.candidate_id)
-            if candidate_id is None:
-                continue
-            dataset_snapshots_by_candidate.setdefault(candidate_id, []).append(row)
-
     hypotheses_by_id: dict[str, list[StrategyHypothesis]] = {}
-    if hypothesis_ids:
-        hypothesis_rows = (
-            session.execute(
-                select(StrategyHypothesis)
-                .where(
-                    StrategyHypothesis.hypothesis_id.in_(hypothesis_ids),
-                    StrategyHypothesis.active.is_(True),
+    try:
+        if candidate_ids:
+            dataset_rows = (
+                session.execute(
+                    select(VNextDatasetSnapshot)
+                    .where(VNextDatasetSnapshot.candidate_id.in_(candidate_ids))
+                    .order_by(VNextDatasetSnapshot.created_at.desc())
                 )
-                .order_by(StrategyHypothesis.created_at.desc())
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
+            for row in dataset_rows:
+                candidate_id = _safe_text(row.candidate_id)
+                if candidate_id is None:
+                    continue
+                dataset_snapshots_by_candidate.setdefault(candidate_id, []).append(row)
+
+        if hypothesis_ids:
+            hypothesis_rows = (
+                session.execute(
+                    select(StrategyHypothesis)
+                    .where(
+                        StrategyHypothesis.hypothesis_id.in_(hypothesis_ids),
+                        StrategyHypothesis.active.is_(True),
+                    )
+                    .order_by(StrategyHypothesis.created_at.desc())
+                )
+                .scalars()
+                .all()
+            )
+            for row in hypothesis_rows:
+                hypothesis_id = _safe_text(row.hypothesis_id)
+                if hypothesis_id is None:
+                    continue
+                hypotheses_by_id.setdefault(hypothesis_id, []).append(row)
+    except SQLAlchemyError as exc:
+        logger.warning("Lineage refs unavailable: %s", exc)
+        _rollback_runtime_ledger_status_session(session)
+        reason_code = (
+            "lineage_ref_query_timeout"
+            if _sqlalchemy_error_indicates_statement_timeout(exc)
+            else "lineage_ref_unavailable"
         )
-        for row in hypothesis_rows:
-            hypothesis_id = _safe_text(row.hypothesis_id)
-            if hypothesis_id is None:
-                continue
-            hypotheses_by_id.setdefault(hypothesis_id, []).append(row)
+        attached_rows: list[dict[str, object]] = []
+        for row in evaluated_rows:
+            evaluated_row = dict(row)
+            reason_codes = list(
+                cast(Sequence[str], evaluated_row.get("reason_codes") or [])
+            )
+            if reason_code not in reason_codes:
+                reason_codes.append(reason_code)
+            evaluated_row["reason_codes"] = _normalize_reason_codes(reason_codes)
+            evaluated_row["lineage_ref"] = _default_lineage_ref(
+                status="unavailable",
+                candidate_id=_safe_text(evaluated_row.get("candidate_id")),
+                hypothesis_id=_safe_text(evaluated_row.get("hypothesis_id")),
+            )
+            attached_rows.append(evaluated_row)
+        return attached_rows
 
     attached_rows: list[dict[str, object]] = []
     for row in evaluated_rows:
@@ -3254,11 +3288,32 @@ def _load_persisted_profit_rejection_summary(
     filters = [TradeDecision.created_at >= lookback_start]
     if account_label:
         filters.append(TradeDecision.alpaca_account_label == account_label)
-    rows = session.execute(
-        select(TradeDecision.status, func.count())
-        .where(*filters)
-        .group_by(TradeDecision.status)
-    ).all()
+    try:
+        _maybe_set_runtime_ledger_status_statement_timeout(session)
+        rows = session.execute(
+            select(TradeDecision.status, func.count())
+            .where(*filters)
+            .group_by(TradeDecision.status)
+        ).all()
+    except SQLAlchemyError as exc:
+        logger.warning("Profit rejection summary unavailable: %s", exc)
+        _rollback_runtime_ledger_status_session(session)
+        reason_code = (
+            "profit_rejection_summary_query_timeout"
+            if _sqlalchemy_error_indicates_statement_timeout(exc)
+            else "profit_rejection_summary_unavailable"
+        )
+        return {
+            "rejected": 0,
+            "blocked": 0,
+            "filled": 0,
+            "planned": 0,
+            "total": 0,
+            "rejection_drag_ratio": None,
+            "status_totals": {},
+            "source_ref": "postgres:trade_decisions:7d",
+            "reason_codes": [reason_code],
+        }
     status_totals: dict[str, int] = {}
     for status, count in rows:
         normalized = str(status or "unknown").strip().lower() or "unknown"

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -34,6 +34,8 @@ from app.trading.submission_council import (
     _coerce_aware_datetime,
     _load_latest_certificate_evidence,
     _load_latest_runtime_ledger_summary,
+    _attach_lineage_refs,
+    _load_persisted_profit_rejection_summary,
     _load_profit_promotion_table_counts,
     _load_runtime_ledger_repair_candidates,
     _merge_runtime_certificate_evidence,
@@ -596,6 +598,47 @@ class TestSubmissionCouncil(TestCase):
 
         self.assertEqual(summary, {"by_hypothesis": {}, "runtime_ledger_buckets": []})
         self.assertEqual(fake_session.rollback_count, 1)
+
+    def test_attach_lineage_refs_fails_closed_on_query_timeout(self) -> None:
+        fake_session = _FailingRuntimeLedgerStatusSession()
+
+        rows = _attach_lineage_refs(
+            fake_session,  # type: ignore[arg-type]
+            evaluated_rows=[
+                {
+                    "candidate_id": "candidate-timeout",
+                    "hypothesis_id": "H-TIMEOUT",
+                    "reason_codes": [],
+                }
+            ],
+        )
+
+        self.assertEqual(fake_session.rollback_count, 1)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["reason_codes"], ["lineage_ref_query_timeout"])
+        self.assertEqual(rows[0]["lineage_ref"]["status"], "unavailable")
+        self.assertEqual(rows[0]["lineage_ref"]["candidate_id"], "candidate-timeout")
+        self.assertEqual(rows[0]["lineage_ref"]["hypothesis_id"], "H-TIMEOUT")
+
+    def test_load_persisted_profit_rejection_summary_fails_closed_on_timeout(
+        self,
+    ) -> None:
+        fake_session = _FailingRuntimeLedgerStatusSession()
+
+        summary = _load_persisted_profit_rejection_summary(
+            fake_session,  # type: ignore[arg-type]
+            account_label="PA3SX7FYNUTF",
+            now=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(fake_session.rollback_count, 1)
+        self.assertEqual(summary["total"], 0)
+        self.assertIsNone(summary["rejection_drag_ratio"])
+        self.assertEqual(summary["status_totals"], {})
+        self.assertEqual(
+            summary["reason_codes"],
+            ["profit_rejection_summary_query_timeout"],
+        )
 
     def test_runtime_ledger_status_timeout_helper_applies_timeout_when_bind_lookup_fails(
         self,


### PR DESCRIPTION
## Summary

- fail closed when paper-route lineage diagnostic queries hit SQLAlchemy statement timeouts
- fail closed when persisted profit rejection summary diagnostics time out
- add regression coverage proving timeout paths return explicit blockers instead of crashing readiness/target-plan reads

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py -k 'lineage_refs_fails_closed or persisted_profit_rejection_summary_fails_closed or load_latest_runtime_ledger_summary_fails_closed'`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan or readyz or live_submission_gate'`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
