### PR TITLE
fix(torghut): bound readiness proof status reads

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6107,6 +6107,30 @@ def _load_options_catalog_freshness_summary(
     cached_payload = _load_cached_options_catalog_freshness_summary(scoped_symbols)
     if cached_payload is not None:
         return cached_payload
+    if not scoped_symbols:
+        return _store_options_catalog_freshness_summary(
+            scoped_symbols,
+            {
+                "status": "unavailable",
+                "scope": "route_symbols",
+                "bounded": True,
+                "coverage_exact": False,
+                "active_contracts_exact": False,
+                "active_contracts": 0,
+                "newest_last_seen_ts": None,
+                "missing_provider_updated_ts_count": 0,
+                "provider_updated_ts_present": False,
+                "newest_provider_updated_ts": None,
+                "missing_close_price_count": 0,
+                "zero_open_interest_count": 0,
+                "route_symbols": [],
+                "route_symbol_freshness": {},
+                "reason_codes": [
+                    "options_catalog_freshness_route_scope_missing",
+                    "options_catalog_freshness_unbounded_global_scan_skipped",
+                ],
+            },
+        )
     try:
         session.execute(text("SET LOCAL statement_timeout = 500"))
         if scoped_symbols:

--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -1622,6 +1622,12 @@ class StrategyHypothesisMetricWindow(Base, TimestampMixin):
         Index("ix_strategy_hypothesis_metric_windows_candidate_id", "candidate_id"),
         Index("ix_strategy_hypothesis_metric_windows_hypothesis_id", "hypothesis_id"),
         Index("ix_strategy_hypothesis_metric_windows_observed_stage", "observed_stage"),
+        Index(
+            "ix_strategy_hypothesis_metric_windows_hypothesis_ended_created",
+            "hypothesis_id",
+            "window_ended_at",
+            "created_at",
+        ),
     )
 
 
@@ -1770,6 +1776,11 @@ class StrategyPromotionDecision(Base, TimestampMixin):
         Index("ix_strategy_promotion_decisions_run_id", "run_id"),
         Index("ix_strategy_promotion_decisions_candidate_id", "candidate_id"),
         Index("ix_strategy_promotion_decisions_hypothesis_id", "hypothesis_id"),
+        Index(
+            "ix_strategy_promotion_decisions_hypothesis_created",
+            "hypothesis_id",
+            "created_at",
+        ),
         Index(
             "uq_strategy_promotion_decisions_run_hypothesis_target",
             "run_id",
@@ -3015,6 +3026,11 @@ class AutoresearchPortfolioCandidate(Base, TimestampMixin):
     __table_args__ = (
         Index("ix_autoresearch_portfolio_candidates_epoch_id", "epoch_id"),
         Index("ix_autoresearch_portfolio_candidates_status", "status"),
+        Index(
+            "ix_autoresearch_portfolio_candidates_status_created",
+            "status",
+            "created_at",
+        ),
     )
 
 

--- a/services/torghut/app/trading/profit_leases.py
+++ b/services/torghut/app/trading/profit_leases.py
@@ -433,6 +433,24 @@ def _promotion_source(
         name: _safe_int(promotion_table_counts.get(name))
         for name in _PROMOTION_TABLE_NAMES
     }
+    count_errors = _string_list(promotion_table_counts.get("count_errors"))
+    truncated_counts = _string_list(promotion_table_counts.get("truncated_counts"))
+    read_blockers = [
+        f"promotion_table_read_unavailable:{name}" for name in count_errors
+    ] + [f"promotion_table_count_truncated:{name}" for name in truncated_counts]
+    if read_blockers:
+        return _source_record(
+            proof_id=proof_id,
+            hypothesis_id=hypothesis_id,
+            account=account,
+            window=window,
+            source_class="research_candidate",
+            source_ref="postgres:promotion_tables:bounded_read",
+            freshness_state="blocked",
+            rows=sum(counts.values()),
+            decision="repair_only",
+            blocking_reason_codes=read_blockers,
+        )
     legacy_counts = {name: counts[name] for name in _LEGACY_PROMOTION_TABLE_NAMES}
     legacy_missing = [name for name, count in legacy_counts.items() if count <= 0]
     if not legacy_missing:
@@ -760,6 +778,12 @@ def build_profit_lease_projection(
     promotion_evidence: dict[str, Any] = dict(counts)
     promotion_evidence["autoresearch_portfolio_ready_refs"] = _string_list(
         raw_promotion_counts.get("autoresearch_portfolio_ready_refs")
+    )
+    promotion_evidence["count_errors"] = _string_list(
+        raw_promotion_counts.get("count_errors")
+    )
+    promotion_evidence["truncated_counts"] = _string_list(
+        raw_promotion_counts.get("truncated_counts")
     )
     readiness = _as_mapping(data_readiness)
     controls = _as_mapping(live_controls)

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -108,6 +108,9 @@ _AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
 _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT = 256
 _RUNTIME_LEDGER_REPAIR_CANDIDATE_LIMIT = 8
 _RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS = 750
+_PROMOTION_TABLE_COUNT_SCAN_LIMIT = 1000
+_PROMOTION_PORTFOLIO_READY_SCAN_LIMIT = 256
+_CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT = 8
 _RUNTIME_WINDOW_IMPORT_CONTINUITY_READY_STATES = frozenset(
     {
         "signals_present",
@@ -166,29 +169,43 @@ def _empty_profit_promotion_table_counts(
         "autoresearch_portfolio_ready": 0,
         "autoresearch_portfolio_blocked": 0,
         "autoresearch_portfolio_ready_refs": [],
+        "count_basis": "bounded_latest_rows",
+        "count_limit": _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
+        "autoresearch_portfolio_scan_limit": _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
+        "truncated_counts": [],
         "count_errors": sorted(set(count_errors or ())),
     }
 
 
-def _load_profit_promotion_scalar_count(
+def _load_profit_promotion_bounded_row_count(
     session: Session,
     *,
     table_name: str,
-    statement: Any,
+    model: Any,
     count_errors: list[str],
+    truncated_counts: list[str],
 ) -> int:
     try:
         _maybe_set_runtime_ledger_status_statement_timeout(session)
-        return int(session.execute(statement).scalar_one())
+        rows = list(
+            session.execute(
+                select(model.id)
+                .order_by(model.created_at.desc())
+                .limit(_PROMOTION_TABLE_COUNT_SCAN_LIMIT + 1)
+            )
+        )
     except SQLAlchemyError as exc:
         logger.warning(
-            "Failed to load profit promotion table count table=%s error=%s",
+            "Failed to load bounded profit promotion table rows table=%s error=%s",
             table_name,
             exc,
         )
         count_errors.append(table_name)
         _rollback_runtime_ledger_status_session(session)
         return 0
+    if len(rows) > _PROMOTION_TABLE_COUNT_SCAN_LIMIT:
+        truncated_counts.append(table_name)
+    return min(len(rows), _PROMOTION_TABLE_COUNT_SCAN_LIMIT)
 
 
 def _runtime_window_import_continuity_signal(state: object) -> tuple[str, str, str]:
@@ -702,6 +719,32 @@ def build_hypothesis_runtime_summary(
         registry=registry,
         dependency_quorum=dependency_quorum,
     )
+    summary["runtime_ledger_read_status"] = {
+        "status": runtime_ledger_summary.get("query_status", "unknown"),
+        "reason_codes": list(
+            cast(
+                Sequence[object],
+                runtime_ledger_summary.get("query_reason_codes") or [],
+            )
+        ),
+        "query_limit": runtime_ledger_summary.get("query_limit"),
+    }
+    certificate_reason_codes = sorted(
+        {
+            str(reason).strip()
+            for row in evidence
+            for reason in cast(
+                Sequence[object],
+                row.get("query_reason_codes") or [],
+            )
+            if str(reason).strip()
+        }
+    )
+    summary["certificate_evidence_read_status"] = {
+        "status": "ok" if not certificate_reason_codes else "degraded",
+        "reason_codes": certificate_reason_codes,
+        "per_hypothesis_limit": _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT,
+    }
     summary["items"] = items
     return summary
 
@@ -1141,7 +1184,13 @@ def _load_latest_runtime_ledger_summary(
     ]
     by_hypothesis: dict[str, dict[str, object]] = {}
     if not normalized_ids:
-        return {"by_hypothesis": by_hypothesis, "runtime_ledger_buckets": []}
+        return {
+            "by_hypothesis": by_hypothesis,
+            "runtime_ledger_buckets": [],
+            "query_status": "skipped",
+            "query_reason_codes": ["runtime_ledger_hypothesis_scope_missing"],
+            "query_limit": _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT,
+        }
 
     rows_by_hypothesis: dict[str, int] = {}
     retained_rows: list[dict[str, object]] = []
@@ -1174,8 +1223,27 @@ def _load_latest_runtime_ledger_summary(
     except SQLAlchemyError as exc:
         logger.warning("Runtime ledger latest summary unavailable: %s", exc)
         _rollback_runtime_ledger_status_session(session)
-        return {"by_hypothesis": by_hypothesis, "runtime_ledger_buckets": []}
-    return {"by_hypothesis": by_hypothesis, "runtime_ledger_buckets": retained_rows}
+        reason_code = (
+            "runtime_ledger_summary_query_timeout"
+            if _sqlalchemy_error_indicates_statement_timeout(exc)
+            else "runtime_ledger_summary_query_unavailable"
+        )
+        return {
+            "by_hypothesis": by_hypothesis,
+            "runtime_ledger_buckets": [],
+            "query_status": "timeout"
+            if reason_code == "runtime_ledger_summary_query_timeout"
+            else "unavailable",
+            "query_reason_codes": [reason_code],
+            "query_limit": _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT,
+        }
+    return {
+        "by_hypothesis": by_hypothesis,
+        "runtime_ledger_buckets": retained_rows,
+        "query_status": "ok",
+        "query_reason_codes": [],
+        "query_limit": _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT,
+    }
 
 
 def _runtime_ledger_selection_score(payload: Mapping[str, object] | None) -> int:
@@ -2140,6 +2208,10 @@ def _load_latest_certificate_evidence(
     ]
     if not normalized_ids:
         return []
+    total_limit = max(
+        1,
+        len(normalized_ids) * _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT,
+    )
 
     windows_by_hypothesis: dict[str, list[StrategyHypothesisMetricWindow]] = {}
     try:
@@ -2151,18 +2223,28 @@ def _load_latest_certificate_evidence(
                 StrategyHypothesisMetricWindow.window_ended_at.desc().nullslast(),
                 StrategyHypothesisMetricWindow.created_at.desc(),
             )
+            .limit(total_limit)
         ).scalars()
         for row in window_rows:
             windows_by_hypothesis.setdefault(row.hypothesis_id, []).append(row)
     except SQLAlchemyError as exc:
         logger.warning("Metric-window certificate evidence unavailable: %s", exc)
         _rollback_runtime_ledger_status_session(session)
+        reason_code = (
+            "certificate_metric_window_query_timeout"
+            if _sqlalchemy_error_indicates_statement_timeout(exc)
+            else "certificate_metric_window_query_unavailable"
+        )
         return [
             {
                 "hypothesis_id": hypothesis_id,
                 "metric_window": None,
                 "promotion_decision": None,
                 "runtime_ledger_bucket": None,
+                "query_status": "timeout"
+                if reason_code == "certificate_metric_window_query_timeout"
+                else "unavailable",
+                "query_reason_codes": [reason_code],
             }
             for hypothesis_id in normalized_ids
         ]
@@ -2176,18 +2258,28 @@ def _load_latest_certificate_evidence(
                 StrategyPromotionDecision.hypothesis_id.in_(normalized_ids),
             )
             .order_by(StrategyPromotionDecision.created_at.desc())
+            .limit(total_limit)
         ).scalars()
         for row in promotion_rows:
             latest_promotions.setdefault(row.hypothesis_id, []).append(row)
     except SQLAlchemyError as exc:
         logger.warning("Promotion-decision certificate evidence unavailable: %s", exc)
         _rollback_runtime_ledger_status_session(session)
+        reason_code = (
+            "certificate_promotion_decision_query_timeout"
+            if _sqlalchemy_error_indicates_statement_timeout(exc)
+            else "certificate_promotion_decision_query_unavailable"
+        )
         return [
             {
                 "hypothesis_id": hypothesis_id,
                 "metric_window": None,
                 "promotion_decision": None,
                 "runtime_ledger_bucket": None,
+                "query_status": "timeout"
+                if reason_code == "certificate_promotion_decision_query_timeout"
+                else "unavailable",
+                "query_reason_codes": [reason_code],
             }
             for hypothesis_id in normalized_ids
         ]
@@ -2210,6 +2302,13 @@ def _load_latest_certificate_evidence(
         logger.warning("Runtime ledger certificate evidence unavailable: %s", exc)
         _rollback_runtime_ledger_status_session(session)
         latest_runtime_ledgers = {}
+        runtime_ledger_reason_code = (
+            "certificate_runtime_ledger_query_timeout"
+            if _sqlalchemy_error_indicates_statement_timeout(exc)
+            else "certificate_runtime_ledger_query_unavailable"
+        )
+    else:
+        runtime_ledger_reason_code = None
 
     evidence: list[dict[str, object]] = []
     for hypothesis_id in normalized_ids:
@@ -2245,6 +2344,15 @@ def _load_latest_certificate_evidence(
                     "metric_window": metric_window,
                     "promotion_decision": promotion_decision,
                     "runtime_ledger_bucket": runtime_ledger_bucket,
+                    "query_status": "ok"
+                    if runtime_ledger_reason_code is None
+                    else "timeout"
+                    if runtime_ledger_reason_code
+                    == "certificate_runtime_ledger_query_timeout"
+                    else "unavailable",
+                    "query_reason_codes": []
+                    if runtime_ledger_reason_code is None
+                    else [runtime_ledger_reason_code],
                 }
             )
         if not candidate_rows:
@@ -2254,6 +2362,15 @@ def _load_latest_certificate_evidence(
                     "metric_window": None,
                     "promotion_decision": None,
                     "runtime_ledger_bucket": None,
+                    "query_status": "ok"
+                    if runtime_ledger_reason_code is None
+                    else "timeout"
+                    if runtime_ledger_reason_code
+                    == "certificate_runtime_ledger_query_timeout"
+                    else "unavailable",
+                    "query_reason_codes": []
+                    if runtime_ledger_reason_code is None
+                    else [runtime_ledger_reason_code],
                 }
             )
             continue
@@ -3115,10 +3232,15 @@ def _attach_lineage_refs(
 
 def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
     count_errors: list[str] = []
+    truncated_counts: list[str] = []
     try:
         _maybe_set_runtime_ledger_status_statement_timeout(session)
         portfolio_rows = list(
-            session.execute(select(AutoresearchPortfolioCandidate)).scalars()
+            session.execute(
+                select(AutoresearchPortfolioCandidate)
+                .order_by(AutoresearchPortfolioCandidate.created_at.desc())
+                .limit(_PROMOTION_PORTFOLIO_READY_SCAN_LIMIT + 1)
+            ).scalars()
         )
     except SQLAlchemyError as exc:
         logger.warning(
@@ -3129,6 +3251,9 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         return _empty_profit_promotion_table_counts(
             count_errors=["autoresearch_portfolio_candidates"]
         )
+    if len(portfolio_rows) > _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT:
+        portfolio_rows = portfolio_rows[:_PROMOTION_PORTFOLIO_READY_SCAN_LIMIT]
+        count_errors.append("autoresearch_portfolio_candidates_bounded_scan_truncated")
 
     current_oracle_ready = 0
     current_policy_blocked = 0
@@ -3182,57 +3307,69 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
             _rollback_runtime_ledger_status_session(session)
 
     return {
-        "research_candidates": _load_profit_promotion_scalar_count(
+        "research_candidates": _load_profit_promotion_bounded_row_count(
             session,
             table_name="research_candidates",
-            statement=select(func.count(ResearchCandidate.id)),
             count_errors=count_errors,
+            truncated_counts=truncated_counts,
+            model=ResearchCandidate,
         ),
-        "research_promotions": _load_profit_promotion_scalar_count(
+        "research_promotions": _load_profit_promotion_bounded_row_count(
             session,
             table_name="research_promotions",
-            statement=select(func.count(ResearchPromotion.id)),
             count_errors=count_errors,
+            truncated_counts=truncated_counts,
+            model=ResearchPromotion,
         ),
-        "strategy_promotion_decisions": _load_profit_promotion_scalar_count(
+        "strategy_promotion_decisions": _load_profit_promotion_bounded_row_count(
             session,
             table_name="strategy_promotion_decisions",
-            statement=select(func.count(StrategyPromotionDecision.id)),
             count_errors=count_errors,
+            truncated_counts=truncated_counts,
+            model=StrategyPromotionDecision,
         ),
-        "vnext_promotion_decisions": _load_profit_promotion_scalar_count(
+        "vnext_promotion_decisions": _load_profit_promotion_bounded_row_count(
             session,
             table_name="vnext_promotion_decisions",
-            statement=select(func.count(VNextPromotionDecision.id)),
             count_errors=count_errors,
+            truncated_counts=truncated_counts,
+            model=VNextPromotionDecision,
         ),
-        "autoresearch_epochs": _load_profit_promotion_scalar_count(
+        "autoresearch_epochs": _load_profit_promotion_bounded_row_count(
             session,
             table_name="autoresearch_epochs",
-            statement=select(func.count(AutoresearchEpoch.id)),
             count_errors=count_errors,
+            truncated_counts=truncated_counts,
+            model=AutoresearchEpoch,
         ),
-        "autoresearch_candidate_specs": _load_profit_promotion_scalar_count(
+        "autoresearch_candidate_specs": _load_profit_promotion_bounded_row_count(
             session,
             table_name="autoresearch_candidate_specs",
-            statement=select(func.count(AutoresearchCandidateSpec.id)),
             count_errors=count_errors,
+            truncated_counts=truncated_counts,
+            model=AutoresearchCandidateSpec,
         ),
-        "autoresearch_proposal_scores": _load_profit_promotion_scalar_count(
+        "autoresearch_proposal_scores": _load_profit_promotion_bounded_row_count(
             session,
             table_name="autoresearch_proposal_scores",
-            statement=select(func.count(AutoresearchProposalScore.id)),
             count_errors=count_errors,
+            truncated_counts=truncated_counts,
+            model=AutoresearchProposalScore,
         ),
-        "autoresearch_portfolio_candidates": _load_profit_promotion_scalar_count(
+        "autoresearch_portfolio_candidates": _load_profit_promotion_bounded_row_count(
             session,
             table_name="autoresearch_portfolio_candidates",
-            statement=select(func.count(AutoresearchPortfolioCandidate.id)),
             count_errors=count_errors,
+            truncated_counts=truncated_counts,
+            model=AutoresearchPortfolioCandidate,
         ),
         "autoresearch_portfolio_ready": current_oracle_ready,
         "autoresearch_portfolio_blocked": current_policy_blocked,
         "autoresearch_portfolio_ready_refs": sorted(ready_refs),
+        "count_basis": "bounded_latest_rows",
+        "count_limit": _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
+        "autoresearch_portfolio_scan_limit": _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
+        "truncated_counts": sorted(set(truncated_counts)),
         "count_errors": sorted(set(count_errors)),
     }
 

--- a/services/torghut/migrations/versions/0043_status_readiness_bounded_read_indexes.py
+++ b/services/torghut/migrations/versions/0043_status_readiness_bounded_read_indexes.py
@@ -1,0 +1,63 @@
+"""Add bounded status/readiness lookup indexes.
+
+Revision ID: 0043_status_readiness_bounded_read_indexes
+Revises: 0042_order_feed_source_window_scope_index
+Create Date: 2026-06-01 10:05:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0043_status_readiness_bounded_read_indexes"
+down_revision = "0042_order_feed_source_window_scope_index"
+branch_labels = None
+depends_on = None
+
+_INDEXES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    (
+        "ix_strategy_hypothesis_metric_windows_hypothesis_ended_created",
+        "strategy_hypothesis_metric_windows",
+        ("hypothesis_id", "window_ended_at", "created_at"),
+    ),
+    (
+        "ix_strategy_promotion_decisions_hypothesis_created",
+        "strategy_promotion_decisions",
+        ("hypothesis_id", "created_at"),
+    ),
+    (
+        "ix_autoresearch_portfolio_candidates_status_created",
+        "autoresearch_portfolio_candidates",
+        ("status", "created_at"),
+    ),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    for index_name, table_name, columns in _INDEXES:
+        if not inspector.has_table(table_name):
+            continue
+        existing_indexes = {
+            index["name"] for index in inspector.get_indexes(table_name)
+        }
+        if index_name in existing_indexes:
+            continue
+        op.create_index(index_name, table_name, list(columns))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    for index_name, table_name, _columns in reversed(_INDEXES):
+        if not inspector.has_table(table_name):
+            continue
+        existing_indexes = {
+            index["name"] for index in inspector.get_indexes(table_name)
+        }
+        if index_name not in existing_indexes:
+            continue
+        op.drop_index(index_name, table_name=table_name)

--- a/services/torghut/tests/test_profit_leases.py
+++ b/services/torghut/tests/test_profit_leases.py
@@ -323,6 +323,51 @@ class TestProfitLeaseProjection(TestCase):
             "autoresearch_candidate_specs_empty", lease["blocking_reason_codes"]
         )
 
+    def test_promotion_table_read_errors_fail_closed_with_specific_blockers(
+        self,
+    ) -> None:
+        counts = _promotion_counts(0)
+        counts.update(
+            {
+                "autoresearch_candidate_specs": 2,
+                "autoresearch_proposal_scores": 2,
+                "autoresearch_portfolio_candidates": 1,
+                "autoresearch_portfolio_ready": 1,
+                "autoresearch_portfolio_ready_refs": [
+                    "hypothesis_id:H-CONT-01",
+                ],
+                "count_errors": ["autoresearch_portfolio_candidates"],
+                "truncated_counts": ["autoresearch_epochs"],
+            }
+        )
+
+        projection = build_profit_lease_projection(
+            runtime_items=[_runtime_item()],
+            quant_evidence=_healthy_quant(),
+            empirical_jobs_status=_current_empirical(),
+            dependency_quorum={"decision": "allow", "reasons": []},
+            rejection_summary={
+                "rejected": 0,
+                "blocked": 0,
+                "filled": 10,
+                "total": 10,
+            },
+            promotion_table_counts=counts,
+            data_readiness={"equity_ta_rows": 100, "equity_ta_symbols": 20},
+            now=datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc),
+        )
+
+        lease = projection["leases"][0]
+        self.assertEqual(lease["capital_decision"], "repair_only")
+        self.assertIn(
+            "promotion_table_read_unavailable:autoresearch_portfolio_candidates",
+            lease["blocking_reason_codes"],
+        )
+        self.assertIn(
+            "promotion_table_count_truncated:autoresearch_epochs",
+            lease["blocking_reason_codes"],
+        )
+
     def test_autoresearch_ledgers_block_on_missing_proposal_scores(self) -> None:
         counts = _promotion_counts(0)
         counts.update(

--- a/services/torghut/tests/test_status_readiness_bounded_read_indexes_migration.py
+++ b/services/torghut/tests/test_status_readiness_bounded_read_indexes_migration.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0043_status_readiness_bounded_read_indexes.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0043", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0043")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestStatusReadinessBoundedReadIndexesMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(module.revision, "0043_status_readiness_bounded_read_indexes")
+        self.assertEqual(
+            module.down_revision, "0042_order_feed_source_window_scope_index"
+        )
+
+    def test_upgrade_adds_bounded_status_read_indexes(self) -> None:
+        module = _load_migration_module()
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_indexes.return_value = []
+
+        with (
+            patch.object(module.op, "get_bind", return_value=object()),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "create_index") as create_index,
+        ):
+            module.upgrade()
+
+        self.assertEqual(create_index.call_count, 3)
+        created_names = [call.args[0] for call in create_index.call_args_list]
+        self.assertIn(
+            "ix_strategy_hypothesis_metric_windows_hypothesis_ended_created",
+            created_names,
+        )
+        self.assertIn(
+            "ix_strategy_promotion_decisions_hypothesis_created",
+            created_names,
+        )
+        self.assertIn(
+            "ix_autoresearch_portfolio_candidates_status_created",
+            created_names,
+        )
+
+    def test_downgrade_drops_existing_indexes(self) -> None:
+        module = _load_migration_module()
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_indexes.return_value = [
+            {"name": "ix_strategy_hypothesis_metric_windows_hypothesis_ended_created"},
+            {"name": "ix_strategy_promotion_decisions_hypothesis_created"},
+            {"name": "ix_autoresearch_portfolio_candidates_status_created"},
+        ]
+
+        with (
+            patch.object(module.op, "get_bind", return_value=object()),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "drop_index") as drop_index,
+        ):
+            module.downgrade()
+
+        self.assertEqual(drop_index.call_count, 3)

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -28,6 +28,9 @@ from app.models import (
 )
 from app.trading.hypotheses import JangarDependencyQuorumStatus
 from app.trading.submission_council import (
+    _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT,
+    _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
+    _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
     _QUANT_HEALTH_CACHE,
     _certificate_evidence_authority_score,
     _certificate_evidence_selection_key,
@@ -435,9 +438,15 @@ class TestSubmissionCouncil(TestCase):
         newer = datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc)
 
         with session_local() as session:
+            empty_summary = _load_latest_runtime_ledger_summary(
+                session, hypothesis_ids=[]
+            )
+            self.assertEqual(empty_summary["by_hypothesis"], {})
+            self.assertEqual(empty_summary["runtime_ledger_buckets"], [])
+            self.assertEqual(empty_summary["query_status"], "skipped")
             self.assertEqual(
-                _load_latest_runtime_ledger_summary(session, hypothesis_ids=[]),
-                {"by_hypothesis": {}, "runtime_ledger_buckets": []},
+                empty_summary["query_reason_codes"],
+                ["runtime_ledger_hypothesis_scope_missing"],
             )
             session.add_all(
                 [
@@ -596,7 +605,12 @@ class TestSubmissionCouncil(TestCase):
             hypothesis_ids=["H-PAIRS-01"],
         )
 
-        self.assertEqual(summary, {"by_hypothesis": {}, "runtime_ledger_buckets": []})
+        self.assertEqual(summary["by_hypothesis"], {})
+        self.assertEqual(summary["runtime_ledger_buckets"], [])
+        self.assertEqual(summary["query_status"], "timeout")
+        self.assertEqual(
+            summary["query_reason_codes"], ["runtime_ledger_summary_query_timeout"]
+        )
         self.assertEqual(fake_session.rollback_count, 1)
 
     def test_load_latest_certificate_evidence_fails_closed_on_window_timeout(
@@ -618,6 +632,8 @@ class TestSubmissionCouncil(TestCase):
                     "metric_window": None,
                     "promotion_decision": None,
                     "runtime_ledger_bucket": None,
+                    "query_status": "timeout",
+                    "query_reason_codes": ["certificate_metric_window_query_timeout"],
                 }
             ],
         )
@@ -690,9 +706,58 @@ class TestSubmissionCouncil(TestCase):
                     "metric_window": None,
                     "promotion_decision": None,
                     "runtime_ledger_bucket": None,
+                    "query_status": "timeout",
+                    "query_reason_codes": [
+                        "certificate_promotion_decision_query_timeout"
+                    ],
                 }
             ],
         )
+
+    def test_load_latest_certificate_evidence_uses_bounded_status_reads(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            execute = session.execute
+            statements: list[str] = []
+
+            def capture_execute(
+                statement: object, *args: object, **kwargs: object
+            ) -> object:
+                statements.append(str(statement))
+                return execute(statement, *args, **kwargs)
+
+            with patch.object(session, "execute", side_effect=capture_execute):
+                evidence = _load_latest_certificate_evidence(
+                    session,
+                    hypothesis_ids=["H-PAIRS-01", "H-REV-01"],
+                )
+
+        self.assertEqual(len(evidence), 2)
+        bounded_limit = 2 * _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT
+        self.assertTrue(
+            any(
+                "FROM strategy_hypothesis_metric_windows" in statement
+                and "LIMIT" in statement
+                for statement in statements
+            )
+        )
+        self.assertTrue(
+            any(
+                "FROM strategy_promotion_decisions" in statement
+                and "LIMIT" in statement
+                for statement in statements
+            )
+        )
+        self.assertGreaterEqual(bounded_limit, 1)
 
     def test_attach_lineage_refs_fails_closed_on_query_timeout(self) -> None:
         fake_session = _FailingRuntimeLedgerStatusSession()
@@ -766,7 +831,12 @@ class TestSubmissionCouncil(TestCase):
             hypothesis_ids=["H-PAIRS-01"],
         )
 
-        self.assertEqual(summary, {"by_hypothesis": {}, "runtime_ledger_buckets": []})
+        self.assertEqual(summary["by_hypothesis"], {})
+        self.assertEqual(summary["runtime_ledger_buckets"], [])
+        self.assertEqual(summary["query_status"], "timeout")
+        self.assertEqual(
+            summary["query_reason_codes"], ["runtime_ledger_summary_query_timeout"]
+        )
         self.assertEqual(fake_session.rollback_count, 1)
 
     def test_load_runtime_ledger_repair_candidates_fails_closed_on_query_timeout(
@@ -3737,6 +3807,92 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(counts["autoresearch_portfolio_blocked"], 1)
         self.assertEqual(counts["autoresearch_portfolio_ready"], 0)
         self.assertEqual(counts["count_errors"], [])
+        self.assertEqual(counts["count_basis"], "bounded_latest_rows")
+        self.assertEqual(counts["count_limit"], _PROMOTION_TABLE_COUNT_SCAN_LIMIT)
+
+    def test_load_profit_promotion_counts_use_bounded_row_reads(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            session.add(
+                AutoresearchEpoch(
+                    epoch_id="epoch-1",
+                    status="complete",
+                    target_net_pnl_per_day=Decimal("500"),
+                    paper_run_ids_json=[],
+                    snapshot_manifest_json={},
+                    runner_config_json={},
+                    summary_json={},
+                    started_at=datetime.now(timezone.utc),
+                    completed_at=datetime.now(timezone.utc),
+                )
+            )
+            session.commit()
+            execute = session.execute
+            statements: list[str] = []
+
+            def capture_execute(
+                statement: object, *args: object, **kwargs: object
+            ) -> object:
+                statements.append(str(statement))
+                return execute(statement, *args, **kwargs)
+
+            with patch.object(session, "execute", side_effect=capture_execute):
+                counts = _load_profit_promotion_table_counts(session)
+
+        self.assertEqual(counts["autoresearch_epochs"], 1)
+        self.assertEqual(counts["truncated_counts"], [])
+        self.assertFalse(any("count(" in statement.lower() for statement in statements))
+        self.assertTrue(
+            any(
+                "FROM autoresearch_epochs" in statement and "LIMIT" in statement
+                for statement in statements
+            )
+        )
+
+    def test_load_profit_promotion_counts_fail_closed_when_portfolio_scan_truncated(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            for idx in range(_PROMOTION_PORTFOLIO_READY_SCAN_LIMIT + 1):
+                session.add(
+                    AutoresearchPortfolioCandidate(
+                        portfolio_candidate_id=f"portfolio-{idx}",
+                        epoch_id="epoch-1",
+                        source_candidate_ids_json=[f"spec-{idx}"],
+                        target_net_pnl_per_day=Decimal("500"),
+                        objective_scorecard_json={},
+                        optimizer_report_json={"selected_count": 1},
+                        payload_json={"portfolio_candidate_id": f"portfolio-{idx}"},
+                        status="blocked",
+                    )
+                )
+            session.commit()
+
+            counts = _load_profit_promotion_table_counts(session)
+
+        self.assertEqual(
+            counts["autoresearch_portfolio_scan_limit"],
+            _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
+        )
+        self.assertIn(
+            "autoresearch_portfolio_candidates_bounded_scan_truncated",
+            counts["count_errors"],
+        )
 
     def test_load_profit_promotion_counts_fail_closed_for_timed_out_count(
         self,
@@ -3796,7 +3952,11 @@ class TestSubmissionCouncil(TestCase):
             def fail_proposal_score_count(
                 statement: object, *args: object, **kwargs: object
             ) -> object:
-                if "count(autoresearch_proposal_scores.id)" in str(statement):
+                statement_text = str(statement)
+                if (
+                    "FROM autoresearch_proposal_scores" in statement_text
+                    and "LIMIT" in statement_text
+                ):
                     raise SQLAlchemyError("statement timeout")
                 return execute(statement, *args, **kwargs)
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -637,7 +637,7 @@ class TestTradingApi(TestCase):
             1,
         )
 
-    def test_options_catalog_freshness_summary_uses_global_scan_without_route_scope(
+    def test_options_catalog_freshness_summary_skips_global_scan_without_route_scope(
         self,
     ) -> None:
         fake_session = _OptionsFreshnessSession()
@@ -646,16 +646,25 @@ class TestTradingApi(TestCase):
             fake_session,  # type: ignore[arg-type]
         )
 
-        self.assertEqual(payload["scope"], "global")
-        self.assertEqual(payload["active_contracts"], 6)
+        self.assertEqual(payload["status"], "unavailable")
+        self.assertEqual(payload["scope"], "route_symbols")
+        self.assertTrue(payload["bounded"])
+        self.assertEqual(payload["active_contracts"], 0)
         self.assertEqual(payload["route_symbols"], [])
-        self.assertIn("WHERE status = 'active'", fake_session.calls[1][0])
+        self.assertIn(
+            "options_catalog_freshness_route_scope_missing",
+            payload["reason_codes"],
+        )
+        self.assertIn(
+            "options_catalog_freshness_unbounded_global_scan_skipped",
+            payload["reason_codes"],
+        )
         self.assertEqual(
             sum(
                 "FROM torghut_options_contract_catalog" in sql
                 for sql, _params in fake_session.calls
             ),
-            1,
+            0,
         )
 
     def test_options_catalog_freshness_summary_caches_unavailable_route_scope(


### PR DESCRIPTION
## Summary

- Bounds Torghut readiness/status proof SQL reads for runtime-ledger summaries, certificate evidence, promotion table counts, and options freshness so normal status paths avoid unscoped history/catalog scans.
- Adds fail-closed, specific read-status/blocker diagnostics for runtime-ledger summary timeouts, certificate evidence timeouts, promotion-table read/truncation issues, and missing options route scope.
- Adds narrow lookup indexes for certificate/readiness ordering paths and regression coverage for bounded query behavior and fail-closed blockers.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (initially failed because `cc` was absent while building `crosshair-tool`; installed Debian `build-essential`, reran successfully)
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_trading_api.py tests/test_profit_leases.py tests/test_runtime_ledger_status_index_migration.py tests/test_status_readiness_bounded_read_indexes_migration.py` (224 passed, 1 warning)
- `cd services/torghut && uv run --frozen pytest tests/test_status_readiness_bounded_read_indexes_migration.py tests/test_runtime_ledger_status_index_migration.py` (6 passed, 1 warning after formatting)
- `cd services/torghut && uv run --frozen ruff check app/main.py app/models/entities.py app/trading/profit_leases.py app/trading/submission_council.py migrations/versions/0043_status_readiness_bounded_read_indexes.py tests/test_submission_council.py tests/test_trading_api.py tests/test_profit_leases.py tests/test_status_readiness_bounded_read_indexes_migration.py` (passed)
- `cd services/torghut && uv run --frozen ruff format --check app/main.py app/models/entities.py app/trading/profit_leases.py app/trading/submission_council.py migrations/versions/0043_status_readiness_bounded_read_indexes.py tests/test_submission_council.py tests/test_trading_api.py tests/test_profit_leases.py tests/test_status_readiness_bounded_read_indexes_migration.py` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (passed; default heap run OOMed before rerun)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (passed)
- `cd services/torghut && uv run --frozen python scripts/check_migration_graph.py` (passed)
- `git diff --check` (passed)

## Screenshots (if applicable)

N/A - backend readiness/query behavior only.

## Breaking Changes

None. Includes a forward Alembic migration that adds bounded-read indexes; runtime readiness remains fail-closed when proof data is missing, stale, timed out, or truncated.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
