### PR TITLE
fix(torghut): isolate bounded paper-route windows

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -458,9 +458,7 @@ def _target_probe_symbol_actions(
             elif sell_count < buy_count:
                 action = "sell"
             else:
-                action = (
-                    first_action if balanced_seed_index % 2 == 0 else second_action
-                )
+                action = first_action if balanced_seed_index % 2 == 0 else second_action
                 balanced_seed_index += 1
             actions[symbol] = action
             if action == "buy":
@@ -820,6 +818,13 @@ class SimpleTradingPipeline(TradingPipeline):
                 positions=positions,
                 allowed_symbols=allowed_symbols,
             )
+            self._process_paper_route_target_source_decisions(
+                session=session,
+                strategies=strategies,
+                account=account,
+                positions=positions,
+                allowed_symbols=allowed_symbols,
+            )
             quality_signals = self._quality_gate_signals(
                 signals=batch.signals,
                 strategies=strategies,
@@ -836,13 +841,6 @@ class SimpleTradingPipeline(TradingPipeline):
                 batch=batch,
                 strategies=strategies,
                 account_snapshot=account_snapshot,
-                account=account,
-                positions=positions,
-                allowed_symbols=allowed_symbols,
-            )
-            self._process_paper_route_target_source_decisions(
-                session=session,
-                strategies=strategies,
                 account=account,
                 positions=positions,
                 allowed_symbols=allowed_symbols,
@@ -2585,6 +2583,66 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         return symbols, load_error, targets
 
+    def _active_bounded_paper_route_target_window(
+        self,
+        decision: StrategyDecision,
+    ) -> dict[str, object] | None:
+        if settings.trading_mode != "paper":
+            return None
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return None
+        symbol = decision.symbol.strip().upper()
+        if not symbol:
+            return None
+
+        target_symbols, target_plan_error, targets = (
+            self._external_paper_route_target_probe_symbols_cached()
+        )
+        if target_plan_error or symbol not in target_symbols:
+            return None
+
+        now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+        active_targets: list[dict[str, Any]] = []
+        active_windows: list[dict[str, str]] = []
+        window_starts: list[datetime] = []
+        window_ends: list[datetime] = []
+        for target in targets:
+            if not _target_requires_bounded_sim_collection_gate(target):
+                continue
+            if symbol not in _target_symbols(target):
+                continue
+            window = _target_probe_window(target)
+            if window is None:
+                continue
+            window_start, window_end = window
+            if now < window_start or now >= window_end:
+                continue
+            active_targets.append(dict(target))
+            window_starts.append(window_start)
+            window_ends.append(window_end)
+            active_windows.append(
+                {
+                    "window_start": window_start.isoformat(),
+                    "window_end": window_end.isoformat(),
+                }
+            )
+        if not active_targets:
+            return None
+        gate: dict[str, object] = {
+            "mode": "paper_route_target_window_submission_gate",
+            "symbol": symbol,
+            "account_label": self.account_label,
+            "target_count": len(active_targets),
+            "target_symbols": sorted(target_symbols),
+            "active_windows": active_windows[:5],
+            "requires_scoped_source_decision": True,
+        }
+        if window_starts and window_ends:
+            gate["window_start"] = min(window_starts).isoformat()
+            gate["window_end"] = max(window_ends).isoformat()
+        gate.update(_target_plan_lineage(active_targets, symbol))
+        return gate
+
     @staticmethod
     def _paper_route_target_strategy(
         target: Mapping[str, Any],
@@ -2644,6 +2702,8 @@ class SimpleTradingPipeline(TradingPipeline):
             "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
             "profit_proof_eligible": False,
             "source_kind": _safe_text(target.get("source_kind")),
+            "account_label": _safe_text(target.get("account_label")),
+            "source_account_label": _safe_text(target.get("source_account_label")),
             "account_stage_runtime_identity": {
                 "account_label": _safe_text(target.get("account_label")),
                 "source_account_label": _safe_text(target.get("source_account_label")),
@@ -2671,10 +2731,11 @@ class SimpleTradingPipeline(TradingPipeline):
                 if str(item).strip()
             ],
             "bounded_evidence_collection_authorized": bounded_collection_authorized,
-            "bounded_live_paper_collection_authorized": (
-                bounded_collection_authorized
-            ),
+            "bounded_live_paper_collection_authorized": (bounded_collection_authorized),
             "canary_collection_authorized": bounded_collection_authorized,
+            "evidence_collection_ok": _target_truthy(
+                target.get("evidence_collection_ok")
+            ),
             "bounded_evidence_collection_scope": (
                 _safe_text(target.get("bounded_evidence_collection_scope"))
                 or "paper_route_probe_next_session_only"
@@ -3688,6 +3749,32 @@ class SimpleTradingPipeline(TradingPipeline):
                 submission_stage="blocked_emergency_stop",
             )
             return False
+        active_target_window = self._active_bounded_paper_route_target_window(decision)
+        if active_target_window is not None:
+            collection_metadata = _bounded_sim_collection_metadata_from_decision(
+                decision,
+                account_label=self.account_label,
+                trading_mode=settings.trading_mode,
+            )
+            exit_metadata = self._paper_route_probe_exit_metadata(decision)
+            if collection_metadata is None and exit_metadata is None:
+                self._block_decision_submission(
+                    session=session,
+                    decision=decision,
+                    decision_row=decision_row,
+                    reason="paper_route_target_window_requires_scoped_source_decision",
+                    submission_stage="blocked_paper_route_target_window_unscoped",
+                    capital_stage="shadow",
+                    extra_metadata={
+                        "paper_route_target_window": active_target_window,
+                        "simple_lane": {
+                            "submit_enabled": settings.trading_simple_submit_enabled,
+                            "bounded_sim_collection_required": True,
+                            "bounded_sim_collection_bypass": False,
+                        },
+                    },
+                )
+                return False
         return True
 
     def _execution_client_for_symbol(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3242,6 +3242,180 @@ class TestTradingPipeline(TestCase):
             self.assertEqual(proof_floor.get("capital_state"), "zero_notional")
             self.assertEqual(control_plane.get("execution_lane"), "simple")
 
+    def test_simple_pipeline_blocks_unscoped_order_during_bounded_target_window(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc)
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = "http://torghut.test/plan"
+
+        strategy_id = uuid4()
+        strategy = Strategy(
+            id=strategy_id,
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded target strategy",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        target: dict[str, Any] = {
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "hypothesis_id": "H-PAIRS-01",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": strategy.name,
+            "runtime_strategy_name": strategy.name,
+            "strategy_lookup_names": [str(strategy_id), strategy.name],
+            "account_label": "TORGHUT_SIM",
+            "source_account_label": "TORGHUT_SIM",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "paper_route_probe_symbols": ["AAPL"],
+            "paper_route_probe_next_session_max_notional": "250",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+            "bounded_evidence_collection_authorized": True,
+            "bounded_live_paper_collection_authorized": True,
+            "bounded_evidence_collection_scope": "paper_route_probe_next_session_only",
+            "evidence_collection_ok": True,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "source_decision_readiness": {"ready": True, "blockers": []},
+        }
+        proof_floor = {
+            "route_state": "collecting",
+            "capital_state": "paper",
+            "max_notional": "250",
+            "market_window": {"session_open": True},
+            "blocking_reasons": [],
+        }
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+
+        unscoped_decision = StrategyDecision(
+            strategy_id=str(strategy_id),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="unscoped target-window order",
+            params={"price": "100"},
+        )
+        scoped_metadata = (
+            SimpleTradingPipeline._paper_route_target_source_decision_metadata(
+                target=target,
+                strategy=strategy,
+                symbol="AAPL",
+                window_start=window_start,
+                window_end=window_end,
+                max_notional=Decimal("250"),
+            )
+        )
+        scoped_decision = unscoped_decision.model_copy(
+            update={
+                "params": {
+                    "price": "100",
+                    "paper_route_target_plan_source_decision": scoped_metadata,
+                }
+            }
+        )
+
+        with self.session_local() as session:
+            unscoped_row = TradeDecision(
+                strategy_id=strategy_id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json=unscoped_decision.model_dump(mode="json"),
+                status="planned",
+            )
+            scoped_row = TradeDecision(
+                strategy_id=strategy_id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json=scoped_decision.model_dump(mode="json"),
+                status="planned",
+            )
+            session.add_all([unscoped_row, scoped_row])
+            session.commit()
+
+            with (
+                patch.object(
+                    pipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=({"AAPL"}, None, [target]),
+                ),
+                patch.object(
+                    SimpleTradingPipeline,
+                    "_profitability_proof_floor",
+                    return_value=proof_floor,
+                ),
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=now,
+                ),
+            ):
+                self.assertFalse(
+                    pipeline._is_trading_submission_allowed(
+                        session=session,
+                        decision=unscoped_decision,
+                        decision_row=unscoped_row,
+                    )
+                )
+                self.assertTrue(
+                    pipeline._is_trading_submission_allowed(
+                        session=session,
+                        decision=scoped_decision,
+                        decision_row=scoped_row,
+                    )
+                )
+
+            session.refresh(unscoped_row)
+            session.refresh(scoped_row)
+            unscoped_json = cast(dict[str, Any], unscoped_row.decision_json)
+            scoped_json = cast(dict[str, Any], scoped_row.decision_json)
+
+        self.assertEqual(unscoped_row.status, "blocked")
+        self.assertEqual(
+            unscoped_json.get("submission_stage"),
+            "blocked_paper_route_target_window_unscoped",
+        )
+        self.assertEqual(
+            unscoped_json.get("submission_block_reason"),
+            "paper_route_target_window_requires_scoped_source_decision",
+        )
+        target_window = cast(
+            dict[str, Any], unscoped_json.get("paper_route_target_window")
+        )
+        self.assertEqual(target_window.get("symbol"), "AAPL")
+        self.assertEqual(target_window.get("source_hypothesis_ids"), ["H-PAIRS-01"])
+        self.assertEqual(scoped_row.status, "planned")
+        self.assertNotIn("submission_block_reason", scoped_json)
+
     def test_simple_pipeline_retry_metadata_requires_prior_profit_floor_block(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Blocks unscoped simple paper submissions for symbols inside an active bounded paper-route target window.
- Moves scoped paper-route target-source decisions ahead of normal signal submission during signal cycles.
- Carries bounded collection account and evidence readiness metadata into target-source decisions so authorized collection can still proceed.
- Adds regression coverage proving unscoped H-PAIRS window orders are blocked while scoped target-source orders remain allowed.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k "bounded_target_window or target_plan_source_decision or target_source_decisions" -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "account_contamination or runtime_window_import or paper_route" -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `uv run --frozen ruff format app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
