### PR TITLE
feat(torghut): add order-feed source-window proof plumbing

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -319,6 +319,17 @@ class OrderFeedSourceWindow(Base, TimestampMixin):
             "end_offset",
         ),
         Index(
+            "ix_order_feed_source_windows_scope_revision_offsets",
+            "source_topic",
+            "source_partition",
+            "alpaca_account_label",
+            "assignment_mode",
+            "collector_identity",
+            "source_revision",
+            "start_offset",
+            "end_offset",
+        ),
+        Index(
             "ix_order_feed_source_windows_account_window",
             "alpaca_account_label",
             "window_started_at",

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -74,6 +74,7 @@ class NormalizationResult:
 
     event: NormalizedOrderEvent | None
     drop_reason: str | None
+    account_label_explicit: bool = False
 
 
 @dataclass(frozen=True)
@@ -161,6 +162,7 @@ class OrderFeedIngestor:
             "malformed_total": 0,
             "missing_payload_total": 0,
             "missing_identity_total": 0,
+            "out_of_scope_account_total": 0,
             "unlinked_execution_total": 0,
             "unlinked_decision_total": 0,
             "failed_unhandled_total": 0,
@@ -223,13 +225,20 @@ class OrderFeedIngestor:
             if normalized.event is not None
             else _coerce_int(getattr(record, "offset", None))
         )
+        out_of_scope_account = (
+            normalized.event is not None
+            and normalized.account_label_explicit
+            and normalized.event.alpaca_account_label != self._default_account_label
+        )
         source_window = _create_order_feed_source_window(
             session,
             source_topic=source_topic,
             source_partition=source_partition,
             source_offset=source_offset,
             alpaca_account_label=(
-                normalized.event.alpaca_account_label
+                self._default_account_label
+                if out_of_scope_account
+                else normalized.event.alpaca_account_label
                 if normalized.event is not None
                 else self._default_account_label
             ),
@@ -238,6 +247,27 @@ class OrderFeedIngestor:
             counters["source_windows_total"] += 1
 
         try:
+            if out_of_scope_account:
+                counters["missing_fields_total"] += 1
+                if source_window is None:
+                    return _IngestRecordOutcome(durable=False)
+                _classify_source_window_drop(source_window, "out_of_scope_account")
+                _increment_drop_counter(counters, "out_of_scope_account")
+                cursor_updated = _upsert_order_feed_consumer_cursor_from_source(
+                    session,
+                    source_topic=source_topic,
+                    source_partition=source_partition,
+                    source_offset=source_offset,
+                    event_fingerprint=None,
+                    event_ts=None,
+                    duplicate=False,
+                    source_window=source_window,
+                )
+                if cursor_updated:
+                    counters["cursor_updates_total"] += 1
+                counters["classified_drops_total"] += 1
+                return _IngestRecordOutcome(durable=True)
+
             if normalized.event is None:
                 counters["missing_fields_total"] += 1
                 if normalized.drop_reason:
@@ -560,12 +590,18 @@ def _classify_source_window_drop(
     source_window.status = "dropped"
     source_window.status_reason = drop_reason or "unknown_drop"
     source_window.dropped_count = 1
-    if drop_reason == "invalid_json":
+    source_window.payload_json = {
+        "classification": drop_reason or "unknown_drop",
+        "classification_counts": {drop_reason or "unknown_drop": 1},
+    }
+    if drop_reason == "malformed_json":
         source_window.malformed_count = 1
     elif drop_reason == "missing_trade_update_payload":
         source_window.missing_payload_count = 1
     elif drop_reason == "missing_order_identity":
         source_window.missing_identity_count = 1
+    elif drop_reason == "out_of_scope_account":
+        source_window.out_of_scope_account_count = 1
 
 
 def _classify_source_window_unhandled_failure(
@@ -574,6 +610,10 @@ def _classify_source_window_unhandled_failure(
     source_window.status = "failed_unhandled"
     source_window.status_reason = _source_window_failure_reason(exc)
     source_window.failed_unhandled_count = 1
+    source_window.payload_json = {
+        "classification": "failed_unhandled",
+        "classification_counts": {"failed_unhandled": 1},
+    }
 
 
 def _source_window_failure_reason(exc: Exception) -> str:
@@ -582,12 +622,14 @@ def _source_window_failure_reason(exc: Exception) -> str:
 
 
 def _increment_drop_counter(counters: dict[str, int], drop_reason: str | None) -> None:
-    if drop_reason == "invalid_json":
+    if drop_reason == "malformed_json":
         counters["malformed_total"] += 1
     elif drop_reason == "missing_trade_update_payload":
         counters["missing_payload_total"] += 1
     elif drop_reason == "missing_order_identity":
         counters["missing_identity_total"] += 1
+    elif drop_reason == "out_of_scope_account":
+        counters["out_of_scope_account_total"] += 1
 
 
 def _classify_source_window_event(
@@ -602,13 +644,24 @@ def _classify_source_window_event(
         source_window.status = "duplicate"
         source_window.status_reason = "duplicate_event_fingerprint"
         source_window.duplicate_count = 1
+        source_window.payload_json = {
+            "classification": "duplicate",
+            "classification_counts": {"duplicate": 1},
+        }
         return
     source_window.status = "inserted"
     source_window.inserted_count = 1
+    classification_counts = {"inserted": 1}
     if persisted.execution_id is None:
         source_window.unlinked_execution_count = 1
+        classification_counts["unlinked_execution"] = 1
     if persisted.trade_decision_id is None:
         source_window.unlinked_decision_count = 1
+        classification_counts["unlinked_decision"] = 1
+    source_window.payload_json = {
+        "classification": "inserted",
+        "classification_counts": classification_counts,
+    }
 
 
 def normalize_order_feed_record(
@@ -619,7 +672,7 @@ def normalize_order_feed_record(
     value = getattr(record, "value", None)
     payload = _decode_json_payload(value)
     if payload is None:
-        return NormalizationResult(event=None, drop_reason="invalid_json")
+        return NormalizationResult(event=None, drop_reason="malformed_json")
 
     envelope = _as_mapping(payload)
     data_payload = _extract_trade_update_payload(payload)
@@ -669,7 +722,7 @@ def normalize_order_feed_record(
     )
     if source_topic is None:
         source_topic = default_topic
-    account_label = (
+    explicit_account_label = (
         _coerce_text(data_payload.get("account_label"))
         or _coerce_text(data_payload.get("accountLabel"))
         or _coerce_text((order or {}).get("alpaca_account_label"))
@@ -677,8 +730,8 @@ def normalize_order_feed_record(
         or _coerce_text((order or {}).get("accountLabel"))
         or _coerce_text(envelope.get("account_label") if envelope else None)
         or _coerce_text(envelope.get("accountLabel") if envelope else None)
-        or default_account_label
     )
+    account_label = explicit_account_label or default_account_label
 
     fingerprint_input = {
         "alpaca_account_label": account_label,
@@ -717,7 +770,11 @@ def normalize_order_feed_record(
         fill_quantity_basis=None,
         raw_event=coerce_json_payload(payload),
     )
-    return NormalizationResult(event=event, drop_reason=None)
+    return NormalizationResult(
+        event=event,
+        drop_reason=None,
+        account_label_explicit=explicit_account_label is not None,
+    )
 
 
 def persist_order_event(

--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -48,6 +48,7 @@ _TCA_PNL_BASES = frozenset(
 _DIAGNOSTIC_EXPECTANCY_SUPPRESSING_BLOCKERS = frozenset(
     {
         "runtime_fills_missing",
+        "execution_economics_missing",
         "zero_fill_runtime_ledger",
         "closed_round_trip_missing",
         "filled_notional_missing",
@@ -147,11 +148,14 @@ class _NormalizedFill:
     filled_qty_delta: Decimal | None = None
     filled_notional_delta: Decimal | None = None
     fill_quantity_basis: str | None = None
+    lifecycle_only: bool = False
+    order_feed_lifecycle_source: bool = False
 
     @property
     def is_usable_fill(self) -> bool:
         return (
             self.event_type in _FILL_EVENTS
+            and not self.lifecycle_only
             and self.executed_at is not None
             and self.side is not None
             and self.filled_qty is not None
@@ -380,9 +384,21 @@ def _build_bucket(
     if accumulator.filled_notional <= 0:
         blockers.append("filled_notional_missing")
     if require_order_lifecycle:
+        source_lifecycle_present = any(
+            row.order_feed_lifecycle_source for row in lifecycle_rows
+        )
         blockers.extend(
             _order_lifecycle_blockers(
                 lifecycle_rows=lifecycle_rows,
+                fill_lifecycle_rows=[
+                    row
+                    for row in lifecycle_rows
+                    if row.event_type in _FILL_EVENTS
+                    and (
+                        row.order_feed_lifecycle_source
+                        or not source_lifecycle_present
+                    )
+                ],
                 usable_fills=all_usable_fills,
                 decision_count=decision_count,
                 submitted_order_count=submitted_order_count,
@@ -460,6 +476,7 @@ def _carry_in_rows_before_bucket(
 def _order_lifecycle_blockers(
     *,
     lifecycle_rows: Sequence[_NormalizedFill],
+    fill_lifecycle_rows: Sequence[_NormalizedFill],
     usable_fills: Sequence[_NormalizedFill],
     decision_count: int,
     submitted_order_count: int,
@@ -472,12 +489,15 @@ def _order_lifecycle_blockers(
     blockers: list[str] = []
     if not lifecycle_rows:
         blockers.append("runtime_order_lifecycle_missing")
+    if not fill_lifecycle_rows:
+        blockers.append("order_feed_lifecycle_missing")
     if decision_count <= 0:
         blockers.append("runtime_decision_lifecycle_missing")
     if submitted_order_count <= 0:
         blockers.append("submitted_order_lifecycle_missing")
     if not usable_fills:
         blockers.append("zero_fill_runtime_ledger")
+        blockers.append("execution_economics_missing")
 
     submitted_order_ids = {
         row.order_id
@@ -492,12 +512,19 @@ def _order_lifecycle_blockers(
     if submitted_without_decision:
         blockers.append("order_decision_linkage_missing")
 
+    fill_lifecycle_order_ids = {
+        row.order_id for row in fill_lifecycle_rows if row.order_id is not None
+    }
     fill_order_ids = {row.order_id for row in usable_fills if row.order_id is not None}
     if any(row.order_id is None for row in usable_fills):
         blockers.append("fill_order_linkage_missing")
-    if fill_order_ids - submitted_order_ids:
+    if any(row.order_id is None for row in fill_lifecycle_rows):
+        blockers.append("fill_order_linkage_missing")
+    if fill_lifecycle_order_ids - submitted_order_ids:
         blockers.append("fill_order_submission_missing")
-    if submitted_order_ids - fill_order_ids:
+    if fill_order_ids - fill_lifecycle_order_ids:
+        blockers.append("order_feed_lifecycle_missing")
+    if submitted_order_ids - fill_lifecycle_order_ids:
         blockers.append("unfilled_order_present")
     if rejected_order_count > 0:
         blockers.append("rejected_order_present")
@@ -650,7 +677,11 @@ def _normalize_fill_row(
     fill_quantity_basis = _coerce_fill_quantity_basis(
         _row_value(row, "fill_quantity_basis", "quantity_basis")
     )
-    order_feed_source_fill = _is_order_feed_source_fill(row)
+    order_feed_lifecycle_source = _is_order_feed_lifecycle_source_row(
+        row, event_type=event_type
+    )
+    order_feed_source_fill = event_type in _FILL_EVENTS and order_feed_lifecycle_source
+    lifecycle_only = _is_order_feed_lifecycle_only_row(row, event_type=event_type)
     if event_type in _FILL_EVENTS and order_feed_source_fill:
         if fill_quantity_basis in {"delta", "cumulative_to_delta"}:
             if filled_qty_delta is not None:
@@ -728,7 +759,7 @@ def _normalize_fill_row(
         blockers.append("tca_shortfall_not_runtime_pnl")
     if executed_at is None and event_type != "diagnostic":
         blockers.append("executed_at_missing")
-    if event_type in _FILL_EVENTS:
+    if event_type in _FILL_EVENTS and not lifecycle_only:
         if side is None:
             blockers.append("side_missing_or_invalid")
         if filled_qty is None:
@@ -778,6 +809,8 @@ def _normalize_fill_row(
         lineage_hash=lineage_hash,
         replay_data_hash=replay_data_hash,
         blockers=tuple(_dedupe(blockers)),
+        lifecycle_only=lifecycle_only,
+        order_feed_lifecycle_source=order_feed_lifecycle_source,
     )
 
 
@@ -859,12 +892,23 @@ def _coerce_fill_quantity_basis(value: object | None) -> str | None:
     return normalized or None
 
 
-def _is_order_feed_source_fill(row: RuntimeLedgerFill | Mapping[str, object]) -> bool:
+def _is_order_feed_lifecycle_source_row(
+    row: RuntimeLedgerFill | Mapping[str, object],
+    *,
+    event_type: str,
+) -> bool:
+    if event_type not in _LIFECYCLE_EVENTS:
+        return False
+    return _is_order_feed_source_row(row)
+
+
+def _is_order_feed_source_row(row: RuntimeLedgerFill | Mapping[str, object]) -> bool:
     source = _coerce_text(
         _row_value(row, "source", "pnl_derivation", "source_materialization")
     )
     authority_class = _coerce_text(_row_value(row, "authority_class"))
     if source in {
+        "order_feed_lifecycle",
         "execution_order_event",
         "execution_order_events",
         "execution_order_events_runtime_ledger",
@@ -885,6 +929,37 @@ def _is_order_feed_source_fill(row: RuntimeLedgerFill | Mapping[str, object]) ->
             "source_window_id",
             "source_offset",
         )
+    )
+
+
+def _is_order_feed_source_fill(row: RuntimeLedgerFill | Mapping[str, object]) -> bool:
+    return _is_order_feed_source_row(row)
+
+
+def _is_order_feed_lifecycle_only_row(
+    row: RuntimeLedgerFill | Mapping[str, object],
+    *,
+    event_type: str,
+) -> bool:
+    if event_type not in _FILL_EVENTS or not _is_order_feed_source_fill(row):
+        return False
+    source = _coerce_text(
+        _row_value(row, "source", "pnl_derivation", "source_materialization")
+    )
+    if source in {"order_feed_lifecycle", "source_execution_lifecycle"}:
+        return True
+    return (
+        _row_value(
+            row,
+            "cost_amount",
+            "total_cost",
+            "explicit_cost",
+            "commission",
+            "fees",
+            "fee_amount",
+        )
+        is None
+        and _row_value(row, "cost_basis", "cost_source", "fee_basis") is None
     )
 
 

--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -26,6 +26,9 @@ RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER = (
 RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER = (
     "runtime_ledger_authority_class_missing"
 )
+ORDER_FEED_SOURCE_WINDOW_GAP_BLOCKER = "order_feed_source_window_gap"
+ORDER_FEED_LIFECYCLE_MISSING_BLOCKER = "order_feed_lifecycle_missing"
+EXECUTION_ECONOMICS_MISSING_BLOCKER = "execution_economics_missing"
 
 _PROMOTION_GRADE_SOURCE_MATERIALIZATIONS = frozenset(
     {
@@ -177,6 +180,44 @@ def _source_row_counts_have_positive_rows(
     return _source_row_count(bucket, table_name) > 0
 
 
+def _nonnegative_mapping_total(value: object) -> int:
+    if not isinstance(value, Mapping):
+        return 0
+    total = 0
+    for item in cast(Mapping[object, object], value).values():
+        try:
+            parsed = Decimal(str(item))
+        except (InvalidOperation, ValueError):
+            continue
+        if parsed.is_finite() and parsed > 0:
+            total += int(parsed)
+    return total
+
+
+def _nonnegative_int(value: object) -> int:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return 0
+    if not parsed.is_finite() or parsed <= 0:
+        return 0
+    return int(parsed)
+
+
+def _truthy_flag(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    text = _text(value)
+    if text is None:
+        return None
+    normalized = text.lower()
+    if normalized in {"1", "true", "yes", "y"}:
+        return True
+    if normalized in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
 def _promotion_grade_source_refs_present(bucket: Mapping[str, object]) -> bool:
     source_ref_tables = _source_ref_table_names(bucket.get("source_refs"))
     return all(
@@ -224,6 +265,38 @@ def _source_offset_count(bucket: Mapping[str, object]) -> int:
         and bucket.get("source_partition") is not None
         and bucket.get("source_offset") is not None
     )
+
+
+def _source_window_gap_count(bucket: Mapping[str, object]) -> int:
+    count = _nonnegative_int(
+        bucket.get("source_window_gap_count")
+        or bucket.get("order_feed_source_window_gap_count")
+    )
+    if count > 0:
+        return count
+    gap_ranges = bucket.get("source_window_gap_ranges") or bucket.get(
+        "order_feed_source_window_gap_ranges"
+    )
+    if isinstance(gap_ranges, Sequence) and not isinstance(
+        gap_ranges, (str, bytes, bytearray)
+    ):
+        return len(cast(Sequence[object], gap_ranges))
+    return _nonnegative_mapping_total(bucket.get("source_window_gap_counts"))
+
+
+def _source_window_classification_count(
+    bucket: Mapping[str, object],
+    *classification_names: str,
+) -> int:
+    counts = bucket.get("source_window_classification_counts") or bucket.get(
+        "order_feed_source_window_classification_counts"
+    )
+    if not isinstance(counts, Mapping):
+        return 0
+    total = 0
+    for name in classification_names:
+        total += _nonnegative_int(cast(Mapping[object, object], counts).get(name))
+    return total
 
 
 def _promotion_grade_source_materialization_present(
@@ -376,6 +449,23 @@ def runtime_ledger_promotion_source_authority_blockers(
         bucket
     ) < _source_row_count(bucket, "execution_order_events"):
         blockers.append(RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER)
+    if _source_window_gap_count(bucket) > 0:
+        blockers.append(ORDER_FEED_SOURCE_WINDOW_GAP_BLOCKER)
+    lifecycle_complete = _truthy_flag(bucket.get("order_feed_lifecycle_complete"))
+    if lifecycle_complete is False or _source_window_classification_count(
+        bucket,
+        "unlinked_execution",
+        "unlinked_decision",
+        "missing_order_identity",
+        "missing_trade_update_payload",
+        "malformed_json",
+        "out_of_scope_account",
+        "failed_unhandled",
+    ) > 0:
+        blockers.append(ORDER_FEED_LIFECYCLE_MISSING_BLOCKER)
+    economics_complete = _truthy_flag(bucket.get("execution_economics_complete"))
+    if economics_complete is False:
+        blockers.append(EXECUTION_ECONOMICS_MISSING_BLOCKER)
     if (
         not _promotion_grade_source_materialization_present(bucket)
         or _non_promotion_authority_marker_present(bucket.get("source_materialization"))
@@ -397,6 +487,9 @@ def runtime_ledger_promotion_source_authority_present(
 
 __all__ = [
     "RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER",
+    "EXECUTION_ECONOMICS_MISSING_BLOCKER",
+    "ORDER_FEED_LIFECYCLE_MISSING_BLOCKER",
+    "ORDER_FEED_SOURCE_WINDOW_GAP_BLOCKER",
     "RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER",
     "RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER",
     "RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER",

--- a/services/torghut/migrations/versions/0042_order_feed_source_window_scope_index.py
+++ b/services/torghut/migrations/versions/0042_order_feed_source_window_scope_index.py
@@ -1,0 +1,44 @@
+"""Add source-window scope/revision offset index."""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import inspect
+
+revision = "0042_order_feed_source_window_scope_index"
+down_revision = "0041_runtime_ledger_status_index"
+branch_labels = None
+depends_on = None
+
+_INDEX_NAME = "ix_order_feed_source_windows_scope_revision_offsets"
+_TABLE_NAME = "order_feed_source_windows"
+_COLUMNS = [
+    "source_topic",
+    "source_partition",
+    "alpaca_account_label",
+    "assignment_mode",
+    "collector_identity",
+    "source_revision",
+    "start_offset",
+    "end_offset",
+]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(_TABLE_NAME):
+        return
+    existing_indexes = {index["name"] for index in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME not in existing_indexes:
+        op.create_index(_INDEX_NAME, _TABLE_NAME, _COLUMNS)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(_TABLE_NAME):
+        return
+    existing_indexes = {index["name"] for index in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME in existing_indexes:
+        op.drop_index(_INDEX_NAME, table_name=_TABLE_NAME)

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1119,6 +1119,12 @@ def _with_runtime_ledger_source_authority_context(
     execution_order_event_ids: Sequence[object] = (),
     source_window_ids: Sequence[object] = (),
     source_offsets: Sequence[Mapping[str, object]] = (),
+    source_window_status_counts: Mapping[str, int] | None = None,
+    source_window_classification_counts: Mapping[str, int] | None = None,
+    source_window_gap_count: int = 0,
+    source_window_gap_ranges: Sequence[Mapping[str, object]] = (),
+    order_feed_lifecycle_complete: bool | None = None,
+    execution_economics_complete: bool | None = None,
     source_materialization: str | None = None,
     authority_class: str | None = None,
 ) -> dict[str, object]:
@@ -1173,6 +1179,36 @@ def _with_runtime_ledger_source_authority_context(
                 seen_offsets.add(key)
         if existing_offsets:
             payload["source_offsets"] = existing_offsets
+    if source_window_status_counts:
+        payload["source_window_status_counts"] = _merge_count_mappings(
+            _as_mapping(payload.get("source_window_status_counts")),
+            source_window_status_counts,
+        )
+    if source_window_classification_counts:
+        payload["source_window_classification_counts"] = _merge_count_mappings(
+            _as_mapping(payload.get("source_window_classification_counts")),
+            source_window_classification_counts,
+        )
+    if source_window_gap_count > 0:
+        payload["source_window_gap_count"] = max(
+            _nonnegative_int(payload.get("source_window_gap_count")),
+            source_window_gap_count,
+        )
+    if source_window_gap_ranges:
+        existing_gap_ranges = [
+            dict(item)
+            for item in cast(
+                Sequence[object], payload.get("source_window_gap_ranges") or []
+            )
+            if isinstance(item, Mapping)
+        ]
+        existing_gap_ranges.extend(dict(item) for item in source_window_gap_ranges)
+        if existing_gap_ranges:
+            payload["source_window_gap_ranges"] = existing_gap_ranges
+    if order_feed_lifecycle_complete is not None:
+        payload["order_feed_lifecycle_complete"] = order_feed_lifecycle_complete
+    if execution_economics_complete is not None:
+        payload["execution_economics_complete"] = execution_economics_complete
     if source_materialization:
         payload.setdefault("source_materialization", source_materialization)
     if authority_class:
@@ -1186,6 +1222,18 @@ def _with_runtime_ledger_source_authority_context(
     if merged_counts:
         payload["source_row_counts"] = dict(sorted(merged_counts.items()))
     return payload
+
+
+def _merge_count_mappings(
+    existing: Mapping[object, object],
+    incoming: Mapping[str, int],
+) -> dict[str, int]:
+    merged = {
+        str(key): _nonnegative_int(value) for key, value in existing.items()
+    }
+    for key, value in incoming.items():
+        merged[str(key)] = max(0, int(value)) + merged.get(str(key), 0)
+    return dict(sorted((key, value) for key, value in merged.items() if value > 0))
 
 
 def _source_identifier_values(
@@ -1219,6 +1267,83 @@ def _source_offset_values(
         offsets.append({"topic": topic, "partition": partition, "offset": offset})
         seen.add(key)
     return offsets
+
+
+def _unique_source_window_rows(
+    rows: Sequence[Mapping[str, object]] | None,
+) -> list[Mapping[str, object]]:
+    unique_rows: list[Mapping[str, object]] = []
+    seen: set[str] = set()
+    for row in rows or ():
+        source_window_id = _text_or_none(row.get("source_window_id"))
+        if source_window_id is None:
+            continue
+        if source_window_id in seen:
+            continue
+        seen.add(source_window_id)
+        unique_rows.append(row)
+    return unique_rows
+
+
+def _source_window_status_counts(
+    rows: Sequence[Mapping[str, object]] | None,
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in _unique_source_window_rows(rows):
+        status = _text_or_none(row.get("source_window_status"))
+        if status is None:
+            continue
+        counts[status] = counts.get(status, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _source_window_classification_counts(
+    rows: Sequence[Mapping[str, object]] | None,
+) -> dict[str, int]:
+    field_names = {
+        "inserted": "source_window_inserted_count",
+        "duplicate": "source_window_duplicate_count",
+        "malformed_json": "source_window_malformed_count",
+        "missing_trade_update_payload": "source_window_missing_payload_count",
+        "missing_order_identity": "source_window_missing_identity_count",
+        "out_of_scope_account": "source_window_out_of_scope_account_count",
+        "unlinked_execution": "source_window_unlinked_execution_count",
+        "unlinked_decision": "source_window_unlinked_decision_count",
+        "failed_unhandled": "source_window_failed_unhandled_count",
+        "dropped": "source_window_dropped_count",
+    }
+    counts: dict[str, int] = {}
+    for row in _unique_source_window_rows(rows):
+        for classification, field_name in field_names.items():
+            count = _nonnegative_int(row.get(field_name))
+            if count > 0:
+                counts[classification] = counts.get(classification, 0) + count
+    return dict(sorted(counts.items()))
+
+
+def _source_window_gap_count(
+    rows: Sequence[Mapping[str, object]] | None,
+) -> int:
+    return sum(
+        _nonnegative_int(row.get("source_window_gap_count"))
+        for row in _unique_source_window_rows(rows)
+    )
+
+
+def _source_window_gap_ranges(
+    rows: Sequence[Mapping[str, object]] | None,
+) -> list[dict[str, object]]:
+    ranges: list[dict[str, object]] = []
+    for row in _unique_source_window_rows(rows):
+        gap_ranges = row.get("source_window_gap_ranges")
+        if not isinstance(gap_ranges, Sequence) or isinstance(
+            gap_ranges, (str, bytes, bytearray)
+        ):
+            continue
+        for item in cast(Sequence[object], gap_ranges):
+            if isinstance(item, Mapping):
+                ranges.append(dict(item))
+    return ranges
 
 
 def _decision_lifecycle_query_row(row: Sequence[object]) -> dict[str, object]:
@@ -1301,6 +1426,32 @@ def _execution_query_row_has_time(row: Sequence[object]) -> bool:
     return (row[3] if len(row) >= 19 else row[1]) is not None
 
 
+def _source_window_query_context(
+    row: Sequence[object],
+    *,
+    start_index: int,
+) -> dict[str, object]:
+    if len(row) < start_index + 15:
+        return {}
+    return {
+        "source_window_status": row[start_index],
+        "source_window_status_reason": row[start_index + 1],
+        "source_window_consumed_count": row[start_index + 2],
+        "source_window_inserted_count": row[start_index + 3],
+        "source_window_duplicate_count": row[start_index + 4],
+        "source_window_malformed_count": row[start_index + 5],
+        "source_window_missing_payload_count": row[start_index + 6],
+        "source_window_missing_identity_count": row[start_index + 7],
+        "source_window_out_of_scope_account_count": row[start_index + 8],
+        "source_window_unlinked_execution_count": row[start_index + 9],
+        "source_window_unlinked_decision_count": row[start_index + 10],
+        "source_window_failed_unhandled_count": row[start_index + 11],
+        "source_window_dropped_count": row[start_index + 12],
+        "source_window_gap_count": row[start_index + 13],
+        "source_window_gap_ranges": row[start_index + 14],
+    }
+
+
 def _order_lifecycle_query_row(row: Sequence[object]) -> dict[str, object]:
     if len(row) >= 28:
         return {
@@ -1332,6 +1483,7 @@ def _order_lifecycle_query_row(row: Sequence[object]) -> dict[str, object]:
             "raw_event": row[25],
             "execution_audit_json": row[26],
             "raw_order": row[27],
+            **_source_window_query_context(row, start_index=28),
         }
     if len(row) >= 25:
         return {
@@ -2963,6 +3115,16 @@ def _runtime_source_context_for_bucket(
     source_materialization = None
     authority_class = None
     source_offsets = _source_offset_values(source_authority_lifecycle_rows)
+    source_window_status_counts = _source_window_status_counts(
+        source_authority_lifecycle_rows
+    )
+    source_window_classification_counts = _source_window_classification_counts(
+        source_authority_lifecycle_rows
+    )
+    source_window_gap_count = _source_window_gap_count(source_authority_lifecycle_rows)
+    source_window_gap_ranges = _source_window_gap_ranges(
+        source_authority_lifecycle_rows
+    )
     execution_order_event_ids = _source_identifier_values(
         source_authority_lifecycle_rows,
         "execution_order_event_id",
@@ -3007,9 +3169,14 @@ def _runtime_source_context_for_bucket(
             "execution_id",
         ),
         "execution_order_event_ids": execution_order_event_ids,
+        "source_window_status_counts": source_window_status_counts,
+        "source_window_classification_counts": source_window_classification_counts,
+        "source_window_gap_count": source_window_gap_count,
+        "source_window_gap_ranges": source_window_gap_ranges,
         "source_offsets": source_offsets,
         "source_materialization": source_materialization,
         "authority_class": authority_class,
+        "order_feed_lifecycle_complete": source_backed_fill_lifecycle_complete,
         "fill_economics_complete": (
             order_feed_fill_economics_complete or execution_fill_economics_complete
         ),
@@ -3322,6 +3489,24 @@ def _build_realized_strategy_pnl_rows(
     ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     carry_in_ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
+    execution_order_ids = {
+        order_id for row in execution_rows if (order_id := _runtime_order_id(row))
+    }
+    execution_ids = {
+        execution_id
+        for row in execution_rows
+        if (execution_id := _first_text(row, "execution_id"))
+    }
+    carry_in_execution_order_ids = {
+        order_id
+        for row in carry_in_execution_rows or []
+        if (order_id := _runtime_order_id(row))
+    }
+    carry_in_execution_ids = {
+        execution_id
+        for row in carry_in_execution_rows or []
+        if (execution_id := _first_text(row, "execution_id"))
+    }
     for row in decision_lifecycle_rows or []:
         lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type="decision")
         if lifecycle_row is None:
@@ -3340,6 +3525,19 @@ def _build_realized_strategy_pnl_rows(
                 event_type=event_type,
                 require_complete_fill=True,
             )
+            if lifecycle_row is None:
+                row_order_id = _runtime_order_id(row)
+                row_execution_id = _first_text(row, "execution_id")
+                if (
+                    row_order_id in execution_order_ids
+                    or row_execution_id in execution_ids
+                ):
+                    lifecycle_row = _runtime_lifecycle_ledger_row(
+                        row,
+                        event_type=event_type,
+                    )
+                    if lifecycle_row is not None:
+                        lifecycle_row["source"] = "order_feed_lifecycle"
             if lifecycle_row is not None:
                 ledger_rows.append(lifecycle_row)
                 event_time = lifecycle_row.get("executed_at")
@@ -3383,6 +3581,19 @@ def _build_realized_strategy_pnl_rows(
             event_type=event_type,
             require_complete_fill=event_type in _RUNTIME_LEDGER_FILL_EVENTS,
         )
+        if lifecycle_row is None and event_type in _RUNTIME_LEDGER_FILL_EVENTS:
+            row_order_id = _runtime_order_id(row)
+            row_execution_id = _first_text(row, "execution_id")
+            if (
+                row_order_id in carry_in_execution_order_ids
+                or row_execution_id in carry_in_execution_ids
+            ):
+                lifecycle_row = _runtime_lifecycle_ledger_row(
+                    row,
+                    event_type=event_type,
+                )
+                if lifecycle_row is not None:
+                    lifecycle_row["source"] = "order_feed_lifecycle"
         if lifecycle_row is not None:
             carry_in_ledger_rows.append(lifecycle_row)
     combined_order_lifecycle_rows = [
@@ -3440,6 +3651,16 @@ def _build_realized_strategy_pnl_rows(
             list[str], source_context["execution_order_event_ids"]
         )
         source_window_ids = cast(list[str], source_context["source_window_ids"])
+        source_window_status_counts = cast(
+            dict[str, int], source_context["source_window_status_counts"]
+        )
+        source_window_classification_counts = cast(
+            dict[str, int], source_context["source_window_classification_counts"]
+        )
+        source_window_gap_count = int(source_context["source_window_gap_count"] or 0)
+        source_window_gap_ranges = cast(
+            list[Mapping[str, object]], source_context["source_window_gap_ranges"]
+        )
         source_window_start = cast(datetime, source_context["source_window_start"])
         source_window_end = cast(datetime, source_context["source_window_end"])
         source_offsets = cast(
@@ -3449,6 +3670,9 @@ def _build_realized_strategy_pnl_rows(
             str | None, source_context["source_materialization"]
         )
         authority_class = cast(str | None, source_context["authority_class"])
+        order_feed_lifecycle_complete = bool(
+            source_context["order_feed_lifecycle_complete"]
+        )
         fill_economics_complete = bool(source_context["fill_economics_complete"])
         bucket_order_feed_fill_lifecycle_blockers = cast(
             list[str], source_context["order_feed_fill_lifecycle_blockers"]
@@ -3508,6 +3732,12 @@ def _build_realized_strategy_pnl_rows(
                 execution_order_event_ids=execution_order_event_ids,
                 source_window_ids=source_window_ids,
                 source_offsets=source_offsets,
+                source_window_status_counts=source_window_status_counts,
+                source_window_classification_counts=source_window_classification_counts,
+                source_window_gap_count=source_window_gap_count,
+                source_window_gap_ranges=source_window_gap_ranges,
+                order_feed_lifecycle_complete=order_feed_lifecycle_complete,
+                execution_economics_complete=fill_economics_complete,
                 source_materialization=source_materialization,
                 authority_class=authority_class,
             )
@@ -4605,8 +4835,24 @@ def _query_timestamps(
                     oe.source_window_id,
                     oe.raw_event,
                     e.execution_audit_json,
-                    e.raw_order
+                    e.raw_order,
+                    sw.status,
+                    sw.status_reason,
+                    sw.consumed_count,
+                    sw.inserted_count,
+                    sw.duplicate_count,
+                    sw.malformed_count,
+                    sw.missing_payload_count,
+                    sw.missing_identity_count,
+                    sw.out_of_scope_account_count,
+                    sw.unlinked_execution_count,
+                    sw.unlinked_decision_count,
+                    sw.failed_unhandled_count,
+                    sw.dropped_count,
+                    sw.gap_count,
+                    sw.gap_ranges
                 from execution_order_events oe
+                left join order_feed_source_windows sw on sw.id = oe.source_window_id
                 left join lateral (
                     select matched.*
                     from (
@@ -4903,8 +5149,24 @@ def _query_timestamps(
                         oe.source_window_id,
                         oe.raw_event,
                         e.execution_audit_json,
-                        e.raw_order
+                        e.raw_order,
+                        sw.status,
+                        sw.status_reason,
+                        sw.consumed_count,
+                        sw.inserted_count,
+                        sw.duplicate_count,
+                        sw.malformed_count,
+                        sw.missing_payload_count,
+                        sw.missing_identity_count,
+                        sw.out_of_scope_account_count,
+                        sw.unlinked_execution_count,
+                        sw.unlinked_decision_count,
+                        sw.failed_unhandled_count,
+                        sw.dropped_count,
+                        sw.gap_count,
+                        sw.gap_ranges
                     from execution_order_events oe
+                    left join order_feed_source_windows sw on sw.id = oe.source_window_id
                     left join lateral (
                         select matched.*
                         from (
@@ -5041,8 +5303,24 @@ def _query_timestamps(
                         oe.source_window_id,
                         oe.raw_event,
                         e.execution_audit_json,
-                        e.raw_order
+                        e.raw_order,
+                        sw.status,
+                        sw.status_reason,
+                        sw.consumed_count,
+                        sw.inserted_count,
+                        sw.duplicate_count,
+                        sw.malformed_count,
+                        sw.missing_payload_count,
+                        sw.missing_identity_count,
+                        sw.out_of_scope_account_count,
+                        sw.unlinked_execution_count,
+                        sw.unlinked_decision_count,
+                        sw.failed_unhandled_count,
+                        sw.dropped_count,
+                        sw.gap_count,
+                        sw.gap_ranges
                     from execution_order_events oe
+                    left join order_feed_source_windows sw on sw.id = oe.source_window_id
                     left join lateral (
                         select matched.*
                         from (

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -66,10 +66,16 @@ from scripts.import_hypothesis_runtime_windows import (
     _source_decision_rows_profit_proof_eligible,
     _source_order_feed_payload_delta_fill,
     _required_order_lifecycle_source_row_count,
+    _source_window_classification_counts,
+    _source_window_gap_count,
+    _source_window_gap_ranges,
+    _source_window_query_context,
+    _source_window_status_counts,
     _stable_payload_digest,
     _strategy_name_candidates,
     _sqlalchemy_dsn,
     _target_persistence_dsn,
+    _with_runtime_ledger_source_authority_context,
     main,
 )
 
@@ -805,6 +811,137 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("runtime_ledger_source_materialization_missing", blockers)
         self.assertIn("runtime_ledger_authority_class_missing", blockers)
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(aggregate_only))
+
+    def test_runtime_ledger_source_context_threads_source_window_classification(
+        self,
+    ) -> None:
+        bucket = _with_runtime_ledger_source_authority_context(
+            _complete_runtime_ledger_bucket(),
+            source_window_start=datetime(2026, 5, 29, 14, 30, tzinfo=timezone.utc),
+            source_window_end=datetime(2026, 5, 29, 15, 0, tzinfo=timezone.utc),
+            source_refs=[
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+            source_row_counts={
+                "trade_decisions": 1,
+                "executions": 1,
+                "execution_order_events": 1,
+                "order_feed_source_windows": 1,
+            },
+            trade_decision_ids=["decision-1"],
+            execution_ids=["execution-1"],
+            execution_order_event_ids=["event-1"],
+            source_window_ids=["window-1"],
+            source_offsets=[
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+            ],
+            source_window_status_counts={"inserted": 1},
+            source_window_classification_counts={"inserted": 1},
+            order_feed_lifecycle_complete=True,
+            execution_economics_complete=True,
+            source_materialization="execution_order_events",
+            authority_class="runtime_order_feed_execution_source",
+        )
+
+        self.assertEqual(bucket["source_window_status_counts"], {"inserted": 1})
+        self.assertEqual(
+            bucket["source_window_classification_counts"], {"inserted": 1}
+        )
+        self.assertTrue(bucket["order_feed_lifecycle_complete"])
+        self.assertTrue(bucket["execution_economics_complete"])
+        self.assertEqual(_runtime_ledger_bucket_profit_proof_blockers(bucket), [])
+
+    def test_runtime_ledger_source_context_merges_gap_metadata(self) -> None:
+        bucket = _with_runtime_ledger_source_authority_context(
+            {
+                **_complete_runtime_ledger_bucket(),
+                "source_window_gap_count": 1,
+                "source_window_gap_ranges": [{"start_offset": 10, "end_offset": 10}],
+            },
+            source_window_start=datetime(2026, 5, 29, 14, 30, tzinfo=timezone.utc),
+            source_window_end=datetime(2026, 5, 29, 15, 0, tzinfo=timezone.utc),
+            source_refs=[],
+            source_row_counts={},
+            source_window_gap_count=2,
+            source_window_gap_ranges=[{"start_offset": 20, "end_offset": 21}],
+        )
+
+        self.assertEqual(bucket["source_window_gap_count"], 2)
+        self.assertEqual(
+            bucket["source_window_gap_ranges"],
+            [
+                {"start_offset": 10, "end_offset": 10},
+                {"start_offset": 20, "end_offset": 21},
+            ],
+        )
+
+    def test_source_window_metadata_helpers_skip_unusable_rows(self) -> None:
+        rows = [
+            {"source_window_status": "inserted"},
+            {
+                "source_window_id": "window-1",
+                "source_window_status": "inserted",
+                "source_window_inserted_count": 1,
+                "source_window_gap_count": 1,
+                "source_window_gap_ranges": [{"start_offset": 4, "end_offset": 4}],
+            },
+            {
+                "source_window_id": "window-1",
+                "source_window_status": "inserted",
+                "source_window_inserted_count": 1,
+                "source_window_gap_count": 1,
+            },
+            {
+                "source_window_id": "window-2",
+                "source_window_malformed_count": 1,
+                "source_window_gap_ranges": "not-a-list",
+            },
+            {
+                "source_window_id": "window-3",
+                "source_window_status": None,
+                "source_window_gap_ranges": ["not-a-mapping"],
+            },
+        ]
+
+        self.assertEqual(_source_window_status_counts(rows), {"inserted": 1})
+        self.assertEqual(
+            _source_window_classification_counts(rows),
+            {"inserted": 1, "malformed_json": 1},
+        )
+        self.assertEqual(_source_window_gap_count(rows), 1)
+        self.assertEqual(
+            _source_window_gap_ranges(rows),
+            [{"start_offset": 4, "end_offset": 4}],
+        )
+
+    def test_source_window_query_context_rejects_short_rows(self) -> None:
+        self.assertEqual(_source_window_query_context([1, 2, 3], start_index=0), {})
+        self.assertEqual(
+            _source_window_query_context(
+                [
+                    "inserted",
+                    "ok",
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    [],
+                ],
+                start_index=0,
+            )["source_window_status"],
+            "inserted",
+        )
 
     def test_runtime_ledger_materialization_metadata_counts_only_source_backed_authority(
         self,

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -1917,9 +1917,73 @@ class TestOrderFeed(TestCase):
         self.assertEqual(event_count, 0)
         self.assertEqual(cursor.high_watermark_offset, 17)
         self.assertEqual(source_window.status, "dropped")
-        self.assertEqual(source_window.status_reason, "invalid_json")
+        self.assertEqual(source_window.status_reason, "malformed_json")
         self.assertEqual(source_window.malformed_count, 1)
         self.assertEqual(source_window.dropped_count, 1)
+
+    def test_out_of_scope_account_is_durably_classified(self) -> None:
+        record = FakeRecord(
+            value=(
+                b'{"channel":"trade_updates","account_label":"paper-b",'
+                b'"payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+                b'"order":{"id":"order-b","client_order_id":"client-b","symbol":"AAPL",'
+                b'"status":"filled","qty":"1","filled_qty":"1","filled_avg_price":"190.2"}},"seq":10}'
+            ),
+            offset=19,
+        )
+        consumer = FakeConsumer([record])
+        ingestor = OrderFeedIngestor(
+            consumer_factory=lambda: consumer,
+            default_account_label="paper-a",
+        )
+
+        with Session(self.engine) as session:
+            counters = ingestor.ingest_once(session)
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+            cursor = session.execute(select(OrderFeedConsumerCursor)).scalar_one()
+            event_count = len(session.execute(select(ExecutionOrderEvent)).all())
+
+        self.assertEqual(counters["classified_drops_total"], 1)
+        self.assertEqual(counters["out_of_scope_account_total"], 1)
+        self.assertEqual(counters["cursor_updates_total"], 1)
+        self.assertEqual(consumer.commit_calls, 1)
+        self.assertEqual(event_count, 0)
+        self.assertEqual(cursor.high_watermark_offset, 19)
+        self.assertEqual(source_window.alpaca_account_label, "paper-a")
+        self.assertEqual(source_window.status, "dropped")
+        self.assertEqual(source_window.status_reason, "out_of_scope_account")
+        self.assertEqual(source_window.out_of_scope_account_count, 1)
+
+    def test_out_of_scope_account_without_source_position_is_not_committed(
+        self,
+    ) -> None:
+        record = SimpleNamespace(
+            value=(
+                b'{"channel":"trade_updates","account_label":"paper-b",'
+                b'"payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+                b'"order":{"id":"order-b","client_order_id":"client-b","symbol":"AAPL",'
+                b'"status":"filled","qty":"1","filled_qty":"1","filled_avg_price":"190.2"}},"seq":10}'
+            ),
+            topic="torghut.trade-updates.v1",
+        )
+        consumer = FakeConsumer([record])
+        ingestor = OrderFeedIngestor(
+            consumer_factory=lambda: consumer,
+            default_account_label="paper-a",
+        )
+
+        with Session(self.engine) as session:
+            counters = ingestor.ingest_once(session)
+            source_window_count = len(
+                session.execute(select(OrderFeedSourceWindow)).all()
+            )
+            cursor_count = len(session.execute(select(OrderFeedConsumerCursor)).all())
+
+        self.assertEqual(counters["messages_total"], 1)
+        self.assertEqual(counters["cursor_updates_total"], 0)
+        self.assertEqual(consumer.commit_calls, 0)
+        self.assertEqual(source_window_count, 0)
+        self.assertEqual(cursor_count, 0)
 
     def test_missing_order_identity_is_durably_classified(self) -> None:
         record = FakeRecord(

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -739,6 +739,201 @@ def test_order_feed_source_fill_requires_delta_basis() -> None:
     assert "runtime_fills_missing" in bucket.blockers
 
 
+def test_order_feed_lifecycle_fill_without_execution_economics_is_not_pnl_proof() -> None:
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                "event_type": "decision",
+                "executed_at": _ts(0),
+                "decision_id": "decision-1",
+                "order_id": "order-1",
+                "execution_policy_hash": "policy",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "new",
+                "executed_at": _ts(1),
+                "source": "order_feed_lifecycle",
+                "decision_id": "decision-1",
+                "order_id": "order-1",
+                "execution_policy_hash": "policy",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(2),
+                "source": "order_feed_lifecycle",
+                "execution_order_event_id": "event-1",
+                "source_window_id": "window-1",
+                "source_offset": 7,
+                "decision_id": "decision-1",
+                "order_id": "order-1",
+                "filled_qty": "1",
+                "avg_fill_price": "100",
+                "lineage_hash": "lineage",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.fill_count == 0
+    assert bucket.post_cost_expectancy_bps is None
+    assert "execution_economics_missing" in bucket.blockers
+    assert "runtime_fills_missing" in bucket.blockers
+    assert "explicit_cost_missing" not in bucket.blockers
+
+
+def test_execution_economics_with_linked_order_feed_lifecycle_satisfies_runtime_inputs() -> None:
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                "event_type": "decision",
+                "executed_at": _ts(0),
+                "decision_id": "decision-1",
+                "order_id": "order-buy",
+                "execution_policy_hash": "policy",
+                "cost_model_hash": "cost-model",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "new",
+                "executed_at": _ts(1),
+                "source": "order_feed_lifecycle",
+                "decision_id": "decision-1",
+                "order_id": "order-buy",
+                "execution_policy_hash": "policy",
+                "cost_model_hash": "cost-model",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "new",
+                "executed_at": _ts(2),
+                "source": "order_feed_lifecycle",
+                "decision_id": "decision-2",
+                "order_id": "order-sell",
+                "execution_policy_hash": "policy",
+                "cost_model_hash": "cost-model",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(3),
+                "source": "order_feed_lifecycle",
+                "execution_order_event_id": "event-buy",
+                "source_window_id": "window-buy",
+                "source_offset": 7,
+                "decision_id": "decision-1",
+                "order_id": "order-buy",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(4),
+                "source": "order_feed_lifecycle",
+                "execution_order_event_id": "event-sell",
+                "source_window_id": "window-sell",
+                "source_offset": 8,
+                "decision_id": "decision-2",
+                "order_id": "order-sell",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(3),
+                "source": "runtime_execution",
+                "decision_id": "decision-1",
+                "order_id": "order-buy",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "1",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+                "execution_policy_hash": "policy",
+                "cost_model_hash": "cost-model",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(4),
+                "source": "runtime_execution",
+                "decision_id": "decision-2",
+                "order_id": "order-sell",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "1",
+                "avg_fill_price": "101",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+                "execution_policy_hash": "policy",
+                "cost_model_hash": "cost-model",
+                "lineage_hash": "lineage",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.fill_count == 2
+    assert bucket.closed_trade_count == 1
+    assert bucket.post_cost_expectancy_bps is not None
+    assert "order_feed_lifecycle_missing" not in bucket.blockers
+    assert "execution_economics_missing" not in bucket.blockers
+
+
+def test_execution_economics_requires_matching_order_feed_fill_lifecycle() -> None:
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                "event_type": "decision",
+                "executed_at": _ts(0),
+                "decision_id": "decision-1",
+                "order_id": "order-1",
+                "execution_policy_hash": "policy",
+                "cost_model_hash": "cost-model",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "new",
+                "executed_at": _ts(1),
+                "source": "order_feed_lifecycle",
+                "decision_id": "decision-1",
+                "order_id": "order-1",
+                "execution_policy_hash": "policy",
+                "cost_model_hash": "cost-model",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(2),
+                "source": "runtime_execution",
+                "decision_id": "decision-1",
+                "order_id": "order-1",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "1",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+                "execution_policy_hash": "policy",
+                "cost_model_hash": "cost-model",
+                "lineage_hash": "lineage",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert "order_feed_lifecycle_missing" in bucket.blockers
+
+
 def test_order_feed_source_fill_requires_positive_delta_quantity() -> None:
     bucket = _bucket(
         [

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -442,3 +442,139 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 }
             )
         )
+
+    def test_promotion_source_authority_rejects_source_window_gaps(self) -> None:
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 1,
+                    "executions": 1,
+                    "execution_order_events": 1,
+                    "order_feed_source_windows": 1,
+                },
+                "trade_decision_id": "decision-1",
+                "execution_id": "execution-1",
+                "execution_order_event_id": "event-1",
+                "source_window_id": "source-window-1",
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+                "source_window_gap_count": 1,
+            }
+        )
+
+        self.assertIn("order_feed_source_window_gap", blockers)
+
+    def test_promotion_source_authority_rejects_source_window_gap_ranges_and_counts(
+        self,
+    ) -> None:
+        base = {
+            "source_window_start": "2026-05-29T14:30:00+00:00",
+            "source_window_end": "2026-05-29T15:00:00+00:00",
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+            "source_row_counts": {
+                "trade_decisions": 1,
+                "executions": 1,
+                "execution_order_events": 1,
+                "order_feed_source_windows": 1,
+            },
+            "trade_decision_id": "decision-1",
+            "execution_id": "execution-1",
+            "execution_order_event_id": "event-1",
+            "source_window_id": "source-window-1",
+            "source_offsets": [
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+            ],
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+        }
+
+        range_blockers = runtime_ledger_promotion_source_authority_blockers(
+            {**base, "source_window_gap_ranges": [{"start_offset": 41, "end_offset": 41}]}
+        )
+        mapping_blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                **base,
+                "source_window_gap_counts": {
+                    "window-ok": 0,
+                    "window-bad": 2,
+                    "window-invalid": "not-a-number",
+                },
+            }
+        )
+
+        self.assertIn("order_feed_source_window_gap", range_blockers)
+        self.assertIn("order_feed_source_window_gap", mapping_blockers)
+
+    def test_promotion_source_authority_distinguishes_lifecycle_and_economics(
+        self,
+    ) -> None:
+        source_backed = {
+            "source_window_start": "2026-05-29T14:30:00+00:00",
+            "source_window_end": "2026-05-29T15:00:00+00:00",
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+            "source_row_counts": {
+                "trade_decisions": 1,
+                "executions": 1,
+                "execution_order_events": 1,
+                "order_feed_source_windows": 1,
+            },
+            "trade_decision_id": "decision-1",
+            "execution_id": "execution-1",
+            "execution_order_event_id": "event-1",
+            "source_window_id": "source-window-1",
+            "source_offsets": [
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+            ],
+            "source_materialization": "source_execution_lifecycle",
+            "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+        }
+
+        lifecycle_blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                **source_backed,
+                "order_feed_lifecycle_complete": False,
+                "execution_economics_complete": True,
+            }
+        )
+        economics_blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                **source_backed,
+                "order_feed_lifecycle_complete": "yes",
+                "execution_economics_complete": "no",
+            }
+        )
+        unknown_flag_blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                **source_backed,
+                "order_feed_lifecycle_complete": "unknown",
+                "execution_economics_complete": "unknown",
+            }
+        )
+
+        self.assertIn("order_feed_lifecycle_missing", lifecycle_blockers)
+        self.assertNotIn("execution_economics_missing", lifecycle_blockers)
+        self.assertIn("execution_economics_missing", economics_blockers)
+        self.assertNotIn("order_feed_lifecycle_missing", economics_blockers)
+        self.assertNotIn("order_feed_lifecycle_missing", unknown_flag_blockers)
+        self.assertNotIn("execution_economics_missing", unknown_flag_blockers)


### PR DESCRIPTION
## Summary

- Adds a scope/revision offset index and migration for append-only `order_feed_source_windows` lookup by collector/account/topic/partition provenance.
- Durably classifies order-feed records before cursor advance, including malformed JSON, missing payload/identity, out-of-scope accounts, duplicates, unlinked lifecycle rows, source-window gaps, and failed-unhandled records that do not commit Kafka offsets.
- Separates order-feed lifecycle coverage from execution economics in runtime-ledger proof, adding fail-closed blockers for missing source windows/gaps, lifecycle coverage, and execution economics without weakening promotion gates.
- Threads source-window status/classification/gap metadata through runtime-ledger import buckets and adds regression coverage for source-backed lifecycle/economics authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (passed)
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_runtime_ledger_source_authority.py tests/test_import_hypothesis_runtime_windows.py tests/test_simple_pipeline.py -q` (passed: 232 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/models/entities.py app/trading/order_feed.py app/trading/runtime_ledger.py app/trading/runtime_ledger_source_authority.py scripts/import_hypothesis_runtime_windows.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_runtime_ledger_source_authority.py tests/test_import_hypothesis_runtime_windows.py tests/test_simple_pipeline.py` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (passed)
- `git diff --check` (passed)

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds Alembic migration `0042_order_feed_source_window_scope_index` for a new non-unique source-window lookup index. No runtime promotion gates are loosened.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
