### PR TITLE
feat(torghut): add hpairs microstructure prefilter

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -5800,7 +5800,7 @@ def compile_candidate_specs(
                     "required_max_drawdown": "900",
                     "required_min_regime_slice_pass_rate": "0.45",
                 }
-                parameter_space = {
+                parameter_space: dict[str, Any] = {
                     "mode": "bounded_grid",
                     "source": "whitepaper_autoresearch",
                     "family_selection_rank": family_rank,
@@ -5819,6 +5819,30 @@ def compile_candidate_specs(
                     "requires_shadow_validation": True,
                     "promotion_policy": "research_only",
                 }
+                if family_template_id == "microbar_cross_sectional_pairs_v1":
+                    feature_contract["hpairs_microstructure_prefilter_contract"] = {
+                        "schema_version": "torghut.hpairs-microstructure-prefilter-contract.v1",
+                        "clusterlob_adapter": "consume_lob_or_microbar_order_flow_fields_only",
+                        "fallback_policy": (
+                            "deterministic_microbar_order_flow_fallback_with_explicit_blockers"
+                        ),
+                        "horizon_ofi_microbars": [3, 12, 36],
+                        "ranking_authority": "candidate_discovery_prefilter_only",
+                    }
+                    parameter_space["hpairs_microstructure_prefilter"] = {
+                        "enabled": True,
+                        "bounded_frontier_handoff": True,
+                        "proof_source": "prefilter_only",
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                    promotion_contract.update(
+                        {
+                            "hpairs_microstructure_prefilter_is_not_promotion_proof": True,
+                            "hpairs_microstructure_prefilter_requires_exact_replay": True,
+                            "hpairs_microstructure_prefilter_requires_runtime_ledger": True,
+                        }
+                    )
                 if validation_requirements:
                     promotion_contract["validation_requirement_claim_ids"] = [
                         str(item.get("claim_id"))

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timezone
 from decimal import Decimal
 from typing import Any, cast
@@ -12,17 +12,23 @@ import numpy as np
 from numpy.typing import NDArray
 
 from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.discovery.microstructure_prefilter import (
+    HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
+    HPAIRS_PREFILTER_PROOF_SOURCE,
+    build_hpairs_microstructure_prefilter,
+)
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v3"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v4"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v4"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v5"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
 FAST_REPLAY_TARGET_NET_PNL_PER_DAY = Decimal("500")
 FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "cluster_lob_event_clustering_proxy",
+    "bounded_hpairs_clusterlob_ofi_candidate_prefilter",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -59,6 +65,9 @@ class FastReplayPreviewRow:
     square_root_impact_capacity_penalty_bps: Decimal
     exploration_score: Decimal
     frontier_bucket: str
+    microstructure_prefilter: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
 
     def to_payload(self) -> dict[str, Any]:
@@ -101,6 +110,10 @@ class FastReplayPreviewRow:
             ),
             "exploration_score": str(self.exploration_score),
             "frontier_bucket": self.frontier_bucket,
+            "microstructure_prefilter": dict(self.microstructure_prefilter),
+            "hpairs_microstructure_prefilter": dict(self.microstructure_prefilter),
+            "proof_source": HPAIRS_PREFILTER_PROOF_SOURCE,
+            "hpairs_prefilter_proof_semantics_label": HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
             "observed_post_cost_expectancy_bps": str(observed_post_cost_expectancy_bps),
             "required_daily_notional": str(required_daily_notional)
             if required_daily_notional is not None
@@ -143,6 +156,8 @@ class FastReplayPreviewRow:
             "promotion_proof": False,
             "proof_authority": False,
             "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
             "proof_authority_reason": (
                 "fast_replay_preview_rank_only_exact_replay_and_source_backed_runtime_ledger_required"
             ),
@@ -160,6 +175,9 @@ class FastReplayPreviewResult:
     exploitation_candidate_count: int
     exploration_candidate_count: int
     exact_replay_candidate_cap: int
+    hpairs_microstructure_prefilter: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
 
     def to_manifest_payload(self) -> dict[str, Any]:
         return {
@@ -172,6 +190,7 @@ class FastReplayPreviewResult:
             "proof_semantics_label": FAST_REPLAY_PROOF_SEMANTICS_LABEL,
             "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
             "implemented_mechanisms": {
+                "hpairs_clusterlob_ofi_prefilter": "deterministic bounded H-PAIRS candidate prefilter metadata only; never promotion authority",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -184,6 +203,9 @@ class FastReplayPreviewResult:
                 "source_backed_runtime_ledger_proof_required",
                 "live_paper_runtime_evidence_required_for_final_promotion",
             ],
+            "hpairs_microstructure_prefilter": dict(
+                self.hpairs_microstructure_prefilter
+            ),
             "requested_top_k": self.requested_top_k,
             "exact_replay_candidate_cap": self.exact_replay_candidate_cap,
             "exploitation_candidate_count": self.exploitation_candidate_count,
@@ -258,6 +280,18 @@ def build_fast_replay_preview(
         min(bounded_top_k - bounded_exploitation_count, int(exploration_count)),
     )
     symbol_stats = _build_symbol_stats(rows)
+    hpairs_prefilter = build_hpairs_microstructure_prefilter(
+        specs=specs,
+        rows=rows,
+        top_k=bounded_top_k,
+        min_rows_per_candidate=max(1, int(min_rows_per_candidate)),
+        exploitation_count=bounded_exploitation_count,
+        exploration_count=bounded_exploration_count,
+        exact_replay_candidate_cap=bounded_top_k,
+    )
+    hpairs_prefilter_payload_by_spec = {
+        row.candidate_spec_id: row.to_payload() for row in hpairs_prefilter.rows
+    }
     scored_rows: list[FastReplayPreviewRow] = []
     for spec in specs:
         scored_rows.append(
@@ -265,16 +299,25 @@ def build_fast_replay_preview(
                 spec=spec,
                 symbol_stats=symbol_stats,
                 min_rows_per_candidate=max(1, int(min_rows_per_candidate)),
+                microstructure_prefilter=hpairs_prefilter_payload_by_spec.get(
+                    spec.candidate_spec_id, {}
+                ),
             )
         )
 
     ranked_rows = sorted(scored_rows, key=_preview_rank_key)
-    selected_bucket_by_id = _select_frontier_buckets(
-        ranked_rows=ranked_rows,
-        exploitation_count=bounded_exploitation_count,
-        exploration_count=bounded_exploration_count,
-        exact_replay_candidate_cap=bounded_top_k,
-    )
+    selected_bucket_by_id = {
+        row.candidate_spec_id: row.frontier_bucket
+        for row in hpairs_prefilter.rows
+        if row.selected
+    }
+    if not selected_bucket_by_id:
+        selected_bucket_by_id = _select_frontier_buckets(
+            ranked_rows=ranked_rows,
+            exploitation_count=bounded_exploitation_count,
+            exploration_count=bounded_exploration_count,
+            exact_replay_candidate_cap=bounded_top_k,
+        )
     final_rows = tuple(
         _row_with_rank_and_selection(
             row=row,
@@ -301,6 +344,7 @@ def build_fast_replay_preview(
             1 for row in final_rows if row.frontier_bucket == "exploration"
         ),
         exact_replay_candidate_cap=bounded_top_k,
+        hpairs_microstructure_prefilter=hpairs_prefilter.to_manifest_payload(),
     )
 
 
@@ -385,6 +429,7 @@ def _score_candidate_spec(
     spec: CandidateSpec,
     symbol_stats: Mapping[str, _SymbolTapeStats],
     min_rows_per_candidate: int,
+    microstructure_prefilter: Mapping[str, Any],
 ) -> FastReplayPreviewRow:
     requested_symbols = _candidate_symbols(spec)
     matched = [
@@ -424,6 +469,7 @@ def _score_candidate_spec(
             square_root_impact_capacity_penalty_bps=Decimal("0"),
             exploration_score=Decimal("0"),
             frontier_bucket="not_selected",
+            microstructure_prefilter=dict(microstructure_prefilter),
         )
 
     return_vectors = [stat.returns_bps for stat in matched if stat.returns_bps.size]
@@ -495,6 +541,11 @@ def _score_candidate_spec(
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
+    hpairs_prefilter_score = _float_or_none(
+        microstructure_prefilter.get("prefilter_score")
+    )
+    if hpairs_prefilter_score is not None:
+        preview_score = preview_score * 0.65 + hpairs_prefilter_score * 0.35
     exploration_score = (
         cluster_lob_activity_score * 4.0
         + abs(ofi_decay_alignment_score) * 5.0
@@ -536,13 +587,17 @@ def _score_candidate_spec(
         ),
         exploration_score=_decimal_from_float(exploration_score),
         frontier_bucket="not_selected",
+        microstructure_prefilter=dict(microstructure_prefilter),
     )
 
 
 def _preview_rank_key(row: FastReplayPreviewRow) -> tuple[bool, float, str]:
+    prefilter_score = _float_or_none(
+        row.microstructure_prefilter.get("prefilter_score")
+    )
     return (
         row.selection_reason == "insufficient_replay_tape_rows",
-        -float(row.preview_score),
+        -(prefilter_score if prefilter_score is not None else float(row.preview_score)),
         row.candidate_spec_id,
     )
 
@@ -616,6 +671,7 @@ def _row_with_rank_and_selection(
         square_root_impact_capacity_penalty_bps=row.square_root_impact_capacity_penalty_bps,
         exploration_score=row.exploration_score,
         frontier_bucket=frontier_bucket,
+        microstructure_prefilter=dict(row.microstructure_prefilter),
         proof_semantics_label=row.proof_semantics_label,
     )
 

--- a/services/torghut/app/trading/discovery/microstructure_prefilter.py
+++ b/services/torghut/app/trading/discovery/microstructure_prefilter.py
@@ -1,0 +1,1193 @@
+"""Bounded H-PAIRS ClusterLOB/OFI candidate prefiltering.
+
+The scores in this module are discovery metadata only. They intentionally rank
+candidate specs for a bounded exact-replay handoff and never create promotion
+or runtime-ledger authority.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import timezone
+from decimal import Decimal
+from math import exp, isfinite, log, sqrt
+from typing import Any, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.models import SignalEnvelope
+
+HPAIRS_PREFILTER_SCHEMA_VERSION = "torghut.hpairs-microstructure-prefilter.v1"
+HPAIRS_PREFILTER_ROW_SCHEMA_VERSION = "torghut.hpairs-microstructure-prefilter-row.v1"
+HPAIRS_PREFILTER_PROOF_SOURCE = "prefilter_only"
+HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL = (
+    "hpairs_clusterlob_ofi_prefilter_only_exact_replay_and_runtime_ledger_required"
+)
+HPAIRS_FAMILY_TEMPLATE_ID = "microbar_cross_sectional_pairs_v1"
+HPAIRS_RUNTIME_STRATEGY_NAME = "microbar-cross-sectional-pairs-v1"
+HPAIRS_AUTHORITY_BLOCKERS = (
+    "prefilter_only_not_promotion_proof",
+    "exact_replay_required",
+    "source_backed_runtime_ledger_required",
+    "live_paper_runtime_evidence_required",
+    "source_window_source_ref_complete_live_paper_evidence_required",
+)
+HPAIRS_HORIZONS = (3, 12, 36)
+
+
+@dataclass(frozen=True)
+class MicrostructureCandidatePrefilterRow:
+    candidate_spec_id: str
+    rank: int
+    prefilter_score: Decimal
+    exploitation_score: Decimal
+    exploration_score: Decimal
+    selected: bool
+    frontier_bucket: str
+    selection_reason: str
+    is_hpairs_candidate: bool
+    matched_row_count: int
+    matched_symbol_count: int
+    requested_symbol_count: int
+    trading_day_count: int
+    source_fields: tuple[str, ...]
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    horizon_ofi_features: Mapping[str, Any]
+    cluster_behavior: Mapping[str, Any]
+    regime_stress_veto: Mapping[str, Any]
+    proof_source: str = HPAIRS_PREFILTER_PROOF_SOURCE
+    proof_semantics_label: str = HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL
+    promotion_allowed: bool = False
+    final_promotion_allowed: bool = False
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": HPAIRS_PREFILTER_ROW_SCHEMA_VERSION,
+            "candidate_spec_id": self.candidate_spec_id,
+            "rank": self.rank,
+            "prefilter_score": str(self.prefilter_score),
+            "exploitation_score": str(self.exploitation_score),
+            "exploration_score": str(self.exploration_score),
+            "selected": self.selected,
+            "frontier_bucket": self.frontier_bucket,
+            "selection_reason": self.selection_reason,
+            "is_hpairs_candidate": self.is_hpairs_candidate,
+            "matched_row_count": self.matched_row_count,
+            "matched_symbol_count": self.matched_symbol_count,
+            "requested_symbol_count": self.requested_symbol_count,
+            "trading_day_count": self.trading_day_count,
+            "source_fields": list(self.source_fields),
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "horizon_ofi_features": dict(self.horizon_ofi_features),
+            "cluster_behavior": dict(self.cluster_behavior),
+            "regime_stress_veto": dict(self.regime_stress_veto),
+            "proof_source": self.proof_source,
+            "proof_semantics_label": self.proof_semantics_label,
+            "promotion_allowed": self.promotion_allowed,
+            "final_promotion_allowed": self.final_promotion_allowed,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "authority": "not_promotion_proof",
+            "authority_blockers": list(HPAIRS_AUTHORITY_BLOCKERS),
+        }
+
+
+@dataclass(frozen=True)
+class MicrostructurePrefilterResult:
+    rows: tuple[MicrostructureCandidatePrefilterRow, ...]
+    selected_candidate_spec_ids: tuple[str, ...]
+    requested_top_k: int
+    input_candidate_count: int
+    selected_row_count: int
+    exploitation_candidate_count: int
+    exploration_candidate_count: int
+    exact_replay_candidate_cap: int
+
+    def to_manifest_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": HPAIRS_PREFILTER_SCHEMA_VERSION,
+            "status": "prefilter_only",
+            "proof_source": HPAIRS_PREFILTER_PROOF_SOURCE,
+            "proof_semantics_label": HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "authority": "not_promotion_proof",
+            "authority_blockers": list(HPAIRS_AUTHORITY_BLOCKERS),
+            "mechanisms": [
+                "cluster_lob_event_behavior_bucket_prefilter",
+                "horizon_specific_ofi_shock_memory_prefilter",
+                "microbar_order_flow_fallback_when_lob_absent",
+                "regime_stress_veto_metadata",
+                "bounded_exploitation_plus_exploration_handoff",
+            ],
+            "requested_top_k": self.requested_top_k,
+            "exact_replay_candidate_cap": self.exact_replay_candidate_cap,
+            "input_candidate_count": self.input_candidate_count,
+            "selected_row_count": self.selected_row_count,
+            "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
+            "selected_candidate_spec_count": len(self.selected_candidate_spec_ids),
+            "exploitation_candidate_count": self.exploitation_candidate_count,
+            "exploration_candidate_count": self.exploration_candidate_count,
+        }
+
+
+@dataclass(frozen=True)
+class _SymbolMicrostructureStats:
+    symbol: str
+    row_count: int
+    trading_day_count: int
+    source_fields: tuple[str, ...]
+    warnings: tuple[str, ...]
+    blockers: tuple[str, ...]
+    returns_bps: NDArray[np.float64]
+    median_price: float
+    ofi_values: NDArray[np.float64]
+    spread_values: NDArray[np.float64]
+    volume_values: NDArray[np.float64]
+    microprice_bias_bps: NDArray[np.float64]
+    event_labels: tuple[str, ...]
+    horizon_features: Mapping[str, Any]
+    cluster_behavior: Mapping[str, Any]
+    regime_stress_veto: Mapping[str, Any]
+
+
+def build_hpairs_microstructure_prefilter(
+    *,
+    specs: Sequence[CandidateSpec],
+    rows: Sequence[SignalEnvelope],
+    top_k: int,
+    min_rows_per_candidate: int = 2,
+    exploitation_count: int | None = None,
+    exploration_count: int = 0,
+    exact_replay_candidate_cap: int | None = None,
+) -> MicrostructurePrefilterResult:
+    """Rank H-PAIRS specs with deterministic ClusterLOB/OFI preview metadata.
+
+    Full LOB data is optional. When it is absent, the adapter falls back to
+    available microbar/order-flow fields and records explicit non-authoritative
+    warnings or blockers instead of inventing evidence.
+    """
+
+    bounded_top_k = max(1, min(len(specs) or 1, int(top_k)))
+    if exact_replay_candidate_cap is not None:
+        bounded_top_k = max(1, min(bounded_top_k, int(exact_replay_candidate_cap)))
+    bounded_exploitation_count = (
+        bounded_top_k
+        if exploitation_count is None
+        else max(0, min(bounded_top_k, int(exploitation_count)))
+    )
+    bounded_exploration_count = max(
+        0,
+        min(bounded_top_k - bounded_exploitation_count, int(exploration_count)),
+    )
+
+    stats_by_symbol = _build_symbol_microstructure_stats(rows)
+    scored_rows = tuple(
+        _score_spec(
+            spec=spec,
+            stats_by_symbol=stats_by_symbol,
+            min_rows_per_candidate=max(1, int(min_rows_per_candidate)),
+        )
+        for spec in specs
+    )
+    ranked = sorted(scored_rows, key=_rank_key)
+    selected_bucket_by_id = _select_frontier_buckets(
+        ranked_rows=ranked,
+        exploitation_count=bounded_exploitation_count,
+        exploration_count=bounded_exploration_count,
+        exact_replay_candidate_cap=bounded_top_k,
+    )
+    final_rows = tuple(
+        _with_rank_and_bucket(
+            row=row,
+            rank=index,
+            frontier_bucket=selected_bucket_by_id.get(
+                row.candidate_spec_id, "not_selected"
+            ),
+        )
+        for index, row in enumerate(ranked, start=1)
+    )
+    return MicrostructurePrefilterResult(
+        rows=final_rows,
+        selected_candidate_spec_ids=tuple(
+            row.candidate_spec_id for row in final_rows if row.selected
+        ),
+        requested_top_k=bounded_top_k,
+        input_candidate_count=len(specs),
+        selected_row_count=len(rows),
+        exploitation_candidate_count=sum(
+            1 for row in final_rows if row.frontier_bucket == "exploitation"
+        ),
+        exploration_candidate_count=sum(
+            1 for row in final_rows if row.frontier_bucket == "exploration"
+        ),
+        exact_replay_candidate_cap=bounded_top_k,
+    )
+
+
+def _build_symbol_microstructure_stats(
+    rows: Sequence[SignalEnvelope],
+) -> dict[str, _SymbolMicrostructureStats]:
+    rows_by_symbol: dict[str, list[SignalEnvelope]] = {}
+    for row in rows:
+        symbol = row.symbol.strip().upper()
+        if symbol:
+            rows_by_symbol.setdefault(symbol, []).append(row)
+
+    stats: dict[str, _SymbolMicrostructureStats] = {}
+    for symbol, symbol_rows in rows_by_symbol.items():
+        ordered = sorted(symbol_rows, key=lambda item: item.event_ts)
+        source_fields: set[str] = set()
+        prices = [_extract_price(row, source_fields=source_fields) for row in ordered]
+        price_array = np.asarray(
+            [price for price in prices if price is not None and price > 0.0],
+            dtype=np.float64,
+        )
+        returns = (
+            np.diff(price_array) / price_array[:-1] * 10_000.0
+            if price_array.size >= 2
+            else np.asarray([], dtype=np.float64)
+        )
+        spread_values = np.asarray(
+            [
+                spread
+                for row in ordered
+                if (spread := _extract_spread_bps(row, source_fields=source_fields))
+                is not None
+            ],
+            dtype=np.float64,
+        )
+        ofi_values = np.asarray(
+            [
+                ofi
+                for row in ordered
+                if (ofi := _extract_ofi_pressure(row, source_fields=source_fields))
+                is not None
+            ],
+            dtype=np.float64,
+        )
+        microprice_bias = np.asarray(
+            [
+                bias
+                for row in ordered
+                if (
+                    bias := _extract_microprice_bias_bps(
+                        row, source_fields=source_fields
+                    )
+                )
+                is not None
+            ],
+            dtype=np.float64,
+        )
+        volume_values = np.asarray(
+            [
+                volume
+                for row in ordered
+                if (volume := _extract_volume(row, source_fields=source_fields))
+                is not None
+            ],
+            dtype=np.float64,
+        )
+        event_labels = tuple(
+            _event_label(row, source_fields=source_fields) for row in ordered
+        )
+        stress_values = [
+            stress
+            for row in ordered
+            if (stress := _extract_regime_stress(row, source_fields=source_fields))
+            is not None
+        ]
+        blockers, warnings = _source_field_diagnostics(
+            row_count=len(ordered),
+            prices=price_array,
+            returns=returns,
+            spread_values=spread_values,
+            ofi_values=ofi_values,
+            microprice_bias=microprice_bias,
+            volume_values=volume_values,
+            event_labels=event_labels,
+            stress_values=stress_values,
+        )
+        horizon_features = _horizon_ofi_features(ofi_values)
+        cluster_behavior = _cluster_behavior(
+            event_labels=event_labels,
+            ofi_values=ofi_values,
+            microprice_bias_bps=microprice_bias,
+            has_cluster_fields="cluster_lob_label" in source_fields
+            or "order_cluster" in source_fields
+            or "lob_event_type" in source_fields,
+        )
+        regime_stress_veto = _regime_stress_veto(
+            spread_values=spread_values,
+            returns_bps=returns,
+            volume_values=volume_values,
+            stress_values=stress_values,
+        )
+        stats[symbol] = _SymbolMicrostructureStats(
+            symbol=symbol,
+            row_count=len(ordered),
+            trading_day_count=len(
+                {row.event_ts.astimezone(timezone.utc).date() for row in ordered}
+            ),
+            source_fields=tuple(sorted(source_fields)),
+            warnings=warnings,
+            blockers=blockers,
+            returns_bps=returns,
+            median_price=_percentile(price_array, 50.0),
+            ofi_values=ofi_values,
+            spread_values=spread_values,
+            volume_values=volume_values,
+            microprice_bias_bps=microprice_bias,
+            event_labels=event_labels,
+            horizon_features=horizon_features,
+            cluster_behavior=cluster_behavior,
+            regime_stress_veto=regime_stress_veto,
+        )
+    return stats
+
+
+def _score_spec(
+    *,
+    spec: CandidateSpec,
+    stats_by_symbol: Mapping[str, _SymbolMicrostructureStats],
+    min_rows_per_candidate: int,
+) -> MicrostructureCandidatePrefilterRow:
+    requested_symbols = _candidate_symbols(spec)
+    matched = [
+        stat for symbol in requested_symbols if (stat := stats_by_symbol.get(symbol))
+    ]
+    is_hpairs_candidate = _is_hpairs_candidate(spec)
+    matched_row_count = sum(stat.row_count for stat in matched)
+    matched_symbol_count = len(matched)
+    requested_symbol_count = len(requested_symbols)
+    blockers: set[str] = set(HPAIRS_AUTHORITY_BLOCKERS)
+    warnings: set[str] = set()
+    source_fields: set[str] = set()
+    for stat in matched:
+        blockers.update(stat.blockers)
+        warnings.update(stat.warnings)
+        source_fields.update(stat.source_fields)
+    if not is_hpairs_candidate:
+        blockers.add("not_hpairs_candidate")
+    if matched_row_count < min_rows_per_candidate or not matched:
+        blockers.add("insufficient_replay_tape_rows")
+
+    if not matched or matched_row_count < min_rows_per_candidate:
+        return MicrostructureCandidatePrefilterRow(
+            candidate_spec_id=spec.candidate_spec_id,
+            rank=0,
+            prefilter_score=Decimal("-1000000"),
+            exploitation_score=Decimal("-1000000"),
+            exploration_score=Decimal("-1000000"),
+            selected=False,
+            frontier_bucket="not_selected",
+            selection_reason="insufficient_replay_tape_rows",
+            is_hpairs_candidate=is_hpairs_candidate,
+            matched_row_count=matched_row_count,
+            matched_symbol_count=matched_symbol_count,
+            requested_symbol_count=requested_symbol_count,
+            trading_day_count=max(
+                (stat.trading_day_count for stat in matched), default=0
+            ),
+            source_fields=tuple(sorted(source_fields)),
+            blockers=tuple(sorted(blockers)),
+            warnings=tuple(sorted(warnings)),
+            horizon_ofi_features=_empty_horizon_features(),
+            cluster_behavior=_empty_cluster_behavior(),
+            regime_stress_veto=_empty_regime_stress_veto(),
+        )
+
+    direction = _candidate_direction(spec)
+    returns = _concat_arrays(tuple(stat.returns_bps for stat in matched))
+    signed_returns = (
+        returns * direction if returns.size else np.asarray([], dtype=np.float64)
+    )
+    ofi_values = _concat_arrays(tuple(stat.ofi_values for stat in matched))
+    spread_values = _concat_arrays(tuple(stat.spread_values for stat in matched))
+    volume_values = _concat_arrays(tuple(stat.volume_values for stat in matched))
+    microprice_bias = _concat_arrays(
+        tuple(stat.microprice_bias_bps for stat in matched)
+    )
+    event_labels = tuple(label for stat in matched for label in stat.event_labels)
+    horizon_features = _merged_horizon_features(matched, direction=direction)
+    cluster_behavior = _cluster_behavior(
+        event_labels=event_labels,
+        ofi_values=ofi_values,
+        microprice_bias_bps=microprice_bias,
+        has_cluster_fields=any(
+            "cluster_lob_label" in stat.source_fields
+            or "order_cluster" in stat.source_fields
+            or "lob_event_type" in stat.source_fields
+            for stat in matched
+        ),
+    )
+    regime_stress_veto = _regime_stress_veto(
+        spread_values=spread_values,
+        returns_bps=returns,
+        volume_values=volume_values,
+        stress_values=[
+            float(stat.regime_stress_veto.get("input_stress_score") or 0.0)
+            for stat in matched
+        ],
+    )
+    if float(regime_stress_veto["veto_score"]) >= 0.65:
+        blockers.add("regime_stress_veto_active")
+    elif float(regime_stress_veto["veto_score"]) > 0.0:
+        warnings.add("regime_stress_veto_metadata_nonzero")
+
+    signed_return_bps = _mean(signed_returns)
+    return_tail_abs_bps = _percentile(np.abs(returns), 95.0)
+    median_spread_bps = _percentile(spread_values, 50.0)
+    spread_tail_bps = _percentile(spread_values, 95.0)
+    volume_score = _volume_score(volume_values)
+    coverage_score = matched_symbol_count / max(1, requested_symbol_count)
+    ofi_alignment = float(horizon_features["directional_alignment_score"])
+    ofi_shock = float(horizon_features["shock_score"])
+    ofi_memory = float(horizon_features["memory_score"])
+    cluster_score = float(cluster_behavior["cluster_score"])
+    stress_veto = float(regime_stress_veto["veto_score"])
+    microprice_alignment = direction * _mean(microprice_bias)
+    capacity_penalty = _capacity_penalty_bps(
+        spec=spec,
+        median_price=_weighted_average(
+            tuple((stat.median_price, stat.row_count) for stat in matched)
+        ),
+        median_volume=_percentile(volume_values, 50.0),
+        median_spread_bps=median_spread_bps,
+    )
+    exploitation_score = (
+        signed_return_bps
+        + ofi_alignment * 18.0
+        + ofi_shock * 9.0
+        + ofi_memory * 6.0
+        + cluster_score * 12.0
+        + microprice_alignment * 0.25
+        + coverage_score * 15.0
+        + volume_score * 5.0
+        - median_spread_bps * 0.06
+        - spread_tail_bps * 0.04
+        - return_tail_abs_bps * 0.025
+        - capacity_penalty * 0.18
+        - stress_veto * 30.0
+    )
+    exploration_score = (
+        abs(ofi_shock) * 12.0
+        + abs(ofi_memory) * 8.0
+        + cluster_score * 10.0
+        + volume_score * 4.0
+        + coverage_score * 8.0
+        - stress_veto * 12.0
+        - capacity_penalty * 0.06
+    )
+    prefilter_score = (
+        exploitation_score if is_hpairs_candidate else exploitation_score - 1_000.0
+    )
+    return MicrostructureCandidatePrefilterRow(
+        candidate_spec_id=spec.candidate_spec_id,
+        rank=0,
+        prefilter_score=_decimal(prefilter_score),
+        exploitation_score=_decimal(exploitation_score),
+        exploration_score=_decimal(exploration_score),
+        selected=False,
+        frontier_bucket="not_selected",
+        selection_reason="hpairs_microstructure_prefilter_ranked",
+        is_hpairs_candidate=is_hpairs_candidate,
+        matched_row_count=matched_row_count,
+        matched_symbol_count=matched_symbol_count,
+        requested_symbol_count=requested_symbol_count,
+        trading_day_count=max((stat.trading_day_count for stat in matched), default=0),
+        source_fields=tuple(sorted(source_fields)),
+        blockers=tuple(sorted(blockers)),
+        warnings=tuple(sorted(warnings)),
+        horizon_ofi_features=horizon_features,
+        cluster_behavior=cluster_behavior,
+        regime_stress_veto=regime_stress_veto,
+    )
+
+
+def _rank_key(
+    row: MicrostructureCandidatePrefilterRow,
+) -> tuple[bool, bool, float, str]:
+    return (
+        not row.is_hpairs_candidate,
+        row.selection_reason == "insufficient_replay_tape_rows",
+        -float(row.prefilter_score),
+        row.candidate_spec_id,
+    )
+
+
+def _select_frontier_buckets(
+    *,
+    ranked_rows: Sequence[MicrostructureCandidatePrefilterRow],
+    exploitation_count: int,
+    exploration_count: int,
+    exact_replay_candidate_cap: int,
+) -> dict[str, str]:
+    eligible = [
+        row
+        for row in ranked_rows
+        if row.is_hpairs_candidate
+        and row.selection_reason != "insufficient_replay_tape_rows"
+    ]
+    selected: dict[str, str] = {}
+    for row in eligible[:exploitation_count]:
+        if len(selected) >= exact_replay_candidate_cap:
+            break
+        selected[row.candidate_spec_id] = "exploitation"
+    exploration_pool = sorted(
+        (row for row in eligible if row.candidate_spec_id not in selected),
+        key=lambda row: (-float(row.exploration_score), row.candidate_spec_id),
+    )
+    for row in exploration_pool[:exploration_count]:
+        if len(selected) >= exact_replay_candidate_cap:
+            break
+        selected[row.candidate_spec_id] = "exploration"
+    for row in eligible:
+        if len(selected) >= exact_replay_candidate_cap:
+            break
+        selected.setdefault(row.candidate_spec_id, "exploitation_backfill")
+    return selected
+
+
+def _with_rank_and_bucket(
+    *, row: MicrostructureCandidatePrefilterRow, rank: int, frontier_bucket: str
+) -> MicrostructureCandidatePrefilterRow:
+    selected = frontier_bucket != "not_selected"
+    selection_reason = row.selection_reason
+    if selected:
+        selection_reason = f"hpairs_microstructure_prefilter_{frontier_bucket}_selected"
+    return MicrostructureCandidatePrefilterRow(
+        candidate_spec_id=row.candidate_spec_id,
+        rank=rank,
+        prefilter_score=row.prefilter_score,
+        exploitation_score=row.exploitation_score,
+        exploration_score=row.exploration_score,
+        selected=selected,
+        frontier_bucket=frontier_bucket,
+        selection_reason=selection_reason,
+        is_hpairs_candidate=row.is_hpairs_candidate,
+        matched_row_count=row.matched_row_count,
+        matched_symbol_count=row.matched_symbol_count,
+        requested_symbol_count=row.requested_symbol_count,
+        trading_day_count=row.trading_day_count,
+        source_fields=row.source_fields,
+        blockers=row.blockers,
+        warnings=row.warnings,
+        horizon_ofi_features=row.horizon_ofi_features,
+        cluster_behavior=row.cluster_behavior,
+        regime_stress_veto=row.regime_stress_veto,
+    )
+
+
+def _source_field_diagnostics(
+    *,
+    row_count: int,
+    prices: NDArray[np.float64],
+    returns: NDArray[np.float64],
+    spread_values: NDArray[np.float64],
+    ofi_values: NDArray[np.float64],
+    microprice_bias: NDArray[np.float64],
+    volume_values: NDArray[np.float64],
+    event_labels: Sequence[str],
+    stress_values: Sequence[float],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    blockers: set[str] = set()
+    warnings: set[str] = set()
+    if row_count <= 0:
+        blockers.add("missing_replay_tape_rows")
+    if prices.size < 2 or returns.size == 0:
+        blockers.add("missing_price_return_microbar_fields")
+    if ofi_values.size == 0:
+        blockers.add("missing_ofi_or_depth_fields")
+    if spread_values.size == 0:
+        warnings.add("missing_spread_fields")
+    if microprice_bias.size == 0:
+        warnings.add("missing_microprice_fields")
+    if volume_values.size == 0:
+        warnings.add("missing_volume_fields")
+    if not event_labels or set(event_labels) == {"unknown"}:
+        warnings.add("missing_cluster_lob_event_fields_using_microbar_fallback")
+    if not stress_values:
+        warnings.add("missing_regime_stress_veto_fields")
+    return tuple(sorted(blockers)), tuple(sorted(warnings))
+
+
+def _horizon_ofi_features(values: NDArray[np.float64]) -> dict[str, Any]:
+    if values.size == 0:
+        return _empty_horizon_features()
+    horizon_payload: dict[str, dict[str, str]] = {}
+    ewma_values: dict[int, float] = {}
+    for horizon in HPAIRS_HORIZONS:
+        ewma_value = _ewma_last(values, half_life=float(horizon))
+        ewma_values[horizon] = ewma_value
+        recent = values[-min(values.size, horizon) :]
+        baseline = values[: max(0, values.size - horizon)]
+        baseline_mean = _mean(baseline)
+        shock = _mean(recent) - baseline_mean if baseline.size else _mean(recent)
+        horizon_payload[f"{horizon}_microbars"] = {
+            "ewma": str(_decimal(ewma_value)),
+            "shock": str(_decimal(shock)),
+            "memory": str(_decimal(baseline_mean)),
+            "sample_count": str(min(values.size, horizon)),
+        }
+    short = ewma_values[HPAIRS_HORIZONS[0]]
+    medium = ewma_values[HPAIRS_HORIZONS[1]]
+    long = ewma_values[HPAIRS_HORIZONS[2]]
+    shock_score = float(np.clip(short - long, -1.0, 1.0))
+    memory_score = float(np.clip(0.65 * medium + 0.35 * long, -1.0, 1.0))
+    return {
+        "status": "available",
+        "horizons": horizon_payload,
+        "shock_score": str(_decimal(shock_score)),
+        "memory_score": str(_decimal(memory_score)),
+        "directional_alignment_score": str(
+            _decimal(0.6 * shock_score + 0.4 * memory_score)
+        ),
+        "source": "available_ofi_or_depth_fields",
+    }
+
+
+def _merged_horizon_features(
+    stats: Sequence[_SymbolMicrostructureStats], *, direction: float
+) -> dict[str, Any]:
+    values = _concat_arrays(tuple(stat.ofi_values for stat in stats))
+    features = _horizon_ofi_features(values)
+    alignment = float(features["directional_alignment_score"])
+    return {
+        **features,
+        "directional_alignment_score": str(_decimal(direction * alignment)),
+        "candidate_direction": "continuation" if direction > 0 else "reversal",
+    }
+
+
+def _empty_horizon_features() -> dict[str, Any]:
+    return {
+        "status": "missing_inputs",
+        "horizons": {},
+        "shock_score": "0",
+        "memory_score": "0",
+        "directional_alignment_score": "0",
+        "source": "missing_ofi_or_depth_fields",
+    }
+
+
+def _cluster_behavior(
+    *,
+    event_labels: Sequence[str],
+    ofi_values: NDArray[np.float64],
+    microprice_bias_bps: NDArray[np.float64],
+    has_cluster_fields: bool,
+) -> dict[str, Any]:
+    entropy = _normalized_entropy(event_labels)
+    pressure = _mean(np.abs(ofi_values))
+    burstiness = (
+        _percentile(np.abs(np.diff(ofi_values)), 75.0) if ofi_values.size >= 3 else 0.0
+    )
+    microprice = _mean(microprice_bias_bps)
+    cluster_score = float(
+        np.clip(
+            0.30 * entropy
+            + 0.40 * pressure
+            + 0.20 * burstiness
+            + 0.10 * min(1.0, abs(microprice) / 5.0),
+            0.0,
+            1.0,
+        )
+    )
+    dominant_label = _dominant_label(event_labels)
+    if pressure >= 0.25 and microprice >= 0.0:
+        behavior_bucket = "clusterlob_accumulation"
+    elif pressure >= 0.25 and microprice < 0.0:
+        behavior_bucket = "clusterlob_distribution"
+    elif burstiness >= 0.20:
+        behavior_bucket = "clusterlob_bursty_order_flow"
+    else:
+        behavior_bucket = "balanced_microbar_flow"
+    source = (
+        "cluster_lob_fields" if has_cluster_fields else "microbar_order_flow_fallback"
+    )
+    return {
+        "status": "available" if ofi_values.size else "missing_ofi_inputs",
+        "behavior_bucket": behavior_bucket,
+        "dominant_event_label": dominant_label,
+        "cluster_score": str(_decimal(cluster_score)),
+        "event_entropy": str(_decimal(entropy)),
+        "ofi_abs_pressure": str(_decimal(pressure)),
+        "ofi_burstiness": str(_decimal(burstiness)),
+        "microprice_bias_bps": str(_decimal(microprice)),
+        "source": source,
+    }
+
+
+def _empty_cluster_behavior() -> dict[str, Any]:
+    return {
+        "status": "missing_inputs",
+        "behavior_bucket": "unknown",
+        "dominant_event_label": "unknown",
+        "cluster_score": "0",
+        "event_entropy": "0",
+        "ofi_abs_pressure": "0",
+        "ofi_burstiness": "0",
+        "microprice_bias_bps": "0",
+        "source": "missing_cluster_lob_and_order_flow_fields",
+    }
+
+
+def _regime_stress_veto(
+    *,
+    spread_values: NDArray[np.float64],
+    returns_bps: NDArray[np.float64],
+    volume_values: NDArray[np.float64],
+    stress_values: Sequence[float],
+) -> dict[str, Any]:
+    spread_tail_bps = _percentile(spread_values, 95.0)
+    return_tail_bps = _percentile(np.abs(returns_bps), 95.0)
+    liquidity_score = _volume_score(volume_values)
+    input_stress_score = (
+        float(np.clip(_mean(np.asarray(stress_values, dtype=np.float64)), 0.0, 1.0))
+        if stress_values
+        else 0.0
+    )
+    spread_stress = float(np.clip(max(0.0, spread_tail_bps - 12.0) / 38.0, 0.0, 1.0))
+    return_stress = float(np.clip(max(0.0, return_tail_bps - 35.0) / 115.0, 0.0, 1.0))
+    liquidity_stress = (
+        float(np.clip(1.0 - liquidity_score, 0.0, 1.0)) if volume_values.size else 0.0
+    )
+    veto_score = float(
+        np.clip(
+            max(
+                input_stress_score,
+                0.45 * spread_stress + 0.35 * return_stress + 0.20 * liquidity_stress,
+            ),
+            0.0,
+            1.0,
+        )
+    )
+    return {
+        "status": "available"
+        if stress_values or spread_values.size or returns_bps.size
+        else "missing_inputs",
+        "veto_score": str(_decimal(veto_score)),
+        "veto_active": veto_score >= 0.65,
+        "input_stress_score": str(_decimal(input_stress_score)),
+        "spread_tail_bps": str(_decimal(spread_tail_bps)),
+        "return_tail_abs_bps": str(_decimal(return_tail_bps)),
+        "liquidity_score": str(_decimal(liquidity_score)),
+        "source": "source_fields_plus_microbar_stress_fallback"
+        if stress_values
+        else "microbar_regime_fallback_missing_explicit_stress_fields",
+    }
+
+
+def _empty_regime_stress_veto() -> dict[str, Any]:
+    return {
+        "status": "missing_inputs",
+        "veto_score": "0",
+        "veto_active": False,
+        "input_stress_score": "0",
+        "spread_tail_bps": "0",
+        "return_tail_abs_bps": "0",
+        "liquidity_score": "0",
+        "source": "missing_regime_stress_fields",
+    }
+
+
+def _extract_price(signal: SignalEnvelope, *, source_fields: set[str]) -> float | None:
+    payload = signal.payload
+    for key in ("price", "mid_price", "mid", "mark", "last_price", "close"):
+        value = _float_or_none(payload.get(key))
+        if value is not None and value > 0.0:
+            source_fields.add(key)
+            return value
+    bid = _float_or_none(payload.get("bid"))
+    ask = _float_or_none(payload.get("ask"))
+    if bid is not None and ask is not None and bid > 0.0 and ask > 0.0:
+        source_fields.update(("bid", "ask"))
+        return (bid + ask) / 2.0
+    return None
+
+
+def _extract_spread_bps(
+    signal: SignalEnvelope, *, source_fields: set[str]
+) -> float | None:
+    payload = signal.payload
+    explicit = _float_or_none(payload.get("spread_bps"))
+    if explicit is not None:
+        source_fields.add("spread_bps")
+        return max(0.0, explicit)
+    bid = _float_or_none(payload.get("bid"))
+    ask = _float_or_none(payload.get("ask"))
+    if bid is not None and ask is not None and bid > 0.0 and ask >= bid:
+        source_fields.update(("bid", "ask"))
+        return (ask - bid) / ((ask + bid) / 2.0) * 10_000.0
+    spread = _float_or_none(payload.get("spread"))
+    price = _extract_price(signal, source_fields=source_fields)
+    if spread is not None and price is not None and price > 0.0:
+        source_fields.add("spread")
+        return max(0.0, spread / price * 10_000.0)
+    return None
+
+
+def _extract_ofi_pressure(
+    signal: SignalEnvelope, *, source_fields: set[str]
+) -> float | None:
+    payload = signal.payload
+    for key in (
+        "ofi_pressure_score",
+        "order_flow_imbalance",
+        "ofi",
+        "signed_order_flow_imbalance",
+        "queue_imbalance",
+        "book_imbalance",
+        "depth_imbalance",
+    ):
+        value = _float_or_none(payload.get(key))
+        if value is None:
+            continue
+        source_fields.add(key)
+        if -1.0 <= value <= 1.0:
+            return value
+        return float(np.tanh(value / 100.0))
+    return _extract_quote_depth_imbalance(signal, source_fields=source_fields)
+
+
+def _extract_quote_depth_imbalance(
+    signal: SignalEnvelope, *, source_fields: set[str]
+) -> float | None:
+    payload = signal.payload
+    bid_size, bid_key = _first_float_with_key(
+        payload,
+        (
+            "bid_size",
+            "bid_qty",
+            "best_bid_size",
+            "best_bid_qty",
+            "bid_depth",
+            "bid_volume",
+        ),
+    )
+    ask_size, ask_key = _first_float_with_key(
+        payload,
+        (
+            "ask_size",
+            "ask_qty",
+            "best_ask_size",
+            "best_ask_qty",
+            "ask_depth",
+            "ask_volume",
+        ),
+    )
+    if (
+        bid_size is None
+        or ask_size is None
+        or bid_size < 0.0
+        or ask_size < 0.0
+        or bid_size + ask_size <= 0.0
+    ):
+        return None
+    if bid_key is not None:
+        source_fields.add(bid_key)
+    if ask_key is not None:
+        source_fields.add(ask_key)
+    return float(np.clip((bid_size - ask_size) / (bid_size + ask_size), -1.0, 1.0))
+
+
+def _extract_microprice_bias_bps(
+    signal: SignalEnvelope, *, source_fields: set[str]
+) -> float | None:
+    payload = signal.payload
+    bid, bid_key = _first_float_with_key(
+        payload, ("bid", "best_bid", "bid_price", "best_bid_price")
+    )
+    ask, ask_key = _first_float_with_key(
+        payload, ("ask", "best_ask", "ask_price", "best_ask_price")
+    )
+    explicit_microprice, microprice_key = _first_float_with_key(
+        payload, ("microprice", "micro_price")
+    )
+    price = _extract_price(signal, source_fields=source_fields)
+    if explicit_microprice is not None and price is not None and price > 0.0:
+        if microprice_key is not None:
+            source_fields.add(microprice_key)
+        return (explicit_microprice - price) / price * 10_000.0
+
+    bid_size, bid_size_key = _first_float_with_key(
+        payload, ("bid_size", "bid_qty", "best_bid_size", "best_bid_qty")
+    )
+    ask_size, ask_size_key = _first_float_with_key(
+        payload, ("ask_size", "ask_qty", "best_ask_size", "best_ask_qty")
+    )
+    if (
+        bid is None
+        or ask is None
+        or bid <= 0.0
+        or ask <= 0.0
+        or ask < bid
+        or bid_size is None
+        or ask_size is None
+        or bid_size < 0.0
+        or ask_size < 0.0
+        or bid_size + ask_size <= 0.0
+    ):
+        return None
+    for key in (bid_key, ask_key, bid_size_key, ask_size_key):
+        if key is not None:
+            source_fields.add(key)
+    mid = (bid + ask) / 2.0
+    microprice = (ask * bid_size + bid * ask_size) / (bid_size + ask_size)
+    return (microprice - mid) / mid * 10_000.0
+
+
+def _extract_volume(signal: SignalEnvelope, *, source_fields: set[str]) -> float | None:
+    payload = signal.payload
+    value, key = _first_float_with_key(
+        payload,
+        ("microbar_volume", "bar_volume", "trade_volume", "volume", "qty", "size"),
+        positive=True,
+    )
+    if value is not None and key is not None:
+        source_fields.add(key)
+    return value
+
+
+def _event_label(signal: SignalEnvelope, *, source_fields: set[str]) -> str:
+    payload = signal.payload
+    for key in (
+        "cluster_lob_label",
+        "order_cluster",
+        "lob_event_type",
+        "event_type",
+        "order_event_type",
+        "side",
+        "liquidity_side",
+    ):
+        value = str(payload.get(key) or "").strip().lower()
+        if value:
+            source_fields.add(key)
+            return value
+    return "unknown"
+
+
+def _extract_regime_stress(
+    signal: SignalEnvelope, *, source_fields: set[str]
+) -> float | None:
+    payload = signal.payload
+    for key in (
+        "regime_stress_score",
+        "stress_veto_score",
+        "macro_news_stress_score",
+        "macro_stress_score",
+        "news_stress_score",
+        "macro_event_window",
+        "macro_announcement_window",
+        "news_event_window",
+        "stress_veto_window",
+        "volatility_shock_veto",
+    ):
+        if key not in payload:
+            continue
+        source_fields.add(key)
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return 1.0 if value else 0.0
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return float(np.clip(parsed, 0.0, 1.0))
+        text = str(value).strip().lower()
+        if text in {"yes", "true", "macro", "news", "event", "stress", "veto"}:
+            return 1.0
+        if text in {"no", "false", "none", "normal"}:
+            return 0.0
+    return None
+
+
+def _candidate_symbols(spec: CandidateSpec) -> tuple[str, ...]:
+    raw = spec.strategy_overrides.get("universe_symbols")
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+        raw_symbols = cast(Sequence[Any], raw)
+        symbols = tuple(
+            sorted({_string(item).upper() for item in raw_symbols if _string(item)})
+        )
+        if symbols:
+            return symbols
+    return (spec.runtime_strategy_name.upper(),)
+
+
+def _candidate_direction(spec: CandidateSpec) -> float:
+    params = _mapping(spec.strategy_overrides.get("params"))
+    text = " ".join(
+        item
+        for item in (
+            spec.runtime_strategy_name,
+            spec.family_template_id,
+            _string(params.get("selection_mode")),
+            _string(params.get("signal_motif")),
+            _string(params.get("rank_feature")),
+        )
+        if item
+    ).lower()
+    if any(
+        token in text for token in ("reversal", "rebound", "washout", "mean_revert")
+    ):
+        return -1.0
+    return 1.0
+
+
+def _is_hpairs_candidate(spec: CandidateSpec) -> bool:
+    return (
+        spec.family_template_id == HPAIRS_FAMILY_TEMPLATE_ID
+        or spec.runtime_strategy_name == HPAIRS_RUNTIME_STRATEGY_NAME
+    )
+
+
+def _candidate_notional(spec: CandidateSpec) -> float:
+    return _float_or_none(spec.strategy_overrides.get("max_notional_per_trade")) or 0.0
+
+
+def _capacity_penalty_bps(
+    *,
+    spec: CandidateSpec,
+    median_price: float,
+    median_volume: float,
+    median_spread_bps: float,
+) -> float:
+    notional = _candidate_notional(spec)
+    if notional <= 0.0:
+        return 0.0
+    dollar_volume = max(0.0, median_price) * max(0.0, median_volume)
+    if dollar_volume <= 0.0:
+        return 25.0 + median_spread_bps
+    participation = notional / dollar_volume
+    return float(
+        np.clip(
+            sqrt(max(0.0, participation)) * 100.0 + median_spread_bps * 0.25, 0.0, 500.0
+        )
+    )
+
+
+def _volume_score(values: NDArray[np.float64]) -> float:
+    if values.size == 0:
+        return 0.0
+    return float(
+        np.clip(log(1.0 + max(0.0, _percentile(values, 50.0))) / 12.0, 0.0, 1.0)
+    )
+
+
+def _weighted_average(values: Sequence[tuple[float, int]]) -> float:
+    total_weight = sum(max(0, weight) for _, weight in values)
+    if total_weight <= 0:
+        return 0.0
+    return sum(value * max(0, weight) for value, weight in values) / total_weight
+
+
+def _ewma_last(values: NDArray[np.float64], *, half_life: float) -> float:
+    if values.size == 0:
+        return 0.0
+    decay = log(2.0) / max(1.0, half_life)
+    total = 0.0
+    weighted = 0.0
+    for distance, value in enumerate(reversed(values.tolist())):
+        weight = exp(-decay * float(distance))
+        total += weight
+        weighted += float(value) * weight
+    if total <= 0.0:
+        return 0.0
+    return float(np.clip(weighted / total, -1.0, 1.0))
+
+
+def _normalized_entropy(labels: Sequence[str]) -> float:
+    clean = [label for label in labels if label and label != "unknown"]
+    if not clean:
+        return 0.0
+    counts = Counter(clean)
+    if len(counts) <= 1:
+        return 0.0
+    probabilities = np.asarray(
+        [count / len(clean) for count in counts.values()], dtype=np.float64
+    )
+    entropy = -float(np.sum(probabilities * np.log(probabilities)))
+    return float(np.clip(entropy / np.log(len(counts)), 0.0, 1.0))
+
+
+def _dominant_label(labels: Sequence[str]) -> str:
+    clean = [label for label in labels if label and label != "unknown"]
+    if not clean:
+        return "unknown"
+    return sorted(Counter(clean).items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _concat_arrays(arrays: Sequence[NDArray[np.float64]]) -> NDArray[np.float64]:
+    non_empty = [array for array in arrays if array.size]
+    if not non_empty:
+        return np.asarray([], dtype=np.float64)
+    return np.concatenate(non_empty)
+
+
+def _first_float_with_key(
+    payload: Mapping[str, Any], keys: Sequence[str], *, positive: bool = False
+) -> tuple[float | None, str | None]:
+    for key in keys:
+        value = _float_or_none(payload.get(key))
+        if value is None:
+            continue
+        if positive and value <= 0.0:
+            continue
+        return value, key
+    return None, None
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(parsed):
+        return None
+    return parsed
+
+
+def _mean(values: NDArray[np.float64]) -> float:
+    return float(np.mean(values)) if values.size else 0.0
+
+
+def _percentile(values: NDArray[np.float64], percentile: float) -> float:
+    return float(np.percentile(values, percentile)) if values.size else 0.0
+
+
+def _decimal(value: float) -> Decimal:
+    return Decimal(str(round(float(value), 8)))
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    mapping = cast(Mapping[Any, Any], value)
+    return {str(key): item for key, item in mapping.items()}
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "HPAIRS_AUTHORITY_BLOCKERS",
+    "HPAIRS_FAMILY_TEMPLATE_ID",
+    "HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL",
+    "HPAIRS_PREFILTER_PROOF_SOURCE",
+    "HPAIRS_PREFILTER_ROW_SCHEMA_VERSION",
+    "HPAIRS_PREFILTER_SCHEMA_VERSION",
+    "HPAIRS_RUNTIME_STRATEGY_NAME",
+    "MicrostructureCandidatePrefilterRow",
+    "MicrostructurePrefilterResult",
+    "build_hpairs_microstructure_prefilter",
+]

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6537,6 +6537,23 @@ def _apply_fast_replay_preview_narrowing(
             updated["fast_replay_proof_semantics_label"] = preview_row[
                 "proof_semantics_label"
             ]
+            microstructure_prefilter = _mapping(
+                preview_row.get("hpairs_microstructure_prefilter")
+                or preview_row.get("microstructure_prefilter")
+            )
+            if microstructure_prefilter:
+                updated["hpairs_microstructure_prefilter_rank"] = (
+                    microstructure_prefilter.get("rank")
+                )
+                updated["hpairs_microstructure_prefilter_score"] = (
+                    microstructure_prefilter.get("prefilter_score")
+                )
+                updated["hpairs_microstructure_behavior_bucket"] = _mapping(
+                    microstructure_prefilter.get("cluster_behavior")
+                ).get("behavior_bucket")
+                updated["hpairs_microstructure_proof_source"] = (
+                    microstructure_prefilter.get("proof_source")
+                )
         if candidate_spec_id in original_selected_ids:
             updated["pre_fast_replay_preview_selected_for_replay"] = bool(
                 row.get("selected_for_replay")
@@ -6694,6 +6711,10 @@ def _bounded_sim_target_queue_metadata(
                 ),
                 "risk_flags": list(cast(Sequence[Any], row.get("risk_flags") or ())),
                 "proof_semantics_label": row.get("proof_semantics_label"),
+                "hpairs_microstructure_prefilter": row.get(
+                    "hpairs_microstructure_prefilter"
+                )
+                or row.get("microstructure_prefilter"),
                 "promotion_proof": False,
                 "proof_authority": False,
                 "promotion_authority": False,

--- a/services/torghut/tests/test_microstructure_prefilter.py
+++ b/services/torghut/tests/test_microstructure_prefilter.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.discovery.microstructure_prefilter import (
+    HPAIRS_AUTHORITY_BLOCKERS,
+    HPAIRS_PREFILTER_PROOF_SOURCE,
+    build_hpairs_microstructure_prefilter,
+)
+from app.trading.models import SignalEnvelope
+
+
+def _spec(
+    candidate_spec_id: str,
+    *,
+    symbol: str,
+    family_template_id: str = "microbar_cross_sectional_pairs_v1",
+) -> CandidateSpec:
+    return CandidateSpec(
+        schema_version="torghut.candidate-spec.v1",
+        candidate_spec_id=candidate_spec_id,
+        hypothesis_id=f"hyp-{candidate_spec_id}",
+        family_template_id=family_template_id,
+        candidate_kind="sleeve",
+        runtime_family="microbar_cross_sectional_pairs",
+        runtime_strategy_name=(
+            "microbar-cross-sectional-pairs-v1"
+            if family_template_id == "microbar_cross_sectional_pairs_v1"
+            else "breakout-continuation-long-v1"
+        ),
+        feature_contract={"mechanism": "test"},
+        parameter_space={},
+        strategy_overrides={
+            "max_notional_per_trade": "5000",
+            "universe_symbols": [symbol],
+            "params": {
+                "selection_mode": "continuation",
+                "signal_motif": "vwap_close_continuation",
+                "rank_feature": "cross_section_vwap_w5m_rank",
+            },
+        },
+        objective={"target_net_pnl_per_day": "500"},
+        hard_vetoes={},
+        expected_failure_modes=(),
+        promotion_contract={},
+    )
+
+
+def _row(
+    minute: int,
+    symbol: str,
+    price: str,
+    *,
+    ofi: str | None = None,
+    bid_size: str = "200",
+    ask_size: str = "80",
+    event_label: str | None = "buy_absorption",
+    stress: str | None = "0",
+) -> SignalEnvelope:
+    bid = Decimal(price) - Decimal("0.01")
+    ask = Decimal(price) + Decimal("0.01")
+    payload: dict[str, object] = {
+        "bid": bid,
+        "ask": ask,
+        "bid_size": Decimal(bid_size),
+        "ask_size": Decimal(ask_size),
+        "microbar_volume": Decimal("15000"),
+    }
+    if ofi is not None:
+        payload["order_flow_imbalance"] = Decimal(ofi)
+    if event_label is not None:
+        payload["cluster_lob_label"] = event_label
+    if stress is not None:
+        payload["regime_stress_score"] = Decimal(stress)
+    return SignalEnvelope(
+        event_ts=datetime(2026, 2, 23, 15, minute, tzinfo=timezone.utc),
+        symbol=symbol,
+        timeframe="1Sec",
+        source="test",
+        payload=payload,
+    )
+
+
+class MicrostructurePrefilterTest(TestCase):
+    def test_deterministic_hpairs_ranking_prefers_ofi_clustered_candidate(self) -> None:
+        specs = (_spec("weak", symbol="AAPL"), _spec("strong", symbol="NVDA"))
+        rows = (
+            _row(30, "NVDA", "100.00", ofi="0.20"),
+            _row(31, "NVDA", "100.12", ofi="0.35", event_label="buy_sweep"),
+            _row(32, "NVDA", "100.28", ofi="0.55", event_label="buy_sweep"),
+            _row(30, "AAPL", "200.00", ofi="-0.10", event_label="sell_sweep"),
+            _row(31, "AAPL", "199.95", ofi="-0.08", event_label="sell_sweep"),
+            _row(32, "AAPL", "199.90", ofi="-0.06", event_label="sell_sweep"),
+        )
+
+        first = build_hpairs_microstructure_prefilter(
+            specs=specs,
+            rows=rows,
+            top_k=2,
+            exploitation_count=1,
+            exploration_count=1,
+            exact_replay_candidate_cap=2,
+        )
+        second = build_hpairs_microstructure_prefilter(
+            specs=specs,
+            rows=rows,
+            top_k=2,
+            exploitation_count=1,
+            exploration_count=1,
+            exact_replay_candidate_cap=2,
+        )
+
+        self.assertEqual(
+            [row.to_payload() for row in first.rows],
+            [row.to_payload() for row in second.rows],
+        )
+        self.assertEqual(first.rows[0].candidate_spec_id, "strong")
+        self.assertEqual(first.rows[0].frontier_bucket, "exploitation")
+        self.assertEqual(first.rows[1].frontier_bucket, "exploration")
+        self.assertEqual(len(first.selected_candidate_spec_ids), 2)
+
+    def test_missing_source_fields_emit_blockers_without_fabricated_scores(
+        self,
+    ) -> None:
+        result = build_hpairs_microstructure_prefilter(
+            specs=(_spec("missing", symbol="NVDA"),),
+            rows=(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    payload={"note": "no price or order flow"},
+                ),
+            ),
+            top_k=1,
+            min_rows_per_candidate=1,
+        )
+
+        payload = result.rows[0].to_payload()
+        self.assertIn("missing_price_return_microbar_fields", payload["blockers"])
+        self.assertIn("missing_ofi_or_depth_fields", payload["blockers"])
+        self.assertIn(
+            "missing_cluster_lob_event_fields_using_microbar_fallback",
+            payload["warnings"],
+        )
+        self.assertEqual(payload["horizon_ofi_features"]["status"], "missing_inputs")
+        self.assertEqual(payload["proof_source"], HPAIRS_PREFILTER_PROOF_SOURCE)
+
+    def test_prefilter_metadata_never_grants_promotion_authority(self) -> None:
+        result = build_hpairs_microstructure_prefilter(
+            specs=(_spec("authority", symbol="NVDA"),),
+            rows=(
+                _row(30, "NVDA", "100.00", ofi="0.20"),
+                _row(31, "NVDA", "100.20", ofi="0.40"),
+            ),
+            top_k=1,
+        )
+        manifest = result.to_manifest_payload()
+        row = result.rows[0].to_payload()
+
+        self.assertFalse(manifest["promotion_allowed"])
+        self.assertFalse(manifest["final_promotion_allowed"])
+        self.assertFalse(row["promotion_allowed"])
+        self.assertFalse(row["final_promotion_allowed"])
+        self.assertFalse(row["proof_authority"])
+        for blocker in HPAIRS_AUTHORITY_BLOCKERS:
+            self.assertIn(blocker, row["authority_blockers"])
+
+    def test_frontier_size_is_bounded_to_exploitation_plus_exploration_cap(
+        self,
+    ) -> None:
+        specs = tuple(
+            _spec(f"spec-{index}", symbol=symbol)
+            for index, symbol in enumerate(("NVDA", "AAPL", "AMD", "INTC"))
+        )
+        rows = tuple(
+            item
+            for symbol, base in (
+                ("NVDA", "100"),
+                ("AAPL", "200"),
+                ("AMD", "120"),
+                ("INTC", "30"),
+            )
+            for item in (
+                _row(30, symbol, base, ofi="0.20"),
+                _row(31, symbol, str(Decimal(base) + Decimal("0.10")), ofi="0.30"),
+            )
+        )
+
+        result = build_hpairs_microstructure_prefilter(
+            specs=specs,
+            rows=rows,
+            top_k=4,
+            exploitation_count=3,
+            exploration_count=3,
+            exact_replay_candidate_cap=2,
+        )
+
+        self.assertEqual(result.exact_replay_candidate_cap, 2)
+        self.assertLessEqual(len(result.selected_candidate_spec_ids), 2)
+        self.assertEqual(sum(1 for row in result.rows if row.selected), 2)
+
+    def test_hpairs_metadata_surfaces_horizons_behavior_and_stress_veto(self) -> None:
+        result = build_hpairs_microstructure_prefilter(
+            specs=(_spec("metadata", symbol="NVDA"),),
+            rows=(
+                _row(30, "NVDA", "100.00", ofi="0.10", stress="0.20"),
+                _row(
+                    31,
+                    "NVDA",
+                    "100.03",
+                    ofi="0.20",
+                    event_label="buy_sweep",
+                    stress="0.20",
+                ),
+                _row(
+                    32,
+                    "NVDA",
+                    "100.08",
+                    ofi="0.55",
+                    event_label="buy_sweep",
+                    stress="0.20",
+                ),
+            ),
+            top_k=1,
+        )
+
+        payload = result.rows[0].to_payload()
+        self.assertIn("3_microbars", payload["horizon_ofi_features"]["horizons"])
+        self.assertIn("12_microbars", payload["horizon_ofi_features"]["horizons"])
+        self.assertIn("36_microbars", payload["horizon_ofi_features"]["horizons"])
+        self.assertEqual(payload["cluster_behavior"]["source"], "cluster_lob_fields")
+        self.assertIn("behavior_bucket", payload["cluster_behavior"])
+        self.assertEqual(payload["regime_stress_veto"]["status"], "available")
+        self.assertEqual(payload["proof_source"], "prefilter_only")

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4750,8 +4750,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             queue_payload["replay_tape"]["feature_schema_hash"],
             "feature-schema-frontier",
         )
-        self.assertEqual(queue_payload["replay_tape"]["cost_model_hash"], "cost-model-frontier")
-        self.assertEqual(queue_payload["replay_tape"]["strategy_family"], "hpairs-frontier-family")
+        self.assertEqual(
+            queue_payload["replay_tape"]["cost_model_hash"], "cost-model-frontier"
+        )
+        self.assertEqual(
+            queue_payload["replay_tape"]["strategy_family"], "hpairs-frontier-family"
+        )
         self.assertEqual(
             [entry["frontier_bucket"] for entry in queue_payload["entries"]],
             [
@@ -4788,6 +4792,18 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn("source_backed_adv_missing", first_entry["lineage_blockers"])
         self.assertFalse(first_entry["promotion_allowed"])
         self.assertFalse(first_entry["final_promotion_allowed"])
+        self.assertIn("hpairs_microstructure_prefilter", first_entry)
+        self.assertEqual(
+            first_entry["hpairs_microstructure_prefilter"]["proof_source"],
+            "prefilter_only",
+        )
+        self.assertFalse(
+            first_entry["hpairs_microstructure_prefilter"]["final_promotion_allowed"]
+        )
+        self.assertIn(
+            "horizon_ofi_features",
+            first_entry["hpairs_microstructure_prefilter"],
+        )
 
     def test_staged_replay_frontier_default_resolvers_fail_closed(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -4940,7 +4956,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         manifest_payload = preview.to_manifest_payload()
 
         self.assertEqual(
-            row_payload["schema_version"], "torghut.fast-replay-preview-row.v4"
+            row_payload["schema_version"], "torghut.fast-replay-preview-row.v5"
         )
         self.assertEqual(manifest_payload["status"], "preview_only")
         self.assertFalse(manifest_payload["promotion_proof"])
@@ -4957,6 +4973,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             Decimal(row_payload["impact_liquidity_penalty_bps"]), Decimal("0")
         )
         self.assertIn("conformal_tail_risk", manifest_payload["implemented_mechanisms"])
+        self.assertEqual(row_payload["proof_source"], "prefilter_only")
+        self.assertFalse(row_payload["final_promotion_allowed"])
+        self.assertIn("hpairs_microstructure_prefilter", row_payload)
+        self.assertEqual(
+            row_payload["hpairs_microstructure_prefilter"]["proof_source"],
+            "prefilter_only",
+        )
+        self.assertIn("hpairs_microstructure_prefilter", manifest_payload)
 
     def test_materialize_replay_tape_writes_run_artifacts_and_updates_args(
         self,


### PR DESCRIPTION
## Summary

- Added a deterministic H-PAIRS ClusterLOB/OFI microstructure prefilter with horizon-specific OFI shock/memory features, cluster behavior buckets, regime/stress veto metadata, and explicit missing-input blockers.
- Wired the prefilter into fast replay preview ranking and bounded exact-replay handoff metadata without increasing Kubernetes fanout or granting promotion authority.
- Tagged H-PAIRS candidate specs and downstream bounded sim target queue entries with non-authoritative prefilter proof-source metadata.
- Added focused regression coverage for deterministic ranking, missing source fields, no synthetic authority, frontier bounds, and downstream H-PAIRS metadata.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed.
- `cd services/torghut && uv run --frozen pytest tests/test_microstructure_prefilter.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_replay_ledger_guided_search.py tests/test_replay_tape.py -q` — passed, 239 passed, 1 existing DeprecationWarning.
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/microstructure_prefilter.py app/trading/discovery/candidate_specs.py app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/whitepaper_candidate_compiler.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_microstructure_prefilter.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_replay_ledger_guided_search.py tests/test_replay_tape.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed, 0 errors.
- `cd services/torghut && git diff --check` — passed.

## Screenshots (if applicable)

N/A — backend discovery/ranking metadata change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
