### PR TITLE
feat(torghut): extend order feed source-window ledger

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -330,6 +330,18 @@ class OrderFeedSourceWindow(Base, TimestampMixin):
             "end_offset",
         ),
         Index(
+            "ix_order_feed_source_windows_consumer_scope_revision_offsets",
+            "consumer_group",
+            "source_topic",
+            "source_partition",
+            "alpaca_account_label",
+            "assignment_mode",
+            "collector_identity",
+            "source_revision",
+            "start_offset",
+            "end_offset",
+        ),
+        Index(
             "ix_order_feed_source_windows_account_window",
             "alpaca_account_label",
             "window_started_at",

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -235,6 +235,7 @@ class OrderFeedIngestor:
             source_topic=source_topic,
             source_partition=source_partition,
             source_offset=source_offset,
+            broker_high_watermark=_broker_high_watermark_from_record(record),
             alpaca_account_label=(
                 self._default_account_label
                 if out_of_scope_account
@@ -542,6 +543,7 @@ def _create_order_feed_source_window(
     source_partition: int | None,
     source_offset: int | None,
     alpaca_account_label: str,
+    broker_high_watermark: int | None = None,
 ) -> OrderFeedSourceWindow | None:
     if source_partition is None or source_offset is None:
         return None
@@ -559,7 +561,7 @@ def _create_order_feed_source_window(
         window_ended_at=now,
         start_offset=source_offset,
         end_offset=source_offset,
-        broker_high_watermark=None,
+        broker_high_watermark=broker_high_watermark,
         consumed_count=1,
         inserted_count=0,
         duplicate_count=0,
@@ -582,6 +584,27 @@ def _create_order_feed_source_window(
     session.add(source_window)
     session.flush()
     return source_window
+
+
+def _broker_high_watermark_from_record(record: Any) -> int | None:
+    """Return a broker high watermark carried by Kafka-like records when present.
+
+    ``kafka-python`` ``ConsumerRecord`` values do not expose partition end offsets,
+    but test harnesses and collector wrappers can attach one. Treat this as optional
+    source telemetry: it enriches the window ledger without affecting cursor
+    authority or offset-commit decisions.
+    """
+
+    for attribute in (
+        "broker_high_watermark",
+        "high_watermark",
+        "highwater",
+        "log_end_offset",
+    ):
+        value = _coerce_int(getattr(record, attribute, None))
+        if value is not None:
+            return value
+    return None
 
 
 def _classify_source_window_drop(

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -10,7 +10,7 @@ from decimal import Decimal, ROUND_DOWN
 from typing import Any, Literal, Optional, cast
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select  # pyright: ignore[reportUnknownVariableType]
 from sqlalchemy.orm import Session
 
 from ...config import settings

--- a/services/torghut/migrations/versions/0044_order_feed_source_window_consumer_scope_index.py
+++ b/services/torghut/migrations/versions/0044_order_feed_source_window_consumer_scope_index.py
@@ -1,0 +1,51 @@
+"""Add consumer-scope order-feed source-window lookup index.
+
+Revision ID: 0044_order_feed_source_window_consumer_scope_index
+Revises: 0043_status_readiness_bounded_read_indexes
+Create Date: 2026-06-01 11:15:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0044_order_feed_source_window_consumer_scope_index"
+down_revision = "0043_status_readiness_bounded_read_indexes"
+branch_labels = None
+depends_on = None
+
+_INDEX_NAME = "ix_order_feed_source_windows_consumer_scope_revision_offsets"
+_TABLE_NAME = "order_feed_source_windows"
+_COLUMNS = [
+    "consumer_group",
+    "source_topic",
+    "source_partition",
+    "alpaca_account_label",
+    "assignment_mode",
+    "collector_identity",
+    "source_revision",
+    "start_offset",
+    "end_offset",
+]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(_TABLE_NAME):
+        return
+    existing_indexes = {index["name"] for index in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME not in existing_indexes:
+        op.create_index(_INDEX_NAME, _TABLE_NAME, _COLUMNS)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(_TABLE_NAME):
+        return
+    existing_indexes = {index["name"] for index in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME in existing_indexes:
+        op.drop_index(_INDEX_NAME, table_name=_TABLE_NAME)

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -61,6 +61,7 @@ class FakeRecord:
     topic: str = "torghut.trade-updates.v1"
     partition: int = 0
     offset: int = 0
+    broker_high_watermark: int | None = None
 
 
 class FakeConsumer:
@@ -1898,6 +1899,44 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.inserted_count, 1)
         self.assertEqual(source_window.unlinked_execution_count, 0)
         self.assertEqual(source_window.unlinked_decision_count, 0)
+
+    def test_source_window_records_scope_revision_and_available_high_watermark(
+        self,
+    ) -> None:
+        settings.trading_order_feed_group_id = "torghut-paper-order-feed-v2"
+        settings.trading_order_feed_client_id = "paper-collector-7"
+        settings.trading_order_feed_assignment_mode = "manual"
+        record = FakeRecord(
+            value=(
+                b'{"channel":"trade_updates","payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+                b'"order":{"id":"order-1","client_order_id":"client-1","symbol":"AAPL","status":"filled",'
+                b'"qty":"1","filled_qty":"1","filled_avg_price":"190.2"}},"seq":10}'
+            ),
+            offset=31,
+            broker_high_watermark=37,
+        )
+        consumer = FakeManualConsumer(
+            [record], partitions={"torghut.trade-updates.v1": {0}}
+        )
+        ingestor = OrderFeedIngestor(consumer_factory=lambda: consumer)
+
+        with Session(self.engine) as session:
+            self._seed_execution(session)
+            counters = ingestor.ingest_once(session)
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(counters["events_persisted_total"], 1)
+        self.assertEqual(source_window.consumer_group, "torghut-paper-order-feed-v2")
+        self.assertEqual(source_window.source_topic, "torghut.trade-updates.v1")
+        self.assertEqual(source_window.source_partition, 0)
+        self.assertEqual(source_window.alpaca_account_label, "paper")
+        self.assertEqual(source_window.assignment_mode, "manual")
+        self.assertEqual(source_window.collector_identity, "paper-collector-7")
+        self.assertEqual(source_window.source_revision, ORDER_FEED_SOURCE_REVISION)
+        self.assertEqual(source_window.start_offset, 31)
+        self.assertEqual(source_window.end_offset, 31)
+        self.assertEqual(source_window.broker_high_watermark, 37)
+        self.assertEqual(source_window.status, "inserted")
 
     def test_invalid_json_is_durably_classified_before_cursor_advance(self) -> None:
         record = FakeRecord(value=b"{not-json", offset=17)


### PR DESCRIPTION
## Summary

- Added a consumer-scoped source-window index and ORM metadata so order-feed windows are keyed by consumer group, topic/partition, account, assignment mode, collector identity, source revision, and offsets.
- Recorded optional broker high-watermark telemetry from Kafka-like records into each order-feed source window without changing cursor authority.
- Added regression coverage for source-window scope/revision/high-watermark persistence and kept strict Pyright green with a targeted SQLAlchemy import ignore.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed after installing missing local build toolchain for `crosshair-tool`.
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_simple_pipeline.py -q` — passed: 100 passed, 1 warning.
- `cd services/torghut && uv run --frozen ruff check app/models/entities.py app/trading/order_feed.py app/trading/scheduler/simple_pipeline.py tests/test_order_feed.py migrations/versions/0044_order_feed_source_window_consumer_scope_index.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed: 0 errors.
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` — passed: 0 errors.
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` — passed: 0 errors.
- `git diff --check` — passed.

## Screenshots (if applicable)

N/A — backend ledger and validation changes only.

## Breaking Changes

None. Adds one non-unique lookup index for existing `order_feed_source_windows` data.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
