### PR TITLE
feat(torghut): reconcile tigerbeetle runtime refs

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5358,6 +5358,17 @@ def _check_tigerbeetle_protocol_health() -> dict[str, object]:
     return payload
 
 
+def _tigerbeetle_status_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return 0
+
+
 def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
     protocol = _check_tigerbeetle_protocol_health()
     latest_reconciliation = latest_tigerbeetle_reconciliation_payload(
@@ -5368,12 +5379,31 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
         session,
         cluster_id=settings.tigerbeetle_cluster_id,
     )
+    runtime_ledger_ref_count = _tigerbeetle_status_int(
+        ref_counts.get("runtime_ledger_ref_count")
+    )
+    runtime_ledger_signed_ref_count = _tigerbeetle_status_int(
+        ref_counts.get("runtime_ledger_signed_ref_count")
+    )
+    runtime_ledger_missing_signed_ref_count = _tigerbeetle_status_int(
+        ref_counts.get("runtime_ledger_missing_signed_ref_count")
+    )
+    runtime_ledger_missing_account_ref_count = _tigerbeetle_status_int(
+        ref_counts.get("runtime_ledger_missing_account_ref_count")
+    )
+    claimed_by_runtime_evidence = runtime_ledger_ref_count > 0
     blockers: list[str] = []
     if settings.tigerbeetle_enabled and not bool(protocol.get("protocol_ok")):
         blockers.append("tigerbeetle_protocol_unhealthy")
     reconciliation_ok = True
+    reconciliation_required = (
+        settings.tigerbeetle_enabled
+        or settings.tigerbeetle_required
+        or settings.tigerbeetle_reconcile_required
+        or claimed_by_runtime_evidence
+    )
     if latest_reconciliation is None:
-        if settings.tigerbeetle_reconcile_required:
+        if reconciliation_required:
             reconciliation_ok = False
             blockers.append("tigerbeetle_reconciliation_missing")
     else:
@@ -5384,15 +5414,26 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
         ):
             blocker_items = cast(Sequence[object], raw_blockers)
             blockers.extend(str(item) for item in blocker_items)
+    if runtime_ledger_missing_signed_ref_count:
+        reconciliation_ok = False
+        blockers.append("tigerbeetle_runtime_ledger_signed_refs_missing")
+    if runtime_ledger_ref_count and runtime_ledger_signed_ref_count <= 0:
+        reconciliation_ok = False
+        blockers.append("tigerbeetle_runtime_ledger_signed_refs_missing")
+    if runtime_ledger_missing_account_ref_count:
+        reconciliation_ok = False
+        blockers.append("tigerbeetle_runtime_ledger_account_refs_missing")
 
     protocol_gate_ok = bool(protocol.get("ok"))
-    reconcile_gate_ok = reconciliation_ok or not settings.tigerbeetle_reconcile_required
+    reconcile_gate_ok = reconciliation_ok or not reconciliation_required
     return {
         "schema_version": "torghut.tigerbeetle-ledger-status.v1",
         "enabled": settings.tigerbeetle_enabled,
         "journal_enabled": settings.tigerbeetle_journal_enabled,
         "required": settings.tigerbeetle_required,
         "reconcile_required": settings.tigerbeetle_reconcile_required,
+        "claimed_by_runtime_evidence": claimed_by_runtime_evidence,
+        "reconciliation_required": reconciliation_required,
         "ok": protocol_gate_ok and reconcile_gate_ok,
         "protocol_ok": bool(protocol.get("protocol_ok")),
         "reconciliation_ok": reconciliation_ok,
@@ -5400,6 +5441,17 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
         "replica_addresses": protocol.get("replica_addresses", []),
         "last_error": protocol.get("last_error"),
         "ref_counts": ref_counts,
+        "account_ref_count": ref_counts.get("account_ref_count", 0),
+        "transfer_ref_count": ref_counts.get("transfer_ref_count", 0),
+        "runtime_ledger_ref_count": runtime_ledger_ref_count,
+        "runtime_ledger_signed_ref_count": runtime_ledger_signed_ref_count,
+        "runtime_ledger_missing_signed_ref_count": (
+            runtime_ledger_missing_signed_ref_count
+        ),
+        "runtime_ledger_missing_account_ref_count": (
+            runtime_ledger_missing_account_ref_count
+        ),
+        "source_materialization": ref_counts.get("source_materialization", {}),
         "latest_reconciliation": latest_reconciliation,
         "blockers": sorted(set(blockers)),
     }

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -17,6 +17,7 @@ from app.models import (
     ExecutionOrderEvent,
     ExecutionTCAMetric,
     StrategyRuntimeLedgerBucket,
+    TigerBeetleAccountRef,
     TigerBeetleReconciliationRun,
     TigerBeetleTransferRef,
     coerce_json_payload,
@@ -61,6 +62,12 @@ BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH = (
 )
 BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH = (
     "tigerbeetle_runtime_ledger_metadata_mismatch"
+)
+BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING = (
+    "tigerbeetle_runtime_ledger_signed_refs_missing"
+)
+BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING = (
+    "tigerbeetle_runtime_ledger_account_refs_missing"
 )
 BLOCKER_CLIENT_UNAVAILABLE = "tigerbeetle_client_unavailable"
 
@@ -191,6 +198,18 @@ def _payload_int(payload: Mapping[str, object], key: str) -> int:
         return 0
 
 
+def _payload_string_list(payload: Mapping[str, object], key: str) -> list[str]:
+    value = payload.get(key)
+    if isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        items = cast(Sequence[object], value)
+        return [str(item) for item in items if item is not None]
+    if value is None:
+        return []
+    return [str(value)]
+
+
 def _uuid_or_none(value: str | None) -> UUID | None:
     if not value:
         return None
@@ -269,6 +288,135 @@ def _expected_source_amount_micros(
     return None
 
 
+def _runtime_ledger_ref_is_signed(ref: TigerBeetleTransferRef) -> bool:
+    payload = _payload_mapping(ref)
+    signed_amount = payload.get("signed_amount_micros")
+    pnl_direction = str(payload.get("pnl_direction") or "")
+    debit_account_id = payload.get("debit_account_id")
+    credit_account_id = payload.get("credit_account_id")
+    try:
+        signed_amount_int = int(str(signed_amount))
+    except (TypeError, ValueError):
+        return False
+    return (
+        signed_amount_int != 0
+        and pnl_direction in {"profit", "loss"}
+        and debit_account_id is not None
+        and credit_account_id is not None
+    )
+
+
+def _runtime_ledger_payload_account_ids(ref: TigerBeetleTransferRef) -> list[str]:
+    payload = _payload_mapping(ref)
+    account_ids = _payload_string_list(payload, "account_ids")
+    for key in ("debit_account_id", "credit_account_id"):
+        value = payload.get(key)
+        if value is None:
+            continue
+        account_id = str(value)
+        if account_id not in account_ids:
+            account_ids.append(account_id)
+    return account_ids
+
+
+def _runtime_ledger_ref_coverage(
+    session: Session,
+    *,
+    cluster_id: int,
+    sample_limit: int = 50,
+) -> dict[str, object]:
+    runtime_refs = (
+        session.execute(
+            select(TigerBeetleTransferRef)
+            .where(
+                TigerBeetleTransferRef.cluster_id == cluster_id,
+                TigerBeetleTransferRef.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL,
+            )
+            .order_by(TigerBeetleTransferRef.created_at.desc())
+        )
+        .scalars()
+        .all()
+    )
+    current_bucket_ids = {
+        str(bucket_id)
+        for bucket_id in session.execute(
+            select(StrategyRuntimeLedgerBucket.id).where(
+                (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
+                | (StrategyRuntimeLedgerBucket.cost_amount != 0)
+            )
+        ).scalars()
+    }
+    current_runtime_refs = [
+        ref
+        for ref in runtime_refs
+        if (
+            ref.runtime_ledger_bucket_id is not None
+            and str(ref.runtime_ledger_bucket_id) in current_bucket_ids
+        )
+        or (ref.source_id is not None and ref.source_id in current_bucket_ids)
+    ]
+    required_runtime_bucket_count = int(
+        session.scalar(
+            select(func.count(StrategyRuntimeLedgerBucket.id)).where(
+                (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
+                | (StrategyRuntimeLedgerBucket.cost_amount != 0)
+            )
+        )
+        or 0
+    )
+    signed_refs = [
+        ref for ref in current_runtime_refs if _runtime_ledger_ref_is_signed(ref)
+    ]
+    signed_bucket_ids = {
+        str(ref.runtime_ledger_bucket_id or ref.source_id)
+        for ref in signed_refs
+        if ref.runtime_ledger_bucket_id is not None or ref.source_id
+    }
+    runtime_source_ids = [
+        str(ref.source_id)
+        for ref in runtime_refs
+        if ref.source_id is not None
+    ][:sample_limit]
+    runtime_transfer_ids = [str(ref.transfer_id) for ref in runtime_refs][:sample_limit]
+    runtime_account_ids: list[str] = []
+    for ref in current_runtime_refs:
+        for account_id in _runtime_ledger_payload_account_ids(ref):
+            if account_id not in runtime_account_ids:
+                runtime_account_ids.append(account_id)
+    account_ref_ids = {
+        str(account_id)
+        for account_id in session.execute(
+            select(TigerBeetleAccountRef.account_id).where(
+                TigerBeetleAccountRef.cluster_id == cluster_id
+            )
+        ).scalars()
+    }
+    missing_account_ids = [
+        account_id
+        for account_id in runtime_account_ids
+        if account_id not in account_ref_ids
+    ]
+    missing_signed_ref_count = max(
+        required_runtime_bucket_count - len(signed_bucket_ids),
+        len(current_runtime_refs) - len(signed_refs),
+        0,
+    )
+    return {
+        "runtime_ledger_required_bucket_count": required_runtime_bucket_count,
+        "runtime_ledger_ref_count": len(runtime_refs),
+        "runtime_ledger_signed_ref_count": len(signed_refs),
+        "runtime_ledger_missing_signed_ref_count": missing_signed_ref_count,
+        "runtime_ledger_account_ref_count": len(runtime_account_ids)
+        - len(missing_account_ids),
+        "runtime_ledger_missing_account_ref_count": len(missing_account_ids),
+        "runtime_ledger_missing_account_ids": missing_account_ids[:sample_limit],
+        "runtime_ledger_source_ids": runtime_source_ids,
+        "runtime_ledger_transfer_ids": runtime_transfer_ids,
+        "runtime_ledger_signed_bucket_ids": sorted(signed_bucket_ids)[:sample_limit],
+    }
+
+
 def _runtime_ledger_ref_matches_expected_bucket(
     ref: TigerBeetleTransferRef,
     actual: object,
@@ -315,6 +463,11 @@ def _runtime_ledger_ref_matches_expected_bucket(
 
 
 def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, object]:
+    account_total = session.scalar(
+        select(func.count(TigerBeetleAccountRef.id)).where(
+            TigerBeetleAccountRef.cluster_id == cluster_id
+        )
+    )
     source_rows = session.execute(
         select(
             TigerBeetleTransferRef.source_type,
@@ -331,9 +484,14 @@ def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, ob
             TigerBeetleTransferRef.cluster_id == cluster_id
         )
     )
+    runtime_coverage = _runtime_ledger_ref_coverage(
+        session,
+        cluster_id=cluster_id,
+    )
     return {
         "schema_version": "torghut.tigerbeetle-ref-counts.v1",
         "cluster_id": cluster_id,
+        "account_ref_count": int(account_total or 0),
         "transfer_ref_count": int(total or 0),
         "by_source_type": by_source,
         "order_event_ref_count": by_source.get(SOURCE_TYPE_EXECUTION_ORDER_EVENT, 0),
@@ -343,6 +501,15 @@ def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, ob
             SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             0,
         ),
+        "source_materialization": {
+            "account_ref_table": "tigerbeetle_account_refs",
+            "transfer_ref_table": "tigerbeetle_transfer_refs",
+            "reconciliation_run_table": "tigerbeetle_reconciliation_runs",
+            "runtime_ledger_source_table": "strategy_runtime_ledger_buckets",
+            "runtime_ledger_source_type": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            "runtime_ledger_transfer_kind": TRANSFER_KIND_RUNTIME_NET_PNL,
+        },
+        **runtime_coverage,
     }
 
 
@@ -382,6 +549,14 @@ def _latest_run_payload(
         ),
         "runtime_ledger_signed_transfer_count": _payload_int(
             payload, "runtime_ledger_signed_transfer_count"
+        ),
+        "runtime_ledger_missing_signed_ref_count": _payload_int(
+            payload,
+            "runtime_ledger_missing_signed_ref_count",
+        ),
+        "runtime_ledger_missing_account_ref_count": _payload_int(
+            payload,
+            "runtime_ledger_missing_account_ref_count",
         ),
         "archived_runtime_ledger_source_missing_count": _payload_int(
             payload, "archived_runtime_ledger_source_missing_count"
@@ -451,6 +626,8 @@ def reconcile_tigerbeetle_transfers(
     source_amount_mismatch_count = 0
     runtime_ledger_checked_transfer_count = 0
     runtime_ledger_signed_transfer_count = 0
+    runtime_ledger_missing_signed_ref_count = 0
+    runtime_ledger_missing_account_ref_count = 0
     archived_runtime_ledger_source_missing_count = 0
     runtime_ledger_direction_mismatch_count = 0
     runtime_ledger_metadata_mismatch_count = 0
@@ -649,8 +826,6 @@ def reconcile_tigerbeetle_transfers(
     if unlinked_runtime_ledger_count:
         blockers.append(BLOCKER_UNLINKED_RUNTIME_LEDGER)
 
-    unique_blockers = sorted(set(blockers))
-    ok = not unique_blockers
     finished_at = datetime.now(timezone.utc)
     source_missing_count = (
         unlinked_event_count
@@ -664,6 +839,20 @@ def reconcile_tigerbeetle_transfers(
         session,
         cluster_id=settings_obj.tigerbeetle_cluster_id,
     )
+    runtime_ledger_missing_signed_ref_count = _payload_int(
+        ref_counts,
+        "runtime_ledger_missing_signed_ref_count",
+    )
+    runtime_ledger_missing_account_ref_count = _payload_int(
+        ref_counts,
+        "runtime_ledger_missing_account_ref_count",
+    )
+    if runtime_ledger_missing_signed_ref_count:
+        blockers.append(BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING)
+    if runtime_ledger_missing_account_ref_count:
+        blockers.append(BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING)
+    unique_blockers = sorted(set(blockers))
+    ok = not unique_blockers
     payload: dict[str, object] = {
         "schema_version": SCHEMA_VERSION,
         "ok": ok,
@@ -676,6 +865,12 @@ def reconcile_tigerbeetle_transfers(
         "source_amount_mismatch_count": source_amount_mismatch_count,
         "runtime_ledger_checked_transfer_count": runtime_ledger_checked_transfer_count,
         "runtime_ledger_signed_transfer_count": runtime_ledger_signed_transfer_count,
+        "runtime_ledger_missing_signed_ref_count": (
+            runtime_ledger_missing_signed_ref_count
+        ),
+        "runtime_ledger_missing_account_ref_count": (
+            runtime_ledger_missing_account_ref_count
+        ),
         "archived_runtime_ledger_source_missing_count": archived_runtime_ledger_source_missing_count,
         "runtime_ledger_direction_mismatch_count": (
             runtime_ledger_direction_mismatch_count

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -57,6 +57,8 @@ from app.trading.tigerbeetle_reconcile import (
     _expected_source_amount_micros,
     _execution_amount_micros,
     _payload_int,
+    _payload_string_list,
+    _runtime_ledger_payload_account_ids,
     _runtime_ledger_amount_micros,
     _usd_to_micros,
     _uuid_or_none,
@@ -355,6 +357,34 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertIn(BLOCKER_SOURCE_ROW_MISSING, payload["blockers"])
             self.assertEqual(payload["source_row_missing_count"], 1)
             self.assertEqual(payload["source_missing_count"], 1)
+
+    def test_runtime_payload_account_ids_normalize_sequence_scalar_and_missing_values(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _payload_string_list({"account_ids": ["11", None, 12]}, "account_ids"),
+            ["11", "12"],
+        )
+        self.assertEqual(_payload_string_list({"account_ids": "11"}, "account_ids"), ["11"])
+
+        ref = TigerBeetleTransferRef(
+            cluster_id=2001,
+            transfer_id="runtime-account-ref",
+            transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+            ledger=LEDGER_USD_MICRO,
+            code=TRANSFER_CODE_RUNTIME_NET_PNL,
+            amount=Decimal("2500000"),
+            status="created",
+            source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            source_id="runtime-source",
+            payload_json={
+                "account_ids": ["11"],
+                "debit_account_id": None,
+                "credit_account_id": "12",
+            },
+        )
+
+        self.assertEqual(_runtime_ledger_payload_account_ids(ref), ["11", "12"])
 
     def test_reconciliation_accepts_signed_runtime_ledger_profit_and_loss_refs(
         self,

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from unittest import TestCase
 from unittest.mock import patch
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
 from app.config import Settings
@@ -15,6 +15,7 @@ from app.models import (
     ExecutionOrderEvent,
     ExecutionTCAMetric,
     StrategyRuntimeLedgerBucket,
+    TigerBeetleAccountRef,
     TigerBeetleReconciliationRun,
     TigerBeetleTransferRef,
 )
@@ -39,8 +40,10 @@ from app.trading.tigerbeetle_reconcile import (
     BLOCKER_DEBIT_ACCOUNT_MISMATCH,
     BLOCKER_LEDGER_MISMATCH,
     BLOCKER_POSTGRES_REF_MISMATCH,
+    BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING,
     BLOCKER_RUNTIME_LEDGER_DIRECTION_MISMATCH,
     BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH,
+    BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING,
     BLOCKER_SOURCE_ROW_MISSING,
     BLOCKER_UNLINKED_COST,
     BLOCKER_UNLINKED_EXECUTION,
@@ -59,6 +62,7 @@ from app.trading.tigerbeetle_reconcile import (
     _uuid_or_none,
     latest_tigerbeetle_reconciliation_payload,
     reconcile_tigerbeetle_transfers,
+    tigerbeetle_ref_counts,
 )
 
 
@@ -150,6 +154,35 @@ def _runtime_bucket(
         pnl_basis="post_cost",
         payload_json={"source": "representative-runtime-ledger"},
     )
+
+
+def _add_account_refs_for_plan(
+    session: Session,
+    plan: object,
+    *,
+    cluster_id: int = 2001,
+) -> None:
+    for spec in getattr(plan, "account_specs"):
+        existing = session.scalar(
+            select(TigerBeetleAccountRef.id).where(
+                TigerBeetleAccountRef.cluster_id == cluster_id,
+                TigerBeetleAccountRef.account_id == str(spec.account_id),
+            )
+        )
+        if existing is not None:
+            continue
+        session.add(
+            TigerBeetleAccountRef(
+                cluster_id=cluster_id,
+                account_id=str(spec.account_id),
+                account_key=spec.account_key,
+                ledger=spec.ledger,
+                code=spec.code,
+                account_label=spec.account_label,
+                symbol=spec.symbol,
+                strategy_id=spec.strategy_id,
+            )
+        )
 
 
 class TestTigerBeetleReconcile(TestCase):
@@ -336,6 +369,7 @@ class TestTigerBeetleReconcile(TestCase):
                 plan = build_runtime_ledger_bucket_transfer_plan(bucket)
                 self.assertIsNotNone(plan)
                 assert plan is not None
+                _add_account_refs_for_plan(session, plan)
                 transfer = plan.transfer_spec
                 session.add(
                     TigerBeetleTransferRef(
@@ -378,6 +412,19 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertTrue(payload["ok"], payload)
             self.assertEqual(payload["runtime_ledger_checked_transfer_count"], 2)
             self.assertEqual(payload["runtime_ledger_signed_transfer_count"], 2)
+            self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 0)
+            self.assertEqual(payload["runtime_ledger_missing_account_ref_count"], 0)
+            ref_counts = payload["ref_counts"]
+            assert isinstance(ref_counts, dict)
+            self.assertEqual(ref_counts["runtime_ledger_signed_ref_count"], 2)
+            self.assertEqual(ref_counts["runtime_ledger_missing_signed_ref_count"], 0)
+            self.assertEqual(ref_counts["runtime_ledger_missing_account_ref_count"], 0)
+            source_materialization = ref_counts["source_materialization"]
+            assert isinstance(source_materialization, dict)
+            self.assertEqual(
+                source_materialization["runtime_ledger_source_type"],
+                SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            )
 
     def test_reconciliation_reports_archived_runtime_ref_without_blocking_current_ref(
         self,
@@ -390,6 +437,7 @@ class TestTigerBeetleReconcile(TestCase):
             plan = build_runtime_ledger_bucket_transfer_plan(bucket)
             self.assertIsNotNone(plan)
             assert plan is not None
+            _add_account_refs_for_plan(session, plan)
             current_transfer = plan.transfer_spec
             session.add(
                 TigerBeetleTransferRef(
@@ -473,6 +521,110 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertEqual(payload["source_missing_count"], 0)
             self.assertNotIn(BLOCKER_SOURCE_ROW_MISSING, payload["blockers"])
 
+    def test_reconciliation_blocks_runtime_ledger_signed_ref_coverage_gap(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket(net_pnl=Decimal("2.50"))
+            session.add(bucket)
+            session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            transfer = plan.transfer_spec
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(transfer.transfer_id),
+                    transfer_kind=transfer.transfer_kind,
+                    ledger=transfer.ledger,
+                    code=transfer.code,
+                    amount=Decimal(transfer.amount),
+                    status="created",
+                    runtime_ledger_bucket_id=bucket.id,
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id=str(bucket.id),
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "debit_account_id": str(transfer.debit_account_id),
+                        "credit_account_id": str(transfer.credit_account_id),
+                    },
+                )
+            )
+            session.flush()
+            client = FakeTigerBeetleClient()
+            client.transfers[transfer.transfer_id] = transfer
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertFalse(payload["ok"], payload)
+            self.assertIn(
+                BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING,
+                payload["blockers"],
+            )
+            self.assertIn(
+                BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING,
+                payload["blockers"],
+            )
+            self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 1)
+            self.assertEqual(payload["runtime_ledger_missing_account_ref_count"], 2)
+
+    def test_ref_counts_expose_source_materialization_identifiers(self) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket(net_pnl=Decimal("2.50"))
+            session.add(bucket)
+            session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            _add_account_refs_for_plan(session, plan)
+            transfer = plan.transfer_spec
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(transfer.transfer_id),
+                    transfer_kind=transfer.transfer_kind,
+                    ledger=transfer.ledger,
+                    code=transfer.code,
+                    amount=Decimal(transfer.amount),
+                    status="created",
+                    runtime_ledger_bucket_id=bucket.id,
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id=str(bucket.id),
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "signed_amount_micros": plan.signed_amount_micros,
+                        "pnl_direction": plan.pnl_direction,
+                        "debit_account_id": str(transfer.debit_account_id),
+                        "credit_account_id": str(transfer.credit_account_id),
+                    },
+                )
+            )
+            session.flush()
+
+            payload = tigerbeetle_ref_counts(session, cluster_id=2001)
+
+        self.assertEqual(payload["account_ref_count"], 4)
+        self.assertEqual(payload["runtime_ledger_ref_count"], 1)
+        self.assertEqual(payload["runtime_ledger_signed_ref_count"], 1)
+        self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 0)
+        self.assertEqual(payload["runtime_ledger_missing_account_ref_count"], 0)
+        self.assertEqual(payload["runtime_ledger_source_ids"], [str(bucket.id)])
+        self.assertEqual(
+            payload["runtime_ledger_transfer_ids"],
+            [str(transfer.transfer_id)],
+        )
+        source_materialization = payload["source_materialization"]
+        assert isinstance(source_materialization, dict)
+        self.assertEqual(
+            source_materialization["runtime_ledger_source_table"],
+            "strategy_runtime_ledger_buckets",
+        )
+
     def test_reconciliation_blocks_runtime_ledger_signed_direction_mismatch(
         self,
     ) -> None:
@@ -483,6 +635,7 @@ class TestTigerBeetleReconcile(TestCase):
             plan = build_runtime_ledger_bucket_transfer_plan(bucket)
             self.assertIsNotNone(plan)
             assert plan is not None
+            _add_account_refs_for_plan(session, plan)
             expected = plan.transfer_spec
             wrong_transfer = TigerBeetleTransferSpec(
                 transfer_id=expected.transfer_id,

--- a/services/torghut/tests/test_tigerbeetle_status.py
+++ b/services/torghut/tests/test_tigerbeetle_status.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timezone
+from decimal import Decimal
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -13,8 +14,18 @@ from app.main import (
     _build_tigerbeetle_ledger_status,
     _check_tigerbeetle_protocol_health,
 )
-from app.models import Base, TigerBeetleReconciliationRun
+from app.models import (
+    Base,
+    StrategyRuntimeLedgerBucket,
+    TigerBeetleReconciliationRun,
+    TigerBeetleTransferRef,
+)
 from app.trading.tigerbeetle_client import TigerBeetleHealth
+from app.trading.tigerbeetle_ledger_model import (
+    LEDGER_USD_MICRO,
+    TRANSFER_CODE_RUNTIME_NET_PNL,
+    TRANSFER_KIND_RUNTIME_NET_PNL,
+)
 
 
 class TestTigerBeetleStatus(TestCase):
@@ -78,6 +89,113 @@ class TestTigerBeetleStatus(TestCase):
         self.assertFalse(payload["ok"])
         self.assertFalse(payload["reconciliation_ok"])
         self.assertIn("tigerbeetle_reconciliation_missing", payload["blockers"])
+
+    def test_enabled_missing_reconciliation_fails_closed(self) -> None:
+        settings.tigerbeetle_enabled = True
+        settings.tigerbeetle_required = False
+        health = TigerBeetleHealth(
+            enabled=True,
+            required=False,
+            ok=True,
+            cluster_id=2001,
+            replica_addresses=["tb:3000"],
+            last_error=None,
+        )
+
+        with Session(self.engine) as session:
+            with patch("app.main.check_tigerbeetle_health", return_value=health):
+                payload = _build_tigerbeetle_ledger_status(session)
+
+        self.assertFalse(payload["ok"])
+        self.assertTrue(payload["reconciliation_required"])
+        self.assertIn("tigerbeetle_reconciliation_missing", payload["blockers"])
+
+    def test_disabled_claimed_runtime_refs_fail_closed_when_unsigned(self) -> None:
+        observed_at = datetime.now(timezone.utc)
+        with Session(self.engine) as session:
+            bucket = StrategyRuntimeLedgerBucket(
+                run_id="runtime-run-claimed",
+                candidate_id="candidate",
+                hypothesis_id="hypothesis",
+                observed_stage="paper",
+                bucket_started_at=observed_at,
+                bucket_ended_at=observed_at,
+                account_label="paper",
+                runtime_strategy_name="demo",
+                strategy_family="demo",
+                fill_count=1,
+                decision_count=1,
+                submitted_order_count=1,
+                cancelled_order_count=0,
+                rejected_order_count=0,
+                unfilled_order_count=0,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("190.25"),
+                gross_strategy_pnl=Decimal("3.00"),
+                cost_amount=Decimal("0.50"),
+                net_strategy_pnl_after_costs=Decimal("2.50"),
+                post_cost_expectancy_bps=Decimal("12.50"),
+                ledger_schema_version="torghut.runtime-ledger.v1",
+                pnl_basis="post_cost",
+                payload_json={"source": "test"},
+            )
+            session.add(bucket)
+            session.flush()
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id="1001",
+                    transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+                    ledger=LEDGER_USD_MICRO,
+                    code=TRANSFER_CODE_RUNTIME_NET_PNL,
+                    amount=Decimal("2500000"),
+                    status="created",
+                    runtime_ledger_bucket_id=bucket.id,
+                    source_type="strategy_runtime_ledger_bucket",
+                    source_id=str(bucket.id),
+                    payload_json={
+                        "source": "strategy_runtime_ledger_bucket",
+                        "debit_account_id": "11",
+                        "credit_account_id": "12",
+                    },
+                )
+            )
+            session.add(
+                TigerBeetleReconciliationRun(
+                    cluster_id=2001,
+                    started_at=observed_at,
+                    finished_at=observed_at,
+                    status="ok",
+                    checked_transfer_count=1,
+                    missing_transfer_count=0,
+                    mismatched_transfer_count=0,
+                    source_missing_count=0,
+                    payload_json={
+                        "blockers": [],
+                        "runtime_ledger_signed_transfer_count": 0,
+                        "ref_counts": {"runtime_ledger_ref_count": 1},
+                    },
+                )
+            )
+            session.flush()
+
+            payload = _build_tigerbeetle_ledger_status(session)
+
+        self.assertFalse(payload["ok"])
+        self.assertTrue(payload["claimed_by_runtime_evidence"])
+        self.assertTrue(payload["reconciliation_required"])
+        self.assertEqual(payload["runtime_ledger_ref_count"], 1)
+        self.assertEqual(payload["runtime_ledger_signed_ref_count"], 0)
+        self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 1)
+        self.assertIn(
+            "tigerbeetle_runtime_ledger_signed_refs_missing",
+            payload["blockers"],
+        )
+        self.assertIn(
+            "tigerbeetle_runtime_ledger_account_refs_missing",
+            payload["blockers"],
+        )
 
     def test_protocol_timeout_is_nonblocking_until_required(self) -> None:
         settings.tigerbeetle_enabled = True

--- a/services/torghut/tests/test_tigerbeetle_status.py
+++ b/services/torghut/tests/test_tigerbeetle_status.py
@@ -13,6 +13,7 @@ from app.config import settings
 from app.main import (
     _build_tigerbeetle_ledger_status,
     _check_tigerbeetle_protocol_health,
+    _tigerbeetle_status_int,
 )
 from app.models import (
     Base,
@@ -59,6 +60,13 @@ class TestTigerBeetleStatus(TestCase):
         self.assertTrue(payload["protocol_ok"])
         self.assertEqual(payload["blockers"], [])
         self.assertEqual(payload["ref_counts"]["transfer_ref_count"], 0)
+
+    def test_tigerbeetle_status_int_normalizes_bool_strings_and_bad_values(self) -> None:
+        self.assertEqual(_tigerbeetle_status_int(True), 1)
+        self.assertEqual(_tigerbeetle_status_int(False), 0)
+        self.assertEqual(_tigerbeetle_status_int("7"), 7)
+        self.assertEqual(_tigerbeetle_status_int("not-an-int"), 0)
+        self.assertEqual(_tigerbeetle_status_int(None), 0)
 
     def test_required_protocol_failure_blocks_readiness_dependency(self) -> None:
         settings.tigerbeetle_enabled = True


### PR DESCRIPTION
## Summary

- Adds deterministic TigerBeetle runtime-ledger reconciliation coverage counts for account refs, transfer refs, signed runtime-ledger refs, missing refs, blockers, and source materialization identifiers.
- Fails TigerBeetle status/readback closed when TigerBeetle is enabled, required, reconcile-required, or claimed by runtime-ledger evidence without signed/account refs or a clean reconciliation.
- Keeps disabled TigerBeetle non-blocking when no runtime evidence claims TigerBeetle lineage.
- Adds regression tests for signed ref coverage gaps, account-ref gaps, enabled/claimed status blocking, and status/readback count payloads.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed.
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_status.py tests/test_verify_tigerbeetle_ledger.py tests/test_journal_tigerbeetle_order_events.py -q` — passed, 111 tests.
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_client.py app/trading/tigerbeetle_ids.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_ledger_model.py app/main.py scripts/journal_tigerbeetle_order_events.py scripts/verify_tigerbeetle_ledger.py tests/test_tigerbeetle_client.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_status.py tests/test_verify_tigerbeetle_ledger.py tests/test_journal_tigerbeetle_order_events.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed.
- `git diff --check` — passed.

## Screenshots (if applicable)

N/A

## Breaking Changes

No migrations. Runtime status/readiness now treats enabled or runtime-claimed TigerBeetle reconciliation gaps as blockers instead of advisory-only status.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
