### PR TITLE
test(torghut): cover H-PAIRS pair-balance gates

### DIFF
--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -65,6 +65,18 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(actions, {"AAPL": "buy", "AMZN": "sell"})
         self.assertEqual(_pair_probe_balance_state(actions), "balanced")
 
+    def test_balanced_pair_probe_accepts_explicit_true_and_short_alias(self) -> None:
+        actions = _balanced_pair_probe_symbol_actions(
+            {
+                "paper_route_probe_pair_balance_required": "true",
+                "paper_route_probe_symbol_actions": {"AAPL": "short"},
+            },
+            ["AAPL", "AMZN"],
+        )
+
+        self.assertEqual(actions, {"AAPL": "sell", "AMZN": "buy"})
+        self.assertEqual(_pair_probe_balance_state(actions), "balanced")
+
     def _runtime_ledger_source_authority_payload(
         self,
         *,

--- a/services/torghut/tests/test_trading_scheduler_safety.py
+++ b/services/torghut/tests/test_trading_scheduler_safety.py
@@ -52,6 +52,10 @@ class TestTradingSchedulerSafety(TestCase):
             "trading_emergency_stop_enabled": config.settings.trading_emergency_stop_enabled,
             "trading_simulation_enabled": config.settings.trading_simulation_enabled,
             "trading_allow_shorts": config.settings.trading_allow_shorts,
+            "trading_mode": config.settings.trading_mode,
+            "trading_simple_paper_route_probe_enabled": (
+                config.settings.trading_simple_paper_route_probe_enabled
+            ),
             "trading_emergency_stop_recovery_cycles": config.settings.trading_emergency_stop_recovery_cycles,
             "trading_rollback_signal_lag_seconds_limit": config.settings.trading_rollback_signal_lag_seconds_limit,
             "trading_rollback_fallback_ratio_limit": config.settings.trading_rollback_fallback_ratio_limit,
@@ -82,6 +86,10 @@ class TestTradingSchedulerSafety(TestCase):
             "trading_simulation_enabled"
         ]
         config.settings.trading_allow_shorts = self._snapshot["trading_allow_shorts"]
+        config.settings.trading_mode = self._snapshot["trading_mode"]
+        config.settings.trading_simple_paper_route_probe_enabled = self._snapshot[
+            "trading_simple_paper_route_probe_enabled"
+        ]
         config.settings.trading_emergency_stop_recovery_cycles = self._snapshot[
             "trading_emergency_stop_recovery_cycles"
         ]
@@ -250,6 +258,141 @@ class TestTradingSchedulerSafety(TestCase):
 
         self.assertEqual(symbol_actions, {"AAPL": "buy", "AMZN": "sell"})
         self.assertEqual(_target_pair_balance_state(target, symbol_actions), "balanced")
+
+    def test_hpairs_target_plan_parses_sequence_symbol_actions(self) -> None:
+        target = {
+            "paper_route_probe_pair_balance_required": False,
+            "paper_route_probe_symbol_actions": [
+                {"symbol": "AAPL", "action": "long"},
+                {"symbol": "AMZN", "side": "short"},
+            ],
+        }
+
+        symbol_actions = _target_probe_symbol_actions(target, ["AAPL", "AMZN"])
+
+        self.assertEqual(symbol_actions, {"AAPL": "buy", "AMZN": "sell"})
+        self.assertEqual(
+            _target_pair_balance_state(target, symbol_actions),
+            "not_required",
+        )
+
+    def test_hpairs_target_plan_balances_missing_buy_from_existing_short(
+        self,
+    ) -> None:
+        target = {
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "paper_route_probe_symbol_actions": {"AAPL": "short"},
+        }
+
+        symbol_actions = _target_probe_symbol_actions(target, ["AAPL", "AMZN"])
+
+        self.assertEqual(symbol_actions, {"AAPL": "sell", "AMZN": "buy"})
+        self.assertEqual(_target_pair_balance_state(target, symbol_actions), "balanced")
+
+    def test_hpairs_target_plan_marks_unbalanced_actions_imbalanced(self) -> None:
+        target = {"paper_route_probe_pair_balance_required": True}
+
+        self.assertEqual(
+            _target_pair_balance_state(target, {"AAPL": "buy"}),
+            "imbalanced",
+        )
+
+    def test_paper_route_source_decisions_skip_imbalanced_pair_targets(self) -> None:
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        target = {
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "paper_route_probe_pair_balance_required": True,
+            "paper_route_probe_symbols": ["AAPL", "AMZN", "MSFT"],
+            "paper_route_probe_symbol_actions": {
+                "AAPL": "buy",
+                "AMZN": "sell",
+                "MSFT": "buy",
+            },
+            "paper_route_probe_next_session_max_notional": "1000",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+        }
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN", "MSFT"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "_is_market_session_open", lambda _now: True)
+        setattr(
+            pipeline,
+            "_external_paper_route_target_probe_symbols_cached",
+            lambda: ({"AAPL", "AMZN", "MSFT"}, None, [target]),
+        )
+        setattr(pipeline, "_paper_route_target_strategy", lambda _target, _strategies: strategy)
+        setattr(
+            pipeline,
+            "_paper_route_target_strategy_symbols",
+            lambda _strategy: {"AAPL", "AMZN", "MSFT"},
+        )
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = True
+
+        with patch("app.trading.scheduler.simple_pipeline.trading_now", return_value=window_start):
+            decisions = pipeline._paper_route_target_source_decisions(
+                strategies=[strategy],
+                allowed_symbols=set(),
+            )
+
+        self.assertEqual(decisions, [])
+
+    def test_paper_route_source_decisions_skip_balanced_pair_when_shorts_disabled(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        target = {
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_symbol_actions": {"AAPL": "buy", "AMZN": "sell"},
+            "paper_route_probe_next_session_max_notional": "1000",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+        }
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "_is_market_session_open", lambda _now: True)
+        setattr(
+            pipeline,
+            "_external_paper_route_target_probe_symbols_cached",
+            lambda: ({"AAPL", "AMZN"}, None, [target]),
+        )
+        setattr(pipeline, "_paper_route_target_strategy", lambda _target, _strategies: strategy)
+        setattr(
+            pipeline,
+            "_paper_route_target_strategy_symbols",
+            lambda _strategy: {"AAPL", "AMZN"},
+        )
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = False
+
+        with patch("app.trading.scheduler.simple_pipeline.trading_now", return_value=window_start):
+            decisions = pipeline._paper_route_target_source_decisions(
+                strategies=[strategy],
+                allowed_symbols=set(),
+            )
+
+        self.assertEqual(decisions, [])
 
     def test_emergency_stop_triggers_on_signal_lag(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Adds focused regression coverage for H-PAIRS pair-balance helper branches that were uncovered after PR #9385 merged.
- Exercises explicit pair-balance flags, short/sell aliases, sequence-form symbol actions, and imbalanced target diagnostics.
- Covers scheduler skips for imbalanced pair targets and balanced pair targets when shorts are disabled so main Torghut diff coverage can pass.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check tests/test_paper_route_evidence.py tests/test_trading_scheduler_safety.py`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_balanced_pair_probe_accepts_explicit_true_and_short_alias tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_hpairs_target_plan_parses_sequence_symbol_actions tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_hpairs_target_plan_balances_missing_buy_from_existing_short tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_hpairs_target_plan_marks_unbalanced_actions_imbalanced tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_paper_route_source_decisions_skip_imbalanced_pair_targets tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_paper_route_source_decisions_skip_balanced_pair_when_shorts_disabled -q`
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_runtime.py tests/test_strategy_specs.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_trading_scheduler_safety.py tests/test_flatten_paper_account_positions.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/strategy_runtime.py app/trading/strategy_specs.py app/trading/runtime_strategy_resolution.py app/trading/paper_route_target_plan.py app/trading/paper_route_evidence.py app/trading/submission_council.py app/trading/scheduler/simple_pipeline.py app/trading/scheduler/pipeline.py app/trading/scheduler/pipeline_helpers.py app/trading/scheduler/runtime.py scripts/flatten_paper_account_positions.py tests/test_strategy_runtime.py tests/test_strategy_specs.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_trading_scheduler_safety.py tests/test_flatten_paper_account_positions.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
