### PR TITLE
fix(torghut): import source collection targets

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -54,6 +54,7 @@ spec:
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
                     --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan \
+                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/status \
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -512,6 +512,120 @@ def _read_runtime_window_target_plan(ref: str) -> dict[str, Any]:
     return plan
 
 
+def _runtime_window_plan_target_items(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
+    targets = plan.get("targets")
+    if not isinstance(targets, Sequence) or isinstance(
+        targets, (str, bytes, bytearray)
+    ):
+        return []
+    return [_as_dict(item) for item in targets if _as_dict(item)]
+
+
+def _runtime_window_target_plan_target_key(
+    target: Mapping[str, Any],
+) -> tuple[str, str, str, str, str, str, str, str]:
+    return (
+        str(target.get("hypothesis_id") or "").strip(),
+        str(target.get("candidate_id") or "").strip(),
+        str(
+            target.get("strategy_name")
+            or target.get("runtime_strategy_name")
+            or target.get("strategy_id")
+            or ""
+        ).strip(),
+        str(target.get("account_label") or "").strip(),
+        str(target.get("source_account_label") or "").strip(),
+        str(target.get("source_kind") or "").strip(),
+        str(target.get("window_start") or "").strip(),
+        str(target.get("window_end") or "").strip(),
+    )
+
+
+def _runtime_window_target_plan_target_truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _runtime_window_target_plan_source_collection_targets(
+    gate_plan: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    targets = []
+    for target in _runtime_window_plan_target_items(gate_plan):
+        source_kind = str(target.get("source_kind") or "").strip()
+        handoff = str(target.get("handoff") or "").strip()
+        selected_by = str(target.get("selected_by") or "").strip()
+        if (
+            _runtime_window_target_plan_target_truthy(
+                target.get("source_collection_authorized")
+            )
+            or source_kind == "runtime_ledger_source_collection_candidate"
+            or handoff == "runtime_ledger_source_collection_import"
+            or selected_by == "runtime_ledger_source_collection"
+        ):
+            targets.append(target)
+    return targets
+
+
+def _runtime_window_target_plan_with_live_gate_source_collection(
+    *,
+    payload: Mapping[str, Any],
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    merged_plan = dict(plan)
+    gate = _as_dict(payload.get("live_submission_gate"))
+    gate_plan = _as_dict(gate.get("runtime_ledger_paper_probation_import_plan"))
+    source_collection_targets = _runtime_window_target_plan_source_collection_targets(
+        gate_plan
+    )
+    if not source_collection_targets:
+        return merged_plan
+
+    blocked_reasons = {
+        str(reason or "").strip()
+        for reason in _as_sequence(gate.get("blocked_reasons"))
+        if str(reason or "").strip()
+    }
+    if "runtime_ledger_source_collection_pending" not in blocked_reasons:
+        return merged_plan
+
+    existing_targets = _runtime_window_plan_target_items(merged_plan)
+    existing_keys = {
+        _runtime_window_target_plan_target_key(target) for target in existing_targets
+    }
+    prepended_targets: list[dict[str, Any]] = []
+    for target in source_collection_targets:
+        key = _runtime_window_target_plan_target_key(target)
+        if key in existing_keys:
+            continue
+        existing_keys.add(key)
+        enriched_target = dict(target)
+        enriched_target.setdefault(
+            "source_collection_authorization_scope",
+            "source_window_evidence_collection_only",
+        )
+        prepended_targets.append(enriched_target)
+    if not prepended_targets:
+        return merged_plan
+
+    merged_targets = [*prepended_targets, *existing_targets]
+    try:
+        existing_source_collection_count = int(
+            merged_plan.get("source_collection_target_count") or 0
+        )
+    except (TypeError, ValueError):
+        existing_source_collection_count = 0
+    merged_plan["targets"] = merged_targets
+    merged_plan["target_count"] = len(merged_targets)
+    merged_plan["source_collection_target_count"] = (
+        len(prepended_targets) + existing_source_collection_count
+    )
+    merged_plan["paper_route_target_count"] = len(existing_targets)
+    merged_plan["merged_live_submission_gate_source_collection"] = True
+    merged_plan["source"] = "paper_route_target_plan_with_live_gate_source_collection"
+    return merged_plan
+
+
 def _runtime_window_target_plan_from_payload(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -543,6 +657,10 @@ def _runtime_window_target_plan_from_payload(
                     plan = paper_route_plan
                 else:
                     plan = _as_dict(payload)
+    plan = _runtime_window_target_plan_with_live_gate_source_collection(
+        payload=payload,
+        plan=plan,
+    )
     plan = _runtime_window_target_plan_with_import_audit_blockers(
         payload=payload,
         plan=plan,

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1496,6 +1496,11 @@ class TestLiveConfigManifestContract(TestCase):
             "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
             args,
         )
+        self.assertIn(
+            "--runtime-window-target-plan-url "
+            "http://torghut.torghut.svc.cluster.local/trading/status",
+            args,
+        )
         self.assertIn("--runtime-window-target-plan-url-timeout-seconds 45", args)
         self.assertIn("--runtime-window-target-plan-url-attempts 3", args)
         self.assertIn(

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1177,6 +1177,60 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertFalse(targets[0].target_metadata["promotion_allowed"])
         self.assertFalse(targets[0].target_metadata["final_promotion_allowed"])
 
+    def test_runtime_window_target_plan_payload_keeps_live_gate_source_collection(
+        self,
+    ) -> None:
+        plan = renewal._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-paper-route",
+                            "hypothesis_id": "H-PAPER-ROUTE",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "window_start": "2026-06-01T13:30:00+00:00",
+                            "window_end": "2026-06-01T20:00:00+00:00",
+                        }
+                    ],
+                },
+                "live_submission_gate": {
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "candidate_id": "cand-source-collection",
+                                "hypothesis_id": "H-SOURCE-COLLECTION",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "source-collection-candidate-v1",
+                                "account_label": "TORGHUT_REPLAY",
+                                "source_kind": "runtime_ledger_source_collection_candidate",
+                                "source_collection_authorized": True,
+                                "window_start": "2026-05-13T17:00:00+00:00",
+                                "window_end": "2026-05-13T17:30:00+00:00",
+                            }
+                        ],
+                    },
+                },
+            }
+        )
+
+        self.assertTrue(plan["merged_live_submission_gate_source_collection"])
+        self.assertEqual(plan["source_collection_target_count"], 1)
+        self.assertEqual(plan["paper_route_target_count"], 1)
+        self.assertEqual(plan["target_count"], 2)
+        self.assertEqual(
+            [target["hypothesis_id"] for target in plan["targets"]],
+            ["H-SOURCE-COLLECTION", "H-PAPER-ROUTE"],
+        )
+
     def test_runtime_window_target_plan_url_failures_are_fail_closed(self) -> None:
         with self.assertRaisesRegex(
             RuntimeError, "runtime_window_target_plan_url_empty"


### PR DESCRIPTION
## Summary

- Teach the runtime-window renewal parser to retain live-gate source-collection targets when a paper-route target-plan payload also has direct runtime-window targets.
- Add live `/trading/status` as a second renewal CronJob target-plan source so `runtime_ledger_source_collection_pending` targets reach the import runner.
- Cover the parser behavior and CronJob contract with focused regression tests.

## Related Issues

None

## Testing

- `C:\Users\gkonu\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\Scripts\uv.exe run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `C:\Users\gkonu\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\Scripts\uv.exe run --frozen pytest tests/test_live_config_manifest_contract.py -q -k empirical_promotion_renewal`
- `C:\Users\gkonu\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\Scripts\uv.exe run --frozen ruff check app scripts tests`
- `C:\Users\gkonu\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\Scripts\uv.exe run --frozen pyright --project pyrightconfig.json`
- `C:\Users\gkonu\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\Scripts\uv.exe run --frozen pyright --project pyrightconfig.alpha.json`
- `C:\Users\gkonu\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\Scripts\uv.exe run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --cached --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
