### PR TITLE
fix(torghut): bound readiness proof read models

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -3952,7 +3952,55 @@ def _daily_runtime_ledger_portfolio_summary(
         stmt = stmt.where(StrategyRuntimeLedgerBucket.observed_stage == stage)
     else:
         stmt = stmt.where(StrategyRuntimeLedgerBucket.observed_stage == "__missing__")
-    rows = list(session.execute(stmt.limit(200)).scalars())
+    try:
+        get_bind = getattr(session, "get_bind", None)
+        if callable(get_bind):
+            try:
+                bind = get_bind()
+                dialect = getattr(getattr(bind, "dialect", None), "name", "")
+                if dialect == "postgresql":
+                    session.execute(text("SET LOCAL statement_timeout = 750"))
+            except SQLAlchemyError:
+                raise
+            except Exception:
+                pass
+        rows = list(session.execute(stmt.limit(200)).scalars())
+    except SQLAlchemyError as exc:
+        logger.warning("Portfolio runtime-ledger daily summary unavailable: %s", exc)
+        rollback = getattr(session, "rollback", None)
+        if callable(rollback):
+            try:
+                rollback()
+            except SQLAlchemyError:
+                logger.warning(
+                    "Failed to roll back portfolio runtime-ledger summary session"
+                )
+        reason_code = (
+            "portfolio_runtime_ledger_summary_query_timeout"
+            if _sqlalchemy_error_indicates_statement_timeout(exc)
+            else "portfolio_runtime_ledger_summary_unavailable"
+        )
+        return {
+            "summary_basis": "runtime_ledger_daily_stage_account_scope",
+            "day_start": day_start.isoformat(),
+            "observed_at": observed.isoformat(),
+            "filters": {
+                "account_label": account,
+                "stage_scope": stage,
+                "observed_stage": stage
+                if stage in {"paper", "live"}
+                else "__missing__",
+            },
+            "bucket_count": 0,
+            "evidence_grade_bucket_count": 0,
+            "post_cost_net_pnl_per_day": "0",
+            "filled_notional": "0",
+            "candidate_ids": [],
+            "db_row_refs": [],
+            "blockers": [reason_code],
+            "read_model_unavailable": True,
+            "query_limit": 200,
+        }
     evidence_rows = [row for row in rows if _runtime_ledger_bucket_evidence_grade(row)]
     net_pnl = sum(
         (row.net_strategy_pnl_after_costs for row in evidence_rows),
@@ -3990,6 +4038,7 @@ def _daily_runtime_ledger_portfolio_summary(
         "candidate_ids": candidate_ids,
         "db_row_refs": [str(row.id) for row in evidence_rows],
         "blockers": blockers,
+        "query_limit": 200,
     }
 
 
@@ -6107,30 +6156,6 @@ def _load_options_catalog_freshness_summary(
     cached_payload = _load_cached_options_catalog_freshness_summary(scoped_symbols)
     if cached_payload is not None:
         return cached_payload
-    if not scoped_symbols:
-        return _store_options_catalog_freshness_summary(
-            scoped_symbols,
-            {
-                "status": "unavailable",
-                "scope": "route_symbols",
-                "bounded": True,
-                "coverage_exact": False,
-                "active_contracts_exact": False,
-                "active_contracts": 0,
-                "newest_last_seen_ts": None,
-                "missing_provider_updated_ts_count": 0,
-                "provider_updated_ts_present": False,
-                "newest_provider_updated_ts": None,
-                "missing_close_price_count": 0,
-                "zero_open_interest_count": 0,
-                "route_symbols": [],
-                "route_symbol_freshness": {},
-                "reason_codes": [
-                    "options_catalog_freshness_route_scope_missing",
-                    "options_catalog_freshness_unbounded_global_scan_skipped",
-                ],
-            },
-        )
     try:
         session.execute(text("SET LOCAL statement_timeout = 500"))
         if scoped_symbols:
@@ -6198,38 +6223,63 @@ GROUP BY underlying_symbol
                 int(row["zero_open_interest_count"] or 0) for row in scoped_rows
             )
         else:
-            row = (
+            global_rows = list(
                 session.execute(
                     text(
                         """
 SELECT
-  COUNT(*) AS active_contracts,
-  MAX(last_seen_ts) AS newest_last_seen_ts,
-  COUNT(*) FILTER (WHERE provider_updated_ts IS NULL) AS missing_provider_updated_ts_count,
-  MAX(provider_updated_ts) AS newest_provider_updated_ts,
-  COUNT(*) FILTER (WHERE close_price IS NULL) AS missing_close_price_count,
-  COUNT(*) FILTER (WHERE COALESCE(open_interest, 0) <= 0) AS zero_open_interest_count
+  underlying_symbol,
+  last_seen_ts,
+  provider_updated_ts,
+  close_price,
+  open_interest
 FROM torghut_options_contract_catalog
 WHERE status = 'active'
+ORDER BY last_seen_ts DESC NULLS LAST
+LIMIT 200
 """
                     )
-                )
-                .mappings()
-                .one()
+                ).mappings()
             )
             scoped_rows = []
-            active_contracts = int(row["active_contracts"] or 0)
-            newest_last_seen_ts = _ensure_utc_datetime(
-                cast(datetime | None, row["newest_last_seen_ts"])
+            active_contracts = len(global_rows)
+            newest_last_seen_values = [
+                value
+                for value in (
+                    _ensure_utc_datetime(cast(datetime | None, row.get("last_seen_ts")))
+                    for row in global_rows
+                )
+                if value is not None
+            ]
+            newest_last_seen_ts = (
+                max(newest_last_seen_values) if newest_last_seen_values else None
             )
-            missing_provider_updated_ts_count = int(
-                row["missing_provider_updated_ts_count"] or 0
+            missing_provider_updated_ts_count = sum(
+                1 for row in global_rows if row.get("provider_updated_ts") is None
             )
-            newest_provider_updated_ts = _ensure_utc_datetime(
-                cast(datetime | None, row["newest_provider_updated_ts"])
+            newest_provider_updated_values = [
+                value
+                for value in (
+                    _ensure_utc_datetime(
+                        cast(datetime | None, row.get("provider_updated_ts"))
+                    )
+                    for row in global_rows
+                )
+                if value is not None
+            ]
+            newest_provider_updated_ts = (
+                max(newest_provider_updated_values)
+                if newest_provider_updated_values
+                else None
             )
-            missing_close_price_count = int(row["missing_close_price_count"] or 0)
-            zero_open_interest_count = int(row["zero_open_interest_count"] or 0)
+            missing_close_price_count = sum(
+                1 for row in global_rows if row.get("close_price") is None
+            )
+            zero_open_interest_count = sum(
+                1
+                for row in global_rows
+                if (_decimal_or_none(row.get("open_interest")) or Decimal("0")) <= 0
+            )
     except SQLAlchemyError as exc:
         logger.warning("Options catalog freshness summary unavailable: %s", exc)
         rollback = getattr(session, "rollback", None)
@@ -6305,6 +6355,9 @@ WHERE status = 'active'
             "status": "current" if active_contracts > 0 else "missing",
             "scope": "route_symbols" if scoped_symbols else "global",
             "active_contracts": active_contracts,
+            "active_contracts_exact": bool(scoped_symbols),
+            "coverage_exact": bool(scoped_symbols),
+            "query_limit": None if scoped_symbols else 200,
             "newest_last_seen_ts": newest_last_seen_ts,
             "missing_provider_updated_ts_count": missing_provider_updated_ts_count,
             "provider_updated_ts_present": missing_provider_updated_ts_count == 0

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -15,7 +15,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, cast
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
@@ -82,6 +82,7 @@ RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet
 RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
 RUNTIME_LEDGER_PROOF_PACKET_ARTIFACT_PREFIX = "runtime-ledger-proof-packets/{run_id}"
 RUNTIME_LEDGER_SUMMARY_ROW_LIMIT = 50
+PAPER_ROUTE_EVIDENCE_QUERY_TIMEOUT_MS = 750
 US_EQUITIES_TIMEZONE = "America/New_York"
 US_EQUITIES_OPEN = time(hour=9, minute=30)
 US_EQUITIES_CLOSE = time(hour=16, minute=0)
@@ -111,6 +112,21 @@ SOURCE_LINEAGE_HYPOTHESIS_KEYS = (
     "source_hypothesis_ids",
 )
 PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER = "paper_route_evidence_db_unavailable"
+
+
+def _maybe_set_paper_route_audit_statement_timeout(session: Session) -> None:
+    get_bind = getattr(session, "get_bind", None)
+    if callable(get_bind):
+        try:
+            bind = get_bind()
+            dialect = getattr(getattr(bind, "dialect", None), "name", "")
+            if dialect != "postgresql":
+                return
+        except Exception:
+            pass
+    session.execute(
+        text(f"SET LOCAL statement_timeout = {PAPER_ROUTE_EVIDENCE_QUERY_TIMEOUT_MS}")
+    )
 
 
 def _as_mapping(value: object) -> dict[str, Any]:
@@ -867,6 +883,7 @@ def _strategy_rows_by_name_for_targets(
                 lookup_names.append(name)
     if not lookup_names:
         return {}
+    _maybe_set_paper_route_audit_statement_timeout(session)
     rows = session.execute(
         select(
             Strategy.id.label("id"),
@@ -906,6 +923,7 @@ def _strategy_universe_symbols(
             if symbols:
                 return symbols
         return []
+    _maybe_set_paper_route_audit_statement_timeout(session)
     rows = session.execute(
         select(Strategy.name, Strategy.universe_symbols).where(
             Strategy.name.in_(list(strategy_lookup_names))
@@ -939,6 +957,7 @@ def _strategy_source_decision_readiness(
     matched: dict[str, object] | None = None
     if lookup_names:
         if strategy_rows_by_name is None:
+            _maybe_set_paper_route_audit_statement_timeout(session)
             rows = [
                 dict(row)
                 for row in session.execute(
@@ -2062,6 +2081,7 @@ def _strategy_source_activity(
             func.upper(TradeDecision.symbol).in_(symbol_filters)
         )
     try:
+        _maybe_set_paper_route_audit_statement_timeout(session)
         decision_rows = list(
             session.execute(
                 decision_stmt.order_by(TradeDecision.created_at.desc()).limit(500)
@@ -2123,6 +2143,7 @@ def _strategy_source_activity(
                 func.upper(Execution.symbol).in_(symbol_filters)
             )
         try:
+            _maybe_set_paper_route_audit_statement_timeout(session)
             execution_rows = list(
                 session.execute(
                     execution_stmt.order_by(execution_activity_ts.desc()).limit(500)
@@ -2165,6 +2186,7 @@ def _strategy_source_activity(
                 func.upper(ExecutionOrderEvent.symbol).in_(symbol_filters)
             )
         try:
+            _maybe_set_paper_route_audit_statement_timeout(session)
             order_event_rows = list(
                 session.execute(
                     order_event_stmt.order_by(order_event_activity_ts.desc()).limit(500)
@@ -2210,6 +2232,7 @@ def _strategy_source_activity(
                 func.upper(ExecutionTCAMetric.symbol).in_(symbol_filters)
             )
         try:
+            _maybe_set_paper_route_audit_statement_timeout(session)
             tca_rows = list(
                 session.execute(
                     tca_stmt.order_by(ExecutionTCAMetric.computed_at.desc()).limit(500)
@@ -2377,6 +2400,7 @@ def _account_contamination_audit(
     )
     if symbol_filters:
         stmt = stmt.where(func.upper(ExecutionOrderEvent.symbol).in_(symbol_filters))
+    _maybe_set_paper_route_audit_statement_timeout(session)
     rows = list(
         session.execute(
             stmt.order_by(order_event_activity_ts.desc()).limit(500)
@@ -2523,6 +2547,7 @@ def _account_window_start_snapshot_audit(
     if not required:
         return base_payload
 
+    _maybe_set_paper_route_audit_statement_timeout(session)
     before_snapshot = session.execute(
         select(PositionSnapshot)
         .where(PositionSnapshot.alpaca_account_label == account_label)
@@ -2532,6 +2557,7 @@ def _account_window_start_snapshot_audit(
     ).scalar_one_or_none()
     after_snapshot = None
     if before_snapshot is None:
+        _maybe_set_paper_route_audit_statement_timeout(session)
         after_snapshot = session.execute(
             select(PositionSnapshot)
             .where(PositionSnapshot.alpaca_account_label == account_label)
@@ -2655,6 +2681,7 @@ def _account_pre_session_snapshot_audit(
             "flat": True,
         }
 
+    _maybe_set_paper_route_audit_statement_timeout(session)
     snapshot = session.execute(
         select(PositionSnapshot)
         .where(PositionSnapshot.alpaca_account_label == account_label)
@@ -2741,6 +2768,7 @@ def _rejected_signal_activity(
         stmt = stmt.where(
             func.upper(RejectedSignalOutcomeEvent.symbol).in_(symbol_filters)
         )
+    _maybe_set_paper_route_audit_statement_timeout(session)
     rows = list(
         session.execute(
             stmt.order_by(
@@ -3070,6 +3098,7 @@ def _runtime_ledger_summary(
         stmt = stmt.where(
             StrategyRuntimeLedgerBucket.strategy_family == strategy_family
         )
+    _maybe_set_paper_route_audit_statement_timeout(session)
     queried_rows = list(
         session.execute(stmt.limit(RUNTIME_LEDGER_SUMMARY_ROW_LIMIT + 1)).scalars()
     )
@@ -3207,6 +3236,7 @@ def _hypothesis_window_summary(
     )
     stmt = stmt.where(StrategyHypothesisMetricWindow.window_started_at <= window_end)
     stmt = stmt.where(StrategyHypothesisMetricWindow.window_ended_at >= window_start)
+    _maybe_set_paper_route_audit_statement_timeout(session)
     rows = list(session.execute(stmt.limit(50)).scalars())
     provenance_counts: dict[str, int] = {}
     maturity_counts: dict[str, int] = {}
@@ -3245,6 +3275,7 @@ def _promotion_decision_summary(
         hypothesis_id=hypothesis_id,
         candidate_id=candidate_id,
     )
+    _maybe_set_paper_route_audit_statement_timeout(session)
     rows = list(session.execute(stmt.limit(20)).scalars())
     latest = rows[0] if rows else None
     return {

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -108,9 +108,14 @@ _AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
 _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT = 256
 _RUNTIME_LEDGER_REPAIR_CANDIDATE_LIMIT = 8
 _RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS = 750
+_RUNTIME_LEDGER_SUMMARY_PER_HYPOTHESIS_LIMIT = 16
 _PROMOTION_TABLE_COUNT_SCAN_LIMIT = 1000
 _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT = 256
 _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT = 8
+_CERTIFICATE_EVIDENCE_WINDOW_LIMIT = _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT
+_CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT = 16
+_PROMOTION_SCALAR_COUNT_LIMIT = _PROMOTION_TABLE_COUNT_SCAN_LIMIT
+_PROMOTION_PORTFOLIO_SAMPLE_LIMIT = _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT
 _RUNTIME_WINDOW_IMPORT_CONTINUITY_READY_STATES = frozenset(
     {
         "signals_present",
@@ -153,6 +158,34 @@ def _sqlalchemy_error_indicates_statement_timeout(exc: SQLAlchemyError) -> bool:
     )
 
 
+def _unavailable_certificate_evidence_rows(
+    *,
+    hypothesis_ids: Sequence[str],
+    reason_code: str,
+) -> list[dict[str, object]]:
+    return [
+        {
+            "hypothesis_id": hypothesis_id,
+            "metric_window": None,
+            "promotion_decision": None,
+            "runtime_ledger_bucket": None,
+            "reason_codes": [reason_code],
+            "read_model_unavailable": True,
+        }
+        for hypothesis_id in hypothesis_ids
+    ]
+
+
+def _certificate_evidence_reason_codes(row: Mapping[str, object]) -> list[str]:
+    return _normalize_reason_codes(
+        [
+            str(reason).strip()
+            for reason in cast(Sequence[object], row.get("reason_codes") or [])
+            if str(reason).strip()
+        ]
+    )
+
+
 def _empty_profit_promotion_table_counts(
     *,
     count_errors: Sequence[str] | None = None,
@@ -173,6 +206,10 @@ def _empty_profit_promotion_table_counts(
         "count_limit": _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
         "autoresearch_portfolio_scan_limit": _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
         "truncated_counts": [],
+        "read_model_scope": "bounded_promotion_scalar_counts",
+        "promotion_scalar_count_limit": _PROMOTION_SCALAR_COUNT_LIMIT,
+        "autoresearch_portfolio_sample_limit": _PROMOTION_PORTFOLIO_SAMPLE_LIMIT,
+        "promotion_scalar_counts_exact": False,
         "count_errors": sorted(set(count_errors or ())),
     }
 
@@ -184,9 +221,21 @@ def _load_profit_promotion_bounded_row_count(
     model: Any,
     count_errors: list[str],
     truncated_counts: list[str],
+    statement: Any | None = None,
 ) -> int:
+    """Return a bounded diagnostic table count without forcing a full-table scan."""
+
     try:
         _maybe_set_runtime_ledger_status_statement_timeout(session)
+        if statement is not None:
+            bounded_count = session.execute(
+                select(func.count()).select_from(
+                    statement.limit(_PROMOTION_SCALAR_COUNT_LIMIT + 1).subquery()
+                )
+            ).scalar_one()
+            if int(bounded_count or 0) > _PROMOTION_SCALAR_COUNT_LIMIT:
+                truncated_counts.append(table_name)
+            return min(int(bounded_count or 0), _PROMOTION_SCALAR_COUNT_LIMIT)
         rows = list(
             session.execute(
                 select(model.id)
@@ -196,7 +245,7 @@ def _load_profit_promotion_bounded_row_count(
         )
     except SQLAlchemyError as exc:
         logger.warning(
-            "Failed to load bounded profit promotion table rows table=%s error=%s",
+            "Failed to load bounded profit promotion table count table=%s error=%s",
             table_name,
             exc,
         )
@@ -720,14 +769,36 @@ def build_hypothesis_runtime_summary(
         dependency_quorum=dependency_quorum,
     )
     summary["runtime_ledger_read_status"] = {
-        "status": runtime_ledger_summary.get("query_status", "unknown"),
+        "status": runtime_ledger_summary.get("query_status")
+        or (
+            "unavailable"
+            if bool(runtime_ledger_summary.get("read_model_unavailable"))
+            else "ok"
+        ),
         "reason_codes": list(
             cast(
                 Sequence[object],
-                runtime_ledger_summary.get("query_reason_codes") or [],
+                runtime_ledger_summary.get("query_reason_codes")
+                or runtime_ledger_summary.get("reason_codes")
+                or [],
             )
         ),
         "query_limit": runtime_ledger_summary.get("query_limit"),
+        "query_limit_per_hypothesis": runtime_ledger_summary.get(
+            "query_limit_per_hypothesis"
+        ),
+    }
+    summary["runtime_ledger_read_model"] = {
+        "query_scope": runtime_ledger_summary.get("query_scope"),
+        "query_limit_per_hypothesis": runtime_ledger_summary.get(
+            "query_limit_per_hypothesis"
+        ),
+        "reason_codes": runtime_ledger_summary.get("reason_codes")
+        or runtime_ledger_summary.get("query_reason_codes")
+        or [],
+        "read_model_unavailable": bool(
+            runtime_ledger_summary.get("read_model_unavailable")
+        ),
     }
     certificate_reason_codes = sorted(
         {
@@ -735,15 +806,22 @@ def build_hypothesis_runtime_summary(
             for row in evidence
             for reason in cast(
                 Sequence[object],
-                row.get("query_reason_codes") or [],
+                row.get("query_reason_codes") or row.get("reason_codes") or [],
             )
             if str(reason).strip()
         }
     )
+    certificate_unavailable = any(
+        bool(row.get("read_model_unavailable")) for row in evidence
+    )
     summary["certificate_evidence_read_status"] = {
-        "status": "ok" if not certificate_reason_codes else "degraded",
+        "status": "ok"
+        if not certificate_reason_codes and not certificate_unavailable
+        else "degraded",
         "reason_codes": certificate_reason_codes,
-        "per_hypothesis_limit": _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT,
+        "per_hypothesis_limit": _CERTIFICATE_EVIDENCE_WINDOW_LIMIT,
+        "runtime_ledger_query_limit": _CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT,
+        "read_model_unavailable": certificate_unavailable,
     }
     summary["items"] = items
     return summary
@@ -1183,43 +1261,50 @@ def _load_latest_runtime_ledger_summary(
         hypothesis_id for hypothesis_id in hypothesis_ids if hypothesis_id
     ]
     by_hypothesis: dict[str, dict[str, object]] = {}
+    retained_rows: list[dict[str, object]] = []
     if not normalized_ids:
         return {
             "by_hypothesis": by_hypothesis,
-            "runtime_ledger_buckets": [],
+            "runtime_ledger_buckets": retained_rows,
             "query_status": "skipped",
             "query_reason_codes": ["runtime_ledger_hypothesis_scope_missing"],
             "query_limit": _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT,
+            "query_scope": "per_hypothesis_latest_runtime_ledger",
+            "query_limit_per_hypothesis": _RUNTIME_LEDGER_SUMMARY_PER_HYPOTHESIS_LIMIT,
+            "reason_codes": ["runtime_ledger_hypothesis_scope_missing"],
         }
 
-    rows_by_hypothesis: dict[str, int] = {}
-    retained_rows: list[dict[str, object]] = []
     try:
-        _maybe_set_runtime_ledger_status_statement_timeout(session)
-        rows = session.execute(
-            select(StrategyRuntimeLedgerBucket)
-            .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(normalized_ids))
-            .order_by(
-                StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
-                StrategyRuntimeLedgerBucket.created_at.desc(),
+        for hypothesis_id in normalized_ids:
+            _maybe_set_runtime_ledger_status_statement_timeout(session)
+            rows = list(
+                session.execute(
+                    select(StrategyRuntimeLedgerBucket)
+                    .where(StrategyRuntimeLedgerBucket.hypothesis_id == hypothesis_id)
+                    .order_by(
+                        StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+                        StrategyRuntimeLedgerBucket.created_at.desc(),
+                    )
+                    .limit(_RUNTIME_LEDGER_SUMMARY_PER_HYPOTHESIS_LIMIT)
+                ).scalars()
             )
-            .limit(_RUNTIME_LEDGER_REPAIR_SCAN_LIMIT)
-        ).scalars()
-        for row in rows:
-            payload = _runtime_ledger_bucket_payload(row)
-            retained_count = rows_by_hypothesis.get(row.hypothesis_id, 0)
-            if retained_count < 8:
-                retained_rows.append(payload)
-                rows_by_hypothesis[row.hypothesis_id] = retained_count + 1
+            retained_for_hypothesis = 0
+            for row in rows:
+                payload = _runtime_ledger_bucket_payload(row)
+                if retained_for_hypothesis < 8:
+                    retained_rows.append(payload)
+                    retained_for_hypothesis += 1
 
-            current = by_hypothesis.get(row.hypothesis_id)
-            if current is None:
-                by_hypothesis[row.hypothesis_id] = payload
-                continue
-            current_is_live = str(current.get("observed_stage") or "").strip() == "live"
-            row_is_live = str(payload.get("observed_stage") or "").strip() == "live"
-            if row_is_live and not current_is_live:
-                by_hypothesis[row.hypothesis_id] = payload
+                current = by_hypothesis.get(row.hypothesis_id)
+                if current is None:
+                    by_hypothesis[row.hypothesis_id] = payload
+                    continue
+                current_is_live = (
+                    str(current.get("observed_stage") or "").strip() == "live"
+                )
+                row_is_live = str(payload.get("observed_stage") or "").strip() == "live"
+                if row_is_live and not current_is_live:
+                    by_hypothesis[row.hypothesis_id] = payload
     except SQLAlchemyError as exc:
         logger.warning("Runtime ledger latest summary unavailable: %s", exc)
         _rollback_runtime_ledger_status_session(session)
@@ -1229,13 +1314,17 @@ def _load_latest_runtime_ledger_summary(
             else "runtime_ledger_summary_query_unavailable"
         )
         return {
-            "by_hypothesis": by_hypothesis,
+            "by_hypothesis": {},
             "runtime_ledger_buckets": [],
             "query_status": "timeout"
             if reason_code == "runtime_ledger_summary_query_timeout"
             else "unavailable",
             "query_reason_codes": [reason_code],
             "query_limit": _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT,
+            "query_scope": "per_hypothesis_latest_runtime_ledger",
+            "query_limit_per_hypothesis": _RUNTIME_LEDGER_SUMMARY_PER_HYPOTHESIS_LIMIT,
+            "reason_codes": [reason_code],
+            "read_model_unavailable": True,
         }
     return {
         "by_hypothesis": by_hypothesis,
@@ -1243,6 +1332,9 @@ def _load_latest_runtime_ledger_summary(
         "query_status": "ok",
         "query_reason_codes": [],
         "query_limit": _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT,
+        "query_scope": "per_hypothesis_latest_runtime_ledger",
+        "query_limit_per_hypothesis": _RUNTIME_LEDGER_SUMMARY_PER_HYPOTHESIS_LIMIT,
+        "reason_codes": [],
     }
 
 
@@ -2208,205 +2300,140 @@ def _load_latest_certificate_evidence(
     ]
     if not normalized_ids:
         return []
-    total_limit = max(
-        1,
-        len(normalized_ids) * _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT,
-    )
-
-    windows_by_hypothesis: dict[str, list[StrategyHypothesisMetricWindow]] = {}
-    try:
-        _maybe_set_runtime_ledger_status_statement_timeout(session)
-        window_rows = session.execute(
-            select(StrategyHypothesisMetricWindow)
-            .where(StrategyHypothesisMetricWindow.hypothesis_id.in_(normalized_ids))
-            .order_by(
-                StrategyHypothesisMetricWindow.window_ended_at.desc().nullslast(),
-                StrategyHypothesisMetricWindow.created_at.desc(),
-            )
-            .limit(total_limit)
-        ).scalars()
-        for row in window_rows:
-            windows_by_hypothesis.setdefault(row.hypothesis_id, []).append(row)
-    except SQLAlchemyError as exc:
-        logger.warning("Metric-window certificate evidence unavailable: %s", exc)
-        _rollback_runtime_ledger_status_session(session)
-        reason_code = (
-            "certificate_metric_window_query_timeout"
-            if _sqlalchemy_error_indicates_statement_timeout(exc)
-            else "certificate_metric_window_query_unavailable"
-        )
-        return [
-            {
-                "hypothesis_id": hypothesis_id,
-                "metric_window": None,
-                "promotion_decision": None,
-                "runtime_ledger_bucket": None,
-                "query_status": "timeout"
-                if reason_code == "certificate_metric_window_query_timeout"
-                else "unavailable",
-                "query_reason_codes": [reason_code],
-            }
-            for hypothesis_id in normalized_ids
-        ]
-
-    latest_promotions: dict[str, list[StrategyPromotionDecision]] = {}
-    try:
-        _maybe_set_runtime_ledger_status_statement_timeout(session)
-        promotion_rows = session.execute(
-            select(StrategyPromotionDecision)
-            .where(
-                StrategyPromotionDecision.hypothesis_id.in_(normalized_ids),
-            )
-            .order_by(StrategyPromotionDecision.created_at.desc())
-            .limit(total_limit)
-        ).scalars()
-        for row in promotion_rows:
-            latest_promotions.setdefault(row.hypothesis_id, []).append(row)
-    except SQLAlchemyError as exc:
-        logger.warning("Promotion-decision certificate evidence unavailable: %s", exc)
-        _rollback_runtime_ledger_status_session(session)
-        reason_code = (
-            "certificate_promotion_decision_query_timeout"
-            if _sqlalchemy_error_indicates_statement_timeout(exc)
-            else "certificate_promotion_decision_query_unavailable"
-        )
-        return [
-            {
-                "hypothesis_id": hypothesis_id,
-                "metric_window": None,
-                "promotion_decision": None,
-                "runtime_ledger_bucket": None,
-                "query_status": "timeout"
-                if reason_code == "certificate_promotion_decision_query_timeout"
-                else "unavailable",
-                "query_reason_codes": [reason_code],
-            }
-            for hypothesis_id in normalized_ids
-        ]
-
-    latest_runtime_ledgers: dict[str, list[StrategyRuntimeLedgerBucket]] = {}
-    try:
-        _maybe_set_runtime_ledger_status_statement_timeout(session)
-        runtime_ledger_rows = session.execute(
-            select(StrategyRuntimeLedgerBucket)
-            .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(normalized_ids))
-            .order_by(
-                StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
-                StrategyRuntimeLedgerBucket.created_at.desc(),
-            )
-            .limit(_RUNTIME_LEDGER_REPAIR_SCAN_LIMIT)
-        ).scalars()
-        for row in runtime_ledger_rows:
-            latest_runtime_ledgers.setdefault(row.hypothesis_id, []).append(row)
-    except SQLAlchemyError as exc:
-        logger.warning("Runtime ledger certificate evidence unavailable: %s", exc)
-        _rollback_runtime_ledger_status_session(session)
-        latest_runtime_ledgers = {}
-        runtime_ledger_reason_code = (
-            "certificate_runtime_ledger_query_timeout"
-            if _sqlalchemy_error_indicates_statement_timeout(exc)
-            else "certificate_runtime_ledger_query_unavailable"
-        )
-    else:
-        runtime_ledger_reason_code = None
 
     evidence: list[dict[str, object]] = []
-    for hypothesis_id in normalized_ids:
-        candidate_rows: list[dict[str, object]] = []
-        for metric_window in windows_by_hypothesis.get(hypothesis_id, []):
-            promotion_decision = None
-            for decision in latest_promotions.get(hypothesis_id, []):
-                if _promotion_decision_matches_metric_window(
-                    decision,
-                    metric_window=metric_window,
-                ):
-                    promotion_decision = decision
-                    break
-            runtime_ledger_bucket = None
-            for ledger in latest_runtime_ledgers.get(hypothesis_id, []):
-                if (
-                    _safe_text(ledger.run_id) != _safe_text(metric_window.run_id)
-                    or _safe_text(ledger.candidate_id)
-                    != _safe_text(metric_window.candidate_id)
-                    or _safe_text(ledger.observed_stage)
-                    != _safe_text(metric_window.observed_stage)
-                    or not _runtime_ledger_bucket_matches_metric_window(
+    try:
+        for hypothesis_id in normalized_ids:
+            _maybe_set_runtime_ledger_status_statement_timeout(session)
+            metric_windows = list(
+                session.execute(
+                    select(StrategyHypothesisMetricWindow)
+                    .where(
+                        StrategyHypothesisMetricWindow.hypothesis_id == hypothesis_id
+                    )
+                    .order_by(
+                        StrategyHypothesisMetricWindow.window_ended_at.desc().nullslast(),
+                        StrategyHypothesisMetricWindow.created_at.desc(),
+                    )
+                    .limit(_CERTIFICATE_EVIDENCE_WINDOW_LIMIT)
+                ).scalars()
+            )
+            candidate_rows: list[dict[str, object]] = []
+            for metric_window in metric_windows:
+                _maybe_set_runtime_ledger_status_statement_timeout(session)
+                promotion_decision = (
+                    session.execute(
+                        select(StrategyPromotionDecision)
+                        .where(StrategyPromotionDecision.hypothesis_id == hypothesis_id)
+                        .where(
+                            StrategyPromotionDecision.run_id == metric_window.run_id,
+                            StrategyPromotionDecision.candidate_id
+                            == metric_window.candidate_id,
+                            StrategyPromotionDecision.promotion_target
+                            == metric_window.observed_stage,
+                        )
+                        .order_by(StrategyPromotionDecision.created_at.desc())
+                        .limit(1)
+                    )
+                    .scalars()
+                    .first()
+                )
+
+                runtime_ledger_bucket = None
+                _maybe_set_runtime_ledger_status_statement_timeout(session)
+                ledger_rows = list(
+                    session.execute(
+                        select(StrategyRuntimeLedgerBucket)
+                        .where(
+                            StrategyRuntimeLedgerBucket.hypothesis_id == hypothesis_id
+                        )
+                        .where(
+                            StrategyRuntimeLedgerBucket.run_id == metric_window.run_id,
+                            StrategyRuntimeLedgerBucket.candidate_id
+                            == metric_window.candidate_id,
+                            StrategyRuntimeLedgerBucket.observed_stage
+                            == metric_window.observed_stage,
+                        )
+                        .order_by(
+                            StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+                            StrategyRuntimeLedgerBucket.created_at.desc(),
+                        )
+                        .limit(_CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT)
+                    ).scalars()
+                )
+                for ledger in ledger_rows:
+                    if _runtime_ledger_bucket_matches_metric_window(
                         ledger,
                         metric_window=metric_window,
-                    )
-                ):
-                    continue
-                runtime_ledger_bucket = _runtime_ledger_bucket_payload(ledger)
-                break
-            candidate_rows.append(
-                {
-                    "hypothesis_id": hypothesis_id,
-                    "metric_window": metric_window,
-                    "promotion_decision": promotion_decision,
-                    "runtime_ledger_bucket": runtime_ledger_bucket,
-                    "query_status": "ok"
-                    if runtime_ledger_reason_code is None
-                    else "timeout"
-                    if runtime_ledger_reason_code
-                    == "certificate_runtime_ledger_query_timeout"
-                    else "unavailable",
-                    "query_reason_codes": []
-                    if runtime_ledger_reason_code is None
-                    else [runtime_ledger_reason_code],
-                }
-            )
-        if not candidate_rows:
+                    ):
+                        runtime_ledger_bucket = _runtime_ledger_bucket_payload(ledger)
+                        break
+                candidate_rows.append(
+                    {
+                        "hypothesis_id": hypothesis_id,
+                        "metric_window": metric_window,
+                        "promotion_decision": promotion_decision,
+                        "runtime_ledger_bucket": runtime_ledger_bucket,
+                        "query_status": "ok",
+                        "query_reason_codes": [],
+                        "query_scope": "per_hypothesis_certificate_evidence",
+                        "query_limit_per_hypothesis": _CERTIFICATE_EVIDENCE_WINDOW_LIMIT,
+                        "runtime_ledger_query_limit": _CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT,
+                        "reason_codes": [],
+                    }
+                )
+            if not candidate_rows:
+                evidence.append(
+                    {
+                        "hypothesis_id": hypothesis_id,
+                        "metric_window": None,
+                        "promotion_decision": None,
+                        "runtime_ledger_bucket": None,
+                        "query_status": "ok",
+                        "query_reason_codes": [],
+                        "query_scope": "per_hypothesis_certificate_evidence",
+                        "query_limit_per_hypothesis": _CERTIFICATE_EVIDENCE_WINDOW_LIMIT,
+                        "runtime_ledger_query_limit": _CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT,
+                        "reason_codes": ["hypothesis_window_evidence_missing"],
+                    }
+                )
+                continue
             evidence.append(
-                {
-                    "hypothesis_id": hypothesis_id,
-                    "metric_window": None,
-                    "promotion_decision": None,
-                    "runtime_ledger_bucket": None,
-                    "query_status": "ok"
-                    if runtime_ledger_reason_code is None
-                    else "timeout"
-                    if runtime_ledger_reason_code
-                    == "certificate_runtime_ledger_query_timeout"
-                    else "unavailable",
-                    "query_reason_codes": []
-                    if runtime_ledger_reason_code is None
-                    else [runtime_ledger_reason_code],
-                }
+                max(
+                    candidate_rows,
+                    key=lambda row: _certificate_evidence_selection_key(
+                        row,
+                        now=now,
+                        max_age_seconds=max_age_seconds,
+                    ),
+                )
             )
-            continue
-        evidence.append(
-            max(
-                candidate_rows,
-                key=lambda row: _certificate_evidence_selection_key(
-                    row,
-                    now=now,
-                    max_age_seconds=max_age_seconds,
-                ),
-            )
+    except SQLAlchemyError as exc:
+        logger.warning("Certificate evidence read model unavailable: %s", exc)
+        _rollback_runtime_ledger_status_session(session)
+        reason_code = (
+            "certificate_evidence_query_timeout"
+            if _sqlalchemy_error_indicates_statement_timeout(exc)
+            else "certificate_evidence_unavailable"
         )
+        rows = _unavailable_certificate_evidence_rows(
+            hypothesis_ids=normalized_ids,
+            reason_code=reason_code,
+        )
+        for row in rows:
+            row["query_status"] = (
+                "timeout"
+                if reason_code == "certificate_evidence_query_timeout"
+                else "unavailable"
+            )
+            row["query_reason_codes"] = [reason_code]
+            row["query_scope"] = "per_hypothesis_certificate_evidence"
+            row["query_limit_per_hypothesis"] = _CERTIFICATE_EVIDENCE_WINDOW_LIMIT
+            row["runtime_ledger_query_limit"] = (
+                _CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT
+            )
+        return rows
     return evidence
-
-
-def _promotion_decision_matches_metric_window(
-    promotion_decision: StrategyPromotionDecision,
-    *,
-    metric_window: StrategyHypothesisMetricWindow,
-) -> bool:
-    if _safe_text(promotion_decision.run_id) != _safe_text(metric_window.run_id):
-        return False
-    if _safe_text(promotion_decision.hypothesis_id) != _safe_text(
-        metric_window.hypothesis_id
-    ):
-        return False
-    if _safe_text(promotion_decision.candidate_id) != _safe_text(
-        metric_window.candidate_id
-    ):
-        return False
-    if _safe_text(promotion_decision.promotion_target) != _safe_text(
-        metric_window.observed_stage
-    ):
-        return False
-    return True
 
 
 def _window_evidence_issued_at(
@@ -2885,7 +2912,7 @@ def _evaluate_certificate_candidates(
         promotion_decision = cast(
             StrategyPromotionDecision | None, row.get("promotion_decision")
         )
-        reasons: list[str] = []
+        reasons: list[str] = _certificate_evidence_reason_codes(row)
         metric_window_id: str | None = None
         promotion_decision_id: str | None = None
         candidate_id = None
@@ -3239,7 +3266,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
             session.execute(
                 select(AutoresearchPortfolioCandidate)
                 .order_by(AutoresearchPortfolioCandidate.created_at.desc())
-                .limit(_PROMOTION_PORTFOLIO_READY_SCAN_LIMIT + 1)
+                .limit(_PROMOTION_PORTFOLIO_SAMPLE_LIMIT + 1)
             ).scalars()
         )
     except SQLAlchemyError as exc:
@@ -3251,8 +3278,9 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         return _empty_profit_promotion_table_counts(
             count_errors=["autoresearch_portfolio_candidates"]
         )
-    if len(portfolio_rows) > _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT:
-        portfolio_rows = portfolio_rows[:_PROMOTION_PORTFOLIO_READY_SCAN_LIMIT]
+    if len(portfolio_rows) > _PROMOTION_PORTFOLIO_SAMPLE_LIMIT:
+        portfolio_rows = portfolio_rows[:_PROMOTION_PORTFOLIO_SAMPLE_LIMIT]
+        truncated_counts.append("autoresearch_portfolio_candidates")
         count_errors.append("autoresearch_portfolio_candidates_bounded_scan_truncated")
 
     current_oracle_ready = 0
@@ -3310,6 +3338,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         "research_candidates": _load_profit_promotion_bounded_row_count(
             session,
             table_name="research_candidates",
+            statement=select(ResearchCandidate.id),
             count_errors=count_errors,
             truncated_counts=truncated_counts,
             model=ResearchCandidate,
@@ -3317,6 +3346,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         "research_promotions": _load_profit_promotion_bounded_row_count(
             session,
             table_name="research_promotions",
+            statement=select(ResearchPromotion.id),
             count_errors=count_errors,
             truncated_counts=truncated_counts,
             model=ResearchPromotion,
@@ -3324,6 +3354,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         "strategy_promotion_decisions": _load_profit_promotion_bounded_row_count(
             session,
             table_name="strategy_promotion_decisions",
+            statement=select(StrategyPromotionDecision.id),
             count_errors=count_errors,
             truncated_counts=truncated_counts,
             model=StrategyPromotionDecision,
@@ -3331,6 +3362,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         "vnext_promotion_decisions": _load_profit_promotion_bounded_row_count(
             session,
             table_name="vnext_promotion_decisions",
+            statement=select(VNextPromotionDecision.id),
             count_errors=count_errors,
             truncated_counts=truncated_counts,
             model=VNextPromotionDecision,
@@ -3338,6 +3370,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         "autoresearch_epochs": _load_profit_promotion_bounded_row_count(
             session,
             table_name="autoresearch_epochs",
+            statement=select(AutoresearchEpoch.id),
             count_errors=count_errors,
             truncated_counts=truncated_counts,
             model=AutoresearchEpoch,
@@ -3345,6 +3378,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         "autoresearch_candidate_specs": _load_profit_promotion_bounded_row_count(
             session,
             table_name="autoresearch_candidate_specs",
+            statement=select(AutoresearchCandidateSpec.id),
             count_errors=count_errors,
             truncated_counts=truncated_counts,
             model=AutoresearchCandidateSpec,
@@ -3352,6 +3386,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         "autoresearch_proposal_scores": _load_profit_promotion_bounded_row_count(
             session,
             table_name="autoresearch_proposal_scores",
+            statement=select(AutoresearchProposalScore.id),
             count_errors=count_errors,
             truncated_counts=truncated_counts,
             model=AutoresearchProposalScore,
@@ -3359,6 +3394,7 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         "autoresearch_portfolio_candidates": _load_profit_promotion_bounded_row_count(
             session,
             table_name="autoresearch_portfolio_candidates",
+            statement=select(AutoresearchPortfolioCandidate.id),
             count_errors=count_errors,
             truncated_counts=truncated_counts,
             model=AutoresearchPortfolioCandidate,
@@ -3370,6 +3406,10 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
         "count_limit": _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
         "autoresearch_portfolio_scan_limit": _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
         "truncated_counts": sorted(set(truncated_counts)),
+        "read_model_scope": "bounded_promotion_scalar_counts",
+        "promotion_scalar_count_limit": _PROMOTION_SCALAR_COUNT_LIMIT,
+        "autoresearch_portfolio_sample_limit": _PROMOTION_PORTFOLIO_SAMPLE_LIMIT,
+        "promotion_scalar_counts_exact": False,
         "count_errors": sorted(set(count_errors)),
     }
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -36,6 +36,7 @@ from app.trading.paper_route_evidence import (
     _runtime_ledger_row_diagnostic_expectancy_bps,
     _strategy_source_activity,
     _strategy_source_decision_readiness,
+    _target_audit_fail_closed,
     build_paper_route_evidence_audit,
     build_paper_route_target_plan_payload,
 )
@@ -76,6 +77,51 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
         self.assertEqual(actions, {"AAPL": "sell", "AMZN": "buy"})
         self.assertEqual(_pair_probe_balance_state(actions), "balanced")
+
+    def test_target_audit_timeout_fails_closed_with_explicit_blockers(self) -> None:
+        with Session(self.engine) as session:
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=SQLAlchemyError("statement timeout"),
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                audit = _target_audit_fail_closed(
+                    session,
+                    raw_target={
+                        "hypothesis_id": "H-CONT-01",
+                        "candidate_id": "candidate-1",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "strategy_lookup_names": ["microbar-cross-sectional-pairs-v1"],
+                        "account_label": "TORGHUT_SIM",
+                        "observed_stage": "paper",
+                        "window_start": "2026-05-29T13:30:00+00:00",
+                        "window_end": "2026-05-29T20:00:00+00:00",
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    },
+                    probe={
+                        "configured_enabled": True,
+                        "eligible_symbol_count": 2,
+                        "symbols": ["AAPL", "MSFT"],
+                        "blocking_reasons": [],
+                    },
+                    generated_at=datetime(2026, 5, 29, 21, 0, tzinfo=timezone.utc),
+                    lookback_hours=72,
+                    error_source="paper_route_source_target_audit",
+                )
+
+        readiness = audit["readiness"]
+        self.assertEqual(readiness["state"], "evidence_collection_blocked")
+        self.assertFalse(readiness["promotion_authority"]["allowed"])
+        self.assertIn("paper_route_evidence_db_unavailable", readiness["blockers"])
+        self.assertIn(
+            "paper_route_source_target_audit_db_unavailable",
+            readiness["blockers"],
+        )
+        self.assertGreaterEqual(rollback.call_count, 1)
 
     def _runtime_ledger_source_authority_payload(
         self,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -439,7 +439,8 @@ class TestSubmissionCouncil(TestCase):
 
         with session_local() as session:
             empty_summary = _load_latest_runtime_ledger_summary(
-                session, hypothesis_ids=[]
+                session,
+                hypothesis_ids=[],
             )
             self.assertEqual(empty_summary["by_hypothesis"], {})
             self.assertEqual(empty_summary["runtime_ledger_buckets"], [])
@@ -447,6 +448,10 @@ class TestSubmissionCouncil(TestCase):
             self.assertEqual(
                 empty_summary["query_reason_codes"],
                 ["runtime_ledger_hypothesis_scope_missing"],
+            )
+            self.assertEqual(
+                empty_summary["query_scope"],
+                "per_hypothesis_latest_runtime_ledger",
             )
             session.add_all(
                 [
@@ -608,8 +613,12 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(summary["by_hypothesis"], {})
         self.assertEqual(summary["runtime_ledger_buckets"], [])
         self.assertEqual(summary["query_status"], "timeout")
+        self.assertTrue(summary["read_model_unavailable"])
         self.assertEqual(
             summary["query_reason_codes"], ["runtime_ledger_summary_query_timeout"]
+        )
+        self.assertEqual(
+            summary["reason_codes"], ["runtime_ledger_summary_query_timeout"]
         )
         self.assertEqual(fake_session.rollback_count, 1)
 
@@ -624,18 +633,17 @@ class TestSubmissionCouncil(TestCase):
         )
 
         self.assertEqual(fake_session.rollback_count, 1)
+        self.assertEqual(evidence[0]["hypothesis_id"], "H-PAIRS-01")
+        self.assertIsNone(evidence[0]["metric_window"])
+        self.assertIsNone(evidence[0]["promotion_decision"])
+        self.assertIsNone(evidence[0]["runtime_ledger_bucket"])
+        self.assertTrue(evidence[0]["read_model_unavailable"])
+        self.assertEqual(evidence[0]["query_status"], "timeout")
         self.assertEqual(
-            evidence,
-            [
-                {
-                    "hypothesis_id": "H-PAIRS-01",
-                    "metric_window": None,
-                    "promotion_decision": None,
-                    "runtime_ledger_bucket": None,
-                    "query_status": "timeout",
-                    "query_reason_codes": ["certificate_metric_window_query_timeout"],
-                }
-            ],
+            evidence[0]["query_reason_codes"], ["certificate_evidence_query_timeout"]
+        )
+        self.assertEqual(
+            evidence[0]["reason_codes"], ["certificate_evidence_query_timeout"]
         )
 
     def test_load_latest_certificate_evidence_fails_closed_on_promotion_timeout(
@@ -698,20 +706,17 @@ class TestSubmissionCouncil(TestCase):
                 )
 
         self.assertEqual(rollback.call_count, 1)
+        self.assertEqual(evidence[0]["hypothesis_id"], "H-PAIRS-01")
+        self.assertIsNone(evidence[0]["metric_window"])
+        self.assertIsNone(evidence[0]["promotion_decision"])
+        self.assertIsNone(evidence[0]["runtime_ledger_bucket"])
+        self.assertTrue(evidence[0]["read_model_unavailable"])
+        self.assertEqual(evidence[0]["query_status"], "timeout")
         self.assertEqual(
-            evidence,
-            [
-                {
-                    "hypothesis_id": "H-PAIRS-01",
-                    "metric_window": None,
-                    "promotion_decision": None,
-                    "runtime_ledger_bucket": None,
-                    "query_status": "timeout",
-                    "query_reason_codes": [
-                        "certificate_promotion_decision_query_timeout"
-                    ],
-                }
-            ],
+            evidence[0]["query_reason_codes"], ["certificate_evidence_query_timeout"]
+        )
+        self.assertEqual(
+            evidence[0]["reason_codes"], ["certificate_evidence_query_timeout"]
         )
 
     def test_load_latest_certificate_evidence_uses_bounded_status_reads(
@@ -751,10 +756,16 @@ class TestSubmissionCouncil(TestCase):
             )
         )
         self.assertTrue(
-            any(
-                "FROM strategy_promotion_decisions" in statement
-                and "LIMIT" in statement
-                for statement in statements
+            all(
+                row["reason_codes"] == ["hypothesis_window_evidence_missing"]
+                for row in evidence
+            )
+        )
+        self.assertTrue(
+            all(
+                row["query_limit_per_hypothesis"]
+                == _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT
+                for row in evidence
             )
         )
         self.assertGreaterEqual(bounded_limit, 1)
@@ -834,8 +845,12 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(summary["by_hypothesis"], {})
         self.assertEqual(summary["runtime_ledger_buckets"], [])
         self.assertEqual(summary["query_status"], "timeout")
+        self.assertTrue(summary["read_model_unavailable"])
         self.assertEqual(
             summary["query_reason_codes"], ["runtime_ledger_summary_query_timeout"]
+        )
+        self.assertEqual(
+            summary["reason_codes"], ["runtime_ledger_summary_query_timeout"]
         )
         self.assertEqual(fake_session.rollback_count, 1)
 
@@ -3848,7 +3863,9 @@ class TestSubmissionCouncil(TestCase):
 
         self.assertEqual(counts["autoresearch_epochs"], 1)
         self.assertEqual(counts["truncated_counts"], [])
-        self.assertFalse(any("count(" in statement.lower() for statement in statements))
+        self.assertEqual(counts["read_model_scope"], "bounded_promotion_scalar_counts")
+        self.assertFalse(counts["promotion_scalar_counts_exact"])
+        self.assertTrue(any("count(" in statement.lower() for statement in statements))
         self.assertTrue(
             any(
                 "FROM autoresearch_epochs" in statement and "LIMIT" in statement
@@ -3973,7 +3990,74 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(counts["autoresearch_epochs"], 1)
         self.assertEqual(counts["autoresearch_candidate_specs"], 1)
         self.assertEqual(counts["autoresearch_proposal_scores"], 0)
+        self.assertEqual(counts["read_model_scope"], "bounded_promotion_scalar_counts")
+        self.assertFalse(counts["promotion_scalar_counts_exact"])
         self.assertEqual(counts["count_errors"], ["autoresearch_proposal_scores"])
+        self.assertEqual(rollback.call_count, 1)
+
+    def test_latest_runtime_ledger_summary_timeout_is_explicit(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=SQLAlchemyError("statement timeout"),
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                summary = _load_latest_runtime_ledger_summary(
+                    session,
+                    hypothesis_ids=["H-CONT-01"],
+                )
+
+        self.assertEqual(summary["by_hypothesis"], {})
+        self.assertEqual(summary["runtime_ledger_buckets"], [])
+        self.assertTrue(summary["read_model_unavailable"])
+        self.assertEqual(
+            summary["reason_codes"], ["runtime_ledger_summary_query_timeout"]
+        )
+        self.assertEqual(rollback.call_count, 1)
+
+    def test_certificate_evidence_timeout_is_explicit_and_fail_closed(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=SQLAlchemyError("statement timeout"),
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                evidence = _load_latest_certificate_evidence(
+                    session,
+                    hypothesis_ids=["H-CONT-01"],
+                    now=datetime.now(timezone.utc),
+                    max_age_seconds=900,
+                )
+
+        self.assertEqual(len(evidence), 1)
+        self.assertIsNone(evidence[0]["metric_window"])
+        self.assertIsNone(evidence[0]["promotion_decision"])
+        self.assertTrue(evidence[0]["read_model_unavailable"])
+        self.assertEqual(
+            evidence[0]["reason_codes"], ["certificate_evidence_query_timeout"]
+        )
         self.assertEqual(rollback.call_count, 1)
 
     def test_load_profit_promotion_counts_fail_closed_for_portfolio_timeout(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -29,6 +29,7 @@ from app.main import (
     _build_live_submission_gate_payload,
     _build_route_image_proof_summary,
     _check_alpaca,
+    _daily_runtime_ledger_portfolio_summary,
     _decimal_or_none,
     _fetch_paper_route_target_plan_url,
     _forecast_service_status,
@@ -233,15 +234,15 @@ class _OptionsFreshnessSession:
         return _ExecuteResult(
             [
                 {
-                    "active_contracts": 6,
-                    "newest_last_seen_ts": datetime(2026, 5, 12, tzinfo=timezone.utc),
-                    "missing_provider_updated_ts_count": 2,
-                    "newest_provider_updated_ts": datetime(
-                        2026, 5, 12, tzinfo=timezone.utc
+                    "underlying_symbol": f"SYM{idx}",
+                    "last_seen_ts": datetime(2026, 5, 12, tzinfo=timezone.utc),
+                    "provider_updated_ts": (
+                        datetime(2026, 5, 12, tzinfo=timezone.utc) if idx < 4 else None
                     ),
-                    "missing_close_price_count": 1,
-                    "zero_open_interest_count": 1,
+                    "close_price": Decimal("1") if idx != 5 else None,
+                    "open_interest": Decimal("10") if idx != 4 else Decimal("0"),
                 }
+                for idx in range(6)
             ]
         )
 
@@ -637,7 +638,7 @@ class TestTradingApi(TestCase):
             1,
         )
 
-    def test_options_catalog_freshness_summary_skips_global_scan_without_route_scope(
+    def test_options_catalog_freshness_summary_uses_bounded_global_scan_without_route_scope(
         self,
     ) -> None:
         fake_session = _OptionsFreshnessSession()
@@ -646,26 +647,56 @@ class TestTradingApi(TestCase):
             fake_session,  # type: ignore[arg-type]
         )
 
-        self.assertEqual(payload["status"], "unavailable")
-        self.assertEqual(payload["scope"], "route_symbols")
-        self.assertTrue(payload["bounded"])
-        self.assertEqual(payload["active_contracts"], 0)
+        self.assertEqual(payload["scope"], "global")
+        self.assertEqual(payload["active_contracts"], 6)
+        self.assertFalse(payload["active_contracts_exact"])
+        self.assertFalse(payload["coverage_exact"])
+        self.assertEqual(payload["query_limit"], 200)
         self.assertEqual(payload["route_symbols"], [])
-        self.assertIn(
-            "options_catalog_freshness_route_scope_missing",
-            payload["reason_codes"],
-        )
-        self.assertIn(
-            "options_catalog_freshness_unbounded_global_scan_skipped",
-            payload["reason_codes"],
-        )
+        self.assertIn("WHERE status = 'active'", fake_session.calls[1][0])
+        self.assertIn("LIMIT 200", fake_session.calls[1][0])
         self.assertEqual(
             sum(
                 "FROM torghut_options_contract_catalog" in sql
                 for sql, _params in fake_session.calls
             ),
-            0,
+            1,
         )
+
+    def test_daily_runtime_ledger_portfolio_summary_timeout_is_fail_closed(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            with (
+                patch.object(
+                    session,
+                    "execute",
+                    side_effect=SQLAlchemyError("statement timeout"),
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                payload = _daily_runtime_ledger_portfolio_summary(
+                    session=session,
+                    account_label="TORGHUT_SIM",
+                    stage_scope="paper",
+                    observed_at=datetime(2026, 6, 1, 12, tzinfo=timezone.utc),
+                )
+
+        self.assertTrue(payload["read_model_unavailable"])
+        self.assertEqual(payload["bucket_count"], 0)
+        self.assertEqual(
+            payload["blockers"], ["portfolio_runtime_ledger_summary_query_timeout"]
+        )
+        self.assertEqual(payload["query_limit"], 200)
+        self.assertEqual(rollback.call_count, 1)
 
     def test_options_catalog_freshness_summary_caches_unavailable_route_scope(
         self,


### PR DESCRIPTION
## Summary

- Added bounded, timeout-safe Torghut runtime-ledger read-model summaries for readiness/proof status, with explicit fail-closed blocker reason codes when the read model is unavailable.
- Reworked certificate evidence and promotion diagnostic counts to use scoped per-hypothesis/per-window lookups and bounded scalar samples instead of broad unbounded scans.
- Hardened options freshness and paper-route audit diagnostics with bounded reads, short PostgreSQL statement timeouts, exactness metadata, and regression coverage for timeout paths.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (passed after installing missing local C compiler packages needed to build `crosshair-tool`)
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_trading_api.py` (260 passed, 1 existing warning)
- `cd services/torghut && uv run --frozen ruff format app/main.py app/trading/submission_council.py app/trading/paper_route_evidence.py tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_trading_api.py` (passed)
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/submission_council.py app/trading/paper_route_evidence.py tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_trading_api.py` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (passed; default Node heap OOMed before increasing heap)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (passed)
- `git diff --check` (passed)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
