### PR TITLE
fix(torghut): balance H-PAIRS paper-route evidence legs

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -807,6 +807,76 @@ def _target_probe_symbols(
     return _paper_route_probe_symbols(probe)
 
 
+def _target_requires_balanced_pair_probe(target: Mapping[str, object]) -> bool:
+    explicit = _safe_text(target.get("paper_route_probe_pair_balance_required"))
+    if explicit is not None:
+        return explicit.lower() in {"1", "true", "yes", "on"}
+    for key in (
+        "strategy_family",
+        "strategy_name",
+        "runtime_strategy_name",
+        "strategy_id",
+        "universe_type",
+    ):
+        value = _safe_text(target.get(key))
+        if value and "microbar_cross_sectional_pairs" in value.lower().replace(
+            "-", "_"
+        ):
+            return True
+    return False
+
+
+def _balanced_pair_probe_symbol_actions(
+    target: Mapping[str, object],
+    symbols: Sequence[str],
+) -> dict[str, str]:
+    normalized_symbols = [
+        str(symbol).strip().upper() for symbol in symbols if str(symbol).strip()
+    ]
+    raw_actions = _as_mapping(target.get("paper_route_probe_symbol_actions"))
+    actions: dict[str, str] = {}
+    for symbol in normalized_symbols:
+        raw_action = _safe_text(raw_actions.get(symbol))
+        if raw_action is not None and raw_action.lower() in {"buy", "long"}:
+            actions[symbol] = "buy"
+        elif raw_action is not None and raw_action.lower() in {"sell", "short"}:
+            actions[symbol] = "sell"
+    missing_symbols = [symbol for symbol in normalized_symbols if symbol not in actions]
+    if missing_symbols and _target_requires_balanced_pair_probe(target):
+        selection_mode = (
+            _safe_text(target.get("selection_mode")) or "continuation"
+        ).lower()
+        first_action = "sell" if selection_mode == "reversal" else "buy"
+        second_action = "buy" if first_action == "sell" else "sell"
+        buy_count = sum(1 for action in actions.values() if action == "buy")
+        sell_count = sum(1 for action in actions.values() if action == "sell")
+        balanced_seed_index = 0
+        for symbol in missing_symbols:
+            if buy_count < sell_count:
+                action = "buy"
+            elif sell_count < buy_count:
+                action = "sell"
+            else:
+                action = (
+                    first_action if balanced_seed_index % 2 == 0 else second_action
+                )
+                balanced_seed_index += 1
+            actions[symbol] = action
+            if action == "buy":
+                buy_count += 1
+            else:
+                sell_count += 1
+    return actions
+
+
+def _pair_probe_balance_state(actions: Mapping[str, str]) -> str:
+    buy_count = sum(1 for action in actions.values() if action == "buy")
+    sell_count = sum(1 for action in actions.values() if action == "sell")
+    if buy_count > 0 and buy_count == sell_count:
+        return "balanced"
+    return "imbalanced"
+
+
 def _target_allows_strategy_universe_probe_fallback(
     target: Mapping[str, object],
 ) -> bool:
@@ -1431,10 +1501,31 @@ def _next_paper_route_runtime_window_targets(
             strategy_names_from_strategy_id(strategy_id),
             derived_strategy_name_from_strategy_id(strategy_id),
         )
+        pair_balance_target = {
+            **dict(target),
+            "strategy_name": canonical_strategy_name or strategy_name or "",
+            "runtime_strategy_name": canonical_strategy_name
+            or runtime_strategy_name
+            or strategy_name
+            or "",
+        }
+        pair_balance_required = _target_requires_balanced_pair_probe(
+            pair_balance_target
+        )
+        pair_symbol_actions = _balanced_pair_probe_symbol_actions(
+            pair_balance_target,
+            target_probe_symbols,
+        )
+        pair_balance_state = (
+            _pair_probe_balance_state(pair_symbol_actions)
+            if pair_balance_required
+            else "not_required"
+        )
         target_probe_ready = (
             bool(probe.get("configured_enabled"))
             and _safe_decimal(next_notional) > 0
             and bool(target_probe_symbols)
+            and pair_balance_state != "imbalanced"
         )
         source_manifest_ref = _safe_text(target.get("source_manifest_ref"))
         missing = [
@@ -1457,6 +1548,8 @@ def _next_paper_route_runtime_window_targets(
                     reasons.append("paper_route_probe_notional_missing")
                 if not target_probe_symbols:
                     reasons.append("paper_route_probe_symbol_missing")
+                if pair_balance_state == "imbalanced":
+                    reasons.append("paper_route_probe_pair_imbalanced")
             skipped_targets.append(
                 {
                     "hypothesis_id": hypothesis_id,
@@ -1577,6 +1670,11 @@ def _next_paper_route_runtime_window_targets(
                 *health_gate_blockers,
                 *_unique_text_items(source_decision_readiness.get("blockers")),
                 *account_pre_session_blockers,
+                *(
+                    ["paper_route_probe_pair_imbalanced"]
+                    if pair_balance_state == "imbalanced"
+                    else []
+                ),
             ]
         )
         evidence_collection_ok = not evidence_collection_blockers
@@ -1620,6 +1718,9 @@ def _next_paper_route_runtime_window_targets(
             "paper_route_probe_symbols": target_probe_symbols,
             "paper_route_probe_symbol_count": len(target_probe_symbols),
             "paper_route_probe_raw_target_symbols": raw_target_probe_symbols,
+            "paper_route_probe_symbol_actions": pair_symbol_actions,
+            "paper_route_probe_pair_balance_required": pair_balance_required,
+            "paper_route_probe_pair_balance_state": pair_balance_state,
             "paper_route_probe_strategy_scope_applied": bool(strategy_universe_symbols),
             "paper_route_probe_strategy_universe_fallback": (
                 strategy_universe_probe_fallback
@@ -4093,6 +4194,16 @@ def _next_paper_route_target_summaries(
                 "account_label": _safe_text(target.get("account_label")),
                 "source_kind": _safe_text(target.get("source_kind")),
                 "symbols": _unique_text_items(target.get("paper_route_probe_symbols")),
+                "symbol_actions": dict(
+                    _as_mapping(target.get("paper_route_probe_symbol_actions"))
+                ),
+                "pair_balance_required": bool(
+                    target.get("paper_route_probe_pair_balance_required")
+                ),
+                "pair_balance_state": _safe_text(
+                    target.get("paper_route_probe_pair_balance_state")
+                )
+                or "not_required",
                 "session_start": _safe_text(target.get("window_start")),
                 "session_end": _safe_text(target.get("window_end")),
                 "next_session_max_notional": _safe_text(

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -234,6 +234,113 @@ def _target_probe_exit_minute_after_open(
     return None, False
 
 
+def _target_strategy_family_tokens(target: Mapping[str, Any]) -> set[str]:
+    tokens: set[str] = set()
+    for key in (
+        "strategy_family",
+        "strategy_name",
+        "runtime_strategy_name",
+        "strategy_id",
+        "universe_type",
+    ):
+        value = _safe_text(target.get(key))
+        if value:
+            tokens.add(value.strip().lower().replace("-", "_"))
+    return tokens
+
+
+def _target_requires_balanced_pair_legs(target: Mapping[str, Any]) -> bool:
+    explicit = _target_bool(target.get("paper_route_probe_pair_balance_required"))
+    if explicit is not None:
+        return explicit
+    return any(
+        "microbar_cross_sectional_pairs" in token
+        for token in _target_strategy_family_tokens(target)
+    )
+
+
+def _target_probe_symbol_actions(
+    target: Mapping[str, Any],
+    symbols: Sequence[str],
+) -> dict[str, Literal["buy", "sell"]]:
+    normalized_symbols = [
+        symbol.strip().upper() for symbol in symbols if symbol.strip()
+    ]
+    actions: dict[str, Literal["buy", "sell"]] = {}
+    raw_actions = target.get("paper_route_probe_symbol_actions")
+    if isinstance(raw_actions, Mapping):
+        for raw_symbol, raw_action in cast(
+            Mapping[object, object], raw_actions
+        ).items():
+            symbol = str(raw_symbol).strip().upper()
+            action = str(raw_action or "").strip().lower()
+            if symbol in normalized_symbols and action in {"buy", "long"}:
+                actions[symbol] = "buy"
+            elif symbol in normalized_symbols and action in {"sell", "short"}:
+                actions[symbol] = "sell"
+    elif isinstance(raw_actions, Sequence) and not isinstance(
+        raw_actions, (str, bytes, bytearray)
+    ):
+        for raw_item in cast(Sequence[object], raw_actions):
+            if not isinstance(raw_item, Mapping):
+                continue
+            item = cast(Mapping[str, object], raw_item)
+            symbol = str(item.get("symbol") or "").strip().upper()
+            action = str(item.get("action") or item.get("side") or "").strip().lower()
+            if symbol in normalized_symbols and action in {"buy", "long"}:
+                actions[symbol] = "buy"
+            elif symbol in normalized_symbols and action in {"sell", "short"}:
+                actions[symbol] = "sell"
+
+    missing_symbols = [symbol for symbol in normalized_symbols if symbol not in actions]
+    if missing_symbols and _target_requires_balanced_pair_legs(target):
+        selection_mode = (
+            str(target.get("selection_mode") or "continuation").strip().lower()
+        )
+        first_action: Literal["buy", "sell"] = (
+            "sell" if selection_mode == "reversal" else "buy"
+        )
+        second_action: Literal["buy", "sell"] = (
+            "buy" if first_action == "sell" else "sell"
+        )
+        buy_count = sum(1 for action in actions.values() if action == "buy")
+        sell_count = sum(1 for action in actions.values() if action == "sell")
+        balanced_seed_index = 0
+        for symbol in missing_symbols:
+            if buy_count < sell_count:
+                action = "buy"
+            elif sell_count < buy_count:
+                action = "sell"
+            else:
+                action = (
+                    first_action if balanced_seed_index % 2 == 0 else second_action
+                )
+                balanced_seed_index += 1
+            actions[symbol] = action
+            if action == "buy":
+                buy_count += 1
+            else:
+                sell_count += 1
+
+    default_action = _target_probe_action(target)
+    return {
+        symbol: actions.get(symbol, default_action) for symbol in normalized_symbols
+    }
+
+
+def _target_pair_balance_state(
+    target: Mapping[str, Any],
+    symbol_actions: Mapping[str, Literal["buy", "sell"]],
+) -> str:
+    if not _target_requires_balanced_pair_legs(target):
+        return "not_required"
+    buy_count = sum(1 for action in symbol_actions.values() if action == "buy")
+    sell_count = sum(1 for action in symbol_actions.values() if action == "sell")
+    if buy_count > 0 and buy_count == sell_count:
+        return "balanced"
+    return "imbalanced"
+
+
 def _target_truthy(value: object) -> bool:
     if isinstance(value, bool):
         return value
@@ -2470,10 +2577,31 @@ class SimpleTradingPipeline(TradingPipeline):
                 symbols = [symbol for symbol in symbols if symbol in normalized_allowed]
             if strategy_symbols:
                 symbols = [symbol for symbol in symbols if symbol in strategy_symbols]
-            action = _target_probe_action(target)
-            if action == "sell" and not settings.trading_allow_shorts:
+            symbol_actions = _target_probe_symbol_actions(target, symbols)
+            pair_balance_state = _target_pair_balance_state(target, symbol_actions)
+            if pair_balance_state == "imbalanced":
+                logger.warning(
+                    "Skipping imbalanced paper-route pair target strategy=%s symbols=%s actions=%s",
+                    strategy.name,
+                    symbols,
+                    symbol_actions,
+                )
+                continue
+            if (
+                pair_balance_state == "balanced"
+                and any(action == "sell" for action in symbol_actions.values())
+                and not settings.trading_allow_shorts
+            ):
+                logger.warning(
+                    "Skipping balanced paper-route pair target because shorts are disabled strategy=%s symbols=%s",
+                    strategy.name,
+                    symbols,
+                )
                 continue
             for symbol in symbols:
+                action = symbol_actions.get(symbol, _target_probe_action(target))
+                if action == "sell" and not settings.trading_allow_shorts:
+                    continue
                 if self._paper_route_target_symbol_has_open_position(
                     positions,
                     symbol,
@@ -2502,12 +2630,21 @@ class SimpleTradingPipeline(TradingPipeline):
                     window_end=window_end,
                     max_notional=target_cap,
                 )
+                metadata["paper_route_probe_symbol_actions"] = dict(symbol_actions)
+                metadata["paper_route_probe_pair_balance_required"] = (
+                    pair_balance_state != "not_required"
+                )
+                metadata["paper_route_probe_pair_balance_state"] = pair_balance_state
+                metadata["paper_route_probe_leg_action"] = action
                 simple_lane = {
                     "source": "external_target_plan_url",
                     "target_plan_source_decision": True,
                     "paper_route_probe_max_notional": str(target_cap),
                     "paper_route_probe_window_start": window_start.isoformat(),
                     "paper_route_probe_window_end": window_end.isoformat(),
+                    "paper_route_probe_symbol_actions": dict(symbol_actions),
+                    "paper_route_probe_pair_balance_state": pair_balance_state,
+                    "paper_route_probe_leg_action": action,
                 }
                 params: dict[str, Any] = {
                     "paper_route_target_plan": metadata,

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -307,6 +307,7 @@ def flatten_paper_account_positions(
     status = "clean" if not positions and not blockers else "blocked"
     cancelled_orders: list[dict[str, Any]] = []
     submitted_orders: list[dict[str, Any]] = []
+    rejected_close_orders: list[dict[str, Any]] = []
     final_positions = positions
     if blockers:
         status = "blocked"
@@ -326,18 +327,36 @@ def flatten_paper_account_positions(
             }
             if extended_hours_limit:
                 extra_params["extended_hours"] = True
-            submitted_orders.append(
-                client.submit_order(
-                    symbol=position.symbol,
-                    side=position.close_side,
-                    qty=float(position.close_qty),
-                    order_type=order_type,
-                    time_in_force="day",
-                    limit_price=float(limit_price) if limit_price is not None else None,
-                    extra_params=extra_params,
+            try:
+                submitted_orders.append(
+                    client.submit_order(
+                        symbol=position.symbol,
+                        side=position.close_side,
+                        qty=float(position.close_qty),
+                        order_type=order_type,
+                        time_in_force="day",
+                        limit_price=float(limit_price)
+                        if limit_price is not None
+                        else None,
+                        extra_params=extra_params,
+                    )
                 )
-            )
-        if wait_flat_seconds > 0:
+            except Exception as exc:
+                rejected_close_orders.append(
+                    {
+                        "symbol": position.symbol,
+                        "side": position.close_side,
+                        "qty": str(position.close_qty),
+                        "order_type": order_type,
+                        "reason": "paper_account_flatten_close_order_rejected",
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    }
+                )
+        if rejected_close_orders:
+            blockers.append("paper_account_flatten_close_order_rejected")
+            status = "failed_close_orders"
+        elif wait_flat_seconds > 0:
             status, final_positions = _wait_until_flat(
                 client=client,
                 deadline_seconds=wait_flat_seconds,
@@ -364,9 +383,13 @@ def flatten_paper_account_positions(
         "max_gross_market_value": str(max_gross_market_value),
         "max_position_count": max_position_count,
         "blockers": blockers,
+        "rejected_close_order_count": len(rejected_close_orders),
+        "rejected_close_orders": rejected_close_orders,
         "extended_hours_limit_missing_symbols": missing_limit_symbols,
         "positions": [_position_payload(position) for position in positions],
-        "final_positions": [_position_payload(position) for position in final_positions],
+        "final_positions": [
+            _position_payload(position) for position in final_positions
+        ],
         "cancelled_order_count": len(cancelled_orders),
         "cancelled_orders": cancelled_orders,
         "submitted_order_count": len(submitted_orders),

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -57,6 +57,31 @@ class FakeFlattenClient:
         return order
 
 
+class RejectingFlattenClient(FakeFlattenClient):
+    def submit_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        time_in_force: str,
+        limit_price: float | None = None,
+        stop_price: float | None = None,
+        extra_params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        _ = (
+            symbol,
+            side,
+            qty,
+            order_type,
+            time_in_force,
+            limit_price,
+            stop_price,
+            extra_params,
+        )
+        raise RuntimeError("simulated close rejection")
+
+
 class SequencedFlattenClient(FakeFlattenClient):
     def __init__(self, position_snapshots: list[list[dict[str, Any]]]) -> None:
         super().__init__(position_snapshots[0] if position_snapshots else [])
@@ -261,6 +286,31 @@ class TestFlattenPaperAccountPositions(TestCase):
         self.assertEqual(payload["status"], "submitted_not_flat")
         self.assertEqual(payload["position_count"], 1)
         self.assertEqual(payload["final_position_count"], 1)
+
+    def test_apply_reports_rejected_close_orders_as_stable_blocker(self) -> None:
+        client = RejectingFlattenClient(
+            [{"symbol": "AMAT", "qty": "2", "side": "long", "current_price": "100"}]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+        )
+
+        self.assertEqual(payload["status"], "failed_close_orders")
+        self.assertIn("paper_account_flatten_close_order_rejected", payload["blockers"])
+        self.assertEqual(payload["rejected_close_order_count"], 1)
+        self.assertEqual(
+            payload["rejected_close_orders"][0]["reason"],
+            "paper_account_flatten_close_order_rejected",
+        )
+        self.assertEqual(payload["submitted_order_count"], 0)
+        self.assertTrue(client.cancelled)
 
     def test_wait_flat_marks_flattened_when_positions_clear(self) -> None:
         client = SequencedFlattenClient(
@@ -548,7 +598,9 @@ class TestFlattenPaperAccountPositions(TestCase):
             patch.object(
                 flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
-            patch.object(flatten_script, "SessionLocal", return_value=FakeSessionContext()),
+            patch.object(
+                flatten_script, "SessionLocal", return_value=FakeSessionContext()
+            ),
             patch.object(
                 flatten_script, "snapshot_account_and_positions", return_value=snapshot
             ) as snapshot_account,
@@ -586,7 +638,9 @@ class TestFlattenPaperAccountPositions(TestCase):
                 flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
             ),
             patch.object(flatten_script, "SessionLocal") as session_local,
-            patch.object(flatten_script, "snapshot_account_and_positions") as snapshot_account,
+            patch.object(
+                flatten_script, "snapshot_account_and_positions"
+            ) as snapshot_account,
             redirect_stdout(StringIO()) as output,
         ):
             exit_code = flatten_script.main()

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -26,9 +26,11 @@ from app.models import (
 from app.trading.paper_route_evidence import (
     RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
     _account_window_start_snapshot_audit,
+    _balanced_pair_probe_symbol_actions,
     _next_regular_equities_session_window,
     _normalized_open_positions,
     _paper_route_probe_summary,
+    _pair_probe_balance_state,
     _runtime_ledger_bucket_evidence_grade,
     _runtime_ledger_non_evidence_diagnostic_summary,
     _runtime_ledger_row_diagnostic_expectancy_bps,
@@ -48,6 +50,20 @@ class TestPaperRouteEvidenceAudit(TestCase):
             poolclass=StaticPool,
         )
         Base.metadata.create_all(self.engine)
+
+    def test_balanced_pair_probe_infers_missing_leg_opposite_existing_action(
+        self,
+    ) -> None:
+        actions = _balanced_pair_probe_symbol_actions(
+            {
+                "strategy_family": "microbar_cross_sectional_pairs",
+                "paper_route_probe_symbol_actions": {"AAPL": "buy"},
+            },
+            ["AAPL", "AMZN"],
+        )
+
+        self.assertEqual(actions, {"AAPL": "buy", "AMZN": "sell"})
+        self.assertEqual(_pair_probe_balance_state(actions), "balanced")
 
     def _runtime_ledger_source_authority_payload(
         self,
@@ -2005,6 +2021,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(target["max_notional"], "0")
         self.assertEqual(target["paper_route_probe_next_session_max_notional"], "63180")
         self.assertEqual(target["paper_route_probe_effective_max_notional"], "63180")
+        self.assertEqual(
+            target["paper_route_probe_symbol_actions"],
+            {"AAPL": "buy", "AMZN": "sell"},
+        )
+        self.assertTrue(target["paper_route_probe_pair_balance_required"])
+        self.assertEqual(target["paper_route_probe_pair_balance_state"], "balanced")
         self.assertTrue(target["evidence_collection_ok"])
         self.assertTrue(target["canary_collection_authorized"])
         self.assertFalse(target["capital_promotion_allowed"])
@@ -2041,6 +2063,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
             summary_target["bounded_evidence_collection_max_notional"], "63180"
         )
         self.assertTrue(summary_target["source_collection_authorized"])
+        self.assertEqual(
+            summary_target["symbol_actions"], {"AAPL": "buy", "AMZN": "sell"}
+        )
+        self.assertTrue(summary_target["pair_balance_required"])
+        self.assertEqual(summary_target["pair_balance_state"], "balanced")
         self.assertEqual(
             summary_target["source_decision_mode"], "route_acquisition_probe"
         )

--- a/services/torghut/tests/test_trading_scheduler_safety.py
+++ b/services/torghut/tests/test_trading_scheduler_safety.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 import json
 import tempfile
 from pathlib import Path
@@ -9,6 +10,12 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from app import config
+from app.models import Strategy
+from app.trading.scheduler.simple_pipeline import (
+    SimpleTradingPipeline,
+    _target_pair_balance_state,
+    _target_probe_symbol_actions,
+)
 from app.trading.scheduler.runtime import TradingScheduler
 from app.trading.scheduler.safety import (
     _coerce_recovery_reason_sequence,
@@ -115,7 +122,9 @@ class TestTradingSchedulerSafety(TestCase):
         scheduler.state.signal_continuity_alert_active = True
         scheduler.state.signal_continuity_alert_reason = "no_signals_in_window"
         scheduler.state.signal_continuity_alert_started_at = datetime.now(timezone.utc)
-        scheduler.state.signal_continuity_alert_last_seen_at = datetime.now(timezone.utc)
+        scheduler.state.signal_continuity_alert_last_seen_at = datetime.now(
+            timezone.utc
+        )
         scheduler.state.signal_continuity_recovery_streak = 2
         scheduler.state.autonomy_no_signal_streak = 4
         scheduler.state.last_evidence_continuity_report = {"status": "stale"}
@@ -123,7 +132,9 @@ class TestTradingSchedulerSafety(TestCase):
         scheduler.state.universe_fail_safe_blocked = True
         scheduler.state.universe_fail_safe_block_reason = "stale_block"
         scheduler.state.emergency_stop_active = True
-        scheduler.state.emergency_stop_reason = "signal_staleness_streak_exceeded:no_signals_in_window:3"
+        scheduler.state.emergency_stop_reason = (
+            "signal_staleness_streak_exceeded:no_signals_in_window:3"
+        )
         scheduler.state.emergency_stop_triggered_at = datetime.now(timezone.utc)
         scheduler.state.emergency_stop_resolved_at = datetime.now(timezone.utc)
         scheduler.state.emergency_stop_recovery_streak = 1
@@ -172,7 +183,73 @@ class TestTradingSchedulerSafety(TestCase):
         self.assertIsNone(scheduler.state.metrics.signal_lag_seconds)
         self.assertEqual(scheduler.state.metrics.signal_continuity_actionable, 0)
         self.assertEqual(scheduler.state.metrics.signal_continuity_alert_active, 0)
-        self.assertEqual(scheduler.state.metrics.signal_continuity_alert_recovery_streak, 0)
+        self.assertEqual(
+            scheduler.state.metrics.signal_continuity_alert_recovery_streak, 0
+        )
+
+    def test_hpairs_target_plan_uses_balanced_pair_actions_and_identity(self) -> None:
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+        }
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="H-PAIRS",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("75000"),
+        )
+
+        symbol_actions = _target_probe_symbol_actions(
+            target,
+            ["AAPL", "AMZN"],
+        )
+        metadata = SimpleTradingPipeline._paper_route_target_source_decision_metadata(
+            target=target,
+            strategy=strategy,
+            symbol="AAPL",
+            window_start=window_start,
+            window_end=window_end,
+            max_notional=Decimal("63180"),
+        )
+        metadata["paper_route_probe_symbol_actions"] = symbol_actions
+        metadata["paper_route_probe_pair_balance_state"] = _target_pair_balance_state(
+            target,
+            symbol_actions,
+        )
+
+        self.assertEqual(symbol_actions, {"AAPL": "buy", "AMZN": "sell"})
+        self.assertEqual(metadata["paper_route_probe_pair_balance_state"], "balanced")
+        self.assertEqual(metadata["candidate_id"], "c88421d619759b2cfaa6f4d0")
+        self.assertEqual(metadata["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(
+            metadata["source_candidate_ids"],
+            ["c88421d619759b2cfaa6f4d0"],
+        )
+        self.assertEqual(metadata["source_hypothesis_ids"], ["H-PAIRS-01"])
+        self.assertFalse(metadata["promotion_allowed"])
+        self.assertFalse(metadata["final_promotion_allowed"])
+
+    def test_hpairs_target_plan_balances_missing_leg_from_existing_action(
+        self,
+    ) -> None:
+        target = {
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "paper_route_probe_symbol_actions": {"AAPL": "buy"},
+        }
+
+        symbol_actions = _target_probe_symbol_actions(target, ["AAPL", "AMZN"])
+
+        self.assertEqual(symbol_actions, {"AAPL": "buy", "AMZN": "sell"})
+        self.assertEqual(_target_pair_balance_state(target, symbol_actions), "balanced")
 
     def test_emergency_stop_triggers_on_signal_lag(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -236,7 +313,9 @@ class TestTradingSchedulerSafety(TestCase):
             self.assertFalse(scheduler.state.emergency_stop_active)
             self.assertEqual(scheduler.state.rollback_incidents_total, 0)
 
-    def test_critical_no_signal_streak_is_suppressed_during_bootstrap_grace(self) -> None:
+    def test_critical_no_signal_streak_is_suppressed_during_bootstrap_grace(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True
@@ -262,7 +341,9 @@ class TestTradingSchedulerSafety(TestCase):
             self.assertFalse(scheduler.state.emergency_stop_active)
             self.assertEqual(scheduler.state.rollback_incidents_total, 0)
 
-    def test_critical_no_signal_streak_triggers_after_bootstrap_grace_expires(self) -> None:
+    def test_critical_no_signal_streak_triggers_after_bootstrap_grace_expires(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config.settings.trading_autonomy_artifact_dir = tmpdir
             config.settings.trading_emergency_stop_enabled = True


### PR DESCRIPTION
## Summary

- Adds H-PAIRS/microbar-pairs balanced paper-route symbol-action metadata to bounded target-plan evidence while keeping capital/final promotion blocked.
- Makes the simple paper route source-decision path consume target-plan per-symbol actions, skip imbalanced pair plans, and carry pair-balance plus hypothesis/candidate diagnostics into submission metadata.
- Reports paper-account flatten close-order submission failures as stable blockers instead of silently succeeding or aborting without structured evidence.
- Integration follow-up: partial explicit pair actions now infer the missing leg on the opposite side so H-PAIRS does not create avoidable same-side paper-route probes.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_strategy_runtime.py tests/test_strategy_specs.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_trading_scheduler_safety.py tests/test_flatten_paper_account_positions.py -q`
- PASS: `cd services/torghut && uv run --frozen ruff check app/trading/strategy_runtime.py app/trading/strategy_specs.py app/trading/runtime_strategy_resolution.py app/trading/paper_route_target_plan.py app/trading/paper_route_evidence.py app/trading/submission_council.py app/trading/scheduler/simple_pipeline.py app/trading/scheduler/pipeline.py app/trading/scheduler/pipeline_helpers.py app/trading/scheduler/runtime.py scripts/flatten_paper_account_positions.py tests/test_strategy_runtime.py tests/test_strategy_specs.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_trading_scheduler_safety.py tests/test_flatten_paper_account_positions.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_balanced_pair_probe_infers_missing_leg_opposite_existing_action tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_hpairs_target_plan_balances_missing_leg_from_existing_action tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_hpairs_target_plan_uses_balanced_pair_actions_and_identity -q`
- PASS: `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/scheduler/simple_pipeline.py tests/test_paper_route_evidence.py tests/test_trading_scheduler_safety.py`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
