### PR TITLE
fix(torghut): link paper flatten close lineage

### DIFF
--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -55,6 +55,7 @@ spec:
                     --wait-flat-seconds 120 \
                     --poll-seconds 10 \
                     --persist-snapshot \
+                    --persist-lineage \
                     --apply \
                     --json
               env:

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -4,19 +4,29 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import time
 from collections.abc import Mapping, Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import Any, Protocol, cast
 
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
 from app.alpaca_client import TorghutAlpacaClient
 from app.config import settings
 from app.db import SessionLocal
-from app.snapshots import snapshot_account_and_positions
+from app.models import Execution, Strategy, TradeDecision, coerce_json_payload
+from app.snapshots import snapshot_account_and_positions, sync_order_to_db
 from app.trading.firewall import OrderFirewall
+from app.trading.runtime_decision_authority import (
+    source_decision_mode_is_profit_proof_eligible,
+)
 
 DEFAULT_ACCOUNT_LABEL = "TORGHUT_SIM"
 DEFAULT_PAPER_BASE_URL = "https://paper-api.alpaca.markets"
@@ -26,6 +36,13 @@ DEFAULT_EXTENDED_HOURS_LIMIT_AWAY_BPS = Decimal("200")
 DEFAULT_WAIT_FLAT_SECONDS = 0.0
 DEFAULT_POLL_SECONDS = 5.0
 TERMINAL_CLEAN_STATUSES = frozenset({"clean", "dry_run", "submitted", "flattened"})
+FLATTEN_CLEANUP_STRATEGY_NAME = "paper-account-flatten-runtime-cleanup"
+FLATTEN_CLOSE_DECISION_SCHEMA_VERSION = (
+    "torghut.paper-account-flatten-close-decision.v1"
+)
+LINEAGE_LINKED_STATUS = "linked_source_lineage"
+LINEAGE_UNLINKED_STATUS = "unlinked_no_source_lineage"
+LINEAGE_PERSIST_FAILED_STATUS = "lineage_persist_failed"
 
 
 class PaperFlattenClient(Protocol):
@@ -126,6 +143,16 @@ def _parse_args() -> argparse.Namespace:
         "--persist-snapshot",
         action="store_true",
         help="Persist a fresh PositionSnapshot after the flatten attempt for runtime-window readiness gates.",
+    )
+    parser.add_argument(
+        "--persist-lineage",
+        action="store_true",
+        help=(
+            "Persist source-backed TradeDecision and Execution rows for submitted "
+            "flatten close orders so order-feed lifecycle events can link by "
+            "client_order_id. Orders without source lineage are tagged "
+            "unlinked_no_source_lineage and remain non-promotion proof."
+        ),
     )
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
@@ -240,6 +267,388 @@ def _extended_hours_limit_price(
     return _quantize_price(raw_price)
 
 
+def _coerce_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _lineage_values(value: object) -> list[str]:
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        values = [str(item) for item in value]
+    else:
+        values = []
+    return list(dict.fromkeys(item.strip() for item in values if item.strip()))
+
+
+def _decision_mapping(decision: TradeDecision) -> Mapping[str, Any]:
+    payload = decision.decision_json
+    if isinstance(payload, Mapping):
+        return cast(Mapping[str, Any], payload)
+    return {}
+
+
+def _decision_params(decision_payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    params = decision_payload.get("params")
+    if isinstance(params, Mapping):
+        return cast(Mapping[str, Any], params)
+    return {}
+
+
+def _first_lineage_values(
+    decision_payload: Mapping[str, Any], params: Mapping[str, Any], key: str
+) -> list[str]:
+    return _lineage_values(decision_payload.get(key)) or _lineage_values(
+        params.get(key)
+    )
+
+
+def _first_lineage_text(
+    decision_payload: Mapping[str, Any], params: Mapping[str, Any], key: str
+) -> str | None:
+    return _coerce_text(decision_payload.get(key)) or _coerce_text(params.get(key))
+
+
+def _first_lineage_bool(
+    decision_payload: Mapping[str, Any], params: Mapping[str, Any], key: str
+) -> bool | None:
+    for value in (decision_payload.get(key), params.get(key)):
+        if isinstance(value, bool):
+            return value
+    return None
+
+
+@dataclass(frozen=True)
+class FlattenSourceLineage:
+    source_decision: TradeDecision | None
+    source_execution: Execution | None
+    strategy_id: Any
+    source_candidate_ids: list[str]
+    source_hypothesis_ids: list[str]
+    source_strategy_names: list[str]
+    source_decision_mode: str | None
+    profit_proof_eligible: bool
+
+    @property
+    def has_source_lineage(self) -> bool:
+        return any(
+            (
+                self.source_candidate_ids,
+                self.source_hypothesis_ids,
+                self.source_strategy_names,
+                self.source_decision_mode,
+            )
+        )
+
+
+def _is_flatten_close_decision(decision: TradeDecision) -> bool:
+    payload = _decision_mapping(decision)
+    return (
+        payload.get("schema_version") == FLATTEN_CLOSE_DECISION_SCHEMA_VERSION
+        or payload.get("flatten_lineage_role") == "close"
+    )
+
+
+def _latest_source_decision(
+    session: Session, *, account_label: str, symbol: str
+) -> TradeDecision | None:
+    stmt = (
+        select(TradeDecision)
+        .where(
+            TradeDecision.alpaca_account_label == account_label,
+            TradeDecision.symbol == symbol,
+        )
+        .order_by(TradeDecision.created_at.desc())
+        .limit(25)
+    )
+    for decision in session.execute(stmt).scalars():
+        if not _is_flatten_close_decision(decision):
+            return decision
+    return None
+
+
+def _latest_source_execution(
+    session: Session, *, account_label: str, symbol: str, decision: TradeDecision | None
+) -> Execution | None:
+    if decision is not None:
+        linked_stmt = (
+            select(Execution)
+            .where(
+                Execution.trade_decision_id == decision.id,
+                Execution.alpaca_account_label == account_label,
+                Execution.symbol == symbol,
+            )
+            .order_by(Execution.created_at.desc())
+            .limit(1)
+        )
+        linked = session.execute(linked_stmt).scalar_one_or_none()
+        if linked is not None:
+            return linked
+
+    stmt = (
+        select(Execution)
+        .where(
+            Execution.alpaca_account_label == account_label,
+            Execution.symbol == symbol,
+            Execution.trade_decision_id.is_not(None),
+        )
+        .order_by(Execution.created_at.desc())
+        .limit(1)
+    )
+    return session.execute(stmt).scalar_one_or_none()
+
+
+def _find_or_create_cleanup_strategy(session: Session) -> Strategy:
+    stmt = select(Strategy).where(Strategy.name == FLATTEN_CLEANUP_STRATEGY_NAME)
+    existing = session.execute(stmt).scalar_one_or_none()
+    if existing is not None:
+        return existing
+
+    strategy = Strategy(
+        name=FLATTEN_CLEANUP_STRATEGY_NAME,
+        description=(
+            "Operational paper-account risk cleanup strategy used only to give "
+            "unlinked flatten close orders an auditable non-promotion decision row."
+        ),
+        enabled=False,
+        base_timeframe="event",
+        universe_type="runtime_cleanup",
+        universe_symbols=[],
+    )
+    session.add(strategy)
+    try:
+        session.commit()
+        session.refresh(strategy)
+    except IntegrityError:
+        session.rollback()
+        existing = session.execute(stmt).scalar_one_or_none()
+        if existing is None:
+            raise
+        return existing
+    return strategy
+
+
+def _source_lineage(
+    session: Session, *, account_label: str, symbol: str
+) -> FlattenSourceLineage:
+    source_decision = _latest_source_decision(
+        session, account_label=account_label, symbol=symbol
+    )
+    source_execution = _latest_source_execution(
+        session,
+        account_label=account_label,
+        symbol=symbol,
+        decision=source_decision,
+    )
+    if source_decision is None:
+        strategy_id = _find_or_create_cleanup_strategy(session).id
+        return FlattenSourceLineage(
+            source_decision=None,
+            source_execution=source_execution,
+            strategy_id=strategy_id,
+            source_candidate_ids=[],
+            source_hypothesis_ids=[],
+            source_strategy_names=[],
+            source_decision_mode=None,
+            profit_proof_eligible=False,
+        )
+
+    decision_payload = _decision_mapping(source_decision)
+    params = _decision_params(decision_payload)
+    source_decision_mode = _first_lineage_text(
+        decision_payload, params, "source_decision_mode"
+    )
+    source_profit_proof = _first_lineage_bool(
+        decision_payload, params, "profit_proof_eligible"
+    )
+    profit_proof_eligible = source_profit_proof is True or (
+        source_profit_proof is not False
+        and source_decision_mode_is_profit_proof_eligible(source_decision_mode)
+    )
+    return FlattenSourceLineage(
+        source_decision=source_decision,
+        source_execution=source_execution,
+        strategy_id=source_decision.strategy_id,
+        source_candidate_ids=_first_lineage_values(
+            decision_payload, params, "source_candidate_ids"
+        ),
+        source_hypothesis_ids=_first_lineage_values(
+            decision_payload, params, "source_hypothesis_ids"
+        ),
+        source_strategy_names=_first_lineage_values(
+            decision_payload, params, "source_strategy_names"
+        ),
+        source_decision_mode=source_decision_mode,
+        profit_proof_eligible=profit_proof_eligible,
+    )
+
+
+def _flatten_client_order_id(*, generated_at: datetime, symbol: str) -> str:
+    normalized_symbol = "".join(
+        char for char in symbol.lower() if char.isalnum() or char in {"-", "_"}
+    )
+    digest = hashlib.sha256(symbol.upper().encode("utf-8")).hexdigest()[:10]
+    prefix = f"tgpf-{generated_at.strftime('%Y%m%d%H%M%S')}-"
+    suffix = f"-{digest}"
+    max_symbol_length = max(1, 64 - len(prefix) - len(suffix))
+    return f"{prefix}{normalized_symbol[:max_symbol_length]}{suffix}"
+
+
+def _close_decision_payload(
+    *,
+    position: FlattenPosition,
+    client_order_id: str,
+    order_type: str,
+    limit_price: Decimal | None,
+    lineage: FlattenSourceLineage,
+) -> dict[str, Any]:
+    lineage_status = (
+        LINEAGE_LINKED_STATUS if lineage.has_source_lineage else LINEAGE_UNLINKED_STATUS
+    )
+    source_trade_decision_id = (
+        str(lineage.source_decision.id) if lineage.source_decision is not None else None
+    )
+    source_execution_id = (
+        str(lineage.source_execution.id)
+        if lineage.source_execution is not None
+        else None
+    )
+    params: dict[str, Any] = {
+        "source_candidate_ids": list(lineage.source_candidate_ids),
+        "source_hypothesis_ids": list(lineage.source_hypothesis_ids),
+        "source_strategy_names": list(lineage.source_strategy_names),
+        "source_decision_mode": lineage.source_decision_mode,
+        "profit_proof_eligible": lineage.profit_proof_eligible,
+        "flatten_lineage_status": lineage_status,
+        "source_trade_decision_id": source_trade_decision_id,
+        "source_execution_id": source_execution_id,
+        "final_promotion_authorized": False,
+    }
+    return {
+        "schema_version": FLATTEN_CLOSE_DECISION_SCHEMA_VERSION,
+        "flatten_lineage_role": "close",
+        "flatten_lineage_status": lineage_status,
+        "source_candidate_ids": list(lineage.source_candidate_ids),
+        "source_hypothesis_ids": list(lineage.source_hypothesis_ids),
+        "source_strategy_names": list(lineage.source_strategy_names),
+        "source_decision_mode": lineage.source_decision_mode,
+        "profit_proof_eligible": lineage.profit_proof_eligible,
+        "final_promotion_authorized": False,
+        "source_trade_decision_id": source_trade_decision_id,
+        "source_execution_id": source_execution_id,
+        "client_order_id": client_order_id,
+        "symbol": position.symbol,
+        "action": position.close_side,
+        "qty": str(position.close_qty),
+        "order_type": order_type,
+        "time_in_force": "day",
+        "limit_price": str(limit_price) if limit_price is not None else None,
+        "position": _position_payload(position),
+        "params": params,
+    }
+
+
+def _persist_close_decision(
+    session: Session,
+    *,
+    account_label: str,
+    position: FlattenPosition,
+    client_order_id: str,
+    order_type: str,
+    limit_price: Decimal | None,
+) -> tuple[TradeDecision, FlattenSourceLineage]:
+    lineage = _source_lineage(
+        session, account_label=account_label, symbol=position.symbol
+    )
+    decision_payload = _close_decision_payload(
+        position=position,
+        client_order_id=client_order_id,
+        order_type=order_type,
+        limit_price=limit_price,
+        lineage=lineage,
+    )
+    stmt = select(TradeDecision).where(
+        TradeDecision.decision_hash == client_order_id,
+        TradeDecision.alpaca_account_label == account_label,
+    )
+    existing = session.execute(stmt).scalar_one_or_none()
+    if existing is not None:
+        return existing, lineage
+
+    decision = TradeDecision(
+        strategy_id=lineage.strategy_id,
+        alpaca_account_label=account_label,
+        symbol=position.symbol,
+        timeframe="event",
+        decision_json=coerce_json_payload(decision_payload),
+        rationale=(
+            "Paper-account flatten close order; source lineage is preserved when "
+            "available, but flatten lineage alone never authorizes promotion."
+        ),
+        decision_hash=client_order_id,
+        status="planned",
+    )
+    session.add(decision)
+    try:
+        session.commit()
+        session.refresh(decision)
+    except IntegrityError:
+        session.rollback()
+        existing = session.execute(stmt).scalar_one_or_none()
+        if existing is None:
+            raise
+        return existing, lineage
+    return decision, lineage
+
+
+def _lineage_payload(
+    *,
+    client_order_id: str,
+    lineage_status: str,
+    decision: TradeDecision | None,
+    execution: Execution | None,
+    lineage: FlattenSourceLineage | None,
+    error: Exception | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "client_order_id": client_order_id,
+        "flatten_lineage_status": lineage_status,
+        "trade_decision_id": str(decision.id) if decision is not None else None,
+        "execution_id": str(execution.id) if execution is not None else None,
+        "source_trade_decision_id": (
+            str(lineage.source_decision.id)
+            if lineage is not None and lineage.source_decision is not None
+            else None
+        ),
+        "source_execution_id": (
+            str(lineage.source_execution.id)
+            if lineage is not None and lineage.source_execution is not None
+            else None
+        ),
+        "source_candidate_ids": list(lineage.source_candidate_ids)
+        if lineage is not None
+        else [],
+        "source_hypothesis_ids": list(lineage.source_hypothesis_ids)
+        if lineage is not None
+        else [],
+        "source_strategy_names": list(lineage.source_strategy_names)
+        if lineage is not None
+        else [],
+        "source_decision_mode": lineage.source_decision_mode
+        if lineage is not None
+        else None,
+        "profit_proof_eligible": lineage.profit_proof_eligible
+        if lineage is not None
+        else False,
+        "final_promotion_authorized": False,
+    }
+    if error is not None:
+        payload["error_type"] = type(error).__name__
+        payload["error"] = str(error)
+    return payload
+
+
 def _wait_until_flat(
     *,
     client: PaperFlattenClient,
@@ -271,6 +680,8 @@ def flatten_paper_account_positions(
     wait_flat_seconds: float = DEFAULT_WAIT_FLAT_SECONDS,
     poll_seconds: float = DEFAULT_POLL_SECONDS,
     generated_at: datetime | None = None,
+    persist_lineage: bool = False,
+    lineage_session: Session | None = None,
 ) -> dict[str, Any]:
     generated_at = generated_at or datetime.now(timezone.utc)
     normalized_mode = trading_mode.strip().lower()
@@ -308,6 +719,7 @@ def flatten_paper_account_positions(
     cancelled_orders: list[dict[str, Any]] = []
     submitted_orders: list[dict[str, Any]] = []
     rejected_close_orders: list[dict[str, Any]] = []
+    lineage_results: list[dict[str, Any]] = []
     final_positions = positions
     if blockers:
         status = "blocked"
@@ -318,30 +730,52 @@ def flatten_paper_account_positions(
         for position in positions:
             order_type = "limit" if extended_hours_limit else "market"
             limit_price = extended_limit_prices.get(position.symbol)
-            extra_params: dict[str, Any] = {
-                "client_order_id": (
-                    "torghut-paper-flatten-"
-                    f"{generated_at.strftime('%Y%m%d%H%M%S')}-"
-                    f"{position.symbol.lower()}"
-                )
-            }
+            client_order_id = _flatten_client_order_id(
+                generated_at=generated_at,
+                symbol=position.symbol,
+            )
+            extra_params: dict[str, Any] = {"client_order_id": client_order_id}
             if extended_hours_limit:
                 extra_params["extended_hours"] = True
-            try:
-                submitted_orders.append(
-                    client.submit_order(
-                        symbol=position.symbol,
-                        side=position.close_side,
-                        qty=float(position.close_qty),
+            decision_row: TradeDecision | None = None
+            source_lineage: FlattenSourceLineage | None = None
+            lineage_persist_error: Exception | None = None
+            if persist_lineage and lineage_session is not None:
+                try:
+                    decision_row, source_lineage = _persist_close_decision(
+                        lineage_session,
+                        account_label=normalized_label,
+                        position=position,
+                        client_order_id=client_order_id,
                         order_type=order_type,
-                        time_in_force="day",
-                        limit_price=float(limit_price)
-                        if limit_price is not None
-                        else None,
-                        extra_params=extra_params,
+                        limit_price=limit_price,
                     )
+                except Exception as exc:
+                    lineage_session.rollback()
+                    lineage_persist_error = exc
+            try:
+                order_response = client.submit_order(
+                    symbol=position.symbol,
+                    side=position.close_side,
+                    qty=float(position.close_qty),
+                    order_type=order_type,
+                    time_in_force="day",
+                    limit_price=float(limit_price) if limit_price is not None else None,
+                    extra_params=extra_params,
                 )
+                submitted_orders.append(order_response)
             except Exception as exc:
+                if (
+                    persist_lineage
+                    and lineage_session is not None
+                    and decision_row is not None
+                ):
+                    try:
+                        decision_row.status = "rejected"
+                        lineage_session.add(decision_row)
+                        lineage_session.commit()
+                    except Exception:
+                        lineage_session.rollback()
                 rejected_close_orders.append(
                     {
                         "symbol": position.symbol,
@@ -352,6 +786,81 @@ def flatten_paper_account_positions(
                         "error_type": type(exc).__name__,
                         "error": str(exc),
                     }
+                )
+                if persist_lineage:
+                    lineage_results.append(
+                        _lineage_payload(
+                            client_order_id=client_order_id,
+                            lineage_status=LINEAGE_PERSIST_FAILED_STATUS
+                            if decision_row is None
+                            else (
+                                LINEAGE_LINKED_STATUS
+                                if source_lineage is not None
+                                and source_lineage.has_source_lineage
+                                else LINEAGE_UNLINKED_STATUS
+                            ),
+                            decision=decision_row,
+                            execution=None,
+                            lineage=source_lineage,
+                            error=exc,
+                        )
+                    )
+                continue
+
+            if not persist_lineage:
+                continue
+            if lineage_persist_error is not None or lineage_session is None:
+                lineage_results.append(
+                    _lineage_payload(
+                        client_order_id=client_order_id,
+                        lineage_status=LINEAGE_PERSIST_FAILED_STATUS,
+                        decision=decision_row,
+                        execution=None,
+                        lineage=source_lineage,
+                        error=lineage_persist_error,
+                    )
+                )
+                continue
+            decision_for_sync = cast(TradeDecision, decision_row)
+            try:
+                execution = sync_order_to_db(
+                    lineage_session,
+                    order_response,
+                    trade_decision_id=str(decision_for_sync.id),
+                    alpaca_account_label=normalized_label,
+                    execution_expected_adapter="alpaca_paper",
+                    execution_actual_adapter="alpaca_paper",
+                )
+                decision_for_sync.status = "submitted"
+                decision_for_sync.executed_at = generated_at
+                lineage_session.add(decision_for_sync)
+                lineage_session.commit()
+                lineage_session.refresh(decision_for_sync)
+                lineage_status = (
+                    LINEAGE_LINKED_STATUS
+                    if source_lineage is not None and source_lineage.has_source_lineage
+                    else LINEAGE_UNLINKED_STATUS
+                )
+                lineage_results.append(
+                    _lineage_payload(
+                        client_order_id=client_order_id,
+                        lineage_status=lineage_status,
+                        decision=decision_for_sync,
+                        execution=execution,
+                        lineage=source_lineage,
+                    )
+                )
+            except Exception as exc:
+                lineage_session.rollback()
+                lineage_results.append(
+                    _lineage_payload(
+                        client_order_id=client_order_id,
+                        lineage_status=LINEAGE_PERSIST_FAILED_STATUS,
+                        decision=decision_for_sync,
+                        execution=None,
+                        lineage=source_lineage,
+                        error=exc,
+                    )
                 )
         if rejected_close_orders:
             blockers.append("paper_account_flatten_close_order_rejected")
@@ -385,6 +894,9 @@ def flatten_paper_account_positions(
         "blockers": blockers,
         "rejected_close_order_count": len(rejected_close_orders),
         "rejected_close_orders": rejected_close_orders,
+        "persist_lineage": persist_lineage,
+        "lineage_result_count": len(lineage_results),
+        "lineage_results": lineage_results,
         "extended_hours_limit_missing_symbols": missing_limit_symbols,
         "positions": [_position_payload(position) for position in positions],
         "final_positions": [
@@ -409,19 +921,23 @@ def main() -> int:
     )
     client = TorghutAlpacaClient(paper=True, base_url=str(args.paper_base_url or ""))
     firewall = OrderFirewall(client)
-    payload = flatten_paper_account_positions(
-        client=firewall,
-        account_label=str(args.account_label or ""),
-        expected_account_label=str(args.expected_account_label or ""),
-        trading_mode=str(args.trading_mode or ""),
-        apply=bool(args.apply),
-        max_gross_market_value=max_gross_market_value,
-        max_position_count=max(0, int(args.max_position_count)),
-        extended_hours_limit=bool(args.extended_hours_limit),
-        limit_away_bps=limit_away_bps,
-        wait_flat_seconds=max(0.0, float(args.wait_flat_seconds or 0.0)),
-        poll_seconds=max(0.1, float(args.poll_seconds or DEFAULT_POLL_SECONDS)),
-    )
+    lineage_context = SessionLocal() if args.persist_lineage else nullcontext(None)
+    with lineage_context as lineage_session:
+        payload = flatten_paper_account_positions(
+            client=firewall,
+            account_label=str(args.account_label or ""),
+            expected_account_label=str(args.expected_account_label or ""),
+            trading_mode=str(args.trading_mode or ""),
+            apply=bool(args.apply),
+            max_gross_market_value=max_gross_market_value,
+            max_position_count=max(0, int(args.max_position_count)),
+            extended_hours_limit=bool(args.extended_hours_limit),
+            limit_away_bps=limit_away_bps,
+            wait_flat_seconds=max(0.0, float(args.wait_flat_seconds or 0.0)),
+            poll_seconds=max(0.1, float(args.poll_seconds or DEFAULT_POLL_SECONDS)),
+            persist_lineage=bool(args.persist_lineage),
+            lineage_session=cast(Session | None, lineage_session),
+        )
     if args.persist_snapshot:
         if (
             payload["trading_mode"] == "paper"

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -7,10 +7,14 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from io import StringIO
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import patch
 
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.models import Base, Execution, ExecutionOrderEvent, Strategy, TradeDecision
 from scripts import flatten_paper_account_positions as flatten_script
 from scripts.flatten_paper_account_positions import (
     flatten_paper_account_positions,
@@ -50,6 +54,8 @@ class FakeFlattenClient:
             "type": order_type,
             "time_in_force": time_in_force,
             "limit_price": limit_price,
+            "status": "accepted",
+            "filled_qty": "0",
             "extended_hours": (extra_params or {}).get("extended_hours"),
             "client_order_id": (extra_params or {}).get("client_order_id"),
         }
@@ -82,6 +88,32 @@ class RejectingFlattenClient(FakeFlattenClient):
         raise RuntimeError("simulated close rejection")
 
 
+class MissingOrderIdFlattenClient(FakeFlattenClient):
+    def submit_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        time_in_force: str,
+        limit_price: float | None = None,
+        stop_price: float | None = None,
+        extra_params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        order = super().submit_order(
+            symbol,
+            side,
+            qty,
+            order_type,
+            time_in_force,
+            limit_price,
+            stop_price,
+            extra_params,
+        )
+        order.pop("id", None)
+        return order
+
+
 class SequencedFlattenClient(FakeFlattenClient):
     def __init__(self, position_snapshots: list[list[dict[str, Any]]]) -> None:
         super().__init__(position_snapshots[0] if position_snapshots else [])
@@ -99,6 +131,52 @@ class FakeSessionContext:
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
         return None
+
+
+def _memory_session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return Session(engine, expire_on_commit=False, future=True)
+
+
+def _source_strategy(session: Session) -> Strategy:
+    strategy = Strategy(
+        name="microbar-cross-sectional-pairs-v1",
+        description="H-PAIRS runtime source strategy",
+        enabled=True,
+        base_timeframe="1Min",
+        universe_type="symbols",
+        universe_symbols=["AMAT"],
+    )
+    session.add(strategy)
+    session.commit()
+    session.refresh(strategy)
+    return strategy
+
+
+def _source_decision(session: Session, strategy: Strategy) -> TradeDecision:
+    decision = TradeDecision(
+        strategy_id=strategy.id,
+        alpaca_account_label="TORGHUT_SIM",
+        symbol="AMAT",
+        timeframe="1Min",
+        decision_json={
+            "action": "buy",
+            "qty": "2",
+            "source_candidate_ids": ["c88421d619759b2cfaa6f4d0"],
+            "source_hypothesis_ids": ["H-PAIRS-01"],
+            "source_strategy_names": ["microbar-cross-sectional-pairs-v1"],
+            "source_decision_mode": "strategy_signal_paper",
+            "profit_proof_eligible": True,
+        },
+        rationale="source runtime paper decision",
+        decision_hash="source-decision-hash",
+        status="submitted",
+    )
+    session.add(decision)
+    session.commit()
+    session.refresh(decision)
+    return decision
 
 
 class TestFlattenPaperAccountPositions(TestCase):
@@ -161,6 +239,346 @@ class TestFlattenPaperAccountPositions(TestCase):
             [("AMAT", "sell", "market"), ("TSM", "buy", "market")],
         )
         self.assertEqual(payload["submitted_order_count"], 2)
+
+    def test_apply_persists_linked_close_decision_and_execution(self) -> None:
+        client = FakeFlattenClient(
+            [{"symbol": "AMAT", "qty": "2", "side": "long", "current_price": "100"}]
+        )
+        with _memory_session() as session:
+            generated_at = datetime(2026, 6, 1, 13, 35, tzinfo=timezone.utc)
+            expected_client_order_id = flatten_script._flatten_client_order_id(
+                generated_at=generated_at,
+                symbol="AMAT",
+            )
+            strategy = _source_strategy(session)
+            source_decision = _source_decision(session, strategy)
+            source_execution = Execution(
+                trade_decision_id=source_decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="source-order-1",
+                client_order_id="source-decision-hash",
+                symbol="AMAT",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("2"),
+                filled_qty=Decimal("2"),
+                status="filled",
+                execution_expected_adapter="alpaca_paper",
+                execution_actual_adapter="alpaca_paper",
+                raw_order={},
+            )
+            session.add(source_execution)
+            pending_order_event = ExecutionOrderEvent(
+                event_fingerprint="pending-flatten-order-event",
+                source_topic="alpaca.orders",
+                alpaca_account_label="TORGHUT_SIM",
+                client_order_id=expected_client_order_id,
+                symbol="AMAT",
+                event_type="new",
+                status="accepted",
+                raw_event={"client_order_id": expected_client_order_id},
+            )
+            session.add(pending_order_event)
+            session.commit()
+
+            payload = flatten_paper_account_positions(
+                client=client,
+                account_label="TORGHUT_SIM",
+                expected_account_label="TORGHUT_SIM",
+                trading_mode="paper",
+                apply=True,
+                max_gross_market_value=Decimal("2500"),
+                max_position_count=10,
+                generated_at=generated_at,
+                persist_lineage=True,
+                lineage_session=session,
+            )
+
+            self.assertEqual(payload["status"], "submitted")
+            self.assertEqual(payload["lineage_result_count"], 1)
+            lineage_result = payload["lineage_results"][0]
+            self.assertEqual(
+                lineage_result["flatten_lineage_status"], "linked_source_lineage"
+            )
+            self.assertEqual(
+                lineage_result["source_candidate_ids"],
+                ["c88421d619759b2cfaa6f4d0"],
+            )
+            self.assertEqual(lineage_result["source_hypothesis_ids"], ["H-PAIRS-01"])
+            self.assertEqual(
+                lineage_result["source_strategy_names"],
+                ["microbar-cross-sectional-pairs-v1"],
+            )
+            self.assertEqual(
+                lineage_result["source_decision_mode"], "strategy_signal_paper"
+            )
+            self.assertTrue(lineage_result["profit_proof_eligible"])
+            self.assertFalse(lineage_result["final_promotion_authorized"])
+
+            client_order_id = client.submitted[0]["client_order_id"]
+            close_decision = session.execute(
+                select(TradeDecision).where(
+                    TradeDecision.decision_hash == client_order_id
+                )
+            ).scalar_one()
+            decision_json = close_decision.decision_json
+            self.assertEqual(
+                decision_json["schema_version"],
+                "torghut.paper-account-flatten-close-decision.v1",
+            )
+            self.assertEqual(
+                decision_json["source_candidate_ids"],
+                ["c88421d619759b2cfaa6f4d0"],
+            )
+            self.assertEqual(decision_json["source_hypothesis_ids"], ["H-PAIRS-01"])
+            self.assertEqual(
+                decision_json["source_strategy_names"],
+                ["microbar-cross-sectional-pairs-v1"],
+            )
+            self.assertTrue(decision_json["profit_proof_eligible"])
+            self.assertFalse(decision_json["final_promotion_authorized"])
+            close_execution = session.execute(
+                select(Execution).where(Execution.client_order_id == client_order_id)
+            ).scalar_one()
+            self.assertEqual(close_execution.trade_decision_id, close_decision.id)
+            self.assertEqual(close_execution.alpaca_order_id, "order-1")
+            session.refresh(pending_order_event)
+            self.assertEqual(pending_order_event.trade_decision_id, close_decision.id)
+            self.assertEqual(pending_order_event.execution_id, close_execution.id)
+
+    def test_apply_persists_unlinked_no_source_lineage_fallback(self) -> None:
+        client = FakeFlattenClient(
+            [{"symbol": "AMAT", "qty": "2", "side": "long", "current_price": "100"}]
+        )
+        with _memory_session() as session:
+            payload = flatten_paper_account_positions(
+                client=client,
+                account_label="TORGHUT_SIM",
+                expected_account_label="TORGHUT_SIM",
+                trading_mode="paper",
+                apply=True,
+                max_gross_market_value=Decimal("2500"),
+                max_position_count=10,
+                generated_at=datetime(2026, 6, 1, 13, 40, tzinfo=timezone.utc),
+                persist_lineage=True,
+                lineage_session=session,
+            )
+
+            self.assertEqual(payload["status"], "submitted")
+            self.assertEqual(payload["lineage_result_count"], 1)
+            lineage_result = payload["lineage_results"][0]
+            self.assertEqual(
+                lineage_result["flatten_lineage_status"], "unlinked_no_source_lineage"
+            )
+            self.assertEqual(lineage_result["source_candidate_ids"], [])
+            self.assertEqual(lineage_result["source_hypothesis_ids"], [])
+            self.assertEqual(lineage_result["source_strategy_names"], [])
+            self.assertIsNone(lineage_result["source_decision_mode"])
+            self.assertFalse(lineage_result["profit_proof_eligible"])
+            self.assertFalse(lineage_result["final_promotion_authorized"])
+
+            client_order_id = client.submitted[0]["client_order_id"]
+            close_decision = session.execute(
+                select(TradeDecision).where(
+                    TradeDecision.decision_hash == client_order_id
+                )
+            ).scalar_one()
+            decision_json = close_decision.decision_json
+            self.assertEqual(
+                decision_json["flatten_lineage_status"], "unlinked_no_source_lineage"
+            )
+            self.assertEqual(decision_json["source_candidate_ids"], [])
+            self.assertFalse(decision_json["profit_proof_eligible"])
+            close_execution = session.execute(
+                select(Execution).where(Execution.client_order_id == client_order_id)
+            ).scalar_one()
+            self.assertEqual(close_execution.trade_decision_id, close_decision.id)
+
+    def test_lineage_helpers_cover_empty_string_and_params_sources(self) -> None:
+        self.assertEqual(flatten_script._lineage_values(" H-PAIRS-01 "), ["H-PAIRS-01"])
+        self.assertEqual(flatten_script._lineage_values(None), [])
+        self.assertEqual(
+            flatten_script._decision_mapping(
+                cast(Any, SimpleNamespace(decision_json=[]))
+            ),
+            {},
+        )
+        payload = {"params": {"source_candidate_ids": ["candidate-from-params"]}}
+        self.assertEqual(
+            flatten_script._decision_params(payload),
+            {"source_candidate_ids": ["candidate-from-params"]},
+        )
+        self.assertIsNone(
+            flatten_script._first_lineage_bool(
+                {"profit_proof_eligible": "unknown"}, {}, "profit_proof_eligible"
+            )
+        )
+        self.assertEqual(
+            flatten_script._lineage_payload(
+                client_order_id="flatten-client-id",
+                lineage_status="lineage_persist_failed",
+                decision=None,
+                execution=None,
+                lineage=None,
+                error=RuntimeError("lineage unavailable"),
+            )["error_type"],
+            "RuntimeError",
+        )
+
+    def test_no_lineage_reuses_cleanup_strategy_and_existing_close_decision(
+        self,
+    ) -> None:
+        client = FakeFlattenClient(
+            [{"symbol": "AMAT", "qty": "2", "side": "long", "current_price": "100"}]
+        )
+        generated_at = datetime(2026, 6, 1, 13, 45, tzinfo=timezone.utc)
+        with _memory_session() as session:
+            first_payload = flatten_paper_account_positions(
+                client=client,
+                account_label="TORGHUT_SIM",
+                expected_account_label="TORGHUT_SIM",
+                trading_mode="paper",
+                apply=True,
+                max_gross_market_value=Decimal("2500"),
+                max_position_count=10,
+                generated_at=generated_at,
+                persist_lineage=True,
+                lineage_session=session,
+            )
+            second_client_order_id = flatten_script._flatten_client_order_id(
+                generated_at=generated_at,
+                symbol="AMAT",
+            )
+            position = flatten_script.FlattenPosition(
+                symbol="AMAT",
+                qty=Decimal("2"),
+                side="long",
+                market_value=Decimal("200"),
+                reference_price=Decimal("100"),
+            )
+            existing_decision, _ = flatten_script._persist_close_decision(
+                session,
+                account_label="TORGHUT_SIM",
+                position=position,
+                client_order_id=second_client_order_id,
+                order_type="market",
+                limit_price=None,
+            )
+            reused_decision, _ = flatten_script._persist_close_decision(
+                session,
+                account_label="TORGHUT_SIM",
+                position=position,
+                client_order_id=second_client_order_id,
+                order_type="market",
+                limit_price=None,
+            )
+
+            self.assertEqual(first_payload["lineage_result_count"], 1)
+            self.assertEqual(existing_decision.id, reused_decision.id)
+            cleanup_strategies = (
+                session.execute(
+                    select(Strategy).where(
+                        Strategy.name == flatten_script.FLATTEN_CLEANUP_STRATEGY_NAME
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            self.assertEqual(len(cleanup_strategies), 1)
+
+    def test_persist_lineage_rejection_marks_close_decision_rejected(self) -> None:
+        client = RejectingFlattenClient(
+            [{"symbol": "AMAT", "qty": "2", "side": "long", "current_price": "100"}]
+        )
+        with _memory_session() as session:
+            strategy = _source_strategy(session)
+            _source_decision(session, strategy)
+            payload = flatten_paper_account_positions(
+                client=client,
+                account_label="TORGHUT_SIM",
+                expected_account_label="TORGHUT_SIM",
+                trading_mode="paper",
+                apply=True,
+                max_gross_market_value=Decimal("2500"),
+                max_position_count=10,
+                generated_at=datetime(2026, 6, 1, 13, 50, tzinfo=timezone.utc),
+                persist_lineage=True,
+                lineage_session=session,
+            )
+
+            self.assertEqual(payload["status"], "failed_close_orders")
+            self.assertEqual(payload["lineage_result_count"], 1)
+            self.assertEqual(
+                payload["lineage_results"][0]["flatten_lineage_status"],
+                "linked_source_lineage",
+            )
+            decision_id = payload["lineage_results"][0]["trade_decision_id"]
+            close_decision = session.get(TradeDecision, decision_id)
+            self.assertIsNotNone(close_decision)
+            self.assertEqual(close_decision.status, "rejected")
+
+    def test_lineage_persist_failure_is_reported_without_blocking_flatten(self) -> None:
+        client = FakeFlattenClient(
+            [{"symbol": "AMAT", "qty": "2", "side": "long", "current_price": "100"}]
+        )
+        with _memory_session() as session:
+            with patch.object(
+                flatten_script,
+                "_persist_close_decision",
+                side_effect=RuntimeError("db unavailable"),
+            ):
+                payload = flatten_paper_account_positions(
+                    client=client,
+                    account_label="TORGHUT_SIM",
+                    expected_account_label="TORGHUT_SIM",
+                    trading_mode="paper",
+                    apply=True,
+                    max_gross_market_value=Decimal("2500"),
+                    max_position_count=10,
+                    generated_at=datetime(2026, 6, 1, 13, 55, tzinfo=timezone.utc),
+                    persist_lineage=True,
+                    lineage_session=session,
+                )
+
+            self.assertEqual(payload["status"], "submitted")
+            self.assertEqual(client.submitted[0]["symbol"], "AMAT")
+            self.assertEqual(
+                payload["lineage_results"][0]["flatten_lineage_status"],
+                "lineage_persist_failed",
+            )
+            self.assertEqual(
+                payload["lineage_results"][0]["error_type"], "RuntimeError"
+            )
+
+    def test_execution_sync_failure_is_reported_without_rejecting_submitted_order(
+        self,
+    ) -> None:
+        client = MissingOrderIdFlattenClient(
+            [{"symbol": "AMAT", "qty": "2", "side": "long", "current_price": "100"}]
+        )
+        with _memory_session() as session:
+            payload = flatten_paper_account_positions(
+                client=client,
+                account_label="TORGHUT_SIM",
+                expected_account_label="TORGHUT_SIM",
+                trading_mode="paper",
+                apply=True,
+                max_gross_market_value=Decimal("2500"),
+                max_position_count=10,
+                generated_at=datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+                persist_lineage=True,
+                lineage_session=session,
+            )
+
+            self.assertEqual(payload["status"], "submitted")
+            self.assertEqual(payload["submitted_order_count"], 1)
+            self.assertEqual(payload["rejected_close_order_count"], 0)
+            self.assertEqual(
+                payload["lineage_results"][0]["flatten_lineage_status"],
+                "lineage_persist_failed",
+            )
+            self.assertEqual(payload["lineage_results"][0]["error_type"], "ValueError")
 
     def test_extended_hours_limit_orders_use_guarded_reference_prices(self) -> None:
         client = FakeFlattenClient(
@@ -525,6 +943,7 @@ class TestFlattenPaperAccountPositions(TestCase):
             "--poll-seconds",
             "3",
             "--persist-snapshot",
+            "--persist-lineage",
             "--apply",
             "--json",
         ]
@@ -543,6 +962,7 @@ class TestFlattenPaperAccountPositions(TestCase):
         self.assertEqual(args.wait_flat_seconds, 45)
         self.assertEqual(args.poll_seconds, 3)
         self.assertTrue(args.persist_snapshot)
+        self.assertTrue(args.persist_lineage)
         self.assertTrue(args.apply)
         self.assertTrue(args.json)
 

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1260,6 +1260,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--wait-flat-seconds 120", args)
         self.assertIn("--poll-seconds 10", args)
         self.assertIn("--persist-snapshot", args)
+        self.assertIn("--persist-lineage", args)
         self.assertIn("--apply", args)
         self.assertIn("--json", args)
 


### PR DESCRIPTION
## Summary

- Adds explicit `--persist-lineage` mode for paper-account flattening so submitted close orders create auditable `TradeDecision` and `Execution` rows before order-feed proof windows ingest lifecycle events.
- Preserves source candidate, hypothesis, strategy-name, source-decision-mode, and profit-proof eligibility metadata from same-account/symbol source decisions; orders without source lineage are tagged `unlinked_no_source_lineage` and remain non-promotion proof.
- Enables the lineage-persisting mode in the Torghut paper-account flatten CronJob and locks the manifest contract with regression coverage.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed after installing the missing system C compiler required to build the locked `crosshair-tool` dependency.
- `cd services/torghut && uv run --frozen pytest tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py -q` — passed, 57 tests.
- `cd services/torghut && uv run --frozen ruff check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py` — passed.
- `cd services/torghut && uv run --frozen ruff format --check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed, 0 errors.
- `git diff --check` — passed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.