### PR TITLE
feat(torghut): add hpairs source proof census

### DIFF
--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -1,0 +1,854 @@
+#!/usr/bin/env python
+"""Read-only H-PAIRS/TORGHUT_SIM source-proof census/readback CLI.
+
+This command deliberately performs diagnostics only: it reads SQLAlchemy rows or
+fixture JSON and emits a deterministic machine-readable census of the gap between
+paper-route activity and authority-grade runtime-ledger proof. It never writes
+proof artifacts, promotion state, or database rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import cast
+
+from sqlalchemy import create_engine, or_, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.models import (
+    Execution,
+    ExecutionOrderEvent,
+    ExecutionTCAMetric,
+    OrderFeedSourceWindow,
+    Strategy,
+    TradeDecision,
+)
+from app.trading.runtime_authority_verifier import (
+    AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER,
+    AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER,
+    AUTHORITY_EVIDENCE_MISSING_BLOCKER,
+    AUTHORITY_EXPLICIT_COSTS_BLOCKER,
+    AUTHORITY_FILLED_NOTIONAL_BLOCKER,
+    AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER,
+    AUTHORITY_MEAN_PNL_BLOCKER,
+    AUTHORITY_MEDIAN_PNL_BLOCKER,
+    AUTHORITY_OPEN_POSITIONS_BLOCKER,
+    AUTHORITY_P10_PNL_BLOCKER,
+    AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+    AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
+    AUTHORITY_TRADING_DAYS_BLOCKER,
+    AUTHORITY_WORST_DAY_BLOCKER,
+    DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    build_runtime_authority_report,
+    load_runtime_authority_rows,
+)
+from app.trading.runtime_ledger_source_authority import (
+    EXECUTION_ECONOMICS_MISSING_BLOCKER,
+    ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+    ORDER_FEED_SOURCE_WINDOW_GAP_BLOCKER,
+    RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
+    RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+)
+
+SCHEMA_VERSION = 'torghut.hpairs-source-proof-census.v1'
+AUTHORITY_CANDIDATE_READY = 'authority_candidate_ready'
+NO_SOURCE_ACTIVITY = 'no_source_activity'
+LIFECYCLE_MISSING = 'lifecycle_missing'
+ECONOMICS_MISSING = 'economics_missing'
+SOURCE_REFS_MISSING = 'source_refs_missing'
+OPEN_POSITIONS = 'open_positions'
+AUTHORITY_DISTRIBUTION_MISSING = 'authority_distribution_missing'
+
+_SOURCE_REF_BLOCKERS = frozenset(
+    {
+        RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
+        RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER,
+        ORDER_FEED_SOURCE_WINDOW_GAP_BLOCKER,
+    }
+)
+_DISTRIBUTION_BLOCKERS = frozenset(
+    {
+        AUTHORITY_EVIDENCE_MISSING_BLOCKER,
+        AUTHORITY_TRADING_DAYS_BLOCKER,
+        AUTHORITY_MEAN_PNL_BLOCKER,
+        AUTHORITY_MEDIAN_PNL_BLOCKER,
+        AUTHORITY_P10_PNL_BLOCKER,
+        AUTHORITY_WORST_DAY_BLOCKER,
+        AUTHORITY_FILLED_NOTIONAL_BLOCKER,
+        AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER,
+    }
+)
+_LIFECYCLE_BLOCKERS = frozenset(
+    {
+        AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+        AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
+        AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER,
+        ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+    }
+)
+_ECONOMICS_BLOCKERS = frozenset(
+    {
+        AUTHORITY_EXPLICIT_COSTS_BLOCKER,
+        AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER,
+        EXECUTION_ECONOMICS_MISSING_BLOCKER,
+    }
+)
+
+
+@dataclass(frozen=True)
+class CensusIdentity:
+    hypothesis_id: str
+    candidate_id: str
+    runtime_strategy_name: str
+    account_label: str
+    observed_stage: str | None
+
+
+@dataclass
+class CensusSourceRows:
+    trade_decisions: list[Mapping[str, object]] = field(default_factory=list)
+    executions: list[Mapping[str, object]] = field(default_factory=list)
+    execution_order_events: list[Mapping[str, object]] = field(default_factory=list)
+    execution_tca_metrics: list[Mapping[str, object]] = field(default_factory=list)
+    order_feed_source_windows: list[Mapping[str, object]] = field(default_factory=list)
+    runtime_ledger_buckets: list[Mapping[str, object]] = field(default_factory=list)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument('--dsn', help='SQLAlchemy DSN to read with a short read-only session')
+    source.add_argument('--fixture-json', type=Path, help='Fixture JSON containing source row arrays')
+    parser.add_argument('--hypothesis-id', default=DEFAULT_HPAIRS_HYPOTHESIS_ID)
+    parser.add_argument('--candidate-id', default=DEFAULT_HPAIRS_CANDIDATE_ID)
+    parser.add_argument('--runtime-strategy-name', default=DEFAULT_HPAIRS_RUNTIME_STRATEGY)
+    parser.add_argument('--account-label', default=DEFAULT_HPAIRS_ACCOUNT_LABEL)
+    parser.add_argument('--observed-stage', default='paper')
+    parser.add_argument('--start', dest='started_at')
+    parser.add_argument('--end', dest='ended_at')
+    parser.add_argument(
+        '--fail-on-blockers',
+        action='store_true',
+        help='exit non-zero unless the census verdict is authority_candidate_ready',
+    )
+    return parser.parse_args(argv)
+
+
+def build_source_proof_census(
+    rows: CensusSourceRows,
+    *,
+    identity: CensusIdentity,
+    started_at: datetime | None = None,
+    ended_at: datetime | None = None,
+    read_error: str | None = None,
+    source_kind: str = 'fixture_json',
+) -> dict[str, object]:
+    """Build a deterministic source-proof census from already-read rows."""
+
+    ledger_report = build_runtime_authority_report(
+        rows.runtime_ledger_buckets,
+        hypothesis_id=identity.hypothesis_id,
+        candidate_id=identity.candidate_id,
+        runtime_strategy_name=identity.runtime_strategy_name,
+        account_label=identity.account_label,
+        observed_stage=identity.observed_stage,
+        started_at=started_at,
+        ended_at=ended_at,
+        evidence_read_error=read_error,
+    )
+    daily = _daily_census(rows, ledger_report)
+    totals = _totals(rows, daily, ledger_report)
+    blockers = _census_blockers(rows, totals, ledger_report, read_error=read_error)
+    missing_source_ref_categories = _missing_source_ref_categories(blockers)
+    classification = _classify_verdict(totals, blockers)
+    return {
+        'schema_version': SCHEMA_VERSION,
+        'identity': {
+            'hypothesis_id': identity.hypothesis_id,
+            'candidate_id': identity.candidate_id,
+            'runtime_strategy_name': identity.runtime_strategy_name,
+            'account_label': identity.account_label,
+            'observed_stage': identity.observed_stage,
+        },
+        'window': {
+            'started_at': _isoformat(started_at) if started_at is not None else None,
+            'ended_at': _isoformat(ended_at) if ended_at is not None else None,
+        },
+        'source': {
+            'kind': source_kind,
+            'read_only': True,
+            'writes_proof': False,
+            'modifies_rows': False,
+        },
+        'totals': totals,
+        'daily': daily,
+        'runtime_authority': {
+            'final_authority_ok': ledger_report['final_authority_ok'],
+            'blockers': ledger_report['blockers'],
+            'aggregate': ledger_report['aggregate'],
+        },
+        'missing_source_ref_categories': missing_source_ref_categories,
+        'blockers': blockers,
+        'verdict': {
+            'classification': classification,
+            'authority_candidate_ready': classification == AUTHORITY_CANDIDATE_READY,
+            'next_action': _next_action(classification),
+        },
+    }
+
+
+def census_json(report: Mapping[str, object]) -> str:
+    """Serialize a census as stable JSON."""
+
+    return json.dumps(report, indent=2, sort_keys=True) + '\n'
+
+
+def load_fixture_rows(path: Path) -> CensusSourceRows:
+    payload = json.loads(path.read_text())
+    data = _mapping(payload)
+    return CensusSourceRows(
+        trade_decisions=_row_list(data.get('trade_decisions')),
+        executions=_row_list(data.get('executions')),
+        execution_order_events=_row_list(data.get('execution_order_events')),
+        execution_tca_metrics=_row_list(data.get('execution_tca_metrics') or data.get('tca_metrics')),
+        order_feed_source_windows=_row_list(data.get('order_feed_source_windows') or data.get('source_windows')),
+        runtime_ledger_buckets=_row_list(data.get('runtime_ledger_buckets')),
+    )
+
+
+def load_dsn_rows(
+    dsn: str,
+    *,
+    identity: CensusIdentity,
+    started_at: datetime | None,
+    ended_at: datetime | None,
+) -> CensusSourceRows:
+    """Read only the bounded H-PAIRS source rows needed for the census."""
+
+    engine = create_engine(dsn)
+    session_factory = sessionmaker(bind=engine)
+    with session_factory() as session:
+        return _load_session_rows(
+            session,
+            identity=identity,
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+
+
+def _load_session_rows(
+    session: Session,
+    *,
+    identity: CensusIdentity,
+    started_at: datetime | None,
+    ended_at: datetime | None,
+) -> CensusSourceRows:
+    decision_stmt = (
+        select(TradeDecision, Strategy.name)
+        .join(Strategy, TradeDecision.strategy_id == Strategy.id)
+        .where(TradeDecision.alpaca_account_label == identity.account_label)
+        .where(Strategy.name == identity.runtime_strategy_name)
+        .order_by(TradeDecision.created_at.asc(), TradeDecision.id.asc())
+    )
+    if started_at is not None:
+        decision_stmt = decision_stmt.where(TradeDecision.created_at >= started_at)
+    if ended_at is not None:
+        decision_stmt = decision_stmt.where(TradeDecision.created_at < ended_at)
+    decision_pairs = list(session.execute(decision_stmt).all())
+    decisions = [_decision_row(row, strategy_name) for row, strategy_name in decision_pairs]
+    decision_ids = {str(row.id) for row, _strategy_name in decision_pairs}
+
+    execution_stmt = (
+        select(Execution)
+        .where(Execution.alpaca_account_label == identity.account_label)
+        .order_by(Execution.created_at.asc(), Execution.id.asc())
+    )
+    if started_at is not None:
+        execution_stmt = execution_stmt.where(Execution.created_at >= started_at)
+    if ended_at is not None:
+        execution_stmt = execution_stmt.where(Execution.created_at < ended_at)
+    if decision_ids:
+        execution_stmt = execution_stmt.where(Execution.trade_decision_id.in_(decision_ids))
+    executions = [_execution_row(row) for row in session.scalars(execution_stmt).all()]
+    execution_ids = {str(row['id']) for row in executions}
+
+    event_stmt = (
+        select(ExecutionOrderEvent)
+        .where(ExecutionOrderEvent.alpaca_account_label == identity.account_label)
+        .order_by(
+            ExecutionOrderEvent.event_ts.asc().nulls_last(),
+            ExecutionOrderEvent.created_at.asc(),
+            ExecutionOrderEvent.id.asc(),
+        )
+    )
+    if started_at is not None:
+        event_stmt = event_stmt.where(
+            or_(ExecutionOrderEvent.event_ts >= started_at, ExecutionOrderEvent.created_at >= started_at)
+        )
+    if ended_at is not None:
+        event_stmt = event_stmt.where(
+            or_(ExecutionOrderEvent.event_ts < ended_at, ExecutionOrderEvent.created_at < ended_at)
+        )
+    if decision_ids or execution_ids:
+        event_filters = []
+        if decision_ids:
+            event_filters.append(ExecutionOrderEvent.trade_decision_id.in_(decision_ids))
+        if execution_ids:
+            event_filters.append(ExecutionOrderEvent.execution_id.in_(execution_ids))
+        event_stmt = event_stmt.where(or_(*event_filters))
+    order_events = [_order_event_row(row) for row in session.scalars(event_stmt).all()]
+
+    tca_stmt = (
+        select(ExecutionTCAMetric)
+        .where(ExecutionTCAMetric.alpaca_account_label == identity.account_label)
+        .order_by(ExecutionTCAMetric.computed_at.asc(), ExecutionTCAMetric.id.asc())
+    )
+    if started_at is not None:
+        tca_stmt = tca_stmt.where(ExecutionTCAMetric.computed_at >= started_at)
+    if ended_at is not None:
+        tca_stmt = tca_stmt.where(ExecutionTCAMetric.computed_at < ended_at)
+    if decision_ids or execution_ids:
+        tca_filters = []
+        if decision_ids:
+            tca_filters.append(ExecutionTCAMetric.trade_decision_id.in_(decision_ids))
+        if execution_ids:
+            tca_filters.append(ExecutionTCAMetric.execution_id.in_(execution_ids))
+        tca_stmt = tca_stmt.where(or_(*tca_filters))
+    tca_metrics = [_tca_row(row) for row in session.scalars(tca_stmt).all()]
+
+    source_window_stmt = (
+        select(OrderFeedSourceWindow)
+        .where(OrderFeedSourceWindow.alpaca_account_label == identity.account_label)
+        .order_by(OrderFeedSourceWindow.window_started_at.asc(), OrderFeedSourceWindow.id.asc())
+    )
+    if started_at is not None:
+        source_window_stmt = source_window_stmt.where(OrderFeedSourceWindow.window_ended_at >= started_at)
+    if ended_at is not None:
+        source_window_stmt = source_window_stmt.where(OrderFeedSourceWindow.window_started_at < ended_at)
+    source_windows = [_source_window_row(row) for row in session.scalars(source_window_stmt).all()]
+
+    ledger_rows = load_runtime_authority_rows(
+        session,
+        hypothesis_id=identity.hypothesis_id,
+        candidate_id=identity.candidate_id,
+        runtime_strategy_name=identity.runtime_strategy_name,
+        account_label=identity.account_label,
+        observed_stage=identity.observed_stage,
+        started_at=started_at,
+        ended_at=ended_at,
+    )
+    runtime_ledger_buckets = [
+        {
+            'id': row.row_id,
+            'run_id': row.run_id,
+            'candidate_id': row.candidate_id,
+            'hypothesis_id': row.hypothesis_id,
+            'observed_stage': row.observed_stage,
+            'bucket_started_at': row.bucket_started_at,
+            'bucket_ended_at': row.bucket_ended_at,
+            'account_label': row.account_label,
+            'runtime_strategy_name': row.runtime_strategy_name,
+            'strategy_family': row.strategy_family,
+            'fill_count': row.fill_count,
+            'decision_count': row.decision_count,
+            'submitted_order_count': row.submitted_order_count,
+            'cancelled_order_count': row.cancelled_order_count,
+            'rejected_order_count': row.rejected_order_count,
+            'unfilled_order_count': row.unfilled_order_count,
+            'closed_trade_count': row.closed_trade_count,
+            'open_position_count': row.open_position_count,
+            'filled_notional': row.filled_notional,
+            'gross_strategy_pnl': row.gross_strategy_pnl,
+            'cost_amount': row.cost_amount,
+            'net_strategy_pnl_after_costs': row.net_strategy_pnl_after_costs,
+            'post_cost_expectancy_bps': row.post_cost_expectancy_bps,
+            'ledger_schema_version': row.ledger_schema_version,
+            'pnl_basis': row.pnl_basis,
+            'execution_policy_hash_counts': dict(row.execution_policy_hash_counts),
+            'cost_model_hash_counts': dict(row.cost_model_hash_counts),
+            'lineage_hash_counts': dict(row.lineage_hash_counts),
+            'blockers': list(row.blockers),
+            'payload': dict(row.payload),
+        }
+        for row in ledger_rows
+    ]
+    return CensusSourceRows(
+        trade_decisions=decisions,
+        executions=executions,
+        execution_order_events=order_events,
+        execution_tca_metrics=tca_metrics,
+        order_feed_source_windows=source_windows,
+        runtime_ledger_buckets=runtime_ledger_buckets,
+    )
+
+
+def _daily_census(rows: CensusSourceRows, ledger_report: Mapping[str, object]) -> list[dict[str, object]]:
+    days = sorted(
+        {
+            *_row_days(rows.trade_decisions, 'created_at'),
+            *_row_days(rows.executions, 'created_at'),
+            *_row_days(rows.execution_order_events, 'event_ts', fallback_key='created_at'),
+            *_row_days(rows.execution_tca_metrics, 'computed_at'),
+            *_row_days(rows.order_feed_source_windows, 'window_started_at'),
+            *_ledger_days(ledger_report),
+        }
+    )
+    return [_daily_payload(day, rows, ledger_report) for day in days]
+
+
+def _daily_payload(day: str, rows: CensusSourceRows, ledger_report: Mapping[str, object]) -> dict[str, object]:
+    day_ledgers = [_mapping(item) for item in _sequence(ledger_report.get('trading_days'))]
+    ledger_by_day = {str(item.get('trading_day')): item for item in day_ledgers}
+    ledger = ledger_by_day.get(day, {})
+    day_executions = _rows_on_day(rows.executions, day, 'created_at')
+    day_events = _rows_on_day(rows.execution_order_events, day, 'event_ts', fallback_key='created_at')
+    return {
+        'trading_day': day,
+        'trade_decision_count': len(_rows_on_day(rows.trade_decisions, day, 'created_at')),
+        'execution_count': len(day_executions),
+        'filled_execution_count': sum(1 for row in day_executions if _filled_execution(row)),
+        'execution_order_event_count': len(day_events),
+        'fill_lifecycle_event_count': sum(1 for row in day_events if _fill_event(row)),
+        'tca_cost_row_count': len(_rows_on_day(rows.execution_tca_metrics, day, 'computed_at')),
+        'source_window_count': len(_rows_on_day(rows.order_feed_source_windows, day, 'window_started_at')),
+        'execution_order_events_with_source_window_count': sum(
+            1 for row in day_events if _text(row.get('source_window_id')) is not None
+        ),
+        'execution_order_events_with_source_offset_count': sum(1 for row in day_events if _event_source_offset_present(row)),
+        'runtime_ledger_bucket_count': _int(ledger.get('bucket_count')),
+        'blocker_free_runtime_ledger_bucket_count': _int(ledger.get('source_authority_bucket_count')),
+        'closed_trade_count': _int(ledger.get('closed_trade_count')),
+        'open_position_count': _int(ledger.get('open_position_count')),
+        'filled_notional': _decimal_text(_decimal(ledger.get('filled_notional'))),
+        'post_cost_pnl': _decimal_text(_decimal(ledger.get('net_strategy_pnl_after_costs'))),
+        'blockers': sorted(str(item) for item in _sequence(ledger.get('blockers'))),
+    }
+
+
+def _totals(
+    rows: CensusSourceRows,
+    daily: Sequence[Mapping[str, object]],
+    ledger_report: Mapping[str, object],
+) -> dict[str, object]:
+    aggregate = _mapping(ledger_report.get('aggregate'))
+    source_authority_bucket_count = _int(aggregate.get('source_authority_bucket_count'))
+    return {
+        'trade_decision_count': len(rows.trade_decisions),
+        'execution_count': len(rows.executions),
+        'filled_execution_count': sum(1 for row in rows.executions if _filled_execution(row)),
+        'execution_order_event_count': len(rows.execution_order_events),
+        'fill_lifecycle_event_count': sum(1 for row in rows.execution_order_events if _fill_event(row)),
+        'tca_cost_row_count': len(rows.execution_tca_metrics),
+        'source_window_count': len(rows.order_feed_source_windows),
+        'execution_order_events_with_source_window_count': sum(
+            1 for row in rows.execution_order_events if _text(row.get('source_window_id')) is not None
+        ),
+        'execution_order_events_with_source_offset_count': sum(
+            1 for row in rows.execution_order_events if _event_source_offset_present(row)
+        ),
+        'runtime_ledger_bucket_count': len(rows.runtime_ledger_buckets),
+        'blocker_free_runtime_ledger_bucket_count': source_authority_bucket_count,
+        'closed_trade_count': _int(aggregate.get('closed_round_trips')),
+        'open_position_count': _int(aggregate.get('open_position_count')),
+        'filled_notional': _text(aggregate.get('total_filled_notional'), default='0'),
+        'post_cost_pnl': _text(aggregate.get('total_net_strategy_pnl_after_costs'), default='0'),
+        'trading_day_count': len(daily),
+    }
+
+
+def _census_blockers(
+    rows: CensusSourceRows,
+    totals: Mapping[str, object],
+    ledger_report: Mapping[str, object],
+    *,
+    read_error: str | None,
+) -> list[str]:
+    blockers: list[str] = []
+    if read_error is not None:
+        blockers.append('source_proof_census_read_error')
+    if _int(totals.get('trade_decision_count')) <= 0:
+        blockers.extend(
+            [
+                AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+                RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+            ]
+        )
+    if _int(totals.get('execution_count')) <= 0:
+        blockers.append(RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER)
+    if _int(totals.get('filled_execution_count')) <= 0:
+        blockers.append(AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER)
+    if _int(totals.get('execution_order_event_count')) <= 0:
+        blockers.extend(
+            [
+                RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+                ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+            ]
+        )
+    if _int(totals.get('fill_lifecycle_event_count')) <= 0:
+        blockers.append(ORDER_FEED_LIFECYCLE_MISSING_BLOCKER)
+    if _int(totals.get('tca_cost_row_count')) <= 0:
+        blockers.extend([AUTHORITY_EXPLICIT_COSTS_BLOCKER, EXECUTION_ECONOMICS_MISSING_BLOCKER])
+    if _int(totals.get('source_window_count')) <= 0:
+        blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER)
+    if _int(totals.get('execution_order_events_with_source_window_count')) < _int(
+        totals.get('execution_order_event_count')
+    ):
+        blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER)
+    if _int(totals.get('execution_order_events_with_source_offset_count')) < _int(
+        totals.get('execution_order_event_count')
+    ):
+        blockers.append(RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER)
+    if _int(totals.get('open_position_count')) > 0:
+        blockers.append(AUTHORITY_OPEN_POSITIONS_BLOCKER)
+    if _int(totals.get('closed_trade_count')) <= 0:
+        blockers.append(AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER)
+    if not rows.runtime_ledger_buckets:
+        blockers.append(AUTHORITY_EVIDENCE_MISSING_BLOCKER)
+    blockers.extend(str(item) for item in _sequence(ledger_report.get('blockers')))
+    return sorted(dict.fromkeys(blockers))
+
+
+def _missing_source_ref_categories(blockers: Sequence[str]) -> dict[str, bool]:
+    return {code: code in blockers for code in sorted(_SOURCE_REF_BLOCKERS)}
+
+
+def _classify_verdict(totals: Mapping[str, object], blockers: Sequence[str]) -> str:
+    blocker_set = set(blockers)
+    source_activity = (
+        _int(totals.get('trade_decision_count'))
+        + _int(totals.get('execution_count'))
+        + _int(totals.get('execution_order_event_count'))
+        + _int(totals.get('tca_cost_row_count'))
+        + _int(totals.get('runtime_ledger_bucket_count'))
+    )
+    if source_activity <= 0:
+        return NO_SOURCE_ACTIVITY
+    if blocker_set.intersection(_LIFECYCLE_BLOCKERS):
+        return LIFECYCLE_MISSING
+    if blocker_set.intersection(_SOURCE_REF_BLOCKERS):
+        return SOURCE_REFS_MISSING
+    if blocker_set.intersection(_ECONOMICS_BLOCKERS):
+        return ECONOMICS_MISSING
+    if AUTHORITY_OPEN_POSITIONS_BLOCKER in blocker_set:
+        return OPEN_POSITIONS
+    if blocker_set.intersection(_DISTRIBUTION_BLOCKERS):
+        return AUTHORITY_DISTRIBUTION_MISSING
+    if blocker_set:
+        return SOURCE_REFS_MISSING
+    return AUTHORITY_CANDIDATE_READY
+
+
+def _next_action(classification: str) -> str:
+    return {
+        NO_SOURCE_ACTIVITY: 'collect bounded paper-route source rows before treating replay output as authority',
+        LIFECYCLE_MISSING: 'materialize linked decisions, executions, order events, fills, and closed round trips',
+        ECONOMICS_MISSING: 'materialize execution TCA/cost rows and explicit runtime cost bases',
+        SOURCE_REFS_MISSING: 'backfill runtime-ledger source refs, source windows, offsets, materialization, and authority class',
+        OPEN_POSITIONS: 'flatten or wait for source-backed closed round trips before authority promotion',
+        AUTHORITY_DISTRIBUTION_MISSING: 'continue source-backed paper runtime until authority distribution thresholds are met',
+        AUTHORITY_CANDIDATE_READY: 'assemble authority proof packet from the same source-backed runtime rows',
+    }[classification]
+
+
+def _row_days(rows: Sequence[Mapping[str, object]], key: str, *, fallback_key: str | None = None) -> set[str]:
+    days: set[str] = set()
+    for row in rows:
+        timestamp = _parse_timestamp(row.get(key))
+        if timestamp is None and fallback_key is not None:
+            timestamp = _parse_timestamp(row.get(fallback_key))
+        if timestamp is not None:
+            days.add(timestamp.date().isoformat())
+    return days
+
+
+def _ledger_days(ledger_report: Mapping[str, object]) -> set[str]:
+    return {
+        text
+        for item in _sequence(ledger_report.get('trading_days'))
+        if (text := _text(_mapping(item).get('trading_day'))) is not None
+    }
+
+
+def _rows_on_day(
+    rows: Sequence[Mapping[str, object]],
+    day: str,
+    key: str,
+    *,
+    fallback_key: str | None = None,
+) -> list[Mapping[str, object]]:
+    matches: list[Mapping[str, object]] = []
+    for row in rows:
+        timestamp = _parse_timestamp(row.get(key))
+        if timestamp is None and fallback_key is not None:
+            timestamp = _parse_timestamp(row.get(fallback_key))
+        if timestamp is not None and timestamp.date().isoformat() == day:
+            matches.append(row)
+    return matches
+
+
+def _filled_execution(row: Mapping[str, object]) -> bool:
+    status = (_text(row.get('status')) or '').lower()
+    return status in {'filled', 'partially_filled'} or _decimal(row.get('filled_qty')) > 0
+
+
+def _fill_event(row: Mapping[str, object]) -> bool:
+    event_type = (_text(row.get('event_type')) or '').lower()
+    status = (_text(row.get('status')) or '').lower()
+    return 'fill' in event_type or status in {'filled', 'partially_filled'} or _decimal(row.get('filled_qty_delta')) > 0
+
+
+def _event_source_offset_present(row: Mapping[str, object]) -> bool:
+    return (
+        _text(row.get('source_topic')) is not None
+        and row.get('source_partition') is not None
+        and row.get('source_offset') is not None
+    )
+
+
+def _decision_row(row: TradeDecision, strategy_name: str | None) -> dict[str, object]:
+    return {
+        'id': str(row.id),
+        'strategy_id': str(row.strategy_id),
+        'strategy_name': strategy_name,
+        'alpaca_account_label': row.alpaca_account_label,
+        'symbol': row.symbol,
+        'status': row.status,
+        'decision_hash': row.decision_hash,
+        'created_at': row.created_at,
+        'executed_at': row.executed_at,
+    }
+
+
+def _execution_row(row: Execution) -> dict[str, object]:
+    return {
+        'id': str(row.id),
+        'trade_decision_id': str(row.trade_decision_id) if row.trade_decision_id is not None else None,
+        'alpaca_account_label': row.alpaca_account_label,
+        'alpaca_order_id': row.alpaca_order_id,
+        'client_order_id': row.client_order_id,
+        'symbol': row.symbol,
+        'side': row.side,
+        'status': row.status,
+        'filled_qty': row.filled_qty,
+        'avg_fill_price': row.avg_fill_price,
+        'created_at': row.created_at,
+        'updated_at': row.updated_at,
+        'order_feed_last_event_ts': row.order_feed_last_event_ts,
+    }
+
+
+def _order_event_row(row: ExecutionOrderEvent) -> dict[str, object]:
+    return {
+        'id': str(row.id),
+        'source_topic': row.source_topic,
+        'source_partition': row.source_partition,
+        'source_offset': row.source_offset,
+        'alpaca_account_label': row.alpaca_account_label,
+        'event_ts': row.event_ts,
+        'created_at': row.created_at,
+        'symbol': row.symbol,
+        'alpaca_order_id': row.alpaca_order_id,
+        'client_order_id': row.client_order_id,
+        'event_type': row.event_type,
+        'status': row.status,
+        'filled_qty': row.filled_qty,
+        'filled_qty_delta': row.filled_qty_delta,
+        'filled_notional_delta': row.filled_notional_delta,
+        'execution_id': str(row.execution_id) if row.execution_id is not None else None,
+        'trade_decision_id': str(row.trade_decision_id) if row.trade_decision_id is not None else None,
+        'source_window_id': str(row.source_window_id) if row.source_window_id is not None else None,
+    }
+
+
+def _tca_row(row: ExecutionTCAMetric) -> dict[str, object]:
+    return {
+        'id': str(row.id),
+        'execution_id': str(row.execution_id),
+        'trade_decision_id': str(row.trade_decision_id) if row.trade_decision_id is not None else None,
+        'strategy_id': str(row.strategy_id) if row.strategy_id is not None else None,
+        'alpaca_account_label': row.alpaca_account_label,
+        'symbol': row.symbol,
+        'side': row.side,
+        'filled_qty': row.filled_qty,
+        'shortfall_notional': row.shortfall_notional,
+        'realized_shortfall_bps': row.realized_shortfall_bps,
+        'computed_at': row.computed_at,
+    }
+
+
+def _source_window_row(row: OrderFeedSourceWindow) -> dict[str, object]:
+    return {
+        'id': str(row.id),
+        'consumer_group': row.consumer_group,
+        'source_topic': row.source_topic,
+        'source_partition': row.source_partition,
+        'alpaca_account_label': row.alpaca_account_label,
+        'window_started_at': row.window_started_at,
+        'window_ended_at': row.window_ended_at,
+        'start_offset': row.start_offset,
+        'end_offset': row.end_offset,
+        'consumed_count': row.consumed_count,
+        'inserted_count': row.inserted_count,
+        'gap_count': row.gap_count,
+        'status': row.status,
+    }
+
+
+def _row_list(value: object) -> list[Mapping[str, object]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    rows: list[Mapping[str, object]] = []
+    for item in cast(Sequence[object], value):
+        if isinstance(item, Mapping):
+            rows.append({str(key): _json_value(raw) for key, raw in cast(Mapping[object, object], item).items()})
+    return rows
+
+
+def _json_value(value: object) -> object:
+    if isinstance(value, str):
+        parsed = _parse_timestamp(value)
+        return parsed if parsed is not None else value
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(raw) for key, raw in cast(Mapping[object, object], value).items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_value(item) for item in cast(Sequence[object], value)]
+    return value
+
+
+def _parse_cli_timestamp(value: str | None) -> datetime | None:
+    if value is None or not value.strip():
+        return None
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        raise ValueError(f'invalid timestamp: {value}')
+    return parsed
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return _utc(value)
+    text = _text(value)
+    if text is None:
+        return None
+    try:
+        return _utc(datetime.fromisoformat(text.replace('Z', '+00:00')))
+    except ValueError:
+        return None
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in cast(Mapping[object, object], value).items()}
+    return {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _text(value: object, *, default: str | None = None) -> str | None:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _int(value: object) -> int:
+    try:
+        return int(str(value if value is not None else '0'))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _decimal(value: object) -> Decimal:
+    try:
+        parsed = Decimal(str(value if value is not None else '0'))
+    except (InvalidOperation, ValueError):
+        return Decimal('0')
+    return parsed if parsed.is_finite() else Decimal('0')
+
+
+def _decimal_text(value: Decimal) -> str:
+    text = format(value.normalize(), 'f')
+    return text.rstrip('0').rstrip('.') if '.' in text else text
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _isoformat(value: datetime) -> str:
+    return _utc(value).isoformat().replace('+00:00', 'Z')
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    started_at = _parse_cli_timestamp(args.started_at)
+    ended_at = _parse_cli_timestamp(args.ended_at)
+    identity = CensusIdentity(
+        hypothesis_id=args.hypothesis_id,
+        candidate_id=args.candidate_id,
+        runtime_strategy_name=args.runtime_strategy_name,
+        account_label=args.account_label,
+        observed_stage=args.observed_stage,
+    )
+    read_error = None
+    try:
+        if args.fixture_json is not None:
+            rows = load_fixture_rows(args.fixture_json)
+            source_kind = 'fixture_json'
+        else:
+            rows = load_dsn_rows(
+                args.dsn,
+                identity=identity,
+                started_at=started_at,
+                ended_at=ended_at,
+            )
+            source_kind = 'sqlalchemy_dsn'
+    except Exception as exc:  # noqa: BLE001 - readback must fail closed into JSON diagnostics.
+        rows = CensusSourceRows()
+        read_error = str(exc)
+        source_kind = 'fixture_json' if args.fixture_json is not None else 'sqlalchemy_dsn'
+    report = build_source_proof_census(
+        rows,
+        identity=identity,
+        started_at=started_at,
+        ended_at=ended_at,
+        read_error=read_error,
+        source_kind=source_kind,
+    )
+    sys.stdout.write(census_json(report))
+    verdict = _mapping(report.get('verdict'))
+    return 1 if args.fail_on_blockers and verdict.get('authority_candidate_ready') is not True else 0
+
+
+if __name__ == '__main__':  # pragma: no cover
+    raise SystemExit(main())

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -1,0 +1,529 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from app.trading.runtime_authority_verifier import (
+    AUTHORITY_EXPLICIT_COSTS_BLOCKER,
+    AUTHORITY_OPEN_POSITIONS_BLOCKER,
+    AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+    AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
+    DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+    RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+)
+from app.trading.runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
+from scripts import audit_hpairs_source_proof_census as census
+
+
+def _iso(day_index: int, hour: int = 14) -> str:
+    return (datetime(2026, 5, 1, hour, tzinfo=timezone.utc) + timedelta(days=day_index)).isoformat().replace(
+        '+00:00', 'Z'
+    )
+
+
+def _source_payload(day_index: int) -> dict[str, object]:
+    return {
+        'source_window_start': _iso(day_index, 14),
+        'source_window_end': _iso(day_index, 21),
+        'source_refs': [
+            'postgres:trade_decisions',
+            'postgres:executions',
+            'postgres:execution_order_events',
+            'postgres:order_feed_source_windows',
+        ],
+        'source_row_counts': {
+            'trade_decisions': 1,
+            'executions': 1,
+            'execution_order_events': 1,
+            'order_feed_source_windows': 1,
+        },
+        'trade_decision_ids': [f'decision-{day_index}'],
+        'execution_ids': [f'execution-{day_index}'],
+        'execution_order_event_ids': [f'event-{day_index}'],
+        'source_window_ids': [f'window-{day_index}'],
+        'source_offsets': [{'topic': 'alpaca.trade_updates', 'partition': 0, 'offset': day_index}],
+        'source_materialization': 'execution_order_events',
+        'authority_class': 'runtime_order_feed_execution_source',
+        'order_feed_lifecycle_complete': True,
+        'execution_economics_complete': True,
+        'cost_basis_counts': {'explicit_broker_fee_runtime': 1},
+    }
+
+
+def _ledger_bucket(day_index: int, *, source_backed: bool = True, open_positions: int = 0) -> dict[str, object]:
+    start = _iso(day_index, 14)
+    return {
+        'id': f'ledger-{day_index}',
+        'run_id': 'hpairs-runtime-run',
+        'candidate_id': DEFAULT_HPAIRS_CANDIDATE_ID,
+        'hypothesis_id': DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        'observed_stage': 'paper',
+        'bucket_started_at': start,
+        'bucket_ended_at': _iso(day_index, 21),
+        'account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        'runtime_strategy_name': DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        'strategy_family': 'pairs',
+        'fill_count': 20,
+        'decision_count': 20,
+        'submitted_order_count': 20,
+        'cancelled_order_count': 0,
+        'rejected_order_count': 0,
+        'unfilled_order_count': 0,
+        'closed_trade_count': 20,
+        'open_position_count': open_positions,
+        'filled_notional': '600000',
+        'gross_strategy_pnl': '610',
+        'cost_amount': '10',
+        'net_strategy_pnl_after_costs': '600',
+        'post_cost_expectancy_bps': '10',
+        'ledger_schema_version': EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        'pnl_basis': POST_COST_PNL_BASIS,
+        'execution_policy_hash_counts': {'policy-hash': 1},
+        'cost_model_hash_counts': {'cost-hash': 1},
+        'lineage_hash_counts': {'lineage-hash': 1},
+        'blockers': [],
+        'payload': _source_payload(day_index) if source_backed else {},
+    }
+
+
+def _fixture(*, days: int = 20, source_backed: bool = True) -> dict[str, object]:
+    return {
+        'trade_decisions': [
+            {
+                'id': f'decision-{day}',
+                'strategy_name': DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                'status': 'executed',
+                'created_at': _iso(day, 14),
+            }
+            for day in range(days)
+        ],
+        'executions': [
+            {
+                'id': f'execution-{day}',
+                'trade_decision_id': f'decision-{day}',
+                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                'status': 'filled',
+                'filled_qty': '10',
+                'avg_fill_price': '100',
+                'created_at': _iso(day, 15),
+            }
+            for day in range(days)
+        ],
+        'execution_order_events': [
+            {
+                'id': f'event-{day}',
+                'execution_id': f'execution-{day}',
+                'trade_decision_id': f'decision-{day}',
+                'source_window_id': f'window-{day}',
+                'source_topic': 'alpaca.trade_updates',
+                'source_partition': 0,
+                'source_offset': day,
+                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                'event_type': 'fill',
+                'status': 'filled',
+                'filled_qty_delta': '10',
+                'event_ts': _iso(day, 15),
+            }
+            for day in range(days)
+        ],
+        'execution_tca_metrics': [
+            {
+                'id': f'tca-{day}',
+                'execution_id': f'execution-{day}',
+                'trade_decision_id': f'decision-{day}',
+                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                'filled_qty': '10',
+                'shortfall_notional': '1',
+                'computed_at': _iso(day, 16),
+            }
+            for day in range(days)
+        ],
+        'order_feed_source_windows': [
+            {
+                'id': f'window-{day}',
+                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                'source_topic': 'alpaca.trade_updates',
+                'source_partition': 0,
+                'window_started_at': _iso(day, 14),
+                'window_ended_at': _iso(day, 21),
+                'start_offset': day,
+                'end_offset': day + 1,
+                'status': 'complete',
+            }
+            for day in range(days)
+        ],
+        'runtime_ledger_buckets': [_ledger_bucket(day, source_backed=source_backed) for day in range(days)],
+    }
+
+
+def _report(payload: dict[str, object]) -> dict[str, object]:
+    rows = census.CensusSourceRows(
+        trade_decisions=census._row_list(payload.get('trade_decisions')),
+        executions=census._row_list(payload.get('executions')),
+        execution_order_events=census._row_list(payload.get('execution_order_events')),
+        execution_tca_metrics=census._row_list(payload.get('execution_tca_metrics')),
+        order_feed_source_windows=census._row_list(payload.get('order_feed_source_windows')),
+        runtime_ledger_buckets=census._row_list(payload.get('runtime_ledger_buckets')),
+    )
+    return census.build_source_proof_census(
+        rows,
+        identity=census.CensusIdentity(
+            hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+            candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+            runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+            account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            observed_stage='paper',
+        ),
+    )
+
+
+def test_full_source_backed_census_is_authority_candidate_ready() -> None:
+    report = _report(_fixture())
+
+    assert report['verdict']['classification'] == census.AUTHORITY_CANDIDATE_READY
+    assert report['blockers'] == []
+    assert report['totals']['trade_decision_count'] == 20
+    assert report['totals']['execution_count'] == 20
+    assert report['totals']['filled_execution_count'] == 20
+    assert report['totals']['execution_order_event_count'] == 20
+    assert report['totals']['fill_lifecycle_event_count'] == 20
+    assert report['totals']['tca_cost_row_count'] == 20
+    assert report['totals']['source_window_count'] == 20
+    assert report['totals']['runtime_ledger_bucket_count'] == 20
+    assert report['totals']['blocker_free_runtime_ledger_bucket_count'] == 20
+    assert report['totals']['closed_trade_count'] == 400
+    assert report['totals']['filled_notional'] == '12000000'
+    assert report['totals']['post_cost_pnl'] == '12000'
+
+
+def test_missing_decisions_reports_exact_trade_decision_ref_gap() -> None:
+    payload = _fixture()
+    payload['trade_decisions'] = []
+    for bucket in payload['runtime_ledger_buckets']:
+        bucket['decision_count'] = 0
+        bucket['payload']['trade_decision_ids'] = []
+
+    report = _report(payload)
+
+    assert report['verdict']['classification'] == census.LIFECYCLE_MISSING
+    assert AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER in report['blockers']
+    assert RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER in report['blockers']
+    assert report['missing_source_ref_categories'][RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER] is True
+
+
+def test_missing_executions_reports_fill_and_execution_ref_gap() -> None:
+    payload = _fixture()
+    payload['executions'] = []
+    for bucket in payload['runtime_ledger_buckets']:
+        bucket['fill_count'] = 0
+        bucket['payload']['execution_ids'] = []
+
+    report = _report(payload)
+
+    assert report['verdict']['classification'] == census.LIFECYCLE_MISSING
+    assert AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER in report['blockers']
+    assert census.RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in report['blockers']
+
+
+def test_missing_order_event_refs_and_source_offsets_are_exact_source_ref_gaps() -> None:
+    payload = _fixture()
+    for event in payload['execution_order_events']:
+        event.pop('source_offset')
+        event.pop('source_window_id')
+    for bucket in payload['runtime_ledger_buckets']:
+        bucket['payload']['execution_order_event_ids'] = []
+        bucket['payload']['source_offsets'] = []
+        bucket['payload']['source_window_ids'] = []
+
+    report = _report(payload)
+
+    assert report['verdict']['classification'] == census.SOURCE_REFS_MISSING
+    assert RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER in report['blockers']
+    assert RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in report['blockers']
+    assert report['missing_source_ref_categories'][RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER] is True
+
+
+def test_missing_tca_costs_are_economics_missing() -> None:
+    payload = _fixture()
+    payload['execution_tca_metrics'] = []
+    for bucket in payload['runtime_ledger_buckets']:
+        bucket['cost_amount'] = '0'
+        bucket['cost_model_hash_counts'] = {}
+        bucket['payload']['execution_economics_complete'] = False
+        bucket['payload']['cost_basis_counts'] = {}
+
+    report = _report(payload)
+
+    assert report['verdict']['classification'] == census.ECONOMICS_MISSING
+    assert AUTHORITY_EXPLICIT_COSTS_BLOCKER in report['blockers']
+    assert census.EXECUTION_ECONOMICS_MISSING_BLOCKER in report['blockers']
+
+
+def test_open_positions_are_called_out_after_source_and_economics_are_present() -> None:
+    payload = _fixture()
+    payload['runtime_ledger_buckets'][-1] = _ledger_bucket(19, open_positions=1)
+
+    report = _report(payload)
+
+    assert report['verdict']['classification'] == census.OPEN_POSITIONS
+    assert AUTHORITY_OPEN_POSITIONS_BLOCKER in report['blockers']
+    assert report['totals']['open_position_count'] == 1
+
+
+def test_runtime_bucket_aggregate_only_is_source_refs_missing() -> None:
+    report = _report(_fixture(source_backed=False))
+
+    assert report['verdict']['classification'] == census.SOURCE_REFS_MISSING
+    assert report['totals']['blocker_free_runtime_ledger_bucket_count'] == 0
+    assert census.RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER in report['blockers']
+    assert census.RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER in report['blockers']
+
+
+def test_json_output_is_stable_and_cli_reads_fixture(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    path = tmp_path / 'fixture.json'
+    path.write_text(json.dumps(_fixture()))
+
+    exit_code = census.main(['--fixture-json', str(path), '--fail-on-blockers'])
+    first = capsys.readouterr().out
+    report = json.loads(first)
+
+    assert exit_code == 0
+    assert first == census.census_json(report)
+    assert list(report) == sorted(report)
+    assert report['schema_version'] == census.SCHEMA_VERSION
+    assert report['source']['read_only'] is True
+    assert report['source']['writes_proof'] is False
+    assert report['source']['modifies_rows'] is False
+
+
+def test_empty_fixture_has_no_source_activity_verdict() -> None:
+    report = _report({})
+
+    assert report['verdict']['classification'] == census.NO_SOURCE_ACTIVITY
+    assert report['totals']['runtime_ledger_bucket_count'] == 0
+
+
+def test_too_few_source_backed_days_are_distribution_missing() -> None:
+    report = _report(_fixture(days=5))
+
+    assert report['verdict']['classification'] == census.AUTHORITY_DISTRIBUTION_MISSING
+    assert census.AUTHORITY_TRADING_DAYS_BLOCKER in report['blockers']
+
+
+def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from types import SimpleNamespace
+
+    start = datetime(2026, 5, 1, 14, tzinfo=timezone.utc)
+    end = start + timedelta(hours=7)
+    decision = SimpleNamespace(
+        id='decision-0',
+        strategy_id='strategy-0',
+        alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        symbol='AAA',
+        status='executed',
+        decision_hash='decision-hash',
+        created_at=start,
+        executed_at=start + timedelta(minutes=1),
+    )
+    execution = SimpleNamespace(
+        id='execution-0',
+        trade_decision_id='decision-0',
+        alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        alpaca_order_id='order-0',
+        client_order_id='decision-hash',
+        symbol='AAA',
+        side='buy',
+        status='filled',
+        filled_qty='10',
+        avg_fill_price='100',
+        created_at=start + timedelta(minutes=2),
+        updated_at=start + timedelta(minutes=3),
+        order_feed_last_event_ts=start + timedelta(minutes=3),
+    )
+    event = SimpleNamespace(
+        id='event-0',
+        source_topic='alpaca.trade_updates',
+        source_partition=0,
+        source_offset=11,
+        alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        event_ts=start + timedelta(minutes=3),
+        created_at=start + timedelta(minutes=3),
+        symbol='AAA',
+        alpaca_order_id='order-0',
+        client_order_id='decision-hash',
+        event_type='fill',
+        status='filled',
+        filled_qty='10',
+        filled_qty_delta='10',
+        filled_notional_delta='1000',
+        execution_id='execution-0',
+        trade_decision_id='decision-0',
+        source_window_id='window-0',
+    )
+    tca = SimpleNamespace(
+        id='tca-0',
+        execution_id='execution-0',
+        trade_decision_id='decision-0',
+        strategy_id='strategy-0',
+        alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        symbol='AAA',
+        side='buy',
+        filled_qty='10',
+        shortfall_notional='1',
+        realized_shortfall_bps='1',
+        computed_at=start + timedelta(minutes=4),
+    )
+    source_window = SimpleNamespace(
+        id='window-0',
+        consumer_group='torghut-order-feed',
+        source_topic='alpaca.trade_updates',
+        source_partition=0,
+        alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        window_started_at=start,
+        window_ended_at=end,
+        start_offset=10,
+        end_offset=12,
+        consumed_count=2,
+        inserted_count=1,
+        gap_count=0,
+        status='complete',
+    )
+    ledger_bucket = SimpleNamespace(
+        row_id='ledger-0',
+        run_id='run-0',
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        observed_stage='paper',
+        bucket_started_at=start,
+        bucket_ended_at=end,
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        strategy_family='pairs',
+        fill_count=20,
+        decision_count=20,
+        submitted_order_count=20,
+        cancelled_order_count=0,
+        rejected_order_count=0,
+        unfilled_order_count=0,
+        closed_trade_count=20,
+        open_position_count=0,
+        filled_notional='600000',
+        gross_strategy_pnl='610',
+        cost_amount='10',
+        net_strategy_pnl_after_costs='600',
+        post_cost_expectancy_bps='10',
+        ledger_schema_version=EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        pnl_basis=POST_COST_PNL_BASIS,
+        execution_policy_hash_counts={'policy': 1},
+        cost_model_hash_counts={'cost': 1},
+        lineage_hash_counts={'lineage': 1},
+        blockers=(),
+        payload=_source_payload(0),
+    )
+
+    class ExecuteResult:
+        def all(self) -> list[tuple[SimpleNamespace, str]]:
+            return [(decision, DEFAULT_HPAIRS_RUNTIME_STRATEGY)]
+
+    class ScalarResult:
+        def __init__(self, rows: list[SimpleNamespace]) -> None:
+            self.rows = rows
+
+        def all(self) -> list[SimpleNamespace]:
+            return self.rows
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.scalar_results = [[execution], [event], [tca], [source_window]]
+
+        def execute(self, statement: object) -> ExecuteResult:
+            assert statement is not None
+            return ExecuteResult()
+
+        def scalars(self, statement: object) -> ScalarResult:
+            assert statement is not None
+            return ScalarResult(self.scalar_results.pop(0))
+
+    monkeypatch.setattr(census, 'load_runtime_authority_rows', lambda *args, **kwargs: [ledger_bucket])
+
+    rows = census._load_session_rows(
+        FakeSession(),  # type: ignore[arg-type]
+        identity=census.CensusIdentity(
+            hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+            candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+            runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+            account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            observed_stage='paper',
+        ),
+        started_at=start,
+        ended_at=end,
+    )
+
+    assert rows.trade_decisions[0]['id'] == 'decision-0'
+    assert rows.executions[0]['id'] == 'execution-0'
+    assert rows.execution_order_events[0]['source_offset'] == 11
+    assert rows.execution_tca_metrics[0]['id'] == 'tca-0'
+    assert rows.order_feed_source_windows[0]['id'] == 'window-0'
+    assert rows.runtime_ledger_buckets[0]['id'] == 'ledger-0'
+
+
+def test_dsn_loader_opens_session_and_delegates(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    identity = census.CensusIdentity(
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        observed_stage='paper',
+    )
+    expected = census.CensusSourceRows(trade_decisions=[{'id': 'decision'}])
+
+    class FakeSession:
+        def __enter__(self) -> 'FakeSession':
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+    monkeypatch.setattr(census, 'create_engine', lambda dsn: f'engine:{dsn}')
+    monkeypatch.setattr(census, 'sessionmaker', lambda bind: lambda: FakeSession())
+    monkeypatch.setattr(census, '_load_session_rows', lambda *args, **kwargs: expected)
+
+    rows = census.load_dsn_rows('sqlite:///:memory:', identity=identity, started_at=None, ended_at=None)
+
+    assert rows is expected
+
+
+def test_main_reports_read_errors_as_json(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    missing = tmp_path / 'missing.json'
+
+    exit_code = census.main(['--fixture-json', str(missing)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert 'source_proof_census_read_error' in payload['blockers']
+    assert payload['verdict']['classification'] == census.NO_SOURCE_ACTIVITY
+
+
+def test_normalizers_fail_closed_on_invalid_shapes() -> None:
+    assert census._row_list({'not': 'a list'}) == []
+    assert census._parse_cli_timestamp(None) is None
+    assert census._parse_timestamp('not-a-timestamp') is None
+    assert census._sequence('not-a-sequence') == ()
+    assert census._mapping('not-a-mapping') == {}
+    assert census._int('not-an-int') == 0
+    assert census._decimal('not-a-decimal') == 0
+    assert census._utc(datetime(2026, 5, 1)).tzinfo is timezone.utc
+
+    try:
+        census._parse_cli_timestamp('not-a-timestamp')
+    except ValueError as exc:
+        assert 'invalid timestamp' in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError('invalid timestamp should fail')


### PR DESCRIPTION
## Summary

- Adds a deterministic read-only H-PAIRS/TORGHUT_SIM source-proof census CLI that accepts SQLAlchemy DSNs or fixture JSON.
- Reports daily and aggregate paper-route/runtime-ledger counts for decisions, executions, filled executions, order events, fill lifecycle events, TCA/cost rows, source-window/source-offset coverage, runtime buckets, closed/open positions, filled notional, and post-cost PnL.
- Emits stable machine-readable blocker codes and verdict classifications so aggregate-only/runtime-ledger rows expose exactly which authority source refs remain missing.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed after installing `build-essential` in the workspace so `crosshair-tool` could compile.
- `cd services/torghut && uv run --frozen pytest tests/test_audit_hpairs_source_proof_census.py tests/test_verify_hpairs_runtime_authority.py -q` — passed, 36 tests.
- `cd services/torghut && uv run --frozen ruff check scripts/audit_hpairs_source_proof_census.py app/trading/runtime_authority_verifier.py tests/test_audit_hpairs_source_proof_census.py tests/test_verify_hpairs_runtime_authority.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — rerun after coverage-test expansion; passed.
- `git diff --check` — passed.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. Pure tooling/tests only; no runtime image promotion is needed.
