### PR TITLE
feat(torghut): add hpairs runtime authority verifier

### DIFF
--- a/services/torghut/app/trading/runtime_authority_verifier.py
+++ b/services/torghut/app/trading/runtime_authority_verifier.py
@@ -1,0 +1,796 @@
+"""Read-only H-PAIRS runtime authority proof verifier.
+
+This module deliberately only reads durable runtime-ledger buckets and turns them
+into a stable JSON-compatible proof report. It does not write promotion
+state, upload proof packets, or mutate cluster/database state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import cast
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import StrategyRuntimeLedgerBucket
+from app.trading.runtime_cost_authority import (
+    cost_basis_counts_have_non_promotion_grade_costs,
+    is_non_promotion_grade_runtime_cost_basis,
+)
+from app.trading.runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
+from app.trading.runtime_ledger_proof_policy import (
+    DEFAULT_RUNTIME_LEDGER_PROOF_POLICY,
+    RuntimeLedgerProofPolicy,
+    normalize_runtime_ledger_proof_mode,
+)
+from app.trading.runtime_ledger_source_authority import (
+    EXECUTION_ECONOMICS_MISSING_BLOCKER,
+    ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+    RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
+    RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+    runtime_ledger_promotion_source_authority_blockers,
+    runtime_ledger_source_window_present,
+)
+
+DEFAULT_HPAIRS_HYPOTHESIS_ID = 'H-PAIRS-01'
+DEFAULT_HPAIRS_CANDIDATE_ID = 'c88421d619759b2cfaa6f4d0'
+DEFAULT_HPAIRS_RUNTIME_STRATEGY = 'microbar-cross-sectional-pairs-v1'
+DEFAULT_HPAIRS_ACCOUNT_LABEL = 'TORGHUT_SIM'
+HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION = 'torghut.hpairs-runtime-authority-proof.v1'
+
+AUTHORITY_TRADING_DAYS_BLOCKER = 'runtime_ledger_trading_days_below_authority_minimum'
+AUTHORITY_MEAN_PNL_BLOCKER = 'mean_daily_net_pnl_after_costs_below_500'
+AUTHORITY_MEDIAN_PNL_BLOCKER = 'median_daily_net_pnl_after_costs_below_250'
+AUTHORITY_P10_PNL_BLOCKER = 'p10_daily_net_pnl_after_costs_below_floor'
+AUTHORITY_WORST_DAY_BLOCKER = 'worst_day_net_pnl_after_costs_below_floor'
+AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER = 'best_day_concentration_above_25pct'
+AUTHORITY_FILLED_NOTIONAL_BLOCKER = 'filled_notional_below_authority_minimum'
+AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER = 'filled_notional_missing'
+AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER = 'closed_round_trips_below_authority_minimum'
+AUTHORITY_OPEN_POSITIONS_BLOCKER = 'open_positions_present'
+AUTHORITY_EXPLICIT_COSTS_BLOCKER = 'explicit_costs_missing'
+AUTHORITY_BUCKET_BLOCKERS_PRESENT = 'runtime_ledger_bucket_blockers_present'
+AUTHORITY_EVIDENCE_MISSING_BLOCKER = 'runtime_ledger_evidence_missing'
+AUTHORITY_READ_ERROR_BLOCKER = 'runtime_ledger_read_error'
+AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER = 'runtime_fills_missing'
+AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER = 'runtime_decisions_missing'
+AUTHORITY_ORDER_LIFECYCLE_MISSING_BLOCKER = ORDER_FEED_LIFECYCLE_MISSING_BLOCKER
+AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER = 'closed_round_trip_missing'
+AUTHORITY_LEDGER_SCHEMA_BLOCKER = 'runtime_ledger_schema_version_invalid'
+AUTHORITY_PNL_BASIS_BLOCKER = 'runtime_ledger_pnl_basis_invalid'
+AUTHORITY_COST_BASIS_BLOCKER = 'runtime_ledger_cost_basis_non_promotion_grade'
+AUTHORITY_POLICY_HASH_BLOCKER = 'execution_policy_hash_missing'
+AUTHORITY_COST_MODEL_HASH_BLOCKER = 'cost_model_hash_missing'
+AUTHORITY_LINEAGE_HASH_BLOCKER = 'lineage_hash_missing'
+
+_PROMOTION_GRADE_LEDGER_SCHEMAS = frozenset({EXACT_REPLAY_LEDGER_SCHEMA_VERSION})
+
+
+@dataclass(frozen=True)
+class RuntimeAuthorityEvidenceRow:
+    """Normalized read-only runtime-ledger bucket evidence."""
+
+    row_id: str
+    run_id: str | None
+    candidate_id: str | None
+    hypothesis_id: str | None
+    observed_stage: str | None
+    bucket_started_at: datetime
+    bucket_ended_at: datetime
+    account_label: str | None
+    runtime_strategy_name: str | None
+    strategy_family: str | None
+    fill_count: int
+    decision_count: int
+    submitted_order_count: int
+    cancelled_order_count: int
+    rejected_order_count: int
+    unfilled_order_count: int
+    closed_trade_count: int
+    open_position_count: int
+    filled_notional: Decimal
+    gross_strategy_pnl: Decimal
+    cost_amount: Decimal
+    net_strategy_pnl_after_costs: Decimal
+    post_cost_expectancy_bps: Decimal | None
+    ledger_schema_version: str | None
+    pnl_basis: str | None
+    execution_policy_hash_counts: Mapping[str, object]
+    cost_model_hash_counts: Mapping[str, object]
+    lineage_hash_counts: Mapping[str, object]
+    blockers: tuple[str, ...]
+    payload: Mapping[str, object]
+
+
+@dataclass
+class _DailyAccumulator:
+    trading_day: str
+    net_strategy_pnl_after_costs: Decimal = Decimal('0')
+    filled_notional: Decimal = Decimal('0')
+    closed_trade_count: int = 0
+    open_position_count: int = 0
+    fill_count: int = 0
+    decision_count: int = 0
+    submitted_order_count: int = 0
+    explicit_cost_bucket_count: int = 0
+    source_window_count: int = 0
+    source_window_id_count: int = 0
+    source_ref_count: int = 0
+    source_offset_count: int = 0
+    trade_decision_ref_count: int = 0
+    execution_ref_count: int = 0
+    execution_order_event_ref_count: int = 0
+    source_materialization_count: int = 0
+    authority_class_count: int = 0
+    bucket_count: int = 0
+    source_authority_bucket_count: int = 0
+    row_refs: list[str] | None = None
+    blockers: list[str] | None = None
+
+    def add_ref(self, row_id: str) -> None:
+        if self.row_refs is None:
+            self.row_refs = []
+        self.row_refs.append(row_id)
+
+    def add_blockers(self, blockers: Sequence[str]) -> None:
+        if self.blockers is None:
+            self.blockers = []
+        for blocker in blockers:
+            if blocker not in self.blockers:
+                self.blockers.append(blocker)
+
+
+def load_runtime_authority_rows(
+    session: Session,
+    *,
+    hypothesis_id: str = DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    candidate_id: str = DEFAULT_HPAIRS_CANDIDATE_ID,
+    runtime_strategy_name: str = DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    account_label: str = DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    observed_stage: str | None = None,
+    started_at: datetime | None = None,
+    ended_at: datetime | None = None,
+) -> list[RuntimeAuthorityEvidenceRow]:
+    """Read runtime-ledger buckets for an H-PAIRS proof window without writes."""
+
+    statement = select(StrategyRuntimeLedgerBucket).where(
+        StrategyRuntimeLedgerBucket.hypothesis_id == hypothesis_id,
+        StrategyRuntimeLedgerBucket.candidate_id == candidate_id,
+        StrategyRuntimeLedgerBucket.account_label == account_label,
+        StrategyRuntimeLedgerBucket.runtime_strategy_name == runtime_strategy_name,
+    )
+    if observed_stage is not None:
+        statement = statement.where(StrategyRuntimeLedgerBucket.observed_stage == observed_stage)
+    if started_at is not None:
+        statement = statement.where(StrategyRuntimeLedgerBucket.bucket_ended_at >= _utc(started_at))
+    if ended_at is not None:
+        statement = statement.where(StrategyRuntimeLedgerBucket.bucket_started_at < _utc(ended_at))
+    statement = statement.order_by(
+        StrategyRuntimeLedgerBucket.bucket_started_at.asc(),
+        StrategyRuntimeLedgerBucket.bucket_ended_at.asc(),
+        StrategyRuntimeLedgerBucket.created_at.asc(),
+        StrategyRuntimeLedgerBucket.id.asc(),
+    )
+    buckets = session.scalars(statement).all()
+    return [_row_from_bucket(bucket) for bucket in buckets]
+
+
+def build_runtime_authority_report(
+    rows: Sequence[RuntimeAuthorityEvidenceRow | Mapping[str, object]],
+    *,
+    mode: str = 'authority',
+    hypothesis_id: str = DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    candidate_id: str = DEFAULT_HPAIRS_CANDIDATE_ID,
+    runtime_strategy_name: str = DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    account_label: str = DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    observed_stage: str | None = None,
+    started_at: datetime | None = None,
+    ended_at: datetime | None = None,
+    evidence_read_error: str | None = None,
+    policy: RuntimeLedgerProofPolicy = DEFAULT_RUNTIME_LEDGER_PROOF_POLICY,
+) -> dict[str, object]:
+    """Build a stable JSON-compatible final-authority proof report."""
+
+    proof_mode = normalize_runtime_ledger_proof_mode(mode)
+    normalized_rows = [_normalize_row(row) for row in rows]
+    daily = _daily_rows(normalized_rows)
+    aggregate = _aggregate(daily, normalized_rows, policy=policy)
+    blockers = _authority_blockers(
+        daily,
+        normalized_rows,
+        aggregate=aggregate,
+        policy=policy,
+        evidence_read_error=evidence_read_error,
+    )
+    return {
+        'schema_version': HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION,
+        'mode': proof_mode,
+        'final_authority_ok': not blockers,
+        'identity': {
+            'hypothesis_id': hypothesis_id,
+            'candidate_id': candidate_id,
+            'runtime_strategy_name': runtime_strategy_name,
+            'account_label': account_label,
+            'observed_stage': observed_stage,
+        },
+        'window': {
+            'started_at': _isoformat(started_at) if started_at is not None else None,
+            'ended_at': _isoformat(ended_at) if ended_at is not None else None,
+        },
+        'evidence_read_error': evidence_read_error,
+        'targets': _authority_targets(policy),
+        'trading_days': [_daily_payload(item) for item in daily],
+        'aggregate': aggregate,
+        'blockers': blockers,
+    }
+
+
+def runtime_authority_report_json(report: Mapping[str, object]) -> str:
+    """Serialize a report as deterministic JSON."""
+
+    import json
+
+    return json.dumps(report, indent=2, sort_keys=True) + '\n'
+
+
+def _row_from_bucket(bucket: StrategyRuntimeLedgerBucket) -> RuntimeAuthorityEvidenceRow:
+    payload = _as_mapping(bucket.payload_json)
+    blockers = _string_tuple([*_as_sequence(bucket.blockers_json), *_as_sequence(payload.get('blockers'))])
+    return RuntimeAuthorityEvidenceRow(
+        row_id=str(bucket.id),
+        run_id=_text(bucket.run_id),
+        candidate_id=_text(bucket.candidate_id),
+        hypothesis_id=_text(bucket.hypothesis_id),
+        observed_stage=_text(bucket.observed_stage),
+        bucket_started_at=_utc(bucket.bucket_started_at),
+        bucket_ended_at=_utc(bucket.bucket_ended_at),
+        account_label=_text(bucket.account_label),
+        runtime_strategy_name=_text(bucket.runtime_strategy_name),
+        strategy_family=_text(bucket.strategy_family),
+        fill_count=_int(bucket.fill_count),
+        decision_count=_int(bucket.decision_count),
+        submitted_order_count=_int(bucket.submitted_order_count),
+        cancelled_order_count=_int(bucket.cancelled_order_count),
+        rejected_order_count=_int(bucket.rejected_order_count),
+        unfilled_order_count=_int(bucket.unfilled_order_count),
+        closed_trade_count=_int(bucket.closed_trade_count),
+        open_position_count=_int(bucket.open_position_count),
+        filled_notional=_decimal(bucket.filled_notional),
+        gross_strategy_pnl=_decimal(bucket.gross_strategy_pnl),
+        cost_amount=_decimal(bucket.cost_amount),
+        net_strategy_pnl_after_costs=_decimal(bucket.net_strategy_pnl_after_costs),
+        post_cost_expectancy_bps=_optional_decimal(bucket.post_cost_expectancy_bps),
+        ledger_schema_version=_text(bucket.ledger_schema_version),
+        pnl_basis=_text(bucket.pnl_basis),
+        execution_policy_hash_counts=_as_mapping(bucket.execution_policy_hash_counts),
+        cost_model_hash_counts=_as_mapping(bucket.cost_model_hash_counts),
+        lineage_hash_counts=_as_mapping(bucket.lineage_hash_counts),
+        blockers=blockers,
+        payload=payload,
+    )
+
+
+def _normalize_row(row: RuntimeAuthorityEvidenceRow | Mapping[str, object]) -> RuntimeAuthorityEvidenceRow:
+    if isinstance(row, RuntimeAuthorityEvidenceRow):
+        return row
+    bucket_start = _required_datetime(row.get('bucket_started_at'), field_name='bucket_started_at')
+    bucket_end = _required_datetime(row.get('bucket_ended_at'), field_name='bucket_ended_at')
+    payload = _as_mapping(row.get('payload_json') or row.get('payload'))
+    blockers = _string_tuple([*_as_sequence(row.get('blockers_json')), *_as_sequence(row.get('blockers'))])
+    return RuntimeAuthorityEvidenceRow(
+        row_id=_text(row.get('id') or row.get('row_id')) or '',
+        run_id=_text(row.get('run_id')),
+        candidate_id=_text(row.get('candidate_id')),
+        hypothesis_id=_text(row.get('hypothesis_id')),
+        observed_stage=_text(row.get('observed_stage')),
+        bucket_started_at=bucket_start,
+        bucket_ended_at=bucket_end,
+        account_label=_text(row.get('account_label')),
+        runtime_strategy_name=_text(row.get('runtime_strategy_name')),
+        strategy_family=_text(row.get('strategy_family')),
+        fill_count=_int(row.get('fill_count')),
+        decision_count=_int(row.get('decision_count')),
+        submitted_order_count=_int(row.get('submitted_order_count')),
+        cancelled_order_count=_int(row.get('cancelled_order_count')),
+        rejected_order_count=_int(row.get('rejected_order_count')),
+        unfilled_order_count=_int(row.get('unfilled_order_count')),
+        closed_trade_count=_int(row.get('closed_trade_count')),
+        open_position_count=_int(row.get('open_position_count')),
+        filled_notional=_decimal(row.get('filled_notional')),
+        gross_strategy_pnl=_decimal(row.get('gross_strategy_pnl')),
+        cost_amount=_decimal(row.get('cost_amount')),
+        net_strategy_pnl_after_costs=_decimal(row.get('net_strategy_pnl_after_costs')),
+        post_cost_expectancy_bps=_optional_decimal(row.get('post_cost_expectancy_bps')),
+        ledger_schema_version=_text(row.get('ledger_schema_version')),
+        pnl_basis=_text(row.get('pnl_basis')),
+        execution_policy_hash_counts=_as_mapping(row.get('execution_policy_hash_counts')),
+        cost_model_hash_counts=_as_mapping(row.get('cost_model_hash_counts')),
+        lineage_hash_counts=_as_mapping(row.get('lineage_hash_counts')),
+        blockers=blockers,
+        payload=payload,
+    )
+
+
+def _daily_rows(rows: Sequence[RuntimeAuthorityEvidenceRow]) -> list[_DailyAccumulator]:
+    accumulators: dict[str, _DailyAccumulator] = {}
+    for row in rows:
+        day = row.bucket_started_at.astimezone(timezone.utc).date().isoformat()
+        accumulator = accumulators.setdefault(day, _DailyAccumulator(trading_day=day))
+        payload = _promotion_payload(row)
+        row_blockers = _row_authority_blockers(row, payload)
+        source_blockers = runtime_ledger_promotion_source_authority_blockers(payload)
+        accumulator.net_strategy_pnl_after_costs += row.net_strategy_pnl_after_costs
+        accumulator.filled_notional += row.filled_notional
+        accumulator.closed_trade_count += max(0, row.closed_trade_count)
+        accumulator.open_position_count += max(0, row.open_position_count)
+        accumulator.fill_count += max(0, row.fill_count)
+        accumulator.decision_count += max(0, row.decision_count)
+        accumulator.submitted_order_count += max(0, row.submitted_order_count)
+        accumulator.bucket_count += 1
+        if _explicit_costs_present(row, payload):
+            accumulator.explicit_cost_bucket_count += 1
+        if runtime_ledger_source_window_present(payload):
+            accumulator.source_window_count += 1
+        if not source_blockers:
+            accumulator.source_authority_bucket_count += 1
+        accumulator.source_window_id_count += _ref_count(
+            payload,
+            'source_window_ids',
+            'source_window_id',
+            'runtime_ledger_source_window_ids',
+            'runtime_ledger_source_window_id',
+        )
+        accumulator.source_ref_count += _ref_count(payload, 'source_refs', 'source_ref')
+        accumulator.source_offset_count += _source_offset_count(payload)
+        accumulator.trade_decision_ref_count += _ref_count(
+            payload,
+            'trade_decision_ids',
+            'trade_decision_refs',
+            'trade_decision_id',
+            'decision_ids',
+            'decision_id',
+        )
+        accumulator.execution_ref_count += _ref_count(payload, 'execution_ids', 'execution_refs', 'execution_id')
+        accumulator.execution_order_event_ref_count += _ref_count(
+            payload,
+            'execution_order_event_ids',
+            'execution_order_event_refs',
+            'execution_order_event_id',
+        )
+        accumulator.source_materialization_count += int(_text(payload.get('source_materialization')) is not None)
+        accumulator.authority_class_count += int(_text(payload.get('authority_class')) is not None)
+        accumulator.add_ref(row.row_id)
+        accumulator.add_blockers([*row_blockers, *source_blockers])
+    return [accumulators[day] for day in sorted(accumulators)]
+
+
+def _aggregate(
+    daily: Sequence[_DailyAccumulator],
+    rows: Sequence[RuntimeAuthorityEvidenceRow],
+    *,
+    policy: RuntimeLedgerProofPolicy,
+) -> dict[str, object]:
+    daily_net = [item.net_strategy_pnl_after_costs for item in daily]
+    total_net = sum(daily_net, Decimal('0'))
+    positive_total_net = sum((max(item, Decimal('0')) for item in daily_net), Decimal('0'))
+    best_day_net = max(daily_net) if daily_net else Decimal('0')
+    best_day_share = (
+        max(best_day_net, Decimal('0')) / positive_total_net if positive_total_net > 0 else None
+    )
+    max_drawdown = _max_drawdown(daily_net)
+    filled_notional = sum((row.filled_notional for row in rows), Decimal('0'))
+    closed_round_trips = sum((max(0, row.closed_trade_count) for row in rows), 0)
+    cost_amount = sum((row.cost_amount for row in rows), Decimal('0'))
+    return {
+        'bucket_count': len(rows),
+        'trading_day_count': len(daily),
+        'mean_daily_net_pnl_after_costs': _decimal_text(_mean(daily_net)),
+        'median_daily_net_pnl_after_costs': _decimal_text(_median(daily_net)),
+        'p10_daily_net_pnl_after_costs': _decimal_text(_p10(daily_net)),
+        'worst_day_net_pnl_after_costs': _decimal_text(min(daily_net) if daily_net else Decimal('0')),
+        'best_day_net_pnl_after_costs': _decimal_text(best_day_net),
+        'best_day_share': _decimal_text(best_day_share) if best_day_share is not None else None,
+        'max_drawdown': _decimal_text(max_drawdown) if daily else None,
+        'total_net_strategy_pnl_after_costs': _decimal_text(total_net),
+        'total_filled_notional': _decimal_text(filled_notional),
+        'total_explicit_costs': _decimal_text(cost_amount),
+        'closed_round_trips': closed_round_trips,
+        'open_position_count': sum((max(0, row.open_position_count) for row in rows), 0),
+        'source_authority_bucket_count': sum(item.source_authority_bucket_count for item in daily),
+        'explicit_cost_bucket_count': sum(item.explicit_cost_bucket_count for item in daily),
+        'authority_min_trading_days': policy.authority_min_trading_days,
+        'authority_min_filled_notional': _decimal_text(policy.authority_min_filled_notional),
+        'authority_min_closed_round_trips': policy.authority_min_closed_round_trips,
+    }
+
+
+def _authority_blockers(
+    daily: Sequence[_DailyAccumulator],
+    rows: Sequence[RuntimeAuthorityEvidenceRow],
+    *,
+    aggregate: Mapping[str, object],
+    policy: RuntimeLedgerProofPolicy,
+    evidence_read_error: str | None = None,
+) -> list[str]:
+    blockers: list[str] = []
+    if evidence_read_error is not None:
+        blockers.append(AUTHORITY_READ_ERROR_BLOCKER)
+    if not rows:
+        blockers.append(AUTHORITY_EVIDENCE_MISSING_BLOCKER)
+    daily_net = [item.net_strategy_pnl_after_costs for item in daily]
+    if len(daily) < policy.authority_min_trading_days:
+        blockers.append(AUTHORITY_TRADING_DAYS_BLOCKER)
+    if _mean(daily_net) < policy.authority_min_mean_daily_net_pnl_after_costs:
+        blockers.append(AUTHORITY_MEAN_PNL_BLOCKER)
+    if _median(daily_net) < policy.authority_min_median_daily_net_pnl_after_costs:
+        blockers.append(AUTHORITY_MEDIAN_PNL_BLOCKER)
+    if _p10(daily_net) < policy.authority_min_p10_daily_net_pnl_after_costs:
+        blockers.append(AUTHORITY_P10_PNL_BLOCKER)
+    if (min(daily_net) if daily_net else Decimal('0')) < policy.authority_min_worst_day_net_pnl_after_costs:
+        blockers.append(AUTHORITY_WORST_DAY_BLOCKER)
+    best_day_share = _optional_decimal(aggregate.get('best_day_share'))
+    if best_day_share is not None and best_day_share > policy.authority_max_best_day_share:
+        blockers.append(AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER)
+    filled_notional = _decimal(aggregate.get('total_filled_notional'))
+    if filled_notional <= 0:
+        blockers.append(AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER)
+    if filled_notional < policy.authority_min_filled_notional:
+        blockers.append(AUTHORITY_FILLED_NOTIONAL_BLOCKER)
+    if _int(aggregate.get('closed_round_trips')) < policy.authority_min_closed_round_trips:
+        blockers.append(AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER)
+    if _int(aggregate.get('open_position_count')) > 0:
+        blockers.append(AUTHORITY_OPEN_POSITIONS_BLOCKER)
+    if rows and _int(aggregate.get('explicit_cost_bucket_count')) < len(rows):
+        blockers.append(AUTHORITY_EXPLICIT_COSTS_BLOCKER)
+    for item in daily:
+        blockers.extend(item.blockers or [])
+    return list(dict.fromkeys(blockers))
+
+
+def _row_authority_blockers(
+    row: RuntimeAuthorityEvidenceRow,
+    payload: Mapping[str, object],
+) -> list[str]:
+    blockers: list[str] = list(row.blockers)
+    if row.blockers:
+        blockers.append(AUTHORITY_BUCKET_BLOCKERS_PRESENT)
+    if row.ledger_schema_version not in _PROMOTION_GRADE_LEDGER_SCHEMAS:
+        blockers.append(AUTHORITY_LEDGER_SCHEMA_BLOCKER)
+    if row.pnl_basis != POST_COST_PNL_BASIS:
+        blockers.append(AUTHORITY_PNL_BASIS_BLOCKER)
+    if row.fill_count <= 0:
+        blockers.append(AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER)
+    if row.decision_count <= 0:
+        blockers.append(AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER)
+    if row.submitted_order_count <= 0:
+        blockers.append(AUTHORITY_ORDER_LIFECYCLE_MISSING_BLOCKER)
+    if row.closed_trade_count <= 0:
+        blockers.append(AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER)
+    if row.open_position_count > 0:
+        blockers.append(AUTHORITY_OPEN_POSITIONS_BLOCKER)
+    if row.filled_notional <= 0:
+        blockers.append(AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER)
+    if not _explicit_costs_present(row, payload):
+        blockers.append(AUTHORITY_EXPLICIT_COSTS_BLOCKER)
+    if not _positive_hash_count(row.execution_policy_hash_counts):
+        blockers.append(AUTHORITY_POLICY_HASH_BLOCKER)
+    if not _positive_hash_count(row.cost_model_hash_counts):
+        blockers.append(AUTHORITY_COST_MODEL_HASH_BLOCKER)
+    if not _positive_hash_count(row.lineage_hash_counts):
+        blockers.append(AUTHORITY_LINEAGE_HASH_BLOCKER)
+    return list(dict.fromkeys(blockers))
+
+
+def _promotion_payload(row: RuntimeAuthorityEvidenceRow) -> dict[str, object]:
+    payload = dict(row.payload)
+    payload.update(
+        {
+            'run_id': row.run_id,
+            'candidate_id': row.candidate_id,
+            'hypothesis_id': row.hypothesis_id,
+            'observed_stage': row.observed_stage,
+            'account_label': row.account_label,
+            'runtime_strategy_name': row.runtime_strategy_name,
+            'strategy_family': row.strategy_family,
+            'fill_count': row.fill_count,
+            'decision_count': row.decision_count,
+            'submitted_order_count': row.submitted_order_count,
+            'cancelled_order_count': row.cancelled_order_count,
+            'rejected_order_count': row.rejected_order_count,
+            'unfilled_order_count': row.unfilled_order_count,
+            'closed_trade_count': row.closed_trade_count,
+            'open_position_count': row.open_position_count,
+            'filled_notional': row.filled_notional,
+            'gross_strategy_pnl': row.gross_strategy_pnl,
+            'cost_amount': row.cost_amount,
+            'net_strategy_pnl_after_costs': row.net_strategy_pnl_after_costs,
+            'post_cost_expectancy_bps': row.post_cost_expectancy_bps,
+            'ledger_schema_version': row.ledger_schema_version,
+            'pnl_basis': row.pnl_basis,
+            'execution_policy_hash_counts': row.execution_policy_hash_counts,
+            'cost_model_hash_counts': row.cost_model_hash_counts,
+            'lineage_hash_counts': row.lineage_hash_counts,
+        }
+    )
+    return payload
+
+
+def _explicit_costs_present(row: RuntimeAuthorityEvidenceRow, payload: Mapping[str, object]) -> bool:
+    if is_non_promotion_grade_runtime_cost_basis(payload.get('cost_basis')):
+        return False
+    if cost_basis_counts_have_non_promotion_grade_costs(payload.get('cost_basis_counts')):
+        return False
+    cost_basis_counts = _as_mapping(payload.get('cost_basis_counts'))
+    return bool(cost_basis_counts) and _positive_hash_count(row.cost_model_hash_counts)
+
+
+def _daily_payload(item: _DailyAccumulator) -> dict[str, object]:
+    return {
+        'trading_day': item.trading_day,
+        'net_strategy_pnl_after_costs': _decimal_text(item.net_strategy_pnl_after_costs),
+        'filled_notional': _decimal_text(item.filled_notional),
+        'closed_trade_count': item.closed_trade_count,
+        'open_position_count': item.open_position_count,
+        'fill_count': item.fill_count,
+        'decision_count': item.decision_count,
+        'submitted_order_count': item.submitted_order_count,
+        'bucket_count': item.bucket_count,
+        'explicit_cost_bucket_count': item.explicit_cost_bucket_count,
+        'source_window_count': item.source_window_count,
+        'source_window_id_count': item.source_window_id_count,
+        'source_ref_count': item.source_ref_count,
+        'source_offset_count': item.source_offset_count,
+        'trade_decision_ref_count': item.trade_decision_ref_count,
+        'execution_ref_count': item.execution_ref_count,
+        'execution_order_event_ref_count': item.execution_order_event_ref_count,
+        'source_materialization_count': item.source_materialization_count,
+        'authority_class_count': item.authority_class_count,
+        'source_authority_bucket_count': item.source_authority_bucket_count,
+        'row_refs': sorted(item.row_refs or []),
+        'blockers': sorted(item.blockers or []),
+    }
+
+
+def _authority_targets(policy: RuntimeLedgerProofPolicy) -> dict[str, object]:
+    return {
+        'min_trading_days': policy.authority_min_trading_days,
+        'min_mean_daily_net_pnl_after_costs': _decimal_text(policy.authority_min_mean_daily_net_pnl_after_costs),
+        'min_median_daily_net_pnl_after_costs': _decimal_text(policy.authority_min_median_daily_net_pnl_after_costs),
+        'min_p10_daily_net_pnl_after_costs': _decimal_text(policy.authority_min_p10_daily_net_pnl_after_costs),
+        'min_worst_day_net_pnl_after_costs': _decimal_text(policy.authority_min_worst_day_net_pnl_after_costs),
+        'max_best_day_share': _decimal_text(policy.authority_max_best_day_share),
+        'min_filled_notional': _decimal_text(policy.authority_min_filled_notional),
+        'min_closed_round_trips': policy.authority_min_closed_round_trips,
+    }
+
+
+def _mean(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal('0')
+    return sum(values, Decimal('0')) / Decimal(len(values))
+
+
+def _median(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal('0')
+    sorted_values = sorted(values)
+    middle = len(sorted_values) // 2
+    if len(sorted_values) % 2:
+        return sorted_values[middle]
+    return (sorted_values[middle - 1] + sorted_values[middle]) / Decimal('2')
+
+
+def _p10(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal('0')
+    sorted_values = sorted(values)
+    index = max(0, ((len(sorted_values) + 9) // 10) - 1)
+    return sorted_values[index]
+
+
+def _max_drawdown(values: Sequence[Decimal]) -> Decimal:
+    cumulative = Decimal('0')
+    peak = Decimal('0')
+    max_drawdown = Decimal('0')
+    for value in values:
+        cumulative += value
+        if cumulative > peak:
+            peak = cumulative
+        drawdown = peak - cumulative
+        if drawdown > max_drawdown:
+            max_drawdown = drawdown
+    return max_drawdown
+
+
+def _ref_count(bucket: Mapping[str, object], *keys: str) -> int:
+    refs: set[str] = set()
+    for key in keys:
+        value = bucket.get(key)
+        if isinstance(value, Mapping):
+            for ref_key, ref_value in cast(Mapping[object, object], value).items():
+                if ref_value is None or ref_value is False:
+                    continue
+                ref_text = _text(ref_value)
+                if ref_value is True or ref_text is None:
+                    ref_text = _text(ref_key)
+                if ref_text is not None:
+                    refs.add(ref_text)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            for item in cast(Sequence[object], value):
+                if (text := _text(item)) is not None:
+                    refs.add(text)
+        elif (text := _text(value)) is not None:
+            refs.add(text)
+    return len(refs)
+
+
+def _source_offset_count(bucket: Mapping[str, object]) -> int:
+    offsets = bucket.get('source_offsets')
+    if isinstance(offsets, Mapping):
+        return int(_source_offset_triplet_present(cast(Mapping[object, object], offsets)))
+    if isinstance(offsets, Sequence) and not isinstance(offsets, (str, bytes, bytearray)):
+        seen: set[tuple[str, str, str]] = set()
+        for item in cast(Sequence[object], offsets):
+            if not isinstance(item, Mapping):
+                continue
+            typed_item = cast(Mapping[object, object], item)
+            if _source_offset_triplet_present(typed_item):
+                seen.add((str(typed_item.get('topic')), str(typed_item.get('partition')), str(typed_item.get('offset'))))
+        return len(seen)
+    return int(
+        _text(bucket.get('source_topic')) is not None
+        and bucket.get('source_partition') is not None
+        and bucket.get('source_offset') is not None
+    )
+
+
+def _source_offset_triplet_present(value: Mapping[object, object]) -> bool:
+    return (
+        _text(value.get('topic')) is not None
+        and value.get('partition') is not None
+        and value.get('offset') is not None
+    )
+
+
+def _positive_hash_count(value: Mapping[str, object]) -> bool:
+    for item in value.values():
+        if _decimal(item) > 0:
+            return True
+    return False
+
+
+def _as_mapping(value: object) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[object, object], value).items()}
+
+
+def _as_sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    if value is None:
+        return ()
+    return (value,)
+
+
+def _string_tuple(values: Sequence[object]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for value in values:
+        text = _text(value)
+        if text is not None and text not in normalized:
+            normalized.append(text)
+    return tuple(normalized)
+
+
+def _text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _int(value: object) -> int:
+    try:
+        return int(str(value or '0'))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _decimal(value: object) -> Decimal:
+    try:
+        parsed = Decimal(str(value if value is not None else '0'))
+    except (InvalidOperation, ValueError):
+        return Decimal('0')
+    return parsed if parsed.is_finite() else Decimal('0')
+
+
+def _optional_decimal(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    return parsed if parsed.is_finite() else None
+
+
+def _required_datetime(value: object, *, field_name: str) -> datetime:
+    parsed = _parse_datetime(value)
+    if parsed is None:
+        raise ValueError(f'{field_name}_invalid')
+    return parsed
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return _utc(value)
+    text = _text(value)
+    if text is None:
+        return None
+    try:
+        return _utc(datetime.fromisoformat(text.replace('Z', '+00:00')))
+    except ValueError:
+        return None
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _isoformat(value: datetime) -> str:
+    return _utc(value).isoformat().replace('+00:00', 'Z')
+
+
+def _decimal_text(value: Decimal | None) -> str:
+    if value is None:
+        return '0'
+    text = format(value.normalize(), 'f')
+    return text.rstrip('0').rstrip('.') if '.' in text else text
+
+
+__all__ = [
+    'AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER',
+    'AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER',
+    'AUTHORITY_EVIDENCE_MISSING_BLOCKER',
+    'AUTHORITY_EXPLICIT_COSTS_BLOCKER',
+    'AUTHORITY_FILLED_NOTIONAL_BLOCKER',
+    'AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER',
+    'AUTHORITY_MEAN_PNL_BLOCKER',
+    'AUTHORITY_MEDIAN_PNL_BLOCKER',
+    'AUTHORITY_OPEN_POSITIONS_BLOCKER',
+    'AUTHORITY_P10_PNL_BLOCKER',
+    'AUTHORITY_READ_ERROR_BLOCKER',
+    'AUTHORITY_TRADING_DAYS_BLOCKER',
+    'AUTHORITY_WORST_DAY_BLOCKER',
+    'DEFAULT_HPAIRS_ACCOUNT_LABEL',
+    'DEFAULT_HPAIRS_CANDIDATE_ID',
+    'DEFAULT_HPAIRS_HYPOTHESIS_ID',
+    'DEFAULT_HPAIRS_RUNTIME_STRATEGY',
+    'EXECUTION_ECONOMICS_MISSING_BLOCKER',
+    'HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION',
+    'ORDER_FEED_LIFECYCLE_MISSING_BLOCKER',
+    'RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER',
+    'RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER',
+    'RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER',
+    'RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER',
+    'RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER',
+    'RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER',
+    'RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER',
+    'RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER',
+    'RuntimeAuthorityEvidenceRow',
+    'build_runtime_authority_report',
+    'load_runtime_authority_rows',
+    'runtime_authority_report_json',
+]

--- a/services/torghut/scripts/verify_hpairs_runtime_authority.py
+++ b/services/torghut/scripts/verify_hpairs_runtime_authority.py
@@ -86,5 +86,5 @@ def main(argv: list[str] | None = None) -> int:
     return 1 if args.fail_on_blockers and report.get('final_authority_ok') is not True else 0
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     raise SystemExit(main())

--- a/services/torghut/scripts/verify_hpairs_runtime_authority.py
+++ b/services/torghut/scripts/verify_hpairs_runtime_authority.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+"""Emit a read-only JSON H-PAIRS runtime authority proof report."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.db import SessionLocal
+from app.trading.runtime_authority_verifier import (
+    DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    build_runtime_authority_report,
+    load_runtime_authority_rows,
+    runtime_authority_report_json,
+)
+from app.trading.runtime_ledger_proof_policy import RUNTIME_LEDGER_PROOF_MODES
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if value is None or not value.strip():
+        return None
+    normalized = value.strip().replace('Z', '+00:00')
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--mode', choices=RUNTIME_LEDGER_PROOF_MODES, default='authority')
+    parser.add_argument('--hypothesis-id', default=DEFAULT_HPAIRS_HYPOTHESIS_ID)
+    parser.add_argument('--candidate-id', default=DEFAULT_HPAIRS_CANDIDATE_ID)
+    parser.add_argument('--runtime-strategy-name', default=DEFAULT_HPAIRS_RUNTIME_STRATEGY)
+    parser.add_argument('--account-label', default=DEFAULT_HPAIRS_ACCOUNT_LABEL)
+    parser.add_argument('--observed-stage')
+    parser.add_argument('--start', dest='started_at')
+    parser.add_argument('--end', dest='ended_at')
+    parser.add_argument(
+        '--fail-on-blockers',
+        action='store_true',
+        help='exit non-zero when final authority blockers are present',
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    started_at = _parse_timestamp(args.started_at)
+    ended_at = _parse_timestamp(args.ended_at)
+    evidence_read_error = None
+    try:
+        with SessionLocal() as session:
+            rows = load_runtime_authority_rows(
+                session,
+                hypothesis_id=args.hypothesis_id,
+                candidate_id=args.candidate_id,
+                runtime_strategy_name=args.runtime_strategy_name,
+                account_label=args.account_label,
+                observed_stage=args.observed_stage,
+                started_at=started_at,
+                ended_at=ended_at,
+            )
+    except SQLAlchemyError as exc:
+        rows = []
+        evidence_read_error = str(exc)
+    report = build_runtime_authority_report(
+        rows,
+        mode=args.mode,
+        hypothesis_id=args.hypothesis_id,
+        candidate_id=args.candidate_id,
+        runtime_strategy_name=args.runtime_strategy_name,
+        account_label=args.account_label,
+        observed_stage=args.observed_stage,
+        started_at=started_at,
+        ended_at=ended_at,
+        evidence_read_error=evidence_read_error,
+    )
+    sys.stdout.write(runtime_authority_report_json(report))
+    return 1 if args.fail_on_blockers and report.get('final_authority_ok') is not True else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/tests/test_verify_hpairs_runtime_authority.py
+++ b/services/torghut/tests/test_verify_hpairs_runtime_authority.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
-from types import SimpleNamespace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import cast
 from unittest.mock import patch
 
@@ -22,6 +22,7 @@ from app.trading.runtime_authority_verifier import (
     AUTHORITY_LEDGER_SCHEMA_BLOCKER,
     AUTHORITY_LINEAGE_HASH_BLOCKER,
     AUTHORITY_MEAN_PNL_BLOCKER,
+    AUTHORITY_ORDER_LIFECYCLE_MISSING_BLOCKER,
     AUTHORITY_OPEN_POSITIONS_BLOCKER,
     AUTHORITY_P10_PNL_BLOCKER,
     AUTHORITY_PNL_BASIS_BLOCKER,
@@ -118,6 +119,44 @@ def _row(day_index: int, *, pnl: str = '600', open_positions: int = 0, source_ba
     }
 
 
+def _bucket(day_index: int) -> SimpleNamespace:
+    row = _row(day_index)
+    return SimpleNamespace(
+        id=row['id'],
+        run_id=row['run_id'],
+        candidate_id=row['candidate_id'],
+        hypothesis_id=row['hypothesis_id'],
+        observed_stage=row['observed_stage'],
+        bucket_started_at=row['bucket_started_at'],
+        bucket_ended_at=row['bucket_ended_at'],
+        account_label=row['account_label'],
+        runtime_strategy_name=row['runtime_strategy_name'],
+        strategy_family=row['strategy_family'],
+        fill_count=row['fill_count'],
+        decision_count=row['decision_count'],
+        submitted_order_count=row['submitted_order_count'],
+        cancelled_order_count=row['cancelled_order_count'],
+        rejected_order_count=row['rejected_order_count'],
+        unfilled_order_count=row['unfilled_order_count'],
+        closed_trade_count=row['closed_trade_count'],
+        open_position_count=row['open_position_count'],
+        filled_notional=row['filled_notional'],
+        gross_strategy_pnl=row['gross_strategy_pnl'],
+        cost_amount=row['cost_amount'],
+        net_strategy_pnl_after_costs=row['net_strategy_pnl_after_costs'],
+        post_cost_expectancy_bps=row['post_cost_expectancy_bps'],
+        ledger_schema_version=row['ledger_schema_version'],
+        pnl_basis=row['pnl_basis'],
+        execution_policy_hash_counts=row['execution_policy_hash_counts'],
+        cost_model_hash_counts=row['cost_model_hash_counts'],
+        lineage_hash_counts=row['lineage_hash_counts'],
+        blockers_json=row['blockers'],
+        payload_json=row['payload'],
+        created_at=row['bucket_started_at'],
+        updated_at=row['bucket_ended_at'],
+    )
+
+
 def test_empty_evidence_is_blocked() -> None:
     report = build_runtime_authority_report([])
 
@@ -137,6 +176,171 @@ def test_aggregate_only_bucket_is_blocked() -> None:
     assert RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER in blockers
     assert RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER in blockers
     assert RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in blockers
+
+
+def test_bucket_loader_applies_identity_and_window_filters() -> None:
+    class FakeScalars:
+        def all(self) -> list[SimpleNamespace]:
+            return [_bucket(0)]
+
+    class FakeSession:
+        statement = None
+
+        def scalars(self, statement):  # type: ignore[no-untyped-def]
+            self.statement = statement
+            return FakeScalars()
+
+    session = FakeSession()
+    rows = load_runtime_authority_rows(
+        session,  # type: ignore[arg-type]
+        observed_stage='paper',
+        started_at=datetime(2026, 5, 1, 12, 0),
+        ended_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert len(rows) == 1
+    assert rows[0].row_id == 'row-00'
+    assert rows[0].bucket_started_at.tzinfo is timezone.utc
+    assert session.statement is not None
+
+
+def test_runtime_authority_row_instances_are_accepted() -> None:
+    dict_report = build_runtime_authority_report([_row(0)])
+    row_payload = dict_report['trading_days'][0]
+    assert row_payload['row_refs'] == ['row-00']
+
+    row_data = _row(0)
+    row = RuntimeAuthorityEvidenceRow(
+        row_id=str(row_data['id']),
+        run_id=str(row_data['run_id']),
+        candidate_id=str(row_data['candidate_id']),
+        hypothesis_id=str(row_data['hypothesis_id']),
+        observed_stage=str(row_data['observed_stage']),
+        bucket_started_at=row_data['bucket_started_at'],  # type: ignore[arg-type]
+        bucket_ended_at=row_data['bucket_ended_at'],  # type: ignore[arg-type]
+        account_label=str(row_data['account_label']),
+        runtime_strategy_name=str(row_data['runtime_strategy_name']),
+        strategy_family=str(row_data['strategy_family']),
+        fill_count=20,
+        decision_count=20,
+        submitted_order_count=20,
+        cancelled_order_count=0,
+        rejected_order_count=0,
+        unfilled_order_count=0,
+        closed_trade_count=20,
+        open_position_count=0,
+        filled_notional=Decimal('600000'),
+        gross_strategy_pnl=Decimal('610'),
+        cost_amount=Decimal('10'),
+        net_strategy_pnl_after_costs=Decimal('600'),
+        post_cost_expectancy_bps=Decimal('10'),
+        ledger_schema_version=EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        pnl_basis=POST_COST_PNL_BASIS,
+        execution_policy_hash_counts={'policy-hash': 20},
+        cost_model_hash_counts={'cost-hash': 20},
+        lineage_hash_counts={'lineage-hash': 20},
+        blockers=(),
+        payload=row_data['payload'],  # type: ignore[arg-type]
+    )
+    object_report = build_runtime_authority_report([row])
+
+    assert object_report['trading_days'][0]['row_refs'] == ['row-00']
+
+
+def test_bad_runtime_bucket_surfaces_all_row_level_blockers() -> None:
+    bad_row = _row(0)
+    bad_row.update(
+        {
+            'fill_count': 0,
+            'decision_count': 0,
+            'submitted_order_count': 0,
+            'closed_trade_count': 0,
+            'filled_notional': Decimal('0'),
+            'ledger_schema_version': 'synthetic-schema',
+            'pnl_basis': 'gross_only',
+            'execution_policy_hash_counts': {},
+            'cost_model_hash_counts': {},
+            'lineage_hash_counts': {'lineage-hash': 0},
+            'blockers': ['source_bucket_has_prior_blocker'],
+            'payload': {
+                **_source_payload(0),
+                'cost_basis': 'execution_reconstructed_non_promotion_grade',
+            },
+        }
+    )
+
+    report = build_runtime_authority_report([bad_row])
+    blockers = set(report['blockers'])
+
+    assert AUTHORITY_BUCKET_BLOCKERS_PRESENT in blockers
+    assert AUTHORITY_LEDGER_SCHEMA_BLOCKER in blockers
+    assert AUTHORITY_PNL_BASIS_BLOCKER in blockers
+    assert AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER in blockers
+    assert AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER in blockers
+    assert AUTHORITY_ORDER_LIFECYCLE_MISSING_BLOCKER in blockers
+    assert AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER in blockers
+    assert AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER in blockers
+    assert AUTHORITY_EXPLICIT_COSTS_BLOCKER in blockers
+    assert AUTHORITY_POLICY_HASH_BLOCKER in blockers
+    assert AUTHORITY_COST_MODEL_HASH_BLOCKER in blockers
+    assert AUTHORITY_LINEAGE_HASH_BLOCKER in blockers
+
+
+def test_source_refs_accept_mapping_and_scalar_offset_forms() -> None:
+    row = _row(0)
+    row['payload'] = {
+        **_source_payload(0),
+        'source_refs': {'trade_decisions': True, 'ignored': False, 'executions': 'custom-exec-ref'},
+        'source_window_ids': {'primary': True, 'secondary': 'window-explicit'},
+        'trade_decision_ids': {'one': 'decision-explicit'},
+        'execution_ids': {'execution-explicit': True},
+        'execution_order_event_ids': {'event': None, 'event-explicit': True},
+        'source_offsets': {'topic': 'alpaca.trade_updates', 'partition': 0, 'offset': 123},
+    }
+    scalar_offset_row = _row(1)
+    scalar_offset_payload = _source_payload(1)
+    scalar_offset_payload.pop('source_offsets')
+    scalar_offset_payload.update({'source_topic': 'alpaca.trade_updates', 'source_partition': 0, 'source_offset': 456})
+    scalar_offset_row['payload'] = scalar_offset_payload
+
+    report = build_runtime_authority_report([row, scalar_offset_row])
+    daily = report['trading_days'][0]
+    scalar_daily = report['trading_days'][1]
+
+    assert daily['source_ref_count'] == 2
+    assert daily['source_window_id_count'] == 2
+    assert daily['trade_decision_ref_count'] == 1
+    assert daily['execution_ref_count'] == 1
+    assert daily['execution_order_event_ref_count'] == 1
+    assert daily['source_offset_count'] == 1
+    assert scalar_daily['source_offset_count'] == 1
+
+
+def test_invalid_normalized_values_fail_closed() -> None:
+    row = _row(0)
+    row.update(
+        {
+            'bucket_started_at': 'not-a-date',
+            'bucket_ended_at': '2026-05-01T21:00:00Z',
+        }
+    )
+
+    with pytest.raises(ValueError, match='bucket_started_at_invalid'):
+        build_runtime_authority_report([row])
+
+    invalid_number_row = _row(0)
+    invalid_number_row.update(
+        {
+            'fill_count': 'not-an-int',
+            'net_strategy_pnl_after_costs': 'not-a-decimal',
+            'post_cost_expectancy_bps': 'not-a-decimal',
+        }
+    )
+
+    report = build_runtime_authority_report([invalid_number_row])
+
+    assert report['aggregate']['mean_daily_net_pnl_after_costs'] == '0'
+    assert AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER in report['blockers']
 
 
 def test_source_backed_too_few_days_is_blocked() -> None:
@@ -449,3 +653,51 @@ def test_cli_emits_read_only_report_from_session_fixture(capsys) -> None:  # typ
     load_rows.assert_called_once()
     payload = json.loads(capsys.readouterr().out)
     assert payload['final_authority_ok'] is True
+
+
+def test_cli_parses_window_arguments_and_fails_on_blockers(capsys) -> None:  # type: ignore[no-untyped-def]
+    class FakeSession:
+        def __enter__(self) -> 'FakeSession':
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+    with (
+        patch.object(cli, 'SessionLocal', return_value=FakeSession()),
+        patch.object(cli, 'load_runtime_authority_rows', return_value=[]),
+    ):
+        exit_code = cli.main(
+            [
+                '--observed-stage',
+                'paper',
+                '--start',
+                '2026-05-01T09:30:00',
+                '--end',
+                '2026-05-02T16:00:00Z',
+                '--fail-on-blockers',
+            ]
+        )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['identity']['observed_stage'] == 'paper'
+    assert payload['window']['started_at'] == '2026-05-01T09:30:00Z'
+    assert payload['window']['ended_at'] == '2026-05-02T16:00:00Z'
+
+
+def test_cli_reports_read_error_as_blocker(capsys) -> None:  # type: ignore[no-untyped-def]
+    class FakeSession:
+        def __enter__(self) -> 'FakeSession':
+            raise SQLAlchemyError('database unavailable')
+
+        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+    with patch.object(cli, 'SessionLocal', return_value=FakeSession()):
+        exit_code = cli.main([])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert AUTHORITY_READ_ERROR_BLOCKER in payload['blockers']
+    assert payload['evidence_read_error'] == 'database unavailable'

--- a/services/torghut/tests/test_verify_hpairs_runtime_authority.py
+++ b/services/torghut/tests/test_verify_hpairs_runtime_authority.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import patch
+
+from app.trading.runtime_authority_verifier import (
+    AUTHORITY_EVIDENCE_MISSING_BLOCKER,
+    AUTHORITY_OPEN_POSITIONS_BLOCKER,
+    AUTHORITY_TRADING_DAYS_BLOCKER,
+    DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+    build_runtime_authority_report,
+    runtime_authority_report_json,
+)
+from app.trading.runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
+from scripts import verify_hpairs_runtime_authority as cli
+
+
+def _source_payload(day_index: int) -> dict[str, object]:
+    return {
+        'source_window_start': f'2026-05-{day_index + 1:02d}T14:30:00Z',
+        'source_window_end': f'2026-05-{day_index + 1:02d}T21:00:00Z',
+        'source_refs': [
+            'postgres:trade_decisions',
+            'postgres:executions',
+            'postgres:execution_order_events',
+            'postgres:order_feed_source_windows',
+        ],
+        'source_row_counts': {
+            'trade_decisions': 20,
+            'executions': 20,
+            'execution_order_events': 20,
+            'order_feed_source_windows': 20,
+        },
+        'trade_decision_ids': [f'decision-{day_index}-{item}' for item in range(20)],
+        'execution_ids': [f'execution-{day_index}-{item}' for item in range(20)],
+        'execution_order_event_ids': [f'event-{day_index}-{item}' for item in range(20)],
+        'source_window_ids': [f'window-{day_index}-{item}' for item in range(20)],
+        'source_offsets': [
+            {'topic': 'alpaca.trade_updates', 'partition': 0, 'offset': day_index * 100 + item}
+            for item in range(20)
+        ],
+        'source_materialization': 'execution_order_events',
+        'authority_class': 'runtime_order_feed_execution_source',
+        'order_feed_lifecycle_complete': True,
+        'execution_economics_complete': True,
+        'cost_basis_counts': {'explicit_broker_fee_runtime': 20},
+    }
+
+
+def _row(day_index: int, *, pnl: str = '600', open_positions: int = 0, source_backed: bool = True) -> dict[str, object]:
+    start = datetime(2026, 5, 1, tzinfo=timezone.utc) + timedelta(days=day_index)
+    payload = _source_payload(day_index) if source_backed else {}
+    return {
+        'id': f'row-{day_index:02d}',
+        'run_id': 'runtime-run',
+        'candidate_id': DEFAULT_HPAIRS_CANDIDATE_ID,
+        'hypothesis_id': DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        'observed_stage': 'paper',
+        'bucket_started_at': start,
+        'bucket_ended_at': start + timedelta(hours=6),
+        'account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        'runtime_strategy_name': DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        'strategy_family': 'pairs',
+        'fill_count': 20,
+        'decision_count': 20,
+        'submitted_order_count': 20,
+        'cancelled_order_count': 0,
+        'rejected_order_count': 0,
+        'unfilled_order_count': 0,
+        'closed_trade_count': 20,
+        'open_position_count': open_positions,
+        'filled_notional': Decimal('600000'),
+        'gross_strategy_pnl': Decimal(pnl) + Decimal('10'),
+        'cost_amount': Decimal('10'),
+        'net_strategy_pnl_after_costs': Decimal(pnl),
+        'post_cost_expectancy_bps': Decimal('10'),
+        'ledger_schema_version': EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        'pnl_basis': POST_COST_PNL_BASIS,
+        'execution_policy_hash_counts': {'policy-hash': 20},
+        'cost_model_hash_counts': {'cost-hash': 20},
+        'lineage_hash_counts': {'lineage-hash': 20},
+        'blockers': [],
+        'payload': payload,
+    }
+
+
+def test_empty_evidence_is_blocked() -> None:
+    report = build_runtime_authority_report([])
+
+    assert report['final_authority_ok'] is False
+    assert AUTHORITY_EVIDENCE_MISSING_BLOCKER in report['blockers']
+    assert AUTHORITY_TRADING_DAYS_BLOCKER in report['blockers']
+    assert report['trading_days'] == []
+
+
+def test_aggregate_only_bucket_is_blocked() -> None:
+    report = build_runtime_authority_report([_row(0, source_backed=False)])
+
+    blockers = set(report['blockers'])
+    assert report['final_authority_ok'] is False
+    assert RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER in blockers
+    assert RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in blockers
+    assert RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER in blockers
+    assert RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER in blockers
+    assert RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in blockers
+
+
+def test_source_backed_too_few_days_is_blocked() -> None:
+    report = build_runtime_authority_report([_row(day) for day in range(5)])
+
+    assert report['final_authority_ok'] is False
+    assert AUTHORITY_TRADING_DAYS_BLOCKER in report['blockers']
+    assert report['aggregate']['trading_day_count'] == 5
+
+
+def test_open_positions_are_blocked() -> None:
+    rows = [_row(day) for day in range(20)]
+    rows[-1] = _row(19, open_positions=1)
+
+    report = build_runtime_authority_report(rows)
+
+    assert report['final_authority_ok'] is False
+    assert AUTHORITY_OPEN_POSITIONS_BLOCKER in report['blockers']
+    assert report['aggregate']['open_position_count'] == 1
+
+
+def test_positive_20_day_source_backed_distribution_passes_thresholds() -> None:
+    report = build_runtime_authority_report([_row(day) for day in range(20)])
+
+    assert report['final_authority_ok'] is True
+    assert report['blockers'] == []
+    assert report['aggregate']['trading_day_count'] == 20
+    assert report['aggregate']['mean_daily_net_pnl_after_costs'] == '600'
+    assert report['aggregate']['median_daily_net_pnl_after_costs'] == '600'
+    assert report['aggregate']['p10_daily_net_pnl_after_costs'] == '600'
+    assert report['aggregate']['worst_day_net_pnl_after_costs'] == '600'
+    assert report['aggregate']['best_day_share'] == '0.05'
+    assert report['aggregate']['total_filled_notional'] == '12000000'
+    assert report['aggregate']['closed_round_trips'] == 400
+
+
+def test_output_is_stable_json() -> None:
+    report = build_runtime_authority_report([_row(day) for day in range(20)])
+    encoded = runtime_authority_report_json(report)
+
+    assert encoded == runtime_authority_report_json(report)
+    decoded = json.loads(encoded)
+    assert list(decoded) == sorted(decoded)
+    assert decoded['schema_version'] == 'torghut.hpairs-runtime-authority-proof.v1'
+
+
+def test_cli_emits_read_only_report_from_session_fixture(capsys) -> None:  # type: ignore[no-untyped-def]
+    class FakeSession:
+        def __enter__(self) -> 'FakeSession':
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+    with (
+        patch.object(cli, 'SessionLocal', return_value=FakeSession()) as session_local,
+        patch.object(cli, 'load_runtime_authority_rows', return_value=[_row(day) for day in range(20)]) as load_rows,
+    ):
+        exit_code = cli.main([])
+
+    assert exit_code == 0
+    session_local.assert_called_once_with()
+    load_rows.assert_called_once()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['final_authority_ok'] is True

--- a/services/torghut/tests/test_verify_hpairs_runtime_authority.py
+++ b/services/torghut/tests/test_verify_hpairs_runtime_authority.py
@@ -1,14 +1,36 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from typing import cast
 from unittest.mock import patch
 
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
 from app.trading.runtime_authority_verifier import (
+    AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER,
+    AUTHORITY_BUCKET_BLOCKERS_PRESENT,
+    AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER,
+    AUTHORITY_COST_MODEL_HASH_BLOCKER,
     AUTHORITY_EVIDENCE_MISSING_BLOCKER,
+    AUTHORITY_EXPLICIT_COSTS_BLOCKER,
+    AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER,
+    AUTHORITY_LEDGER_SCHEMA_BLOCKER,
+    AUTHORITY_LINEAGE_HASH_BLOCKER,
+    AUTHORITY_MEAN_PNL_BLOCKER,
     AUTHORITY_OPEN_POSITIONS_BLOCKER,
+    AUTHORITY_P10_PNL_BLOCKER,
+    AUTHORITY_PNL_BASIS_BLOCKER,
+    AUTHORITY_POLICY_HASH_BLOCKER,
+    AUTHORITY_READ_ERROR_BLOCKER,
+    AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+    AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
     AUTHORITY_TRADING_DAYS_BLOCKER,
+    AUTHORITY_WORST_DAY_BLOCKER,
     DEFAULT_HPAIRS_ACCOUNT_LABEL,
     DEFAULT_HPAIRS_CANDIDATE_ID,
     DEFAULT_HPAIRS_HYPOTHESIS_ID,
@@ -18,7 +40,9 @@ from app.trading.runtime_authority_verifier import (
     RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
     RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
     RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+    RuntimeAuthorityEvidenceRow,
     build_runtime_authority_report,
+    load_runtime_authority_rows,
     runtime_authority_report_json,
 )
 from app.trading.runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
@@ -134,6 +158,208 @@ def test_open_positions_are_blocked() -> None:
     assert report['aggregate']['open_position_count'] == 1
 
 
+def test_distribution_risk_gates_are_blocked() -> None:
+    rows = [_row(day, pnl='600') for day in range(20)]
+    rows[0] = _row(0, pnl='8000')
+    rows[1] = _row(1, pnl='-1200')
+    rows[2] = _row(2, pnl='-500')
+    for day in range(3, 20):
+        rows[day] = _row(day, pnl='100')
+
+    report = build_runtime_authority_report(rows)
+
+    blockers = set(report['blockers'])
+    assert report['final_authority_ok'] is False
+    assert AUTHORITY_MEAN_PNL_BLOCKER in blockers
+    assert AUTHORITY_P10_PNL_BLOCKER in blockers
+    assert AUTHORITY_WORST_DAY_BLOCKER in blockers
+    assert AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER in blockers
+    assert report['aggregate']['max_drawdown'] == '1700'
+
+
+def test_row_level_runtime_authority_blockers_are_reported() -> None:
+    row = _row(0)
+    row.update(
+        {
+            'fill_count': 0,
+            'decision_count': 0,
+            'submitted_order_count': 0,
+            'closed_trade_count': 0,
+            'open_position_count': 1,
+            'filled_notional': 0,
+            'ledger_schema_version': 'artifact-only',
+            'pnl_basis': 'gross_strategy_pnl',
+            'execution_policy_hash_counts': {},
+            'cost_model_hash_counts': {},
+            'lineage_hash_counts': {},
+            'blockers': ['upstream_bucket_blocker'],
+            'payload': {
+                **_source_payload(0),
+                'cost_basis': 'synthetic_estimated_costs',
+                'cost_basis_counts': {'synthetic_estimated_costs': 1},
+            },
+        }
+    )
+
+    report = build_runtime_authority_report([row])
+
+    blockers = set(report['blockers'])
+    assert AUTHORITY_BUCKET_BLOCKERS_PRESENT in blockers
+    assert AUTHORITY_LEDGER_SCHEMA_BLOCKER in blockers
+    assert AUTHORITY_PNL_BASIS_BLOCKER in blockers
+    assert AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER in blockers
+    assert AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER in blockers
+    assert AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER in blockers
+    assert AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER in blockers
+    assert AUTHORITY_EXPLICIT_COSTS_BLOCKER in blockers
+    assert AUTHORITY_POLICY_HASH_BLOCKER in blockers
+    assert AUTHORITY_COST_MODEL_HASH_BLOCKER in blockers
+    assert AUTHORITY_LINEAGE_HASH_BLOCKER in blockers
+    assert 'upstream_bucket_blocker' in blockers
+
+
+def test_ref_counting_accepts_mapping_and_scalar_offset_shapes() -> None:
+    row = _row(0)
+    payload = _source_payload(0)
+    payload.update(
+        {
+            'source_window_ids': {'window-a': True, 'window-b': False, 'window-c': 'window-c-alias'},
+            'trade_decision_ids': {'decision-a': True, 'decision-b': 'decision-b-alias'},
+            'execution_ids': {'execution-a': True},
+            'execution_order_event_ids': {'event-a': True},
+            'source_refs': {'orders': True, 'ignored': False},
+            'source_offsets': {'topic': 'alpaca.trade_updates', 'partition': 0, 'offset': 33},
+        }
+    )
+    row['payload'] = payload
+
+    report = build_runtime_authority_report([row])
+    day = cast(dict[str, object], report['trading_days'][0])
+
+    assert day['source_window_id_count'] == 2
+    assert day['trade_decision_ref_count'] == 2
+    assert day['execution_ref_count'] == 1
+    assert day['execution_order_event_ref_count'] == 1
+    assert day['source_ref_count'] == 1
+    assert day['source_offset_count'] == 1
+
+
+def test_dataclass_rows_and_invalid_scalar_values_normalize_fail_closed() -> None:
+    row = RuntimeAuthorityEvidenceRow(
+        row_id='dataclass-row',
+        run_id='runtime-run',
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        observed_stage='paper',
+        bucket_started_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        bucket_ended_at=datetime(2026, 5, 1, 6, tzinfo=timezone.utc),
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        strategy_family='pairs',
+        fill_count=20,
+        decision_count=20,
+        submitted_order_count=20,
+        cancelled_order_count=0,
+        rejected_order_count=0,
+        unfilled_order_count=0,
+        closed_trade_count=20,
+        open_position_count=0,
+        filled_notional=Decimal('600000'),
+        gross_strategy_pnl=Decimal('610'),
+        cost_amount=Decimal('10'),
+        net_strategy_pnl_after_costs=Decimal('0'),
+        post_cost_expectancy_bps=None,
+        ledger_schema_version=EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        pnl_basis=POST_COST_PNL_BASIS,
+        execution_policy_hash_counts={'policy': 'not-a-number'},
+        cost_model_hash_counts={'cost': '1'},
+        lineage_hash_counts={'lineage': '1'},
+        blockers=(),
+        payload=_source_payload(0),
+    )
+
+    report = build_runtime_authority_report([row])
+
+    assert report['final_authority_ok'] is False
+    assert AUTHORITY_POLICY_HASH_BLOCKER in report['blockers']
+    assert report['aggregate']['total_net_strategy_pnl_after_costs'] == '0'
+
+
+def test_invalid_mapping_timestamps_are_rejected() -> None:
+    row = _row(0)
+    row['bucket_started_at'] = 'not-a-timestamp'
+
+    with pytest.raises(ValueError, match='bucket_started_at_invalid'):
+        build_runtime_authority_report([row])
+
+
+def test_load_runtime_authority_rows_filters_and_normalizes_bucket() -> None:
+    class ScalarResult:
+        def __init__(self, bucket: SimpleNamespace) -> None:
+            self.bucket = bucket
+
+        def all(self) -> list[SimpleNamespace]:
+            return [self.bucket]
+
+    class FakeSession:
+        statement: object | None = None
+
+        def __init__(self, bucket: SimpleNamespace) -> None:
+            self.bucket = bucket
+
+        def scalars(self, statement: object) -> ScalarResult:
+            self.statement = statement
+            return ScalarResult(self.bucket)
+
+    start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    bucket = SimpleNamespace(
+        id='bucket-1',
+        run_id='runtime-run',
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        observed_stage='paper',
+        bucket_started_at=start,
+        bucket_ended_at=start + timedelta(hours=6),
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        strategy_family='pairs',
+        fill_count='2',
+        decision_count='2',
+        submitted_order_count='2',
+        cancelled_order_count=0,
+        rejected_order_count=0,
+        unfilled_order_count=0,
+        closed_trade_count=1,
+        open_position_count=0,
+        filled_notional='1000.50',
+        gross_strategy_pnl='11',
+        cost_amount='1',
+        net_strategy_pnl_after_costs='10',
+        post_cost_expectancy_bps='8',
+        ledger_schema_version=EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        pnl_basis=POST_COST_PNL_BASIS,
+        execution_policy_hash_counts={'policy': 1},
+        cost_model_hash_counts={'cost': 1},
+        lineage_hash_counts={'lineage': 1},
+        blockers_json=['stored_blocker'],
+        payload_json={**_source_payload(0), 'blockers': ['payload_blocker']},
+        created_at=start,
+    )
+    session = FakeSession(bucket)
+
+    rows = load_runtime_authority_rows(
+        cast(Session, session),
+        observed_stage='paper',
+        started_at=start,
+        ended_at=start + timedelta(days=1),
+    )
+
+    assert session.statement is not None
+    assert rows[0].row_id == 'bucket-1'
+    assert rows[0].filled_notional == Decimal('1000.50')
+    assert rows[0].blockers == ('stored_blocker', 'payload_blocker')
+
+
 def test_positive_20_day_source_backed_distribution_passes_thresholds() -> None:
     report = build_runtime_authority_report([_row(day) for day in range(20)])
 
@@ -157,6 +383,51 @@ def test_output_is_stable_json() -> None:
     decoded = json.loads(encoded)
     assert list(decoded) == sorted(decoded)
     assert decoded['schema_version'] == 'torghut.hpairs-runtime-authority-proof.v1'
+
+
+def test_cli_parses_window_filters_and_fail_on_blockers(capsys) -> None:  # type: ignore[no-untyped-def]
+    class FakeSession:
+        def __enter__(self) -> 'FakeSession':
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+    with (
+        patch.object(cli, 'SessionLocal', return_value=FakeSession()),
+        patch.object(cli, 'load_runtime_authority_rows', return_value=[]) as load_rows,
+    ):
+        exit_code = cli.main(
+            [
+                '--mode',
+                'authority',
+                '--observed-stage',
+                'paper',
+                '--start',
+                '2026-05-01T14:30:00',
+                '--end',
+                '2026-05-02T21:00:00Z',
+                '--fail-on-blockers',
+            ]
+        )
+
+    assert exit_code == 1
+    kwargs = load_rows.call_args.kwargs
+    assert kwargs['observed_stage'] == 'paper'
+    assert kwargs['started_at'] == datetime(2026, 5, 1, 14, 30, tzinfo=timezone.utc)
+    assert kwargs['ended_at'] == datetime(2026, 5, 2, 21, tzinfo=timezone.utc)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['final_authority_ok'] is False
+
+
+def test_cli_reports_database_read_errors(capsys) -> None:  # type: ignore[no-untyped-def]
+    with patch.object(cli, 'SessionLocal', side_effect=SQLAlchemyError('db unavailable')):
+        exit_code = cli.main(['--fail-on-blockers'])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['evidence_read_error'] == 'db unavailable'
+    assert AUTHORITY_READ_ERROR_BLOCKER in payload['blockers']
 
 
 def test_cli_emits_read_only_report_from_session_fixture(capsys) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary

- Added a read-only H-PAIRS runtime authority verifier helper that converts strategy runtime ledger buckets into a deterministic JSON proof report.
- Reports daily post-cost PnL, filled notional, closed trades, open positions, source-window/source-ref coverage, aggregate authority metrics, and exact final-authority blockers.
- Added a CLI wrapper with default H-PAIRS-01 / c88421d619759b2cfaa6f4d0 / microbar-cross-sectional-pairs-v1 / TORGHUT_SIM identity and flags for mode, identity, stage, and time window overrides.
- Added regression tests for empty evidence, aggregate-only evidence, too-few source-backed days, open positions, passing 20-day source-backed distributions, stable JSON, and CLI read-only session usage.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_verify_hpairs_runtime_authority.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_authority_verifier.py scripts/verify_hpairs_runtime_authority.py tests/test_verify_hpairs_runtime_authority.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `cd services/torghut && uv run --frozen python scripts/verify_hpairs_runtime_authority.py --mode authority` emitted a blocked JSON report because local DB access to `localhost:15438` was refused.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
