### PR TITLE
feat(torghut): add route repair audit receipts

### DIFF
--- a/services/torghut/app/trading/repair_receipt_frontier.py
+++ b/services/torghut/app/trading/repair_receipt_frontier.py
@@ -284,6 +284,8 @@ def _frontier_lot_from_compacted(
             raw_lot.get("max_runtime_seconds"), _DEFAULT_MAX_RUNTIME_SECONDS
         ),
         "max_notional": _ZERO_NOTIONAL,
+        "promotion_authority": False,
+        "authority_semantics": "audit_only",
         "dispatchable": dispatchable,
         "hold_reason_codes": hold_reasons,
         "settlement_status": _settlement_status(
@@ -355,6 +357,8 @@ def _frontier_lot_from_profit_repair(
         ],
         "max_runtime_seconds": _DEFAULT_MAX_RUNTIME_SECONDS,
         "max_notional": _ZERO_NOTIONAL,
+        "promotion_authority": False,
+        "authority_semantics": "audit_only",
         "dispatchable": dispatchable,
         "hold_reason_codes": hold_reasons,
         "settlement_status": _settlement_status(
@@ -406,6 +410,8 @@ def _source_serving_lot(
         ],
         "max_runtime_seconds": _DEFAULT_MAX_RUNTIME_SECONDS,
         "max_notional": _ZERO_NOTIONAL,
+        "promotion_authority": False,
+        "authority_semantics": "audit_only",
         "dispatchable": True,
         "hold_reason_codes": [],
         "settlement_status": "pending",
@@ -562,6 +568,18 @@ def _live_requirements(
     gate_allowed = _bool(live_submission_gate.get("allowed"))
     proof_route_state = _text(proof_floor_receipt.get("route_state"), "missing").lower()
     capital_state = _text(proof_floor_receipt.get("capital_state"), "missing").lower()
+    runtime_ledger_source_proof = _mapping(
+        proof_floor_receipt.get("runtime_ledger_source_proof")
+        or proof_floor_receipt.get("source_backed_runtime_ledger_proof")
+    )
+    runtime_source_proof_current = (
+        _bool(runtime_ledger_source_proof.get("source_backed"))
+        and _bool(runtime_ledger_source_proof.get("closed_round_trips"))
+        and _bool(runtime_ledger_source_proof.get("explicit_costs"))
+        and _bool(runtime_ledger_source_proof.get("flat_after_close_grace"))
+        and _text(runtime_ledger_source_proof.get("state"), "missing").lower()
+        in {"current", "pass", "ready"}
+    )
     human_approved = _bool(
         live_submission_gate.get("human_approved_capital_limits")
         or live_submission_gate.get("human_approved_capital_limit")
@@ -600,6 +618,16 @@ def _live_requirements(
             or proof_floor_receipt.get("schema_version"),
             value_gate="post_cost_daily_net_pnl",
             reason_codes=[f"proof_floor_{proof_route_state}_{capital_state}"],
+        ),
+        _requirement(
+            requirement="runtime_ledger_source_proof_current",
+            passed=runtime_source_proof_current,
+            evidence_ref=runtime_ledger_source_proof.get("receipt_id")
+            or runtime_ledger_source_proof.get("ledger_id")
+            or proof_floor_receipt.get("receipt_id")
+            or proof_floor_receipt.get("schema_version"),
+            value_gate="post_cost_daily_net_pnl",
+            reason_codes=["runtime_ledger_source_proof_missing"],
         ),
     ]
 
@@ -719,6 +747,8 @@ def build_repair_receipt_frontier(
         "route_warrant_ref": route_warrant_exchange.get("warrant_id"),
         "capital_state": "zero_notional",
         "max_notional": _ZERO_NOTIONAL,
+        "promotion_authority": False,
+        "authority_semantics": "audit_only_until_source_backed_runtime_ledger_fill_proof",
         "frontier_state": state,
         "selected_lot_id": selected_lot_id,
         "dispatchable_lot_ids": dispatchable_ids,
@@ -747,6 +777,7 @@ def build_repair_receipt_frontier(
             "repair_receipt_frontier_projection_enabled": False,
             "capital_state": "zero_notional",
             "live_submit_enabled": False,
+            "promotion_authority": False,
             "fallback_payloads": [
                 "torghut.profit-freshness-frontier.v1",
                 "torghut.repair-bid-settlement-ledger.v1",

--- a/services/torghut/app/trading/route_evidence_clearinghouse.py
+++ b/services/torghut/app/trading/route_evidence_clearinghouse.py
@@ -9,9 +9,14 @@ from hashlib import sha256
 import json
 from typing import Any, cast
 
+from .route_metadata import route_repair_recommendation
+
 
 ROUTE_EVIDENCE_CLEARINGHOUSE_SCHEMA_VERSION = (
     "torghut.route-evidence-clearinghouse-packet.v1"
+)
+ROUTE_EVIDENCE_REPAIR_AUDIT_RECEIPT_SCHEMA_VERSION = (
+    "torghut.route-evidence-repair-audit-receipt.v1"
 )
 
 _FRESHNESS_SECONDS = 60
@@ -461,15 +466,51 @@ def _repair_class(reason: str) -> tuple[str, str]:
     return "evidence_freshness_repair", "zero_notional_or_stale_evidence_rate"
 
 
+def _repair_audit_receipt(
+    *,
+    reason: str,
+    repair_class: str,
+    value_gate: str,
+    repair_recommendation: str,
+) -> dict[str, object]:
+    payload = {
+        "reason": reason,
+        "repair_class": repair_class,
+        "value_gate": value_gate,
+        "repair_recommendation": repair_recommendation,
+    }
+    return {
+        "schema_version": ROUTE_EVIDENCE_REPAIR_AUDIT_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": _ref("route-evidence-repair-audit-receipt", payload),
+        "state": "audit_only",
+        "reason_codes": [reason],
+        "repair_class": repair_class,
+        "value_gate": value_gate,
+        "repair_recommendation": repair_recommendation,
+        "promotion_authority": False,
+        "capital_authority": "none",
+        "max_notional": "0",
+        "requires_runtime_ledger_source_proof": True,
+    }
+
+
 def _repair_bid_book(reason_codes: Sequence[str]) -> dict[str, object]:
     bids: list[dict[str, object]] = []
     for reason in _unique(list(reason_codes)):
         repair_class, value_gate = _repair_class(reason)
+        repair_recommendation = route_repair_recommendation(reason)
         payload = {
             "reason": reason,
             "repair_class": repair_class,
             "value_gate": value_gate,
+            "repair_recommendation": repair_recommendation,
         }
+        audit_receipt = _repair_audit_receipt(
+            reason=reason,
+            repair_class=repair_class,
+            value_gate=value_gate,
+            repair_recommendation=repair_recommendation,
+        )
         bids.append(
             {
                 "bid_id": _ref("route-evidence-repair-bid", payload),
@@ -480,6 +521,11 @@ def _repair_bid_book(reason_codes: Sequence[str]) -> dict[str, object]:
                 "reason_codes": [reason],
                 "max_notional": "0",
                 "required_output_receipt": f"{repair_class}_receipt",
+                "repair_recommendation": repair_recommendation,
+                "audit_receipt": audit_receipt,
+                "audit_receipt_ref": audit_receipt["receipt_id"],
+                "promotion_authority": False,
+                "capital_authority": "none",
             }
         )
     return {
@@ -488,6 +534,7 @@ def _repair_bid_book(reason_codes: Sequence[str]) -> dict[str, object]:
         "repair_bids": bids,
         "summary": {
             "bid_count": len(bids),
+            "audit_receipt_count": len(bids),
             "value_gates": _unique([str(bid["value_gate"]) for bid in bids]),
         },
     }
@@ -557,6 +604,10 @@ def _route_claims(
                     route_tca_details, "post_cost_expectancy_bps_proxy"
                 ),
                 "expected_repair_value": 0 if decision == "accepted" else 1,
+                "repair_recommendations": [
+                    route_repair_recommendation(reason) for reason in reason_codes
+                ],
+                "promotion_authority": False,
                 "routeability_decision": decision,
                 "max_notional": "0",
                 "reason_codes": reason_codes,
@@ -678,6 +729,10 @@ def build_route_evidence_clearinghouse_packet(
         "profit_window_custody_book": profit_window_book,
         "capital_hold_book": capital_book,
         "repair_bid_book": repair_book,
+        "repair_audit_receipts": [
+            bid["audit_receipt"]
+            for bid in cast(Sequence[Mapping[str, object]], repair_book["repair_bids"])
+        ],
         "route_claims": claims,
         "selected_repair_bids": repair_book["repair_bids"],
         "held_action_classes": []
@@ -694,6 +749,8 @@ def build_route_evidence_clearinghouse_packet(
         "capital_decision": "observe_only"
         if accepted_count > 0 and not capital_book["reason_codes"]
         else "repair_only",
+        "promotion_authority": False,
+        "authority_semantics": "audit_only_until_source_backed_runtime_ledger_fill_proof",
         "max_notional": "0",
         "summary": {
             "route_claim_count": len(claims),

--- a/services/torghut/app/trading/route_metadata.py
+++ b/services/torghut/app/trading/route_metadata.py
@@ -5,6 +5,56 @@ from __future__ import annotations
 from typing import Any, Mapping, Optional
 
 
+ROUTE_REPAIR_RECOMMENDATIONS: dict[str, str] = {
+    "stale_quote": "refresh_quote_snapshot_and_recompute_route_fillability",
+    "missing_bid_ask": "collect_bid_ask_quote_before_routeability_claim",
+    "session_closed": "wait_for_regular_session_open_then_refresh_route_probe",
+    "market_session_closed": "wait_for_regular_session_open_then_refresh_route_probe",
+    "pair_imbalance": "repair_pair_leg_balance_before_routeability_claim",
+    "missing_target": "collect_target_notional_and_side_plan_before_probe",
+    "blocked_submit": "keep_submit_disabled_and_collect_submit_gate_receipt",
+    "simple_submit_disabled": "keep_submit_disabled_and_collect_submit_gate_receipt",
+    "missing_close_flatten_handoff": "collect_close_flatten_handoff_receipt_before_reentry",
+    "runtime_import_pending": "complete_runtime_import_reconciliation_before_authority",
+}
+
+_ROUTE_REPAIR_RECOMMENDATION_FRAGMENTS: tuple[tuple[str, str], ...] = (
+    ("stale_quote", ROUTE_REPAIR_RECOMMENDATIONS["stale_quote"]),
+    ("quote_stale", ROUTE_REPAIR_RECOMMENDATIONS["stale_quote"]),
+    ("missing_bid_ask", ROUTE_REPAIR_RECOMMENDATIONS["missing_bid_ask"]),
+    ("bid_ask_missing", ROUTE_REPAIR_RECOMMENDATIONS["missing_bid_ask"]),
+    ("session_closed", ROUTE_REPAIR_RECOMMENDATIONS["session_closed"]),
+    ("market_session_closed", ROUTE_REPAIR_RECOMMENDATIONS["market_session_closed"]),
+    ("pair_imbalance", ROUTE_REPAIR_RECOMMENDATIONS["pair_imbalance"]),
+    ("missing_target", ROUTE_REPAIR_RECOMMENDATIONS["missing_target"]),
+    ("target_missing", ROUTE_REPAIR_RECOMMENDATIONS["missing_target"]),
+    ("blocked_submit", ROUTE_REPAIR_RECOMMENDATIONS["blocked_submit"]),
+    ("simple_submit_disabled", ROUTE_REPAIR_RECOMMENDATIONS["simple_submit_disabled"]),
+    ("submit", ROUTE_REPAIR_RECOMMENDATIONS["blocked_submit"]),
+    ("missing_close_flatten_handoff", ROUTE_REPAIR_RECOMMENDATIONS["missing_close_flatten_handoff"]),
+    ("close_flatten_handoff_missing", ROUTE_REPAIR_RECOMMENDATIONS["missing_close_flatten_handoff"]),
+    ("runtime_import_pending", ROUTE_REPAIR_RECOMMENDATIONS["runtime_import_pending"]),
+    ("runtime_ledger_import_pending", ROUTE_REPAIR_RECOMMENDATIONS["runtime_import_pending"]),
+    ("tca_stale", "refresh_execution_tca_and_quote_samples_before_routeability_claim"),
+    ("execution_tca_stale", "refresh_execution_tca_and_quote_samples_before_routeability_claim"),
+    ("slippage", "reduce_route_slippage_and_collect_fresh_tca_receipt"),
+    ("route_universe", "refresh_route_universe_and_symbol_fillability_receipts"),
+)
+
+
+def route_repair_recommendation(reason: str | None) -> str:
+    """Map route/fillability blockers to bounded collection-only repair work."""
+
+    normalized = coerce_route_text(reason) or "unknown"
+    lowered = normalized.lower()
+    if lowered in ROUTE_REPAIR_RECOMMENDATIONS:
+        return ROUTE_REPAIR_RECOMMENDATIONS[lowered]
+    for token, recommendation in _ROUTE_REPAIR_RECOMMENDATION_FRAGMENTS:
+        if token in lowered:
+            return recommendation
+    return "collect_source_backed_route_repair_receipt_before_authority"
+
+
 def resolve_order_route_metadata(
     *,
     expected_adapter: Optional[str],

--- a/services/torghut/app/trading/route_reacquisition.py
+++ b/services/torghut/app/trading/route_reacquisition.py
@@ -3,15 +3,28 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from hashlib import sha256
+import json
 from typing import Any, cast
+
+from .route_metadata import route_repair_recommendation
 
 
 SCHEMA_VERSION = "torghut.route-reacquisition-book.v1"
+ROUTE_REPAIR_AUDIT_RECEIPT_SCHEMA_VERSION = "torghut.route-repair-audit-receipt.v1"
 _PAPER_ROUTE_PROBE_REASONS = {
     "execution_tca_route_universe_empty",
     "execution_tca_symbol_missing",
     "route_tca_passed_but_dependency_receipts_block_capital",
     "tca_evidence_stale",
+    "stale_quote",
+    "missing_bid_ask",
+    "session_closed",
+    "pair_imbalance",
+    "missing_target",
+    "blocked_submit",
+    "missing_close_flatten_handoff",
+    "runtime_import_pending",
 }
 _PAPER_ROUTE_PROBE_STATES = {"missing", "probing"}
 
@@ -71,6 +84,11 @@ def _sequence(value: object) -> Sequence[object]:
     return []
 
 
+def _stable_ref(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return f"{prefix}:{sha256(encoded.encode()).hexdigest()[:20]}"
+
+
 def _dimension(
     proof_floor_receipt: Mapping[str, Any], dimension_name: str
 ) -> Mapping[str, Any]:
@@ -107,6 +125,168 @@ def _hypothesis_ids(source_ref: Mapping[str, Any]) -> list[str]:
     return sorted(set(ids))
 
 
+def _strings(value: object) -> list[str]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for item in _sequence(value):
+        normalized = _text(item)
+        if normalized and normalized not in seen:
+            values.append(normalized)
+            seen.add(normalized)
+    return values
+
+
+def _first_text(*values: object) -> str | None:
+    for value in values:
+        normalized = _text(value)
+        if normalized:
+            return normalized
+    return None
+
+
+def _first_sequence_text(source: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        for item in _sequence(source.get(key)):
+            normalized = _text(item)
+            if normalized:
+                return normalized
+    return None
+
+
+def _symbol_reason(symbol_payload: Mapping[str, Any], fallback_reason: str) -> str:
+    for key in (
+        "reason",
+        "reason_code",
+        "blocker",
+        "blocking_reason",
+        "current_blocker",
+    ):
+        reason = _text(symbol_payload.get(key))
+        if reason:
+            return reason
+    reason_codes = _strings(symbol_payload.get("reason_codes")) or _strings(
+        symbol_payload.get("blocking_reasons")
+    )
+    return reason_codes[0] if reason_codes else fallback_reason
+
+
+def _source_metadata(
+    *,
+    proof_floor_receipt: Mapping[str, Any],
+    symbol_payload: Mapping[str, Any],
+    account_label: str | None,
+    symbol: str,
+    tca_source_ref: Mapping[str, Any],
+    alpha_source_ref: Mapping[str, Any],
+) -> dict[str, object]:
+    hypothesis_id = _first_text(
+        symbol_payload.get("hypothesis_id"),
+        symbol_payload.get("hypothesisId"),
+        _first_sequence_text(alpha_source_ref, "hypothesis_ids"),
+    )
+    candidate_id = _first_text(
+        symbol_payload.get("candidate_id"),
+        symbol_payload.get("candidateId"),
+        _first_sequence_text(alpha_source_ref, "candidate_ids"),
+    )
+    runtime_strategy_id = _first_text(
+        symbol_payload.get("runtime_strategy_id"),
+        symbol_payload.get("runtimeStrategyId"),
+        symbol_payload.get("strategy_id"),
+        alpha_source_ref.get("runtime_strategy_id"),
+        alpha_source_ref.get("strategy_id"),
+        proof_floor_receipt.get("runtime_strategy_id"),
+    )
+    runtime_strategy_name = _first_text(
+        symbol_payload.get("runtime_strategy_name"),
+        symbol_payload.get("runtimeStrategyName"),
+        symbol_payload.get("strategy_name"),
+        alpha_source_ref.get("runtime_strategy_name"),
+        alpha_source_ref.get("strategy_name"),
+        proof_floor_receipt.get("runtime_strategy_name"),
+    )
+    source_manifest_ref = _first_text(
+        symbol_payload.get("source_manifest_ref"),
+        symbol_payload.get("sourceManifestRef"),
+        tca_source_ref.get("source_manifest_ref"),
+        alpha_source_ref.get("source_manifest_ref"),
+        proof_floor_receipt.get("source_manifest_ref"),
+    )
+    metadata: dict[str, object] = {
+        "account_label": account_label,
+        "symbol": symbol,
+    }
+    for key, value in (
+        ("hypothesis_id", hypothesis_id),
+        ("candidate_id", candidate_id),
+        ("runtime_strategy_id", runtime_strategy_id),
+        ("runtime_strategy_name", runtime_strategy_name),
+        ("source_manifest_ref", source_manifest_ref),
+    ):
+        if value is not None:
+            metadata[key] = value
+    for key in ("pair_id", "pair_side", "target_side", "leg_role"):
+        value = _text(symbol_payload.get(key))
+        if value:
+            metadata[key] = value
+    return metadata
+
+
+def _audit_receipt(
+    *,
+    account_label: str | None,
+    symbol: str,
+    state: str,
+    reason: str,
+    repair_recommendation: str,
+    source_metadata: Mapping[str, object],
+    tca_source_ref: Mapping[str, Any],
+    market_context_source_ref: Mapping[str, Any],
+    quant_source_ref: Mapping[str, Any],
+    alpha_source_ref: Mapping[str, Any],
+) -> dict[str, object]:
+    payload = {
+        "account_label": account_label,
+        "symbol": symbol,
+        "state": state,
+        "reason": reason,
+        "source_metadata": dict(source_metadata),
+    }
+    return {
+        "schema_version": ROUTE_REPAIR_AUDIT_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": _stable_ref("route-repair-audit-receipt", payload),
+        "state": "audit_only",
+        "source_metadata": dict(source_metadata),
+        "symbol": symbol,
+        "account_label": account_label,
+        "route_state": state,
+        "reason_codes": [reason],
+        "repair_recommendation": repair_recommendation,
+        "promotion_authority": False,
+        "capital_authority": "none",
+        "max_notional": "0",
+        "requires_runtime_ledger_source_proof": True,
+        "source_refs": {
+            "execution_tca_ref": _receipt_id(
+                tca_source_ref, "receipt_id", "last_receipt_id", "source_ref"
+            ),
+            "market_context_receipt_id": _receipt_id(
+                market_context_source_ref,
+                "receipt_id",
+                "last_receipt_id",
+                "repair_cell_receipt_id",
+            ),
+            "quant_pipeline_receipt_id": _receipt_id(
+                quant_source_ref,
+                "receipt_id",
+                "last_receipt_id",
+                "quant_pipeline_receipt_id",
+            ),
+            "alpha_hypothesis_ids": _hypothesis_ids(alpha_source_ref),
+        },
+    }
+
+
 def _next_action(*, state: str, reason: str) -> str:
     if state == "missing":
         return "create_simulation_probe_before_capital"
@@ -125,6 +305,7 @@ def _next_action(*, state: str, reason: str) -> str:
 
 def _record_from_symbol(
     *,
+    proof_floor_receipt: Mapping[str, Any],
     symbol_payload: Mapping[str, Any],
     account_label: str | None,
     state: str,
@@ -135,6 +316,28 @@ def _record_from_symbol(
     alpha_source_ref: Mapping[str, Any],
 ) -> dict[str, object]:
     symbol = _text(symbol_payload.get("symbol"))
+    normalized_reason = _symbol_reason(symbol_payload, reason)
+    recommendation = route_repair_recommendation(normalized_reason)
+    source_metadata = _source_metadata(
+        proof_floor_receipt=proof_floor_receipt,
+        symbol_payload=symbol_payload,
+        account_label=account_label,
+        symbol=symbol,
+        tca_source_ref=tca_source_ref,
+        alpha_source_ref=alpha_source_ref,
+    )
+    audit_receipt = _audit_receipt(
+        account_label=account_label,
+        symbol=symbol,
+        state=state,
+        reason=normalized_reason,
+        repair_recommendation=recommendation,
+        source_metadata=source_metadata,
+        tca_source_ref=tca_source_ref,
+        market_context_source_ref=market_context_source_ref,
+        quant_source_ref=quant_source_ref,
+        alpha_source_ref=alpha_source_ref,
+    )
     filled_execution_count = _int(
         symbol_payload.get("filled_execution_count"),
         _int(symbol_payload.get("order_count")),
@@ -143,7 +346,7 @@ def _record_from_symbol(
         "symbol": symbol,
         "account_label": account_label,
         "state": state,
-        "reason": reason,
+        "reason": normalized_reason,
         "avg_abs_slippage_bps": symbol_payload.get("avg_abs_slippage_bps"),
         "max_abs_slippage_bps": symbol_payload.get("max_abs_slippage_bps"),
         "slippage_guardrail_bps": tca_source_ref.get("slippage_guardrail_bps"),
@@ -166,8 +369,14 @@ def _record_from_symbol(
         ),
         "hypothesis_ids": _hypothesis_ids(alpha_source_ref),
         "paper_probe_notional_limit": "0",
-        "rollback_trigger": reason,
-        "next_repair_action": _next_action(state=state, reason=reason),
+        "rollback_trigger": normalized_reason,
+        "next_repair_action": _next_action(state=state, reason=normalized_reason),
+        "repair_recommendation": recommendation,
+        "source_metadata": source_metadata,
+        "audit_receipt": audit_receipt,
+        "audit_receipt_ref": audit_receipt["receipt_id"],
+        "promotion_authority": False,
+        "capital_authority": "none",
     }
     for key in (
         "avg_realized_shortfall_bps",
@@ -182,15 +391,19 @@ def _record_from_symbol(
 
 def _missing_record(
     *,
-    symbol: str,
+    proof_floor_receipt: Mapping[str, Any],
+    symbol_payload: Mapping[str, Any],
     account_label: str | None,
     tca_source_ref: Mapping[str, Any],
     market_context_source_ref: Mapping[str, Any],
     quant_source_ref: Mapping[str, Any],
     alpha_source_ref: Mapping[str, Any],
 ) -> dict[str, object]:
+    symbol = _text(symbol_payload.get("symbol"))
     return _record_from_symbol(
+        proof_floor_receipt=proof_floor_receipt,
         symbol_payload={
+            **dict(symbol_payload),
             "symbol": symbol,
             "order_count": 0,
             "avg_abs_slippage_bps": None,
@@ -231,6 +444,9 @@ def _repair_candidate(record: Mapping[str, object], *, rank: int) -> dict[str, o
         "filled_execution_count": _int(record.get("filled_execution_count")),
         "paper_probe_notional_limit": "0",
         "next_repair_action": _text(record.get("next_repair_action")),
+        "repair_recommendation": _text(record.get("repair_recommendation")),
+        "audit_receipt_ref": _text(record.get("audit_receipt_ref")),
+        "promotion_authority": False,
     }
     for key in (
         "avg_realized_shortfall_bps",
@@ -269,11 +485,7 @@ def _paper_route_probe_blockers(
     if configured_limit is None:
         blockers.append("paper_route_probe_max_notional_invalid")
     if market_session_open is not True:
-        blockers.append(
-            "market_session_closed"
-            if market_session_open is False
-            else "market_session_unknown"
-        )
+        blockers.append("session_closed" if market_session_open is False else "market_session_unknown")
     if eligible_symbol_count <= 0:
         blockers.append("paper_route_probe_candidate_missing")
     return blockers
@@ -327,6 +539,7 @@ def build_route_reacquisition_book(
         )
         records.append(
             _record_from_symbol(
+                proof_floor_receipt=proof_floor_receipt,
                 symbol_payload=symbol_payload,
                 account_label=account_label,
                 state=state,
@@ -343,6 +556,7 @@ def build_route_reacquisition_book(
             continue
         records.append(
             _record_from_symbol(
+                proof_floor_receipt=proof_floor_receipt,
                 symbol_payload=symbol_payload,
                 account_label=account_label,
                 state="blocked",
@@ -354,12 +568,18 @@ def build_route_reacquisition_book(
             )
         )
     for raw_symbol in _sequence(symbol_routes.get("missing_symbols")):
-        symbol = _text(raw_symbol)
+        symbol_payload = (
+            cast(Mapping[str, Any], raw_symbol)
+            if isinstance(raw_symbol, Mapping)
+            else {"symbol": raw_symbol}
+        )
+        symbol = _text(symbol_payload.get("symbol"))
         if not symbol:
             continue
         records.append(
             _missing_record(
-                symbol=symbol,
+                proof_floor_receipt=proof_floor_receipt,
+                symbol_payload=symbol_payload,
                 account_label=account_label,
                 tca_source_ref=tca_source_ref,
                 market_context_source_ref=market_context_source_ref,
@@ -400,6 +620,7 @@ def build_route_reacquisition_book(
             else "0",
             "blocking_reasons": probe_blockers if eligible else [],
             "capital_authority": "none",
+            "promotion_authority": False,
         }
 
     counts = {
@@ -445,7 +666,10 @@ def build_route_reacquisition_book(
         "capital_rule": "live_zero_notional_unchanged"
         if live_mode
         else "paper_probe_requires_receipt_chain",
+        "promotion_authority": False,
+        "authority_semantics": "audit_only_until_source_backed_runtime_ledger_fill_proof",
         "records": records,
+        "repair_audit_receipts": [record["audit_receipt"] for record in records],
         "summary": {
             "scope_symbols": list(_sequence(symbol_routes.get("scope_symbols"))),
             "scope_symbol_count": _int(symbol_routes.get("scope_symbol_count")),
@@ -475,6 +699,7 @@ def build_route_reacquisition_book(
             "active_symbols": active_probe_symbols,
             "blocking_reasons": probe_blockers,
             "capital_authority": "none",
+            "promotion_authority": False,
         },
         "source_refs": {
             "proof_floor_generated_at": generated_at,
@@ -488,6 +713,7 @@ def build_route_reacquisition_book(
         "rollback_target": {
             "paper_probe_notional_limit": "0",
             "live_submit_enabled": False,
+            "promotion_authority": False,
         },
     }
 

--- a/services/torghut/app/trading/route_reacquisition_board.py
+++ b/services/torghut/app/trading/route_reacquisition_board.py
@@ -166,6 +166,11 @@ def _required_receipts(
         _text(item) for item in _sequence(record.get("hypothesis_ids")) if _text(item)
     ]
     return {
+        "route_repair_audit_receipt": {
+            "receipt_id": record.get("audit_receipt_ref"),
+            "state": "present" if record.get("audit_receipt_ref") else "missing",
+            "promotion_authority": False,
+        },
         "tca_route_receipt": {
             "last_computed_at": record.get("last_computed_at"),
             "state": _text(tca_dimension.get("state"), "missing"),
@@ -224,6 +229,12 @@ def _board_row(
         "state": state,
         "current_blocker": reason,
         "repair_action": _text(record.get("next_repair_action")),
+        "repair_recommendation": _text(record.get("repair_recommendation")),
+        "source_metadata": dict(_mapping(record.get("source_metadata"))),
+        "audit_receipt": dict(_mapping(record.get("audit_receipt"))),
+        "audit_receipt_ref": record.get("audit_receipt_ref"),
+        "promotion_authority": False,
+        "capital_authority": "none",
         "expected_unblock_value": _row_expected_unblock_value(record),
         "expected_cost_class": _expected_cost_class(record),
         "expected_profit_effect": _expected_profit_effect(record),
@@ -238,6 +249,7 @@ def _board_row(
         "rollback_target": {
             "state": "blocked" if zero_notional_hold else state,
             "live_submit_enabled": False,
+            "promotion_authority": False,
         },
     }
 
@@ -319,6 +331,8 @@ def build_route_reacquisition_board(
         "capital_state": proof_floor_receipt.get("capital_state"),
         "market_session_open": route_book.get("market_session_open"),
         "state": "repair_only" if repair_only else "candidate",
+        "promotion_authority": False,
+        "authority_semantics": "audit_only_until_source_backed_runtime_ledger_fill_proof",
         "capital_rule": "zero_notional_until_receipts_close"
         if repair_only
         else "zero_notional_until_jangar_continuity"
@@ -349,6 +363,7 @@ def build_route_reacquisition_board(
         "rollback_target": {
             "capital_state": "zero_notional",
             "live_submit_enabled": False,
+            "promotion_authority": False,
         },
     }
 

--- a/services/torghut/app/trading/route_warrant_exchange.py
+++ b/services/torghut/app/trading/route_warrant_exchange.py
@@ -8,6 +8,8 @@ from hashlib import sha256
 import json
 from typing import Any, cast
 
+from .route_metadata import route_repair_recommendation
+
 
 ROUTE_WARRANT_EXCHANGE_SCHEMA_VERSION = "torghut.route-warrant-exchange.v1"
 
@@ -401,10 +403,12 @@ def _witness(
 def _repair_packet(witness: Mapping[str, Any]) -> dict[str, object]:
     dependency_name = _text(witness.get("published_clock"))
     dependency = _WARRANT_DEPENDENCIES[dependency_name]
+    reason_codes = _strings(witness.get("reason_codes"))
+    primary_reason = reason_codes[0] if reason_codes else _text(witness.get("state"), "missing")
     payload = {
         "dependency": dependency["target_dependency"],
         "state": _text(witness.get("state")),
-        "reason_codes": _strings(witness.get("reason_codes")),
+        "reason_codes": reason_codes,
         "source_ref": _text(witness.get("source_ref")),
     }
     return {
@@ -413,20 +417,26 @@ def _repair_packet(witness: Mapping[str, Any]) -> dict[str, object]:
         "target_dependency": dependency["target_dependency"],
         "repair_class": dependency["repair_class"],
         "current_state": _text(witness.get("state"), "missing"),
-        "reason_codes": _strings(witness.get("reason_codes")),
+        "reason_codes": reason_codes,
         "source_ref": witness.get("source_ref"),
         "expected_output_receipt": dependency["output_receipt"],
         "expected_unblock_value": f"{dependency['target_dependency']}_current",
+        "repair_recommendation": route_repair_recommendation(primary_reason),
+        "promotion_authority": False,
+        "capital_authority": "none",
+        "authority_semantics": "audit_only",
         "max_notional": "0",
         "stop_conditions": [
             "paper_or_live_notional_requested",
             "required_output_receipt_missing",
             "warrant_dependency_still_not_current",
+            "runtime_ledger_source_proof_missing",
         ],
         "rollback_target": {
             "capital_state": "zero_notional",
             "live_submit_enabled": False,
             "route_warrant_consumption_enabled": False,
+            "promotion_authority": False,
         },
     }
 
@@ -654,6 +664,8 @@ def build_route_warrant_exchange(
             accepted_routeable_candidate_count=accepted_routeable_candidate_count,
         ),
         "warrant_state": warrant_state,
+        "promotion_authority": False,
+        "authority_semantics": "audit_only_until_source_backed_runtime_ledger_fill_proof",
         "max_notional": "0",
         "blocking_reason_codes": blocking_reason_codes,
         "summary": {

--- a/services/torghut/app/trading/routeability_repair_acceptance.py
+++ b/services/torghut/app/trading/routeability_repair_acceptance.py
@@ -497,6 +497,8 @@ def _lot(
         "next_repair_action": next_repair_action,
         "paper_notional_limit": "0",
         "live_notional_limit": "0",
+        "promotion_authority": False,
+        "authority_semantics": "audit_only_until_source_backed_runtime_ledger_fill_proof",
         "rollback_trigger": rollback_trigger,
     }
 
@@ -745,6 +747,8 @@ def build_routeability_repair_acceptance_ledger(
         "aggregate_state": aggregate_state,
         "aggregate_blocking_reason_codes": aggregate_blockers,
         "accepted_routeable_candidate_count": accepted_routeable_candidate_count,
+        "promotion_authority": False,
+        "authority_semantics": "audit_only_until_source_backed_runtime_ledger_fill_proof",
         "zero_notional_or_stale_evidence_rate": round(
             max(unsettled_lot_count, zero_notional_lot_count) / denominator,
             4,
@@ -773,6 +777,7 @@ def build_routeability_repair_acceptance_ledger(
             "capital_state": "zero_notional",
             "live_submit_enabled": False,
             "routeability_acceptance_consumption_enabled": False,
+            "promotion_authority": False,
         },
     }
 

--- a/services/torghut/tests/test_repair_receipt_frontier.py
+++ b/services/torghut/tests/test_repair_receipt_frontier.py
@@ -309,3 +309,66 @@ def test_empty_frontier_promotes_only_to_paper_candidate_until_live_requirements
         and requirement["state"] == "block"
         for requirement in live_requirements
     )
+    runtime_requirement = next(
+        requirement
+        for requirement in live_requirements
+        if requirement["requirement"] == "runtime_ledger_source_proof_current"
+    )
+    assert runtime_requirement["state"] == "block"
+    assert runtime_requirement["reason_codes"] == [
+        "runtime_ledger_source_proof_missing"
+    ]
+    assert frontier["promotion_authority"] is False
+
+
+def test_live_candidate_requires_source_backed_runtime_ledger_proof() -> None:
+    base_kwargs = {
+        "source_ledger": _source_ledger(state="converged", reasons=[]),
+        "repair_bid_ledger": _repair_bid_ledger(compacted_lots=[]),
+        "profit_frontier": {
+            "schema_version": "torghut.profit-freshness-frontier.v1",
+            "frontier_id": "profit-freshness-frontier:ready",
+            "freshness_dimensions": [
+                {"dimension": "feature_coverage", "state": "current"},
+                {"dimension": "tca_fill_quality", "state": "current"},
+            ],
+            "aggregate_blocking_reason_codes": [],
+            "selected_zero_notional_repairs": [],
+            "summary": {"selected_expected_daily_net_pnl_unlock": None},
+        },
+        "route_warrant": _route_warrant(routeable_count=2),
+        "live_submission_gate": {
+            "allowed": True,
+            "reason": "ready",
+            "human_approved_capital_limits": True,
+        },
+    }
+
+    missing_runtime_proof = _build(
+        **base_kwargs,
+        proof_floor={
+            "route_state": "paper_candidate",
+            "capital_state": "paper_allowed",
+            "human_approved_capital_limits": True,
+        },
+    )
+    assert missing_runtime_proof["frontier_state"] == "paper_candidate"
+
+    source_backed_runtime_proof = _build(
+        **base_kwargs,
+        proof_floor={
+            "route_state": "paper_candidate",
+            "capital_state": "paper_allowed",
+            "human_approved_capital_limits": True,
+            "runtime_ledger_source_proof": {
+                "receipt_id": "runtime-ledger-source-proof:H-PAIRS-01",
+                "state": "current",
+                "source_backed": True,
+                "closed_round_trips": True,
+                "explicit_costs": True,
+                "flat_after_close_grace": True,
+            },
+        },
+    )
+    assert source_backed_runtime_proof["frontier_state"] == "live_candidate"
+    assert source_backed_runtime_proof["promotion_authority"] is False

--- a/services/torghut/tests/test_route_evidence_clearinghouse.py
+++ b/services/torghut/tests/test_route_evidence_clearinghouse.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -288,3 +289,61 @@ def test_blocking_evidence_yields_zero_notional_repair_bid(
     assert packet["max_notional"] == route_claim["max_notional"] == "0"
     assert reason in route_claim["reason_codes"]
     assert _has_bid(packet, value_gate)
+
+
+def test_route_repair_bids_emit_audit_receipts_and_blocker_recommendations() -> None:
+    blockers = [
+        "stale_quote",
+        "missing_bid_ask",
+        "session_closed",
+        "pair_imbalance",
+        "missing_target",
+        "blocked_submit",
+        "missing_close_flatten_handoff",
+        "runtime_import_pending",
+    ]
+    packet = _build(
+        profit_signal_quorum={
+            **BASE_PROFIT_QUORUM,
+            "aggregate_reason_codes": blockers,
+        },
+        live_submission_gate={"allowed": False, "reason": "blocked_submit"},
+    )
+
+    repair_bids = cast(list[Mapping[str, Any]], packet["selected_repair_bids"])
+    by_reason = {bid["reason_codes"][0]: bid for bid in repair_bids}
+    assert set(blockers).issubset(by_reason)
+    assert by_reason["stale_quote"]["repair_recommendation"] == (
+        "refresh_quote_snapshot_and_recompute_route_fillability"
+    )
+    assert by_reason["missing_bid_ask"]["repair_recommendation"] == (
+        "collect_bid_ask_quote_before_routeability_claim"
+    )
+    assert by_reason["session_closed"]["repair_recommendation"] == (
+        "wait_for_regular_session_open_then_refresh_route_probe"
+    )
+    assert by_reason["pair_imbalance"]["repair_recommendation"] == (
+        "repair_pair_leg_balance_before_routeability_claim"
+    )
+    assert by_reason["missing_target"]["repair_recommendation"] == (
+        "collect_target_notional_and_side_plan_before_probe"
+    )
+    assert by_reason["blocked_submit"]["repair_recommendation"] == (
+        "keep_submit_disabled_and_collect_submit_gate_receipt"
+    )
+    assert by_reason["missing_close_flatten_handoff"]["repair_recommendation"] == (
+        "collect_close_flatten_handoff_receipt_before_reentry"
+    )
+    assert by_reason["runtime_import_pending"]["repair_recommendation"] == (
+        "complete_runtime_import_reconciliation_before_authority"
+    )
+    for bid in by_reason.values():
+        receipt = cast(Mapping[str, Any], bid["audit_receipt"])
+        assert bid["max_notional"] == "0"
+        assert bid["promotion_authority"] is False
+        assert receipt["state"] == "audit_only"
+        assert receipt["promotion_authority"] is False
+        assert receipt["requires_runtime_ledger_source_proof"] is True
+    route_claim = cast(Mapping[str, Any], packet["route_claims"][0])
+    assert route_claim["promotion_authority"] is False
+    assert packet["promotion_authority"] is False

--- a/services/torghut/tests/test_route_metadata.py
+++ b/services/torghut/tests/test_route_metadata.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from unittest import TestCase
 
-from app.trading.route_metadata import normalize_route_provenance, resolve_order_route_metadata
+from app.trading.route_metadata import (
+    normalize_route_provenance,
+    resolve_order_route_metadata,
+    route_repair_recommendation,
+)
 
 
 class _BasicClient:
@@ -51,3 +55,37 @@ class TestRouteMetadata(TestCase):
         self.assertEqual(actual, 'alpaca')
         self.assertEqual(reason, 'lean_get_order_contract_violation')
         self.assertEqual(count, 1)
+
+    def test_route_repair_recommendations_map_actionable_blockers(self) -> None:
+        self.assertEqual(
+            route_repair_recommendation('stale_quote'),
+            'refresh_quote_snapshot_and_recompute_route_fillability',
+        )
+        self.assertEqual(
+            route_repair_recommendation('missing_bid_ask'),
+            'collect_bid_ask_quote_before_routeability_claim',
+        )
+        self.assertEqual(
+            route_repair_recommendation('session_closed'),
+            'wait_for_regular_session_open_then_refresh_route_probe',
+        )
+        self.assertEqual(
+            route_repair_recommendation('pair_imbalance'),
+            'repair_pair_leg_balance_before_routeability_claim',
+        )
+        self.assertEqual(
+            route_repair_recommendation('missing_target'),
+            'collect_target_notional_and_side_plan_before_probe',
+        )
+        self.assertEqual(
+            route_repair_recommendation('blocked_submit'),
+            'keep_submit_disabled_and_collect_submit_gate_receipt',
+        )
+        self.assertEqual(
+            route_repair_recommendation('missing_close_flatten_handoff'),
+            'collect_close_flatten_handoff_receipt_before_reentry',
+        )
+        self.assertEqual(
+            route_repair_recommendation('runtime_import_pending'),
+            'complete_runtime_import_reconciliation_before_authority',
+        )

--- a/services/torghut/tests/test_route_reacquisition.py
+++ b/services/torghut/tests/test_route_reacquisition.py
@@ -272,17 +272,16 @@ def test_route_book_ranks_zero_notional_repair_candidates_from_live_shape() -> N
         "ORCL",
     ]
     candidates = cast(list[Mapping[str, Any]], summary["repair_candidates"])
-    assert candidates[0] == {
-        "rank": 1,
-        "symbol": "AAPL",
-        "state": "blocked",
-        "reason": "execution_tca_route_universe_empty",
-        "avg_abs_slippage_bps": "9.2512103573044345",
-        "slippage_guardrail_bps": "8",
-        "filled_execution_count": 2033,
-        "paper_probe_notional_limit": "0",
-        "next_repair_action": "repair_route_evidence_before_paper_probe",
-    }
+    assert candidates[0]["rank"] == 1
+    assert candidates[0]["symbol"] == "AAPL"
+    assert candidates[0]["state"] == "blocked"
+    assert candidates[0]["reason"] == "execution_tca_route_universe_empty"
+    assert candidates[0]["avg_abs_slippage_bps"] == "9.2512103573044345"
+    assert candidates[0]["slippage_guardrail_bps"] == "8"
+    assert candidates[0]["filled_execution_count"] == 2033
+    assert candidates[0]["paper_probe_notional_limit"] == "0"
+    assert candidates[0]["next_repair_action"] == "repair_route_evidence_before_paper_probe"
+    assert candidates[0]["promotion_authority"] is False
     assert candidates[-1]["symbol"] == "ORCL"
     assert (
         candidates[-1]["next_repair_action"] == "create_simulation_probe_before_capital"
@@ -346,7 +345,7 @@ def test_route_book_surfaces_paper_route_probe_readiness_without_capital_authori
     assert probe["next_session_max_notional"] == "25.0"
     assert probe["eligible_symbols"] == ["AMZN", "AAPL", "INTC"]
     assert probe["active_symbols"] == []
-    assert probe["blocking_reasons"] == ["market_session_closed"]
+    assert probe["blocking_reasons"] == ["session_closed"]
     assert probe["capital_authority"] == "none"
 
     summary = cast(Mapping[str, Any], book["summary"])
@@ -425,7 +424,7 @@ def test_live_route_book_can_advertise_next_session_paper_probe_without_capital_
     assert probe["next_session_max_notional"] == "25"
     assert probe["eligible_symbols"] == ["AAPL"]
     assert probe["active_symbols"] == []
-    assert probe["blocking_reasons"] == ["not_paper_mode", "market_session_closed"]
+    assert probe["blocking_reasons"] == ["not_paper_mode", "session_closed"]
     assert probe["capital_authority"] == "none"
     assert book["capital_rule"] == "live_zero_notional_unchanged"
 
@@ -688,3 +687,113 @@ def test_route_reacquisition_board_holds_candidate_without_jangar_continuity() -
     summary = cast(Mapping[str, Any], board["summary"])
     assert summary["capital_eligible_symbol_count"] == 0
     assert summary["zero_notional_row_count"] == 1
+
+
+def test_hpairs_route_repair_receipts_keep_pair_legs_separate_and_audit_only() -> None:
+    proof_floor = {
+        "generated_at": "2026-06-01T14:30:00+00:00",
+        "account_label": "TORGHUT_SIM",
+        "runtime_strategy_id": "microbar-cross-sectional-pairs-v1",
+        "runtime_strategy_name": "H-PAIRS microbar cross-sectional pairs",
+        "source_manifest_ref": "runtime-manifest:H-PAIRS-01",
+        "route_state": "repair_only",
+        "capital_state": "zero_notional",
+        "proof_dimensions": [
+            {
+                "dimension": "execution_tca",
+                "state": "fail",
+                "reason": "pair_imbalance",
+                "source_ref": {
+                    "source_manifest_ref": "runtime-manifest:H-PAIRS-01",
+                    "symbol_routes": {
+                        "scope_symbols": ["AAPL", "AMZN"],
+                        "scope_symbol_count": 2,
+                        "routeable_symbols": [],
+                        "blocked_symbols": [
+                            {
+                                "symbol": "AAPL",
+                                "reason": "missing_bid_ask",
+                                "pair_id": "H-PAIRS:AAPL-AMZN",
+                                "pair_side": "long",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-hpairs",
+                                "runtime_strategy_id": "microbar-cross-sectional-pairs-v1",
+                                "runtime_strategy_name": "H-PAIRS microbar cross-sectional pairs",
+                            },
+                            {
+                                "symbol": "AMZN",
+                                "reason": "stale_quote",
+                                "pair_id": "H-PAIRS:AAPL-AMZN",
+                                "pair_side": "short",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-hpairs",
+                            },
+                        ],
+                        "missing_symbols": [
+                            {
+                                "symbol": "MSFT",
+                                "reason": "runtime_import_pending",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-hpairs",
+                            }
+                        ],
+                    },
+                },
+            },
+            {"dimension": "market_context", "state": "pass"},
+            {"dimension": "quant_ingestion", "state": "pass"},
+            {
+                "dimension": "alpha_readiness",
+                "state": "pass",
+                "source_ref": {
+                    "hypothesis_ids": ["H-PAIRS-01"],
+                    "candidate_ids": ["candidate-hpairs"],
+                },
+            },
+        ],
+    }
+
+    book = build_route_reacquisition_book(
+        proof_floor_receipt=proof_floor,
+        trading_mode="paper",
+        market_session_open=False,
+        paper_route_probe_enabled=True,
+        paper_route_probe_max_notional="25",
+    )
+    records = cast(list[Mapping[str, Any]], book["records"])
+    by_symbol = {record["symbol"]: record for record in records}
+
+    assert list(by_symbol) == ["AAPL", "AMZN", "MSFT"]
+    assert by_symbol["AAPL"]["reason"] == "missing_bid_ask"
+    assert by_symbol["AMZN"]["reason"] == "stale_quote"
+    assert by_symbol["AAPL"]["repair_recommendation"] == (
+        "collect_bid_ask_quote_before_routeability_claim"
+    )
+    assert by_symbol["AMZN"]["repair_recommendation"] == (
+        "refresh_quote_snapshot_and_recompute_route_fillability"
+    )
+    assert by_symbol["MSFT"]["repair_recommendation"] == (
+        "complete_runtime_import_reconciliation_before_authority"
+    )
+    for symbol in ("AAPL", "AMZN"):
+        metadata = cast(Mapping[str, Any], by_symbol[symbol]["source_metadata"])
+        receipt = cast(Mapping[str, Any], by_symbol[symbol]["audit_receipt"])
+        assert metadata["hypothesis_id"] == "H-PAIRS-01"
+        assert metadata["candidate_id"] == "candidate-hpairs"
+        assert metadata["runtime_strategy_id"] == "microbar-cross-sectional-pairs-v1"
+        assert metadata["account_label"] == "TORGHUT_SIM"
+        assert metadata["symbol"] == symbol
+        assert metadata["source_manifest_ref"] == "runtime-manifest:H-PAIRS-01"
+        assert metadata["pair_side"] in {"long", "short"}
+        assert receipt["state"] == "audit_only"
+        assert receipt["promotion_authority"] is False
+        assert receipt["capital_authority"] == "none"
+
+    board = build_route_reacquisition_board(
+        proof_floor_receipt={**proof_floor, "route_reacquisition_book": book},
+        active_revision="torghut-hpairs",
+    )
+    rows = cast(list[Mapping[str, Any]], board["rows"])
+    assert [row["symbol"] for row in rows] == ["AAPL", "AMZN", "MSFT"]
+    assert {row["promotion_authority"] for row in rows} == {False}
+    assert board["promotion_authority"] is False

--- a/services/torghut/tests/test_route_warrant_exchange.py
+++ b/services/torghut/tests/test_route_warrant_exchange.py
@@ -227,6 +227,8 @@ def test_repair_packets_are_zero_notional_and_single_receipt() -> None:
     for raw_packet in warrant["repair_packets"]:
         packet = dict(raw_packet)
         assert packet["max_notional"] == "0"
+        assert packet["promotion_authority"] is False
+        assert packet["capital_authority"] == "none"
         assert isinstance(packet["expected_output_receipt"], str)
         assert packet["expected_output_receipt"].startswith("torghut.")
         assert packet["target_value_gate"] in {

--- a/services/torghut/tests/test_routeability_repair_acceptance.py
+++ b/services/torghut/tests/test_routeability_repair_acceptance.py
@@ -162,6 +162,8 @@ def test_routeability_acceptance_ledger_projects_all_doc185_lots_at_zero_notiona
     lots = cast(list[Mapping[str, Any]], ledger["lots"])
     assert {lot["paper_notional_limit"] for lot in lots} == {"0"}
     assert {lot["live_notional_limit"] for lot in lots} == {"0"}
+    assert {lot["promotion_authority"] for lot in lots} == {False}
+    assert ledger["promotion_authority"] is False
     assert {lot["lot_type"] for lot in lots} == {
         "quant_scoped_stage_repair",
         "market_context_domain_repair",


### PR DESCRIPTION
## Summary

- Added shared route/fillability blocker-to-repair recommendations for stale quotes, missing bid/ask, closed sessions, pair imbalance, missing targets, submit holds, close/flatten handoff gaps, and runtime import pending states.
- Added audit-only route repair receipts across route evidence, reacquisition books/boards, warrant packets, acceptance lots, and frontier lots with zero notional, no capital authority, and `promotion_authority=false` semantics.
- Preserved H-PAIRS per-leg AAPL/AMZN diagnostics with source metadata for hypothesis, candidate, runtime strategy, account, symbol, and source manifest where available.
- Tightened the repair frontier so live promotion remains blocked until current source-backed runtime-ledger proof exists.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — pass
- `cd services/torghut && uv run --frozen pytest tests/test_route_evidence_clearinghouse.py tests/test_route_reacquisition.py tests/test_routeability_repair_acceptance.py tests/test_repair_receipt_frontier.py tests/test_route_warrant_exchange.py tests/test_route_metadata.py -q` — pass (52 passed, 1 existing deprecation warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/route_evidence_clearinghouse.py app/trading/route_reacquisition.py app/trading/route_reacquisition_board.py app/trading/routeability_repair_acceptance.py app/trading/repair_receipt_frontier.py app/trading/route_warrant_exchange.py app/trading/route_metadata.py tests/test_route_evidence_clearinghouse.py tests/test_route_reacquisition.py tests/test_routeability_repair_acceptance.py tests/test_repair_receipt_frontier.py tests/test_route_warrant_exchange.py tests/test_route_metadata.py` — pass
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — pass
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — pass
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — pass
- `git diff --check` — pass

## Screenshots (if applicable)

N/A — backend evidence plumbing and tests only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
