### PR TITLE
fix(torghut): shorten paper route audit index names

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -1656,7 +1656,7 @@ class StrategyHypothesisMetricWindow(Base, TimestampMixin):
             "created_at",
         ),
         Index(
-            "ix_strategy_hypothesis_metric_windows_hypothesis_candidate_window",
+            "ix_strategy_hyp_metric_windows_hyp_cand_window",
             "hypothesis_id",
             "candidate_id",
             "window_started_at",
@@ -1757,7 +1757,7 @@ class StrategyRuntimeLedgerBucket(Base, TimestampMixin):
             "created_at",
         ),
         Index(
-            "ix_strategy_runtime_ledger_buckets_hypothesis_run_candidate_stage_ended",
+            "ix_strategy_runtime_ledger_buckets_hyp_run_cand_stage_ended",
             "hypothesis_id",
             "run_id",
             "candidate_id",

--- a/services/torghut/migrations/versions/0045_paper_route_audit_bounded_read_indexes.py
+++ b/services/torghut/migrations/versions/0045_paper_route_audit_bounded_read_indexes.py
@@ -33,7 +33,7 @@ _INDEXES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
         ("alpaca_account_label", "event_ts", "symbol", "trade_decision_id"),
     ),
     (
-        "ix_strategy_hypothesis_metric_windows_hypothesis_candidate_window",
+        "ix_strategy_hyp_metric_windows_hyp_cand_window",
         "strategy_hypothesis_metric_windows",
         (
             "hypothesis_id",
@@ -44,7 +44,7 @@ _INDEXES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "ix_strategy_runtime_ledger_buckets_hypothesis_run_candidate_stage_ended",
+        "ix_strategy_runtime_ledger_buckets_hyp_run_cand_stage_ended",
         "strategy_runtime_ledger_buckets",
         (
             "hypothesis_id",

--- a/services/torghut/tests/test_paper_route_audit_bounded_read_indexes_migration.py
+++ b/services/torghut/tests/test_paper_route_audit_bounded_read_indexes_migration.py
@@ -23,6 +23,12 @@ def _load_migration_module() -> ModuleType:
 
 
 class TestPaperRouteAuditBoundedReadIndexesMigration(TestCase):
+    def test_index_names_fit_postgres_identifier_limit(self) -> None:
+        module = _load_migration_module()
+
+        for index_name, _table_name, _columns in module._INDEXES:
+            self.assertLessEqual(len(index_name), 63, index_name)
+
     def test_revision_follows_current_head(self) -> None:
         module = _load_migration_module()
 
@@ -58,7 +64,7 @@ class TestPaperRouteAuditBoundedReadIndexesMigration(TestCase):
             created_names,
         )
         self.assertIn(
-            "ix_strategy_runtime_ledger_buckets_hypothesis_run_candidate_stage_ended",
+            "ix_strategy_runtime_ledger_buckets_hyp_run_cand_stage_ended",
             created_names,
         )
 


### PR DESCRIPTION
## Summary

- Shortens the two over-length PostgreSQL index names introduced by the Torghut paper-route audit migration.
- Keeps SQLAlchemy ORM metadata aligned with the migration index names.
- Adds a migration regression test that rejects index names over PostgreSQL's 63-character identifier limit.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_audit_bounded_read_indexes_migration.py -q`
- `cd services/torghut && uv run --frozen ruff check app/models/entities.py migrations/versions/0045_paper_route_audit_bounded_read_indexes.py tests/test_paper_route_audit_bounded_read_indexes_migration.py`
- `cd services/torghut && python3` import check to print and verify every 0045 index name length is at most 63 characters.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
