### PR TITLE
fix(torghut): gate bounded hpairs sim collection

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1183,6 +1183,11 @@ def _target_identity(
             target.get("canary_collection_authorized")
             or target.get("bounded_evidence_collection_authorized")
         ),
+        "bounded_live_paper_collection_authorized": bool(
+            target.get("bounded_live_paper_collection_authorized")
+            or target.get("canary_collection_authorized")
+            or target.get("bounded_evidence_collection_authorized")
+        ),
         "capital_promotion_allowed": False,
         "final_authority_ok": False,
         "source_promotion_allowed": source_promotion_allowed,
@@ -1855,6 +1860,9 @@ def _next_paper_route_runtime_window_targets(
             "capital_promotion_allowed": False,
             "final_authority_ok": False,
             "bounded_evidence_collection_authorized": canary_collection_authorized,
+            "bounded_live_paper_collection_authorized": (
+                canary_collection_authorized
+            ),
             "bounded_evidence_collection_scope": (
                 "paper_route_probe_next_session_only"
             ),

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -79,6 +79,32 @@ _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS = 60
 _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS = 600
 _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK = timedelta(days=7)
 _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON = Decimal("0.00000001")
+_BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL = "TORGHUT_SIM"
+_BOUNDED_SIM_COLLECTION_SOURCE_KIND = "paper_route_probe_runtime_observed"
+_BOUNDED_SIM_COLLECTION_SCOPE = "paper_route_probe_next_session_only"
+_BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS = (
+    "bounded_evidence_collection_blockers",
+    "runtime_window_import_health_gate_blockers",
+    "paper_route_account_pre_session_blockers",
+    "paper_route_hpairs_symbol_blockers",
+)
+_BOUNDED_SIM_COLLECTION_LINEAGE_KEYS = (
+    "account_label",
+    "source_account_label",
+    "observed_stage",
+    "runtime_strategy_name",
+    "source_kind",
+    "source_manifest_ref",
+    "bounded_evidence_collection_scope",
+    "bounded_evidence_collection_max_notional",
+)
+_BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS = (
+    "bounded_evidence_collection_authorized",
+    "bounded_live_paper_collection_authorized",
+    "canary_collection_authorized",
+    "evidence_collection_ok",
+)
+_BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS = ("source_decision_readiness",)
 
 
 def _safe_int(value: object) -> int:
@@ -155,6 +181,126 @@ def _target_plan_lineage(
         "source_hypothesis_ids": hypothesis_ids,
         "source_strategy_names": strategy_names,
     }
+
+
+def _bounded_sim_collection_blockers(
+    target: Mapping[str, Any],
+    *,
+    account_label: str | None,
+) -> list[str]:
+    blockers: list[str] = []
+    runtime_account = _safe_text(account_label)
+    target_account = _safe_text(target.get("account_label"))
+    if (
+        runtime_account is not None
+        and runtime_account != _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL
+    ):
+        blockers.append("bounded_sim_collection_runtime_account_not_torghut_sim")
+    if target_account != _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL:
+        blockers.append("bounded_sim_collection_target_account_not_torghut_sim")
+    if _safe_text(target.get("observed_stage")) != "paper":
+        blockers.append("bounded_sim_collection_paper_stage_required")
+    if _safe_text(target.get("source_kind")) != _BOUNDED_SIM_COLLECTION_SOURCE_KIND:
+        blockers.append("bounded_sim_collection_source_kind_required")
+    if not (
+        _safe_text(target.get("candidate_id"))
+        or _lineage_text_values(target.get("source_candidate_ids"))
+    ):
+        blockers.append("bounded_sim_collection_candidate_id_missing")
+    if not (
+        _safe_text(target.get("hypothesis_id"))
+        or _lineage_text_values(target.get("source_hypothesis_ids"))
+    ):
+        blockers.append("bounded_sim_collection_hypothesis_id_missing")
+    if not (
+        _safe_text(target.get("runtime_strategy_name"))
+        or _safe_text(target.get("strategy_name"))
+        or _lineage_text_values(target.get("source_strategy_names"))
+    ):
+        blockers.append("bounded_sim_collection_runtime_strategy_missing")
+    if _safe_text(target.get("source_manifest_ref")) is None:
+        blockers.append("bounded_sim_collection_source_manifest_missing")
+    if not (
+        _target_truthy(target.get("bounded_evidence_collection_authorized"))
+        or _target_truthy(target.get("bounded_live_paper_collection_authorized"))
+        or _target_truthy(target.get("canary_collection_authorized"))
+    ):
+        blockers.append("bounded_sim_collection_authorization_missing")
+    if not _target_truthy(target.get("evidence_collection_ok")):
+        blockers.append("bounded_sim_collection_evidence_collection_not_ready")
+    if (
+        _target_truthy(target.get("promotion_allowed"))
+        or _target_truthy(target.get("final_promotion_allowed"))
+        or _target_truthy(target.get("final_promotion_authorized"))
+        or _target_truthy(target.get("capital_promotion_allowed"))
+    ):
+        blockers.append("bounded_sim_collection_non_final_state_required")
+    if _safe_text(target.get("bounded_evidence_collection_scope")) not in {
+        None,
+        _BOUNDED_SIM_COLLECTION_SCOPE,
+    }:
+        blockers.append("bounded_sim_collection_scope_not_supported")
+    if not _target_symbols(target):
+        blockers.append("bounded_sim_collection_probe_symbols_missing")
+
+    readiness = target.get("source_decision_readiness")
+    if isinstance(readiness, Mapping):
+        typed_readiness = cast(Mapping[str, Any], readiness)
+        if not _target_truthy(typed_readiness.get("ready")):
+            blockers.append("bounded_sim_collection_source_decision_not_ready")
+        blockers.extend(_lineage_text_values(typed_readiness.get("blockers")))
+    else:
+        blockers.append("bounded_sim_collection_source_decision_readiness_missing")
+
+    if _safe_text(target.get("paper_route_probe_pair_balance_state")) == "imbalanced":
+        blockers.append("paper_route_probe_pair_imbalanced")
+    for key in _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS:
+        blockers.extend(_lineage_text_values(target.get(key)))
+    return list(dict.fromkeys(blockers))
+
+
+def _bounded_sim_collection_authorized(
+    target: Mapping[str, Any],
+    *,
+    account_label: str | None,
+) -> bool:
+    return not _bounded_sim_collection_blockers(target, account_label=account_label)
+
+
+def _target_requires_bounded_sim_collection_gate(target: Mapping[str, Any]) -> bool:
+    hypothesis_id = _safe_text(target.get("hypothesis_id"))
+    candidate_id = _safe_text(target.get("candidate_id"))
+    account_label = _safe_text(target.get("account_label"))
+    family_tokens = _target_strategy_family_tokens(target)
+    return (
+        hypothesis_id == "H-PAIRS-01"
+        or candidate_id == "c88421d619759b2cfaa6f4d0"
+        or account_label == _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL
+        or any("microbar_cross_sectional_pairs" in token for token in family_tokens)
+    )
+
+
+def _bounded_sim_collection_metadata_from_decision(
+    decision: StrategyDecision,
+    *,
+    account_label: str | None,
+    trading_mode: str,
+) -> Mapping[str, Any] | None:
+    if trading_mode != "paper":
+        return None
+    for key in (
+        "paper_route_target_plan_source_decision",
+        "paper_route_target_plan",
+        "paper_route_probe",
+        "paper_route_probe_exit",
+    ):
+        value = decision.params.get(key)
+        if not isinstance(value, Mapping):
+            continue
+        metadata = cast(Mapping[str, Any], value)
+        if _bounded_sim_collection_authorized(metadata, account_label=account_label):
+            return metadata
+    return None
 
 
 def _target_lookup_names(target: Mapping[str, Any]) -> list[str]:
@@ -401,6 +547,7 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
     profit_proof_eligible = _target_bool(params.get("profit_proof_eligible"))
     fallback_source_decision_modes: list[str] = []
     fallback_profit_proof_values: list[bool] = []
+    collection_lineage: dict[str, Any] = {}
     for payload in payloads:
         _merge_unique_texts(
             candidate_ids, _lineage_text_values(payload.get("source_candidate_id"))
@@ -427,6 +574,23 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
                 eligible := _target_bool(payload.get("profit_proof_eligible"))
             ) is not None:
                 fallback_profit_proof_values.append(eligible)
+        for key in _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS:
+            if key not in collection_lineage and (
+                value := _safe_text(payload.get(key))
+            ):
+                collection_lineage[key] = value
+        for key in _BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS:
+            value = _target_bool(payload.get(key))
+            if key not in collection_lineage and value is not None:
+                collection_lineage[key] = value
+        if "paper_route_probe_symbols" not in collection_lineage:
+            symbols = _lineage_text_values(payload.get("paper_route_probe_symbols"))
+            if symbols:
+                collection_lineage["paper_route_probe_symbols"] = symbols
+        for key in _BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS:
+            value = payload.get(key)
+            if key not in collection_lineage and isinstance(value, Mapping):
+                collection_lineage[key] = dict(cast(Mapping[str, Any], value))
 
         raw_targets = payload.get("paper_route_probe_lineage_targets")
         if isinstance(raw_targets, Sequence) and not isinstance(
@@ -464,6 +628,7 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
         lineage["profit_proof_eligible"] = profit_proof_eligible
     elif fallback_profit_proof_values:
         lineage["profit_proof_eligible"] = all(fallback_profit_proof_values)
+    lineage.update(collection_lineage)
     return lineage
 
 
@@ -537,6 +702,21 @@ def _merge_paper_route_probe_lineage(
     for key in ("source_decision_mode", "profit_proof_eligible"):
         if key in lineage and key not in target:
             target[key] = lineage[key]
+    for key in _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS:
+        value = _safe_text(lineage.get(key))
+        if value is not None and key not in target:
+            target[key] = value
+    for key in _BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS:
+        value = _target_bool(lineage.get(key))
+        if value is not None and key not in target:
+            target[key] = value
+    symbols = _lineage_text_values(lineage.get("paper_route_probe_symbols"))
+    if symbols and "paper_route_probe_symbols" not in target:
+        target["paper_route_probe_symbols"] = symbols
+    for key in _BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS:
+        value = lineage.get(key)
+        if key not in target and isinstance(value, Mapping):
+            target[key] = dict(cast(Mapping[str, Any], value))
 
     raw_targets = lineage.get("paper_route_probe_lineage_targets")
     if not isinstance(raw_targets, Sequence) or isinstance(
@@ -2442,6 +2622,11 @@ class SimpleTradingPipeline(TradingPipeline):
         max_notional: Decimal,
     ) -> dict[str, Any]:
         lineage = _target_plan_lineage([dict(target)], symbol)
+        bounded_collection_authorized = (
+            _target_truthy(target.get("bounded_evidence_collection_authorized"))
+            or _target_truthy(target.get("bounded_live_paper_collection_authorized"))
+            or _target_truthy(target.get("canary_collection_authorized"))
+        )
         metadata: dict[str, Any] = {
             "mode": "paper_route_target_plan_source_decision",
             "source": "external_target_plan_url",
@@ -2485,7 +2670,11 @@ class SimpleTradingPipeline(TradingPipeline):
                 )
                 if str(item).strip()
             ],
-            "bounded_evidence_collection_authorized": True,
+            "bounded_evidence_collection_authorized": bounded_collection_authorized,
+            "bounded_live_paper_collection_authorized": (
+                bounded_collection_authorized
+            ),
+            "canary_collection_authorized": bounded_collection_authorized,
             "bounded_evidence_collection_scope": (
                 _safe_text(target.get("bounded_evidence_collection_scope"))
                 or "paper_route_probe_next_session_only"
@@ -2497,6 +2686,16 @@ class SimpleTradingPipeline(TradingPipeline):
             "final_promotion_allowed": False,
             **lineage,
         }
+        for key in (
+            "source_decision_readiness",
+            "bounded_evidence_collection_blockers",
+            "runtime_window_import_health_gate_blockers",
+            "paper_route_account_pre_session_blockers",
+            "paper_route_hpairs_symbol_blockers",
+            "paper_route_probe_pair_balance_state",
+        ):
+            if key in target:
+                metadata[key] = target[key]
         exit_minute, exit_defaulted = _target_probe_exit_minute_after_open(target)
         if exit_minute is not None:
             effective_exit_minute = min(exit_minute, _REGULAR_SESSION_MINUTES - 1)
@@ -2567,6 +2766,17 @@ class SimpleTradingPipeline(TradingPipeline):
         decisions: list[StrategyDecision] = []
         seen: set[tuple[str, str, str, str]] = set()
         for target in target_plan_targets:
+            if _target_requires_bounded_sim_collection_gate(target):
+                collection_blockers = _bounded_sim_collection_blockers(
+                    target,
+                    account_label=self.account_label,
+                )
+                if collection_blockers:
+                    logger.warning(
+                        "Skipping paper-route target source collection because bounded SIM collection is not authorized blockers=%s",
+                        ",".join(collection_blockers),
+                    )
+                    continue
             window = _target_probe_window(target)
             if window is None:
                 continue
@@ -3408,6 +3618,30 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         paper_route_probe_applied = False
         if proof_floor_block_reason is not None:
+            if not settings.trading_simple_submit_enabled:
+                collection_metadata = _bounded_sim_collection_metadata_from_decision(
+                    decision,
+                    account_label=self.account_label,
+                    trading_mode=settings.trading_mode,
+                )
+                if collection_metadata is None:
+                    self._block_decision_submission(
+                        session=session,
+                        decision=decision,
+                        decision_row=decision_row,
+                        reason="simple_submit_disabled",
+                        submission_stage="blocked_simple_submit_disabled",
+                        capital_stage="shadow",
+                        extra_metadata={
+                            "simple_lane": {
+                                "submit_enabled": False,
+                                "bounded_sim_collection_bypass": False,
+                                "bounded_sim_collection_required": True,
+                                "proof_floor_block_reason": proof_floor_block_reason,
+                            }
+                        },
+                    )
+                    return False
             if settings.trading_mode == "paper" and (
                 self._paper_route_probe_exit_metadata(decision) is not None
                 or _paper_route_probe_entry_metadata(decision.params) is not None

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1641,6 +1641,7 @@ def _runtime_ledger_paper_probation_candidates(
             "proof_mode": "probation",
             "evidence_collection_ok": True,
             "canary_collection_authorized": True,
+            "bounded_live_paper_collection_authorized": True,
             "capital_promotion_allowed": False,
             "final_authority_ok": False,
             "final_promotion_allowed": False,
@@ -1685,6 +1686,7 @@ def _runtime_ledger_source_collection_candidates(
             "proof_mode": "probation",
             "evidence_collection_ok": True,
             "canary_collection_authorized": False,
+            "bounded_live_paper_collection_authorized": False,
             "capital_promotion_allowed": False,
             "final_authority_ok": False,
             "final_promotion_allowed": False,
@@ -1910,6 +1912,7 @@ def _runtime_ledger_paper_probation_import_plan(
             "proof_mode": "probation",
             "evidence_collection_ok": True,
             "canary_collection_authorized": not source_collection,
+            "bounded_live_paper_collection_authorized": not source_collection,
             "capital_promotion_allowed": False,
             "final_authority_ok": False,
             "evidence_collection_stage": "paper",
@@ -1955,6 +1958,10 @@ def _runtime_ledger_paper_probation_import_plan(
         "evidence_collection_ok": bool(targets),
         "canary_collection_authorized": any(
             bool(target.get("canary_collection_authorized")) for target in targets
+        ),
+        "bounded_live_paper_collection_authorized": any(
+            bool(target.get("bounded_live_paper_collection_authorized"))
+            for target in targets
         ),
         "capital_promotion_allowed": False,
         "final_authority_ok": False,

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -5,7 +5,12 @@ from decimal import Decimal
 
 from app.config import settings
 from app.models import Strategy
-from app.trading.scheduler.simple_pipeline import SimpleTradingPipeline
+from app.trading.models import StrategyDecision
+from app.trading.scheduler.simple_pipeline import (
+    SimpleTradingPipeline,
+    _bounded_sim_collection_blockers,
+    _bounded_sim_collection_metadata_from_decision,
+)
 from app.trading.runtime_window_import import (
     _runtime_promotion_blocking_reasons,
     resolve_hypothesis_manifest,
@@ -217,8 +222,14 @@ def test_paper_route_target_metadata_is_collection_only_without_live_capital_mut
         'runtime_strategy_name': 'microbar-cross-sectional-pairs-v1',
         'source_kind': 'paper_route_probe_runtime_observed',
         'paper_probation_authorized': True,
+        'evidence_collection_ok': True,
+        'canary_collection_authorized': True,
+        'bounded_evidence_collection_authorized': True,
+        'bounded_live_paper_collection_authorized': True,
         'bounded_evidence_collection_scope': 'paper_route_probe_next_session_only',
         'paper_route_probe_symbols': ['AAPL', 'AMZN'],
+        'source_manifest_ref': 'config/trading/hypotheses/h-pairs-01.json',
+        'source_decision_readiness': {'ready': True, 'blockers': []},
     }
 
     metadata = SimpleTradingPipeline._paper_route_target_source_decision_metadata(
@@ -239,6 +250,8 @@ def test_paper_route_target_metadata_is_collection_only_without_live_capital_mut
 
     assert settings.trading_mode == trading_mode_before
     assert metadata['bounded_evidence_collection_authorized'] is True
+    assert metadata['bounded_live_paper_collection_authorized'] is True
+    assert metadata['canary_collection_authorized'] is True
     assert metadata['promotion_allowed'] is False
     assert metadata['final_authority_ok'] is False
     assert metadata['final_promotion_allowed'] is False
@@ -249,3 +262,125 @@ def test_paper_route_target_metadata_is_collection_only_without_live_capital_mut
         'runtime_strategy_name': 'microbar-cross-sectional-pairs-v1',
         'source_kind': 'paper_route_probe_runtime_observed',
     }
+
+
+def _bounded_hpairs_target(**overrides: object) -> dict[str, object]:
+    target: dict[str, object] = {
+        'hypothesis_id': 'H-PAIRS-01',
+        'candidate_id': 'c88421d619759b2cfaa6f4d0',
+        'account_label': 'TORGHUT_SIM',
+        'source_account_label': 'TORGHUT_SIM',
+        'observed_stage': 'paper',
+        'strategy_family': 'microbar_cross_sectional_pairs',
+        'strategy_name': 'microbar-cross-sectional-pairs-v1',
+        'runtime_strategy_name': 'microbar-cross-sectional-pairs-v1',
+        'source_kind': 'paper_route_probe_runtime_observed',
+        'source_manifest_ref': 'config/trading/hypotheses/h-pairs-01.json',
+        'paper_route_probe_symbols': ['AAPL', 'AMZN'],
+        'paper_route_probe_pair_balance_state': 'balanced',
+        'evidence_collection_ok': True,
+        'canary_collection_authorized': True,
+        'bounded_evidence_collection_authorized': True,
+        'bounded_live_paper_collection_authorized': True,
+        'bounded_evidence_collection_scope': 'paper_route_probe_next_session_only',
+        'bounded_evidence_collection_blockers': [],
+        'runtime_window_import_health_gate_blockers': [],
+        'paper_route_account_pre_session_blockers': [],
+        'paper_route_hpairs_symbol_blockers': [],
+        'source_decision_readiness': {'ready': True, 'blockers': []},
+        'promotion_allowed': False,
+        'final_promotion_authorized': False,
+        'final_promotion_allowed': False,
+        'capital_promotion_allowed': False,
+    }
+    target.update(overrides)
+    return target
+
+
+def test_bounded_sim_collection_authorizes_non_final_hpairs_target_only() -> None:
+    target = _bounded_hpairs_target()
+
+    assert _bounded_sim_collection_blockers(target, account_label='TORGHUT_SIM') == []
+
+    assert 'bounded_sim_collection_runtime_account_not_torghut_sim' in (
+        _bounded_sim_collection_blockers(target, account_label='TORGHUT_LIVE')
+    )
+    assert 'bounded_sim_collection_non_final_state_required' in (
+        _bounded_sim_collection_blockers(
+            _bounded_hpairs_target(final_promotion_allowed=True),
+            account_label='TORGHUT_SIM',
+        )
+    )
+
+
+def test_bounded_sim_collection_blocks_missing_source_lineage_prerequisites() -> None:
+    blockers = _bounded_sim_collection_blockers(
+        _bounded_hpairs_target(
+            candidate_id='',
+            hypothesis_id='',
+            source_manifest_ref='',
+            evidence_collection_ok=False,
+            source_decision_readiness={'ready': False, 'blockers': ['source_strategy_missing']},
+        ),
+        account_label='TORGHUT_SIM',
+    )
+
+    assert 'bounded_sim_collection_candidate_id_missing' in blockers
+    assert 'bounded_sim_collection_hypothesis_id_missing' in blockers
+    assert 'bounded_sim_collection_source_manifest_missing' in blockers
+    assert 'bounded_sim_collection_evidence_collection_not_ready' in blockers
+    assert 'bounded_sim_collection_source_decision_not_ready' in blockers
+    assert 'source_strategy_missing' in blockers
+
+
+def test_simple_submit_disabled_bypass_requires_explicit_bounded_sim_collection() -> None:
+    ordinary_probe = StrategyDecision(
+        strategy_id='00000000-0000-0000-0000-000000000001',
+        symbol='AAPL',
+        event_ts=datetime(2026, 6, 1, 14, 30, tzinfo=timezone.utc),
+        timeframe='1Min',
+        action='buy',
+        qty=Decimal('1'),
+        params={
+            'paper_route_probe': {
+                'source_decision_mode': 'route_acquisition',
+                'profit_proof_eligible': False,
+            }
+        },
+    )
+    bounded_probe = ordinary_probe.model_copy(
+        update={'params': {'paper_route_probe': _bounded_hpairs_target()}}
+    )
+
+    assert (
+        _bounded_sim_collection_metadata_from_decision(
+            ordinary_probe,
+            account_label='TORGHUT_SIM',
+            trading_mode='paper',
+        )
+        is None
+    )
+    assert (
+        _bounded_sim_collection_metadata_from_decision(
+            bounded_probe,
+            account_label='TORGHUT_SIM',
+            trading_mode='paper',
+        )
+        is not None
+    )
+    assert (
+        _bounded_sim_collection_metadata_from_decision(
+            bounded_probe,
+            account_label='TORGHUT_LIVE',
+            trading_mode='paper',
+        )
+        is None
+    )
+    assert (
+        _bounded_sim_collection_metadata_from_decision(
+            bounded_probe,
+            account_label='TORGHUT_SIM',
+            trading_mode='live',
+        )
+        is None
+    )

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -1226,6 +1226,9 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(paper_candidates[0]["proof_mode"], "probation")
         self.assertTrue(paper_candidates[0]["evidence_collection_ok"])
         self.assertTrue(paper_candidates[0]["canary_collection_authorized"])
+        self.assertTrue(
+            paper_candidates[0]["bounded_live_paper_collection_authorized"]
+        )
         self.assertFalse(paper_candidates[0]["capital_promotion_allowed"])
         self.assertFalse(paper_candidates[0]["final_authority_ok"])
         self.assertFalse(paper_candidates[0]["final_promotion_allowed"])
@@ -1241,6 +1244,7 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(import_plan["proof_mode"], "probation")
         self.assertTrue(import_plan["evidence_collection_ok"])
         self.assertTrue(import_plan["canary_collection_authorized"])
+        self.assertTrue(import_plan["bounded_live_paper_collection_authorized"])
         self.assertFalse(import_plan["capital_promotion_allowed"])
         self.assertFalse(import_plan["final_authority_ok"])
         self.assertFalse(import_plan["final_promotion_allowed"])
@@ -1280,6 +1284,7 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(target["proof_mode"], "probation")
         self.assertTrue(target["evidence_collection_ok"])
         self.assertTrue(target["canary_collection_authorized"])
+        self.assertTrue(target["bounded_live_paper_collection_authorized"])
         self.assertFalse(target["capital_promotion_allowed"])
         self.assertFalse(target["final_authority_ok"])
         self.assertEqual(target["promotion_allowed"], False)


### PR DESCRIPTION
## Summary

- Adds an explicit bounded H-PAIRS TORGHUT_SIM collection gate for paper-route target source decisions.
- Requires deterministic source-lineage/readiness prerequisites before collecting SIM evidence, including TORGHUT_SIM paper-stage identity, source readiness, no collection blockers, and non-final promotion flags.
- Keeps final promotion blocked by preserving promotion_allowed=false/final_promotion_allowed=false and surfacing bounded_live_paper_collection_authorized as collection-only state.
- Prevents simple_submit_disabled from being bypassed except by the explicit bounded SIM collection metadata path.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_completion_trace.py tests/test_simple_pipeline.py tests/test_paper_route_evidence.py -q` — passed, 163 passed
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council.py app/trading/completion.py app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py tests/test_submission_council.py tests/test_completion_trace.py tests/test_simple_pipeline.py tests/test_paper_route_evidence.py` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed
- `git diff --check` — passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
