### PR TITLE
fix(torghut): fail closed on signal ingest timeouts

### DIFF
--- a/services/torghut/app/trading/ingest.py
+++ b/services/torghut/app/trading/ingest.py
@@ -161,28 +161,45 @@ class ClickHouseSignalIngestor:
             )
 
         poll_started_at = trading_now(account_label=self.account_label)
-        time_column = self._resolve_time_column()
-        latest_signal_at = self._latest_signal_timestamp(time_column)
-        cursor_at, cursor_seq, cursor_symbol, fast_forwarded = (
-            self._prepare_fetch_cursor(
-                session=session,
-                poll_started_at=poll_started_at,
-                latest_signal_at=latest_signal_at,
+        query_window_start: datetime | None = None
+        try:
+            time_column = self._resolve_time_column()
+            latest_signal_at = self._latest_signal_timestamp(time_column)
+            cursor_at, cursor_seq, cursor_symbol, fast_forwarded = (
+                self._prepare_fetch_cursor(
+                    session=session,
+                    poll_started_at=poll_started_at,
+                    latest_signal_at=latest_signal_at,
+                )
             )
-        )
-        if self.simulation_mode:
-            return self._fetch_simulation_signals(
-                cursor_at=cursor_at,
-                cursor_seq=cursor_seq,
-                cursor_symbol=cursor_symbol,
-                latest_signal_at=latest_signal_at,
-                poll_started_at=poll_started_at,
-                fast_forwarded=fast_forwarded,
+            query_window_start = cursor_at
+            if self.simulation_mode:
+                return self._fetch_simulation_signals(
+                    cursor_at=cursor_at,
+                    cursor_seq=cursor_seq,
+                    cursor_symbol=cursor_symbol,
+                    latest_signal_at=latest_signal_at,
+                    poll_started_at=poll_started_at,
+                    fast_forwarded=fast_forwarded,
+                )
+            overlap_cutoff = self._overlap_cutoff(time_column, cursor_at)
+            query = self._build_query(cursor_at, cursor_seq, cursor_symbol)
+            rows = self._query_clickhouse(query)
+        except TimeoutError as exc:
+            logger.warning(
+                "ClickHouse signal ingestion timed out; returning empty batch account_label=%s error=%s",
+                self.account_label,
+                exc,
             )
-        query_window_start = cursor_at
-        overlap_cutoff = self._overlap_cutoff(time_column, cursor_at)
-        query = self._build_query(cursor_at, cursor_seq, cursor_symbol)
-        rows = self._query_clickhouse(query)
+            return SignalBatch(
+                signals=[],
+                cursor_at=None,
+                cursor_seq=None,
+                cursor_symbol=None,
+                query_start=query_window_start,
+                query_end=poll_started_at,
+                no_signal_reason="clickhouse_signal_query_timeout",
+            )
         signals, max_event_ts, max_seq, max_symbol = self._collect_batch_signals(
             rows,
             overlap_cutoff,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -4649,6 +4649,7 @@ class TestTradingApi(TestCase):
         original = {
             "trading_enabled": settings.trading_enabled,
             "trading_mode": settings.trading_mode,
+            "trading_pipeline_mode": settings.trading_pipeline_mode,
             "trading_autonomy_enabled": settings.trading_autonomy_enabled,
             "trading_autonomy_allow_live_promotion": settings.trading_autonomy_allow_live_promotion,
             "trading_kill_switch_enabled": settings.trading_kill_switch_enabled,
@@ -4656,6 +4657,7 @@ class TestTradingApi(TestCase):
         try:
             settings.trading_enabled = True
             settings.trading_mode = "live"
+            settings.trading_pipeline_mode = "legacy"
             settings.trading_autonomy_enabled = False
             settings.trading_autonomy_allow_live_promotion = False
             settings.trading_kill_switch_enabled = True
@@ -4719,6 +4721,7 @@ class TestTradingApi(TestCase):
         finally:
             settings.trading_enabled = original["trading_enabled"]
             settings.trading_mode = original["trading_mode"]
+            settings.trading_pipeline_mode = original["trading_pipeline_mode"]
             settings.trading_autonomy_enabled = original["trading_autonomy_enabled"]
             settings.trading_autonomy_allow_live_promotion = original[
                 "trading_autonomy_allow_live_promotion"

--- a/services/torghut/tests/zz_signal_ingest_timeout/test_signal_ingest_timeout.py
+++ b/services/torghut/tests/zz_signal_ingest_timeout/test_signal_ingest_timeout.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest import TestCase
+from unittest.mock import patch
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.config import settings
+from app.models import Base, TradeCursor
+from app.trading.ingest import ClickHouseSignalIngestor
+
+
+class TimeoutAfterLatestIngestor(ClickHouseSignalIngestor):
+    def __init__(self, *args, latest_signal_ts: datetime, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._latest_signal_ts = latest_signal_ts
+
+    def _query_clickhouse(self, query: str) -> list[dict[str, object]]:
+        if "latest_signal_ts" in query:
+            return [{"latest_signal_ts": self._latest_signal_ts.isoformat()}]
+        raise TimeoutError("timed out")
+
+
+class TestSignalIngestTimeout(TestCase):
+    def test_fetch_signals_returns_empty_batch_on_clickhouse_timeout(self) -> None:
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+        latest_signal = datetime(2026, 1, 1, 0, 10, 0, tzinfo=timezone.utc)
+        ingestor = TimeoutAfterLatestIngestor(
+            schema="envelope",
+            table="torghut.ta_signals",
+            url="http://example",
+            latest_signal_ts=latest_signal,
+            fast_forward_stale_cursor=False,
+        )
+        with session_local() as session:
+            batch = ingestor.fetch_signals(session)
+            ingestor.commit_cursor(session, batch)
+            cursor = session.execute(select(TradeCursor)).scalar_one_or_none()
+
+        self.assertEqual(batch.signals, [])
+        self.assertEqual(batch.no_signal_reason, "clickhouse_signal_query_timeout")
+        self.assertIsNone(batch.cursor_at)
+        self.assertIsNone(batch.cursor_seq)
+        self.assertIsNone(batch.cursor_symbol)
+        self.assertIsNotNone(batch.query_start)
+        self.assertIsNotNone(batch.query_end)
+        self.assertIsNone(cursor)
+
+    def test_simulation_fetch_returns_empty_batch_on_clickhouse_timeout(self) -> None:
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+        snapshot = {
+            "enabled": settings.trading_simulation_enabled,
+            "window_start": settings.trading_simulation_window_start,
+            "window_end": settings.trading_simulation_window_end,
+        }
+        latest_signal = datetime(2026, 3, 6, 14, 35, 0, tzinfo=timezone.utc)
+        try:
+            settings.trading_simulation_enabled = True
+            settings.trading_simulation_window_start = "2026-03-06T14:30:00Z"
+            settings.trading_simulation_window_end = "2026-03-06T14:45:00Z"
+            ingestor = TimeoutAfterLatestIngestor(
+                schema="envelope",
+                table="torghut.ta_signals",
+                url="http://example",
+                latest_signal_ts=latest_signal,
+                fast_forward_stale_cursor=False,
+            )
+            with (
+                session_local() as session,
+                patch(
+                    "app.trading.ingest.trading_now",
+                    return_value=datetime(2026, 3, 6, 14, 30, 0, tzinfo=timezone.utc),
+                ),
+            ):
+                batch = ingestor.fetch_signals(session)
+                ingestor.commit_cursor(session, batch)
+                cursor = session.execute(select(TradeCursor)).scalar_one_or_none()
+
+            self.assertEqual(batch.signals, [])
+            self.assertEqual(batch.no_signal_reason, "clickhouse_signal_query_timeout")
+            self.assertIsNone(batch.cursor_at)
+            self.assertIsNone(batch.cursor_seq)
+            self.assertIsNone(batch.cursor_symbol)
+            self.assertIsNotNone(batch.query_start)
+            self.assertIsNotNone(batch.query_end)
+            self.assertIsNone(cursor)
+        finally:
+            settings.trading_simulation_enabled = snapshot["enabled"]
+            settings.trading_simulation_window_start = snapshot["window_start"]
+            settings.trading_simulation_window_end = snapshot["window_end"]


### PR DESCRIPTION
## Summary

- Converts ClickHouse signal-ingest timeouts into explicit empty no-signal batches instead of letting the trading lane abort.
- Preserves cursor safety by returning no cursor advancement on timeout.
- Adds focused regression coverage for normal and simulation signal fetch timeout paths.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_signal_ingest_timeout.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/ingest.py tests/test_signal_ingest_timeout.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/ingest.py tests/test_signal_ingest_timeout.py`
- `cd services/torghut && uv run --frozen pytest tests/test_signal_ingest.py tests/test_signal_ingest_timeout.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
