### PR TITLE
revert(torghut): rollback failed promotion 2b593d455091ce9c2263ac258ae7597805d4634d

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.586.0-127-g9106b938f
+              value: v0.586.0-122-g814fb41aa
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9106b938f86201c539c7caff207d2370caecce4e
+              value: 814fb41aa4122d025ca870942b2b6067e648e1a7
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.586.0-127-g9106b938f
+              value: v0.586.0-122-g814fb41aa
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9106b938f86201c539c7caff207d2370caecce4e
+              value: 814fb41aa4122d025ca870942b2b6067e648e1a7
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -119,7 +119,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+                  value: sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-01T06:26:16Z"
+        client.knative.dev/updateTimestamp: "2026-06-01T06:09:18Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           ports:
             - name: http1
               containerPort: 8181
@@ -529,11 +529,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.586.0-127-g9106b938f
+              value: v0.586.0-122-g814fb41aa
             - name: TORGHUT_COMMIT
-              value: 9106b938f86201c539c7caff207d2370caecce4e
+              value: 814fb41aa4122d025ca870942b2b6067e648e1a7
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+              value: sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-01T06:26:16Z"
+        client.knative.dev/updateTimestamp: "2026-06-01T06:09:18Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           ports:
             - name: http1
               containerPort: 8181
@@ -371,11 +371,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.586.0-127-g9106b938f
+              value: v0.586.0-122-g814fb41aa
             - name: TORGHUT_COMMIT
-              value: 9106b938f86201c539c7caff207d2370caecce4e
+              value: 814fb41aa4122d025ca870942b2b6067e648e1a7
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+              value: sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -101,6 +101,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+                  value: sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:325ebca3f8c31ea7a5205bc1eb895bed7d15c77cef88693370418ff901b81d3c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:38b0d51742acfaf52a534d0eb7941954e1a536bbebb6a04e40735bf2d35f0d27
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `2b593d455091ce9c2263ac258ae7597805d4634d`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/26738887481`
- Rollback source: `HEAD^` manifests from the failed run checkout