### PR TITLE
fix(torghut): require source evidence for closed paper imports

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -814,9 +814,10 @@ def _hpairs_round_trip_identity_blockers(target: Mapping[str, object]) -> list[s
     observed_stage = (_safe_text(target.get("observed_stage")) or "").lower()
     if observed_stage != "paper":
         blockers.append("paper_route_hpairs_paper_stage_required")
-    if _safe_text(target.get("runtime_strategy_name")) is None and _safe_text(
-        target.get("strategy_name")
-    ) is None:
+    if (
+        _safe_text(target.get("runtime_strategy_name")) is None
+        and _safe_text(target.get("strategy_name")) is None
+    ):
         blockers.append("paper_route_hpairs_runtime_strategy_name_missing")
     if _safe_text(target.get("source_kind")) is None:
         blockers.append("paper_route_hpairs_source_kind_missing")
@@ -1860,9 +1861,7 @@ def _next_paper_route_runtime_window_targets(
             "capital_promotion_allowed": False,
             "final_authority_ok": False,
             "bounded_evidence_collection_authorized": canary_collection_authorized,
-            "bounded_live_paper_collection_authorized": (
-                canary_collection_authorized
-            ),
+            "bounded_live_paper_collection_authorized": (canary_collection_authorized),
             "bounded_evidence_collection_scope": (
                 "paper_route_probe_next_session_only"
             ),
@@ -4836,7 +4835,7 @@ def _runtime_window_target_counts(
     }
 
 
-def _target_audits_have_material_runtime_window_evidence(
+def _target_audits_have_source_backed_runtime_window_import_evidence(
     target_audits: Sequence[Mapping[str, object]],
 ) -> bool:
     counts = _runtime_window_target_counts(target_audits)
@@ -4847,7 +4846,6 @@ def _target_audits_have_material_runtime_window_evidence(
             "rejected_signal_activity",
             "runtime_ledger",
             "evidence_grade_runtime_ledger",
-            "promotion_decision",
         )
     )
 
@@ -5171,16 +5169,6 @@ def _runtime_window_import_plan_for_audit(
     return next_targets
 
 
-def _targets_have_explicit_window_bounds(
-    targets: Sequence[Mapping[str, object]],
-) -> bool:
-    return any(
-        _parse_datetime(target.get("window_start")) is not None
-        and _parse_datetime(target.get("window_end")) is not None
-        for target in targets
-    )
-
-
 def build_paper_route_target_plan_payload(
     session: Session,
     *,
@@ -5237,10 +5225,33 @@ def build_paper_route_target_plan_payload(
         generated_at=resolved_generated_at,
         require_clean_pre_session=False,
     )
-    runtime_window_import_plan = _runtime_window_import_plan_for_audit(
+    runtime_window_import_plan = next_targets
+    latest_closed_runtime_window_import_target_audits: (
+        list[dict[str, object]] | None
+    ) = None
+    latest_closed_runtime_window_import_plan = _runtime_window_import_plan_for_audit(
         latest_closed_targets=latest_closed_targets,
         next_targets=next_targets,
     )
+    if (
+        latest_closed_runtime_window_import_plan is latest_closed_targets
+        and include_runtime_window_import_audit is not False
+    ):
+        latest_closed_runtime_window_import_target_audits = [
+            _target_audit_fail_closed(
+                session,
+                raw_target=target,
+                probe=probe,
+                generated_at=resolved_generated_at,
+                lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+                error_source="target_plan_runtime_window_target_audit",
+            )
+            for target in _as_mapping_items(latest_closed_targets.get("targets"))
+        ]
+        if _target_audits_have_source_backed_runtime_window_import_evidence(
+            latest_closed_runtime_window_import_target_audits
+        ):
+            runtime_window_import_plan = latest_closed_targets
     runtime_import_readiness = _as_mapping(
         runtime_window_import_plan.get("session_readiness")
     )
@@ -5271,17 +5282,27 @@ def build_paper_route_target_plan_payload(
             )
             for target in targets
         ]
-        runtime_window_import_target_audits = [
-            _target_audit_fail_closed(
-                session,
-                raw_target=target,
-                probe=probe,
-                generated_at=resolved_generated_at,
-                lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
-                error_source="target_plan_runtime_window_target_audit",
+        if (
+            runtime_window_import_plan is latest_closed_targets
+            and latest_closed_runtime_window_import_target_audits is not None
+        ):
+            runtime_window_import_target_audits = (
+                latest_closed_runtime_window_import_target_audits
             )
-            for target in _as_mapping_items(runtime_window_import_plan.get("targets"))
-        ]
+        else:
+            runtime_window_import_target_audits = [
+                _target_audit_fail_closed(
+                    session,
+                    raw_target=target,
+                    probe=probe,
+                    generated_at=resolved_generated_at,
+                    lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+                    error_source="target_plan_runtime_window_target_audit",
+                )
+                for target in _as_mapping_items(
+                    runtime_window_import_plan.get("targets")
+                )
+            ]
     else:
         source_target_audits = _deferred_runtime_window_target_audits(targets)
         runtime_window_import_target_audits = _deferred_runtime_window_target_audits(
@@ -5474,9 +5495,6 @@ def build_paper_route_evidence_audit(
         next_targets=next_targets,
     )
     if latest_closed_runtime_window_import_plan is latest_closed_targets:
-        targets_have_explicit_window_bounds = _targets_have_explicit_window_bounds(
-            targets
-        )
         latest_closed_target_audits = [
             _target_audit_fail_closed(
                 session,
@@ -5488,11 +5506,8 @@ def build_paper_route_evidence_audit(
             )
             for target in _as_mapping_items(latest_closed_targets.get("targets"))
         ]
-        if (
-            not targets_have_explicit_window_bounds
-            or _target_audits_have_material_runtime_window_evidence(
-                latest_closed_target_audits
-            )
+        if _target_audits_have_source_backed_runtime_window_import_evidence(
+            latest_closed_target_audits
         ):
             runtime_window_import_plan = latest_closed_targets
             runtime_window_import_target_audits = latest_closed_target_audits

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -589,13 +589,13 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "deferred_until_import_ready",
         )
         import_audit = payload["runtime_window_import_audit"]
-        self.assertEqual(import_audit["state"], "import_due_source_activity_missing")
+        self.assertEqual(import_audit["state"], "waiting_for_session_open")
         self.assertEqual(
             import_audit["next_action"],
-            "inspect_paper_route_source_activity_before_import",
+            "wait_for_regular_session_open",
         )
         self.assertIn(
-            "runtime_window_import_audit_deferred_until_import_ready",
+            "paper_route_session_window_not_open",
             import_audit["blockers"],
         )
         self.assertEqual(
@@ -1109,7 +1109,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             ["paper_route_account_pre_session_snapshot_missing"],
         )
 
-    def test_target_plan_import_plan_uses_latest_closed_window_on_weekend(
+    def test_target_plan_import_plan_skips_closed_window_without_source_evidence(
         self,
     ) -> None:
         generated_at = datetime(2026, 5, 30, 8, 23, tzinfo=timezone.utc)
@@ -1122,30 +1122,31 @@ class TestPaperRouteEvidenceAudit(TestCase):
         import_plan = payload["runtime_window_import_plan"]
         self.assertEqual(
             import_plan["purpose"],
-            "latest_closed_session_paper_route_runtime_window_import",
+            "next_session_paper_route_runtime_window_evidence_collection",
         )
         self.assertEqual(
             import_plan["session_window"],
-            {
-                "start": "2026-05-29T13:30:00+00:00",
-                "end": "2026-05-29T20:00:00+00:00",
-            },
-        )
-        self.assertTrue(import_plan["session_readiness"]["import_ready"])
-        self.assertEqual(import_plan["target_count"], 1)
-        latest_closed = payload["latest_closed_paper_route_runtime_window_targets"]
-        self.assertEqual(latest_closed["session_window"], import_plan["session_window"])
-        next_plan = payload["next_paper_route_runtime_window_targets"]
-        self.assertEqual(
-            next_plan["session_window"],
             {
                 "start": "2026-06-01T13:30:00+00:00",
                 "end": "2026-06-01T20:00:00+00:00",
             },
         )
+        self.assertFalse(import_plan["session_readiness"]["import_ready"])
+        self.assertEqual(import_plan["target_count"], 1)
+        latest_closed = payload["latest_closed_paper_route_runtime_window_targets"]
+        self.assertEqual(
+            latest_closed["session_window"],
+            {
+                "start": "2026-05-29T13:30:00+00:00",
+                "end": "2026-05-29T20:00:00+00:00",
+            },
+        )
+        self.assertTrue(latest_closed["session_readiness"]["import_ready"])
+        next_plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(next_plan["session_window"], import_plan["session_window"])
         self.assertEqual(
             payload["summary"]["runtime_window_import_plan_purpose"],
-            "latest_closed_session_paper_route_runtime_window_import",
+            "next_session_paper_route_runtime_window_evidence_collection",
         )
 
     def test_evidence_import_audit_uses_latest_closed_window_before_next_open(
@@ -1864,16 +1865,16 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             payload["runtime_window_import_plan"]["purpose"],
-            "latest_closed_session_paper_route_runtime_window_import",
+            "next_session_paper_route_runtime_window_evidence_collection",
         )
-        self.assertEqual(import_audit["state"], "import_due_account_state_not_clean")
+        self.assertEqual(import_audit["state"], "waiting_for_session_open")
         self.assertEqual(
             import_audit["next_action"],
-            "reset_paper_account_or_discard_contaminated_window",
+            "wait_for_regular_session_open",
         )
-        self.assertTrue(import_audit["import_ready"])
+        self.assertFalse(import_audit["import_ready"])
         self.assertIn(
-            "paper_route_account_window_start_snapshot_missing",
+            "paper_route_session_window_not_open",
             import_audit["blockers"],
         )
         self.assertEqual(import_audit["counts"]["source_plan_target_count"], 2)
@@ -1892,7 +1893,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             summary["next_runtime_window_import_next_action"],
-            "reset_paper_account_or_discard_contaminated_window",
+            "wait_for_regular_session_open",
         )
         self.assertEqual(len(summary["next_paper_route_targets"]), 1)
         summary_target = summary["next_paper_route_targets"][0]
@@ -1993,10 +1994,10 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             proof_handoff["runtime_window"]["import_audit_state"],
-            "import_due_account_state_not_clean",
+            "waiting_for_session_open",
         )
         self.assertIn(
-            "paper_route_account_window_start_snapshot_missing",
+            "paper_route_session_window_not_open",
             proof_handoff["runtime_window"]["import_blockers"],
         )
         self.assertEqual(
@@ -2858,7 +2859,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
             1,
         )
         self.assertFalse(payload["runtime_window_import_plan"]["promotion_allowed"])
-        self.assertFalse(payload["runtime_window_import_plan"]["final_promotion_allowed"])
+        self.assertFalse(
+            payload["runtime_window_import_plan"]["final_promotion_allowed"]
+        )
 
     def test_strategy_source_decision_readiness_queries_session_without_prefetch(
         self,


### PR DESCRIPTION
## Summary

- Require source-backed runtime-window evidence before selecting a latest closed paper-route session for import.
- Keep stale closed-window diagnostics visible, but let the active import plan advance to the next collectable session when closed-window source evidence is absent.
- Update paper-route evidence tests for the stricter closed-window selection behavior.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -k "paper_route_target_plan or paper_route_evidence" -q`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
