### PR TITLE
fix(torghut): dedupe runtime window reimports

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -122,6 +122,7 @@ class ObservedRuntimeBucket:
 @dataclass(frozen=True)
 class _NormalizedTcaRow:
     computed_at: datetime
+    bucketed_at: datetime
     abs_slippage_bps: Decimal | None
     post_cost_expectancy_bps: Decimal | None
     post_cost_expectancy_basis: str
@@ -1074,9 +1075,14 @@ def build_observed_runtime_buckets(
             source_decision_mode is None
             or source_decision_mode_is_profit_proof_eligible(source_decision_mode)
         )
+        computed_at = _utc(computed_at_raw)
         normalized_tca_rows.append(
             _NormalizedTcaRow(
-                computed_at=_utc(computed_at_raw),
+                computed_at=computed_at,
+                bucketed_at=_runtime_ledger_payload_bucketed_at(
+                    computed_at=computed_at,
+                    payload=runtime_ledger_bucket,
+                ),
                 abs_slippage_bps=_optional_decimal(row.get("abs_slippage_bps")),
                 post_cost_expectancy_bps=_optional_decimal(
                     row.get("post_cost_expectancy_bps")
@@ -1092,6 +1098,12 @@ def build_observed_runtime_buckets(
             )
         )
 
+    def row_computed_at_is_in_import_window(row: _NormalizedTcaRow) -> bool:
+        return any(
+            bucket_start <= row.computed_at < bucket_end
+            for bucket_start, bucket_end, _ in bucket_ranges
+        )
+
     buckets: list[ObservedRuntimeBucket] = []
     for bucket_start, bucket_end, market_session_count in bucket_ranges:
         decisions = [
@@ -1103,7 +1115,11 @@ def build_observed_runtime_buckets(
         bucket_tca = [
             row
             for row in normalized_tca_rows
-            if bucket_start <= row.computed_at < bucket_end
+            if (
+                bucket_start <= row.computed_at < bucket_end
+                if row_computed_at_is_in_import_window(row)
+                else bucket_start <= row.bucketed_at < bucket_end
+            )
         ]
         runtime_ledger_decision_count = sum(
             _observation_int(row.runtime_ledger_bucket.get("decision_count"))
@@ -1205,6 +1221,207 @@ def build_observed_runtime_buckets(
     return buckets
 
 
+def _runtime_ledger_payload_interval(
+    payload: Mapping[str, Any],
+) -> tuple[datetime, datetime] | None:
+    source_started_at = _parse_observation_datetime(payload.get("source_window_start"))
+    source_ended_at = _parse_observation_datetime(payload.get("source_window_end"))
+    if (
+        source_started_at is not None
+        and source_ended_at is not None
+        and source_ended_at > source_started_at
+    ):
+        return source_started_at, source_ended_at
+    bucket_started_at = _parse_observation_datetime(payload.get("bucket_started_at"))
+    bucket_ended_at = _parse_observation_datetime(payload.get("bucket_ended_at"))
+    if (
+        bucket_started_at is not None
+        and bucket_ended_at is not None
+        and bucket_ended_at > bucket_started_at
+    ):
+        return bucket_started_at, bucket_ended_at
+    return None
+
+
+def _runtime_ledger_payload_bucketed_at(
+    *,
+    computed_at: datetime,
+    payload: Mapping[str, Any],
+) -> datetime:
+    interval = _runtime_ledger_payload_interval(payload)
+    if interval is None:
+        return computed_at
+    started_at, ended_at = interval
+    bucketed_at = ended_at - timedelta(microseconds=1)
+    if bucketed_at < started_at:
+        return started_at
+    return bucketed_at
+
+
+def _runtime_ledger_payload_is_readback(payload: Mapping[str, Any]) -> bool:
+    return _text(payload.get("runtime_ledger_readback_source")) is not None
+
+
+def _runtime_ledger_payload_identity_values(
+    payload: Mapping[str, Any],
+    *keys: str,
+) -> tuple[str, ...]:
+    values: list[str] = []
+    for key in keys:
+        raw_value = payload.get(key)
+        if isinstance(raw_value, Sequence) and not isinstance(
+            raw_value, (str, bytes, bytearray)
+        ):
+            values.extend(_string_list(raw_value))
+            continue
+        text = _text(raw_value)
+        if text is not None:
+            values.append(text)
+    return tuple(sorted(dict.fromkeys(values)))
+
+
+def _runtime_ledger_payload_dedupe_key(
+    payload: Mapping[str, Any],
+) -> tuple[object, ...]:
+    interval = _runtime_ledger_payload_interval(payload)
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+    if interval is not None:
+        started_at, ended_at = interval
+    return (
+        _text(payload.get("account_label")),
+        _text(payload.get("strategy_id"))
+        or _text(payload.get("runtime_strategy_name")),
+        _text(payload.get("symbol")),
+        started_at,
+        ended_at,
+        _runtime_ledger_payload_identity_values(
+            payload,
+            "source_window_ids",
+            "source_window_id",
+        ),
+        _runtime_ledger_payload_identity_values(
+            payload,
+            "execution_order_event_ids",
+            "execution_order_event_id",
+        ),
+        _runtime_ledger_payload_identity_values(
+            payload,
+            "execution_ids",
+            "execution_id",
+        ),
+        _runtime_ledger_payload_identity_values(
+            payload,
+            "trade_decision_ids",
+            "trade_decision_id",
+            "decision_ids",
+            "decision_id",
+        ),
+        _text(payload.get("source_decision_mode_partition"))
+        or _text(payload.get("source_decision_mode")),
+    )
+
+
+def _runtime_ledger_payloads_overlap(
+    left: Mapping[str, Any],
+    right: Mapping[str, Any],
+) -> bool:
+    for left_key, right_key in (
+        ("account_label", "account_label"),
+        ("strategy_id", "strategy_id"),
+        ("symbol", "symbol"),
+    ):
+        left_value = _text(left.get(left_key))
+        right_value = _text(right.get(right_key))
+        if left_key == "strategy_id":
+            left_value = left_value or _text(left.get("runtime_strategy_name"))
+            right_value = right_value or _text(right.get("runtime_strategy_name"))
+        if (
+            left_value is not None
+            and right_value is not None
+            and left_value != right_value
+        ):
+            return False
+    left_interval = _runtime_ledger_payload_interval(left)
+    right_interval = _runtime_ledger_payload_interval(right)
+    if left_interval is None or right_interval is None:
+        return False
+    left_start, left_end = left_interval
+    right_start, right_end = right_interval
+    return left_start < right_end and left_end > right_start
+
+
+def _runtime_ledger_payload_preference_key(
+    payload: Mapping[str, Any],
+) -> tuple[int, int, int, int, Decimal, datetime]:
+    interval = _runtime_ledger_payload_interval(payload)
+    ended_at = (
+        interval[1]
+        if interval is not None
+        else datetime.min.replace(tzinfo=timezone.utc)
+    )
+    return (
+        0 if _runtime_ledger_payload_is_readback(payload) else 1,
+        _observation_int(payload.get("closed_trade_count")),
+        -_observation_int(payload.get("open_position_count")),
+        _observation_int(payload.get("fill_count"))
+        + len(
+            _runtime_ledger_payload_identity_values(
+                payload, "execution_order_event_ids", "execution_order_event_id"
+            )
+        )
+        + len(
+            _runtime_ledger_payload_identity_values(
+                payload, "execution_ids", "execution_id"
+            )
+        )
+        + len(
+            _runtime_ledger_payload_identity_values(
+                payload,
+                "trade_decision_ids",
+                "trade_decision_id",
+                "decision_ids",
+                "decision_id",
+            )
+        ),
+        _observation_decimal(payload.get("filled_notional")),
+        ended_at,
+    )
+
+
+def _dedupe_runtime_ledger_bucket_payloads(
+    payloads: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    fresh_payloads = [
+        payload
+        for payload in payloads
+        if not _runtime_ledger_payload_is_readback(payload)
+    ]
+    candidates = [
+        payload
+        for payload in payloads
+        if not (
+            _runtime_ledger_payload_is_readback(payload)
+            and any(
+                _runtime_ledger_payloads_overlap(payload, fresh_payload)
+                for fresh_payload in fresh_payloads
+            )
+        )
+    ]
+    indexed_by_key: dict[tuple[object, ...], tuple[int, dict[str, Any]]] = {}
+    for index, payload in enumerate(candidates):
+        key = _runtime_ledger_payload_dedupe_key(payload)
+        existing = indexed_by_key.get(key)
+        if existing is None or _runtime_ledger_payload_preference_key(
+            payload
+        ) > _runtime_ledger_payload_preference_key(existing[1]):
+            indexed_by_key[key] = (index, payload)
+    return [
+        payload
+        for _, payload in sorted(indexed_by_key.values(), key=lambda item: item[0])
+    ]
+
+
 def _runtime_ledger_bucket_payloads(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
     raw_payloads = payload.get("runtime_ledger_buckets")
     if isinstance(raw_payloads, Sequence) and not isinstance(
@@ -1215,7 +1432,7 @@ def _runtime_ledger_bucket_payloads(payload: Mapping[str, Any]) -> list[dict[str
             payload = _runtime_ledger_bucket_payload(item)
             if payload:
                 payloads.append(payload)
-        return payloads
+        return _dedupe_runtime_ledger_bucket_payloads(payloads)
     single_payload = _runtime_ledger_bucket_payload(
         payload.get("runtime_ledger_bucket")
     )

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1232,9 +1232,7 @@ def _merge_count_mappings(
     existing: Mapping[object, object],
     incoming: Mapping[str, int],
 ) -> dict[str, int]:
-    merged = {
-        str(key): _nonnegative_int(value) for key, value in existing.items()
-    }
+    merged = {str(key): _nonnegative_int(value) for key, value in existing.items()}
     for key, value in incoming.items():
         merged[str(key)] = max(0, int(value)) + merged.get(str(key), 0)
     return dict(sorted((key, value) for key, value in merged.items() if value > 0))
@@ -4246,7 +4244,10 @@ def _runtime_ledger_tca_row_from_payload(
             ]
         )
     )
-    bucket_payload = dict(payload)
+    bucket_payload = {
+        **dict(payload),
+        "runtime_ledger_readback_source": "strategy_runtime_ledger_buckets",
+    }
     if proof_blockers:
         bucket_payload["runtime_ledger_profit_proof_blockers"] = proof_blockers
         bucket_payload["blockers"] = runtime_ledger_blockers

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -270,6 +270,58 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(buckets[0].avg_abs_slippage_bps, Decimal("0"))
         self.assertEqual(buckets[0].post_cost_promotion_sample_count, 0)
 
+    def test_build_observed_runtime_buckets_assigns_late_settled_source_bucket_to_source_window(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc),
+                    datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+                    6,
+                )
+            ],
+            decision_times=[],
+            execution_times=[],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 6, 1, 14, 5, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("25"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        bucket_started_at="2026-06-01T13:41:00+00:00",
+                        bucket_ended_at="2026-06-01T13:41:00.000001+00:00",
+                        source_window_start="2026-06-01T13:41:00+00:00",
+                        source_window_end="2026-06-01T13:41:00.000001+00:00",
+                        source_window_ids=["source-window-late-close"],
+                        execution_ids=["execution-late-close"],
+                        trade_decision_ids=["decision-late-close"],
+                        execution_order_event_ids=["event-late-close"],
+                        source_offsets=[
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 41,
+                            }
+                        ],
+                    ),
+                    **_runtime_pnl_basis(),
+                }
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        self.assertEqual(len(buckets), 1)
+        self.assertEqual(buckets[0].payload_json["tca_row_count"], 1)
+        self.assertEqual(buckets[0].trade_count, 2)
+        runtime_payloads = buckets[0].payload_json["runtime_ledger_buckets"]
+        self.assertEqual(len(runtime_payloads), 1)
+        self.assertEqual(
+            runtime_payloads[0]["source_window_ids"], ["source-window-late-close"]
+        )
+
     def test_build_observed_runtime_buckets_quarantines_simulation_report_pnl(
         self,
     ) -> None:
@@ -1279,6 +1331,135 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(ledger_rows[0].run_id, "import-source-window-new-close")
         self.assertEqual(ledger_rows[0].open_position_count, 0)
         self.assertEqual(ledger_rows[0].closed_trade_count, 1)
+
+    def test_persist_observed_runtime_windows_dedupes_readback_when_fresh_late_source_bucket_arrives(
+        self,
+    ) -> None:
+        def source_buckets():
+            return build_observed_runtime_buckets(
+                bucket_ranges=[
+                    (
+                        datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc),
+                        datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+                        6,
+                    )
+                ],
+                decision_times=[],
+                execution_times=[],
+                tca_rows=[
+                    {
+                        "computed_at": datetime(2026, 6, 1, 14, 4, tzinfo=timezone.utc),
+                        "abs_slippage_bps": Decimal("1"),
+                        "post_cost_expectancy_bps": None,
+                        "runtime_ledger_bucket": _runtime_ledger_bucket(
+                            bucket_started_at="2026-06-01T13:41:00+00:00",
+                            bucket_ended_at="2026-06-01T13:41:00.000001+00:00",
+                            source_window_start="2026-06-01T13:41:00+00:00",
+                            source_window_end="2026-06-01T13:41:00.000001+00:00",
+                            runtime_ledger_readback_source=(
+                                "strategy_runtime_ledger_buckets"
+                            ),
+                            source_window_ids=["source-window-late-close"],
+                            execution_ids=["execution-late-close"],
+                            trade_decision_ids=["decision-late-close"],
+                            execution_order_event_ids=["event-late-close"],
+                            fill_count=1,
+                            closed_trade_count=0,
+                            open_position_count=1,
+                            filled_notional="100",
+                            net_strategy_pnl_after_costs="0",
+                        ),
+                        **_runtime_pnl_basis(),
+                    },
+                    {
+                        "computed_at": datetime(2026, 6, 1, 14, 5, tzinfo=timezone.utc),
+                        "abs_slippage_bps": Decimal("1"),
+                        "post_cost_expectancy_bps": Decimal("25"),
+                        "runtime_ledger_bucket": _runtime_ledger_bucket(
+                            bucket_started_at="2026-06-01T13:41:00+00:00",
+                            bucket_ended_at="2026-06-01T13:41:00.000001+00:00",
+                            source_window_start="2026-06-01T13:41:00+00:00",
+                            source_window_end="2026-06-01T13:41:00.000001+00:00",
+                            source_window_ids=["source-window-late-close"],
+                            execution_ids=["execution-late-close"],
+                            trade_decision_ids=["decision-late-close"],
+                            execution_order_event_ids=["event-late-close"],
+                            source_decision_mode_counts={"route_acquisition_probe": 2},
+                            source_decision_mode="route_acquisition_probe",
+                            profit_proof_eligible=False,
+                            closed_trade_count=1,
+                            open_position_count=0,
+                            filled_notional="200",
+                            net_strategy_pnl_after_costs="0.50",
+                        ),
+                        **_runtime_pnl_basis(),
+                    },
+                ],
+                continuity_ok=True,
+                drift_ok=True,
+                dependency_quorum_decision="allow",
+            )
+
+        with self.session_local() as session:
+            first_summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-late-linked-fill-idempotent",
+                candidate_id="cand-late-linked-fill",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=source_buckets(),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "runtime_ledger_profit_proof_present": False,
+                },
+            )
+            second_summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-late-linked-fill-idempotent",
+                candidate_id="cand-late-linked-fill",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=source_buckets(),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "runtime_ledger_profit_proof_present": False,
+                },
+            )
+            session.commit()
+            ledger_rows = (
+                session.execute(select(StrategyRuntimeLedgerBucket)).scalars().all()
+            )
+
+        self.assertEqual(
+            first_summary["runtime_materialization_target"][
+                "runtime_ledger_bucket_count"
+            ],
+            1,
+        )
+        self.assertEqual(
+            second_summary["runtime_materialization_target"][
+                "runtime_ledger_bucket_count"
+            ],
+            1,
+        )
+        self.assertEqual(
+            second_summary["current_runtime_ledger_bucket_replacement_count"], 1
+        )
+        self.assertEqual(len(ledger_rows), 1)
+        self.assertEqual(ledger_rows[0].closed_trade_count, 1)
+        self.assertEqual(ledger_rows[0].open_position_count, 0)
+        self.assertEqual(ledger_rows[0].filled_notional, Decimal("200"))
+        self.assertIn(
+            "source_decision_mode_not_profit_proof_eligible",
+            ledger_rows[0].blockers_json,
+        )
+        self.assertNotIn("runtime_ledger_readback_source", ledger_rows[0].payload_json)
 
     def test_persist_observed_runtime_windows_uses_notional_weighted_ledger_summary(
         self,


### PR DESCRIPTION
## Summary

- Assign runtime-ledger rows to the source/bucket interval when settlement-time `computed_at` falls outside the import window, so late linked fills/close events materialize in the proper H-PAIRS runtime window.
- Mark runtime-ledger rows read back from `strategy_runtime_ledger_buckets` and skip overlapping readback payloads when fresh source-backed payloads are present, avoiding duplicate bucket clutter on reimport.
- Add deterministic payload dedupe for repeated runtime-ledger payloads while preserving strict blockers such as `source_decision_mode_not_profit_proof_eligible`.
- Cover late source-window inclusion, idempotent same-run reimport, readback/fresh dedupe, and blocker preservation in Torghut runtime-window tests.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py -q` (225 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py` (passed)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` hit local Node heap OOM; reran with `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (0 errors)
- `cd services/torghut && git diff --check` (passed)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
