### PR TITLE
fix(torghut): shorten bounded read index names

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -1656,7 +1656,7 @@ class StrategyHypothesisMetricWindow(Base, TimestampMixin):
             "created_at",
         ),
         Index(
-            "ix_strategy_hypothesis_metric_windows_hypothesis_candidate_window",
+            "ix_metric_windows_hyp_candidate_window",
             "hypothesis_id",
             "candidate_id",
             "window_started_at",
@@ -1757,7 +1757,7 @@ class StrategyRuntimeLedgerBucket(Base, TimestampMixin):
             "created_at",
         ),
         Index(
-            "ix_strategy_runtime_ledger_buckets_hypothesis_run_candidate_stage_ended",
+            "ix_runtime_ledger_buckets_hyp_run_candidate_stage_ended",
             "hypothesis_id",
             "run_id",
             "candidate_id",

--- a/services/torghut/migrations/versions/0045_paper_route_audit_bounded_read_indexes.py
+++ b/services/torghut/migrations/versions/0045_paper_route_audit_bounded_read_indexes.py
@@ -33,7 +33,7 @@ _INDEXES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
         ("alpaca_account_label", "event_ts", "symbol", "trade_decision_id"),
     ),
     (
-        "ix_strategy_hypothesis_metric_windows_hypothesis_candidate_window",
+        "ix_metric_windows_hyp_candidate_window",
         "strategy_hypothesis_metric_windows",
         (
             "hypothesis_id",
@@ -44,7 +44,7 @@ _INDEXES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
         ),
     ),
     (
-        "ix_strategy_runtime_ledger_buckets_hypothesis_run_candidate_stage_ended",
+        "ix_runtime_ledger_buckets_hyp_run_candidate_stage_ended",
         "strategy_runtime_ledger_buckets",
         (
             "hypothesis_id",

--- a/services/torghut/tests/test_paper_route_audit_bounded_read_indexes_migration.py
+++ b/services/torghut/tests/test_paper_route_audit_bounded_read_indexes_migration.py
@@ -23,6 +23,32 @@ def _load_migration_module() -> ModuleType:
 
 
 class TestPaperRouteAuditBoundedReadIndexesMigration(TestCase):
+    def test_index_names_fit_postgres_identifier_limit(self) -> None:
+        module = _load_migration_module()
+
+        too_long = [
+            index_name
+            for index_name, _table_name, _columns in module._INDEXES
+            if len(index_name) > 63
+        ]
+
+        self.assertEqual(too_long, [])
+
+    def test_model_index_names_fit_postgres_identifier_limit(self) -> None:
+        from app.models import StrategyHypothesisMetricWindow, StrategyRuntimeLedgerBucket
+
+        too_long = [
+            index.name
+            for table in (
+                StrategyHypothesisMetricWindow.__table__,
+                StrategyRuntimeLedgerBucket.__table__,
+            )
+            for index in table.indexes
+            if index.name is not None and len(index.name) > 63
+        ]
+
+        self.assertEqual(sorted(too_long), [])
+
     def test_revision_follows_current_head(self) -> None:
         module = _load_migration_module()
 
@@ -58,7 +84,11 @@ class TestPaperRouteAuditBoundedReadIndexesMigration(TestCase):
             created_names,
         )
         self.assertIn(
-            "ix_strategy_runtime_ledger_buckets_hypothesis_run_candidate_stage_ended",
+            "ix_metric_windows_hyp_candidate_window",
+            created_names,
+        )
+        self.assertIn(
+            "ix_runtime_ledger_buckets_hyp_run_candidate_stage_ended",
             created_names,
         )
 


### PR DESCRIPTION
## Summary

- Shortens the new 0045 bounded-read migration indexes that exceeded PostgreSQL's 63-character identifier limit.
- Keeps the Torghut ORM metadata index names aligned with the migration names.
- Adds regression coverage for both migration and model index identifier lengths.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_audit_bounded_read_indexes_migration.py -q`
- `uv run --frozen ruff check app/models/entities.py migrations/versions/0045_paper_route_audit_bounded_read_indexes.py tests/test_paper_route_audit_bounded_read_indexes_migration.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
