### PR TITLE
fix(torghut): require source row ids for runtime imports

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1218,7 +1218,11 @@ def _with_runtime_ledger_source_authority_context(
         str(key): _nonnegative_int(value) for key, value in existing_counts.items()
     }
     for key, value in source_row_counts.items():
-        merged_counts.setdefault(str(key), max(0, int(value)))
+        table_name = str(key)
+        merged_counts[table_name] = max(
+            merged_counts.get(table_name, 0),
+            max(0, int(value)),
+        )
     if merged_counts:
         payload["source_row_counts"] = dict(sorted(merged_counts.items()))
     return payload
@@ -2843,9 +2847,7 @@ def _source_backed_fill_lifecycle_rows(
             continue
         if _runtime_order_id(normalized) is None:
             continue
-        if not _source_identifier_values(
-            [normalized], "execution_order_event_id", "event_fingerprint"
-        ):
+        if not _source_identifier_values([normalized], "execution_order_event_id"):
             continue
         if not _source_identifier_values([normalized], "source_window_id"):
             continue
@@ -2868,9 +2870,7 @@ def _source_backed_order_lifecycle_rows(
             continue
         if _runtime_order_id(normalized) is None:
             continue
-        if not _source_identifier_values(
-            [normalized], "execution_order_event_id", "event_fingerprint"
-        ):
+        if not _source_identifier_values([normalized], "execution_order_event_id"):
             continue
         if not _source_identifier_values([normalized], "source_window_id"):
             continue
@@ -3128,7 +3128,6 @@ def _runtime_source_context_for_bucket(
     execution_order_event_ids = _source_identifier_values(
         source_authority_lifecycle_rows,
         "execution_order_event_id",
-        "event_fingerprint",
     )
     if source_offsets and execution_order_event_ids:
         if order_feed_fill_economics_complete:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -816,7 +816,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self,
     ) -> None:
         bucket = _with_runtime_ledger_source_authority_context(
-            _complete_runtime_ledger_bucket(),
+            _complete_runtime_ledger_bucket(
+                source_row_counts={
+                    "trade_decisions": 1,
+                    "executions": 1,
+                    "execution_order_events": 1,
+                    "order_feed_source_windows": 1,
+                }
+            ),
             source_window_start=datetime(2026, 5, 29, 14, 30, tzinfo=timezone.utc),
             source_window_end=datetime(2026, 5, 29, 15, 0, tzinfo=timezone.utc),
             source_refs=[
@@ -852,6 +859,78 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertTrue(bucket["order_feed_lifecycle_complete"])
         self.assertTrue(bucket["execution_economics_complete"])
+        self.assertEqual(
+            bucket["source_row_counts"],
+            {
+                "execution_order_events": 1,
+                "executions": 1,
+                "order_feed_source_windows": 1,
+                "trade_decisions": 1,
+            },
+        )
+        self.assertEqual(_runtime_ledger_bucket_profit_proof_blockers(bucket), [])
+
+    def test_runtime_ledger_source_context_raises_stale_aggregate_counts(
+        self,
+    ) -> None:
+        bucket = _with_runtime_ledger_source_authority_context(
+            _complete_runtime_ledger_bucket(
+                source_row_counts={
+                    "trade_decisions": 1,
+                    "executions": 1,
+                    "execution_order_events": 1,
+                    "order_feed_source_windows": 1,
+                }
+            ),
+            source_window_start=datetime(2026, 5, 29, 14, 30, tzinfo=timezone.utc),
+            source_window_end=datetime(2026, 5, 29, 15, 0, tzinfo=timezone.utc),
+            source_refs=[
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+            source_row_counts={
+                "trade_decisions": 2,
+                "executions": 2,
+                "execution_order_events": 4,
+                "order_feed_source_windows": 4,
+            },
+            trade_decision_ids=["decision-buy", "decision-sell"],
+            execution_ids=["execution-buy", "execution-sell"],
+            execution_order_event_ids=[
+                "event-new-buy",
+                "event-fill-buy",
+                "event-new-sell",
+                "event-fill-sell",
+            ],
+            source_window_ids=[
+                "window-new-buy",
+                "window-fill-buy",
+                "window-new-sell",
+                "window-fill-sell",
+            ],
+            source_offsets=[
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 1},
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 2},
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 3},
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 4},
+            ],
+            order_feed_lifecycle_complete=True,
+            execution_economics_complete=True,
+            source_materialization="execution_order_events",
+            authority_class="runtime_order_feed_execution_source",
+        )
+
+        self.assertEqual(
+            bucket["source_row_counts"],
+            {
+                "execution_order_events": 4,
+                "executions": 2,
+                "order_feed_source_windows": 4,
+                "trade_decisions": 2,
+            },
+        )
         self.assertEqual(_runtime_ledger_bucket_profit_proof_blockers(bucket), [])
 
     def test_runtime_ledger_source_context_merges_gap_metadata(self) -> None:
@@ -3740,6 +3819,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "event_type": "filled",
                     "symbol": "AAPL",
                     "alpaca_order_id": "order-missing-event-ref",
+                    "event_fingerprint": "fingerprint-is-not-row-id",
                     "source_topic": "alpaca.trade_updates",
                     "source_partition": 0,
                     "source_offset": 111,
@@ -3797,6 +3877,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 {
                     "event_type": "new",
                     "alpaca_order_id": "order-missing-event-ref",
+                    "event_fingerprint": "fingerprint-is-not-row-id",
                     "source_topic": "alpaca.trade_updates",
                     "source_partition": 0,
                     "source_offset": 122,

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -438,6 +438,86 @@ class TestRuntimeWindowImport(TestCase):
             "2",
         )
 
+    def test_build_observed_runtime_buckets_counts_only_source_backed_rows(
+        self,
+    ) -> None:
+        source_backed_bucket = _runtime_ledger_bucket(
+            filled_notional="100",
+            net_strategy_pnl_after_costs="1",
+            cost_amount="0.01",
+            post_cost_expectancy_bps="100",
+        )
+        replay_only_bucket = _runtime_ledger_bucket(
+            filled_notional="10000",
+            net_strategy_pnl_after_costs="1000",
+            cost_amount="0.01",
+            post_cost_expectancy_bps="1000",
+            source_window_ids=[],
+            trade_decision_ids=[],
+            execution_ids=[],
+            execution_order_event_ids=[],
+            source_offsets=[],
+            source_materialization=None,
+            authority_class="exact_replay_artifact_only_not_live",
+            authority_reason="exact_replay_artifact_not_runtime_proof",
+            pnl_derivation="exact_replay_artifact_only_not_live",
+            blockers=["exact_replay_artifact_not_runtime_proof"],
+        )
+
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    6,
+                )
+            ],
+            decision_times=[
+                datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+            ],
+            execution_times=[
+                datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 14, 41, tzinfo=timezone.utc),
+            ],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("100"),
+                    "runtime_ledger_bucket": source_backed_bucket,
+                    **_runtime_pnl_basis(),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 41, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("1000"),
+                    "runtime_ledger_bucket": replay_only_bucket,
+                    **_runtime_pnl_basis(),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        self.assertEqual(buckets[0].post_cost_promotion_sample_count, 1)
+        self.assertEqual(buckets[0].post_cost_expectancy_bps, Decimal("100"))
+        self.assertEqual(
+            buckets[0].payload_json["runtime_ledger_notional_weighted_sample_count"],
+            1,
+        )
+        self.assertEqual(
+            buckets[0].payload_json["runtime_ledger_filled_notional"], "100"
+        )
+        self.assertEqual(
+            buckets[0].payload_json["runtime_ledger_net_strategy_pnl_after_costs"],
+            "1",
+        )
+        runtime_ledger_buckets = buckets[0].payload_json["runtime_ledger_buckets"]
+        self.assertIsInstance(runtime_ledger_buckets, list)
+        self.assertEqual(len(runtime_ledger_buckets), 2)
+
     def test_runtime_ledger_bucket_blockers_require_complete_lifecycle_proof(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Requires source-backed runtime-window import reconciliation to preserve the highest observed source row counts instead of trusting stale aggregate counts.
- Requires concrete `execution_order_event_id` values for source-backed order-feed fill/order lifecycle authority; event fingerprints alone remain non-authoritative.
- Adds regression coverage for aggregate/replay-only evidence staying out of promotion-grade authority while source-backed runtime-ledger rows still count.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass; after installing `build-essential` so `crosshair-tool` can compile)
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py -q` (pass: 164 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py app/trading/runtime_ledger_source_authority.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (pass: 0 errors)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no documentation or release-note changes are required for this importer hardening.
