### PR TITLE
feat(torghut): harden hpairs replay frontier

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -26,6 +26,9 @@ FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
 FAST_REPLAY_TARGET_NET_PNL_PER_DAY = Decimal("500")
+FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT = 4
+FAST_REPLAY_DEFAULT_EXPLORATION_COUNT = 2
+FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP = 6
 FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "cluster_lob_event_clustering_proxy",
     "bounded_hpairs_clusterlob_ofi_candidate_prefilter",
@@ -75,6 +78,7 @@ class FastReplayPreviewRow:
         required_daily_notional = _required_daily_notional_for_target(
             observed_post_cost_expectancy_bps
         )
+        notional_blocked = required_daily_notional is None
         lineage_blockers = _lineage_blockers_for_row(self)
         risk_flags = _risk_flags_for_row(self, lineage_blockers=lineage_blockers)
         return {
@@ -123,10 +127,16 @@ class FastReplayPreviewRow:
                 "observed_post_cost_expectancy_bps": str(
                     observed_post_cost_expectancy_bps
                 ),
+                "formula": "target_net_pnl_per_day/(observed_post_cost_expectancy_bps/10000)",
                 "required_daily_notional": str(required_daily_notional)
                 if required_daily_notional is not None
                 else None,
-                "feasibility_status": "unknown_source_backed_adv_required",
+                "feasibility_status": (
+                    "blocked_non_positive_post_cost_expectancy"
+                    if notional_blocked
+                    else "unknown_source_backed_adv_required"
+                ),
+                "blocked": notional_blocked,
                 "prefilter_only": True,
             },
             "cost_impact_lineage": {
@@ -186,8 +196,16 @@ class FastReplayPreviewResult:
             "promotion_proof": False,
             "proof_authority": False,
             "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
             "authority": "not_promotion_proof",
             "proof_semantics_label": FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+            "selection_policy": {
+                "exact_replay_candidate_cap": FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP,
+                "exploitation_slots": FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
+                "exploration_slots": FAST_REPLAY_DEFAULT_EXPLORATION_COUNT,
+                "broad_cluster_fanout_allowed": False,
+            },
             "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
             "implemented_mechanisms": {
                 "hpairs_clusterlob_ofi_prefilter": "deterministic bounded H-PAIRS candidate prefilter metadata only; never promotion authority",
@@ -258,7 +276,7 @@ def build_fast_replay_preview(
     top_k: int,
     min_rows_per_candidate: int = 2,
     exploitation_count: int | None = None,
-    exploration_count: int = 0,
+    exploration_count: int | None = None,
     exact_replay_candidate_cap: int | None = None,
 ) -> FastReplayPreviewResult:
     """Rank candidate specs with cheap tape-derived features only.
@@ -267,17 +285,48 @@ def build_fast_replay_preview(
     scheduler replay and runtime ledger proof remain required downstream.
     """
 
-    bounded_top_k = max(1, min(len(specs) or 1, int(top_k)))
+    requested_exact_cap = (
+        FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP
+        if exact_replay_candidate_cap is None
+        else int(exact_replay_candidate_cap)
+    )
+    bounded_exact_cap = max(
+        1,
+        min(
+            FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP,
+            requested_exact_cap,
+        ),
+    )
+    bounded_top_k = max(1, min(len(specs) or 1, int(top_k), bounded_exact_cap))
     if exact_replay_candidate_cap is not None:
-        bounded_top_k = max(1, min(bounded_top_k, int(exact_replay_candidate_cap)))
-    bounded_exploitation_count = (
-        bounded_top_k
+        bounded_top_k = max(1, min(bounded_top_k, bounded_exact_cap))
+    requested_exploitation_count = (
+        FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT
         if exploitation_count is None
-        else max(0, min(bounded_top_k, int(exploitation_count)))
+        else int(exploitation_count)
+    )
+    requested_exploration_count = (
+        FAST_REPLAY_DEFAULT_EXPLORATION_COUNT
+        if exploration_count is None
+        else int(exploration_count)
+    )
+    bounded_exploitation_count = (
+        max(
+            0,
+            min(
+                bounded_top_k,
+                FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
+                requested_exploitation_count,
+            ),
+        )
     )
     bounded_exploration_count = max(
         0,
-        min(bounded_top_k - bounded_exploitation_count, int(exploration_count)),
+        min(
+            bounded_top_k - bounded_exploitation_count,
+            FAST_REPLAY_DEFAULT_EXPLORATION_COUNT,
+            requested_exploration_count,
+        ),
     )
     symbol_stats = _build_symbol_stats(rows)
     hpairs_prefilter = build_hpairs_microstructure_prefilter(
@@ -309,7 +358,7 @@ def build_fast_replay_preview(
     selected_bucket_by_id = {
         row.candidate_spec_id: row.frontier_bucket
         for row in hpairs_prefilter.rows
-        if row.selected
+        if row.selected and row.frontier_bucket in {"exploitation", "exploration"}
     }
     if not selected_bucket_by_id:
         selected_bucket_by_id = _select_frontier_buckets(
@@ -627,10 +676,6 @@ def _select_frontier_buckets(
         if len(selected) >= exact_replay_candidate_cap:
             break
         selected[row.candidate_spec_id] = "exploration"
-    for row in eligible:
-        if len(selected) >= exact_replay_candidate_cap:
-            break
-        selected.setdefault(row.candidate_spec_id, "exploitation_backfill")
     if not selected and ranked_rows:
         selected[ranked_rows[0].candidate_spec_id] = "exploitation_backfill"
     return selected
@@ -1058,6 +1103,7 @@ def _lineage_blockers_for_row(row: FastReplayPreviewRow) -> tuple[str, ...]:
     ]
     if _observed_post_cost_expectancy_bps(row) <= 0:
         blockers.append("positive_post_cost_expectancy_missing")
+        blockers.append("target_implied_notional_blocked_non_positive_expectancy")
     return tuple(blockers)
 
 
@@ -1095,6 +1141,9 @@ __all__ = [
     "FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION",
     "FAST_REPLAY_PREVIEW_SCHEMA_VERSION",
     "FAST_REPLAY_PROOF_SEMANTICS_LABEL",
+    "FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT",
+    "FAST_REPLAY_DEFAULT_EXPLORATION_COUNT",
+    "FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP",
     "FAST_REPLAY_WHITEPAPER_MECHANISMS",
     "FastReplayPreviewResult",
     "FastReplayPreviewRow",

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -651,9 +651,9 @@ def _parse_args() -> argparse.Namespace:
         "--allow-unsafe-replay-tape-exact-cap-override",
         action="store_true",
         help=(
-            "Allow --replay-tape-exact-candidate-cap above the production-safe "
-            f"default cap of {_DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP}. "
-            "Keep disabled for CI and normal research runs."
+            "Deprecated no-op retained for CLI compatibility. Replay-tape preview "
+            f"handoff is always capped at {_DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP} "
+            "exact-replay candidates."
         ),
     )
     parser.add_argument(
@@ -6634,8 +6634,7 @@ def _resolved_fast_replay_exact_candidate_cap(
             or _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP
         ),
     )
-    if not bool(getattr(args, "allow_unsafe_replay_tape_exact_cap_override", False)):
-        requested_cap = min(requested_cap, _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP)
+    requested_cap = min(requested_cap, _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP)
     return max(1, min(max(1, preview_top_k), requested_cap))
 
 
@@ -6646,6 +6645,8 @@ def _fast_replay_preview_proof_semantics() -> dict[str, Any]:
         "promotion_proof": False,
         "proof_authority": False,
         "promotion_authority": False,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
         "authority": "preview_prefilter_only",
         "prefilter_only": True,
         "no_kubernetes_fanout": True,

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -145,6 +145,8 @@ class TestFastReplayPreview(TestCase):
         payload = preview.to_manifest_payload()
         row_payload = good.to_payload()
         self.assertFalse(payload["promotion_proof"])
+        self.assertFalse(payload["promotion_allowed"])
+        self.assertFalse(payload["final_promotion_allowed"])
         self.assertEqual(
             payload["proof_semantics_label"], FAST_REPLAY_PROOF_SEMANTICS_LABEL
         )
@@ -171,6 +173,75 @@ class TestFastReplayPreview(TestCase):
         self.assertIn("cost_model_hash", payload["replay_tape"])
         self.assertIn("strategy_family", payload["replay_tape"])
         self.assertFalse(payload["proof_authority"])
+
+    def test_target_implied_notional_blocks_non_positive_expectancy(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            rows = [
+                self._signal(symbol="AAA", offset=1, price="100", ofi="0.50"),
+                self._signal(symbol="AAA", offset=2, price="102", ofi="0.50"),
+                self._signal(symbol="BBB", offset=1, price="102", ofi="0.50"),
+                self._signal(symbol="BBB", offset=2, price="100", ofi="0.50"),
+            ]
+            manifest = materialize_signal_tape(
+                rows=rows,
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-notional",
+                symbols=("AAA", "BBB"),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest({"window": "notional"}),
+            )
+
+        preview = build_fast_replay_preview(
+            specs=(
+                self._spec(
+                    "spec-positive",
+                    symbols=["AAA"],
+                    max_notional_per_trade="0",
+                ),
+                self._spec(
+                    "spec-negative",
+                    symbols=["BBB"],
+                    max_notional_per_trade="0",
+                ),
+            ),
+            rows=rows,
+            replay_tape_manifest=manifest,
+            top_k=2,
+            min_rows_per_candidate=2,
+            exploitation_count=1,
+            exploration_count=1,
+            exact_replay_candidate_cap=2,
+        )
+
+        payloads = {row.candidate_spec_id: row.to_payload() for row in preview.rows}
+        positive = payloads["spec-positive"]
+        positive_expectancy = Decimal(positive["observed_post_cost_expectancy_bps"])
+        self.assertGreater(positive_expectancy, Decimal("0"))
+        self.assertEqual(
+            Decimal(positive["required_daily_notional"]),
+            Decimal("500") / (positive_expectancy / Decimal("10000")),
+        )
+        self.assertFalse(positive["target_implied_notional_context"]["blocked"])
+        self.assertEqual(
+            positive["target_implied_notional_context"]["formula"],
+            "target_net_pnl_per_day/(observed_post_cost_expectancy_bps/10000)",
+        )
+
+        negative = payloads["spec-negative"]
+        self.assertLessEqual(
+            Decimal(negative["observed_post_cost_expectancy_bps"]), Decimal("0")
+        )
+        self.assertIsNone(negative["required_daily_notional"])
+        self.assertTrue(negative["target_implied_notional_context"]["blocked"])
+        self.assertEqual(
+            negative["target_implied_notional_context"]["feasibility_status"],
+            "blocked_non_positive_post_cost_expectancy",
+        )
+        self.assertIn(
+            "target_implied_notional_blocked_non_positive_expectancy",
+            negative["lineage_blockers"],
+        )
 
     def test_frontier_selection_caps_exact_replay_with_exploration_slots(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -201,7 +272,7 @@ class TestFastReplayPreview(TestCase):
             min_rows_per_candidate=2,
             exploitation_count=4,
             exploration_count=2,
-            exact_replay_candidate_cap=6,
+            exact_replay_candidate_cap=99,
         )
 
         self.assertEqual(len(preview.selected_candidate_spec_ids), 6)

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -261,6 +261,14 @@ class TestReplayTape(TestCase):
             source_query_digest=first_digest,
             source_table_versions={"signals": "v1"},
         )
+        changed_source_digest_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("AAPL", "NVDA"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=build_source_query_digest({"window": "b"}),
+            source_table_versions={"signals": "v1"},
+        )
         changed_dataset_key = build_replay_tape_cache_key(
             dataset_snapshot_ref="snapshot-b",
             symbols=("AAPL", "NVDA"),
@@ -299,6 +307,7 @@ class TestReplayTape(TestCase):
 
         self.assertEqual(first_key, reordered_key)
         self.assertNotEqual(first_key, changed_key)
+        self.assertNotEqual(first_key, changed_source_digest_key)
         self.assertNotEqual(first_key, changed_dataset_key)
         self.assertNotEqual(first_key, changed_feature_schema_key)
         self.assertNotEqual(first_key, changed_cost_model_key)

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4693,6 +4693,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.replay_tape_path = tape_path
             args.replay_tape_preview_top_k = 8
             args.replay_tape_exact_candidate_cap = 99
+            args.allow_unsafe_replay_tape_exact_cap_override = True
             candidate_selection = {
                 "schema_version": "torghut.whitepaper-autoresearch-selection.v1",
                 "budget": {"selected_count": len(specs)},
@@ -4733,6 +4734,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertFalse(queue_payload["proof_authority"])
         self.assertFalse(queue_payload["promotion_allowed"])
         self.assertFalse(queue_payload["final_promotion_allowed"])
+        self.assertFalse(queue_payload["proof_semantics"]["promotion_allowed"])
+        self.assertFalse(queue_payload["proof_semantics"]["final_promotion_allowed"])
         self.assertEqual(
             queue_payload["runner_policy"]["default_shard_timeout_seconds"], 900
         )


### PR DESCRIPTION
## Summary

- Enforces a hard six-candidate H-PAIRS offline frontier handoff with the production 4 exploitation + 2 exploration split and no unsafe exact-cap expansion.
- Adds explicit replay-only non-authority metadata, including promotion_allowed=false and final_promotion_allowed=false on preview/proof-semantics outputs.
- Adds target-implied daily notional metadata using observed post-cost expectancy and blocks non-positive expectancy instead of implying infinite optimism.
- Strengthens replay tape cache-key regression coverage for source/query and frontier-reproducibility inputs.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- PASS: `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. The deprecated unsafe replay-tape exact-cap override remains accepted for CLI compatibility but no longer expands the production six-candidate offline frontier cap.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
