### PR TITLE
feat(torghut): materialize source-backed fill economics

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -3481,14 +3481,45 @@ def _positive_hash_count(value: object) -> bool:
     return bool(counts) and any(_safe_int(count) > 0 for count in counts.values())
 
 
+def _runtime_ledger_bucket_authority_payload(
+    row: StrategyRuntimeLedgerBucket,
+) -> dict[str, Any]:
+    payload = _as_mapping(row.payload_json)
+    cost_basis_counts = payload.get("cost_basis_counts") or payload.get(
+        "post_cost_basis_counts"
+    )
+    merged: dict[str, Any] = {
+        **payload,
+        "fill_count": row.fill_count,
+        "decision_count": row.decision_count,
+        "submitted_order_count": row.submitted_order_count,
+        "closed_trade_count": row.closed_trade_count,
+        "open_position_count": row.open_position_count,
+        "filled_notional": row.filled_notional,
+        "gross_strategy_pnl": row.gross_strategy_pnl,
+        "cost_amount": row.cost_amount,
+        "net_strategy_pnl_after_costs": row.net_strategy_pnl_after_costs,
+        "post_cost_expectancy_bps": row.post_cost_expectancy_bps,
+        "ledger_schema_version": row.ledger_schema_version,
+        "pnl_basis": row.pnl_basis,
+        "execution_policy_hash_counts": row.execution_policy_hash_counts,
+        "cost_model_hash_counts": row.cost_model_hash_counts,
+        "lineage_hash_counts": row.lineage_hash_counts,
+    }
+    if cost_basis_counts is not None:
+        merged.setdefault("cost_basis_counts", cost_basis_counts)
+    return merged
+
+
 def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> bool:
     blockers = [
         str(item).strip()
         for item in _as_sequence(row.blockers_json)
         if str(item).strip()
     ]
+    authority_payload = _runtime_ledger_bucket_authority_payload(row)
     source_authority_blockers = runtime_ledger_promotion_source_authority_blockers(
-        _as_mapping(row.payload_json)
+        authority_payload
     )
     return (
         row.pnl_basis == POST_COST_PNL_BASIS
@@ -3501,7 +3532,7 @@ def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> b
         and _positive_hash_count(row.cost_model_hash_counts)
         and _positive_hash_count(row.lineage_hash_counts)
         and not cost_basis_counts_have_non_promotion_grade_costs(
-            _as_mapping(row.payload_json).get("cost_basis_counts")
+            authority_payload.get("cost_basis_counts")
         )
         and not blockers
         and not source_authority_blockers
@@ -3518,7 +3549,7 @@ def _runtime_ledger_bucket_diagnostic_blockers(
     ]
     blockers.extend(
         runtime_ledger_promotion_source_authority_blockers(
-            _as_mapping(row.payload_json)
+            _runtime_ledger_bucket_authority_payload(row)
         )
     )
     return list(dict.fromkeys(blockers))

--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import cast
 
 from .runtime_cost_authority import is_non_promotion_grade_runtime_cost_basis
 
@@ -43,6 +44,32 @@ _TCA_PNL_BASES = frozenset(
         "shortfall_proxy",
         "realized_pnl_proxy_from_tca_shortfall",
         "execution_tca_shortfall_cost",
+    }
+)
+_DELTA_FILL_QUANTITY_BASES = frozenset(
+    {"delta", "cumulative_to_delta", "source_notional_delta"}
+)
+_PROMOTION_GRADE_SOURCE_MATERIALIZATIONS = frozenset(
+    {
+        "execution_order_event",
+        "execution_order_events",
+        "execution_order_events_runtime_ledger",
+        "runtime_order_feed_execution_source",
+        "source_execution_lifecycle",
+        "source_execution_lifecycle_materialized_runtime_ledger",
+    }
+)
+_NON_PROMOTION_SOURCE_MARKERS = frozenset(
+    {
+        "aggregate_only",
+        "artifact_only",
+        "paper_route_probe",
+        "probe",
+        "recovery",
+        "replay_artifact",
+        "route_acquisition",
+        "route_reacquisition",
+        "simulation_source_replay_only",
     }
 )
 _DIAGNOSTIC_EXPECTANCY_SUPPRESSING_BLOCKERS = frozenset(
@@ -683,13 +710,20 @@ def _normalize_fill_row(
     order_feed_source_fill = event_type in _FILL_EVENTS and order_feed_lifecycle_source
     lifecycle_only = _is_order_feed_lifecycle_only_row(row, event_type=event_type)
     if event_type in _FILL_EVENTS and order_feed_source_fill:
-        if fill_quantity_basis in {"delta", "cumulative_to_delta"}:
+        if fill_quantity_basis in _DELTA_FILL_QUANTITY_BASES:
             if filled_qty_delta is not None:
                 filled_qty = filled_qty_delta
                 if filled_notional_delta is not None:
                     filled_notional = filled_notional_delta
                 elif avg_fill_price is not None:
                     filled_notional = filled_qty_delta * avg_fill_price
+        elif _is_linked_materialized_order_event_fill(row) and (
+            filled_notional_delta is not None and avg_fill_price is not None
+        ):
+            filled_notional = filled_notional_delta
+            filled_qty = filled_qty_delta or (filled_notional_delta / avg_fill_price)
+            filled_qty_delta = filled_qty
+            fill_quantity_basis = "source_notional_delta"
         else:
             filled_qty = None
             filled_notional = None
@@ -708,9 +742,22 @@ def _normalize_fill_row(
             "commission",
             "fees",
             "fee_amount",
+            "broker_fee",
+            "explicit_cost_amount",
+            "total_fees",
+            "total_fee_amount",
         )
     )
-    cost_basis = _coerce_text(_row_value(row, "cost_basis", "cost_source", "fee_basis"))
+    cost_basis = _coerce_text(
+        _row_value(
+            row,
+            "cost_basis",
+            "cost_source",
+            "fee_basis",
+            "commission_basis",
+            "broker_fee_basis",
+        )
+    )
     decision_id = _coerce_text(
         _row_value(row, "decision_id", "trade_decision_id", "decision_hash")
     )
@@ -757,6 +804,8 @@ def _normalize_fill_row(
     blockers: list[str] = []
     if _has_tca_pnl_shortcut(row):
         blockers.append("tca_shortfall_not_runtime_pnl")
+    if _is_non_promotion_runtime_source_row(row):
+        blockers.append("runtime_source_not_promotion_authority")
     if executed_at is None and event_type != "diagnostic":
         blockers.append("executed_at_missing")
     if event_type in _FILL_EVENTS and not lifecycle_only:
@@ -764,10 +813,7 @@ def _normalize_fill_row(
             blockers.append("side_missing_or_invalid")
         if filled_qty is None:
             blockers.append("filled_qty_missing_or_non_positive")
-        if order_feed_source_fill and fill_quantity_basis not in {
-            "delta",
-            "cumulative_to_delta",
-        }:
+        if order_feed_source_fill and fill_quantity_basis not in _DELTA_FILL_QUANTITY_BASES:
             blockers.append("fill_quantity_delta_basis_missing")
         elif (
             order_feed_source_fill
@@ -936,6 +982,79 @@ def _is_order_feed_source_fill(row: RuntimeLedgerFill | Mapping[str, object]) ->
     return _is_order_feed_source_row(row)
 
 
+def _is_linked_materialized_order_event_fill(
+    row: RuntimeLedgerFill | Mapping[str, object],
+) -> bool:
+    """Return true for row-level order-feed fills with source/economics lineage.
+
+    This is intentionally stricter than general order-feed source detection so
+    cumulative/aggregate rows do not become fill authority merely because they
+    carry a quantity. A linked order-event fill can infer delta quantity from a
+    positive filled_notional_delta and avg price only when the row also carries
+    execution, decision, source-window, offset, and materialization lineage.
+    """
+
+    if _is_non_promotion_runtime_source_row(row):
+        return False
+    materialization = _coerce_text(
+        _row_value(row, "source_materialization", "authority_class", "source")
+    )
+    if materialization not in _PROMOTION_GRADE_SOURCE_MATERIALIZATIONS:
+        return False
+    return (
+        _row_value(row, "execution_order_event_id", "event_fingerprint") is not None
+        and _row_value(row, "execution_id", "execution_correlation_id") is not None
+        and _row_value(row, "trade_decision_id", "decision_id", "decision_hash")
+        is not None
+        and _row_value(row, "source_window_id", "runtime_ledger_source_window_id")
+        is not None
+        and _source_offset_present(row)
+    )
+
+
+def _source_offset_present(row: RuntimeLedgerFill | Mapping[str, object]) -> bool:
+    source_offsets = _row_value(row, "source_offsets")
+    if isinstance(source_offsets, Mapping):
+        typed_offsets = cast(Mapping[str, object], source_offsets)
+        return (
+            _row_value(typed_offsets, "topic") is not None
+            and _row_value(typed_offsets, "partition") is not None
+            and _row_value(typed_offsets, "offset") is not None
+        )
+    return (
+        _row_value(row, "source_topic") is not None
+        and _row_value(row, "source_partition") is not None
+        and _row_value(row, "source_offset") is not None
+    ) or _row_value(row, "source_offset") is not None
+
+
+def _is_non_promotion_runtime_source_row(
+    row: RuntimeLedgerFill | Mapping[str, object],
+) -> bool:
+    promotion_authority = _row_value(row, "promotion_authority", "promotion_authority_eligible")
+    if promotion_authority is False:
+        return True
+    for key in (
+        "authority_class",
+        "authority_reason",
+        "pnl_derivation",
+        "route_mode",
+        "source",
+        "source_kind",
+        "source_materialization",
+        "promotion_authority",
+    ):
+        text = _coerce_text(_row_value(row, key))
+        if text is None:
+            continue
+        normalized = text.lower().replace("-", "_")
+        if normalized in {"0", "false", "no", "n"} and key == "promotion_authority":
+            return True
+        if any(marker in normalized for marker in _NON_PROMOTION_SOURCE_MARKERS):
+            return True
+    return False
+
+
 def _is_order_feed_lifecycle_only_row(
     row: RuntimeLedgerFill | Mapping[str, object],
     *,
@@ -957,9 +1076,21 @@ def _is_order_feed_lifecycle_only_row(
             "commission",
             "fees",
             "fee_amount",
+            "broker_fee",
+            "explicit_cost_amount",
+            "total_fees",
+            "total_fee_amount",
         )
         is None
-        and _row_value(row, "cost_basis", "cost_source", "fee_basis") is None
+        and _row_value(
+            row,
+            "cost_basis",
+            "cost_source",
+            "fee_basis",
+            "commission_basis",
+            "broker_fee_basis",
+        )
+        is None
     )
 
 

--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -7,6 +7,11 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import cast
 
+from .runtime_cost_authority import (
+    cost_basis_counts_have_non_promotion_grade_costs,
+    is_non_promotion_grade_runtime_cost_basis,
+)
+
 RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
 RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER = (
     "runtime_ledger_source_window_ids_missing"
@@ -55,9 +60,15 @@ _PROMOTION_GRADE_SOURCE_REF_TABLES = frozenset(
 )
 _NON_PROMOTION_AUTHORITY_MARKERS = frozenset(
     {
+        "aggregate_only",
         "exact_replay",
         "artifact_only",
+        "paper_route_probe",
+        "probe",
+        "recovery",
         "replay_artifact",
+        "route_acquisition",
+        "route_reacquisition",
         "simulation_source_replay_only",
     }
 )
@@ -326,6 +337,9 @@ def _promotion_grade_authority_marker_present(bucket: Mapping[str, object]) -> b
 
 
 def _non_promotion_derivation_present(bucket: Mapping[str, object]) -> bool:
+    promotion_authority = _truthy_flag(bucket.get("promotion_authority"))
+    if promotion_authority is False:
+        return True
     return any(
         _non_promotion_authority_marker_present(bucket.get(key))
         for key in (
@@ -336,6 +350,89 @@ def _non_promotion_derivation_present(bucket: Mapping[str, object]) -> bool:
             "source_kind",
             "promotion_authority",
         )
+    )
+
+
+def _positive_decimal_present(value: object) -> bool:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return False
+    return parsed.is_finite() and parsed > 0
+
+
+def _filled_notional_present(bucket: Mapping[str, object]) -> bool:
+    return any(
+        _positive_decimal_present(bucket.get(key))
+        for key in (
+            "filled_notional",
+            "runtime_ledger_filled_notional",
+            "filled_notional_delta",
+            "fill_notional_delta",
+            "delta_filled_notional",
+        )
+    )
+
+
+def _explicit_cost_basis_present(bucket: Mapping[str, object]) -> bool:
+    if is_non_promotion_grade_runtime_cost_basis(bucket.get("cost_basis")):
+        return False
+    if cost_basis_counts_have_non_promotion_grade_costs(bucket.get("cost_basis_counts")):
+        return False
+    if cost_basis_counts_have_non_promotion_grade_costs(
+        bucket.get("post_cost_basis_counts")
+    ):
+        return False
+    cost_basis_counts = bucket.get("cost_basis_counts") or bucket.get(
+        "post_cost_basis_counts"
+    )
+    if _positive_mapping_value_count(cost_basis_counts) > 0:
+        return True
+    return _text(
+        bucket.get("cost_basis")
+        or bucket.get("cost_source")
+        or bucket.get("fee_basis")
+        or bucket.get("commission_basis")
+        or bucket.get("broker_fee_basis")
+    ) is not None
+
+
+def _explicit_cost_amount_present(bucket: Mapping[str, object]) -> bool:
+    for key in (
+        "cost_amount",
+        "runtime_ledger_cost_amount",
+        "explicit_cost",
+        "explicit_cost_amount",
+        "commission",
+        "fees",
+        "fee_amount",
+        "broker_fee",
+    ):
+        if bucket.get(key) is None:
+            continue
+        try:
+            parsed = Decimal(str(bucket.get(key)))
+        except (InvalidOperation, ValueError):
+            continue
+        if parsed.is_finite() and parsed >= 0:
+            return True
+    # Bucket-level readback can prove explicit zero/non-zero costs with a cost
+    # basis histogram and a cost-model lineage hash even when it does not carry
+    # per-fill fee amounts in payload_json.
+    cost_basis_counts = bucket.get("cost_basis_counts") or bucket.get(
+        "post_cost_basis_counts"
+    )
+    return _positive_mapping_value_count(cost_basis_counts) > 0 and (
+        _positive_mapping_value_count(bucket.get("cost_model_hash_counts")) > 0
+        or _source_refs_present(bucket, "cost_model_hashes", "cost_model_hash")
+    )
+
+
+def _execution_economics_present(bucket: Mapping[str, object]) -> bool:
+    return (
+        _filled_notional_present(bucket)
+        and _explicit_cost_basis_present(bucket)
+        and _explicit_cost_amount_present(bucket)
     )
 
 
@@ -464,7 +561,13 @@ def runtime_ledger_promotion_source_authority_blockers(
     ) > 0:
         blockers.append(ORDER_FEED_LIFECYCLE_MISSING_BLOCKER)
     economics_complete = _truthy_flag(bucket.get("execution_economics_complete"))
-    if economics_complete is False:
+    economics_required = _truthy_flag(
+        bucket.get("execution_economics_required")
+        or bucket.get("requires_execution_economics")
+    )
+    if economics_complete is False or (
+        economics_required is True and not _execution_economics_present(bucket)
+    ):
         blockers.append(EXECUTION_ECONOMICS_MISSING_BLOCKER)
     if (
         not _promotion_grade_source_materialization_present(bucket)

--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -184,6 +184,7 @@ def build_source_proof_census(
     totals = _totals(rows, daily, ledger_report)
     blockers = _census_blockers(rows, totals, ledger_report, read_error=read_error)
     missing_source_ref_categories = _missing_source_ref_categories(blockers)
+    missing_requirement_categories = _missing_requirement_categories(blockers)
     classification = _classify_verdict(totals, blockers)
     return {
         'schema_version': SCHEMA_VERSION,
@@ -212,6 +213,7 @@ def build_source_proof_census(
             'aggregate': ledger_report['aggregate'],
         },
         'missing_source_ref_categories': missing_source_ref_categories,
+        'missing_requirement_categories': missing_requirement_categories,
         'blockers': blockers,
         'verdict': {
             'classification': classification,
@@ -426,6 +428,7 @@ def _daily_payload(day: str, rows: CensusSourceRows, ledger_report: Mapping[str,
     ledger = ledger_by_day.get(day, {})
     day_executions = _rows_on_day(rows.executions, day, 'created_at')
     day_events = _rows_on_day(rows.execution_order_events, day, 'event_ts', fallback_key='created_at')
+    day_tca_metrics = _rows_on_day(rows.execution_tca_metrics, day, 'computed_at')
     return {
         'trading_day': day,
         'trade_decision_count': len(_rows_on_day(rows.trade_decisions, day, 'created_at')),
@@ -433,7 +436,27 @@ def _daily_payload(day: str, rows: CensusSourceRows, ledger_report: Mapping[str,
         'filled_execution_count': sum(1 for row in day_executions if _filled_execution(row)),
         'execution_order_event_count': len(day_events),
         'fill_lifecycle_event_count': sum(1 for row in day_events if _fill_event(row)),
-        'tca_cost_row_count': len(_rows_on_day(rows.execution_tca_metrics, day, 'computed_at')),
+        'linked_order_event_fill_count': sum(1 for row in day_events if _linked_order_event_fill(row)),
+        'execution_order_events_with_execution_ref_count': sum(
+            1 for row in day_events if _text(row.get('execution_id')) is not None
+        ),
+        'execution_order_events_with_trade_decision_ref_count': sum(
+            1 for row in day_events if _text(row.get('trade_decision_id')) is not None
+        ),
+        'execution_order_events_with_filled_notional_delta_count': sum(
+            1 for row in day_events if _decimal(row.get('filled_notional_delta')) > 0
+        ),
+        'execution_order_events_with_quantity_count': sum(1 for row in day_events if _event_quantity_present(row)),
+        'execution_order_events_with_avg_price_count': sum(
+            1 for row in day_events if _decimal(row.get('avg_fill_price')) > 0
+        ),
+        'tca_cost_row_count': len(day_tca_metrics),
+        'tca_cost_rows_with_execution_ref_count': sum(
+            1 for row in day_tca_metrics if _text(row.get('execution_id')) is not None
+        ),
+        'tca_cost_rows_with_trade_decision_ref_count': sum(
+            1 for row in day_tca_metrics if _text(row.get('trade_decision_id')) is not None
+        ),
         'source_window_count': len(_rows_on_day(rows.order_feed_source_windows, day, 'window_started_at')),
         'execution_order_events_with_source_window_count': sum(
             1 for row in day_events if _text(row.get('source_window_id')) is not None
@@ -441,6 +464,7 @@ def _daily_payload(day: str, rows: CensusSourceRows, ledger_report: Mapping[str,
         'execution_order_events_with_source_offset_count': sum(1 for row in day_events if _event_source_offset_present(row)),
         'runtime_ledger_bucket_count': _int(ledger.get('bucket_count')),
         'blocker_free_runtime_ledger_bucket_count': _int(ledger.get('source_authority_bucket_count')),
+        'explicit_cost_runtime_ledger_bucket_count': _int(ledger.get('explicit_cost_bucket_count')),
         'closed_trade_count': _int(ledger.get('closed_trade_count')),
         'open_position_count': _int(ledger.get('open_position_count')),
         'filled_notional': _decimal_text(_decimal(ledger.get('filled_notional'))),
@@ -462,7 +486,29 @@ def _totals(
         'filled_execution_count': sum(1 for row in rows.executions if _filled_execution(row)),
         'execution_order_event_count': len(rows.execution_order_events),
         'fill_lifecycle_event_count': sum(1 for row in rows.execution_order_events if _fill_event(row)),
+        'linked_order_event_fill_count': sum(1 for row in rows.execution_order_events if _linked_order_event_fill(row)),
+        'execution_order_events_with_execution_ref_count': sum(
+            1 for row in rows.execution_order_events if _text(row.get('execution_id')) is not None
+        ),
+        'execution_order_events_with_trade_decision_ref_count': sum(
+            1 for row in rows.execution_order_events if _text(row.get('trade_decision_id')) is not None
+        ),
+        'execution_order_events_with_filled_notional_delta_count': sum(
+            1 for row in rows.execution_order_events if _decimal(row.get('filled_notional_delta')) > 0
+        ),
+        'execution_order_events_with_quantity_count': sum(
+            1 for row in rows.execution_order_events if _event_quantity_present(row)
+        ),
+        'execution_order_events_with_avg_price_count': sum(
+            1 for row in rows.execution_order_events if _decimal(row.get('avg_fill_price')) > 0
+        ),
         'tca_cost_row_count': len(rows.execution_tca_metrics),
+        'tca_cost_rows_with_execution_ref_count': sum(
+            1 for row in rows.execution_tca_metrics if _text(row.get('execution_id')) is not None
+        ),
+        'tca_cost_rows_with_trade_decision_ref_count': sum(
+            1 for row in rows.execution_tca_metrics if _text(row.get('trade_decision_id')) is not None
+        ),
         'source_window_count': len(rows.order_feed_source_windows),
         'execution_order_events_with_source_window_count': sum(
             1 for row in rows.execution_order_events if _text(row.get('source_window_id')) is not None
@@ -472,6 +518,10 @@ def _totals(
         ),
         'runtime_ledger_bucket_count': len(rows.runtime_ledger_buckets),
         'blocker_free_runtime_ledger_bucket_count': source_authority_bucket_count,
+        'explicit_cost_runtime_ledger_bucket_count': _int(aggregate.get('explicit_cost_bucket_count')),
+        'runtime_ledger_buckets_with_filled_notional_count': sum(
+            1 for row in rows.runtime_ledger_buckets if _decimal(row.get('filled_notional')) > 0
+        ),
         'closed_trade_count': _int(aggregate.get('closed_round_trips')),
         'open_position_count': _int(aggregate.get('open_position_count')),
         'filled_notional': _text(aggregate.get('total_filled_notional'), default='0'),
@@ -510,6 +560,18 @@ def _census_blockers(
         )
     if _int(totals.get('fill_lifecycle_event_count')) <= 0:
         blockers.append(ORDER_FEED_LIFECYCLE_MISSING_BLOCKER)
+    if _int(totals.get('execution_order_events_with_execution_ref_count')) < _int(
+        totals.get('execution_order_event_count')
+    ):
+        blockers.append(RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER)
+    if _int(totals.get('execution_order_events_with_trade_decision_ref_count')) < _int(
+        totals.get('execution_order_event_count')
+    ):
+        blockers.append(RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER)
+    if _int(totals.get('execution_order_events_with_filled_notional_delta_count')) < _int(
+        totals.get('fill_lifecycle_event_count')
+    ):
+        blockers.append(AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER)
     if _int(totals.get('tca_cost_row_count')) <= 0:
         blockers.extend([AUTHORITY_EXPLICIT_COSTS_BLOCKER, EXECUTION_ECONOMICS_MISSING_BLOCKER])
     if _int(totals.get('source_window_count')) <= 0:
@@ -526,6 +588,12 @@ def _census_blockers(
         blockers.append(AUTHORITY_OPEN_POSITIONS_BLOCKER)
     if _int(totals.get('closed_trade_count')) <= 0:
         blockers.append(AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER)
+    if _decimal(totals.get('filled_notional')) <= 0:
+        blockers.append(AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER)
+    if rows.runtime_ledger_buckets and _int(totals.get('explicit_cost_runtime_ledger_bucket_count')) < len(
+        rows.runtime_ledger_buckets
+    ):
+        blockers.append(AUTHORITY_EXPLICIT_COSTS_BLOCKER)
     if not rows.runtime_ledger_buckets:
         blockers.append(AUTHORITY_EVIDENCE_MISSING_BLOCKER)
     blockers.extend(str(item) for item in _sequence(ledger_report.get('blockers')))
@@ -534,6 +602,22 @@ def _census_blockers(
 
 def _missing_source_ref_categories(blockers: Sequence[str]) -> dict[str, bool]:
     return {code: code in blockers for code in sorted(_SOURCE_REF_BLOCKERS)}
+
+
+def _missing_requirement_categories(blockers: Sequence[str]) -> dict[str, bool]:
+    blocker_set = set(blockers)
+    return {
+        'filled_notional': AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER in blocker_set,
+        'explicit_costs': AUTHORITY_EXPLICIT_COSTS_BLOCKER in blocker_set
+        or EXECUTION_ECONOMICS_MISSING_BLOCKER in blocker_set,
+        'closed_round_trip': AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER in blocker_set,
+        'execution_refs': RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in blocker_set,
+        'execution_order_event_refs': RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER in blocker_set,
+        'source_window_refs': RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER in blocker_set
+        or RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER in blocker_set,
+        'source_offsets': RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in blocker_set,
+        'tca_cost_rows': AUTHORITY_EXPLICIT_COSTS_BLOCKER in blocker_set,
+    }
 
 
 def _classify_verdict(totals: Mapping[str, object], blockers: Sequence[str]) -> str:
@@ -621,6 +705,23 @@ def _fill_event(row: Mapping[str, object]) -> bool:
     return 'fill' in event_type or status in {'filled', 'partially_filled'} or _decimal(row.get('filled_qty_delta')) > 0
 
 
+def _event_quantity_present(row: Mapping[str, object]) -> bool:
+    return any(_decimal(row.get(key)) > 0 for key in ('filled_qty_delta', 'filled_qty', 'qty', 'quantity'))
+
+
+def _linked_order_event_fill(row: Mapping[str, object]) -> bool:
+    return (
+        _fill_event(row)
+        and _text(row.get('execution_id')) is not None
+        and _text(row.get('trade_decision_id')) is not None
+        and _text(row.get('source_window_id')) is not None
+        and _event_source_offset_present(row)
+        and _event_quantity_present(row)
+        and _decimal(row.get('avg_fill_price')) > 0
+        and _decimal(row.get('filled_notional_delta')) > 0
+    )
+
+
 def _event_source_offset_present(row: Mapping[str, object]) -> bool:
     return (
         _text(row.get('source_topic')) is not None
@@ -677,6 +778,7 @@ def _order_event_row(row: ExecutionOrderEvent) -> dict[str, object]:
         'status': row.status,
         'filled_qty': row.filled_qty,
         'filled_qty_delta': row.filled_qty_delta,
+        'avg_fill_price': row.avg_fill_price,
         'filled_notional_delta': row.filled_notional_delta,
         'execution_id': str(row.execution_id) if row.execution_id is not None else None,
         'trade_decision_id': str(row.trade_decision_id) if row.trade_decision_id is not None else None,

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -8361,80 +8361,10 @@ def _portfolio_executable_max_notional(portfolio: PortfolioCandidateSpec) -> Dec
 def _runtime_closure_exact_replay_ledger_update(
     runtime_closure: Mapping[str, Any],
 ) -> dict[str, Any]:
-    artifact_ref = next(
-        (
-            ref
-            for ref in (
-                _string(runtime_closure.get("exact_replay_ledger_artifact_path")),
-                _string(runtime_closure.get("exact_replay_ledger_artifact_ref")),
-                _string(runtime_closure.get("runtime_ledger_artifact_path")),
-                _string(runtime_closure.get("runtime_ledger_artifact_ref")),
-            )
-            if ref and Path(ref).exists()
-        ),
-        "",
-    )
-    if not artifact_ref:
-        return {}
-    ledger = _load_json_mapping_artifact(artifact_ref)
-    if _string(ledger.get("artifact_kind")) != _EXACT_REPLAY_LEDGER_ARTIFACT_KIND:
-        return {}
-    schema_version = _string(
-        ledger.get("schema_version")
-        or ledger.get("ledger_schema_version")
-        or ledger.get("runtime_ledger_schema_version")
-    )
-    if schema_version not in _EXACT_REPLAY_LEDGER_SCHEMA_VERSIONS:
-        return {}
-    raw_rows = ledger.get("runtime_ledger_rows")
-    if not isinstance(raw_rows, list) or not raw_rows:
-        return {}
-    if not all(isinstance(row, Mapping) for row in raw_rows):
-        return {}
-    runtime_rows = [
-        cast(Mapping[str, object], row)
-        for row in cast(Sequence[object], raw_rows)
-        if isinstance(row, Mapping)
-    ]
-    runtime_bucket = _runtime_closure_exact_replay_bucket(
-        ledger=ledger,
-        rows=runtime_rows,
-    )
-    if runtime_bucket is None:
-        return {}
-    row_count = len(raw_rows)
-    fill_count = _runtime_report_int(
-        ledger.get("runtime_ledger_artifact_fill_count")
-        or ledger.get("exact_replay_ledger_artifact_fill_count")
-        or ledger.get("fill_row_count")
-    )
-    if fill_count != runtime_bucket.fill_count:
-        return {}
-    return {
-        "exact_replay_ledger_artifact_ref": artifact_ref,
-        "runtime_ledger_artifact_ref": artifact_ref,
-        "exact_replay_ledger_artifact_row_count": row_count,
-        "runtime_ledger_artifact_row_count": row_count,
-        "exact_replay_ledger_artifact_fill_count": fill_count,
-        "runtime_ledger_artifact_fill_count": fill_count,
-        "runtime_ledger_closed_trade_count": runtime_bucket.closed_trade_count,
-        "runtime_ledger_open_position_count": runtime_bucket.open_position_count,
-        "runtime_ledger_filled_notional": str(runtime_bucket.filled_notional),
-        "runtime_ledger_net_strategy_pnl_after_costs": str(
-            runtime_bucket.net_strategy_pnl_after_costs
-        ),
-        "runtime_ledger_post_cost_expectancy_bps": str(
-            runtime_bucket.post_cost_expectancy_bps
-        )
-        if runtime_bucket.post_cost_expectancy_bps is not None
-        else None,
-        "portfolio_post_cost_net_pnl_basis": POST_COST_PNL_BASIS,
-        "portfolio_post_cost_net_pnl_source": _EXACT_REPLAY_RUNTIME_LEDGER_PNL_SOURCE,
-        "runtime_ledger_pnl_basis": POST_COST_PNL_BASIS,
-        "runtime_ledger_pnl_source": _EXACT_REPLAY_RUNTIME_LEDGER_PNL_SOURCE,
-        "exact_replay_ledger_pnl_basis": POST_COST_PNL_BASIS,
-        "exact_replay_ledger_pnl_source": _EXACT_REPLAY_RUNTIME_LEDGER_PNL_SOURCE,
-    }
+    # Exact-replay rows are useful diagnostics, but they are not runtime or
+    # live-paper ledger authority. Final proof must come from source-backed
+    # runtime-ledger materialization instead of replay artifacts.
+    return {}
 
 
 def _runtime_closure_market_impact_stress_update(

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -129,6 +129,8 @@ def _fixture(*, days: int = 20, source_backed: bool = True) -> dict[str, object]
                 'event_type': 'fill',
                 'status': 'filled',
                 'filled_qty_delta': '10',
+                'avg_fill_price': '100',
+                'filled_notional_delta': '1000',
                 'event_ts': _iso(day, 15),
             }
             for day in range(days)
@@ -194,6 +196,9 @@ def test_full_source_backed_census_is_authority_candidate_ready() -> None:
     assert report['totals']['filled_execution_count'] == 20
     assert report['totals']['execution_order_event_count'] == 20
     assert report['totals']['fill_lifecycle_event_count'] == 20
+    assert report['totals']['linked_order_event_fill_count'] == 20
+    assert report['totals']['execution_order_events_with_execution_ref_count'] == 20
+    assert report['totals']['execution_order_events_with_filled_notional_delta_count'] == 20
     assert report['totals']['tca_cost_row_count'] == 20
     assert report['totals']['source_window_count'] == 20
     assert report['totals']['runtime_ledger_bucket_count'] == 20
@@ -237,6 +242,7 @@ def test_missing_order_event_refs_and_source_offsets_are_exact_source_ref_gaps()
     for event in payload['execution_order_events']:
         event.pop('source_offset')
         event.pop('source_window_id')
+        event.pop('filled_notional_delta')
     for bucket in payload['runtime_ledger_buckets']:
         bucket['payload']['execution_order_event_ids'] = []
         bucket['payload']['source_offsets'] = []
@@ -248,6 +254,19 @@ def test_missing_order_event_refs_and_source_offsets_are_exact_source_ref_gaps()
     assert RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER in report['blockers']
     assert RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in report['blockers']
     assert report['missing_source_ref_categories'][RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER] is True
+
+
+def test_order_events_missing_execution_and_decision_refs_are_exact_source_ref_gaps() -> None:
+    payload = _fixture()
+    for event in payload['execution_order_events']:
+        event.pop('execution_id')
+        event.pop('trade_decision_id')
+
+    report = _report(payload)
+
+    assert report['verdict']['classification'] == census.SOURCE_REFS_MISSING
+    assert census.RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in report['blockers']
+    assert RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER in report['blockers']
 
 
 def test_missing_tca_costs_are_economics_missing() -> None:
@@ -362,6 +381,7 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
         status='filled',
         filled_qty='10',
         filled_qty_delta='10',
+        avg_fill_price='100',
         filled_notional_delta='1000',
         execution_id='execution-0',
         trade_decision_id='decision-0',

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -346,6 +346,7 @@ def _complete_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
         "pnl_basis": POST_COST_BASIS_RUNTIME_LEDGER,
         "execution_policy_hash_counts": {"policy-sha": 2},
         "cost_model_hash_counts": {"cost-sha": 2},
+        "cost_basis_counts": {"broker_reported": 2},
         "lineage_hash_counts": {"lineage-sha": 2},
         "source_decision_mode_counts": {"strategy_signal_paper": 2},
         "source_window_start": "2026-03-06T14:30:00+00:00",
@@ -1282,6 +1283,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     blockers_json=[],
                     payload_json={
                         "source_decision_mode_counts": {"strategy_signal_paper": 2},
+                        "cost_basis_counts": {"broker_reported": 2},
                         "source_window_start": "2026-03-06T14:30:00+00:00",
                         "source_window_end": "2026-03-06T15:00:00+00:00",
                         "source_refs": [

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6169,24 +6169,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 {"exact_replay_ledger_artifact_path": str(artifact_path)}
             )
 
-        self.assertEqual(update["exact_replay_ledger_artifact_row_count"], 6)
-        self.assertEqual(update["runtime_ledger_artifact_row_count"], 6)
-        self.assertEqual(update["exact_replay_ledger_artifact_fill_count"], 2)
-        self.assertEqual(update["runtime_ledger_artifact_fill_count"], 2)
-        self.assertEqual(update["runtime_ledger_closed_trade_count"], 1)
-        self.assertEqual(update["runtime_ledger_open_position_count"], 0)
-        self.assertEqual(update["runtime_ledger_filled_notional"], "201")
-        self.assertEqual(update["runtime_ledger_net_strategy_pnl_after_costs"], "0.80")
-        self.assertEqual(
-            update["portfolio_post_cost_net_pnl_basis"],
-            "realized_strategy_pnl_after_explicit_costs",
-        )
-        self.assertEqual(
-            update["portfolio_post_cost_net_pnl_source"],
-            "exact_replay_runtime_ledger",
-        )
+        self.assertEqual(update, {})
 
-    def test_runtime_closure_proof_updates_portfolio_oracle_from_real_artifacts(
+    def test_runtime_closure_proof_blocks_oracle_without_source_runtime_ledger(
         self,
     ) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -6409,7 +6394,16 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 oracle_policy=policy,
             )
 
-        self.assertTrue(updated.objective_scorecard["oracle_passed"])
+        self.assertFalse(updated.objective_scorecard["oracle_passed"])
+        self.assertFalse(updated.objective_scorecard["profit_target_oracle"]["passed"])
+        oracle_blockers = updated.objective_scorecard["profit_target_oracle"][
+            "blockers"
+        ]
+        self.assertIn("exact_replay_ledger_artifact_present_failed", oracle_blockers)
+        self.assertIn("exact_replay_ledger_artifact_row_count_failed", oracle_blockers)
+        self.assertIn("exact_replay_ledger_artifact_fill_count_failed", oracle_blockers)
+        self.assertIn("portfolio_post_cost_net_pnl_basis_failed", oracle_blockers)
+        self.assertIn("portfolio_post_cost_net_pnl_source_failed", oracle_blockers)
         self.assertTrue(updated.objective_scorecard["executable_replay_passed"])
         self.assertEqual(
             updated.objective_scorecard["shadow_parity_status"], "within_budget"
@@ -6421,17 +6415,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             updated.objective_scorecard["executable_replay_artifact_ref"],
             str(approval_replay_path),
         )
-        self.assertEqual(
-            updated.objective_scorecard["exact_replay_ledger_artifact_ref"],
-            str(exact_ledger_path),
+        self.assertNotIn("exact_replay_ledger_artifact_ref", updated.objective_scorecard)
+        self.assertNotIn(
+            "exact_replay_ledger_artifact_row_count",
+            updated.objective_scorecard,
         )
-        self.assertEqual(
-            updated.objective_scorecard["exact_replay_ledger_artifact_row_count"],
-            6,
-        )
-        self.assertEqual(
-            updated.objective_scorecard["exact_replay_ledger_artifact_fill_count"],
-            2,
+        self.assertNotIn(
+            "exact_replay_ledger_artifact_fill_count",
+            updated.objective_scorecard,
         )
         self.assertEqual(
             updated.objective_scorecard["market_impact_stress_artifact_ref"],

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -1011,6 +1011,256 @@ def test_order_feed_source_fill_uses_delta_not_cumulative_quantity() -> None:
     assert bucket.gross_strategy_pnl == Decimal("1")
 
 
+def test_linked_order_feed_fill_materializes_fill_economics_lineage() -> None:
+    common = {
+        "account_label": "paper",
+        "strategy_id": "strategy-1",
+        "symbol": "NVDA",
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
+        "execution_policy_hash": "policy",
+        "cost_model_hash": "broker-cost-v1",
+        "lineage_hash": "lineage",
+    }
+
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(0),
+                "decision_id": "decision-buy",
+                "order_id": "execution-buy",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(1),
+                "decision_id": "decision-buy",
+                "order_id": "execution-buy",
+            },
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(2),
+                "decision_id": "decision-sell",
+                "order_id": "execution-sell",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(3),
+                "decision_id": "decision-sell",
+                "order_id": "execution-sell",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(4),
+                "execution_order_event_id": "event-buy",
+                "execution_id": "execution-buy",
+                "trade_decision_id": "decision-buy",
+                "source_window_id": "window-buy",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 7,
+                "side": "buy",
+                "quantity": "1",
+                "avg_fill_price": "100",
+                "filled_notional_delta": "100",
+                "explicit_cost_amount": "0.25",
+                "broker_fee_basis": "broker_reported_commission_and_fees",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(5),
+                "execution_order_event_id": "event-sell",
+                "execution_id": "execution-sell",
+                "trade_decision_id": "decision-sell",
+                "source_window_id": "window-sell",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 8,
+                "side": "sell",
+                "quantity": "1",
+                "avg_fill_price": "101",
+                "filled_notional_delta": "101",
+                "broker_fee": "0.25",
+                "broker_fee_basis": "broker_reported_commission_and_fees",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.blockers == []
+    assert bucket.fill_count == 2
+    assert bucket.closed_trade_count == 1
+    assert bucket.open_position_count == 0
+    assert bucket.filled_notional == Decimal("201")
+    assert bucket.cost_amount == Decimal("0.50")
+    assert bucket.net_strategy_pnl_after_costs == Decimal("0.50")
+    assert bucket.cost_basis_counts == {"broker_reported_commission_and_fees": 2}
+    assert bucket.cost_model_hash_counts == {"broker-cost-v1": 2}
+    assert bucket.post_cost_expectancy_bps is not None
+
+
+def test_linked_order_feed_fill_accepts_structured_source_offsets_mapping() -> None:
+    bucket = _bucket(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(1),
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+                "execution_order_event_id": "event-buy",
+                "execution_id": "execution-buy",
+                "trade_decision_id": "decision-buy",
+                "source_window_id": "window-buy",
+                "source_offsets": {
+                    "topic": "alpaca.trade_updates",
+                    "partition": 0,
+                    "offset": 7,
+                },
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "avg_fill_price": "100",
+                "filled_notional_delta": "100",
+                "broker_fee": "0",
+                "broker_fee_basis": "broker_reported_zero_cost",
+            }
+        ]
+    )
+
+    assert bucket.fill_count == 1
+    assert "runtime_fills_missing" not in bucket.blockers
+    assert "filled_notional_missing" in bucket.blockers
+
+
+def test_linked_order_feed_fill_without_explicit_costs_stays_non_authority() -> None:
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                "event_type": "decision",
+                "executed_at": _ts(0),
+                "decision_id": "decision-buy",
+                "order_id": "execution-buy",
+                "execution_policy_hash": "policy",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "order_submitted",
+                "executed_at": _ts(1),
+                "decision_id": "decision-buy",
+                "order_id": "execution-buy",
+                "execution_policy_hash": "policy",
+                "lineage_hash": "lineage",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(2),
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+                "execution_order_event_id": "event-buy",
+                "execution_id": "execution-buy",
+                "trade_decision_id": "decision-buy",
+                "source_window_id": "window-buy",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 7,
+                "side": "buy",
+                "quantity": "1",
+                "avg_fill_price": "100",
+                "filled_notional_delta": "100",
+                "execution_policy_hash": "policy",
+                "lineage_hash": "lineage",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.fill_count == 0
+    assert bucket.post_cost_expectancy_bps is None
+    assert "execution_economics_missing" in bucket.blockers
+    assert "runtime_fills_missing" in bucket.blockers
+
+
+def test_probe_route_order_feed_fill_remains_non_promotion_authority() -> None:
+    bucket = _bucket(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(1),
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+                "source_kind": "paper_route_probe_runtime_observed",
+                "promotion_authority": False,
+                "execution_order_event_id": "event-buy",
+                "execution_id": "execution-buy",
+                "trade_decision_id": "decision-buy",
+                "source_window_id": "window-buy",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 7,
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "quantity": "1",
+                "avg_fill_price": "100",
+                "filled_notional_delta": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            }
+        ]
+    )
+
+    assert bucket.fill_count == 0
+    assert "runtime_source_not_promotion_authority" in bucket.blockers
+    assert bucket.post_cost_expectancy_bps is None
+
+
+def test_non_promotion_source_marker_strings_block_fill_authority() -> None:
+    for marker in (
+        {"promotion_authority": "false"},
+        {"authority_reason": "route_reacquisition"},
+    ):
+        bucket = _bucket(
+            [
+                {
+                    "event_type": "fill",
+                    "executed_at": _ts(1),
+                    "source_materialization": "execution_order_events",
+                    "authority_class": "runtime_order_feed_execution_source",
+                    **marker,
+                    "execution_order_event_id": "event-buy",
+                    "execution_id": "execution-buy",
+                    "trade_decision_id": "decision-buy",
+                    "source_window_id": "window-buy",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 7,
+                    "account_label": "paper",
+                    "strategy_id": "strategy-1",
+                    "symbol": "NVDA",
+                    "side": "buy",
+                    "quantity": "1",
+                    "avg_fill_price": "100",
+                    "filled_notional_delta": "100",
+                    "cost_amount": "0",
+                    "cost_basis": "broker_reported_zero_cost",
+                }
+            ]
+        )
+
+        assert bucket.fill_count == 0
+        assert "runtime_source_not_promotion_authority" in bucket.blockers
+
+
 def test_order_feed_source_fill_accepts_authority_class_marker() -> None:
     bucket = _bucket(
         [

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -12,6 +12,46 @@ from app.trading.runtime_ledger_source_authority import (
 )
 
 
+def _economics_payload() -> dict[str, object]:
+    return {
+        "filled_notional": "1000",
+        "cost_amount": "0",
+        "cost_basis_counts": {"broker_reported_zero_cost": 1},
+        "cost_model_hash_counts": {"cost-model": 1},
+    }
+
+
+def _source_backed_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "source_window_start": "2026-05-29T14:30:00+00:00",
+        "source_window_end": "2026-05-29T15:00:00+00:00",
+        "source_refs": [
+            "postgres:trade_decisions",
+            "postgres:executions",
+            "postgres:execution_order_events",
+            "postgres:order_feed_source_windows",
+        ],
+        "source_row_counts": {
+            "trade_decisions": 1,
+            "executions": 1,
+            "execution_order_events": 1,
+            "order_feed_source_windows": 1,
+        },
+        **_economics_payload(),
+        "trade_decision_id": "decision-1",
+        "execution_id": "execution-1",
+        "execution_order_event_id": "event-1",
+        "source_window_id": "source-window-1",
+        "source_offsets": [
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+        ],
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
+    }
+    payload.update(overrides)
+    return payload
+
+
 class TestRuntimeLedgerSourceAuthority(TestCase):
     def test_source_window_accepts_naive_datetime_objects(self) -> None:
         self.assertTrue(
@@ -102,6 +142,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
 
         source_backed = {
             **aggregate_only,
+            **_economics_payload(),
             "trade_decision_ids": ["decision-1", "decision-2"],
             "execution_ids": ["execution-1", "execution-2"],
             "execution_order_event_ids": ["event-1", "event-2"],
@@ -112,6 +153,44 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
+        }
+
+        self.assertEqual(
+            runtime_ledger_promotion_source_authority_blockers(source_backed),
+            [],
+        )
+
+    def test_promotion_source_authority_accepts_post_cost_basis_counts(
+        self,
+    ) -> None:
+        source_backed = {
+            "source_window_start": "2026-05-29T14:30:00+00:00",
+            "source_window_end": "2026-05-29T15:00:00+00:00",
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+            "source_row_counts": {
+                "trade_decisions": 1,
+                "executions": 1,
+                "execution_order_events": 1,
+                "order_feed_source_windows": 1,
+            },
+            "trade_decision_id": "decision-1",
+            "execution_id": "execution-1",
+            "execution_order_event_id": "event-1",
+            "source_window_id": "source-window-1",
+            "source_offsets": [
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+            ],
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+            "filled_notional": "1000",
+            "cost_amount": "0",
+            "post_cost_basis_counts": {"broker_reported_zero_cost": 1},
+            "cost_model_hash_counts": {"cost-model": 1},
         }
 
         self.assertEqual(
@@ -175,6 +254,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                     "execution_order_events": 1,
                     "order_feed_source_windows": 1,
                 },
+                **_economics_payload(),
                 "trade_decision_id": "decision-1",
                 "execution_id": "execution-1",
                 "execution_order_event_id": "event-1",
@@ -332,6 +412,76 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
 
         self.assertIn("runtime_ledger_authority_class_missing", blockers)
 
+    def test_promotion_source_authority_requires_explicit_economics(
+        self,
+    ) -> None:
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 1,
+                    "executions": 1,
+                    "execution_order_events": 1,
+                    "order_feed_source_windows": 1,
+                },
+                "trade_decision_id": "decision-1",
+                "execution_id": "execution-1",
+                "execution_order_event_id": "event-1",
+                "source_window_id": "source-window-1",
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+                "execution_economics_complete": False,
+            }
+        )
+
+        self.assertIn("execution_economics_missing", blockers)
+
+    def test_promotion_source_authority_rejects_probe_route_authority(
+        self,
+    ) -> None:
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 1,
+                    "executions": 1,
+                    "execution_order_events": 1,
+                    "order_feed_source_windows": 1,
+                },
+                **_economics_payload(),
+                "trade_decision_id": "decision-1",
+                "execution_id": "execution-1",
+                "execution_order_event_id": "event-1",
+                "source_window_id": "source-window-1",
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+                "source_kind": "paper_route_probe_runtime_observed",
+                "promotion_authority": False,
+            }
+        )
+
+        self.assertIn("runtime_ledger_authority_class_missing", blockers)
+
     def test_promotion_source_authority_accepts_runtime_authority_reason_only(
         self,
     ) -> None:
@@ -351,6 +501,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                     "execution_order_events": 1,
                     "order_feed_source_windows": 1,
                 },
+                **_economics_payload(),
                 "trade_decision_id": "decision-1",
                 "execution_id": "execution-1",
                 "execution_order_event_id": "event-1",
@@ -415,6 +566,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "execution_order_events": 1,
                 "order_feed_source_windows": 1,
             },
+            **_economics_payload(),
             "trade_decision_id": "decision-1",
             "execution_id": "execution-1",
             "execution_order_event_id": "event-1",
@@ -493,6 +645,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "execution_order_events": 1,
                 "order_feed_source_windows": 1,
             },
+            **_economics_payload(),
             "trade_decision_id": "decision-1",
             "execution_id": "execution-1",
             "execution_order_event_id": "event-1",
@@ -539,6 +692,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "execution_order_events": 1,
                 "order_feed_source_windows": 1,
             },
+            **_economics_payload(),
             "trade_decision_id": "decision-1",
             "execution_id": "execution-1",
             "execution_order_event_id": "event-1",
@@ -578,3 +732,49 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
         self.assertNotIn("order_feed_lifecycle_missing", economics_blockers)
         self.assertNotIn("order_feed_lifecycle_missing", unknown_flag_blockers)
         self.assertNotIn("execution_economics_missing", unknown_flag_blockers)
+
+    def test_promotion_source_authority_accepts_required_economics_aliases(
+        self,
+    ) -> None:
+        payload = _source_backed_payload(
+            execution_economics_required=True,
+            cost_amount=None,
+            broker_fee="0",
+            filled_notional="not-a-decimal",
+            runtime_ledger_filled_notional="1000",
+        )
+
+        self.assertEqual(runtime_ledger_promotion_source_authority_blockers(payload), [])
+
+    def test_promotion_source_authority_rejects_non_promotion_cost_basis_inputs(
+        self,
+    ) -> None:
+        for overrides in (
+            {"cost_basis": "paper_cost_model_estimate"},
+            {"cost_basis_counts": {"paper_cost_model_estimate": 1}},
+            {
+                "cost_basis_counts": {},
+                "post_cost_basis_counts": {"paper_cost_model_estimate": 1},
+            },
+        ):
+            with self.subTest(overrides=overrides):
+                blockers = runtime_ledger_promotion_source_authority_blockers(
+                    _source_backed_payload(
+                        execution_economics_required=True,
+                        **overrides,
+                    )
+                )
+
+                self.assertIn("execution_economics_missing", blockers)
+
+    def test_promotion_source_authority_accepts_cost_model_ref_for_zero_cost_bucket(
+        self,
+    ) -> None:
+        payload = _source_backed_payload(
+            execution_economics_required=True,
+            cost_amount=None,
+            cost_model_hash_counts={},
+            cost_model_hash="broker-cost-v1",
+        )
+
+        self.assertEqual(runtime_ledger_promotion_source_authority_blockers(payload), [])

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7383,6 +7383,7 @@ class TestTradingApi(TestCase):
                     "source_materialization": "execution_order_events",
                     "authority_class": "runtime_order_feed_execution_source",
                     "source_decision_mode_counts": {"strategy_signal_paper": 5},
+                    "cost_basis_counts": {"broker_reported": 4},
                 },
             )
             metric_window = StrategyHypothesisMetricWindow(


### PR DESCRIPTION
## Summary

- Materializes linked order-feed execution rows with execution/order-event/source-window refs, source offsets, filled notional deltas, quantity/price, and explicit broker cost fields into runtime fill economics lineage.
- Keeps promotion authority fail-closed for aggregate-only, exact-replay, probe/recovery route evidence, missing explicit economics, missing lifecycle, and missing row-level source refs.
- Expands the H-PAIRS source proof census with readback counts for execution refs, order-event refs, source windows/offsets, filled notional deltas, quantity/price, TCA refs, explicit-cost buckets, and missing requirement categories.
- Prevents exact-replay runtime-closure artifacts from populating runtime-ledger or portfolio post-cost authority fields.
- Adds regression coverage for source-backed fills, aggregate-only/probe non-authority, missing costs, missing filled-notional/cost/closed-round-trip census output, and exact-replay non-authority.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_ledger_source_authority.py tests/test_audit_hpairs_source_proof_census.py tests/test_verify_hpairs_runtime_authority.py tests/test_trading_api.py::TestTradingApi::test_trading_paper_route_evidence_endpoint_audits_probation_targets tests/test_import_hypothesis_runtime_windows.py tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_exact_replay_ledger_rejects_summary_counts_without_rows tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_proof_blocks_oracle_without_source_runtime_ledger -q`
- PASS: `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger.py app/trading/runtime_ledger_source_authority.py app/trading/paper_route_evidence.py scripts/audit_hpairs_source_proof_census.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_runtime_ledger.py tests/test_runtime_ledger_source_authority.py tests/test_audit_hpairs_source_proof_census.py tests/test_import_hypothesis_runtime_windows.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_trading_api.py`
- PASS: `git diff --check`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
