### PR TITLE
fix(torghut): seal authority proof packet readiness modes

### DIFF
--- a/services/torghut/app/trading/completion.py
+++ b/services/torghut/app/trading/completion.py
@@ -27,7 +27,7 @@ from .runtime_cost_authority import (
     cost_basis_counts_have_non_promotion_grade_costs,
     is_non_promotion_grade_runtime_cost_basis,
 )
-from .runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
+from .runtime_ledger import POST_COST_PNL_BASIS
 from .runtime_ledger_source_authority import runtime_ledger_promotion_source_authority_blockers
 
 
@@ -600,7 +600,6 @@ def _windows_with_allowed_promotion_decisions(
 
 _RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
     {
-        EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
         'torghut.runtime-ledger-bucket.v1',
     }
 )
@@ -749,6 +748,19 @@ def _runtime_ledger_bucket_summary(
         (row.net_strategy_pnl_after_costs for row in rows),
         Decimal('0'),
     )
+    total_cost_amount = sum((row.cost_amount for row in rows), Decimal('0'))
+    cost_basis_counts: dict[str, int] = {}
+    source_authority_blockers: list[str] = []
+    for row in rows:
+        payload = _runtime_ledger_bucket_promotion_payload(row)
+        for cost_basis, count in _as_dict(payload.get('cost_basis_counts')).items():
+            key = _as_text(cost_basis)
+            if key is None:
+                continue
+            cost_basis_counts[key] = cost_basis_counts.get(key, 0) + _safe_int(count)
+        for blocker in runtime_ledger_promotion_source_authority_blockers(payload):
+            if blocker not in source_authority_blockers:
+                source_authority_blockers.append(blocker)
     expectancy_bps = (
         float((total_net_pnl / total_filled_notional) * Decimal('10000')) if total_filled_notional > 0 else 0.0
     )
@@ -758,9 +770,28 @@ def _runtime_ledger_bucket_summary(
         'runtime_ledger_fill_count': sum(max(0, _safe_int(row.fill_count)) for row in rows),
         'runtime_ledger_submitted_order_count': sum(max(0, _safe_int(row.submitted_order_count)) for row in rows),
         'runtime_ledger_closed_trade_count': sum(max(0, _safe_int(row.closed_trade_count)) for row in rows),
+        'runtime_ledger_closed_round_trip_count': sum(max(0, _safe_int(row.closed_trade_count)) for row in rows),
+        'runtime_ledger_open_position_count': sum(max(0, _safe_int(row.open_position_count)) for row in rows),
         'runtime_ledger_filled_notional': float(total_filled_notional),
+        'runtime_ledger_cost_amount': float(total_cost_amount),
+        'runtime_ledger_cost_basis_counts': cost_basis_counts,
+        'runtime_ledger_cost_model_hash_count': sum(
+            len(_as_dict(row.cost_model_hash_counts)) for row in rows
+        ),
         'runtime_ledger_net_strategy_pnl_after_costs': float(total_net_pnl),
         'runtime_ledger_post_cost_expectancy_bps': expectancy_bps,
+        'runtime_ledger_schema_versions': sorted(
+            {
+                schema_version
+                for row in rows
+                if (schema_version := _as_text(row.ledger_schema_version)) is not None
+            }
+        ),
+        'runtime_ledger_source_authority_bucket_count': len(rows)
+        if not source_authority_blockers
+        else 0,
+        'runtime_ledger_source_authority_blockers': source_authority_blockers,
+        'runtime_ledger_authority_blockers': [],
         **daily_summary,
         'db_row_refs': [str(row.id) for row in rows],
     }

--- a/services/torghut/app/trading/runtime_ledger_proof_policy.py
+++ b/services/torghut/app/trading/runtime_ledger_proof_policy.py
@@ -37,6 +37,8 @@ class RuntimeLedgerProofPolicy:
     authority_max_drawdown_pct_equity: Decimal = Decimal("0.03")
     authority_max_best_day_share: Decimal = Decimal("0.25")
     authority_max_symbol_concentration_share: Decimal = Decimal("0.35")
+    authority_min_closed_round_trips: int = 300
+    authority_min_filled_notional: Decimal = Decimal("10000000")
 
     def target_payload(
         self,
@@ -67,6 +69,12 @@ class RuntimeLedgerProofPolicy:
             "max_runtime_ledger_symbol_concentration_share": _decimal_text(
                 _target_decimal(targets, "max_symbol_concentration_share")
             ),
+            "min_runtime_ledger_closed_round_trips": targets[
+                "min_closed_round_trips"
+            ],
+            "min_runtime_ledger_filled_notional": _decimal_text(
+                _target_decimal(targets, "min_filled_notional")
+            ),
         }
 
     def targets_for_mode(self, proof_mode: str) -> dict[str, object]:
@@ -77,6 +85,8 @@ class RuntimeLedgerProofPolicy:
         max_drawdown_pct_equity = self.max_drawdown_pct_equity
         max_best_day_share = self.max_best_day_share
         max_symbol_concentration_share = self.max_symbol_concentration_share
+        min_closed_round_trips = 1
+        min_filled_notional = Decimal("0")
         if mode == "probation":
             min_days = max(min_days, self.probation_min_trading_days)
             min_net = max(min_net, min_daily * Decimal(min_days))
@@ -99,6 +109,8 @@ class RuntimeLedgerProofPolicy:
                 max_symbol_concentration_share,
                 self.authority_max_symbol_concentration_share,
             )
+            min_closed_round_trips = self.authority_min_closed_round_trips
+            min_filled_notional = self.authority_min_filled_notional
         return {
             "proof_mode": mode,
             "final_authority": mode == "authority",
@@ -111,6 +123,8 @@ class RuntimeLedgerProofPolicy:
             "max_drawdown_pct_equity": max_drawdown_pct_equity,
             "max_best_day_share": max_best_day_share,
             "max_symbol_concentration_share": max_symbol_concentration_share,
+            "min_closed_round_trips": min_closed_round_trips,
+            "min_filled_notional": min_filled_notional,
         }
 
 
@@ -150,6 +164,9 @@ _DECIMAL_ENV_FIELDS = {
     "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MAX_SYMBOL_CONCENTRATION_SHARE": (
         "authority_max_symbol_concentration_share"
     ),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_FILLED_NOTIONAL": (
+        "authority_min_filled_notional"
+    ),
 }
 _INT_ENV_FIELDS = {
     "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_TRADING_DAYS": "min_trading_days",
@@ -157,6 +174,9 @@ _INT_ENV_FIELDS = {
         "probation_min_trading_days"
     ),
     "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS": ("authority_min_trading_days"),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_CLOSED_ROUND_TRIPS": (
+        "authority_min_closed_round_trips"
+    ),
 }
 
 

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1353,6 +1353,10 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
         elif blocker in {
             "runtime_ledger_net_pnl_below_target",
             "runtime_ledger_daily_net_pnl_below_target",
+            "runtime_ledger_mean_daily_net_pnl_after_costs_below_floor",
+            "runtime_ledger_median_daily_net_pnl_after_costs_below_floor",
+            "runtime_ledger_p10_daily_net_pnl_after_costs_below_floor",
+            "runtime_ledger_worst_day_net_pnl_after_costs_below_floor",
         }:
             _extend_unique(
                 actions, ["collect_or_improve_post_cost_runtime_profit_evidence"]
@@ -1364,6 +1368,8 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
             "runtime_ledger_best_day_share_above_limit",
             "runtime_ledger_symbol_concentration_share_missing",
             "runtime_ledger_symbol_concentration_share_above_limit",
+            "runtime_ledger_max_intraday_drawdown_missing",
+            "runtime_ledger_max_intraday_drawdown_above_limit",
         }:
             _extend_unique(
                 actions,
@@ -1416,7 +1422,7 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
 def build_runtime_ledger_proof_packet(
     status: Mapping[str, Any],
     *,
-    proof_mode: str = "authority",
+    proof_mode: str = DEFAULT_RUNTIME_LEDGER_PROOF_MODE,
     paper_route_evidence: Mapping[str, Any] | None = None,
     runtime_window_import: Mapping[str, Any] | None = None,
     completion_status: Mapping[str, Any] | None = None,
@@ -1470,6 +1476,12 @@ def build_runtime_ledger_proof_packet(
     max_runtime_ledger_symbol_concentration_share = min(
         max_runtime_ledger_symbol_concentration_share,
         cast(Decimal, proof_mode_targets["max_symbol_concentration_share"]),
+    )
+    min_runtime_ledger_closed_round_trips = cast(
+        int, proof_mode_targets["min_closed_round_trips"]
+    )
+    min_runtime_ledger_filled_notional = cast(
+        Decimal, proof_mode_targets["min_filled_notional"]
     )
     final_authority_mode = bool(proof_mode_targets["final_authority"])
     evidence_collection_mode = not final_authority_mode
@@ -1810,7 +1822,16 @@ def build_runtime_ledger_proof_packet(
     bucket_count = _int(runtime_summary.get("runtime_ledger_bucket_count"))
     fill_count = _int(runtime_summary.get("runtime_ledger_fill_count"))
     closed_trade_count = _int(runtime_summary.get("runtime_ledger_closed_trade_count"))
+    closed_round_trip_count = _int(
+        runtime_summary.get(
+            "runtime_ledger_closed_round_trip_count",
+            runtime_summary.get("runtime_ledger_closed_trade_count"),
+        )
+    )
+    open_position_count_present = "runtime_ledger_open_position_count" in runtime_summary
+    open_position_count = _int(runtime_summary.get("runtime_ledger_open_position_count"))
     filled_notional = _decimal(runtime_summary.get("runtime_ledger_filled_notional"))
+    cost_amount = _decimal(runtime_summary.get("runtime_ledger_cost_amount"))
     net_pnl = _decimal(
         runtime_summary.get("runtime_ledger_net_strategy_pnl_after_costs")
     )
@@ -1818,7 +1839,10 @@ def build_runtime_ledger_proof_packet(
         runtime_summary.get("runtime_ledger_post_cost_expectancy_bps")
     )
     trading_days = _runtime_ledger_trading_day_count(runtime_summary)
-    daily_net_pnl = (
+    explicit_mean_daily_net_pnl = _decimal(
+        runtime_summary.get("runtime_ledger_mean_daily_net_pnl_after_costs")
+    )
+    daily_net_pnl = explicit_mean_daily_net_pnl or (
         net_pnl / Decimal(trading_days)
         if net_pnl is not None and trading_days > 0
         else None
@@ -1867,6 +1891,26 @@ def build_runtime_ledger_proof_packet(
     avg_daily_filled_notional = _decimal(
         runtime_summary.get("runtime_ledger_avg_daily_filled_notional")
     )
+    source_authority_bucket_count = _int(
+        runtime_summary.get("runtime_ledger_source_authority_bucket_count")
+    )
+    source_authority_blockers = _text_list(
+        runtime_summary.get("runtime_ledger_source_authority_blockers")
+    )
+    authority_blockers_from_summary = _text_list(
+        runtime_summary.get("runtime_ledger_authority_blockers")
+    )
+    _extend_unique(
+        authority_blockers_from_summary,
+        _text_list(runtime_summary.get("runtime_ledger_profit_authority_blockers")),
+    )
+    ledger_schema_versions = _text_list(
+        runtime_summary.get("runtime_ledger_schema_versions")
+    )
+    cost_basis_counts = _mapping(runtime_summary.get("runtime_ledger_cost_basis_counts"))
+    cost_model_hash_count = _int(
+        runtime_summary.get("runtime_ledger_cost_model_hash_count")
+    )
     target_implied_avg_daily_filled_notional = (
         min_runtime_ledger_daily_net_pnl * Decimal("10000") / expectancy_bps
         if expectancy_bps is not None and expectancy_bps > 0
@@ -1909,7 +1953,12 @@ def build_runtime_ledger_proof_packet(
             "bucket_count": bucket_count,
             "fill_count": fill_count,
             "closed_trade_count": closed_trade_count,
+            "closed_round_trip_count": closed_round_trip_count,
+            "open_position_count": open_position_count
+            if open_position_count_present
+            else None,
             "filled_notional": _decimal_text(filled_notional),
+            "cost_amount": _decimal_text(cost_amount),
             "post_cost_expectancy_bps": _decimal_text(expectancy_bps),
         },
         expected="positive buckets, fills, closed trips, filled notional, and post-cost expectancy",
@@ -1917,6 +1966,77 @@ def build_runtime_ledger_proof_packet(
         status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     _extend_unique(blockers, lifecycle_blockers)
+    authority_mechanical_blockers: list[str] = []
+    if runtime_import_due and final_authority_mode:
+        if closed_round_trip_count < min_runtime_ledger_closed_round_trips:
+            authority_mechanical_blockers.append(
+                "runtime_ledger_closed_round_trips_below_authority_floor"
+            )
+        if (
+            filled_notional is None
+            or filled_notional < min_runtime_ledger_filled_notional
+        ):
+            authority_mechanical_blockers.append(
+                "runtime_ledger_filled_notional_below_authority_floor"
+            )
+        if not open_position_count_present:
+            authority_mechanical_blockers.append(
+                "runtime_ledger_open_position_count_missing"
+            )
+        elif open_position_count != 0:
+            authority_mechanical_blockers.append(
+                "runtime_ledger_open_position_count_nonzero"
+            )
+        if cost_amount is None or (not cost_basis_counts and cost_model_hash_count <= 0):
+            authority_mechanical_blockers.append("runtime_ledger_explicit_costs_missing")
+        if source_authority_bucket_count < max(1, bucket_count):
+            authority_mechanical_blockers.append(
+                "runtime_ledger_source_authority_missing"
+            )
+        _extend_unique(authority_mechanical_blockers, source_authority_blockers)
+        if authority_blockers_from_summary:
+            authority_mechanical_blockers.append(
+                "runtime_ledger_authority_blockers_present"
+            )
+        if "torghut.exact_replay_ledger.v1" in ledger_schema_versions:
+            authority_mechanical_blockers.append(
+                "runtime_ledger_exact_replay_schema_not_authority"
+            )
+    _check(
+        checks,
+        "runtime_ledger_authority_mechanical_floor",
+        passed=not authority_mechanical_blockers,
+        observed={
+            "runtime_import_due": runtime_import_due,
+            "final_authority": final_authority_mode,
+            "closed_round_trip_count": closed_round_trip_count,
+            "filled_notional": _decimal_text(filled_notional),
+            "open_position_count": open_position_count
+            if open_position_count_present
+            else None,
+            "cost_amount": _decimal_text(cost_amount),
+            "cost_basis_counts": dict(cost_basis_counts),
+            "cost_model_hash_count": cost_model_hash_count,
+            "source_authority_bucket_count": source_authority_bucket_count,
+            "source_authority_blockers": source_authority_blockers,
+            "authority_blockers": authority_blockers_from_summary,
+            "ledger_schema_versions": ledger_schema_versions,
+        },
+        expected={
+            "min_closed_round_trips": min_runtime_ledger_closed_round_trips,
+            "min_filled_notional": _decimal_text(
+                min_runtime_ledger_filled_notional
+            ),
+            "open_position_count": 0,
+            "explicit_costs": True,
+            "source_backed_runtime_ledger_refs": True,
+            "authority_blockers": [],
+            "non_authority_schema_versions": ["torghut.exact_replay_ledger.v1"],
+        },
+        blockers=authority_mechanical_blockers,
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
+    )
+    _extend_unique(blockers, authority_mechanical_blockers)
     pnl_blockers: list[str] = []
     if runtime_import_due and (net_pnl is None or net_pnl < min_runtime_ledger_net_pnl):
         pnl_blockers.append("runtime_ledger_net_pnl_below_target")
@@ -1925,7 +2045,7 @@ def build_runtime_ledger_proof_packet(
     if runtime_import_due and (
         daily_net_pnl is None or daily_net_pnl < min_runtime_ledger_daily_net_pnl
     ):
-        pnl_blockers.append("runtime_ledger_daily_net_pnl_below_target")
+        pnl_blockers.append("runtime_ledger_mean_daily_net_pnl_after_costs_below_floor")
     _check(
         checks,
         "runtime_ledger_post_cost_profit_target",
@@ -1934,7 +2054,14 @@ def build_runtime_ledger_proof_packet(
             "runtime_import_due": runtime_import_due,
             "net_pnl_after_costs": _decimal_text(net_pnl),
             "trading_days": trading_days,
-            "daily_net_pnl_after_costs": _decimal_text(daily_net_pnl),
+            "mean_daily_net_pnl_after_costs": _decimal_text(daily_net_pnl),
+            "mean_daily_net_pnl_after_costs_source": (
+                "runtime_ledger_mean_daily_net_pnl_after_costs"
+                if explicit_mean_daily_net_pnl is not None
+                else "computed_from_total_net_pnl"
+                if daily_net_pnl is not None
+                else "missing"
+            ),
         },
         expected={
             "min_net_pnl_after_costs": _decimal_text(min_runtime_ledger_net_pnl),
@@ -2052,24 +2179,33 @@ def build_runtime_ledger_proof_packet(
     )
     _extend_unique(blockers, scale_blockers)
     risk_blockers: list[str] = []
-    if runtime_import_due and drawdown_pct is None:
-        risk_blockers.append("runtime_ledger_drawdown_pct_equity_missing")
-    elif (
-        runtime_import_due
-        and drawdown_pct is not None
-        and drawdown_pct > max_runtime_ledger_drawdown_pct_equity
-    ):
-        risk_blockers.append("runtime_ledger_drawdown_pct_equity_above_limit")
-    if runtime_import_due and final_authority_mode and max_intraday_drawdown is None:
-        risk_blockers.append("runtime_ledger_max_intraday_drawdown_missing")
-    elif (
-        runtime_import_due
-        and final_authority_mode
-        and max_intraday_drawdown is not None
+    drawdown_pct_ok = (
+        drawdown_pct is not None
+        and drawdown_pct <= max_runtime_ledger_drawdown_pct_equity
+    )
+    intraday_drawdown_ok = (
+        max_intraday_drawdown is not None
         and max_intraday_drawdown
-        > DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_max_intraday_drawdown
-    ):
-        risk_blockers.append("runtime_ledger_max_intraday_drawdown_above_limit")
+        <= DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_max_intraday_drawdown
+    )
+    if runtime_import_due and final_authority_mode:
+        if not drawdown_pct_ok and not intraday_drawdown_ok:
+            if max_intraday_drawdown is None:
+                risk_blockers.append("runtime_ledger_max_intraday_drawdown_missing")
+            elif (
+                max_intraday_drawdown
+                > DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_max_intraday_drawdown
+            ):
+                risk_blockers.append("runtime_ledger_max_intraday_drawdown_above_limit")
+            if drawdown_pct is None:
+                risk_blockers.append("runtime_ledger_drawdown_pct_equity_missing")
+            elif drawdown_pct > max_runtime_ledger_drawdown_pct_equity:
+                risk_blockers.append("runtime_ledger_drawdown_pct_equity_above_limit")
+    elif runtime_import_due:
+        if drawdown_pct is None:
+            risk_blockers.append("runtime_ledger_drawdown_pct_equity_missing")
+        elif drawdown_pct > max_runtime_ledger_drawdown_pct_equity:
+            risk_blockers.append("runtime_ledger_drawdown_pct_equity_above_limit")
     if runtime_import_due and best_day_share is None:
         risk_blockers.append("runtime_ledger_best_day_share_missing")
     elif (
@@ -2100,6 +2236,11 @@ def build_runtime_ledger_proof_packet(
             "best_day_share_source": best_day_share_source,
             "symbol_concentration_share": _decimal_text(symbol_concentration_share),
             "symbol_concentration_share_source": symbol_concentration_source,
+            "authority_drawdown_limit_satisfied": (
+                drawdown_pct_ok or intraday_drawdown_ok
+            )
+            if final_authority_mode
+            else None,
         },
         expected={
             "max_drawdown_pct_equity": _decimal_text(
@@ -2269,6 +2410,7 @@ def build_runtime_ledger_proof_packet(
         reason = "runtime_ledger_live_paper_post_cost_proof_blocked"
         promotion_reason = reason
         capital_reason = "post_cost_proof_not_satisfied"
+    required_actions = _required_actions(promotion_blockers, verdict=verdict)
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -2284,6 +2426,8 @@ def build_runtime_ledger_proof_packet(
         and post_cost_proof_satisfied,
         "capital_promotion_allowed": capital_promotion_allowed,
         "final_promotion_allowed": capital_promotion_allowed,
+        "blockers": promotion_blockers,
+        "next_action": required_actions[0] if required_actions else "none",
         "post_cost_proof_authority": {
             "allowed": post_cost_proof_authority_allowed,
             "proof_satisfied": post_cost_proof_satisfied,
@@ -2325,6 +2469,12 @@ def build_runtime_ledger_proof_packet(
                 min_runtime_ledger_daily_net_pnl
             ),
             "min_runtime_ledger_trading_days": min_runtime_ledger_trading_days,
+            "min_runtime_ledger_closed_round_trips": (
+                min_runtime_ledger_closed_round_trips
+            ),
+            "min_runtime_ledger_filled_notional": _decimal_text(
+                min_runtime_ledger_filled_notional
+            ),
             "min_runtime_ledger_median_daily_net_pnl_after_costs": _decimal_text(
                 DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_median_daily_net_pnl_after_costs
             ),
@@ -2355,7 +2505,7 @@ def build_runtime_ledger_proof_packet(
             runtime_import=runtime_import,
             completion_gate=live_scale_gate,
         ),
-        "required_actions": _required_actions(promotion_blockers, verdict=verdict),
+        "required_actions": required_actions,
         "checks": checks,
         "evidence": {
             "status": {

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -695,9 +695,15 @@ def _add_runtime_ledger_proof_packet_check(
 ) -> None:
     packet = _mapping(runtime_ledger_proof_packet)
     authority = _mapping(packet.get("promotion_authority"))
+    capital_authority = _mapping(packet.get("capital_promotion_authority"))
     schema_version = _text(packet.get("schema_version"))
     allowed = authority.get("allowed") is True
-    packet_ok = packet.get("ok") is True and allowed
+    packet_ok = (
+        packet.get("ok") is True
+        and packet.get("final_authority_ok") is True
+        and packet.get("capital_promotion_allowed") is True
+        and allowed
+    )
     expected_schema = schema_version == RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION
     _add_check(
         checks,
@@ -708,9 +714,13 @@ def _add_runtime_ledger_proof_packet_check(
             "schema_version": schema_version,
             "proof_mode": _text(packet.get("proof_mode")),
             "final_authority_ok": packet.get("final_authority_ok"),
+            "capital_promotion_allowed": packet.get("capital_promotion_allowed"),
+            "evidence_collection_ok": packet.get("evidence_collection_ok"),
             "ok": packet.get("ok"),
             "verdict": _text(packet.get("verdict")),
+            "next_action": _text(packet.get("next_action")),
             "authority_allowed": authority.get("allowed"),
+            "capital_authority_allowed": capital_authority.get("allowed"),
             "authority_reason": _text(authority.get("reason")),
             "blocking_reasons": [
                 _text(reason)
@@ -726,9 +736,69 @@ def _add_runtime_ledger_proof_packet_check(
         expected={
             "schema_version": RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
             "ok": True,
+            "proof_mode": "authority",
+            "final_authority_ok": True,
+            "capital_promotion_allowed": True,
             "promotion_authority.allowed": True,
         },
     )
+
+
+def _readiness_next_action(
+    *,
+    failed_checks: Sequence[str],
+    checks: Mapping[str, Mapping[str, Any]],
+    runtime_ledger_proof_packet: Mapping[str, Any] | None,
+) -> str:
+    packet = _mapping(runtime_ledger_proof_packet)
+    packet_next_action = _text(packet.get("next_action"))
+    if "runtime_ledger_proof_packet_authority" in failed_checks and packet_next_action:
+        return packet_next_action
+    blockers: list[str] = []
+    for check_name in failed_checks:
+        check = _mapping(checks.get(check_name))
+        observed = _mapping(check.get("observed"))
+        for key in ("blocking_reasons", "import_blockers", "failed_checks"):
+            for reason in _sequence(observed.get(key)):
+                text = _text(reason)
+                if text and text not in blockers:
+                    blockers.append(text)
+    for blocker in blockers:
+        if blocker in {
+            "runtime_window_import_missing",
+            "runtime_window_import_runtime_ledger_materialization_missing",
+            "paper_route_runtime_ledger_import_pending",
+            "paper_route_import_not_ready",
+        }:
+            return "run_runtime_window_import_from_paper_route_target_plan"
+        if blocker in {
+            "paper_route_source_activity_missing",
+            "runtime_ledger_source_authority_missing",
+        } or blocker.startswith("runtime_ledger_source_"):
+            return "inspect_runtime_ledger_source_activity"
+        if blocker in {
+            "runtime_ledger_trading_days_below_target",
+            "runtime_ledger_observed_trading_day_count_below_target",
+        }:
+            return "collect_more_runtime_ledger_trading_days"
+        if blocker in {
+            "runtime_ledger_closed_round_trips_below_authority_floor",
+            "runtime_ledger_closed_trade_count_zero",
+        }:
+            return "collect_more_closed_runtime_round_trips"
+        if blocker in {
+            "runtime_ledger_filled_notional_below_authority_floor",
+            "runtime_ledger_avg_daily_filled_notional_below_target_implied_floor",
+        }:
+            return "collect_more_runtime_ledger_filled_notional"
+        if blocker.startswith("runtime_ledger_"):
+            return "repair_runtime_ledger_lifecycle_cost_or_lineage_evidence"
+    for failed_check in failed_checks:
+        if failed_check.startswith("paper_route_target_plan"):
+            return "repair_candidate_frontier_or_paper_route_target_plan"
+        if failed_check.startswith("runtime_ledger"):
+            return "inspect_runtime_live_paper_ledger_evidence"
+    return "none" if not failed_checks else "inspect_failed_readiness_checks"
 
 
 def _add_runtime_ledger_profit_proof_checks(
@@ -1366,11 +1436,18 @@ def evaluate_trading_readiness(
     )
 
     failed_checks = [key for key, value in checks.items() if not value["passed"]]
+    readiness_next_action = _readiness_next_action(
+        failed_checks=failed_checks,
+        checks=checks,
+        runtime_ledger_proof_packet=runtime_ledger_proof_packet,
+    )
+    packet_summary = _mapping(runtime_ledger_proof_packet)
     return {
         "schema_version": SCHEMA_VERSION,
         "ok": not failed_checks,
         "profile": profile,
         "failed_checks": failed_checks,
+        "next_action": readiness_next_action,
         "checks": checks,
         "paper_route_probe": paper_route_probe,
         "paper_route_target_plan": paper_route_target_plan,
@@ -1387,8 +1464,15 @@ def evaluate_trading_readiness(
         "runtime_ledger_proof_packet": {
             "required": require_runtime_ledger_proof_packet,
             "schema_version": _text(
-                _mapping(runtime_ledger_proof_packet).get("schema_version")
+                packet_summary.get("schema_version")
             ),
+            "proof_mode": _text(packet_summary.get("proof_mode")),
+            "final_authority_ok": packet_summary.get("final_authority_ok"),
+            "capital_promotion_allowed": packet_summary.get(
+                "capital_promotion_allowed"
+            ),
+            "evidence_collection_ok": packet_summary.get("evidence_collection_ok"),
+            "next_action": _text(packet_summary.get("next_action")),
         },
     }
 

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -324,15 +324,27 @@ def _completion(
     symbol_concentration_share: str | None = "0.35",
     ledger_refs: list[str] | None = None,
     unbacked_refs: list[str] | None = None,
+    summary_overrides: dict[str, object] | None = None,
 ) -> dict[str, object]:
     runtime_ledger_summary: dict[str, object] = {
         "runtime_ledger_bucket_count": 1,
         "runtime_ledger_fill_count": 4,
-        "runtime_ledger_closed_trade_count": 2,
+        "runtime_ledger_closed_trade_count": 300,
+        "runtime_ledger_closed_round_trip_count": 300,
+        "runtime_ledger_open_position_count": 0,
         "runtime_ledger_filled_notional": filled_notional,
+        "runtime_ledger_cost_amount": "1250",
+        "runtime_ledger_cost_basis_counts": {
+            "alpaca_2026_equity_fee_schedule": 300,
+        },
+        "runtime_ledger_cost_model_hash_count": 1,
         "runtime_ledger_net_strategy_pnl_after_costs": net_pnl,
         "runtime_ledger_post_cost_expectancy_bps": expectancy_bps,
         "runtime_ledger_observed_trading_day_count": trading_days,
+        "runtime_ledger_schema_versions": ["torghut.runtime-ledger-bucket.v1"],
+        "runtime_ledger_source_authority_bucket_count": 1,
+        "runtime_ledger_source_authority_blockers": [],
+        "runtime_ledger_authority_blockers": [],
     }
     if avg_daily_filled_notional is not None:
         runtime_ledger_summary["runtime_ledger_avg_daily_filled_notional"] = (
@@ -362,6 +374,8 @@ def _completion(
         runtime_ledger_summary["runtime_ledger_symbol_concentration_share"] = (
             symbol_concentration_share
         )
+    if summary_overrides:
+        runtime_ledger_summary.update(summary_overrides)
     return {
         "doc_id": "doc29",
         "summary": {"all_satisfied": status == "satisfied"},
@@ -478,6 +492,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
     def test_packet_allows_only_complete_post_cost_runtime_ledger_proof(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
@@ -494,7 +509,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(result["candidate"]["hypothesis_id"], "H-PAIRS-01")
         self.assertEqual(
             result["checks"]["runtime_ledger_post_cost_profit_target"]["observed"][
-                "daily_net_pnl_after_costs"
+                "mean_daily_net_pnl_after_costs"
             ],
             "500",
         )
@@ -600,6 +615,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=evidence,
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
@@ -624,6 +640,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
     ) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(tigerbeetle_ledger=_tigerbeetle_ledger_status()),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
@@ -650,6 +667,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                     signed_ref_count=0,
                 )
             ),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
@@ -673,6 +691,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
     def test_authority_packet_requires_daily_distribution_and_scale(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(),
             completion_status=_completion(
@@ -681,6 +700,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 p10_daily_net_pnl="-300",
                 worst_day_net_pnl="-800",
                 max_intraday_drawdown="1600",
+                drawdown_pct="0.031",
             ),
             generated_at="2026-05-26T21:05:00+00:00",
         )
@@ -715,6 +735,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
     def test_authority_packet_requires_daily_distribution_fields(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(),
             completion_status=_completion(
@@ -723,6 +744,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 p10_daily_net_pnl=None,
                 worst_day_net_pnl=None,
                 max_intraday_drawdown=None,
+                drawdown_pct=None,
             ),
             generated_at="2026-05-26T21:05:00+00:00",
         )
@@ -747,6 +769,130 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertIn(
             "runtime_ledger_max_intraday_drawdown_missing",
             result["promotion_authority"]["blocking_reasons"],
+        )
+
+    def test_default_one_day_packet_is_smoke_not_authority(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(trading_days=1, net_pnl="600"),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertEqual(result["proof_mode"], "smoke")
+        self.assertTrue(result["ok"], result)
+        self.assertFalse(result["final_authority_ok"])
+        self.assertFalse(result["capital_promotion_allowed"])
+        self.assertEqual(
+            result["post_cost_proof_authority"]["blocking_reasons"],
+            ["runtime_ledger_proof_mode_not_authority"],
+        )
+        self.assertEqual(result["next_action"], "rerun_proof_packet_in_authority_mode")
+
+    def test_authority_packet_fails_each_mechanical_authority_floor(self) -> None:
+        cases = [
+            (
+                {"trading_days": 19, "net_pnl": "9500"},
+                "runtime_ledger_trading_days_below_target",
+            ),
+            (
+                {
+                    "summary_overrides": {
+                        "runtime_ledger_closed_round_trip_count": 299,
+                        "runtime_ledger_closed_trade_count": 299,
+                    }
+                },
+                "runtime_ledger_closed_round_trips_below_authority_floor",
+            ),
+            (
+                {"filled_notional": "9999999"},
+                "runtime_ledger_filled_notional_below_authority_floor",
+            ),
+            (
+                {"summary_overrides": {"runtime_ledger_open_position_count": 1}},
+                "runtime_ledger_open_position_count_nonzero",
+            ),
+            (
+                {
+                    "summary_overrides": {
+                        "runtime_ledger_cost_amount": None,
+                        "runtime_ledger_cost_basis_counts": {},
+                        "runtime_ledger_cost_model_hash_count": 0,
+                    }
+                },
+                "runtime_ledger_explicit_costs_missing",
+            ),
+            (
+                {
+                    "summary_overrides": {
+                        "runtime_ledger_source_authority_bucket_count": 0,
+                    }
+                },
+                "runtime_ledger_source_authority_missing",
+            ),
+            (
+                {
+                    "summary_overrides": {
+                        "runtime_ledger_authority_blockers": [
+                            "runtime_ledger_cost_basis_modeled"
+                        ],
+                    }
+                },
+                "runtime_ledger_authority_blockers_present",
+            ),
+            (
+                {
+                    "summary_overrides": {
+                        "runtime_ledger_schema_versions": [
+                            "torghut.exact_replay_ledger.v1"
+                        ],
+                    }
+                },
+                "runtime_ledger_exact_replay_schema_not_authority",
+            ),
+            (
+                {"best_day_share": "0.251"},
+                "runtime_ledger_best_day_share_above_limit",
+            ),
+            (
+                {"symbol_concentration_share": "0.351"},
+                "runtime_ledger_symbol_concentration_share_above_limit",
+            ),
+            (
+                {"max_intraday_drawdown": "1501", "drawdown_pct": "0.031"},
+                "runtime_ledger_max_intraday_drawdown_above_limit",
+            ),
+        ]
+        for completion_kwargs, blocker in cases:
+            with self.subTest(blocker=blocker):
+                result = packet.build_runtime_ledger_proof_packet(
+                    _status(),
+                    proof_mode="authority",
+                    paper_route_evidence=_paper_route_evidence(),
+                    runtime_window_import=_runtime_import(),
+                    completion_status=_completion(**completion_kwargs),
+                    generated_at="2026-05-26T21:05:00+00:00",
+                )
+                self.assertFalse(result["final_authority_ok"], result)
+                self.assertIn(
+                    blocker, result["promotion_authority"]["blocking_reasons"]
+                )
+
+    def test_source_backed_fixture_preserves_missing_live_data_blockers(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=None,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["final_authority_ok"])
+        self.assertIn("runtime_window_import_missing", result["blockers"])
+        self.assertEqual(
+            result["next_action"], "run_runtime_window_import_from_paper_route_target_plan"
         )
 
     def test_smoke_packet_cannot_grant_promotion_authority(self) -> None:
@@ -827,6 +973,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                     "promotion_certificate_shadow_only",
                 ]
             ),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
@@ -901,6 +1048,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=evidence,
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
@@ -1095,6 +1243,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
     def test_packet_waits_before_paper_route_window_is_importable(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(
                 import_ready=False,
                 import_blockers=["paper_route_session_window_not_open"],
@@ -1144,6 +1293,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=evidence,
             generated_at="2026-05-25T21:05:00+00:00",
         )
@@ -1173,6 +1323,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(
                 import_ready=False,
                 import_blockers=["paper_route_session_window_not_open"],
@@ -1211,6 +1362,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
     ) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(
                 import_ready=True,
                 import_audit={
@@ -1300,6 +1452,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=paper,
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
@@ -1341,6 +1494,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=evidence,
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
@@ -1390,6 +1544,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=evidence,
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
@@ -1434,6 +1589,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
     def test_packet_blocks_non_authoritative_import_and_weak_daily_profit(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(
                 proof_status="blocked",
@@ -1454,7 +1610,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["promotion_authority"]["blocking_reasons"],
         )
         self.assertIn(
-            "runtime_ledger_daily_net_pnl_below_target",
+            "runtime_ledger_mean_daily_net_pnl_after_costs_below_floor",
             result["promotion_authority"]["blocking_reasons"],
         )
 
@@ -1463,10 +1619,12 @@ class TestRuntimeLedgerProofPacket(TestCase):
     ) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(),
             completion_status=_completion(
                 drawdown_pct=None,
+                max_intraday_drawdown=None,
                 best_day_share=None,
                 symbol_concentration_share=None,
             ),
@@ -1505,10 +1663,12 @@ class TestRuntimeLedgerProofPacket(TestCase):
     def test_packet_blocks_excessive_runtime_ledger_risk_quality(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(),
             completion_status=_completion(
                 drawdown_pct="0.13",
+                max_intraday_drawdown="1600",
                 best_day_share="0.40",
                 symbol_concentration_share="0.75",
             ),
@@ -1567,6 +1727,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(blockers=["simple_submit_disabled"]),
+            proof_mode="authority",
             paper_route_evidence=paper,
             runtime_window_import={"runtime_window_import": _runtime_import()},
             completion_status=completion,
@@ -1590,7 +1751,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertIn("runtime_ledger_post_cost_expectancy_not_positive", blockers)
         self.assertIn("runtime_ledger_net_pnl_below_target", blockers)
         self.assertIn("runtime_ledger_trading_days_below_target", blockers)
-        self.assertIn("runtime_ledger_daily_net_pnl_below_target", blockers)
+        self.assertIn("runtime_ledger_mean_daily_net_pnl_after_costs_below_floor", blockers)
         self.assertIn(
             "keep_promotion_blocked_until_live_gate_and_proof_floor_pass",
             result["required_actions"],
@@ -1625,6 +1786,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -1672,6 +1834,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -1707,6 +1870,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -1758,6 +1922,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -1792,6 +1957,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -1825,6 +1991,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -1864,6 +2031,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -1899,6 +2067,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -1973,6 +2142,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -2010,6 +2180,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
     ) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(authoritative=False),
             completion_status=_completion(),
@@ -2036,6 +2207,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -2083,6 +2255,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -2124,6 +2297,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=runtime_import,
             completion_status=_completion(),
@@ -2166,6 +2340,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=paper,
             generated_at="2026-05-26T20:01:00+00:00",
         )
@@ -2191,6 +2366,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         result = packet.build_runtime_ledger_proof_packet(
             {"mode": "paper", "running": True, "live_gate": {"allowed": True}},
+            proof_mode="authority",
             paper_route_evidence=paper,
             runtime_window_import={
                 "status": "ok",
@@ -2243,6 +2419,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
     def test_packet_preserves_string_proof_blockers_from_runtime_imports(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
+            proof_mode="authority",
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import={
                 "proof_status": "blocked",

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -925,6 +925,38 @@ class TestCompletionTrace(TestCase):
         self.assertEqual(matched_buckets, [])
         self.assertEqual(unbacked_window_refs, [str(window.id)])
 
+    def test_runtime_ledger_window_refs_reject_exact_replay_aggregate_ledgers(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        with self.session_local() as session:
+            window = StrategyHypothesisMetricWindow(
+                run_id='exact-replay-run',
+                candidate_id='cand-1',
+                hypothesis_id='legacy_macd_rsi',
+                observed_stage='live',
+                window_started_at=window_start,
+                window_ended_at=window_end,
+            )
+            exact_replay = _runtime_ledger_bucket(
+                run_id='exact-replay-run',
+                bucket_started_at=window_start,
+                bucket_ended_at=window_end,
+                ledger_schema_version='torghut.exact_replay_ledger.v1',
+            )
+            session.add_all([window, exact_replay])
+            session.commit()
+
+            backed_windows, matched_buckets, unbacked_window_refs = _runtime_ledger_bucket_refs_for_windows(
+                session,
+                [window],
+            )
+
+        self.assertEqual(backed_windows, [])
+        self.assertEqual(matched_buckets, [])
+        self.assertEqual(unbacked_window_refs, [str(window.id)])
+
     def test_doc29_live_scale_blocks_non_runtime_ledger_window_pnl(self) -> None:
         trace = build_completion_trace(
             doc_id='doc29',

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1783,6 +1783,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "min_runtime_ledger_net_pnl_after_costs": "10000",
                 "min_runtime_ledger_daily_net_pnl_after_costs": "500",
                 "min_runtime_ledger_trading_days": 20,
+                "min_runtime_ledger_closed_round_trips": 300,
+                "min_runtime_ledger_filled_notional": "10000000",
                 "max_runtime_ledger_drawdown_pct_equity": "0.03",
                 "max_runtime_ledger_best_day_share": "0.25",
                 "max_runtime_ledger_symbol_concentration_share": "0.35",

--- a/services/torghut/tests/test_runtime_ledger_proof_policy.py
+++ b/services/torghut/tests/test_runtime_ledger_proof_policy.py
@@ -27,6 +27,8 @@ class TestRuntimeLedgerProofPolicy(TestCase):
                 "max_runtime_ledger_drawdown_pct_equity": "0.08",
                 "max_runtime_ledger_best_day_share": "0.25",
                 "max_runtime_ledger_symbol_concentration_share": "0.5",
+                "min_runtime_ledger_closed_round_trips": 1,
+                "min_runtime_ledger_filled_notional": "0",
             },
         )
         self.assertEqual(
@@ -83,6 +85,8 @@ class TestRuntimeLedgerProofPolicy(TestCase):
                 "max_runtime_ledger_drawdown_pct_equity": "0.12",
                 "max_runtime_ledger_best_day_share": "0.25",
                 "max_runtime_ledger_symbol_concentration_share": "0.5",
+                "min_runtime_ledger_closed_round_trips": 1,
+                "min_runtime_ledger_filled_notional": "0",
             },
         )
         self.assertEqual(
@@ -101,6 +105,8 @@ class TestRuntimeLedgerProofPolicy(TestCase):
                 "max_runtime_ledger_drawdown_pct_equity": "0.025",
                 "max_runtime_ledger_best_day_share": "0.25",
                 "max_runtime_ledger_symbol_concentration_share": "0.3",
+                "min_runtime_ledger_closed_round_trips": 300,
+                "min_runtime_ledger_filled_notional": "10000000",
             },
         )
 

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -273,6 +273,21 @@ def _runtime_ledger_proof_packet(
         "proof_mode": "authority",
         "ok": allowed,
         "final_authority_ok": allowed,
+        "capital_promotion_allowed": allowed,
+        "evidence_collection_ok": False,
+        "next_action": "none"
+        if allowed
+        else "collect_or_improve_post_cost_runtime_profit_evidence",
+        "capital_promotion_authority": {
+            "allowed": allowed,
+            "reason": "live_capital_promotion_gate_clear"
+            if allowed
+            else "post_cost_proof_not_satisfied",
+            "blocking_reasons": blocking_reasons,
+            "failed_checks": []
+            if allowed
+            else ["runtime_ledger_post_cost_profit_target"],
+        },
         "verdict": "promotion_authority_allowed" if allowed else "blocked",
         "promotion_authority": {
             "allowed": allowed,
@@ -440,6 +455,9 @@ class TestVerifyTradingReadiness(TestCase):
         packet = _runtime_ledger_proof_packet()
         packet["proof_mode"] = "smoke"
         packet["final_authority_ok"] = False
+        packet["capital_promotion_allowed"] = False
+        packet["evidence_collection_ok"] = True
+        packet["next_action"] = "rerun_proof_packet_in_authority_mode"
         packet["promotion_authority"] = {
             "allowed": False,
             "reason": "runtime_ledger_proof_mode_not_authority",
@@ -457,6 +475,48 @@ class TestVerifyTradingReadiness(TestCase):
         observed = result["checks"]["runtime_ledger_proof_packet_authority"]["observed"]
         self.assertEqual(observed["proof_mode"], "smoke")
         self.assertFalse(observed["authority_allowed"])
+        self.assertEqual(result["next_action"], "rerun_proof_packet_in_authority_mode")
+
+    def test_runtime_ledger_blockers_map_to_concrete_next_actions(self) -> None:
+        cases = [
+            (
+                "runtime_window_import_missing",
+                "run_runtime_window_import_from_paper_route_target_plan",
+            ),
+            (
+                "runtime_ledger_source_authority_missing",
+                "inspect_runtime_ledger_source_activity",
+            ),
+            (
+                "runtime_ledger_trading_days_below_target",
+                "collect_more_runtime_ledger_trading_days",
+            ),
+            (
+                "runtime_ledger_closed_round_trips_below_authority_floor",
+                "collect_more_closed_runtime_round_trips",
+            ),
+            (
+                "runtime_ledger_filled_notional_below_authority_floor",
+                "collect_more_runtime_ledger_filled_notional",
+            ),
+            (
+                "runtime_ledger_explicit_costs_missing",
+                "repair_runtime_ledger_lifecycle_cost_or_lineage_evidence",
+            ),
+        ]
+        for blocker, expected_action in cases:
+            with self.subTest(blocker=blocker):
+                action = verifier._readiness_next_action(
+                    failed_checks=["runtime_ledger_proof_packet_authority"],
+                    checks={
+                        "runtime_ledger_proof_packet_authority": {
+                            "observed": {"blocking_reasons": [blocker]}
+                        }
+                    },
+                    runtime_ledger_proof_packet={},
+                )
+
+                self.assertEqual(action, expected_action)
 
     def test_runtime_ledger_profit_proof_requires_observed_days_and_daily_pnl(
         self,


### PR DESCRIPTION
## Summary

- Makes runtime-ledger proof modes explicit: smoke/probation remain evidence-collection only, while authority is the only final proof mode.
- Fails authority closed on post-cost economics, days, drawdown/concentration, $10M filled notional, 300 closed round trips, explicit costs, source-backed runtime-ledger refs, zero open positions, and replay-only materialization.
- Surfaces `proof_mode`, `final_authority_ok`, `capital_promotion_allowed`, `evidence_collection_ok`, stable blockers, and concrete `next_action` in proof packets and readiness output.
- Extends completion/runtime-ledger reporting and regression tests so aggregate/exact-replay evidence cannot become final authority proof.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py tests/test_runtime_ledger_proof_policy.py tests/test_completion_trace.py -q`
- PASS: `cd services/torghut && uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py app/trading/runtime_ledger_proof_policy.py app/trading/completion.py app/trading/hypotheses.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py tests/test_runtime_ledger_proof_policy.py tests/test_completion_trace.py`
- PASS with local Node heap bump after plain local run exhausted the 1 GiB default heap: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_builder_exports_next_paper_route_runtime_window_targets -q`
- PASS: `cd services/torghut && uv run --frozen ruff check tests/test_paper_route_evidence.py`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Authority proof packets become intentionally stricter and fail closed until real source-backed live-paper/runtime-ledger post-cost evidence satisfies the authority floors.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.