### PR TITLE
fix(torghut): isolate shared paper account schedule

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
@@ -14,7 +14,7 @@ spec:
   implementationSpecRef:
     name: autonomous-trader-v1
   goal:
-    objective: Reach 500000 USD account equity in the Alpaca paper account using autonomous day trading through Alpaca MCP across stocks, ETFs, options, or any other financial instruments available in the account.
+    objective: Run a read-only autonomous-trader dry run while the Alpaca paper account is shared with Torghut profitability proof collection; do not mutate broker state.
   vcsRef:
     name: github
   vcsPolicy:
@@ -31,8 +31,8 @@ spec:
     repository: proompteng/lab
     base: main
     head: codex/synthesis-autonomous-trader-session
-    mode: market-open
-    synthesisSessionMode: market_open
+    mode: dry-run
+    synthesisSessionMode: dry_run
     accountType: paper
     targetEquityUsd: "500000"
     marketOpenTimezone: America/New_York

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-schedule.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-schedule.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: synthesis
   annotations:
     argocd.argoproj.io/sync-options: Prune=false
+    proompteng.ai/account-isolation-mode: read-only-shared-paper-account
   labels:
     app.kubernetes.io/part-of: synthesis
     app.kubernetes.io/component: autonomous-trader

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -595,7 +595,7 @@ describe('scheduled AgentRun templates', () => {
 })
 
 describe('synthesis autonomous trader provider', () => {
-  it('enables the market-open trader template for scheduled paper trading', () => {
+  it('keeps the market-open trader schedule read-only while the paper account is shared', () => {
     const kustomization = readYamlObjects('argocd/applications/synthesis/agents-domain/kustomization.yaml')[0]
     const resources = objectAt(kustomization, 'resources') as string[] | undefined
     const provider = readYamlObjects(
@@ -623,9 +623,10 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(scheduleSpec, 'cron')).toBe('15 9 * * 1-5')
     expect(objectAt(scheduleSpec, 'timezone')).toBe('America/New_York')
     expect(objectAt(objectAt(scheduleSpec, 'targetRef'), 'name')).toBe('autonomous-trader-template')
-    expect(objectAt(objectAt(templateSpec, 'goal'), 'objective')).toContain('Reach 500000 USD account equity')
-    expect(objectAt(parameters, 'mode')).toBe('market-open')
-    expect(objectAt(parameters, 'synthesisSessionMode')).toBe('market_open')
+    expect(objectAt(objectAt(templateSpec, 'goal'), 'objective')).toContain('read-only autonomous-trader dry run')
+    expect(objectAt(objectAt(templateSpec, 'goal'), 'objective')).toContain('do not mutate broker state')
+    expect(objectAt(parameters, 'mode')).toBe('dry-run')
+    expect(objectAt(parameters, 'synthesisSessionMode')).toBe('dry_run')
     expect(objectAt(parameters, 'accountType')).toBe('paper')
     expect(objectAt(parameters, 'targetEquityUsd')).toBe('500000')
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_MODE')).toBe('{{parameters.mode}}')


### PR DESCRIPTION
## Summary

- Suspends the scheduled Synthesis market-open broker-mutation path by converting `autonomous-trader-template` to read-only `dry-run` / `dry_run` mode while its Alpaca paper credentials are shared with Torghut proof collection.
- Marks the Synthesis market-open schedule with `proompteng.ai/account-isolation-mode=read-only-shared-paper-account` so the containment reason is visible in rendered GitOps.
- Updates the scheduled AgentRun smoke test to require the read-only shared-account posture instead of scheduled paper trading.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `git diff --check`
- `kubectl kustomize argocd/applications/synthesis/agents-domain >/tmp/synthesis-agents-domain-render.yaml` and verified the rendered schedule/template show `read-only-shared-paper-account`, `mode: dry-run`, and `synthesisSessionMode: dry_run`.
- Live containment check: suspended `synthesis/autonomous-trader-market-open-gnk4k-job`, verified `suspend=true`, no active pod, and `0` Torghut `TORGHUT_SIM` order events after `2026-06-01T14:25:00Z`.

## Breaking Changes

Scheduled `autonomous-trader-market-open` runs no longer mutate the shared Alpaca paper account. This is intentional until Synthesis has dedicated paper credentials or Torghut proof collection no longer depends on the shared account staying uncontaminated.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
