### PR TITLE
feat(torghut): harden paper route roundtrip evidence

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -779,6 +779,50 @@ def _target_is_hpairs(target: Mapping[str, object]) -> bool:
     return False
 
 
+def _target_requires_hpairs_round_trip_identity(target: Mapping[str, object]) -> bool:
+    """Return whether a target is a bounded H-PAIRS collection handoff.
+
+    Historical paper-probation imports can point at already-materialized buckets with
+    legacy metadata. The stricter account/stage/runtime identity contract is for
+    the bounded paper-route/live-paper collection handoff that will submit new
+    TORGHUT_SIM source decisions.
+    """
+
+    if not _target_is_hpairs(target):
+        return False
+    source_kind = _safe_text(target.get("source_kind"))
+    return (
+        source_kind == "paper_route_probe_runtime_observed"
+        or bool(target.get("bounded_evidence_collection_authorized"))
+        or bool(target.get("canary_collection_authorized"))
+    )
+
+
+def _hpairs_round_trip_identity_blockers(target: Mapping[str, object]) -> list[str]:
+    if not _target_requires_hpairs_round_trip_identity(target):
+        return []
+    blockers: list[str] = []
+    if _safe_text(target.get("candidate_id")) is None:
+        blockers.append("paper_route_hpairs_candidate_id_missing")
+    if _safe_text(target.get("hypothesis_id")) is None:
+        blockers.append("paper_route_hpairs_hypothesis_id_missing")
+    account_label = _safe_text(target.get("account_label"))
+    if account_label is None:
+        blockers.append("paper_route_hpairs_account_label_missing")
+    elif account_label != PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL:
+        blockers.append("paper_route_hpairs_torghut_sim_account_required")
+    observed_stage = (_safe_text(target.get("observed_stage")) or "").lower()
+    if observed_stage != "paper":
+        blockers.append("paper_route_hpairs_paper_stage_required")
+    if _safe_text(target.get("runtime_strategy_name")) is None and _safe_text(
+        target.get("strategy_name")
+    ) is None:
+        blockers.append("paper_route_hpairs_runtime_strategy_name_missing")
+    if _safe_text(target.get("source_kind")) is None:
+        blockers.append("paper_route_hpairs_source_kind_missing")
+    return blockers
+
+
 def _target_requires_balanced_pair_probe(target: Mapping[str, object]) -> bool:
     explicit = _safe_text(target.get("paper_route_probe_pair_balance_required"))
     if explicit is not None:
@@ -1117,6 +1161,13 @@ def _target_identity(
         "runtime_ledger_bucket_ref": _safe_text(
             target.get("runtime_ledger_bucket_ref")
         ),
+        "account_stage_runtime_identity": {
+            "account_label": _safe_text(target.get("account_label")),
+            "source_account_label": _safe_text(target.get("source_account_label")),
+            "observed_stage": _safe_text(target.get("observed_stage")) or "paper",
+            "runtime_strategy_name": runtime_strategy_name,
+            "source_kind": _safe_text(target.get("source_kind")),
+        },
         "paper_probation_authorized": bool(target.get("paper_probation_authorized")),
         "paper_probation_authorization_scope": _safe_text(
             target.get("paper_probation_authorization_scope")
@@ -1133,6 +1184,7 @@ def _target_identity(
             or target.get("bounded_evidence_collection_authorized")
         ),
         "capital_promotion_allowed": False,
+        "final_authority_ok": False,
         "source_promotion_allowed": source_promotion_allowed,
         "source_final_promotion_allowed": source_final_promotion_allowed,
         "promotion_allowed": False,
@@ -1769,6 +1821,13 @@ def _next_paper_route_runtime_window_targets(
                 "window_end": _isoformat(window_end),
                 "paper_route_probe_symbols": target_probe_symbols,
             },
+            "account_stage_runtime_identity": {
+                "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+                "source_account_label": source_account_label or "",
+                "observed_stage": "paper",
+                "runtime_strategy_name": canonical_strategy_name or "",
+                "source_kind": "paper_route_probe_runtime_observed",
+            },
             "source_decision_readiness": source_decision_readiness,
             "paper_route_session_readiness_state": _safe_text(
                 session_readiness.get("state")
@@ -1794,6 +1853,7 @@ def _next_paper_route_runtime_window_targets(
             "evidence_collection_ok": evidence_collection_ok,
             "canary_collection_authorized": canary_collection_authorized,
             "capital_promotion_allowed": False,
+            "final_authority_ok": False,
             "bounded_evidence_collection_authorized": canary_collection_authorized,
             "bounded_evidence_collection_scope": (
                 "paper_route_probe_next_session_only"
@@ -2059,6 +2119,15 @@ def _unavailable_source_activity(
         "raw_decision_count": raw_decision_count,
         "lineage_matched_decision_count": lineage_matched_decision_count,
         "lineage_blockers": [],
+        "decision_refs": [],
+        "execution_refs": [],
+        "order_lifecycle_refs": [],
+        "tca_metric_refs": [],
+        "source_reference_blockers": [
+            "source_execution_refs_missing",
+            "source_order_lifecycle_refs_missing",
+            "source_explicit_costs_missing",
+        ],
         "decision_count": lineage_matched_decision_count,
         "execution_count": 0,
         "filled_execution_count": 0,
@@ -2072,6 +2141,11 @@ def _unavailable_source_activity(
         "last_tca_at": None,
         "missing": True,
         "missing_reasons": [missing_reason],
+        "source_lifecycle_blockers": [
+            "source_execution_refs_missing",
+            "source_order_lifecycle_refs_missing",
+            "source_explicit_costs_missing",
+        ],
         "query_unavailable": True,
         "unavailable_source": source,
     }
@@ -2231,6 +2305,16 @@ def _strategy_source_activity(
             "raw_decision_count": 0,
             "lineage_matched_decision_count": 0,
             "lineage_blockers": [],
+            "decision_refs": [],
+            "execution_refs": [],
+            "order_lifecycle_refs": [],
+            "tca_metric_refs": [],
+            "source_reference_blockers": [
+                "source_decision_refs_missing",
+                "source_execution_refs_missing",
+                "source_order_lifecycle_refs_missing",
+                "source_explicit_costs_missing",
+            ],
             "decision_count": 0,
             "execution_count": 0,
             "filled_execution_count": 0,
@@ -2244,6 +2328,12 @@ def _strategy_source_activity(
             "last_tca_at": None,
             "missing": True,
             "missing_reasons": ["strategy_name_missing"],
+            "source_lifecycle_blockers": [
+                "source_decision_refs_missing",
+                "source_execution_refs_missing",
+                "source_order_lifecycle_refs_missing",
+                "source_explicit_costs_missing",
+            ],
         }
 
     decision_stmt = (
@@ -2458,6 +2548,28 @@ def _strategy_source_activity(
         order_event_rows=order_event_rows,
         tca_rows=tca_rows,
     )
+    decision_refs = [str(row.id) for row in decision_rows]
+    execution_refs = [str(row.id) for row in execution_rows]
+    order_lifecycle_refs = [str(row.id) for row in order_event_rows]
+    tca_metric_refs = [str(row.id) for row in tca_rows]
+    source_reference_blockers = _unique_text_items(
+        [
+            *(["source_decision_refs_missing"] if not decision_refs else []),
+            *(["source_execution_refs_missing"] if not execution_refs else []),
+            *(
+                ["source_order_lifecycle_refs_missing"]
+                if not order_lifecycle_refs
+                else []
+            ),
+            *(["source_explicit_costs_missing"] if not tca_metric_refs else []),
+        ]
+    )
+    source_lifecycle_blockers = _unique_text_items(
+        [
+            *_unique_text_items(lifecycle_summary.get("blockers")),
+            *source_reference_blockers,
+        ]
+    )
     return {
         "strategy_name": strategy_name,
         "strategy_lookup_names": strategy_filters,
@@ -2469,6 +2581,11 @@ def _strategy_source_activity(
         "raw_decision_count": raw_decision_count,
         "lineage_matched_decision_count": decision_count,
         "lineage_blockers": lineage_blockers,
+        "decision_refs": decision_refs,
+        "execution_refs": execution_refs,
+        "order_lifecycle_refs": order_lifecycle_refs,
+        "tca_metric_refs": tca_metric_refs,
+        "source_reference_blockers": source_reference_blockers,
         "decision_count": decision_count,
         "execution_count": execution_count,
         "filled_execution_count": filled_execution_count,
@@ -2478,9 +2595,7 @@ def _strategy_source_activity(
         "tca_sample_count": tca_sample_count,
         "submitted_order_count": execution_count,
         "source_lifecycle": lifecycle_summary,
-        "source_lifecycle_blockers": _unique_text_items(
-            lifecycle_summary.get("blockers")
-        ),
+        "source_lifecycle_blockers": source_lifecycle_blockers,
         "last_decision_at": _isoformat(
             decision_rows[0].created_at if decision_rows else None
         ),
@@ -2519,6 +2634,16 @@ def _database_unavailable_source_activity(
         "raw_decision_count": 0,
         "lineage_matched_decision_count": 0,
         "lineage_blockers": [source_blocker],
+        "decision_refs": [],
+        "execution_refs": [],
+        "order_lifecycle_refs": [],
+        "tca_metric_refs": [],
+        "source_reference_blockers": [
+            "source_decision_refs_missing",
+            "source_execution_refs_missing",
+            "source_order_lifecycle_refs_missing",
+            "source_explicit_costs_missing",
+        ],
         "decision_count": 0,
         "execution_count": 0,
         "filled_execution_count": 0,
@@ -2537,6 +2662,12 @@ def _database_unavailable_source_activity(
             "source_decisions_missing",
             "source_executions_missing",
             "source_tca_missing",
+        ],
+        "source_lifecycle_blockers": [
+            "source_decision_refs_missing",
+            "source_execution_refs_missing",
+            "source_order_lifecycle_refs_missing",
+            "source_explicit_costs_missing",
         ],
         "db_load_error": _paper_route_audit_error_payload(
             error_source=error_source,
@@ -3672,6 +3803,7 @@ def _readiness_blockers(
         if str(item).strip()
     )
     if _target_is_hpairs(target) and not bool(source_activity.get("missing")):
+        blockers.update(_hpairs_round_trip_identity_blockers(target))
         blockers.update(
             str(item).strip()
             for item in _as_sequence(source_activity.get("source_lifecycle_blockers"))
@@ -3728,14 +3860,20 @@ def _source_backed_import_ready_metadata(
         "source_backed": True,
         "synthetic_pnl_used": False,
         "decision_count": _safe_int(source_activity.get("decision_count")),
+        "decision_refs": _unique_text_items(source_activity.get("decision_refs")),
         "submitted_order_count": _safe_int(
             source_lifecycle.get("submitted_order_count")
             or source_activity.get("submitted_order_count")
+        ),
+        "execution_refs": _unique_text_items(source_activity.get("execution_refs")),
+        "order_lifecycle_refs": _unique_text_items(
+            source_activity.get("order_lifecycle_refs")
         ),
         "fill_count": _safe_int(source_lifecycle.get("fill_count")),
         "fill_order_event_count": _safe_int(
             source_lifecycle.get("fill_order_event_count")
         ),
+        "tca_metric_refs": _unique_text_items(source_activity.get("tca_metric_refs")),
         "filled_notional": _safe_text(source_lifecycle.get("filled_notional")) or "0",
         "closed_round_trip_evidence": bool(
             source_lifecycle.get("closed_round_trip_evidence")
@@ -3757,6 +3895,7 @@ def _source_backed_import_ready_metadata(
                     else []
                 ),
                 *_unique_text_items(source_activity.get("source_lifecycle_blockers")),
+                *_unique_text_items(source_activity.get("source_reference_blockers")),
                 *_unique_text_items(account_close_state.get("blockers")),
                 *(
                     ["runtime_ledger_evidence_grade_bucket_missing"]
@@ -3917,12 +4056,14 @@ def _target_audit(
             )
             and not evidence_collection_blockers,
             "capital_promotion_allowed": False,
+            "final_authority_ok": False,
             "promotion_allowed": bool(target.get("promotion_allowed")),
             "final_promotion_allowed": bool(target.get("final_promotion_allowed")),
             "blockers": blockers,
             "evidence_collection_blockers": evidence_collection_blockers,
             "promotion_authority": {
                 "allowed": False,
+                "final_authority_ok": False,
                 "reason": "paper_route_evidence_audit_observability_only",
                 "source_promotion_allowed": bool(
                     target.get("source_promotion_allowed")
@@ -3984,6 +4125,16 @@ def _database_unavailable_target_audit(
         "raw_decision_count": 0,
         "lineage_matched_decision_count": 0,
         "lineage_blockers": [source_blocker],
+        "decision_refs": [],
+        "execution_refs": [],
+        "order_lifecycle_refs": [],
+        "tca_metric_refs": [],
+        "source_reference_blockers": [
+            "source_decision_refs_missing",
+            "source_execution_refs_missing",
+            "source_order_lifecycle_refs_missing",
+            "source_explicit_costs_missing",
+        ],
         "decision_count": 0,
         "execution_count": 0,
         "filled_execution_count": 0,
@@ -4002,6 +4153,12 @@ def _database_unavailable_target_audit(
             "source_decisions_missing",
             "source_executions_missing",
             "source_tca_missing",
+        ],
+        "source_lifecycle_blockers": [
+            "source_decision_refs_missing",
+            "source_execution_refs_missing",
+            "source_order_lifecycle_refs_missing",
+            "source_explicit_costs_missing",
         ],
         "db_load_error": error_payload,
     }
@@ -4115,12 +4272,17 @@ def _database_unavailable_target_audit(
         },
         "readiness": {
             "state": "evidence_collection_blocked",
+            "evidence_collection_ok": False,
+            "canary_collection_authorized": False,
+            "capital_promotion_allowed": False,
+            "final_authority_ok": False,
             "promotion_allowed": bool(target.get("promotion_allowed")),
             "final_promotion_allowed": bool(target.get("final_promotion_allowed")),
             "blockers": blockers,
             "evidence_collection_blockers": blockers,
             "promotion_authority": {
                 "allowed": False,
+                "final_authority_ok": False,
                 "reason": "paper_route_evidence_audit_observability_only",
                 "source_promotion_allowed": bool(
                     target.get("source_promotion_allowed")

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -2459,6 +2459,15 @@ class SimpleTradingPipeline(TradingPipeline):
             "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
             "profit_proof_eligible": False,
             "source_kind": _safe_text(target.get("source_kind")),
+            "account_stage_runtime_identity": {
+                "account_label": _safe_text(target.get("account_label")),
+                "source_account_label": _safe_text(target.get("source_account_label")),
+                "observed_stage": _safe_text(target.get("observed_stage")) or "paper",
+                "runtime_strategy_name": _safe_text(
+                    target.get("runtime_strategy_name")
+                ),
+                "source_kind": _safe_text(target.get("source_kind")),
+            },
             "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
             "paper_probation_authorized": bool(
                 target.get("paper_probation_authorized")
@@ -2484,6 +2493,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "bounded_evidence_collection_max_notional": str(max_notional),
             "promotion_allowed": False,
             "final_promotion_authorized": False,
+            "final_authority_ok": False,
             "final_promotion_allowed": False,
             **lineage,
         }
@@ -2654,6 +2664,7 @@ class SimpleTradingPipeline(TradingPipeline):
                     "profit_proof_eligible": False,
                     "promotion_allowed": False,
                     "final_promotion_authorized": False,
+                    "final_authority_ok": False,
                     "final_promotion_allowed": False,
                     **_target_plan_lineage([dict(target)], symbol),
                 }
@@ -2940,6 +2951,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "paper_probation_authorized": True,
             "promotion_allowed": False,
             "final_promotion_authorized": False,
+            "final_authority_ok": False,
             "final_promotion_allowed": False,
             **lineage,
         }

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1642,6 +1642,7 @@ def _runtime_ledger_paper_probation_candidates(
             "evidence_collection_ok": True,
             "canary_collection_authorized": True,
             "capital_promotion_allowed": False,
+            "final_authority_ok": False,
             "final_promotion_allowed": False,
             "paper_probation_reason_codes": [_RUNTIME_LEDGER_PAPER_PROBATION_REASON],
             "paper_probation_target_capital_stage": "shadow",
@@ -1685,6 +1686,7 @@ def _runtime_ledger_source_collection_candidates(
             "evidence_collection_ok": True,
             "canary_collection_authorized": False,
             "capital_promotion_allowed": False,
+            "final_authority_ok": False,
             "final_promotion_allowed": False,
             "source_collection_reason_codes": [
                 reason
@@ -1873,6 +1875,13 @@ def _runtime_ledger_paper_probation_import_plan(
             "strategy_lookup_names": strategy_lookup_names,
             "account_label": account_label,
             "source_account_label": account_label,
+            "account_stage_runtime_identity": {
+                "account_label": account_label,
+                "source_account_label": account_label,
+                "observed_stage": "paper",
+                "runtime_strategy_name": strategy_name,
+                "source_kind": source_kind,
+            },
             "source_dsn_env": source_dsn_env,
             "target_dsn_env": target_dsn_env,
             "dataset_snapshot_ref": dataset_snapshot_ref or "",
@@ -1902,6 +1911,7 @@ def _runtime_ledger_paper_probation_import_plan(
             "evidence_collection_ok": True,
             "canary_collection_authorized": not source_collection,
             "capital_promotion_allowed": False,
+            "final_authority_ok": False,
             "evidence_collection_stage": "paper",
             "probation_allowed": not source_collection,
             "probation_reason": (
@@ -1947,6 +1957,7 @@ def _runtime_ledger_paper_probation_import_plan(
             bool(target.get("canary_collection_authorized")) for target in targets
         ),
         "capital_promotion_allowed": False,
+        "final_authority_ok": False,
         "promotion_allowed": False,
         "final_promotion_authorized": False,
         "final_promotion_allowed": False,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -103,9 +103,38 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     "account_label": "TORGHUT_SIM",
                     "observed_stage": "paper",
                     "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "source_kind": "paper_route_probe_runtime_observed",
                 }
             ),
             [],
+        )
+
+        missing_identity_blockers = _hpairs_round_trip_identity_blockers(
+            {
+                "source_manifest_ref": "H-PAIRS-01",
+                "bounded_evidence_collection_authorized": True,
+            }
+        )
+
+        self.assertIn(
+            "paper_route_hpairs_candidate_id_missing",
+            missing_identity_blockers,
+        )
+        self.assertIn(
+            "paper_route_hpairs_hypothesis_id_missing",
+            missing_identity_blockers,
+        )
+        self.assertIn(
+            "paper_route_hpairs_account_label_missing",
+            missing_identity_blockers,
+        )
+        self.assertIn(
+            "paper_route_hpairs_runtime_strategy_name_missing",
+            missing_identity_blockers,
+        )
+        self.assertIn(
+            "paper_route_hpairs_source_kind_missing",
+            missing_identity_blockers,
         )
 
         blockers = _hpairs_round_trip_identity_blockers(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -129,6 +129,10 @@ class TestPaperRouteEvidenceAudit(TestCase):
             missing_identity_blockers,
         )
         self.assertIn(
+            "paper_route_hpairs_paper_stage_required",
+            missing_identity_blockers,
+        )
+        self.assertIn(
             "paper_route_hpairs_runtime_strategy_name_missing",
             missing_identity_blockers,
         )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -27,6 +27,7 @@ from app.trading.paper_route_evidence import (
     RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
     _account_window_start_snapshot_audit,
     _balanced_pair_probe_symbol_actions,
+    _hpairs_round_trip_identity_blockers,
     _next_regular_equities_session_window,
     _normalized_open_positions,
     _paper_route_probe_summary,
@@ -77,6 +78,79 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
         self.assertEqual(actions, {"AAPL": "sell", "AMZN": "buy"})
         self.assertEqual(_pair_probe_balance_state(actions), "balanced")
+
+    def test_hpairs_bounded_collection_requires_torghut_sim_paper_identity(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _hpairs_round_trip_identity_blockers(
+                {
+                    "hypothesis_id": "H-CONTROL-01",
+                    "candidate_id": "candidate-control",
+                    "account_label": "TORGHUT_SIM",
+                    "observed_stage": "paper",
+                    "runtime_strategy_name": "control-strategy",
+                    "source_kind": "paper_route_probe_runtime_observed",
+                }
+            ),
+            [],
+        )
+        self.assertEqual(
+            _hpairs_round_trip_identity_blockers(
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "candidate-hpairs",
+                    "account_label": "TORGHUT_SIM",
+                    "observed_stage": "paper",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                }
+            ),
+            [],
+        )
+
+        blockers = _hpairs_round_trip_identity_blockers(
+            {
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": "candidate-hpairs",
+                "account_label": "TORGHUT_LIVE",
+                "observed_stage": "live",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "source_kind": "paper_route_probe_runtime_observed",
+            }
+        )
+
+        self.assertIn("paper_route_hpairs_torghut_sim_account_required", blockers)
+        self.assertIn("paper_route_hpairs_paper_stage_required", blockers)
+
+        missing_blockers = _hpairs_round_trip_identity_blockers(
+            {
+                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                "observed_stage": "paper",
+                "bounded_evidence_collection_authorized": True,
+            }
+        )
+        for blocker in (
+            "paper_route_hpairs_candidate_id_missing",
+            "paper_route_hpairs_hypothesis_id_missing",
+            "paper_route_hpairs_account_label_missing",
+            "paper_route_hpairs_runtime_strategy_name_missing",
+            "paper_route_hpairs_source_kind_missing",
+        ):
+            self.assertIn(blocker, missing_blockers)
+
+        self.assertEqual(
+            _hpairs_round_trip_identity_blockers(
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "candidate-hpairs",
+                    "account_label": "TORGHUT_SIM",
+                    "observed_stage": "paper",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "source_kind": "paper_route_probe_runtime_observed",
+                }
+            ),
+            [],
+        )
 
     def test_target_audit_timeout_fails_closed_with_explicit_blockers(self) -> None:
         with Session(self.engine) as session:
@@ -2381,6 +2455,41 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 session.add(execution)
                 session.flush()
                 session.add(
+                    ExecutionOrderEvent(
+                        event_fingerprint=f"flatten-handoff-fill-{index}",
+                        source_topic="trade_updates",
+                        source_partition=0,
+                        source_offset=200 + index,
+                        alpaca_account_label="TORGHUT_SIM",
+                        feed_seq=200 + index,
+                        event_ts=event_at,
+                        symbol=symbol,
+                        alpaca_order_id=f"flatten-handoff-order-{index}",
+                        client_order_id=f"flatten-handoff-{side}-{symbol.lower()}-{index}",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        filled_qty_delta=Decimal("1"),
+                        filled_notional_delta=Decimal("100"),
+                        avg_fill_price=Decimal("100"),
+                        raw_event={
+                            "event": "fill",
+                            "side": side,
+                            "order": {
+                                "id": f"flatten-handoff-order-{index}",
+                                "client_order_id": f"flatten-handoff-{side}-{symbol.lower()}-{index}",
+                                "symbol": symbol,
+                                "side": side,
+                                "status": "filled",
+                            },
+                        },
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        created_at=event_at,
+                    )
+                )
+                session.add(
                     ExecutionTCAMetric(
                         execution_id=execution.id,
                         trade_decision_id=decision.id,
@@ -4126,6 +4235,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     created_at=event_at,
                 )
             )
+            decision_ref = str(decision.id)
+            execution_ref = str(execution.id)
             self._add_flat_account_start_snapshot(
                 session,
                 account_label="TORGHUT_SIM",
@@ -4192,6 +4303,13 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(source_activity["complete_fill_order_event_count"], 1)
         self.assertEqual(source_activity["last_order_event_at"], event_at.isoformat())
         self.assertEqual(source_activity["missing_reasons"], [])
+        self.assertEqual(source_activity["decision_refs"], [decision_ref])
+        self.assertEqual(source_activity["execution_refs"], [execution_ref])
+        self.assertEqual(len(source_activity["order_lifecycle_refs"]), 1)
+        self.assertIn(
+            "source_explicit_costs_missing",
+            source_activity["source_reference_blockers"],
+        )
         import_audit = payload["runtime_window_import_audit"]
         self.assertEqual(import_audit["state"], "import_due_runtime_ledger_missing")
         self.assertEqual(import_audit["counts"]["targets_with_source_activity"], 1)
@@ -4199,6 +4317,157 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "paper_route_source_activity_missing", import_audit["blockers"]
         )
         self.assertNotIn("source_tca_missing", import_audit["blockers"])
+
+    def test_hpairs_collection_blocks_missing_lifecycle_costs_and_flatten(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        event_at = window_start + timedelta(minutes=20)
+        strategy_name = "hpairs-missing-roundtrip"
+        candidate_id = "candidate-hpairs-missing-roundtrip"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="H-PAIRS missing round-trip fixture",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": candidate_id,
+                    "hypothesis_id": "H-PAIRS-01",
+                },
+                rationale="H-PAIRS missing round-trip fixture",
+                status="executed",
+                created_at=event_at,
+                executed_at=event_at,
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="hpairs-missing-roundtrip-order",
+                client_order_id="hpairs-missing-roundtrip-client",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=event_at,
+                updated_at=event_at,
+                last_update_at=event_at,
+            )
+            session.add(execution)
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
+            session.flush()
+            decision_ref = str(decision.id)
+            execution_ref = str(execution.id)
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": candidate_id,
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": strategy_name,
+                                "runtime_strategy_name": strategy_name,
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_active_symbols": ["AAPL", "AMZN"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 2,
+                    },
+                },
+                generated_at=window_end + timedelta(hours=2),
+            )
+
+        source_activity = payload["targets"][0]["source_activity"]
+        self.assertTrue(source_activity["missing"])
+        self.assertEqual(source_activity["decision_refs"], [decision_ref])
+        self.assertEqual(source_activity["execution_refs"], [execution_ref])
+        self.assertEqual(source_activity["order_lifecycle_refs"], [])
+        self.assertIn(
+            "source_order_lifecycle_refs_missing",
+            source_activity["source_reference_blockers"],
+        )
+        self.assertIn(
+            "source_explicit_costs_missing",
+            source_activity["source_reference_blockers"],
+        )
+        for blocker in (
+            "source_order_lifecycle_refs_missing",
+            "source_explicit_costs_missing",
+            "source_close_missing",
+            "source_closed_round_trip_missing",
+        ):
+            self.assertIn(blocker, source_activity["source_lifecycle_blockers"])
+        readiness = payload["targets"][0]["readiness"]
+        self.assertEqual(readiness["state"], "evidence_collection_blocked")
+        self.assertFalse(readiness["evidence_collection_ok"])
+        self.assertFalse(readiness["capital_promotion_allowed"])
+        self.assertFalse(readiness["final_authority_ok"])
+        for blocker in (
+            "source_tca_missing",
+            "runtime_ledger_bucket_missing",
+            "runtime_ledger_evidence_grade_bucket_missing",
+        ):
+            self.assertIn(blocker, readiness["evidence_collection_blockers"])
+        self.assertFalse(readiness["promotion_authority"]["allowed"])
+        self.assertFalse(readiness["promotion_authority"]["final_authority_ok"])
 
     def test_current_paper_route_probe_symbols_extend_next_window_target_scope(
         self,
@@ -5051,6 +5320,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             audit["readiness"]["promotion_authority"],
             {
                 "allowed": False,
+                "final_authority_ok": False,
                 "reason": "paper_route_evidence_audit_observability_only",
                 "source_promotion_allowed": True,
                 "source_final_promotion_allowed": True,

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from decimal import Decimal
 
+from app.config import settings
+from app.models import Strategy
+from app.trading.scheduler.simple_pipeline import SimpleTradingPipeline
 from app.trading.runtime_window_import import (
     _runtime_promotion_blocking_reasons,
     resolve_hypothesis_manifest,
@@ -202,3 +205,47 @@ def test_live_paper_runtime_ledger_close_loop_still_respects_profitability_gates
     )
 
     assert 'runtime_ledger_mean_daily_net_pnl_after_costs_below_target' in final_gate_blockers
+
+
+def test_paper_route_target_metadata_is_collection_only_without_live_capital_mutation() -> None:
+    trading_mode_before = settings.trading_mode
+    target = {
+        'hypothesis_id': 'H-PAIRS-01',
+        'candidate_id': 'c88421d619759b2cfaa6f4d0',
+        'account_label': 'TORGHUT_SIM',
+        'observed_stage': 'paper',
+        'runtime_strategy_name': 'microbar-cross-sectional-pairs-v1',
+        'source_kind': 'paper_route_probe_runtime_observed',
+        'paper_probation_authorized': True,
+        'bounded_evidence_collection_scope': 'paper_route_probe_next_session_only',
+        'paper_route_probe_symbols': ['AAPL', 'AMZN'],
+    }
+
+    metadata = SimpleTradingPipeline._paper_route_target_source_decision_metadata(
+        target=target,
+        strategy=Strategy(
+            name='microbar-cross-sectional-pairs-v1',
+            description='metadata fixture',
+            enabled=True,
+            base_timeframe='1Sec',
+            universe_type='static',
+            universe_symbols=['AAPL', 'AMZN'],
+        ),
+        symbol='AAPL',
+        window_start=datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc),
+        window_end=datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc),
+        max_notional=Decimal('25'),
+    )
+
+    assert settings.trading_mode == trading_mode_before
+    assert metadata['bounded_evidence_collection_authorized'] is True
+    assert metadata['promotion_allowed'] is False
+    assert metadata['final_authority_ok'] is False
+    assert metadata['final_promotion_allowed'] is False
+    assert metadata['account_stage_runtime_identity'] == {
+        'account_label': 'TORGHUT_SIM',
+        'source_account_label': None,
+        'observed_stage': 'paper',
+        'runtime_strategy_name': 'microbar-cross-sectional-pairs-v1',
+        'source_kind': 'paper_route_probe_runtime_observed',
+    }

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -1227,6 +1227,7 @@ class TestSubmissionCouncil(TestCase):
         self.assertTrue(paper_candidates[0]["evidence_collection_ok"])
         self.assertTrue(paper_candidates[0]["canary_collection_authorized"])
         self.assertFalse(paper_candidates[0]["capital_promotion_allowed"])
+        self.assertFalse(paper_candidates[0]["final_authority_ok"])
         self.assertFalse(paper_candidates[0]["final_promotion_allowed"])
         self.assertEqual(paper_candidates[0]["max_notional"], "0")
         import_plan = gate["runtime_ledger_paper_probation_import_plan"]
@@ -1241,6 +1242,7 @@ class TestSubmissionCouncil(TestCase):
         self.assertTrue(import_plan["evidence_collection_ok"])
         self.assertTrue(import_plan["canary_collection_authorized"])
         self.assertFalse(import_plan["capital_promotion_allowed"])
+        self.assertFalse(import_plan["final_authority_ok"])
         self.assertFalse(import_plan["final_promotion_allowed"])
         target = import_plan["targets"][0]
         self.assertEqual(target["hypothesis_id"], "H-PAIRS-01")
@@ -1279,6 +1281,7 @@ class TestSubmissionCouncil(TestCase):
         self.assertTrue(target["evidence_collection_ok"])
         self.assertTrue(target["canary_collection_authorized"])
         self.assertFalse(target["capital_promotion_allowed"])
+        self.assertFalse(target["final_authority_ok"])
         self.assertEqual(target["promotion_allowed"], False)
         self.assertEqual(target["final_promotion_authorized"], False)
         self.assertEqual(target["final_promotion_allowed"], False)


### PR DESCRIPTION
## Summary

- Added explicit H-PAIRS bounded paper-route identity checks for TORGHUT_SIM paper collection handoffs.
- Exposed source-backed decision, execution, order-lifecycle, and TCA refs with fail-closed blockers for missing lifecycle, explicit costs, closed round trips, and flatten proof.
- Kept evidence collection separate from capital/final promotion by carrying `final_authority_ok: false` through paper-route audit, submission council plans, and simple-pipeline metadata.
- Added regression coverage for H-PAIRS identity, missing lifecycle/cost blockers, collection-only promotion state, and no live-capital setting mutation.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_completion_trace.py tests/test_simple_pipeline.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/submission_council.py app/trading/completion.py app/trading/scheduler/simple_pipeline.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_completion_trace.py tests/test_simple_pipeline.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
