### PR TITLE
fix(torghut): carry order-feed lifecycle refs into runtime ledger

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -86,6 +86,9 @@ _RUNTIME_LEDGER_DECISION_EVENTS = frozenset(
 _RUNTIME_LEDGER_FILL_EVENTS = frozenset(
     {"fill", "filled", "partial_fill", "partially_filled"}
 )
+_RUNTIME_LEDGER_ORDER_LIFECYCLE_EVENTS = _RUNTIME_LEDGER_FILL_EVENTS | frozenset(
+    {"order_submitted"}
+)
 ORDER_FEED_FILL_LIFECYCLE_MISSING_BLOCKER = "order_feed_fill_lifecycle_missing"
 ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER = "order_feed_fill_lifecycle_incomplete"
 ORDER_FEED_FILL_LIFECYCLE_ORDER_ID_MISSING_BLOCKER = (
@@ -2707,6 +2710,53 @@ def _source_backed_fill_lifecycle_rows(
     return source_backed_rows
 
 
+def _source_backed_order_lifecycle_rows(
+    rows: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    source_backed_rows: list[dict[str, object]] = []
+    for row in rows:
+        normalized = {str(key): value for key, value in row.items()}
+        if (
+            _runtime_ledger_event_type(normalized)
+            not in _RUNTIME_LEDGER_ORDER_LIFECYCLE_EVENTS
+        ):
+            continue
+        if _runtime_order_id(normalized) is None:
+            continue
+        if not _source_identifier_values(
+            [normalized], "execution_order_event_id", "event_fingerprint"
+        ):
+            continue
+        if not _source_identifier_values([normalized], "source_window_id"):
+            continue
+        if not _source_offset_values([normalized]):
+            continue
+        source_backed_rows.append(dict(normalized))
+    return source_backed_rows
+
+
+def _required_order_lifecycle_source_row_count(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    expected_order_ids: set[str],
+) -> int:
+    if not expected_order_ids:
+        return 0
+    count = 0
+    for row in rows:
+        normalized = {str(key): value for key, value in row.items()}
+        if (
+            _runtime_ledger_event_type(normalized)
+            not in _RUNTIME_LEDGER_ORDER_LIFECYCLE_EVENTS
+        ):
+            continue
+        order_id = _runtime_order_id(normalized)
+        if order_id is None or order_id not in expected_order_ids:
+            continue
+        count += 1
+    return max(count, len(expected_order_ids))
+
+
 def _source_backed_fill_lifecycle_order_ids(
     rows: Sequence[Mapping[str, object]],
 ) -> set[str]:
@@ -2840,37 +2890,9 @@ def _runtime_source_context_for_bucket(
     source_backed_fill_lifecycle_rows = _source_backed_fill_lifecycle_rows(
         bucket_order_rows
     )
-    source_backed_fill_lifecycle_times = [
-        event_time
-        for row in source_backed_fill_lifecycle_rows
-        if (
-            event_time := _runtime_ledger_row_time(
-                {str(key): value for key, value in row.items()}
-            )
-        )
-        is not None
-    ]
-    source_window_ids = _source_identifier_values(
-        source_backed_fill_lifecycle_rows,
-        "source_window_id",
+    source_backed_order_lifecycle_rows = _source_backed_order_lifecycle_rows(
+        bucket_order_rows
     )
-    source_row_counts = {
-        "trade_decisions": len(bucket_decision_rows),
-        "executions": len(bucket_execution_rows),
-        "execution_order_events": len(source_backed_fill_lifecycle_rows),
-    }
-    if source_window_ids:
-        source_row_counts["order_feed_source_windows"] = len(source_window_ids)
-    source_refs = [
-        ref
-        for table, ref in (
-            ("trade_decisions", "postgres:trade_decisions"),
-            ("executions", "postgres:executions"),
-            ("execution_order_events", "postgres:execution_order_events"),
-            ("order_feed_source_windows", "postgres:order_feed_source_windows"),
-        )
-        if source_row_counts.get(table, 0) > 0
-    ]
     expected_execution_fill_order_ids = set()
     for row in bucket_execution_rows:
         if (
@@ -2901,11 +2923,55 @@ def _runtime_source_context_for_bucket(
     ) and expected_execution_fill_order_ids.issubset(
         source_backed_fill_lifecycle_order_ids
     )
+    source_authority_lifecycle_rows = (
+        source_backed_order_lifecycle_rows
+        if source_backed_fill_lifecycle_complete
+        else source_backed_fill_lifecycle_rows
+    )
+    source_authority_lifecycle_times = [
+        event_time
+        for row in source_authority_lifecycle_rows
+        if (
+            event_time := _runtime_ledger_row_time(
+                {str(key): value for key, value in row.items()}
+            )
+        )
+        is not None
+    ]
+    source_window_ids = _source_identifier_values(
+        source_authority_lifecycle_rows,
+        "source_window_id",
+    )
+    required_order_lifecycle_source_row_count = (
+        _required_order_lifecycle_source_row_count(
+            bucket_order_rows,
+            expected_order_ids=expected_execution_fill_order_ids,
+        )
+    )
+    source_row_counts = {
+        "trade_decisions": len(bucket_decision_rows),
+        "executions": len(bucket_execution_rows),
+        "execution_order_events": required_order_lifecycle_source_row_count,
+    }
+    if source_window_ids:
+        source_row_counts["order_feed_source_windows"] = len(source_window_ids)
+    elif required_order_lifecycle_source_row_count > 0:
+        source_row_counts["order_feed_source_windows"] = 1
+    source_refs = [
+        ref
+        for table, ref in (
+            ("trade_decisions", "postgres:trade_decisions"),
+            ("executions", "postgres:executions"),
+            ("execution_order_events", "postgres:execution_order_events"),
+            ("order_feed_source_windows", "postgres:order_feed_source_windows"),
+        )
+        if source_row_counts.get(table, 0) > 0
+    ]
     source_materialization = None
     authority_class = None
-    source_offsets = _source_offset_values(source_backed_fill_lifecycle_rows)
+    source_offsets = _source_offset_values(source_authority_lifecycle_rows)
     execution_order_event_ids = _source_identifier_values(
-        source_backed_fill_lifecycle_rows,
+        source_authority_lifecycle_rows,
         "execution_order_event_id",
         "event_fingerprint",
     )
@@ -2926,13 +2992,13 @@ def _runtime_source_context_for_bucket(
         "source_rows": source_rows,
         "source_window_ids": source_window_ids,
         "source_window_start": (
-            min(source_backed_fill_lifecycle_times)
-            if source_backed_fill_lifecycle_times
+            min(source_authority_lifecycle_times)
+            if source_authority_lifecycle_times
             else bucket.bucket_started_at
         ),
         "source_window_end": (
-            max(source_backed_fill_lifecycle_times) + timedelta(microseconds=1)
-            if source_backed_fill_lifecycle_times
+            max(source_authority_lifecycle_times) + timedelta(microseconds=1)
+            if source_authority_lifecycle_times
             else bucket.bucket_ended_at
         ),
         "source_row_counts": source_row_counts,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -60,10 +60,12 @@ from scripts.import_hypothesis_runtime_windows import (
     _persistence_session,
     _source_activity_missing_summary,
     _source_backed_fill_lifecycle_rows,
+    _source_backed_order_lifecycle_rows,
     _source_decision_mode,
     _source_decision_mode_counts,
     _source_decision_rows_profit_proof_eligible,
     _source_order_feed_payload_delta_fill,
+    _required_order_lifecycle_source_row_count,
     _stable_payload_digest,
     _strategy_name_candidates,
     _sqlalchemy_dsn,
@@ -2210,7 +2212,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
         self.assertEqual(bucket["account_equity"], "10000")
         self.assertEqual(bucket["account_equity_source"], "equity")
-        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:35:01+00:00")
+        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:34:01+00:00")
         self.assertEqual(
             bucket["source_window_end"], "2026-03-06T14:40:01.000001+00:00"
         )
@@ -2227,16 +2229,27 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             bucket["source_row_counts"],
             {
                 "executions": 2,
-                "execution_order_events": 2,
-                "order_feed_source_windows": 2,
+                "execution_order_events": 4,
+                "order_feed_source_windows": 4,
                 "trade_decisions": 2,
             },
         )
         self.assertEqual(
             bucket["source_window_ids"],
             [
+                "source-window-new-buy",
+                "source-window-new-sell",
                 "source-window-fill-buy",
                 "source-window-fill-sell",
+            ],
+        )
+        self.assertEqual(
+            bucket["execution_order_event_ids"],
+            [
+                "event-new-buy",
+                "event-new-sell",
+                "event-fill-buy",
+                "event-fill-sell",
             ],
         )
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
@@ -2429,14 +2442,16 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["net_strategy_pnl_after_costs"], "0.70")
         self.assertEqual(bucket["open_position_count"], 0)
         self.assertEqual(bucket["closed_trade_count"], 1)
-        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:35:01+00:00")
+        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:34:01+00:00")
         self.assertEqual(
             bucket["source_window_end"], "2026-03-06T14:40:01.000001+00:00"
         )
         self.assertEqual(
             bucket["source_window_ids"],
             [
+                "source-window-new-buy",
                 "source-window-fill-buy",
+                "source-window-new-sell",
                 "source-window-fill-sell",
             ],
         )
@@ -2444,8 +2459,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             bucket["source_row_counts"],
             {
                 "executions": 2,
-                "execution_order_events": 2,
-                "order_feed_source_windows": 2,
+                "execution_order_events": 4,
+                "order_feed_source_windows": 4,
                 "trade_decisions": 2,
             },
         )
@@ -3539,6 +3554,90 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             rows[0]["execution_order_event_id"], "source-backed-fill-event"
         )
 
+    def test_source_backed_order_lifecycle_rows_require_row_level_refs(
+        self,
+    ) -> None:
+        rows = _source_backed_order_lifecycle_rows(
+            [
+                {
+                    "execution_order_event_id": "decision-event",
+                    "event_type": "decision",
+                    "alpaca_order_id": "order-decision",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 120,
+                    "source_window_id": "source-window-decision",
+                },
+                {
+                    "execution_order_event_id": "missing-order-id-event",
+                    "event_type": "new",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 121,
+                    "source_window_id": "source-window-missing-order",
+                },
+                {
+                    "event_type": "new",
+                    "alpaca_order_id": "order-missing-event-ref",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 122,
+                    "source_window_id": "source-window-missing-event-ref",
+                },
+                {
+                    "execution_order_event_id": "missing-source-window-event",
+                    "event_type": "new",
+                    "alpaca_order_id": "order-missing-source-window",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 123,
+                },
+                {
+                    "execution_order_event_id": "missing-source-offset-event",
+                    "event_type": "new",
+                    "alpaca_order_id": "order-missing-source-offset",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_window_id": "source-window-missing-offset",
+                },
+                {
+                    "execution_order_event_id": "source-backed-new-event",
+                    "event_type": "new",
+                    "alpaca_order_id": "order-source-backed",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 124,
+                    "source_window_id": "source-window-backed",
+                },
+            ]
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["execution_order_event_id"], "source-backed-new-event")
+        self.assertEqual(
+            _required_order_lifecycle_source_row_count(
+                rows,
+                expected_order_ids={"order-source-backed", "order-missing"},
+            ),
+            2,
+        )
+        self.assertEqual(
+            _required_order_lifecycle_source_row_count(
+                [
+                    {
+                        "event_type": "decision",
+                        "alpaca_order_id": "order-source-backed",
+                    },
+                    {
+                        "event_type": "new",
+                        "alpaca_order_id": "order-other",
+                    },
+                ],
+                expected_order_ids={"order-source-backed"},
+            ),
+            1,
+        )
+
     def test_build_realized_strategy_pnl_rows_accepts_execution_economics_with_order_feed_lifecycle(
         self,
     ) -> None:
@@ -3699,7 +3798,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["source_materialization"], "source_execution_lifecycle")
         self.assertEqual(
             bucket["source_window_start"],
-            "2026-03-06T14:31:01+00:00",
+            "2026-03-06T14:30:01+00:00",
         )
         self.assertEqual(
             bucket["source_window_end"],
@@ -3707,7 +3806,12 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertEqual(
             bucket["source_window_ids"],
-            ["source-window-fill-buy", "source-window-fill-sell"],
+            [
+                "source-window-new-buy",
+                "source-window-new-sell",
+                "source-window-fill-buy",
+                "source-window-fill-sell",
+            ],
         )
         self.assertEqual(
             bucket["cost_basis_counts"],

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from app.trading.runtime_window_import import (
+    _runtime_promotion_blocking_reasons,
+    resolve_hypothesis_manifest,
+)
+from scripts.import_hypothesis_runtime_windows import (
+    POST_COST_BASIS_RUNTIME_LEDGER,
+    _build_realized_strategy_pnl_rows,
+    _runtime_ledger_bucket_profit_proof_present,
+)
+
+
+def test_live_paper_runtime_ledger_close_loop_still_respects_profitability_gates() -> None:
+    rows = _build_realized_strategy_pnl_rows(
+        [
+            {
+                'execution_id': 'execution-buy',
+                'computed_at': datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                'execution_event_at': datetime(
+                    2026, 3, 6, 14, 31, tzinfo=timezone.utc
+                ),
+                'symbol': 'AAPL',
+                'side': 'buy',
+                'filled_qty': Decimal('1'),
+                'avg_fill_price': Decimal('100'),
+                'cost_amount': Decimal('0.20'),
+                'cost_basis': 'broker_reported_commission_and_fees',
+                'decision_hash': 'decision-buy',
+                'alpaca_order_id': 'order-buy',
+                'execution_policy_hash': 'policy-sha',
+                'cost_model_hash': 'cost-sha',
+                'lineage_hash': 'lineage-sha',
+            },
+            {
+                'execution_id': 'execution-sell',
+                'computed_at': datetime(2026, 3, 6, 14, 31, tzinfo=timezone.utc),
+                'execution_event_at': datetime(
+                    2026, 3, 6, 14, 32, tzinfo=timezone.utc
+                ),
+                'symbol': 'AAPL',
+                'side': 'sell',
+                'filled_qty': Decimal('1'),
+                'avg_fill_price': Decimal('101'),
+                'cost_amount': Decimal('0.10'),
+                'cost_basis': 'broker_reported_commission_and_fees',
+                'decision_hash': 'decision-sell',
+                'alpaca_order_id': 'order-sell',
+                'execution_policy_hash': 'policy-sha',
+                'cost_model_hash': 'cost-sha',
+                'lineage_hash': 'lineage-sha',
+            },
+        ],
+        decision_lifecycle_rows=[
+            {
+                'computed_at': datetime(2026, 3, 6, 14, 29, tzinfo=timezone.utc),
+                'event_type': 'decision',
+                'symbol': 'AAPL',
+                'account_label': 'TORGHUT_SIM',
+                'strategy_id': 'microbar-cross-sectional-pairs-v1',
+                'decision_hash': 'decision-buy',
+                'source_decision_mode': 'strategy_signal_paper',
+                'profit_proof_eligible': True,
+                'lineage_hash': 'lineage-sha',
+            },
+            {
+                'computed_at': datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                'event_type': 'decision',
+                'symbol': 'AAPL',
+                'account_label': 'TORGHUT_SIM',
+                'strategy_id': 'microbar-cross-sectional-pairs-v1',
+                'decision_hash': 'decision-sell',
+                'source_decision_mode': 'strategy_signal_paper',
+                'profit_proof_eligible': True,
+                'lineage_hash': 'lineage-sha',
+            },
+        ],
+        order_lifecycle_rows=[
+            {
+                'execution_order_event_id': 'event-new-buy',
+                'trade_decision_id': 'decision-buy',
+                'event_ts': datetime(2026, 3, 6, 14, 30, 1, tzinfo=timezone.utc),
+                'event_type': 'new',
+                'symbol': 'AAPL',
+                'decision_hash': 'decision-buy',
+                'alpaca_order_id': 'order-buy',
+                'execution_policy_hash': 'policy-sha',
+                'lineage_hash': 'lineage-sha',
+                'source_topic': 'alpaca.trade_updates',
+                'source_partition': 0,
+                'source_offset': 210,
+                'source_window_id': 'source-window-new-buy',
+            },
+            {
+                'execution_order_event_id': 'event-fill-buy',
+                'trade_decision_id': 'decision-buy',
+                'execution_id': 'execution-buy',
+                'event_ts': datetime(2026, 3, 6, 14, 31, 1, tzinfo=timezone.utc),
+                'event_type': 'filled',
+                'symbol': 'AAPL',
+                'decision_hash': 'decision-buy',
+                'alpaca_order_id': 'order-buy',
+                'execution_policy_hash': 'policy-sha',
+                'lineage_hash': 'lineage-sha',
+                'source_topic': 'alpaca.trade_updates',
+                'source_partition': 0,
+                'source_offset': 211,
+                'source_window_id': 'source-window-fill-buy',
+            },
+            {
+                'execution_order_event_id': 'event-new-sell',
+                'trade_decision_id': 'decision-sell',
+                'event_ts': datetime(2026, 3, 6, 14, 31, 1, tzinfo=timezone.utc),
+                'event_type': 'new',
+                'symbol': 'AAPL',
+                'decision_hash': 'decision-sell',
+                'alpaca_order_id': 'order-sell',
+                'execution_policy_hash': 'policy-sha',
+                'lineage_hash': 'lineage-sha',
+                'source_topic': 'alpaca.trade_updates',
+                'source_partition': 0,
+                'source_offset': 212,
+                'source_window_id': 'source-window-new-sell',
+            },
+            {
+                'execution_order_event_id': 'event-fill-sell',
+                'trade_decision_id': 'decision-sell',
+                'execution_id': 'execution-sell',
+                'event_ts': datetime(2026, 3, 6, 14, 32, 1, tzinfo=timezone.utc),
+                'event_type': 'filled',
+                'symbol': 'AAPL',
+                'decision_hash': 'decision-sell',
+                'alpaca_order_id': 'order-sell',
+                'execution_policy_hash': 'policy-sha',
+                'lineage_hash': 'lineage-sha',
+                'source_topic': 'alpaca.trade_updates',
+                'source_partition': 0,
+                'source_offset': 213,
+                'source_window_id': 'source-window-fill-sell',
+            },
+        ],
+        allow_authoritative_runtime_ledger_materialization=True,
+    )
+
+    assert len(rows) == 1
+    assert rows[0]['post_cost_expectancy_basis'] == POST_COST_BASIS_RUNTIME_LEDGER
+    assert rows[0]['authoritative'] is True
+    bucket = rows[0]['runtime_ledger_bucket']
+    assert isinstance(bucket, dict)
+    assert bucket['blockers'] == []
+    assert bucket['closed_trade_count'] == 1
+    assert bucket['open_position_count'] == 0
+    assert bucket['cost_amount'] == '0.30'
+    assert bucket['source_window_ids'] == [
+        'source-window-new-buy',
+        'source-window-fill-buy',
+        'source-window-new-sell',
+        'source-window-fill-sell',
+    ]
+    assert bucket['execution_order_event_ids'] == [
+        'event-new-buy',
+        'event-fill-buy',
+        'event-new-sell',
+        'event-fill-sell',
+    ]
+    assert _runtime_ledger_bucket_profit_proof_present(bucket)
+
+    _, manifest = resolve_hypothesis_manifest(
+        hypothesis_id='H-MICRO-01',
+        strategy_family='microstructure_breakout',
+    )
+    final_gate_blockers = _runtime_promotion_blocking_reasons(
+        observed_stage='live',
+        inserted=1,
+        total_session_samples=manifest.min_sample_count_for_live_canary,
+        total_decision_count=2,
+        total_trade_count=2,
+        total_order_count=2,
+        total_post_cost_promotion_sample_count=1,
+        runtime_ledger_notional_weighted_sample_count=1,
+        total_post_cost_basis_counts={POST_COST_BASIS_RUNTIME_LEDGER: 1},
+        average_slippage=Decimal('0'),
+        average_post_cost=Decimal('34.82587064676616915422885572'),
+        runtime_ledger_daily_summary={
+            'runtime_ledger_observed_trading_day_count': '1',
+            'runtime_ledger_mean_daily_net_pnl_after_costs': '0.70',
+            'runtime_ledger_median_daily_net_pnl_after_costs': '0.70',
+            'runtime_ledger_p10_daily_net_pnl_after_costs': '0.70',
+            'runtime_ledger_worst_day_net_pnl_after_costs': '0.70',
+            'runtime_ledger_max_intraday_drawdown': '0',
+            'runtime_ledger_avg_daily_filled_notional': '201',
+        },
+        latest_three_budget_ok=True,
+        all_continuity_ok=True,
+        all_drift_ok=True,
+        dependency_quorum_allowed=True,
+        manifest=manifest,
+        budget=Decimal('100'),
+    )
+
+    assert 'runtime_ledger_mean_daily_net_pnl_after_costs_below_target' in final_gate_blockers

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -4649,6 +4649,7 @@ class TestTradingApi(TestCase):
         original = {
             "trading_enabled": settings.trading_enabled,
             "trading_mode": settings.trading_mode,
+            "trading_pipeline_mode": settings.trading_pipeline_mode,
             "trading_autonomy_enabled": settings.trading_autonomy_enabled,
             "trading_autonomy_allow_live_promotion": settings.trading_autonomy_allow_live_promotion,
             "trading_kill_switch_enabled": settings.trading_kill_switch_enabled,
@@ -4656,6 +4657,7 @@ class TestTradingApi(TestCase):
         try:
             settings.trading_enabled = True
             settings.trading_mode = "live"
+            settings.trading_pipeline_mode = "legacy"
             settings.trading_autonomy_enabled = False
             settings.trading_autonomy_allow_live_promotion = False
             settings.trading_kill_switch_enabled = True
@@ -4719,6 +4721,7 @@ class TestTradingApi(TestCase):
         finally:
             settings.trading_enabled = original["trading_enabled"]
             settings.trading_mode = original["trading_mode"]
+            settings.trading_pipeline_mode = original["trading_pipeline_mode"]
             settings.trading_autonomy_enabled = original["trading_autonomy_enabled"]
             settings.trading_autonomy_allow_live_promotion = original[
                 "trading_autonomy_allow_live_promotion"


### PR DESCRIPTION
## Summary

- Carries row-level order-feed lifecycle source refs (submitted/new plus fill) into source-backed runtime ledger bucket metadata once fill lifecycle refs are complete.
- Keeps authority fail-closed by not borrowing non-fill lifecycle refs when fill refs are missing and by counting required lifecycle rows against execution-order-event/source-offset evidence.
- Adds regression coverage for source-backed execution economics, full lifecycle source windows/event IDs, closed round trips, zero open positions, and final $500/day gate blockers.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_simple_pipeline.py tests/test_repair_order_feed_source_windows_script.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/order_feed.py app/trading/runtime_ledger.py app/trading/runtime_window_import.py scripts/repair_order_feed_source_windows.py scripts/import_hypothesis_runtime_windows.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_simple_pipeline.py tests/test_repair_order_feed_source_windows_script.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
