### PR TITLE
feat(torghut): bound hpairs exact replay handoff

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -15,8 +15,8 @@ from app.trading.discovery.candidate_specs import CandidateSpec
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v2"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v3"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v3"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v4"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -67,6 +67,7 @@ class FastReplayPreviewRow:
             observed_post_cost_expectancy_bps
         )
         lineage_blockers = _lineage_blockers_for_row(self)
+        risk_flags = _risk_flags_for_row(self, lineage_blockers=lineage_blockers)
         return {
             "schema_version": FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION,
             "candidate_spec_id": self.candidate_spec_id,
@@ -136,9 +137,15 @@ class FastReplayPreviewRow:
                 "prefilter_only": True,
             },
             "lineage_blockers": list(lineage_blockers),
+            "risk_flags": list(risk_flags),
             "proof_semantics_label": self.proof_semantics_label,
             "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
             "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "proof_authority_reason": (
+                "fast_replay_preview_rank_only_exact_replay_and_source_backed_runtime_ledger_required"
+            ),
         }
 
 
@@ -159,6 +166,8 @@ class FastReplayPreviewResult:
             "schema_version": FAST_REPLAY_PREVIEW_SCHEMA_VERSION,
             "status": "preview_only",
             "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
             "authority": "not_promotion_proof",
             "proof_semantics_label": FAST_REPLAY_PROOF_SEMANTICS_LABEL,
             "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
@@ -187,6 +196,9 @@ class FastReplayPreviewResult:
                 "dataset_snapshot_ref": self.replay_tape_manifest.dataset_snapshot_ref,
                 "content_sha256": self.replay_tape_manifest.content_sha256,
                 "replay_cache_key": self.replay_tape_manifest.replay_cache_key,
+                "feature_schema_hash": self.replay_tape_manifest.feature_schema_hash,
+                "cost_model_hash": self.replay_tape_manifest.cost_model_hash,
+                "strategy_family": self.replay_tape_manifest.strategy_family,
                 "row_count": self.replay_tape_manifest.row_count,
                 "trading_day_count": self.replay_tape_manifest.trading_day_count,
                 "start_date": self.replay_tape_manifest.start_date.isoformat(),
@@ -991,6 +1003,25 @@ def _lineage_blockers_for_row(row: FastReplayPreviewRow) -> tuple[str, ...]:
     if _observed_post_cost_expectancy_bps(row) <= 0:
         blockers.append("positive_post_cost_expectancy_missing")
     return tuple(blockers)
+
+
+def _risk_flags_for_row(
+    row: FastReplayPreviewRow, *, lineage_blockers: Sequence[str]
+) -> tuple[str, ...]:
+    flags = set(lineage_blockers)
+    if row.macro_stress_veto_score > 0:
+        flags.add("macro_news_stress_veto_active")
+    if row.conformal_tail_risk_penalty_bps > 0:
+        flags.add("conformal_tail_risk_penalty_active")
+    if row.square_root_impact_capacity_penalty_bps > 0:
+        flags.add("square_root_impact_capacity_penalty_active")
+    if row.matched_symbol_count < row.requested_symbol_count:
+        flags.add("partial_symbol_coverage")
+    if row.trading_day_count <= 0:
+        flags.add("no_trading_day_coverage")
+    if row.selection_reason == "insufficient_replay_tape_rows":
+        flags.add("insufficient_replay_tape_rows")
+    return tuple(sorted(flags))
 
 
 def _mapping(value: Any) -> dict[str, Any]:

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -92,6 +92,7 @@ from app.trading.runtime_ledger import (
     build_runtime_ledger_buckets,
 )
 from app.trading.discovery.replay_tape import (
+    ReplayTapeManifest,
     build_source_query_digest,
     materialize_signal_tape,
     load_replay_tape,
@@ -140,7 +141,9 @@ _CANDIDATE_BOARD_RUNTIME_SESSION_TZ = ZoneInfo("America/New_York")
 _CANDIDATE_BOARD_RUNTIME_SESSION_OPEN = time(hour=9, minute=30)
 _CANDIDATE_BOARD_RUNTIME_SESSION_CLOSE = time(hour=16, minute=0)
 _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC = 8
-_DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES = 12
+_DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS = 900
+_DEFAULT_REAL_REPLAY_SHARD_WORKERS = 2
+_DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES = 6
 _DEFAULT_FAST_REPLAY_PREVIEW_TOP_K = 48
 _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP = 6
 _DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS = 4
@@ -502,19 +505,19 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--real-replay-shard-timeout-seconds",
         type=int,
-        default=0,
+        default=_DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
         help=(
-            "Per-shard timeout for sharded real replay. Defaults to "
-            "--real-replay-timeout-seconds when omitted."
+            "Per-shard timeout for sharded real replay. Defaults to the "
+            f"production-safe {_DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS}s cap."
         ),
     )
     parser.add_argument(
         "--real-replay-shard-workers",
         type=int,
-        default=1,
+        default=_DEFAULT_REAL_REPLAY_SHARD_WORKERS,
         help=(
             "Maximum number of bounded real-replay shards to run concurrently. "
-            "Defaults to 1 for the legacy sequential behavior."
+            f"Defaults to {_DEFAULT_REAL_REPLAY_SHARD_WORKERS}; no Kubernetes fanout is created."
         ),
     )
     parser.add_argument(
@@ -3673,13 +3676,17 @@ def _profitability_next_epoch_plan(
     if real_replay_shard_size > 0:
         flags["--real-replay-shard-size"] = str(real_replay_shard_size)
     real_replay_shard_timeout_seconds = _int_arg(
-        args, "real_replay_shard_timeout_seconds", 0
+        args,
+        "real_replay_shard_timeout_seconds",
+        _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
     )
     if real_replay_shard_timeout_seconds > 0:
         flags["--real-replay-shard-timeout-seconds"] = str(
             real_replay_shard_timeout_seconds
         )
-    real_replay_shard_workers = _int_arg(args, "real_replay_shard_workers", 1)
+    real_replay_shard_workers = _int_arg(
+        args, "real_replay_shard_workers", _DEFAULT_REAL_REPLAY_SHARD_WORKERS
+    )
     if real_replay_shard_workers > 1:
         flags["--real-replay-shard-workers"] = str(real_replay_shard_workers)
     real_replay_failed_spec_retries = _int_arg(
@@ -6564,6 +6571,7 @@ def _apply_fast_replay_preview_narrowing(
         },
         "bounded_sim_target_queue": _bounded_sim_target_queue_metadata(
             preview_rows=[row.to_payload() for row in preview.rows],
+            replay_tape_manifest=tape.manifest,
             exact_replay_candidate_cap=exact_replay_candidate_cap,
             exploitation_slots=exploitation_slots,
             exploration_slots=exploration_slots,
@@ -6619,10 +6627,16 @@ def _fast_replay_preview_proof_semantics() -> dict[str, Any]:
         "schema_version": "torghut.fast-replay-proof-semantics.v1",
         "label": FAST_REPLAY_PROOF_SEMANTICS_LABEL,
         "promotion_proof": False,
+        "proof_authority": False,
+        "promotion_authority": False,
         "authority": "preview_prefilter_only",
         "prefilter_only": True,
         "no_kubernetes_fanout": True,
-        "default_local_worker_cap": 2,
+        "default_local_worker_cap": _DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+        "default_shard_timeout_seconds": _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+        "default_parallel_frontier_candidate_cap": (
+            _DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES
+        ),
         "safe_exact_replay_candidate_cap": _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
         "final_promotion_requires": [
             "exact_replay_evidence",
@@ -6639,6 +6653,7 @@ def _fast_replay_preview_proof_semantics() -> dict[str, Any]:
 def _bounded_sim_target_queue_metadata(
     *,
     preview_rows: Sequence[Mapping[str, Any]],
+    replay_tape_manifest: ReplayTapeManifest,
     exact_replay_candidate_cap: int,
     exploitation_slots: int,
     exploration_slots: int,
@@ -6662,13 +6677,26 @@ def _bounded_sim_target_queue_metadata(
                 "target_implied_notional_context": row.get(
                     "target_implied_notional_context"
                 ),
+                "reproducibility_metadata": {
+                    "dataset_snapshot_ref": replay_tape_manifest.dataset_snapshot_ref,
+                    "replay_tape_content_sha256": replay_tape_manifest.content_sha256,
+                    "replay_cache_key": replay_tape_manifest.replay_cache_key,
+                    "feature_schema_hash": replay_tape_manifest.feature_schema_hash,
+                    "cost_model_hash": replay_tape_manifest.cost_model_hash,
+                    "strategy_family": replay_tape_manifest.strategy_family,
+                    "preview_score": row.get("preview_score"),
+                    "frontier_bucket": row.get("frontier_bucket"),
+                },
                 "cost_impact_lineage": row.get("cost_impact_lineage"),
                 "adv_capacity_context": row.get("adv_capacity_context"),
                 "lineage_blockers": list(
                     cast(Sequence[Any], row.get("lineage_blockers") or ())
                 ),
+                "risk_flags": list(cast(Sequence[Any], row.get("risk_flags") or ())),
                 "proof_semantics_label": row.get("proof_semantics_label"),
                 "promotion_proof": False,
+                "proof_authority": False,
+                "promotion_authority": False,
                 "promotion_allowed": False,
                 "final_promotion_allowed": False,
             }
@@ -6679,11 +6707,40 @@ def _bounded_sim_target_queue_metadata(
         "authority": "not_promotion_proof",
         "prefilter_only": True,
         "promotion_proof": False,
+        "proof_authority": False,
+        "promotion_authority": False,
         "promotion_allowed": False,
         "final_promotion_allowed": False,
         "proof_semantics": _fast_replay_preview_proof_semantics(),
         "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
         "queue_policy": "top_exploitation_plus_exploration_exact_replay_cap",
+        "runner_policy": {
+            "default_shard_timeout_seconds": _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            "default_worker_cap": _DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+            "default_parallel_frontier_candidate_cap": (
+                _DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES
+            ),
+            "kubernetes_fanout_enabled": False,
+            "handoff_mode": "metadata_only_no_live_submit",
+        },
+        "target_queue": {
+            "sim_account_label": "TORGHUT_SIM",
+            "live_paper_account_label": "TORGHUT_LIVE_PAPER_AFTER_PROBATION",
+            "status": "sim_target_queue_ready_live_paper_blocked",
+            "live_paper_blockers": [
+                "exact_replay_probation_required",
+                "source_backed_runtime_ledger_required",
+                "operator_enablement_required",
+            ],
+        },
+        "replay_tape": {
+            "dataset_snapshot_ref": replay_tape_manifest.dataset_snapshot_ref,
+            "content_sha256": replay_tape_manifest.content_sha256,
+            "replay_cache_key": replay_tape_manifest.replay_cache_key,
+            "feature_schema_hash": replay_tape_manifest.feature_schema_hash,
+            "cost_model_hash": replay_tape_manifest.cost_model_hash,
+            "strategy_family": replay_tape_manifest.strategy_family,
+        },
         "exact_replay_candidate_cap": exact_replay_candidate_cap,
         "exploitation_slots": exploitation_slots,
         "exploration_slots": exploration_slots,
@@ -7348,14 +7405,24 @@ def _run_replay_with_optional_timeout(
     shard_size = max(0, int(getattr(args, "real_replay_shard_size", 0) or 0))
     if shard_size > 0 and len(specs) > shard_size:
         shard_timeout_seconds = max(
-            0, int(getattr(args, "real_replay_shard_timeout_seconds", 0) or 0)
+            0,
+            int(
+                getattr(
+                    args,
+                    "real_replay_shard_timeout_seconds",
+                    _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+                )
+                or 0
+            ),
         )
         return _run_real_replay_shards(
             args=args,
             output_dir=output_dir,
             specs=specs,
             shard_size=shard_size,
-            shard_timeout_seconds=shard_timeout_seconds or timeout_seconds,
+            shard_timeout_seconds=shard_timeout_seconds
+            or timeout_seconds
+            or _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
         )
 
     return _run_real_replay_once_with_optional_timeout(
@@ -7763,7 +7830,14 @@ def _bounded_real_replay_shard_workers(
         1,
         min(
             len(plans) or 1,
-            int(getattr(args, "real_replay_shard_workers", 1) or 1),
+            int(
+                getattr(
+                    args,
+                    "real_replay_shard_workers",
+                    _DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+                )
+                or _DEFAULT_REAL_REPLAY_SHARD_WORKERS
+            ),
         ),
     )
     max_parallel_frontier_candidates = max(
@@ -12194,10 +12268,20 @@ def run_whitepaper_autoresearch_profit_target(
                 getattr(args, "real_replay_shard_size", 0) or 0
             ),
             "real_replay_shard_timeout_seconds": int(
-                getattr(args, "real_replay_shard_timeout_seconds", 0) or 0
+                getattr(
+                    args,
+                    "real_replay_shard_timeout_seconds",
+                    _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+                )
+                or _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS
             ),
             "real_replay_shard_workers": int(
-                getattr(args, "real_replay_shard_workers", 1) or 1
+                getattr(
+                    args,
+                    "real_replay_shard_workers",
+                    _DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+                )
+                or _DEFAULT_REAL_REPLAY_SHARD_WORKERS
             ),
             "real_replay_max_parallel_frontier_candidates": int(
                 getattr(

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -2182,6 +2182,14 @@ def _exact_replay_ledger_artifact_update(
         "artifact_ref": artifact_ref,
         "artifact_kind": "exact_replay_ledger",
         "candidate_id": candidate_id,
+        "proof_authority": False,
+        "promotion_authority": False,
+        "promotion_proof": False,
+        "authority": "exact_replay_probation_only",
+        "authority_blockers": [
+            "source_backed_runtime_ledger_required",
+            "live_paper_runtime_evidence_required",
+        ],
     }
     if dataset_snapshot_id:
         artifact_payload["dataset_snapshot_id"] = dataset_snapshot_id
@@ -2256,6 +2264,14 @@ def _exact_replay_ledger_artifact_update(
         ),
         "runtime_ledger_pnl_basis": POST_COST_PNL_BASIS,
         "runtime_ledger_pnl_source": "exact_replay_runtime_ledger",
+        "exact_replay_ledger_artifact_proof_authority": False,
+        "runtime_ledger_artifact_proof_authority": False,
+        "promotion_authority": False,
+        "final_promotion_authority": False,
+        "promotion_authority_blockers": [
+            "source_backed_runtime_ledger_required",
+            "live_paper_runtime_evidence_required",
+        ],
     }
     if proof_only_reason:
         update["exact_replay_ledger_artifact_proof_only"] = True

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -163,6 +163,14 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn("source_backed_adv_missing", row_payload["lineage_blockers"])
         self.assertFalse(row_payload["promotion_proof"])
+        self.assertFalse(row_payload["proof_authority"])
+        self.assertIn("risk_flags", row_payload)
+        self.assertIn("source_backed_adv_missing", row_payload["risk_flags"])
+        self.assertEqual(payload["replay_tape"]["dataset_snapshot_ref"], "snapshot-fast")
+        self.assertIn("feature_schema_hash", payload["replay_tape"])
+        self.assertIn("cost_model_hash", payload["replay_tape"])
+        self.assertIn("strategy_family", payload["replay_tape"])
+        self.assertFalse(payload["proof_authority"])
 
     def test_frontier_selection_caps_exact_replay_with_exploration_slots(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -267,8 +267,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             consistency_repair_candidates=0,
             real_replay_timeout_seconds=0,
             real_replay_shard_size=0,
-            real_replay_shard_timeout_seconds=0,
-            real_replay_shard_workers=1,
+            real_replay_shard_timeout_seconds=runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            real_replay_shard_workers=runner._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
             real_replay_max_parallel_frontier_candidates=runner._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
             real_replay_failed_spec_retries=1,
             real_replay_retry_timeout_seconds=0,
@@ -4678,6 +4678,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
                 source_query_digest=build_source_query_digest({"window": "frontier"}),
+                feature_schema_hash="feature-schema-frontier",
+                cost_model_hash="cost-model-frontier",
+                strategy_family="hpairs-frontier-family",
             )
             specs = [
                 self._candidate_spec(f"spec-frontier-{index}") for index in range(8)
@@ -4727,8 +4730,28 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             fast_replay.FAST_REPLAY_PROOF_SEMANTICS_LABEL,
         )
         self.assertTrue(queue_payload["prefilter_only"])
+        self.assertFalse(queue_payload["proof_authority"])
         self.assertFalse(queue_payload["promotion_allowed"])
         self.assertFalse(queue_payload["final_promotion_allowed"])
+        self.assertEqual(
+            queue_payload["runner_policy"]["default_shard_timeout_seconds"], 900
+        )
+        self.assertEqual(queue_payload["runner_policy"]["default_worker_cap"], 2)
+        self.assertFalse(queue_payload["runner_policy"]["kubernetes_fanout_enabled"])
+        self.assertEqual(
+            queue_payload["runner_policy"]["default_parallel_frontier_candidate_cap"],
+            6,
+        )
+        self.assertEqual(
+            queue_payload["target_queue"]["status"],
+            "sim_target_queue_ready_live_paper_blocked",
+        )
+        self.assertEqual(
+            queue_payload["replay_tape"]["feature_schema_hash"],
+            "feature-schema-frontier",
+        )
+        self.assertEqual(queue_payload["replay_tape"]["cost_model_hash"], "cost-model-frontier")
+        self.assertEqual(queue_payload["replay_tape"]["strategy_family"], "hpairs-frontier-family")
         self.assertEqual(
             [entry["frontier_bucket"] for entry in queue_payload["entries"]],
             [
@@ -4743,6 +4766,20 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         first_entry = queue_payload["entries"][0]
         self.assertIn("observed_post_cost_expectancy_bps", first_entry)
         self.assertIn("required_daily_notional", first_entry)
+        self.assertFalse(first_entry["proof_authority"])
+        self.assertIn("risk_flags", first_entry)
+        self.assertEqual(
+            first_entry["reproducibility_metadata"]["dataset_snapshot_ref"],
+            "frontier-preview",
+        )
+        self.assertEqual(
+            first_entry["reproducibility_metadata"]["feature_schema_hash"],
+            "feature-schema-frontier",
+        )
+        self.assertEqual(
+            first_entry["reproducibility_metadata"]["preview_score"],
+            first_entry["preview_score"],
+        )
         self.assertIn("target_implied_notional_context", first_entry)
         self.assertIn("cost_impact_lineage", first_entry)
         self.assertEqual(
@@ -4903,7 +4940,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         manifest_payload = preview.to_manifest_payload()
 
         self.assertEqual(
-            row_payload["schema_version"], "torghut.fast-replay-preview-row.v3"
+            row_payload["schema_version"], "torghut.fast-replay-preview-row.v4"
         )
         self.assertEqual(manifest_payload["status"], "preview_only")
         self.assertFalse(manifest_payload["promotion_proof"])
@@ -10754,8 +10791,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(parsed.consistency_repair_iterations, 1)
         self.assertEqual(parsed.consistency_repair_candidates, 5)
         self.assertEqual(parsed.real_replay_shard_size, 0)
-        self.assertEqual(parsed.real_replay_shard_timeout_seconds, 0)
-        self.assertEqual(parsed.real_replay_shard_workers, 1)
+        self.assertEqual(
+            parsed.real_replay_shard_timeout_seconds,
+            runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            parsed.real_replay_shard_workers,
+            runner._DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+        )
         self.assertEqual(
             parsed.real_replay_max_parallel_frontier_candidates,
             runner._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
@@ -11453,6 +11496,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.replay_mode = "real"
             args.real_replay_shard_size = 1
             args.real_replay_shard_timeout_seconds = 7
+            args.real_replay_shard_workers = 1
             args.real_replay_failed_spec_retries = 0
             with (
                 patch.object(runner, "signal", _FakeSigalrmSignal()),
@@ -11943,6 +11987,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.replay_mode = "real"
             args.real_replay_shard_size = 1
             args.real_replay_shard_timeout_seconds = 7
+            args.real_replay_shard_workers = 1
             args.real_replay_failed_spec_retries = 1
             args.real_replay_retry_timeout_seconds = 11
             args.real_replay_retry_max_frontier_candidates_per_spec = 1
@@ -12277,7 +12322,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     shard_timeout_seconds=7,
                 )
 
-        self.assertEqual(workers_seen, [3])
+        self.assertEqual(workers_seen, [2])
         self.assertEqual(len(submitted), 3)
         self.assertTrue(
             all(fn is runner._execute_real_replay_shard for fn, _plan in submitted)

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -1663,6 +1663,20 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             self.assertEqual(
                 exact_ledger_artifact["artifact_kind"], "exact_replay_ledger"
             )
+            self.assertFalse(exact_ledger_artifact["proof_authority"])
+            self.assertEqual(
+                exact_ledger_artifact["authority"],
+                "exact_replay_probation_only",
+            )
+            self.assertIn(
+                "source_backed_runtime_ledger_required",
+                exact_ledger_artifact["authority_blockers"],
+            )
+            self.assertFalse(
+                scorecard["exact_replay_ledger_artifact_proof_authority"]
+            )
+            self.assertFalse(scorecard["runtime_ledger_artifact_proof_authority"])
+            self.assertFalse(scorecard["final_promotion_authority"])
             self.assertEqual(scorecard["runtime_ledger_artifact_row_count"], 6)
             self.assertEqual(scorecard["runtime_ledger_artifact_fill_count"], 2)
             self.assertEqual(scorecard["runtime_ledger_closed_trade_count"], 1)


### PR DESCRIPTION
## Summary

- Adds explicit non-authority proof labels, risk flags, and replay-tape reproducibility metadata to H-PAIRS fast replay preview rows/manifests.
- Builds a bounded SIM target queue handoff from the top 4 exploitation plus 2 exploration preview candidates, capped at 6 exact replay candidates with live-paper promotion blocked.
- Sets production-safe exact replay shard defaults: 900s shard timeout, 2 local workers, 6 parallel frontier candidate cap, and no Kubernetes fanout metadata.
- Marks exact replay ledger artifacts as probation-only/non-authoritative unless source-backed runtime ledger and live-paper evidence exist.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py -q`
- PASS: `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py scripts/search_consistent_profitability_frontier.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
