### PR TITLE
fix(torghut): schedule replay source materialization

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -66,7 +66,6 @@ spec:
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \
-                    --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \
                     --runtime-window-targets-from-latest-autoresearch \

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -42,6 +42,7 @@ resources:
   - execution-tca-refresh-cronjob.yaml
   - paper-account-flatten-cronjob.yaml
   - whitepaper-autoresearch-workflowtemplate.yaml
+  - whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
   - empirical-promotion-workflowtemplate.yaml
   - historical-simulation-workflowtemplate.yaml
   - analysis-template-runtime-ready.yaml

--- a/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
@@ -1,0 +1,47 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: torghut-replay-source-materialization
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: replay-materialization
+    app.kubernetes.io/part-of: lab
+spec:
+  schedules:
+    - "5 5 * * 2-6"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 900
+  workflowSpec:
+    workflowTemplateRef:
+      name: torghut-whitepaper-autoresearch-profit-target
+    arguments:
+      parameters:
+        - name: replayTapePreviewTopK
+          value: "16"
+        - name: replayTapePreviewMinRows
+          value: "2"
+        - name: maxCandidates
+          value: "64"
+        - name: topK
+          value: "24"
+        - name: explorationSlots
+          value: "16"
+        - name: feedbackBlockReauditSlots
+          value: "16"
+        - name: maxFrontierCandidatesPerSpec
+          value: "1"
+        - name: maxTotalFrontierCandidates
+          value: "32"
+        - name: realReplayTimeoutSeconds
+          value: "5400"
+        - name: realReplayShardSize
+          value: "1"
+        - name: realReplayShardTimeoutSeconds
+          value: "900"
+        - name: realReplayShardWorkers
+          value: "4"
+        - name: persistResults
+          value: "true"

--- a/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
@@ -20,28 +20,28 @@ spec:
     arguments:
       parameters:
         - name: replayTapePreviewTopK
-          value: "16"
+          value: "8"
         - name: replayTapePreviewMinRows
           value: "2"
         - name: maxCandidates
-          value: "64"
+          value: "16"
         - name: topK
-          value: "24"
+          value: "8"
         - name: explorationSlots
-          value: "16"
+          value: "2"
         - name: feedbackBlockReauditSlots
-          value: "16"
+          value: "2"
         - name: maxFrontierCandidatesPerSpec
           value: "1"
         - name: maxTotalFrontierCandidates
-          value: "32"
+          value: "6"
         - name: realReplayTimeoutSeconds
-          value: "5400"
+          value: "1800"
         - name: realReplayShardSize
           value: "1"
         - name: realReplayShardTimeoutSeconds
           value: "900"
         - name: realReplayShardWorkers
-          value: "4"
+          value: "2"
         - name: persistResults
           value: "true"

--- a/scripts/argo-lint.sh
+++ b/scripts/argo-lint.sh
@@ -4,20 +4,26 @@ set -euo pipefail
 ROOT_DIR="${1:-$(pwd)}"
 FOUND=0
 STATUS=0
+WORKFLOW_DIRS="$(mktemp)"
+trap 'rm -f "$WORKFLOW_DIRS"' EXIT
 
 while IFS= read -r -d '' file; do
   if grep -Eq '^(kind|  kind):\s*(Workflow|WorkflowTemplate|CronWorkflow)' "$file"; then
     FOUND=1
-    echo "::group::argo lint $file"
-    if ! argo lint --offline "$file"; then
-      STATUS=1
-    fi
-    echo "::endgroup::"
+    dirname "$file" >> "$WORKFLOW_DIRS"
   fi
 done < <(find "$ROOT_DIR" -type f -name '*.yaml' -print0)
 
 if [[ "$FOUND" -eq 0 ]]; then
   echo "No Argo Workflow manifests detected under $ROOT_DIR" >&2
 fi
+
+while IFS= read -r dir; do
+  echo "::group::argo lint $dir"
+  if ! argo lint --offline "$dir"; then
+    STATUS=1
+  fi
+  echo "::endgroup::"
+done < <(sort -u "$WORKFLOW_DIRS")
 
 exit "$STATUS"

--- a/scripts/argo-lint.sh
+++ b/scripts/argo-lint.sh
@@ -6,13 +6,50 @@ FOUND=0
 STATUS=0
 WORKFLOW_DIRS="$(mktemp)"
 trap 'rm -f "$WORKFLOW_DIRS"' EXIT
+SEARCH_ROOTS=("$ROOT_DIR")
 
-while IFS= read -r -d '' file; do
-  if grep -Eq '^(kind|  kind):\s*(Workflow|WorkflowTemplate|CronWorkflow)' "$file"; then
-    FOUND=1
-    dirname "$file" >> "$WORKFLOW_DIRS"
+if [[ "$#" -eq 0 && -d "$ROOT_DIR/argocd" ]]; then
+  SEARCH_ROOTS=("$ROOT_DIR/argocd")
+  if [[ -d "$ROOT_DIR/kubernetes" ]]; then
+    SEARCH_ROOTS+=("$ROOT_DIR/kubernetes")
   fi
-done < <(find "$ROOT_DIR" -type f -name '*.yaml' -print0)
+fi
+
+for search_root in "${SEARCH_ROOTS[@]}"; do
+  if command -v rg >/dev/null 2>&1; then
+    while IFS= read -r -d '' file; do
+      FOUND=1
+      dirname "$file" >> "$WORKFLOW_DIRS"
+    done < <(
+      rg -l -0 \
+        --glob '*.yaml' \
+        --glob '!**/.git/**' \
+        --glob '!**/node_modules/**' \
+        --glob '!**/dist/**' \
+        --glob '!**/build/**' \
+        --glob '!**/.next/**' \
+        --glob '!**/.turbo/**' \
+        --glob '!**/.venv/**' \
+        --glob '!**/__pycache__/**' \
+        '^(kind|  kind):\s*(Workflow|WorkflowTemplate|CronWorkflow)' \
+        "$search_root"
+    )
+  else
+    while IFS= read -r -d '' file; do
+      if grep -Eq '^(kind|  kind):\s*(Workflow|WorkflowTemplate|CronWorkflow)' "$file"; then
+        FOUND=1
+        dirname "$file" >> "$WORKFLOW_DIRS"
+      fi
+    done < <(
+      find "$search_root" \
+        \( -type d \( \
+          -name .git -o -name node_modules -o -name dist -o -name build -o \
+          -name .next -o -name .turbo -o -name .venv -o -name __pycache__ \
+        \) -prune \) \
+        -o \( -type f -name '*.yaml' -print0 \)
+    )
+  fi
+done
 
 if [[ "$FOUND" -eq 0 ]]; then
   echo "No Argo Workflow manifests detected under $ROOT_DIR" >&2

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -930,12 +930,15 @@ class TestLiveConfigManifestContract(TestCase):
                 list[Mapping[str, object]], arguments.get("parameters", [])
             )
         }
-        self.assertEqual(parameters["replayTapePreviewTopK"], "16")
+        self.assertEqual(parameters["replayTapePreviewTopK"], "8")
         self.assertEqual(parameters["replayTapePreviewMinRows"], "2")
-        self.assertEqual(parameters["maxCandidates"], "64")
-        self.assertEqual(parameters["topK"], "24")
-        self.assertEqual(parameters["maxTotalFrontierCandidates"], "32")
-        self.assertEqual(parameters["realReplayTimeoutSeconds"], "5400")
+        self.assertEqual(parameters["maxCandidates"], "16")
+        self.assertEqual(parameters["topK"], "8")
+        self.assertEqual(parameters["explorationSlots"], "2")
+        self.assertEqual(parameters["feedbackBlockReauditSlots"], "2")
+        self.assertEqual(parameters["maxTotalFrontierCandidates"], "6")
+        self.assertEqual(parameters["realReplayTimeoutSeconds"], "1800")
+        self.assertEqual(parameters["realReplayShardWorkers"], "2")
         self.assertEqual(parameters["persistResults"], "true")
 
     def test_torghut_knative_manifests_enable_tigerbeetle_journal(self) -> None:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -913,6 +913,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(manifest.get("kind"), "CronWorkflow")
         metadata = cast(Mapping[str, object], manifest.get("metadata", {}))
         self.assertEqual(metadata.get("name"), "torghut-replay-source-materialization")
+        self.assertLessEqual(len(str(metadata.get("name"))), 52)
         spec = cast(Mapping[str, object], manifest.get("spec", {}))
         self.assertEqual(spec.get("schedules"), ["5 5 * * 2-6"])
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -897,6 +897,46 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("tigerbeetle-cluster.yaml", resources)
         self.assertIn("tigerbeetle-smoke-job.yaml", resources)
         self.assertIn("tigerbeetle-journal-order-events-cronjob.yaml", resources)
+        self.assertIn(
+            "whitepaper-autoresearch-replay-materialization-cronworkflow.yaml",
+            resources,
+        )
+
+    def test_whitepaper_autoresearch_replay_materialization_cronworkflow_feeds_renewal(
+        self,
+    ) -> None:
+        manifest = _load_yaml_mapping(
+            "argocd/applications/torghut/"
+            "whitepaper-autoresearch-replay-materialization-cronworkflow.yaml"
+        )
+
+        self.assertEqual(manifest.get("kind"), "CronWorkflow")
+        metadata = cast(Mapping[str, object], manifest.get("metadata", {}))
+        self.assertEqual(metadata.get("name"), "torghut-replay-source-materialization")
+        spec = cast(Mapping[str, object], manifest.get("spec", {}))
+        self.assertEqual(spec.get("schedules"), ["5 5 * * 2-6"])
+        self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
+        self.assertEqual(spec.get("startingDeadlineSeconds"), 900)
+
+        workflow_spec = cast(Mapping[str, object], spec.get("workflowSpec", {}))
+        self.assertEqual(
+            workflow_spec.get("workflowTemplateRef"),
+            {"name": "torghut-whitepaper-autoresearch-profit-target"},
+        )
+        arguments = cast(Mapping[str, object], workflow_spec.get("arguments", {}))
+        parameters = {
+            str(item.get("name")): str(item.get("value"))
+            for item in cast(
+                list[Mapping[str, object]], arguments.get("parameters", [])
+            )
+        }
+        self.assertEqual(parameters["replayTapePreviewTopK"], "16")
+        self.assertEqual(parameters["replayTapePreviewMinRows"], "2")
+        self.assertEqual(parameters["maxCandidates"], "64")
+        self.assertEqual(parameters["topK"], "24")
+        self.assertEqual(parameters["maxTotalFrontierCandidates"], "32")
+        self.assertEqual(parameters["realReplayTimeoutSeconds"], "5400")
+        self.assertEqual(parameters["persistResults"], "true")
 
     def test_torghut_knative_manifests_enable_tigerbeetle_journal(self) -> None:
         expected = {
@@ -1530,7 +1570,7 @@ class TestLiveConfigManifestContract(TestCase):
             "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
-        self.assertIn("--runtime-window-target-plan-exclusive", args)
+        self.assertNotIn("--runtime-window-target-plan-exclusive", args)
         self.assertIn("--runtime-window-target-plan-required", args)
         self.assertIn("--runtime-window-target-plan-settlement-seconds 3600", args)
         self.assertIn("--runtime-window-targets-from-latest-autoresearch", args)


### PR DESCRIPTION
## Summary

- Adds a Torghut CronWorkflow that runs bounded replay-tape materialization from the existing whitepaper autoresearch WorkflowTemplate.
- Keeps the workflow evidence-collection only: persisted results feed runtime-window import candidates without authorizing promotion.
- Lets empirical promotion renewal actually include latest autoresearch and registry targets by removing the contradictory target-plan-exclusive flag.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -f argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q -k 'whitepaper_autoresearch_replay_materialization_cronworkflow_feeds_renewal or empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db or torghut_kustomization_includes_tigerbeetle_cluster'`
- `uv run --frozen ruff format tests/test_live_config_manifest_contract.py --check`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `scripts/argo-lint.sh`
- `bun run lint:argocd`
- `git diff --check HEAD~1..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
