### PR TITLE
fix(torghut): accept constrained sim paper route scope

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -211,6 +211,45 @@ describe('validatePostDeployEvidence', () => {
     ).toThrow('torghut-sim paper-route target symbols differ from live target')
   })
 
+  it('accepts a sim paper-route plan scoped to a smaller strategy universe', () => {
+    const result = validatePostDeployEvidence({
+      readyzHttpStatus: '200',
+      readyz: { status: 'ok' },
+      revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+      tradingStatus: baseTradingStatus,
+      paperRouteEvidence: buildPaperRouteEvidence([
+        { ...paperRouteTarget, paper_route_probe_symbols: ['AAPL', 'AMZN', 'INTC', 'NVDA'] },
+      ]),
+      simPaperRouteEvidence: buildPaperRouteEvidence([
+        {
+          ...paperRouteTarget,
+          paper_route_probe_symbols: ['AAPL', 'AMZN'],
+          paper_route_probe_strategy_scope_applied: true,
+          paper_route_probe_scope_authority: 'strategy_universe',
+        },
+      ]),
+    })
+
+    expect(result.summaryLines.join('\n')).toContain('Sim constrained target count: `1`')
+  })
+
+  it('rejects a narrower sim paper-route plan without explicit strategy-universe scope', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: buildPaperRouteEvidence([
+          { ...paperRouteTarget, paper_route_probe_symbols: ['AAPL', 'AMZN', 'INTC'] },
+        ]),
+        simPaperRouteEvidence: buildPaperRouteEvidence([
+          { ...paperRouteTarget, paper_route_probe_symbols: ['AAPL', 'AMZN'] },
+        ]),
+      }),
+    ).toThrow('torghut-sim paper-route target symbols differ from live target')
+  })
+
   it('rejects a sim paper-route plan with a different notional envelope than live', () => {
     expect(() =>
       validatePostDeployEvidence({

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -155,12 +155,13 @@ type PaperRouteTargetEnvelope = {
   identity: string
   probeSymbols: string[]
   maxNotional: string
+  scopeAuthority: string
+  strategyScopeApplied: boolean
 }
 
 const uniqueSortedSymbols = (value: unknown, label: string): string[] => {
-  const symbols = requireArray(value, label)
-    .map((symbol) => formatScalar(symbol, '').trim().toUpperCase())
-    .filter(Boolean)
+  const values = typeof value === 'string' ? value.split(',') : requireArray(value, label)
+  const symbols = values.map((symbol) => formatScalar(symbol, '').trim().toUpperCase()).filter(Boolean)
   return [...new Set(symbols)].sort()
 }
 
@@ -184,6 +185,8 @@ const targetEnvelope = (target: unknown, label: string): PaperRouteTargetEnvelop
     identity,
     probeSymbols,
     maxNotional: formatScalar(targetObject.paper_route_probe_next_session_max_notional, '0'),
+    scopeAuthority: formatScalar(targetObject.paper_route_probe_scope_authority, '').trim().toLowerCase(),
+    strategyScopeApplied: targetObject.paper_route_probe_strategy_scope_applied === true,
   }
 }
 
@@ -314,10 +317,25 @@ const requireSameList = (left: string[], right: string[], label: string) => {
   }
 }
 
+const missingFrom = (expected: string[], actual: string[]): string[] => {
+  const actualValues = new Set(actual)
+  return expected.filter((value) => !actualValues.has(value))
+}
+
+const extraIn = (actual: string[], expected: string[]): string[] => {
+  const expectedValues = new Set(expected)
+  return actual.filter((value) => !expectedValues.has(value))
+}
+
 const validatePaperRouteMirror = (
   paperRouteEvidence: unknown,
   simPaperRouteEvidence: unknown,
-): { liveTargetCount: number; simTargetCount: number } => {
+): {
+  liveTargetCount: number
+  simTargetCount: number
+  constrainedTargetCount: number
+  constrainedTargets: string[]
+} => {
   const liveTargets = parsePaperRouteTargets(paperRouteEvidence, 'torghut paper-route evidence')
   const simTargets = parsePaperRouteTargets(simPaperRouteEvidence, 'torghut-sim paper-route evidence')
   if (liveTargets.targetCount > 0 && simTargets.targetCount === 0) {
@@ -332,18 +350,41 @@ const validatePaperRouteMirror = (
   for (const [identity, liveEnvelope] of liveTargets.targetsByIdentity) {
     const simEnvelope = simTargets.targetsByIdentity.get(identity)
     if (!simEnvelope) continue
-    requireSameList(
-      liveEnvelope.probeSymbols,
-      simEnvelope.probeSymbols,
-      `torghut-sim paper-route target symbols differ from live target ${identity}`,
-    )
+    const unexpectedSimSymbols = extraIn(simEnvelope.probeSymbols, liveEnvelope.probeSymbols)
+    if (unexpectedSimSymbols.length > 0) {
+      throw new Error(
+        `torghut-sim paper-route target symbols differ from live target ${identity}: unexpected ${unexpectedSimSymbols.join(',')}`,
+      )
+    }
+    const missingLiveSymbols = missingFrom(liveEnvelope.probeSymbols, simEnvelope.probeSymbols)
+    if (missingLiveSymbols.length > 0) {
+      const explicitlyScoped = simEnvelope.strategyScopeApplied && simEnvelope.scopeAuthority === 'strategy_universe'
+      if (!explicitlyScoped) {
+        requireSameList(
+          liveEnvelope.probeSymbols,
+          simEnvelope.probeSymbols,
+          `torghut-sim paper-route target symbols differ from live target ${identity}`,
+        )
+      }
+    }
     if (simEnvelope.maxNotional !== liveEnvelope.maxNotional) {
       throw new Error(
         `torghut-sim paper-route target notional differs from live target ${identity}: expected ${liveEnvelope.maxNotional}, got ${simEnvelope.maxNotional}`,
       )
     }
   }
-  return { liveTargetCount: liveTargets.targetCount, simTargetCount: simTargets.targetCount }
+  const constrainedTargets = [...liveTargets.targetsByIdentity.entries()]
+    .filter(([identity, liveEnvelope]) => {
+      const simEnvelope = simTargets.targetsByIdentity.get(identity)
+      return Boolean(simEnvelope && missingFrom(liveEnvelope.probeSymbols, simEnvelope.probeSymbols).length > 0)
+    })
+    .map(([identity]) => identity)
+  return {
+    liveTargetCount: liveTargets.targetCount,
+    simTargetCount: simTargets.targetCount,
+    constrainedTargetCount: constrainedTargets.length,
+    constrainedTargets,
+  }
 }
 
 export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): PostDeployEvidenceResult => {
@@ -468,7 +509,11 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
       '',
       `- Live target count: \`${mirror.liveTargetCount}\``,
       `- Sim target count: \`${mirror.simTargetCount}\``,
+      `- Sim constrained target count: \`${mirror.constrainedTargetCount}\``,
     )
+    if (mirror.constrainedTargets.length > 0) {
+      lines.push(`- Sim constrained targets: ${mirror.constrainedTargets.map((target) => `\`${target}\``).join(', ')}`)
+    }
   }
 
   return { readyzAcceptedReason, readyzStatusCode, summaryLines: lines }


### PR DESCRIPTION
## Summary

- Allow Torghut post-deploy verification to accept a narrower `torghut-sim` target symbol set only when the SIM target explicitly reports `paper_route_probe_strategy_scope_applied=true` and `paper_route_probe_scope_authority=strategy_universe`.
- Keep the verifier fail-closed for missing live target identities, empty SIM plans, broader SIM symbol envelopes, notional mismatches, and accidental promotion authorization.
- Add summary output for constrained SIM targets so the rollout record shows collection scope instead of hiding the difference.
- Add regression coverage for accepted explicit strategy-universe scoping and rejected unscoped narrowing.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
