### PR TITLE
fix(torghut): make source collection handoff explicit

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1418,6 +1418,8 @@ _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND = (
     "runtime_ledger_source_collection_candidate"
 )
 _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_DSN_ENV = "SIM_DB_DSN"
+_RUNTIME_LEDGER_SOURCE_COLLECTION_TARGET_DSN_ENV = "SIM_DB_DSN"
+_RUNTIME_LEDGER_PAPER_PROBATION_TARGET_DSN_ENV = "SIM_DB_DSN"
 _RUNTIME_LEDGER_SOURCE_COLLECTION_TRIGGER_REASONS = frozenset(
     {
         RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
@@ -1652,6 +1654,11 @@ def _runtime_ledger_paper_probation_import_plan(
             if source_collection
             else _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_DSN_ENV
         )
+        target_dsn_env = (
+            _RUNTIME_LEDGER_SOURCE_COLLECTION_TARGET_DSN_ENV
+            if source_collection
+            else _RUNTIME_LEDGER_PAPER_PROBATION_TARGET_DSN_ENV
+        )
         final_blockers = list(
             _RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS
             if source_collection
@@ -1705,7 +1712,9 @@ def _runtime_ledger_paper_probation_import_plan(
             "runtime_strategy_name": strategy_name,
             "strategy_lookup_names": strategy_lookup_names,
             "account_label": account_label,
+            "source_account_label": account_label,
             "source_dsn_env": source_dsn_env,
+            "target_dsn_env": target_dsn_env,
             "dataset_snapshot_ref": dataset_snapshot_ref or "",
             "source_manifest_ref": source_manifest_ref,
             "source_kind": source_kind,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -1358,6 +1358,8 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(target["strategy_id"], "intraday_tsmom_v2@research")
         self.assertEqual(target["strategy_name"], "intraday-tsmom-profit-v3")
         self.assertEqual(target["runtime_strategy_name"], "intraday-tsmom-profit-v3")
+        self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["source_account_label"], "TORGHUT_SIM")
         self.assertEqual(
             target["strategy_lookup_names"],
             ["intraday-tsmom-profit-v3", "intraday-tsmom-v2"],
@@ -1448,6 +1450,8 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(plan["source_collection_target_count"], 1)
         target = plan["targets"][0]
         self.assertEqual(target["source_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["source_account_label"], "TORGHUT_SIM")
         self.assertEqual(
             target["source_kind"], "runtime_ledger_source_collection_candidate"
         )
@@ -1518,6 +1522,8 @@ class TestSubmissionCouncil(TestCase):
 
         self.assertEqual(plan["target_count"], 1)
         target = plan["targets"][0]
+        self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["source_account_label"], "TORGHUT_SIM")
         self.assertFalse(target["paper_probation_authorized"])
         self.assertTrue(target["source_collection_authorized"])
         self.assertEqual(target["proof_mode"], "probation")


### PR DESCRIPTION
## Summary

- Adds explicit `target_dsn_env` and `source_account_label` to runtime-ledger paper-probation and source-collection import targets.
- Keeps source-collection targets evidence-only: no paper probation, no capital promotion, no live submit authorization.
- Covers the handoff contract in submission-council tests so importer targets no longer rely on implicit persistence/account defaults.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py -q -k 'runtime_ledger_source_collection or runtime_ledger_paper_probation_import_plan_uses_family_runtime_harness'`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q -k 'runtime_window_target_plan or runtime_window_import_target_passes_source_account_label or target_dsn_env'`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/submission_council.py tests/test_submission_council.py --check`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
