### PR TITLE
fix(torghut): make proof packet authority modes explicit

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1507,6 +1507,7 @@ def build_runtime_ledger_proof_packet(
             "canary_collection_authorized": bool(
                 proof_mode_targets["canary_collection_authorized"]
             ),
+            "promotion_allowed": False,
             "capital_promotion_allowed": False,
             "final_promotion_allowed": False,
         },
@@ -2424,8 +2425,10 @@ def build_runtime_ledger_proof_packet(
         and post_cost_proof_satisfied,
         "canary_collection_authorized": resolved_proof_mode == "probation"
         and post_cost_proof_satisfied,
+        "promotion_allowed": capital_promotion_allowed,
         "capital_promotion_allowed": capital_promotion_allowed,
         "final_promotion_allowed": capital_promotion_allowed,
+        "authority_blockers": authority_blockers,
         "blockers": promotion_blockers,
         "next_action": required_actions[0] if required_actions else "none",
         "post_cost_proof_authority": {
@@ -2460,6 +2463,7 @@ def build_runtime_ledger_proof_packet(
             "canary_collection_authorized": bool(
                 proof_mode_targets["canary_collection_authorized"]
             ),
+            "promotion_allowed": False,
             "capital_promotion_allowed": False,
             "final_promotion_allowed": False,
             "min_runtime_ledger_net_pnl_after_costs": _decimal_text(

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -697,11 +697,15 @@ def _add_runtime_ledger_proof_packet_check(
     authority = _mapping(packet.get("promotion_authority"))
     capital_authority = _mapping(packet.get("capital_promotion_authority"))
     schema_version = _text(packet.get("schema_version"))
+    proof_mode = _text(packet.get("proof_mode"))
     allowed = authority.get("allowed") is True
     packet_ok = (
         packet.get("ok") is True
+        and proof_mode == "authority"
         and packet.get("final_authority_ok") is True
+        and packet.get("promotion_allowed") is True
         and packet.get("capital_promotion_allowed") is True
+        and packet.get("final_promotion_allowed") is True
         and allowed
     )
     expected_schema = schema_version == RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION
@@ -712,9 +716,11 @@ def _add_runtime_ledger_proof_packet_check(
         observed={
             "present": bool(packet),
             "schema_version": schema_version,
-            "proof_mode": _text(packet.get("proof_mode")),
+            "proof_mode": proof_mode,
             "final_authority_ok": packet.get("final_authority_ok"),
+            "promotion_allowed": packet.get("promotion_allowed"),
             "capital_promotion_allowed": packet.get("capital_promotion_allowed"),
+            "final_promotion_allowed": packet.get("final_promotion_allowed"),
             "evidence_collection_ok": packet.get("evidence_collection_ok"),
             "ok": packet.get("ok"),
             "verdict": _text(packet.get("verdict")),
@@ -738,7 +744,9 @@ def _add_runtime_ledger_proof_packet_check(
             "ok": True,
             "proof_mode": "authority",
             "final_authority_ok": True,
+            "promotion_allowed": True,
             "capital_promotion_allowed": True,
+            "final_promotion_allowed": True,
             "promotion_authority.allowed": True,
         },
     )

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -548,7 +548,21 @@ class TestRuntimeLedgerProofPacket(TestCase):
         )
         self.assertEqual(result["proof_mode"], "authority")
         self.assertTrue(result["final_authority_ok"])
+        self.assertTrue(result["promotion_allowed"])
+        self.assertTrue(result["capital_promotion_allowed"])
+        self.assertTrue(result["final_promotion_allowed"])
+        self.assertEqual(result["authority_blockers"], [])
         self.assertFalse(result["evidence_collection_only"])
+        self.assertEqual(
+            result["target"]["min_runtime_ledger_net_pnl_after_costs"], "10000"
+        )
+        self.assertEqual(
+            result["target"]["min_runtime_ledger_daily_net_pnl_after_costs"], "500"
+        )
+        self.assertEqual(result["target"]["min_runtime_ledger_trading_days"], 20)
+        self.assertEqual(
+            result["target"]["min_runtime_ledger_filled_notional"], "10000000"
+        )
         tigerbeetle_refs = result["evidence"]["runtime_window_import"][
             "materialization"
         ]["materialized_targets"][0]["tigerbeetle"]
@@ -783,7 +797,14 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(result["proof_mode"], "smoke")
         self.assertTrue(result["ok"], result)
         self.assertFalse(result["final_authority_ok"])
+        self.assertFalse(result["promotion_allowed"])
         self.assertFalse(result["capital_promotion_allowed"])
+        self.assertFalse(result["final_promotion_allowed"])
+        self.assertEqual(
+            result["authority_blockers"],
+            ["runtime_ledger_proof_mode_not_authority"],
+        )
+        self.assertFalse(result["target"]["promotion_allowed"])
         self.assertEqual(
             result["post_cost_proof_authority"]["blocking_reasons"],
             ["runtime_ledger_proof_mode_not_authority"],
@@ -914,8 +935,13 @@ class TestRuntimeLedgerProofPacket(TestCase):
         )
         self.assertTrue(result["evidence_collection_ok"])
         self.assertFalse(result["canary_collection_authorized"])
+        self.assertFalse(result["promotion_allowed"])
         self.assertFalse(result["capital_promotion_allowed"])
         self.assertFalse(result["final_promotion_allowed"])
+        self.assertEqual(
+            result["authority_blockers"],
+            ["runtime_ledger_proof_mode_not_authority"],
+        )
         self.assertFalse(result["promotion_authority"]["allowed"])
         self.assertEqual(
             result["target"]["max_runtime_ledger_drawdown_pct_equity"], "0.08"
@@ -954,8 +980,13 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertTrue(result["evidence_collection_ok"])
         self.assertTrue(result["canary_collection_authorized"])
         self.assertFalse(result["final_authority_ok"])
+        self.assertFalse(result["promotion_allowed"])
         self.assertFalse(result["capital_promotion_allowed"])
         self.assertFalse(result["final_promotion_allowed"])
+        self.assertEqual(
+            result["authority_blockers"],
+            ["runtime_ledger_proof_mode_not_authority"],
+        )
         self.assertFalse(result["capital_promotion_authority"]["allowed"])
         self.assertFalse(result["promotion_authority"]["allowed"])
         self.assertIn(
@@ -2496,6 +2527,57 @@ class TestRuntimeLedgerProofPacket(TestCase):
             self.assertIn(
                 "runtime_ledger_pnl_basis_missing",
                 payload["promotion_authority"]["blocking_reasons"],
+            )
+
+    def test_cli_defaults_to_smoke_mode_without_promotion_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            status_path = tmp_path / "status.json"
+            paper_path = tmp_path / "paper.json"
+            import_path = tmp_path / "import.json"
+            completion_path = tmp_path / "completion.json"
+            output_path = tmp_path / "packet.json"
+            status_path.write_text(json.dumps(_status()), encoding="utf-8")
+            paper_path.write_text(json.dumps(_paper_route_evidence()), encoding="utf-8")
+            import_path.write_text(json.dumps(_runtime_import()), encoding="utf-8")
+            completion_path.write_text(
+                json.dumps(_completion(trading_days=1, net_pnl="600")),
+                encoding="utf-8",
+            )
+
+            exit_code = packet.main(
+                [
+                    "--status-file",
+                    str(status_path),
+                    "--paper-route-evidence-file",
+                    str(paper_path),
+                    "--runtime-window-import-file",
+                    str(import_path),
+                    "--completion-file",
+                    str(completion_path),
+                    "--output-file",
+                    str(output_path),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["proof_mode"], "smoke")
+            self.assertEqual(
+                payload["verdict"],
+                "smoke_proof_satisfied_evidence_collection_only",
+            )
+            self.assertFalse(payload["promotion_allowed"])
+            self.assertFalse(payload["final_promotion_allowed"])
+            self.assertEqual(
+                payload["authority_blockers"],
+                ["runtime_ledger_proof_mode_not_authority"],
+            )
+            self.assertEqual(
+                payload["checks"]["runtime_ledger_proof_mode_contract"]["observed"][
+                    "promotion_allowed"
+                ],
+                False,
             )
 
     def test_cli_can_write_blocked_packet_without_failing_scheduled_collection(

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -273,7 +273,9 @@ def _runtime_ledger_proof_packet(
         "proof_mode": "authority",
         "ok": allowed,
         "final_authority_ok": allowed,
+        "promotion_allowed": allowed,
         "capital_promotion_allowed": allowed,
+        "final_promotion_allowed": allowed,
         "evidence_collection_ok": False,
         "next_action": "none"
         if allowed
@@ -476,6 +478,28 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertEqual(observed["proof_mode"], "smoke")
         self.assertFalse(observed["authority_allowed"])
         self.assertEqual(result["next_action"], "rerun_proof_packet_in_authority_mode")
+
+    def test_runtime_ledger_proof_packet_rejects_mislabeled_smoke_authority(
+        self,
+    ) -> None:
+        packet = _runtime_ledger_proof_packet(allowed=True)
+        packet["proof_mode"] = "smoke"
+
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            runtime_ledger_proof_packet=packet,
+            require_runtime_ledger_proof_packet=True,
+        )
+
+        self.assertFalse(result["ok"])
+        observed = result["checks"]["runtime_ledger_proof_packet_authority"]["observed"]
+        self.assertEqual(observed["proof_mode"], "smoke")
+        self.assertTrue(observed["promotion_allowed"])
+        self.assertTrue(observed["final_promotion_allowed"])
+        self.assertIn(
+            "runtime_ledger_proof_packet_authority",
+            result["failed_checks"],
+        )
 
     def test_runtime_ledger_blockers_map_to_concrete_next_actions(self) -> None:
         cases = [


### PR DESCRIPTION
## Summary

- Adds explicit `promotion_allowed` and `authority_blockers` surfaces to runtime-ledger proof packets so smoke/probation evidence is visibly non-authoritative.
- Hardens readiness verification to require `proof_mode=authority` plus final promotion flags before accepting a proof packet as capital-promotion authority.
- Extends focused Torghut tests for default smoke CLI behavior, authority floors, and mislabeled smoke proof rejection.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass after installing `build-essential` in the workspace to provide `cc` for `crosshair-tool`)
- `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py tests/test_runtime_window_import.py -q` (pass: 135 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py app/trading/runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py tests/test_runtime_window_import.py` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (pass: 0 errors)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A; script/policy/readiness gate change only.

## Breaking Changes

Readiness proof-packet authority now requires packets to expose `proof_mode=authority`, `promotion_allowed=true`, `capital_promotion_allowed=true`, and `final_promotion_allowed=true`. Smoke/probation packets remain evidence-collection only and cannot satisfy the authority check.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
