### PR TITLE
fix(torghut): repair replay source windows

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -49,6 +49,14 @@ spec:
                     --max-batches 2 \
                     --apply \
                     --json
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_REPLAY \
+                    --batch-size 1000 \
+                    --max-batches 2 \
+                    --backfill-execution-events \
+                    --apply \
+                    --json
                   /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -58,6 +58,14 @@ spec:
                     --max-batches 4 \
                     --apply \
                     --json
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_REPLAY \
+                    --batch-size 100 \
+                    --max-batches 4 \
+                    --backfill-execution-events \
+                    --apply \
+                    --json
                   echo "stage=order_feed_source_window_repair completed_at=$(date -Iseconds)"
               securityContext:
                 seccompProfile:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1292,6 +1292,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--account-label TORGHUT_SIM", args)
         self.assertIn("--batch-size 100", args)
         self.assertIn("--max-batches 4", args)
+        self.assertIn("--account-label TORGHUT_REPLAY", args)
+        self.assertEqual(args.count("scripts/repair_order_feed_source_windows.py"), 3)
+        self.assertEqual(args.count("--dsn-env SIM_DB_DSN"), 2)
+        self.assertEqual(args.count("--backfill-execution-events"), 2)
         self.assertIn("--apply", args)
         self.assertNotIn("scripts/journal_tigerbeetle_order_events.py", args)
         self.assertNotIn("--reconcile-limit 1000", args)
@@ -1490,6 +1494,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--account-label TORGHUT_SIM", args)
         self.assertIn("--batch-size 1000", args)
         self.assertIn("--max-batches 2", args)
+        self.assertIn("--account-label TORGHUT_REPLAY", args)
+        self.assertIn("--backfill-execution-events", args)
+        self.assertEqual(args.count("scripts/repair_order_feed_source_windows.py"), 2)
+        self.assertEqual(args.count("--dsn-env SIM_DB_DSN"), 2)
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "


### PR DESCRIPTION
## Summary

- Repair `TORGHUT_REPLAY` source windows in `SIM_DB_DSN` during the half-hourly source-window CronJob.
- Run the same replay source-window repair before empirical promotion renewal imports runtime windows.
- Extend the live manifest contract tests so both GitOps jobs keep the replay repair path wired.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q -k 'order_feed_source_window_repair_cronjob_is_bounded_live_and_sim or empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db'`
- `uv run --frozen ruff format tests/test_live_config_manifest_contract.py --check`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `git diff --check`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
