### PR TITLE
fix(torghut): seal runtime ledger source authority

### DIFF
--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -33,7 +33,7 @@ _PROMOTION_GRADE_SOURCE_MATERIALIZATIONS = frozenset(
         "source_execution_lifecycle",
     }
 )
-_PROMOTION_GRADE_AUTHORITY_CLASSES = frozenset(
+_PROMOTION_GRADE_AUTHORITY_MARKERS = frozenset(
     {
         "runtime_order_feed_execution_source",
         "event_sourced_runtime_ledger_profit_proof",
@@ -48,6 +48,14 @@ _PROMOTION_GRADE_SOURCE_REF_TABLES = frozenset(
         "executions",
         "execution_order_events",
         "order_feed_source_windows",
+    }
+)
+_NON_PROMOTION_AUTHORITY_MARKERS = frozenset(
+    {
+        "exact_replay",
+        "artifact_only",
+        "replay_artifact",
+        "simulation_source_replay_only",
     }
 )
 
@@ -228,8 +236,34 @@ def _promotion_grade_source_materialization_present(
     )
 
 
-def _promotion_grade_authority_class_present(bucket: Mapping[str, object]) -> bool:
-    return _text(bucket.get("authority_class")) in _PROMOTION_GRADE_AUTHORITY_CLASSES
+def _non_promotion_authority_marker_present(value: object) -> bool:
+    text = _text(value)
+    if text is None:
+        return False
+    normalized = text.lower().replace("-", "_")
+    return any(marker in normalized for marker in _NON_PROMOTION_AUTHORITY_MARKERS)
+
+
+def _promotion_grade_authority_marker_present(bucket: Mapping[str, object]) -> bool:
+    for key in ("authority_class", "authority_reason"):
+        marker = _text(bucket.get(key))
+        if marker in _PROMOTION_GRADE_AUTHORITY_MARKERS:
+            return True
+    return False
+
+
+def _non_promotion_derivation_present(bucket: Mapping[str, object]) -> bool:
+    return any(
+        _non_promotion_authority_marker_present(bucket.get(key))
+        for key in (
+            "authority_class",
+            "authority_reason",
+            "pnl_derivation",
+            "source",
+            "source_kind",
+            "promotion_authority",
+        )
+    )
 
 
 def runtime_ledger_source_window_present(bucket: Mapping[str, object]) -> bool:
@@ -342,11 +376,23 @@ def runtime_ledger_promotion_source_authority_blockers(
         bucket
     ) < _source_row_count(bucket, "execution_order_events"):
         blockers.append(RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER)
-    if not _promotion_grade_source_materialization_present(bucket):
+    if (
+        not _promotion_grade_source_materialization_present(bucket)
+        or _non_promotion_authority_marker_present(bucket.get("source_materialization"))
+    ):
         blockers.append(RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER)
-    if not _promotion_grade_authority_class_present(bucket):
+    if (
+        not _promotion_grade_authority_marker_present(bucket)
+        or _non_promotion_derivation_present(bucket)
+    ):
         blockers.append(RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER)
     return list(dict.fromkeys(blockers))
+
+
+def runtime_ledger_promotion_source_authority_present(
+    bucket: Mapping[str, object],
+) -> bool:
+    return not runtime_ledger_promotion_source_authority_blockers(bucket)
 
 
 __all__ = [
@@ -360,6 +406,7 @@ __all__ = [
     "RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER",
     "RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER",
     "runtime_ledger_promotion_source_authority_blockers",
+    "runtime_ledger_promotion_source_authority_present",
     "runtime_ledger_source_authority_blockers",
     "runtime_ledger_source_refs_present",
     "runtime_ledger_source_window_present",

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -28,6 +28,7 @@ from app.trading.runtime_ledger import (
 )
 from app.trading.runtime_ledger_source_authority import (
     runtime_ledger_promotion_source_authority_blockers,
+    runtime_ledger_promotion_source_authority_present,
 )
 from app.trading.runtime_cost_authority import (
     cost_basis_counts_have_non_promotion_grade_costs,
@@ -1816,15 +1817,7 @@ def _runtime_ledger_tca_materialization_metadata(
         )
         if source_materialization is not None:
             source_materializations.append(source_materialization)
-        if (
-            authority_reason == "source_execution_runtime_ledger_materialized"
-            or authority_reason == "event_sourced_runtime_ledger_profit_proof"
-            or pnl_derivation
-            == "source_execution_lifecycle_materialized_runtime_ledger"
-            or pnl_derivation == "execution_order_events_runtime_ledger"
-            or source_materialization == "source_execution_lifecycle"
-            or source_materialization == "execution_order_events"
-        ):
+        if runtime_ledger_promotion_source_authority_present(bucket_payload):
             source_execution_materialized_count += 1
         if authority_reason == "execution_reconstruction_not_runtime_ledger_proof":
             execution_reconstruction_count += 1

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -806,6 +806,37 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("runtime_ledger_authority_class_missing", blockers)
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(aggregate_only))
 
+    def test_runtime_ledger_materialization_metadata_counts_only_source_backed_authority(
+        self,
+    ) -> None:
+        aggregate_only = _complete_runtime_ledger_bucket(
+            source_window_ids=[],
+            trade_decision_ids=[],
+            execution_ids=[],
+            execution_order_event_ids=[],
+            source_offsets=[],
+            source_materialization="execution_order_events",
+            authority_class="runtime_order_feed_execution_source",
+        )
+        source_backed = _complete_runtime_ledger_bucket()
+
+        metadata = _runtime_ledger_tca_materialization_metadata(
+            [
+                {"runtime_ledger_bucket": aggregate_only},
+                {"runtime_ledger_bucket": source_backed},
+            ]
+        )
+
+        self.assertEqual(
+            metadata["runtime_ledger_source_execution_materialized_bucket_count"],
+            1,
+        )
+        self.assertEqual(metadata["runtime_ledger_tca_profit_proof_count"], 1)
+        self.assertIn(
+            "runtime_ledger_execution_order_event_refs_missing",
+            metadata["runtime_ledger_profit_proof_blockers"],
+        )
+
     def test_runtime_ledger_profit_proof_rejects_modeled_cost_basis(
         self,
     ) -> None:
@@ -1305,6 +1336,56 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "TORGHUT_SIM",
                 ["intraday-tsmom-profit-v3"],
             ),
+        )
+
+    def test_runtime_ledger_tca_rows_from_source_dsn_block_aggregate_only_proof(
+        self,
+    ) -> None:
+        cursor = _SourceLedgerCursor()
+        row = list(cursor._results[0][0])
+        payload = dict(cast(Mapping[str, object], row[-1]))
+        payload.update(
+            {
+                "source_window_ids": [],
+                "trade_decision_ids": [],
+                "execution_ids": [],
+                "execution_order_event_ids": [],
+                "source_offsets": [],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+            }
+        )
+        row[-1] = payload
+        cursor._results[0] = [tuple(row)]
+        connection = _SourceLedgerConnection(cursor)
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            rows, metadata = _runtime_ledger_tca_rows_from_source_dsn(
+                dsn="postgresql://source",
+                candidate_id="H-TSMOM-LIQ-01",
+                hypothesis_id="H-TSMOM-LIQ-01",
+                observed_stage="paper",
+                strategy_names=["intraday-tsmom-profit-v3"],
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+            )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(metadata["runtime_ledger_source_bucket_profit_proof_count"], 0)
+        self.assertIn(
+            "runtime_ledger_trade_decision_refs_missing",
+            metadata["runtime_ledger_source_bucket_profit_proof_blockers"],
+        )
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        self.assertIn(
+            "runtime_ledger_execution_order_event_refs_missing",
+            rows[0]["runtime_ledger_blockers"],
         )
 
     def test_parse_target_metadata_requires_json_mapping(self) -> None:

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 
 from app.trading.runtime_ledger_source_authority import (
     runtime_ledger_promotion_source_authority_blockers,
+    runtime_ledger_promotion_source_authority_present,
     runtime_ledger_source_authority_blockers,
     runtime_ledger_source_refs_present,
     runtime_ledger_source_window_present,
@@ -331,7 +332,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
 
         self.assertIn("runtime_ledger_authority_class_missing", blockers)
 
-    def test_promotion_source_authority_rejects_authority_reason_only(
+    def test_promotion_source_authority_accepts_runtime_authority_reason_only(
         self,
     ) -> None:
         blockers = runtime_ledger_promotion_source_authority_blockers(
@@ -362,7 +363,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             }
         )
 
-        self.assertIn("runtime_ledger_authority_class_missing", blockers)
+        self.assertEqual(blockers, [])
 
     def test_promotion_source_authority_requires_named_source_ref_tables(
         self,
@@ -395,3 +396,49 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
         )
 
         self.assertIn("runtime_ledger_source_refs_missing", blockers)
+
+    def test_promotion_source_authority_rejects_exact_replay_artifact_derivation(
+        self,
+    ) -> None:
+        source_backed = {
+            "source_window_start": "2026-05-29T14:30:00+00:00",
+            "source_window_end": "2026-05-29T15:00:00+00:00",
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+            "source_row_counts": {
+                "trade_decisions": 1,
+                "executions": 1,
+                "execution_order_events": 1,
+                "order_feed_source_windows": 1,
+            },
+            "trade_decision_id": "decision-1",
+            "execution_id": "execution-1",
+            "execution_order_event_id": "event-1",
+            "source_window_id": "source-window-1",
+            "source_offsets": [
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+            ],
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+        }
+
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                **source_backed,
+                "pnl_derivation": "exact_replay_artifact_only_not_live",
+            }
+        )
+
+        self.assertIn("runtime_ledger_authority_class_missing", blockers)
+        self.assertFalse(
+            runtime_ledger_promotion_source_authority_present(
+                {
+                    **source_backed,
+                    "source_materialization": "exact_replay_artifact",
+                }
+            )
+        )


### PR DESCRIPTION
## Summary

- Tightens runtime-ledger promotion source authority so authority can be supplied by explicit runtime/order-feed `authority_class` or `authority_reason`, while exact-replay/artifact-only derivations fail closed.
- Reuses the source-backed authority predicate for runtime-ledger materialization metadata so aggregate-shaped buckets do not count as source materialized authority.
- Adds regressions for aggregate-only source/durable imports, authority-reason source proof, and exact-replay/artifact-only derivation blockers.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_source_authority.py tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q` — passed (288 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_source_authority.py app/trading/runtime_ledger.py app/trading/runtime_window_import.py app/trading/runtime_ledger_proof_policy.py scripts/import_hypothesis_runtime_windows.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py scripts/repair_order_feed_source_windows.py tests/test_runtime_ledger_source_authority.py tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py tests/test_repair_order_feed_source_windows_script.py` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed
- `git diff --check` — passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
