### PR TITLE
feat(torghut): bound hpairs replay frontier staging

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -17,7 +17,10 @@ from app.trading.models import SignalEnvelope
 
 FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v2"
 FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v3"
-FAST_REPLAY_PROOF_SEMANTICS_LABEL = "preview_ranking_only_exact_replay_and_runtime_ledger_required"
+FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
+    "preview_ranking_only_exact_replay_and_runtime_ledger_required"
+)
+FAST_REPLAY_TARGET_NET_PNL_PER_DAY = Decimal("500")
 FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "cluster_lob_event_clustering_proxy",
     "ofi_horizon_decay_regime_screen",
@@ -59,6 +62,11 @@ class FastReplayPreviewRow:
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
 
     def to_payload(self) -> dict[str, Any]:
+        observed_post_cost_expectancy_bps = _observed_post_cost_expectancy_bps(self)
+        required_daily_notional = _required_daily_notional_for_target(
+            observed_post_cost_expectancy_bps
+        )
+        lineage_blockers = _lineage_blockers_for_row(self)
         return {
             "schema_version": FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION,
             "candidate_spec_id": self.candidate_spec_id,
@@ -84,12 +92,50 @@ class FastReplayPreviewRow:
             "ofi_decay_alignment_score": str(self.ofi_decay_alignment_score),
             "liquidity_regime_score": str(self.liquidity_regime_score),
             "macro_stress_veto_score": str(self.macro_stress_veto_score),
-            "conformal_tail_risk_penalty_bps": str(self.conformal_tail_risk_penalty_bps),
+            "conformal_tail_risk_penalty_bps": str(
+                self.conformal_tail_risk_penalty_bps
+            ),
             "square_root_impact_capacity_penalty_bps": str(
                 self.square_root_impact_capacity_penalty_bps
             ),
             "exploration_score": str(self.exploration_score),
             "frontier_bucket": self.frontier_bucket,
+            "observed_post_cost_expectancy_bps": str(observed_post_cost_expectancy_bps),
+            "required_daily_notional": str(required_daily_notional)
+            if required_daily_notional is not None
+            else None,
+            "target_implied_notional_context": {
+                "target_net_pnl_per_day": str(FAST_REPLAY_TARGET_NET_PNL_PER_DAY),
+                "observed_post_cost_expectancy_bps": str(
+                    observed_post_cost_expectancy_bps
+                ),
+                "required_daily_notional": str(required_daily_notional)
+                if required_daily_notional is not None
+                else None,
+                "feasibility_status": "unknown_source_backed_adv_required",
+                "prefilter_only": True,
+            },
+            "cost_impact_lineage": {
+                "status": "preview_prefilter_only",
+                "source": "manifest_verified_replay_tape",
+                "cost_basis": "signed_return_minus_spread_plus_square_root_impact_penalty",
+                "median_spread_bps": str(self.median_spread_bps),
+                "impact_liquidity_penalty_bps": str(self.impact_liquidity_penalty_bps),
+                "square_root_impact_capacity_penalty_bps": str(
+                    self.square_root_impact_capacity_penalty_bps
+                ),
+                "observed_post_cost_expectancy_bps": str(
+                    observed_post_cost_expectancy_bps
+                ),
+            },
+            "adv_capacity_context": {
+                "status": "missing_source_backed_adv",
+                "source": "missing_external_adv_source",
+                "as_of": None,
+                "as_of_status": "missing",
+                "prefilter_only": True,
+            },
+            "lineage_blockers": list(lineage_blockers),
             "proof_semantics_label": self.proof_semantics_label,
             "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
             "promotion_proof": False,
@@ -221,7 +267,9 @@ def build_fast_replay_preview(
         _row_with_rank_and_selection(
             row=row,
             rank=index,
-            frontier_bucket=selected_bucket_by_id.get(row.candidate_spec_id, "not_selected"),
+            frontier_bucket=selected_bucket_by_id.get(
+                row.candidate_spec_id, "not_selected"
+            ),
         )
         for index, row in enumerate(ranked_rows, start=1)
     )
@@ -282,7 +330,9 @@ def _build_symbol_stats(rows: Sequence[SignalEnvelope]) -> dict[str, _SymbolTape
         volume_values = [
             volume for row in ordered if (volume := _extract_volume(row)) is not None
         ]
-        abs_returns = np.abs(returns) if returns.size else np.asarray([], dtype=np.float64)
+        abs_returns = (
+            np.abs(returns) if returns.size else np.asarray([], dtype=np.float64)
+        )
         stats[symbol] = _SymbolTapeStats(
             symbol=symbol,
             row_count=len(ordered),
@@ -325,7 +375,9 @@ def _score_candidate_spec(
     min_rows_per_candidate: int,
 ) -> FastReplayPreviewRow:
     requested_symbols = _candidate_symbols(spec)
-    matched = [stat for symbol in requested_symbols if (stat := symbol_stats.get(symbol))]
+    matched = [
+        stat for symbol in requested_symbols if (stat := symbol_stats.get(symbol))
+    ]
     matched_row_count = sum(stat.row_count for stat in matched)
     requested_symbol_count = len(requested_symbols)
     matched_symbol_count = len(matched)
@@ -339,7 +391,9 @@ def _score_candidate_spec(
             matched_row_count=matched_row_count,
             matched_symbol_count=matched_symbol_count,
             requested_symbol_count=requested_symbol_count,
-            trading_day_count=max((stat.trading_day_count for stat in matched), default=0),
+            trading_day_count=max(
+                (stat.trading_day_count for stat in matched), default=0
+            ),
             signed_return_bps=Decimal("0"),
             avg_abs_return_bps=Decimal("0"),
             median_spread_bps=Decimal("0"),
@@ -361,9 +415,15 @@ def _score_candidate_spec(
         )
 
     return_vectors = [stat.returns_bps for stat in matched if stat.returns_bps.size]
-    returns = np.concatenate(return_vectors) if return_vectors else np.asarray([], dtype=np.float64)
+    returns = (
+        np.concatenate(return_vectors)
+        if return_vectors
+        else np.asarray([], dtype=np.float64)
+    )
     direction = _candidate_direction(spec)
-    signed_returns = returns * direction if returns.size else np.asarray([], dtype=np.float64)
+    signed_returns = (
+        returns * direction if returns.size else np.asarray([], dtype=np.float64)
+    )
     signed_return_bps = float(np.mean(signed_returns)) if signed_returns.size else 0.0
     avg_abs_return_bps = float(np.mean(np.abs(returns))) if returns.size else 0.0
     median_spread_bps = float(np.median([stat.median_spread_bps for stat in matched]))
@@ -377,7 +437,9 @@ def _score_candidate_spec(
     microprice_bias_bps = _weighted_average(
         [(stat.microprice_bias_bps, stat.row_count) for stat in matched]
     )
-    return_tail_abs_bps = float(np.median([stat.return_tail_abs_bps for stat in matched]))
+    return_tail_abs_bps = float(
+        np.median([stat.return_tail_abs_bps for stat in matched])
+    )
     median_volume = float(np.median([stat.median_volume for stat in matched]))
     median_price = float(np.median([stat.median_price for stat in matched]))
     activity_score = float(np.log1p(matched_row_count))
@@ -454,7 +516,9 @@ def _score_candidate_spec(
         ofi_decay_alignment_score=_decimal_from_float(ofi_decay_alignment_score),
         liquidity_regime_score=_decimal_from_float(liquidity_regime_score),
         macro_stress_veto_score=_decimal_from_float(macro_stress_veto_score),
-        conformal_tail_risk_penalty_bps=_decimal_from_float(conformal_tail_risk_penalty_bps),
+        conformal_tail_risk_penalty_bps=_decimal_from_float(
+            conformal_tail_risk_penalty_bps
+        ),
         square_root_impact_capacity_penalty_bps=_decimal_from_float(
             square_root_impact_capacity_penalty_bps
         ),
@@ -478,7 +542,11 @@ def _select_frontier_buckets(
     exploration_count: int,
     exact_replay_candidate_cap: int,
 ) -> dict[str, str]:
-    eligible = [row for row in ranked_rows if row.selection_reason != "insufficient_replay_tape_rows"]
+    eligible = [
+        row
+        for row in ranked_rows
+        if row.selection_reason != "insufficient_replay_tape_rows"
+    ]
     selected: dict[str, str] = {}
     for row in eligible[:exploitation_count]:
         if len(selected) >= exact_replay_candidate_cap:
@@ -560,7 +628,9 @@ def _ewma_last(values: NDArray[np.float64], *, half_life: float) -> float:
     return float(np.sum(values * weights) / total)
 
 
-def _cluster_lob_activity_score(rows: Sequence[SignalEnvelope], ofi_values: NDArray[np.float64]) -> float:
+def _cluster_lob_activity_score(
+    rows: Sequence[SignalEnvelope], ofi_values: NDArray[np.float64]
+) -> float:
     event_labels = [_event_label(row) for row in rows]
     label_entropy = _normalized_entropy(event_labels)
     pressure = float(np.mean(np.abs(ofi_values))) if ofi_values.size else 0.0
@@ -569,12 +639,21 @@ def _cluster_lob_activity_score(rows: Sequence[SignalEnvelope], ofi_values: NDAr
         burstiness = float(np.clip(np.percentile(changes, 75), 0.0, 1.0))
     else:
         burstiness = 0.0
-    return float(np.clip(0.35 * label_entropy + 0.45 * pressure + 0.20 * burstiness, 0.0, 1.0))
+    return float(
+        np.clip(0.35 * label_entropy + 0.45 * pressure + 0.20 * burstiness, 0.0, 1.0)
+    )
 
 
 def _event_label(signal: SignalEnvelope) -> str:
     payload = signal.payload
-    for key in ("cluster_lob_label", "order_cluster", "event_type", "order_event_type", "side", "liquidity_side"):
+    for key in (
+        "cluster_lob_label",
+        "order_cluster",
+        "event_type",
+        "order_event_type",
+        "side",
+        "liquidity_side",
+    ):
         value = str(payload.get(key) or "").strip().lower()
         if value:
             return value
@@ -589,7 +668,9 @@ def _normalized_entropy(labels: Sequence[str]) -> float:
         counts[label] = counts.get(label, 0) + 1
     if len(counts) <= 1:
         return 0.0
-    probabilities = np.asarray([count / len(labels) for count in counts.values()], dtype=np.float64)
+    probabilities = np.asarray(
+        [count / len(labels) for count in counts.values()], dtype=np.float64
+    )
     entropy = -float(np.sum(probabilities * np.log(probabilities)))
     return float(np.clip(entropy / np.log(len(counts)), 0.0, 1.0))
 
@@ -604,7 +685,13 @@ def _liquidity_regime_score(
     tight_spread_score = 1.0 / (1.0 + max(0.0, median_spread) / 10.0)
     volume_score = float(np.clip(np.log1p(max(0.0, median_volume)) / 12.0, 0.0, 1.0))
     coverage_score = float(np.clip(np.log1p(row_count) / 8.0, 0.0, 1.0))
-    return float(np.clip(0.45 * tight_spread_score + 0.35 * volume_score + 0.20 * coverage_score, 0.0, 1.0))
+    return float(
+        np.clip(
+            0.45 * tight_spread_score + 0.35 * volume_score + 0.20 * coverage_score,
+            0.0,
+            1.0,
+        )
+    )
 
 
 def _macro_stress_veto_score(rows: Sequence[SignalEnvelope]) -> float:
@@ -654,7 +741,11 @@ def _conformal_tail_risk_penalty_bps(signed_returns_bps: NDArray[np.float64]) ->
 
 
 def _square_root_impact_capacity_penalty_bps(
-    *, spec: CandidateSpec, median_price: float, median_volume: float, median_spread_bps: float
+    *,
+    spec: CandidateSpec,
+    median_price: float,
+    median_volume: float,
+    median_spread_bps: float,
 ) -> float:
     notional = _candidate_notional(spec)
     if notional <= 0.0:
@@ -663,7 +754,13 @@ def _square_root_impact_capacity_penalty_bps(
     if dollar_volume <= 0.0:
         return 25.0 + median_spread_bps
     participation = notional / dollar_volume
-    return float(np.clip(np.sqrt(max(0.0, participation)) * 100.0 + median_spread_bps * 0.25, 0.0, 500.0))
+    return float(
+        np.clip(
+            np.sqrt(max(0.0, participation)) * 100.0 + median_spread_bps * 0.25,
+            0.0,
+            500.0,
+        )
+    )
 
 
 def _candidate_notional(spec: CandidateSpec) -> float:
@@ -675,7 +772,9 @@ def _candidate_symbols(spec: CandidateSpec) -> tuple[str, ...]:
     if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
         raw_symbols = cast(Sequence[Any], raw)
         symbols = tuple(
-            sorted({_string(item).upper() for item in raw_symbols if _string(item).strip()})
+            sorted(
+                {_string(item).upper() for item in raw_symbols if _string(item).strip()}
+            )
         )
         if symbols:
             return symbols
@@ -695,7 +794,9 @@ def _candidate_direction(spec: CandidateSpec) -> float:
         )
         if item
     ).lower()
-    if any(token in text for token in ("reversal", "rebound", "washout", "mean_revert")):
+    if any(
+        token in text for token in ("reversal", "rebound", "washout", "mean_revert")
+    ):
         return -1.0
     return 1.0
 
@@ -753,11 +854,25 @@ def _extract_quote_depth_imbalance(signal: SignalEnvelope) -> float | None:
     payload = signal.payload
     bid_size = _first_float(
         payload,
-        ("bid_size", "bid_qty", "best_bid_size", "best_bid_qty", "bid_depth", "bid_volume"),
+        (
+            "bid_size",
+            "bid_qty",
+            "best_bid_size",
+            "best_bid_qty",
+            "bid_depth",
+            "bid_volume",
+        ),
     )
     ask_size = _first_float(
         payload,
-        ("ask_size", "ask_qty", "best_ask_size", "best_ask_qty", "ask_depth", "ask_volume"),
+        (
+            "ask_size",
+            "ask_qty",
+            "best_ask_size",
+            "best_ask_qty",
+            "ask_depth",
+            "ask_volume",
+        ),
     )
     if (
         bid_size is None
@@ -779,8 +894,12 @@ def _extract_microprice_bias_bps(signal: SignalEnvelope) -> float | None:
     if explicit_microprice is not None and price is not None and price > 0.0:
         return (explicit_microprice - price) / price * 10_000.0
 
-    bid_size = _first_float(payload, ("bid_size", "bid_qty", "best_bid_size", "best_bid_qty"))
-    ask_size = _first_float(payload, ("ask_size", "ask_qty", "best_ask_size", "best_ask_qty"))
+    bid_size = _first_float(
+        payload, ("bid_size", "bid_qty", "best_bid_size", "best_bid_qty")
+    )
+    ask_size = _first_float(
+        payload, ("ask_size", "ask_qty", "best_ask_size", "best_ask_qty")
+    )
     if (
         bid is None
         or ask is None
@@ -847,6 +966,31 @@ def _float_or_none(value: Any) -> float | None:
 
 def _decimal_from_float(value: float) -> Decimal:
     return Decimal(str(round(float(value), 8)))
+
+
+def _observed_post_cost_expectancy_bps(row: FastReplayPreviewRow) -> Decimal:
+    return (
+        row.signed_return_bps - row.median_spread_bps - row.impact_liquidity_penalty_bps
+    )
+
+
+def _required_daily_notional_for_target(expectancy_bps: Decimal) -> Decimal | None:
+    if expectancy_bps <= 0:
+        return None
+    return FAST_REPLAY_TARGET_NET_PNL_PER_DAY / (expectancy_bps / Decimal("10000"))
+
+
+def _lineage_blockers_for_row(row: FastReplayPreviewRow) -> tuple[str, ...]:
+    blockers = [
+        "source_backed_adv_missing",
+        "adv_as_of_missing",
+        "source_backed_cost_impact_model_required",
+        "exact_replay_required",
+        "live_paper_runtime_ledger_required",
+    ]
+    if _observed_post_cost_expectancy_bps(row) <= 0:
+        blockers.append("positive_post_cost_expectancy_missing")
+    return tuple(blockers)
 
 
 def _mapping(value: Any) -> dict[str, Any]:

--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -58,6 +58,9 @@ class ReplayTapeManifest:
     artifact_refs: Mapping[str, str]
     source_table_versions: Mapping[str, str]
     created_at: datetime
+    feature_schema_hash: str = ""
+    cost_model_hash: str = ""
+    strategy_family: str = ""
     replay_cache_key: str = ""
     requested_trading_days: tuple[date, ...] = ()
     observed_trading_days: tuple[date, ...] = ()
@@ -90,6 +93,9 @@ class ReplayTapeManifest:
             "row_count": self.row_count,
             "source_query_digest": self.source_query_digest,
             "content_sha256": self.content_sha256,
+            "feature_schema_hash": self.feature_schema_hash,
+            "cost_model_hash": self.cost_model_hash,
+            "strategy_family": self.strategy_family,
             "replay_cache_key": self.replay_cache_key,
             "artifact_refs": dict(self.artifact_refs),
             "source_table_versions": dict(self.source_table_versions),
@@ -143,6 +149,9 @@ class ReplayTapeManifest:
             row_count=int(payload.get("row_count") or 0),
             source_query_digest=str(payload.get("source_query_digest") or ""),
             content_sha256=str(payload.get("content_sha256") or ""),
+            feature_schema_hash=str(payload.get("feature_schema_hash") or ""),
+            cost_model_hash=str(payload.get("cost_model_hash") or ""),
+            strategy_family=str(payload.get("strategy_family") or ""),
             replay_cache_key=str(payload.get("replay_cache_key") or ""),
             artifact_refs=_string_mapping(payload.get("artifact_refs")),
             source_table_versions=_string_mapping(payload.get("source_table_versions")),
@@ -188,6 +197,9 @@ def build_replay_tape_cache_key(
     start_date: date,
     end_date: date,
     source_query_digest: str,
+    feature_schema_hash: str = "",
+    cost_model_hash: str = "",
+    strategy_family: str = "",
     source_table_versions: Mapping[str, str] | None = None,
 ) -> str:
     """Build a stable cache key for a manifest-verified replay tape input set."""
@@ -200,6 +212,9 @@ def build_replay_tape_cache_key(
             "start_date": start_date,
             "end_date": end_date,
             "source_query_digest": source_query_digest,
+            "feature_schema_hash": str(feature_schema_hash or ""),
+            "cost_model_hash": str(cost_model_hash or ""),
+            "strategy_family": str(strategy_family or ""),
             "source_table_versions": dict(source_table_versions or {}),
         }
     )
@@ -215,6 +230,9 @@ def materialize_signal_tape(
     start_date: date,
     end_date: date,
     source_query_digest: str,
+    feature_schema_hash: str = "",
+    cost_model_hash: str = "",
+    strategy_family: str = "",
     source_table_versions: Mapping[str, str] | None = None,
     artifact_refs: Mapping[str, str] | None = None,
     created_at: datetime | None = None,
@@ -283,6 +301,9 @@ def materialize_signal_tape(
         start_date=start_date,
         end_date=end_date,
         source_query_digest=source_query_digest,
+        feature_schema_hash=feature_schema_hash,
+        cost_model_hash=cost_model_hash,
+        strategy_family=strategy_family,
         source_table_versions=source_table_versions,
     )
     manifest = ReplayTapeManifest(
@@ -300,6 +321,9 @@ def materialize_signal_tape(
         row_count=len(ordered_rows),
         source_query_digest=source_query_digest,
         content_sha256=content_hash.hexdigest(),
+        feature_schema_hash=str(feature_schema_hash or ""),
+        cost_model_hash=str(cost_model_hash or ""),
+        strategy_family=str(strategy_family or ""),
         replay_cache_key=replay_cache_key,
         artifact_refs=resolved_artifact_refs,
         source_table_versions=dict(source_table_versions or {}),

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -139,7 +139,8 @@ _CANDIDATE_BOARD_RUNTIME_SESSION_TZ = ZoneInfo("America/New_York")
 _CANDIDATE_BOARD_RUNTIME_SESSION_OPEN = time(hour=9, minute=30)
 _CANDIDATE_BOARD_RUNTIME_SESSION_CLOSE = time(hour=16, minute=0)
 _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC = 8
-_DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES = 16
+_DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES = 12
+_DEFAULT_FAST_REPLAY_PREVIEW_TOP_K = 48
 _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP = 6
 _DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS = 4
 _DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS = 2
@@ -575,7 +576,9 @@ def _parse_args() -> argparse.Namespace:
         default=0,
         help=(
             "Preview-only tape-vectorized narrowing budget before exact replay. "
-            "Requires --replay-tape-path and never counts as promotion proof."
+            "When omitted, real H-PAIRS replay runs with a replay tape default "
+            f"to {_DEFAULT_FAST_REPLAY_PREVIEW_TOP_K} preview candidates. "
+            "Never counts as promotion proof."
         ),
     )
     parser.add_argument(
@@ -591,6 +594,15 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Maximum candidate specs forwarded from preview ranking to exact replay. "
             "Defaults to a bounded 4 exploitation + 2 exploration frontier."
+        ),
+    )
+    parser.add_argument(
+        "--allow-unsafe-replay-tape-exact-cap-override",
+        action="store_true",
+        help=(
+            "Allow --replay-tape-exact-candidate-cap above the production-safe "
+            f"default cap of {_DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP}. "
+            "Keep disabled for CI and normal research runs."
         ),
     )
     parser.add_argument(
@@ -611,6 +623,14 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Fetch the resolved full-window signal rows once, write a run-scoped "
             "manifest-verified replay tape, and use it for preview narrowing and exact replay."
+        ),
+    )
+    parser.add_argument(
+        "--disable-staged-replay-frontier",
+        action="store_true",
+        help=(
+            "Disable the default bounded replay-tape -> fast-preview -> exact-top-six "
+            "frontier when a replay tape is available."
         ),
     )
     parser.add_argument(
@@ -664,6 +684,7 @@ def _parse_args() -> argparse.Namespace:
     parser.set_defaults(
         persist_results=True,
         collect_train_gate_diagnostics=True,
+        staged_replay_frontier_default=True,
     )
     return parser.parse_args()
 
@@ -6323,7 +6344,7 @@ def _apply_fast_replay_preview_narrowing(
     specs: Sequence[CandidateSpec],
     candidate_selection: Mapping[str, Any],
 ) -> tuple[list[CandidateSpec], dict[str, Any]]:
-    preview_top_k = max(0, int(getattr(args, "replay_tape_preview_top_k", 0) or 0))
+    preview_top_k = _resolved_fast_replay_preview_top_k(args)
     if preview_top_k <= 0:
         return list(specs), dict(candidate_selection)
     if str(getattr(args, "replay_mode", "") or "") != "real":
@@ -6331,19 +6352,9 @@ def _apply_fast_replay_preview_narrowing(
     tape_path = getattr(args, "replay_tape_path", None)
     if tape_path is None:
         raise ValueError("fast_replay_preview_requires_replay_tape_path")
-    exact_replay_candidate_cap = max(
-        1,
-        min(
-            preview_top_k,
-            int(
-                getattr(
-                    args,
-                    "replay_tape_exact_candidate_cap",
-                    _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
-                )
-                or _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP
-            ),
-        ),
+    exact_replay_candidate_cap = _resolved_fast_replay_exact_candidate_cap(
+        args,
+        preview_top_k=preview_top_k,
     )
     exploitation_slots = max(
         0,
@@ -6513,12 +6524,58 @@ def _apply_fast_replay_preview_narrowing(
     return narrowed_specs, updated_selection
 
 
+def _resolved_fast_replay_preview_top_k(args: argparse.Namespace) -> int:
+    explicit_top_k = max(
+        0,
+        int(getattr(args, "replay_tape_preview_top_k", 0) or 0),
+    )
+    if explicit_top_k > 0:
+        return explicit_top_k
+    if not bool(getattr(args, "staged_replay_frontier_default", False)):
+        return 0
+    if bool(getattr(args, "disable_staged_replay_frontier", False)):
+        return 0
+    if str(getattr(args, "replay_mode", "") or "") != "real":
+        return 0
+    if getattr(args, "replay_tape_path", None) is None:
+        return 0
+    return max(
+        _DEFAULT_FAST_REPLAY_PREVIEW_TOP_K,
+        int(getattr(args, "max_candidates", 0) or 0),
+    )
+
+
+def _resolved_fast_replay_exact_candidate_cap(
+    args: argparse.Namespace,
+    *,
+    preview_top_k: int,
+) -> int:
+    requested_cap = max(
+        1,
+        int(
+            getattr(
+                args,
+                "replay_tape_exact_candidate_cap",
+                _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
+            )
+            or _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP
+        ),
+    )
+    if not bool(getattr(args, "allow_unsafe_replay_tape_exact_cap_override", False)):
+        requested_cap = min(requested_cap, _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP)
+    return max(1, min(max(1, preview_top_k), requested_cap))
+
+
 def _fast_replay_preview_proof_semantics() -> dict[str, Any]:
     return {
         "schema_version": "torghut.fast-replay-proof-semantics.v1",
         "label": FAST_REPLAY_PROOF_SEMANTICS_LABEL,
         "promotion_proof": False,
         "authority": "preview_prefilter_only",
+        "prefilter_only": True,
+        "no_kubernetes_fanout": True,
+        "default_local_worker_cap": 2,
+        "safe_exact_replay_candidate_cap": _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
         "final_promotion_requires": [
             "exact_replay_evidence",
             "source_backed_runtime_ledger",
@@ -6538,11 +6595,9 @@ def _bounded_sim_target_queue_metadata(
     exploitation_slots: int,
     exploration_slots: int,
 ) -> dict[str, Any]:
-    selected_rows = [
-        dict(row)
-        for row in preview_rows
-        if bool(row.get("selected"))
-    ][:exact_replay_candidate_cap]
+    selected_rows = [dict(row) for row in preview_rows if bool(row.get("selected"))][
+        :exact_replay_candidate_cap
+    ]
     entries: list[dict[str, Any]] = []
     for index, row in enumerate(selected_rows, start=1):
         entries.append(
@@ -6552,15 +6607,32 @@ def _bounded_sim_target_queue_metadata(
                 "frontier_bucket": _string(row.get("frontier_bucket")),
                 "preview_rank": row.get("rank"),
                 "preview_score": row.get("preview_score"),
+                "observed_post_cost_expectancy_bps": row.get(
+                    "observed_post_cost_expectancy_bps"
+                ),
+                "required_daily_notional": row.get("required_daily_notional"),
+                "target_implied_notional_context": row.get(
+                    "target_implied_notional_context"
+                ),
+                "cost_impact_lineage": row.get("cost_impact_lineage"),
+                "adv_capacity_context": row.get("adv_capacity_context"),
+                "lineage_blockers": list(
+                    cast(Sequence[Any], row.get("lineage_blockers") or ())
+                ),
                 "proof_semantics_label": row.get("proof_semantics_label"),
                 "promotion_proof": False,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
             }
         )
     return {
         "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v1",
         "status": "metadata_only_preview_to_exact_replay_queue",
         "authority": "not_promotion_proof",
+        "prefilter_only": True,
         "promotion_proof": False,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
         "proof_semantics": _fast_replay_preview_proof_semantics(),
         "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
         "queue_policy": "top_exploitation_plus_exploration_exact_replay_cap",
@@ -6579,7 +6651,9 @@ def _maybe_materialize_epoch_replay_tape(
     output_dir: Path,
     epoch_id: str,
 ) -> tuple[argparse.Namespace, dict[str, Any] | None]:
-    if not bool(getattr(args, "materialize_replay_tape", False)):
+    explicit_materialize = bool(getattr(args, "materialize_replay_tape", False))
+    auto_materialize = _auto_materialize_staged_replay_tape(args)
+    if not explicit_materialize and not auto_materialize:
         return args, None
     if getattr(args, "replay_tape_path", None) is not None:
         return args, None
@@ -6621,6 +6695,9 @@ def _maybe_materialize_epoch_replay_tape(
         start_date=start_date,
         end_date=end_date,
         source_query_digest=source_query_digest,
+        feature_schema_hash=_materialized_replay_tape_feature_schema_hash(args),
+        cost_model_hash=_materialized_replay_tape_cost_model_hash(args),
+        strategy_family=_materialized_replay_tape_strategy_family(args),
         require_complete_coverage=not bool(getattr(args, "allow_stale_tape", False)),
     )
     receipt_path = output_dir / "replay-tape-receipt.json"
@@ -6636,6 +6713,10 @@ def _maybe_materialize_epoch_replay_tape(
         "row_symbols": list(manifest.row_symbols),
         "content_sha256": manifest.content_sha256,
         "source_query_digest": manifest.source_query_digest,
+        "replay_cache_key": manifest.replay_cache_key,
+        "feature_schema_hash": manifest.feature_schema_hash,
+        "cost_model_hash": manifest.cost_model_hash,
+        "strategy_family": manifest.strategy_family,
     }
     _write_json(receipt_path, receipt)
     updated_args = argparse.Namespace(
@@ -6646,6 +6727,24 @@ def _maybe_materialize_epoch_replay_tape(
         }
     )
     return updated_args, receipt
+
+
+def _auto_materialize_staged_replay_tape(args: argparse.Namespace) -> bool:
+    if not bool(getattr(args, "staged_replay_frontier_default", False)):
+        return False
+    if bool(getattr(args, "disable_staged_replay_frontier", False)):
+        return False
+    if str(getattr(args, "replay_mode", "") or "") != "real":
+        return False
+    if bool(getattr(args, "selection_only", False)):
+        return False
+    if getattr(args, "replay_tape_path", None) is not None:
+        return False
+    if not str(getattr(args, "full_window_start_date", "") or "").strip():
+        return False
+    if not str(getattr(args, "full_window_end_date", "") or "").strip():
+        return False
+    return True
 
 
 def _materialized_replay_tape_date_arg(
@@ -6678,6 +6777,35 @@ def _materialized_replay_tape_source_query_digest(
             "join": "torghut.ta_microbars",
         }
     )
+
+
+def _materialized_replay_tape_feature_schema_hash(args: argparse.Namespace) -> str:
+    return _stable_hash(
+        {
+            "schema_version": "torghut.replay-tape-feature-schema.v1",
+            "signal_schema": "SignalEnvelope",
+            "source": "ta",
+            "window_size": "PT1S",
+            "microbar_join": "torghut.ta_microbars",
+            "chunk_minutes": max(1, int(getattr(args, "chunk_minutes", 10) or 10)),
+        }
+    )
+
+
+def _materialized_replay_tape_cost_model_hash(args: argparse.Namespace) -> str:
+    return _stable_hash(
+        {
+            "schema_version": "torghut.replay-tape-cost-model.v1",
+            "pnl_basis": POST_COST_PNL_BASIS,
+            "start_equity": str(getattr(args, "start_equity", "31590.02")),
+            "preview_cost_lineage": "spread_plus_square_root_impact_prefilter",
+        }
+    )
+
+
+def _materialized_replay_tape_strategy_family(args: argparse.Namespace) -> str:
+    path = Path(getattr(args, "strategy_configmap", "strategy-configmap.yaml"))
+    return f"whitepaper-autoresearch:{path.name}"
 
 
 def _fast_replay_preview_date_arg(args: argparse.Namespace, key: str) -> date:

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, ROUND_FLOOR
 from pathlib import Path
 from typing import Any, Iterable, Mapping, cast
 
@@ -32,6 +32,7 @@ from scripts.local_intraday_tsmom_replay import (
 _SWEEP_SCHEMA_VERSION = "torghut.replay-frontier-sweep.v1"
 _REPLAY_SIGNAL_TABLE = "torghut.ta_signals"
 _LOCAL_ONLY_STRATEGY_OVERRIDE_KEYS = frozenset({"normalization_regime"})
+_DEFAULT_FRONTIER_TARGET_NET_PNL_PER_DAY = Decimal("500")
 
 
 @dataclass(frozen=True)
@@ -384,7 +385,14 @@ def main() -> int:
         for symbol in str(args.symbols or "").split(",")
         if symbol.strip()
     )
-    scored = []
+    target_net_pnl_per_day = Decimal(
+        str(
+            constraints.get(
+                "target_net_pnl_per_day", _DEFAULT_FRONTIER_TARGET_NET_PNL_PER_DAY
+            )
+        )
+    )
+    scored: list[tuple[Any, dict[str, Any]]] = []
 
     with tempfile.TemporaryDirectory(
         prefix="torghut-profitability-frontier-"
@@ -447,31 +455,34 @@ def main() -> int:
                         ),
                     )
                 )
+                result = score_replay_profitability_candidate(
+                    family=family,
+                    strategy_name=strategy_name,
+                    replay_config={
+                        "candidate_index": index,
+                        "params": candidate,
+                        "strategy_overrides": dict(strategy_overrides),
+                        "train_start_date": window.train_start.isoformat(),
+                        "train_end_date": window.train_end.isoformat(),
+                        "holdout_start_date": window.holdout_start.isoformat(),
+                        "holdout_end_date": window.holdout_end.isoformat(),
+                    },
+                    train_payload=train_payload,
+                    holdout_payload=holdout_payload,
+                    policy=policy,
+                )
                 scored.append(
-                    score_replay_profitability_candidate(
-                        family=family,
-                        strategy_name=strategy_name,
-                        replay_config={
-                            "candidate_index": index,
-                            "params": candidate,
-                            "strategy_overrides": dict(strategy_overrides),
-                            "train_start_date": window.train_start.isoformat(),
-                            "train_end_date": window.train_end.isoformat(),
-                            "holdout_start_date": window.holdout_start.isoformat(),
-                            "holdout_end_date": window.holdout_end.isoformat(),
-                        },
-                        train_payload=train_payload,
-                        holdout_payload=holdout_payload,
-                        policy=policy,
+                    (
+                        result,
+                        _frontier_ranking_diagnostics(
+                            holdout_payload=holdout_payload,
+                            target_net_pnl_per_day=target_net_pnl_per_day,
+                        ),
                     )
                 )
 
     scored.sort(
-        key=lambda item: (
-            item.score,
-            item.holdout_net_per_day,
-            item.profit_factor or Decimal("-1"),
-        ),
+        key=lambda item: _frontier_ranking_key(item[0], item[1]),
         reverse=True,
     )
     payload = {
@@ -499,7 +510,23 @@ def main() -> int:
             "require_holdout_decisions": policy.require_holdout_decisions,
         },
         "candidate_count": len(scored),
-        "top": [item.to_payload() for item in scored[: max(1, int(args.top_n))]],
+        "frontier_ranking_policy": {
+            "schema_version": "torghut.replay-frontier-ranking-policy.v1",
+            "target_net_pnl_per_day": str(target_net_pnl_per_day),
+            "prefers_distribution_over_single_lucky_day": True,
+            "sort_terms": [
+                "target_implied_notional_feasible",
+                "median_daily_net_pnl",
+                "p10_daily_net_pnl",
+                "inverse_best_day_share",
+                "inverse_drawdown",
+                "score",
+            ],
+        },
+        "top": [
+            _sweep_candidate_payload_with_frontier_metrics(item, metrics)
+            for item, metrics in scored[: max(1, int(args.top_n))]
+        ],
     }
 
     if args.json_output:
@@ -516,6 +543,186 @@ def cli_main() -> int:
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1
+
+
+def _frontier_ranking_diagnostics(
+    *,
+    holdout_payload: Mapping[str, Any],
+    target_net_pnl_per_day: Decimal,
+) -> dict[str, Any]:
+    daily_net = _daily_decimal_mapping(holdout_payload, field="net_pnl")
+    daily_filled_notional = _daily_decimal_mapping(
+        holdout_payload, field="filled_notional"
+    )
+    values = list(daily_net.values())
+    total_net = sum(values, Decimal("0"))
+    total_filled_notional = _total_filled_notional(
+        holdout_payload=holdout_payload,
+        daily_filled_notional=daily_filled_notional,
+    )
+    day_count = len(values)
+    avg_filled_notional_per_day = (
+        total_filled_notional / Decimal(day_count) if day_count > 0 else Decimal("0")
+    )
+    observed_post_cost_expectancy_bps = (
+        (total_net / total_filled_notional) * Decimal("10000")
+        if total_filled_notional > 0
+        else Decimal("0")
+    )
+    required_daily_notional = (
+        target_net_pnl_per_day / (observed_post_cost_expectancy_bps / Decimal("10000"))
+        if observed_post_cost_expectancy_bps > 0
+        else None
+    )
+    best_day_share = _best_day_share(daily_net)
+    drawdown = _daily_drawdown(daily_net)
+    closed_trade_count = int(holdout_payload.get("filled_count", 0) or 0)
+    feasible = (
+        required_daily_notional is not None
+        and avg_filled_notional_per_day >= required_daily_notional
+    )
+    blockers: list[str] = []
+    if total_filled_notional <= 0:
+        blockers.append("filled_notional_missing")
+    if required_daily_notional is None:
+        blockers.append("positive_post_cost_expectancy_missing")
+    if not feasible:
+        blockers.append("target_implied_notional_not_observed_feasible")
+    return {
+        "schema_version": "torghut.replay-frontier-ranking-metrics.v1",
+        "median_daily_net_pnl": str(_median_decimal(values)),
+        "p10_daily_net_pnl": str(_quantile_floor(values, Decimal("0.10"))),
+        "worst_day_net_pnl": str(min(values) if values else Decimal("0")),
+        "best_day_share": str(best_day_share),
+        "drawdown": str(drawdown),
+        "closed_trade_count": closed_trade_count,
+        "filled_notional": str(total_filled_notional),
+        "avg_filled_notional_per_day": str(avg_filled_notional_per_day),
+        "observed_post_cost_expectancy_bps": str(observed_post_cost_expectancy_bps),
+        "target_implied_notional": {
+            "target_net_pnl_per_day": str(target_net_pnl_per_day),
+            "required_daily_notional": str(required_daily_notional)
+            if required_daily_notional is not None
+            else None,
+            "feasible": feasible,
+            "feasibility_status": "observed_feasible"
+            if feasible
+            else "not_observed_feasible",
+        },
+        "blockers": blockers,
+    }
+
+
+def _frontier_ranking_key(result: Any, metrics: Mapping[str, Any]) -> tuple[Any, ...]:
+    target_implied = metrics.get("target_implied_notional")
+    feasible = (
+        bool(target_implied.get("feasible"))
+        if isinstance(target_implied, Mapping)
+        else False
+    )
+    return (
+        feasible,
+        _decimal_from_mapping(metrics, "median_daily_net_pnl"),
+        _decimal_from_mapping(metrics, "p10_daily_net_pnl"),
+        -_decimal_from_mapping(metrics, "best_day_share"),
+        -_decimal_from_mapping(metrics, "drawdown"),
+        result.score,
+        result.holdout_net_per_day,
+        result.profit_factor or Decimal("-1"),
+    )
+
+
+def _sweep_candidate_payload_with_frontier_metrics(
+    result: Any,
+    metrics: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload = result.to_payload()
+    payload["frontier_ranking"] = dict(metrics)
+    return payload
+
+
+def _daily_decimal_mapping(
+    payload: Mapping[str, Any], *, field: str
+) -> dict[str, Decimal]:
+    daily_payload = payload.get("daily")
+    if not isinstance(daily_payload, Mapping):
+        return {}
+    values: dict[str, Decimal] = {}
+    for day, raw in cast(Mapping[str, Any], daily_payload).items():
+        if not isinstance(raw, Mapping):
+            continue
+        values[str(day)] = _decimal_or_zero(cast(Mapping[str, Any], raw).get(field))
+    return values
+
+
+def _total_filled_notional(
+    *,
+    holdout_payload: Mapping[str, Any],
+    daily_filled_notional: Mapping[str, Decimal],
+) -> Decimal:
+    total = sum(daily_filled_notional.values(), Decimal("0"))
+    if total > 0:
+        return total
+    return _decimal_or_zero(
+        holdout_payload.get("filled_notional")
+        or holdout_payload.get("total_filled_notional")
+        or holdout_payload.get("turnover_notional")
+    )
+
+
+def _median_decimal(values: list[Decimal]) -> Decimal:
+    if not values:
+        return Decimal("0")
+    ordered = sorted(values)
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2 == 1:
+        return ordered[midpoint]
+    return (ordered[midpoint - 1] + ordered[midpoint]) / Decimal("2")
+
+
+def _quantile_floor(values: list[Decimal], quantile: Decimal) -> Decimal:
+    if not values:
+        return Decimal("0")
+    ordered = sorted(values)
+    index = int(
+        (
+            Decimal(len(ordered) - 1) * min(max(quantile, Decimal("0")), Decimal("1"))
+        ).to_integral_value(rounding=ROUND_FLOOR)
+    )
+    return ordered[index]
+
+
+def _best_day_share(daily_net: Mapping[str, Decimal]) -> Decimal:
+    positive_total = sum(
+        (value for value in daily_net.values() if value > 0), Decimal("0")
+    )
+    if positive_total <= 0:
+        return Decimal("1")
+    return max(daily_net.values(), default=Decimal("0")) / positive_total
+
+
+def _daily_drawdown(daily_net: Mapping[str, Decimal]) -> Decimal:
+    peak = Decimal("0")
+    cumulative = Decimal("0")
+    drawdown = Decimal("0")
+    for day in sorted(daily_net):
+        cumulative += daily_net[day]
+        peak = max(peak, cumulative)
+        drawdown = max(drawdown, peak - cumulative)
+    return drawdown
+
+
+def _decimal_or_zero(value: Any) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return Decimal("0")
+
+
+def _decimal_from_mapping(payload: Mapping[str, Any], key: str) -> Decimal:
+    return _decimal_or_zero(payload.get(key))
 
 
 if __name__ == "__main__":

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -6,12 +6,18 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from app.trading.discovery.candidate_specs import CANDIDATE_SPEC_SCHEMA_VERSION, CandidateSpec
+from app.trading.discovery.candidate_specs import (
+    CANDIDATE_SPEC_SCHEMA_VERSION,
+    CandidateSpec,
+)
 from app.trading.discovery.fast_replay import (
     FAST_REPLAY_PROOF_SEMANTICS_LABEL,
     build_fast_replay_preview,
 )
-from app.trading.discovery.replay_tape import build_source_query_digest, materialize_signal_tape
+from app.trading.discovery.replay_tape import (
+    build_source_query_digest,
+    materialize_signal_tape,
+)
 from app.trading.models import SignalEnvelope
 
 
@@ -61,7 +67,8 @@ class TestFastReplayPreview(TestCase):
         event_type: str = "trade",
     ) -> SignalEnvelope:
         return SignalEnvelope(
-            event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc) + timedelta(minutes=offset),
+            event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc)
+            + timedelta(minutes=offset),
             symbol=symbol,
             timeframe="1Min",
             seq=offset,
@@ -82,12 +89,24 @@ class TestFastReplayPreview(TestCase):
     def test_whitepaper_features_rank_and_label_preview_only(self) -> None:
         with TemporaryDirectory() as tmpdir:
             rows = [
-                self._signal(symbol="AAA", offset=1, price="100", ofi="0.65", event_type="add"),
-                self._signal(symbol="AAA", offset=2, price="101", ofi="0.80", event_type="trade"),
-                self._signal(symbol="AAA", offset=3, price="102", ofi="0.85", event_type="cancel"),
-                self._signal(symbol="BBB", offset=1, price="100", ofi="-0.10", stress=True),
-                self._signal(symbol="BBB", offset=2, price="99", ofi="-0.20", stress=True),
-                self._signal(symbol="BBB", offset=3, price="98", ofi="-0.20", stress=True),
+                self._signal(
+                    symbol="AAA", offset=1, price="100", ofi="0.65", event_type="add"
+                ),
+                self._signal(
+                    symbol="AAA", offset=2, price="101", ofi="0.80", event_type="trade"
+                ),
+                self._signal(
+                    symbol="AAA", offset=3, price="102", ofi="0.85", event_type="cancel"
+                ),
+                self._signal(
+                    symbol="BBB", offset=1, price="100", ofi="-0.10", stress=True
+                ),
+                self._signal(
+                    symbol="BBB", offset=2, price="99", ofi="-0.20", stress=True
+                ),
+                self._signal(
+                    symbol="BBB", offset=3, price="98", ofi="-0.20", stress=True
+                ),
             ]
             manifest = materialize_signal_tape(
                 rows=rows,
@@ -113,7 +132,9 @@ class TestFastReplayPreview(TestCase):
             exact_replay_candidate_cap=2,
         )
 
-        self.assertEqual(preview.selected_candidate_spec_ids, ("spec-good", "spec-stress"))
+        self.assertEqual(
+            preview.selected_candidate_spec_ids, ("spec-good", "spec-stress")
+        )
         good, stress = preview.rows
         self.assertEqual(good.candidate_spec_id, "spec-good")
         self.assertGreater(good.cluster_lob_activity_score, Decimal("0"))
@@ -122,15 +143,33 @@ class TestFastReplayPreview(TestCase):
         self.assertEqual(stress.frontier_bucket, "exploration")
         self.assertGreater(stress.macro_stress_veto_score, Decimal("0"))
         payload = preview.to_manifest_payload()
+        row_payload = good.to_payload()
         self.assertFalse(payload["promotion_proof"])
-        self.assertEqual(payload["proof_semantics_label"], FAST_REPLAY_PROOF_SEMANTICS_LABEL)
-        self.assertIn("source_backed_runtime_ledger_proof_required", payload["blockers"])
+        self.assertEqual(
+            payload["proof_semantics_label"], FAST_REPLAY_PROOF_SEMANTICS_LABEL
+        )
+        self.assertIn(
+            "source_backed_runtime_ledger_proof_required", payload["blockers"]
+        )
         self.assertIn("conformal_tail_risk", payload["implemented_mechanisms"])
+        self.assertEqual(
+            row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
+            "500",
+        )
+        self.assertIn("observed_post_cost_expectancy_bps", row_payload)
+        self.assertIn("cost_impact_lineage", row_payload)
+        self.assertEqual(
+            row_payload["adv_capacity_context"]["status"], "missing_source_backed_adv"
+        )
+        self.assertIn("source_backed_adv_missing", row_payload["lineage_blockers"])
+        self.assertFalse(row_payload["promotion_proof"])
 
     def test_frontier_selection_caps_exact_replay_with_exploration_slots(self) -> None:
         with TemporaryDirectory() as tmpdir:
             rows = [
-                self._signal(symbol="AAA", offset=index, price=str(100 + index), ofi="0.50")
+                self._signal(
+                    symbol="AAA", offset=index, price=str(100 + index), ofi="0.50"
+                )
                 for index in range(1, 8)
             ]
             manifest = materialize_signal_tape(
@@ -142,7 +181,9 @@ class TestFastReplayPreview(TestCase):
                 end_date=date(2026, 2, 23),
                 source_query_digest=build_source_query_digest({"window": "cap"}),
             )
-        specs = tuple(self._spec(f"spec-{index}", symbols=["AAA"]) for index in range(8))
+        specs = tuple(
+            self._spec(f"spec-{index}", symbols=["AAA"]) for index in range(8)
+        )
 
         preview = build_fast_replay_preview(
             specs=specs,
@@ -161,5 +202,12 @@ class TestFastReplayPreview(TestCase):
         self.assertEqual(preview.exact_replay_candidate_cap, 6)
         self.assertEqual(
             [row.frontier_bucket for row in preview.rows if row.selected],
-            ["exploitation", "exploitation", "exploitation", "exploitation", "exploration", "exploration"],
+            [
+                "exploitation",
+                "exploitation",
+                "exploitation",
+                "exploitation",
+                "exploration",
+                "exploration",
+            ],
         )

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -209,9 +209,48 @@ class TestReplayTape(TestCase):
             source_query_digest=first_digest,
             source_table_versions={"signals": "v1"},
         )
+        changed_dataset_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-b",
+            symbols=("AAPL", "NVDA"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=first_digest,
+            source_table_versions={"signals": "v1"},
+        )
+        changed_feature_schema_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("AAPL", "NVDA"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=first_digest,
+            feature_schema_hash="feature-schema-v2",
+            source_table_versions={"signals": "v1"},
+        )
+        changed_cost_model_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("AAPL", "NVDA"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=first_digest,
+            cost_model_hash="cost-model-v2",
+            source_table_versions={"signals": "v1"},
+        )
+        changed_family_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("AAPL", "NVDA"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=first_digest,
+            strategy_family="hpairs-v2",
+            source_table_versions={"signals": "v1"},
+        )
 
         self.assertEqual(first_key, reordered_key)
         self.assertNotEqual(first_key, changed_key)
+        self.assertNotEqual(first_key, changed_dataset_key)
+        self.assertNotEqual(first_key, changed_feature_schema_key)
+        self.assertNotEqual(first_key, changed_cost_model_key)
+        self.assertNotEqual(first_key, changed_family_key)
 
         with TemporaryDirectory() as tmpdir:
             manifest = materialize_signal_tape(
@@ -222,11 +261,32 @@ class TestReplayTape(TestCase):
                 start_date=date(2026, 3, 27),
                 end_date=date(2026, 3, 27),
                 source_query_digest=first_digest,
+                feature_schema_hash="feature-schema-v1",
+                cost_model_hash="cost-model-v1",
+                strategy_family="hpairs-v1",
                 source_table_versions={"signals": "v1"},
             )
 
-        self.assertEqual(manifest.replay_cache_key, first_key)
-        self.assertEqual(manifest.to_payload()["replay_cache_key"], first_key)
+        expected_materialized_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("NVDA", "AAPL"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=first_digest,
+            feature_schema_hash="feature-schema-v1",
+            cost_model_hash="cost-model-v1",
+            strategy_family="hpairs-v1",
+            source_table_versions={"signals": "v1"},
+        )
+        self.assertEqual(manifest.replay_cache_key, expected_materialized_key)
+        self.assertEqual(
+            manifest.to_payload()["replay_cache_key"], expected_materialized_key
+        )
+        self.assertEqual(
+            manifest.to_payload()["feature_schema_hash"], "feature-schema-v1"
+        )
+        self.assertEqual(manifest.to_payload()["cost_model_hash"], "cost-model-v1")
+        self.assertEqual(manifest.to_payload()["strategy_family"], "hpairs-v1")
 
     def test_materialize_manifest_session_window_follows_new_york_dst(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4615,9 +4615,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             tape_path = Path(tmpdir) / "tape.jsonl"
             rows = [
                 SignalEnvelope(
-                    event_ts=datetime(
-                        2026, 2, 23, 14, 30 + index, tzinfo=timezone.utc
-                    ),
+                    event_ts=datetime(2026, 2, 23, 14, 30 + index, tzinfo=timezone.utc),
                     symbol=symbol,
                     timeframe="1Min",
                     seq=index,
@@ -4651,6 +4649,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.symbols = "NVDA,AAPL,INTC"
             args.replay_tape_path = tape_path
             args.replay_tape_preview_top_k = 8
+            args.replay_tape_exact_candidate_cap = 99
             candidate_selection = {
                 "schema_version": "torghut.whitepaper-autoresearch-selection.v1",
                 "budget": {"selected_count": len(specs)},
@@ -4687,6 +4686,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             queue_payload["proof_semantics"]["label"],
             fast_replay.FAST_REPLAY_PROOF_SEMANTICS_LABEL,
         )
+        self.assertTrue(queue_payload["prefilter_only"])
+        self.assertFalse(queue_payload["promotion_allowed"])
+        self.assertFalse(queue_payload["final_promotion_allowed"])
         self.assertEqual(
             [entry["frontier_bucket"] for entry in queue_payload["entries"]],
             [
@@ -4698,6 +4700,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "exploration",
             ],
         )
+        first_entry = queue_payload["entries"][0]
+        self.assertIn("observed_post_cost_expectancy_bps", first_entry)
+        self.assertIn("required_daily_notional", first_entry)
+        self.assertIn("target_implied_notional_context", first_entry)
+        self.assertIn("cost_impact_lineage", first_entry)
+        self.assertEqual(
+            first_entry["adv_capacity_context"]["status"], "missing_source_backed_adv"
+        )
+        self.assertIn("source_backed_adv_missing", first_entry["lineage_blockers"])
+        self.assertFalse(first_entry["promotion_allowed"])
+        self.assertFalse(first_entry["final_promotion_allowed"])
 
     def test_fast_replay_preview_scores_microstructure_diagnostics_preview_only(
         self,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4712,6 +4712,69 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertFalse(first_entry["promotion_allowed"])
         self.assertFalse(first_entry["final_promotion_allowed"])
 
+    def test_staged_replay_frontier_default_resolvers_fail_closed(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir))
+            args.staged_replay_frontier_default = False
+            args.disable_staged_replay_frontier = False
+            args.replay_mode = "real"
+            args.replay_tape_path = Path(tmpdir) / "tape.jsonl"
+            args.selection_only = False
+            args.full_window_start_date = "2026-02-23"
+            args.full_window_end_date = "2026-02-27"
+
+            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
+            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+
+            args.staged_replay_frontier_default = True
+            args.disable_staged_replay_frontier = True
+            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
+            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+
+            args.disable_staged_replay_frontier = False
+            args.replay_mode = "synthetic"
+            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
+            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+
+            args.replay_mode = "real"
+            args.replay_tape_path = None
+            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 0)
+
+            args.selection_only = True
+            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+
+            args.selection_only = False
+            args.replay_tape_path = Path(tmpdir) / "provided-tape.jsonl"
+            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+
+            args.replay_tape_path = None
+            args.full_window_start_date = ""
+            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+
+            args.full_window_start_date = "2026-02-23"
+            args.full_window_end_date = ""
+            self.assertFalse(runner._auto_materialize_staged_replay_tape(args))
+
+    def test_staged_replay_frontier_default_resolvers_enable_bounded_real_path(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir))
+            args.staged_replay_frontier_default = True
+            args.disable_staged_replay_frontier = False
+            args.replay_mode = "real"
+            args.replay_tape_path = Path(tmpdir) / "tape.jsonl"
+            args.replay_tape_preview_top_k = 0
+            args.max_candidates = 77
+            args.selection_only = False
+            args.full_window_start_date = "2026-02-23"
+            args.full_window_end_date = "2026-02-27"
+
+            self.assertEqual(runner._resolved_fast_replay_preview_top_k(args), 77)
+
+            args.replay_tape_path = None
+            self.assertTrue(runner._auto_materialize_staged_replay_tape(args))
+
     def test_fast_replay_preview_scores_microstructure_diagnostics_preview_only(
         self,
     ) -> None:

--- a/services/torghut/tests/test_search_profitability_frontier.py
+++ b/services/torghut/tests/test_search_profitability_frontier.py
@@ -239,6 +239,31 @@ class TestSearchProfitabilityFrontier(TestCase):
     ) -> None:
         self.assertEqual(iter_parameter_candidates({}), [{}])
 
+    def test_frontier_ranking_helpers_cover_sparse_and_invalid_payloads(self) -> None:
+        self.assertEqual(frontier._daily_decimal_mapping({}, field="net_pnl"), {})
+        self.assertEqual(
+            frontier._daily_decimal_mapping(
+                {"daily": {"2026-03-21": "not-a-mapping"}}, field="net_pnl"
+            ),
+            {},
+        )
+        self.assertEqual(
+            frontier._total_filled_notional(
+                holdout_payload={"filled_notional": "999"},
+                daily_filled_notional={"2026-03-21": Decimal("250")},
+            ),
+            Decimal("250"),
+        )
+        self.assertEqual(frontier._median_decimal([]), Decimal("0"))
+        self.assertEqual(
+            frontier._median_decimal([Decimal("10"), Decimal("20")]), Decimal("15")
+        )
+        self.assertEqual(frontier._quantile_floor([], Decimal("0.10")), Decimal("0"))
+        self.assertEqual(
+            frontier._best_day_share({"2026-03-21": Decimal("-1")}), Decimal("1")
+        )
+        self.assertEqual(frontier._decimal_or_zero("not-a-decimal"), Decimal("0"))
+
     def test_apply_candidate_to_configmap_updates_target_and_disables_others(
         self,
     ) -> None:

--- a/services/torghut/tests/test_search_profitability_frontier.py
+++ b/services/torghut/tests/test_search_profitability_frontier.py
@@ -694,6 +694,20 @@ class TestSearchProfitabilityFrontier(TestCase):
                 ],
                 "0.55",
             )
+            self.assertTrue(
+                payload["frontier_ranking_policy"][
+                    "prefers_distribution_over_single_lucky_day"
+                ]
+            )
+            ranking = payload["top"][0]["frontier_ranking"]
+            self.assertEqual(ranking["median_daily_net_pnl"], "300")
+            self.assertEqual(ranking["p10_daily_net_pnl"], "0")
+            self.assertIn("best_day_share", ranking)
+            self.assertIn("drawdown", ranking)
+            self.assertEqual(ranking["closed_trade_count"], 3)
+            self.assertIn("filled_notional", ranking)
+            self.assertIn("target_implied_notional", ranking)
+            self.assertIn("filled_notional_missing", ranking["blockers"])
 
     def test_main_ranks_three_candidates_deterministically(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Added replay tape cache key lineage for dataset snapshot, symbol universe, date range, feature schema hash, cost model hash, strategy family, and source table versions.
- Made parsed H-PAIRS autoresearch runs default to a bounded staged frontier: materialized/loaded replay tape, fast preview breadth, exact replay cap of six, and a SIM/evidence target queue that is explicitly not promotion authority.
- Added preview candidate cost/impact lineage, target-implied required daily notional, ADV/source/as-of blockers, and fail-closed promotion flags on preview/queue artifacts.
- Expanded frontier ranking output to include median/p10/worst daily net PnL, best-day share, drawdown, closed trades, filled notional, and target-implied notional feasibility so selection does not chase a single lucky day.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py tests/test_search_profitability_frontier.py -q`
- PASS: `cd services/torghut && uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py scripts/search_profitability_frontier.py scripts/search_consistent_profitability_frontier.py app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py app/trading/discovery/objectives.py app/trading/discovery/portfolio_candidates.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py tests/test_search_profitability_frontier.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
