### PR TITLE
fix(torghut): keep pre-session snapshots valid through window

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -72,7 +72,6 @@ PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS = 3600
 PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_STALE_SECONDS = 900
 PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS = 300
 PAPER_ROUTE_ACCOUNT_PRE_SESSION_READINESS_SECONDS = 900
-PAPER_ROUTE_ACCOUNT_PRE_SESSION_SNAPSHOT_STALE_SECONDS = 900
 PAPER_ROUTE_ACCOUNT_CLOSE_SNAPSHOT_STALE_SECONDS = 3600
 HPAIRS_REQUIRED_PAPER_ROUTE_SYMBOLS = ("AAPL", "AMZN")
 PAPER_ROUTE_TARGET_PLAN_ENDPOINT = "/trading/paper-route-target-plan"
@@ -2984,6 +2983,7 @@ def _account_pre_session_snapshot_audit(
         "snapshot_id": None,
         "snapshot_as_of": None,
         "snapshot_age_seconds": None,
+        "snapshot_window_start_offset_seconds": None,
         "flat": None,
         "position_count": 0,
         "target_symbol_position_count": 0,
@@ -3004,11 +3004,12 @@ def _account_pre_session_snapshot_audit(
             "flat": True,
         }
 
+    snapshot_cutoff = min(generated_at, window_start)
     _maybe_set_paper_route_audit_statement_timeout(session)
     snapshot = session.execute(
         select(PositionSnapshot)
         .where(PositionSnapshot.alpaca_account_label == account_label)
-        .where(PositionSnapshot.as_of <= generated_at)
+        .where(PositionSnapshot.as_of <= snapshot_cutoff)
         .order_by(PositionSnapshot.as_of.desc())
         .limit(1)
     ).scalar_one_or_none()
@@ -3025,8 +3026,11 @@ def _account_pre_session_snapshot_audit(
         snapshot_as_of = snapshot_as_of.replace(tzinfo=timezone.utc)
     snapshot_as_of = snapshot_as_of.astimezone(timezone.utc)
     snapshot_age_seconds = int((generated_at - snapshot_as_of).total_seconds())
+    snapshot_window_start_offset_seconds = int(
+        (snapshot_as_of - window_start).total_seconds()
+    )
     blockers: list[str] = []
-    if snapshot_age_seconds > PAPER_ROUTE_ACCOUNT_PRE_SESSION_SNAPSHOT_STALE_SECONDS:
+    if snapshot_as_of < required_after:
         blockers.append("paper_route_account_pre_session_snapshot_stale")
 
     positions = _normalized_open_positions(
@@ -3059,6 +3063,7 @@ def _account_pre_session_snapshot_audit(
         "snapshot_id": str(snapshot.id),
         "snapshot_as_of": _isoformat(snapshot_as_of),
         "snapshot_age_seconds": snapshot_age_seconds,
+        "snapshot_window_start_offset_seconds": snapshot_window_start_offset_seconds,
         "flat": not positions and not blockers,
         "position_count": len(positions),
         "target_symbol_position_count": target_position_count,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -25,6 +25,7 @@ from app.models import (
 )
 from app.trading.paper_route_evidence import (
     RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
+    _account_pre_session_snapshot_audit,
     _account_window_start_snapshot_audit,
     _balanced_pair_probe_symbol_actions,
     _hpairs_round_trip_identity_blockers,
@@ -1108,6 +1109,94 @@ class TestPaperRouteEvidenceAudit(TestCase):
             source_plan["account_pre_session_readiness"]["blockers"],
             ["paper_route_account_pre_session_snapshot_missing"],
         )
+
+    def test_pre_session_snapshot_within_readiness_window_remains_clean_after_open(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 26, 13, 41, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            self._add_account_position_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                as_of=datetime(2026, 5, 26, 13, 25, tzinfo=timezone.utc),
+                positions=[],
+            )
+            session.commit()
+
+            payload = self._build_basic_paper_route_target_plan(
+                session,
+                generated_at=generated_at,
+            )
+
+        plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["skipped_target_count"], 0)
+        readiness = plan["account_pre_session_readiness"]
+        self.assertEqual(readiness["state"], "clean")
+        self.assertEqual(readiness["clean_target_count"], 1)
+        target_state = plan["targets"][0]["paper_route_account_pre_session_state"]
+        self.assertEqual(target_state["state"], "clean")
+        self.assertEqual(target_state["snapshot_age_seconds"], 960)
+        self.assertEqual(target_state["snapshot_window_start_offset_seconds"], -300)
+        self.assertNotIn(
+            "paper_route_account_pre_session_snapshot_stale",
+            target_state["blockers"],
+        )
+
+    def test_pre_session_after_open_snapshot_does_not_satisfy_readiness(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 26, 13, 41, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            self._add_account_position_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                as_of=datetime(2026, 5, 26, 13, 35, tzinfo=timezone.utc),
+                positions=[],
+            )
+            session.commit()
+
+            payload = self._build_basic_paper_route_target_plan(
+                session,
+                generated_at=generated_at,
+            )
+
+        plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(plan["target_count"], 0)
+        self.assertEqual(plan["skipped_target_count"], 1)
+        self.assertEqual(
+            plan["account_pre_session_readiness"]["blockers"],
+            ["paper_route_account_pre_session_snapshot_missing"],
+        )
+
+    def test_pre_session_snapshot_before_readiness_window_blocks_stale(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        generated_at = datetime(2026, 5, 26, 13, 41, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            self._add_account_position_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                as_of=datetime(2026, 5, 26, 13, 14, 59, tzinfo=timezone.utc),
+                positions=[],
+            )
+            session.commit()
+
+            audit = _account_pre_session_snapshot_audit(
+                session,
+                account_label="TORGHUT_SIM",
+                symbols=["AAPL", "AMZN"],
+                generated_at=generated_at,
+                window_start=window_start,
+                window_end=datetime(2026, 5, 26, 20, tzinfo=timezone.utc),
+            )
+
+        self.assertFalse(audit["flat"])
+        self.assertEqual(
+            audit["blockers"], ["paper_route_account_pre_session_snapshot_stale"]
+        )
+        self.assertEqual(audit["snapshot_window_start_offset_seconds"], -901)
 
     def test_target_plan_import_plan_skips_closed_window_without_source_evidence(
         self,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -49,6 +49,7 @@ from app.trading.paper_route_target_plan import (
     fetch_paper_route_target_plan_url as shared_fetch_paper_route_target_plan_url,
     paper_route_target_plan_probe_symbols,
 )
+from app.trading.paper_route_evidence import _next_regular_equities_session_window
 from app.trading.forecast_runtime import forecast_registry
 from app.trading.scheduler import TradingScheduler
 from app.trading.feature_quality import FeatureQualityReport
@@ -108,6 +109,11 @@ def _install_pipeline_universe_resolver(
     resolver: object,
 ) -> None:
     setattr(scheduler, "_pipeline", SimpleNamespace(universe_resolver=resolver))
+
+
+def _paper_route_pre_session_snapshot_as_of(generated_at: datetime) -> datetime:
+    window_start, _ = _next_regular_equities_session_window(generated_at)
+    return window_start - timedelta(minutes=15)
 
 
 def _freshness_carry_ledger_for_test(dimension_id: str) -> dict[str, object]:
@@ -521,10 +527,11 @@ class TestTradingApi(TestCase):
             session.add(review)
             session.commit()
 
+            now = datetime.now(timezone.utc)
             session.add(
                 PositionSnapshot(
                     alpaca_account_label="TORGHUT_SIM",
-                    as_of=datetime.now(timezone.utc),
+                    as_of=_paper_route_pre_session_snapshot_as_of(now),
                     equity=Decimal("100000"),
                     cash=Decimal("100000"),
                     buying_power=Decimal("200000"),


### PR DESCRIPTION
## Summary

- Validate pre-session paper-account snapshots against the 15-minute window before the runtime session starts instead of expiring them by wall-clock age after the market opens.
- Ignore snapshots captured after runtime-window start for the pre-session cleanliness gate, keeping intraday state from satisfying the pre-session proof.
- Add regressions for open-window validity, after-open snapshot rejection, stale pre-session snapshots, and API fixtures.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -k "paper_route_target_plan or paper_route_evidence" -q`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
