### PR TITLE
fix(torghut): scope runtime ledger bucket reruns

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -1322,6 +1322,43 @@ def _delete_replaced_runtime_ledger_buckets(
     return int(getattr(result, "rowcount", 0) or 0)
 
 
+def _delete_current_runtime_ledger_buckets(
+    *,
+    session: Session,
+    run_id: str,
+    candidate_id: str | None,
+    hypothesis_id: str,
+    observed_stage: str,
+    replacement_scopes: Sequence[tuple[datetime, datetime, str | None, str | None]],
+) -> int:
+    if not replacement_scopes:
+        return 0
+    overlap_predicates = [
+        and_(
+            StrategyRuntimeLedgerBucket.bucket_started_at < bucket_ended_at,
+            StrategyRuntimeLedgerBucket.bucket_ended_at > bucket_started_at,
+            StrategyRuntimeLedgerBucket.account_label == account_label,
+            StrategyRuntimeLedgerBucket.runtime_strategy_name == runtime_strategy_name,
+        )
+        for (
+            bucket_started_at,
+            bucket_ended_at,
+            account_label,
+            runtime_strategy_name,
+        ) in replacement_scopes
+    ]
+    result = session.execute(
+        delete(StrategyRuntimeLedgerBucket).where(
+            StrategyRuntimeLedgerBucket.run_id == run_id,
+            StrategyRuntimeLedgerBucket.candidate_id == candidate_id,
+            StrategyRuntimeLedgerBucket.hypothesis_id == hypothesis_id,
+            StrategyRuntimeLedgerBucket.observed_stage == observed_stage,
+            or_(*overlap_predicates),
+        )
+    )
+    return int(getattr(result, "rowcount", 0) or 0)
+
+
 def _runtime_ledger_post_cost_from_observed_buckets(
     buckets: Sequence[ObservedRuntimeBucket],
 ) -> tuple[Decimal | None, Decimal, Decimal, int]:
@@ -1952,13 +1989,6 @@ def persist_observed_runtime_windows(
             StrategyPromotionDecision.promotion_target == observed_stage,
         )
     )
-    session.execute(
-        delete(StrategyRuntimeLedgerBucket).where(
-            StrategyRuntimeLedgerBucket.run_id == run_id,
-            StrategyRuntimeLedgerBucket.hypothesis_id == hypothesis_id,
-            StrategyRuntimeLedgerBucket.observed_stage == observed_stage,
-        )
-    )
 
     evidence_provenance = (
         "paper_runtime_observed"
@@ -1971,16 +2001,27 @@ def persist_observed_runtime_windows(
         for bucket in raw_buckets
         if bucket.decision_count > 0 or bucket.trade_count > 0 or bucket.order_count > 0
     ]
+    runtime_ledger_replacement_scopes = _runtime_ledger_bucket_replacement_scopes(
+        buckets=sorted_buckets,
+        runtime_payload=runtime_payload,
+    )
+    current_runtime_ledger_bucket_replacement_count = (
+        _delete_current_runtime_ledger_buckets(
+            session=session,
+            run_id=run_id,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            observed_stage=observed_stage,
+            replacement_scopes=runtime_ledger_replacement_scopes,
+        )
+    )
     replaced_runtime_ledger_bucket_count = _delete_replaced_runtime_ledger_buckets(
         session=session,
         run_id=run_id,
         candidate_id=candidate_id,
         hypothesis_id=hypothesis_id,
         observed_stage=observed_stage,
-        replacement_scopes=_runtime_ledger_bucket_replacement_scopes(
-            buckets=sorted_buckets,
-            runtime_payload=runtime_payload,
-        ),
+        replacement_scopes=runtime_ledger_replacement_scopes,
     )
     raw_window_count = len(raw_buckets)
     skipped_zero_activity_window_count = raw_window_count - len(sorted_buckets)
@@ -2362,6 +2403,9 @@ def persist_observed_runtime_windows(
         "evidence_grade_runtime_ledger_bucket_count": len(
             evidence_grade_runtime_ledger_rows
         ),
+        "current_runtime_ledger_bucket_replacement_count": (
+            current_runtime_ledger_bucket_replacement_count
+        ),
         "replaced_runtime_ledger_bucket_count": replaced_runtime_ledger_bucket_count,
         "runtime_ledger_fill_count": sum(
             max(0, int(row.fill_count or 0)) for row in runtime_ledger_rows
@@ -2436,6 +2480,9 @@ def persist_observed_runtime_windows(
             "replaced_runtime_ledger_bucket_count": (
                 replaced_runtime_ledger_bucket_count
             ),
+            "current_runtime_ledger_bucket_replacement_count": (
+                current_runtime_ledger_bucket_replacement_count
+            ),
         }
     )
     return {
@@ -2468,6 +2515,9 @@ def persist_observed_runtime_windows(
         "evidence_blocking_reasons": evidence_blocking_reasons,
         "proof_status": proof_status,
         "proof_blockers": proof_blockers,
+        "current_runtime_ledger_bucket_replacement_count": (
+            current_runtime_ledger_bucket_replacement_count
+        ),
         "replaced_runtime_ledger_bucket_count": replaced_runtime_ledger_bucket_count,
         "runtime_materialization_target": runtime_materialization_target,
         "runtime_observation": runtime_payload,

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, StrategyRuntimeLedgerBucket
+from app.trading.runtime_window_import import (
+    build_observed_runtime_buckets,
+    persist_observed_runtime_windows,
+)
+
+
+def _runtime_pnl_basis() -> dict[str, object]:
+    return {
+        "post_cost_expectancy_basis": "realized_strategy_pnl_after_explicit_costs",
+        "post_cost_promotion_eligible": True,
+    }
+
+
+def _source_backed_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "bucket_started_at": "2026-03-06T14:35:00+00:00",
+        "bucket_ended_at": "2026-03-06T14:36:00+00:00",
+        "account_label": "TORGHUT_SIM",
+        "strategy_id": "microbar-cross-sectional-pairs-v1",
+        "symbol": "AAPL",
+        "fill_count": 2,
+        "decision_count": 2,
+        "submitted_order_count": 2,
+        "cancelled_order_count": 0,
+        "rejected_order_count": 0,
+        "unfilled_order_count": 0,
+        "closed_trade_count": 1,
+        "open_position_count": 0,
+        "filled_notional": "200",
+        "gross_strategy_pnl": "1",
+        "cost_amount": "0.20",
+        "net_strategy_pnl_after_costs": "0.80",
+        "post_cost_expectancy_bps": "40",
+        "ledger_schema_version": "torghut.runtime-ledger-bucket.v1",
+        "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+        "execution_policy_hash_counts": {"policy-sha": 2},
+        "cost_model_hash_counts": {"cost-sha": 2},
+        "lineage_hash_counts": {"lineage-sha": 2},
+        "source_decision_mode_counts": {"strategy_signal_paper": 2},
+        "profit_proof_eligible": True,
+        "source_window_start": "2026-03-06T14:30:00+00:00",
+        "source_window_end": "2026-03-06T15:00:00+00:00",
+        "source_refs": [
+            "postgres:trade_decisions",
+            "postgres:executions",
+            "postgres:execution_order_events",
+            "postgres:order_feed_source_windows",
+        ],
+        "source_row_counts": {
+            "trade_decisions": 2,
+            "executions": 2,
+            "execution_order_events": 2,
+            "order_feed_source_windows": 2,
+        },
+        "trade_decision_ids": ["decision-buy", "decision-sell"],
+        "execution_ids": ["execution-buy", "execution-sell"],
+        "execution_order_event_ids": ["event-fill-buy", "event-fill-sell"],
+        "source_window_ids": ["source-window-buy", "source-window-sell"],
+        "source_offsets": [
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100},
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 101},
+        ],
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
+        "blockers": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _observed_bucket_for_ledger_payload(
+    ledger_payload: dict[str, object],
+):
+    return build_observed_runtime_buckets(
+        bucket_ranges=[
+            (
+                datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                6,
+            )
+        ],
+        decision_times=[datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+        execution_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+        tca_rows=[
+            {
+                "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                "abs_slippage_bps": Decimal("1"),
+                "post_cost_expectancy_bps": Decimal("40"),
+                "runtime_ledger_bucket": ledger_payload,
+                **_runtime_pnl_basis(),
+            }
+        ],
+        continuity_ok=True,
+        drift_ok=True,
+        dependency_quorum_decision="allow",
+    )
+
+
+class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
+    def setUp(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        self.session_local = sessionmaker(
+            bind=engine, expire_on_commit=False, future=True
+        )
+
+    def test_runtime_bucket_materialization_rerun_is_idempotent_for_same_scope(
+        self,
+    ) -> None:
+        first_payload = _source_backed_runtime_ledger_bucket(
+            net_strategy_pnl_after_costs="0.80"
+        )
+        second_payload = _source_backed_runtime_ledger_bucket(
+            net_strategy_pnl_after_costs="1.25"
+        )
+
+        with self.session_local() as session:
+            first_summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="hpairs-runtime-import",
+                candidate_id="c88421d619759b2cfaa6f4d0",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=_observed_bucket_for_ledger_payload(first_payload),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "runtime_ledger_profit_proof_present": True,
+                },
+            )
+            second_summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="hpairs-runtime-import",
+                candidate_id="c88421d619759b2cfaa6f4d0",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=_observed_bucket_for_ledger_payload(second_payload),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "runtime_ledger_profit_proof_present": True,
+                },
+            )
+            session.commit()
+            rows = (
+                session.execute(select(StrategyRuntimeLedgerBucket))
+                .scalars()
+                .all()
+            )
+
+        self.assertEqual(first_summary["current_runtime_ledger_bucket_replacement_count"], 0)
+        self.assertEqual(second_summary["current_runtime_ledger_bucket_replacement_count"], 1)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].account_label, "TORGHUT_SIM")
+        self.assertEqual(
+            rows[0].runtime_strategy_name,
+            "microbar-cross-sectional-pairs-v1",
+        )
+        self.assertEqual(rows[0].net_strategy_pnl_after_costs, Decimal("1.25"))
+
+    def test_runtime_bucket_materialization_keeps_hpairs_account_identity_separate(
+        self,
+    ) -> None:
+        torghut_sim_payload = _source_backed_runtime_ledger_bucket(
+            account_label="TORGHUT_SIM",
+            net_strategy_pnl_after_costs="0.80",
+        )
+        alternate_account_payload = _source_backed_runtime_ledger_bucket(
+            account_label="TORGHUT_SIM_ALT",
+            net_strategy_pnl_after_costs="0.55",
+            trade_decision_ids=["alt-decision-buy", "alt-decision-sell"],
+            execution_ids=["alt-execution-buy", "alt-execution-sell"],
+            execution_order_event_ids=["alt-event-fill-buy", "alt-event-fill-sell"],
+            source_window_ids=["alt-source-window-buy", "alt-source-window-sell"],
+            source_offsets=[
+                {"topic": "alpaca.trade_updates", "partition": 1, "offset": 200},
+                {"topic": "alpaca.trade_updates", "partition": 1, "offset": 201},
+            ],
+        )
+
+        with self.session_local() as session:
+            persist_observed_runtime_windows(
+                session=session,
+                run_id="hpairs-runtime-import",
+                candidate_id="c88421d619759b2cfaa6f4d0",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=_observed_bucket_for_ledger_payload(torghut_sim_payload),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "runtime_ledger_profit_proof_present": True,
+                },
+            )
+            persist_observed_runtime_windows(
+                session=session,
+                run_id="hpairs-runtime-import",
+                candidate_id="c88421d619759b2cfaa6f4d0",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=_observed_bucket_for_ledger_payload(alternate_account_payload),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM_ALT",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "runtime_ledger_profit_proof_present": True,
+                },
+            )
+            session.commit()
+            rows = (
+                session.execute(
+                    select(StrategyRuntimeLedgerBucket).order_by(
+                        StrategyRuntimeLedgerBucket.account_label
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        self.assertEqual([row.account_label for row in rows], ["TORGHUT_SIM", "TORGHUT_SIM_ALT"])
+        self.assertEqual(
+            [row.observed_stage for row in rows],
+            ["paper", "paper"],
+        )
+        self.assertEqual(
+            [row.runtime_strategy_name for row in rows],
+            [
+                "microbar-cross-sectional-pairs-v1",
+                "microbar-cross-sectional-pairs-v1",
+            ],
+        )


### PR DESCRIPTION
## Summary

- Scoped Torghut runtime-ledger bucket replacement to the current source-backed account, runtime strategy, and time window instead of deleting every bucket for the same run/hypothesis/stage.
- Preserved stale-overlap cleanup for older runs while adding a same-run replacement count to runtime materialization summaries.
- Added regression coverage for idempotent same-scope reruns and H-PAIRS/TORGHUT_SIM account identity separation.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed.
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_renew_latest_empirical_promotion_jobs.py -q` — passed, 197 tests.
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger.py app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_renew_latest_empirical_promotion_jobs.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed.
- `git diff --check` — passed.

## Screenshots (if applicable)

N/A — backend runtime-ledger persistence change with automated regression tests.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
