### PR TITLE
fix(torghut): fail closed on certificate evidence timeouts

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -2133,27 +2133,55 @@ def _load_latest_certificate_evidence(
         return []
 
     windows_by_hypothesis: dict[str, list[StrategyHypothesisMetricWindow]] = {}
-    window_rows = session.execute(
-        select(StrategyHypothesisMetricWindow)
-        .where(StrategyHypothesisMetricWindow.hypothesis_id.in_(normalized_ids))
-        .order_by(
-            StrategyHypothesisMetricWindow.window_ended_at.desc().nullslast(),
-            StrategyHypothesisMetricWindow.created_at.desc(),
-        )
-    ).scalars()
-    for row in window_rows:
-        windows_by_hypothesis.setdefault(row.hypothesis_id, []).append(row)
+    try:
+        _maybe_set_runtime_ledger_status_statement_timeout(session)
+        window_rows = session.execute(
+            select(StrategyHypothesisMetricWindow)
+            .where(StrategyHypothesisMetricWindow.hypothesis_id.in_(normalized_ids))
+            .order_by(
+                StrategyHypothesisMetricWindow.window_ended_at.desc().nullslast(),
+                StrategyHypothesisMetricWindow.created_at.desc(),
+            )
+        ).scalars()
+        for row in window_rows:
+            windows_by_hypothesis.setdefault(row.hypothesis_id, []).append(row)
+    except SQLAlchemyError as exc:
+        logger.warning("Metric-window certificate evidence unavailable: %s", exc)
+        _rollback_runtime_ledger_status_session(session)
+        return [
+            {
+                "hypothesis_id": hypothesis_id,
+                "metric_window": None,
+                "promotion_decision": None,
+                "runtime_ledger_bucket": None,
+            }
+            for hypothesis_id in normalized_ids
+        ]
 
     latest_promotions: dict[str, list[StrategyPromotionDecision]] = {}
-    promotion_rows = session.execute(
-        select(StrategyPromotionDecision)
-        .where(
-            StrategyPromotionDecision.hypothesis_id.in_(normalized_ids),
-        )
-        .order_by(StrategyPromotionDecision.created_at.desc())
-    ).scalars()
-    for row in promotion_rows:
-        latest_promotions.setdefault(row.hypothesis_id, []).append(row)
+    try:
+        _maybe_set_runtime_ledger_status_statement_timeout(session)
+        promotion_rows = session.execute(
+            select(StrategyPromotionDecision)
+            .where(
+                StrategyPromotionDecision.hypothesis_id.in_(normalized_ids),
+            )
+            .order_by(StrategyPromotionDecision.created_at.desc())
+        ).scalars()
+        for row in promotion_rows:
+            latest_promotions.setdefault(row.hypothesis_id, []).append(row)
+    except SQLAlchemyError as exc:
+        logger.warning("Promotion-decision certificate evidence unavailable: %s", exc)
+        _rollback_runtime_ledger_status_session(session)
+        return [
+            {
+                "hypothesis_id": hypothesis_id,
+                "metric_window": None,
+                "promotion_decision": None,
+                "runtime_ledger_bucket": None,
+            }
+            for hypothesis_id in normalized_ids
+        ]
 
     latest_runtime_ledgers: dict[str, list[StrategyRuntimeLedgerBucket]] = {}
     try:

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -599,6 +599,101 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(summary, {"by_hypothesis": {}, "runtime_ledger_buckets": []})
         self.assertEqual(fake_session.rollback_count, 1)
 
+    def test_load_latest_certificate_evidence_fails_closed_on_window_timeout(
+        self,
+    ) -> None:
+        fake_session = _FailingRuntimeLedgerStatusSession()
+
+        evidence = _load_latest_certificate_evidence(
+            fake_session,  # type: ignore[arg-type]
+            hypothesis_ids=["H-PAIRS-01"],
+        )
+
+        self.assertEqual(fake_session.rollback_count, 1)
+        self.assertEqual(
+            evidence,
+            [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "metric_window": None,
+                    "promotion_decision": None,
+                    "runtime_ledger_bucket": None,
+                }
+            ],
+        )
+
+    def test_load_latest_certificate_evidence_fails_closed_on_promotion_timeout(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+        with session_local() as session:
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-PAIRS-01",
+                    observed_stage="live",
+                    window_started_at=now - timedelta(minutes=15),
+                    window_ended_at=now,
+                    market_session_count=1,
+                    decision_count=1,
+                    trade_count=1,
+                    order_count=1,
+                    post_cost_expectancy_bps="1.0",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="shadow",
+                    payload_json={},
+                )
+            )
+            session.commit()
+
+            execute = session.execute
+
+            def fail_promotion_decision_query(
+                statement: object, *args: object, **kwargs: object
+            ) -> object:
+                if "strategy_promotion_decisions" in str(statement):
+                    raise SQLAlchemyError("statement timeout")
+                return execute(statement, *args, **kwargs)
+
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=fail_promotion_decision_query,
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                evidence = _load_latest_certificate_evidence(
+                    session,
+                    hypothesis_ids=["H-PAIRS-01"],
+                    now=now,
+                )
+
+        self.assertEqual(rollback.call_count, 1)
+        self.assertEqual(
+            evidence,
+            [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "metric_window": None,
+                    "promotion_decision": None,
+                    "runtime_ledger_bucket": None,
+                }
+            ],
+        )
+
     def test_attach_lineage_refs_fails_closed_on_query_timeout(self) -> None:
         fake_session = _FailingRuntimeLedgerStatusSession()
 


### PR DESCRIPTION
## Summary

- Wrap Torghut certificate-evidence metric-window reads in a fail-closed timeout guard.
- Wrap Torghut certificate-evidence promotion-decision reads in the same fail-closed path.
- Add regression coverage for both timeout modes so readiness/status diagnostics do not surface unhandled SQLAlchemy exceptions.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py -k 'certificate_evidence_fails_closed or lineage_refs_fails_closed or persisted_profit_rejection_summary_fails_closed or load_latest_runtime_ledger_summary_fails_closed'`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan or readyz or live_submission_gate'`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
