### PR TITLE
fix(torghut): pin replay materialization window

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
@@ -19,6 +19,18 @@ spec:
       name: torghut-whitepaper-autoresearch-profit-target
     arguments:
       parameters:
+        - name: fullWindowStartDate
+          value: "2026-05-18"
+        - name: fullWindowEndDate
+          value: "2026-05-22"
+        - name: expectedLastTradingDay
+          value: "2026-05-22"
+        - name: trainDays
+          value: "3"
+        - name: holdoutDays
+          value: "2"
+        - name: secondOosDays
+          value: "0"
         - name: replayTapePreviewTopK
           value: "8"
         - name: replayTapePreviewMinRows

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -931,6 +931,12 @@ class TestLiveConfigManifestContract(TestCase):
                 list[Mapping[str, object]], arguments.get("parameters", [])
             )
         }
+        self.assertEqual(parameters["fullWindowStartDate"], "2026-05-18")
+        self.assertEqual(parameters["fullWindowEndDate"], "2026-05-22")
+        self.assertEqual(parameters["expectedLastTradingDay"], "2026-05-22")
+        self.assertEqual(parameters["trainDays"], "3")
+        self.assertEqual(parameters["holdoutDays"], "2")
+        self.assertEqual(parameters["secondOosDays"], "0")
         self.assertEqual(parameters["replayTapePreviewTopK"], "8")
         self.assertEqual(parameters["replayTapePreviewMinRows"], "2")
         self.assertEqual(parameters["maxCandidates"], "16")


### PR DESCRIPTION
## Summary

- Pins the new replay source materialization CronWorkflow to a complete live microbar window instead of leaving the materialized replay tape dates blank.
- Adds matching train, holdout, and second-OOS parameters so the referenced replay tape window is internally consistent.
- Extends the manifest contract test to prevent the schedule from regressing to a date-less materialization run.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q -k 'whitepaper_autoresearch_replay_materialization_cronworkflow_feeds_renewal or empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db or torghut_kustomization_includes_tigerbeetle_cluster'`
- `uv run --frozen ruff format tests/test_live_config_manifest_contract.py --check`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `scripts/argo-lint.sh argocd/applications/torghut`
- `kubectl apply --dry-run=server -f argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
