### PR TITLE
feat(torghut): add hpairs replay cache diagnostics

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -239,6 +239,9 @@ class FastReplayPreviewResult:
                 "feature_schema_hash": self.replay_tape_manifest.feature_schema_hash,
                 "cost_model_hash": self.replay_tape_manifest.cost_model_hash,
                 "strategy_family": self.replay_tape_manifest.strategy_family,
+                "cache_identity": (
+                    self.replay_tape_manifest.cache_identity_diagnostics()
+                ),
                 "row_count": self.replay_tape_manifest.row_count,
                 "trading_day_count": self.replay_tape_manifest.trading_day_count,
                 "start_date": self.replay_tape_manifest.start_date.isoformat(),
@@ -310,15 +313,13 @@ def build_fast_replay_preview(
         if exploration_count is None
         else int(exploration_count)
     )
-    bounded_exploitation_count = (
-        max(
-            0,
-            min(
-                bounded_top_k,
-                FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
-                requested_exploitation_count,
-            ),
-        )
+    bounded_exploitation_count = max(
+        0,
+        min(
+            bounded_top_k,
+            FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
+            requested_exploitation_count,
+        ),
     )
     bounded_exploration_count = max(
         0,

--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -21,6 +21,7 @@ from app.trading.session_context import (
 
 REPLAY_TAPE_SCHEMA_VERSION = "torghut.replay-tape.v1"
 REPLAY_TAPE_MANIFEST_SCHEMA_VERSION = "torghut.replay-tape-manifest.v1"
+REPLAY_TAPE_CACHE_IDENTITY_SCHEMA_VERSION = "torghut.replay-tape-cache-identity.v1"
 _DECIMAL_TAG = "__torghut_decimal__"
 _DATETIME_TAG = "__torghut_datetime__"
 
@@ -98,6 +99,7 @@ class ReplayTapeManifest:
             "cost_model_hash": self.cost_model_hash,
             "strategy_family": self.strategy_family,
             "replay_cache_key": self.replay_cache_key,
+            "cache_identity": self.cache_identity_diagnostics(),
             "artifact_refs": dict(self.artifact_refs),
             "source_table_versions": dict(self.source_table_versions),
             "created_at": self.created_at.isoformat(),
@@ -121,6 +123,19 @@ class ReplayTapeManifest:
                 missing_symbol_trading_days=self.missing_symbol_trading_days,
             ),
         }
+
+    def cache_identity_diagnostics(self) -> dict[str, Any]:
+        return build_replay_tape_cache_identity_diagnostics(
+            dataset_snapshot_ref=self.dataset_snapshot_ref,
+            symbols=self.symbols,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            source_query_digest=self.source_query_digest,
+            feature_schema_hash=self.feature_schema_hash,
+            cost_model_hash=self.cost_model_hash,
+            strategy_family=self.strategy_family,
+            source_table_versions=self.source_table_versions,
+        )
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, Any]) -> "ReplayTapeManifest":
@@ -219,6 +234,68 @@ def build_replay_tape_cache_key(
             "source_table_versions": dict(source_table_versions or {}),
         }
     )
+
+
+def build_replay_tape_cache_identity_diagnostics(
+    *,
+    dataset_snapshot_ref: str,
+    symbols: Sequence[str],
+    start_date: date,
+    end_date: date,
+    source_query_digest: str,
+    feature_schema_hash: str = "",
+    cost_model_hash: str = "",
+    strategy_family: str = "",
+    source_table_versions: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Report whether the replay/cache identity has all local reproducibility keys.
+
+    This does not synthesize missing values. Empty optional hashes/family values are
+    preserved in the cache key for deterministic compatibility, while the returned
+    blockers make missing local identity components explicit to downstream preview
+    and SIM queue artifacts.
+    """
+
+    normalized_symbols = _normalize_symbols(symbols)
+    missing_components: list[str] = []
+    if not str(dataset_snapshot_ref or "").strip():
+        missing_components.append("dataset_snapshot_ref")
+    if not normalized_symbols:
+        missing_components.append("symbol_universe")
+    if not str(source_query_digest or "").strip():
+        missing_components.append("source_query_digest")
+    if not str(feature_schema_hash or "").strip():
+        missing_components.append("feature_schema_hash")
+    if not str(cost_model_hash or "").strip():
+        missing_components.append("cost_model_hash")
+    if not str(strategy_family or "").strip():
+        missing_components.append("strategy_family")
+
+    blockers = [
+        f"replay_tape_cache_identity_missing_{component}"
+        for component in missing_components
+    ]
+    return {
+        "schema_version": REPLAY_TAPE_CACHE_IDENTITY_SCHEMA_VERSION,
+        "status": "complete" if not missing_components else "incomplete",
+        "diagnostic_only": True,
+        "cache_reuse_identity_complete": not missing_components,
+        "missing_components": missing_components,
+        "blockers": blockers,
+        "components": {
+            "dataset_snapshot_ref": str(dataset_snapshot_ref or ""),
+            "symbol_universe": list(normalized_symbols),
+            "date_range": {
+                "start_date": start_date.isoformat(),
+                "end_date": end_date.isoformat(),
+            },
+            "source_query_digest": str(source_query_digest or ""),
+            "feature_schema_hash": str(feature_schema_hash or ""),
+            "cost_model_hash": str(cost_model_hash or ""),
+            "strategy_family": str(strategy_family or ""),
+            "source_table_versions": dict(source_table_versions or {}),
+        },
+    }
 
 
 def materialize_signal_tape(
@@ -785,12 +862,14 @@ def _json_ready(value: Any) -> Any:
 
 
 __all__ = [
+    "REPLAY_TAPE_CACHE_IDENTITY_SCHEMA_VERSION",
     "REPLAY_TAPE_MANIFEST_SCHEMA_VERSION",
     "REPLAY_TAPE_SCHEMA_VERSION",
     "ReplayTape",
     "ReplayTapeCoverageError",
     "ReplayTapeManifest",
     "build_replay_tape_cache_key",
+    "build_replay_tape_cache_identity_diagnostics",
     "build_source_query_digest",
     "default_manifest_path",
     "load_replay_tape",

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6702,6 +6702,9 @@ def _bounded_sim_target_queue_metadata(
                     "feature_schema_hash": replay_tape_manifest.feature_schema_hash,
                     "cost_model_hash": replay_tape_manifest.cost_model_hash,
                     "strategy_family": replay_tape_manifest.strategy_family,
+                    "cache_identity": (
+                        replay_tape_manifest.cache_identity_diagnostics()
+                    ),
                     "preview_score": row.get("preview_score"),
                     "frontier_bucket": row.get("frontier_bucket"),
                 },
@@ -6762,6 +6765,7 @@ def _bounded_sim_target_queue_metadata(
             "feature_schema_hash": replay_tape_manifest.feature_schema_hash,
             "cost_model_hash": replay_tape_manifest.cost_model_hash,
             "strategy_family": replay_tape_manifest.strategy_family,
+            "cache_identity": replay_tape_manifest.cache_identity_diagnostics(),
         },
         "exact_replay_candidate_cap": exact_replay_candidate_cap,
         "exploitation_slots": exploitation_slots,
@@ -6844,6 +6848,7 @@ def _maybe_materialize_epoch_replay_tape(
         "feature_schema_hash": manifest.feature_schema_hash,
         "cost_model_hash": manifest.cost_model_hash,
         "strategy_family": manifest.strategy_family,
+        "cache_identity": manifest.cache_identity_diagnostics(),
     }
     _write_json(receipt_path, receipt)
     updated_args = argparse.Namespace(

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -168,10 +168,19 @@ class TestFastReplayPreview(TestCase):
         self.assertFalse(row_payload["proof_authority"])
         self.assertIn("risk_flags", row_payload)
         self.assertIn("source_backed_adv_missing", row_payload["risk_flags"])
-        self.assertEqual(payload["replay_tape"]["dataset_snapshot_ref"], "snapshot-fast")
+        self.assertEqual(
+            payload["replay_tape"]["dataset_snapshot_ref"], "snapshot-fast"
+        )
         self.assertIn("feature_schema_hash", payload["replay_tape"])
         self.assertIn("cost_model_hash", payload["replay_tape"])
         self.assertIn("strategy_family", payload["replay_tape"])
+        self.assertEqual(
+            payload["replay_tape"]["cache_identity"]["status"], "incomplete"
+        )
+        self.assertIn(
+            "replay_tape_cache_identity_missing_feature_schema_hash",
+            payload["replay_tape"]["cache_identity"]["blockers"],
+        )
         self.assertFalse(payload["proof_authority"])
 
     def test_target_implied_notional_blocks_non_positive_expectancy(self) -> None:

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -16,6 +16,7 @@ from app.trading.discovery.replay_tape import (
     REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
     ReplayTapeCoverageError,
     ReplayTapeManifest,
+    build_replay_tape_cache_identity_diagnostics,
     build_replay_tape_cache_key,
     build_source_query_digest,
     default_manifest_path,
@@ -348,6 +349,44 @@ class TestReplayTape(TestCase):
         )
         self.assertEqual(manifest.to_payload()["cost_model_hash"], "cost-model-v1")
         self.assertEqual(manifest.to_payload()["strategy_family"], "hpairs-v1")
+
+    def test_replay_tape_cache_identity_reports_missing_components(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            manifest = materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, symbol="NVDA")],
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-missing-identity",
+                symbols=(),
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "identity"}),
+            )
+
+        diagnostics = manifest.cache_identity_diagnostics()
+        self.assertEqual(diagnostics["status"], "incomplete")
+        self.assertIn("symbol_universe", diagnostics["missing_components"])
+        self.assertIn("feature_schema_hash", diagnostics["missing_components"])
+        self.assertIn("cost_model_hash", diagnostics["missing_components"])
+        self.assertIn("strategy_family", diagnostics["missing_components"])
+        self.assertIn(
+            "replay_tape_cache_identity_missing_feature_schema_hash",
+            diagnostics["blockers"],
+        )
+        self.assertEqual(manifest.to_payload()["cache_identity"], diagnostics)
+
+        complete = build_replay_tape_cache_identity_diagnostics(
+            dataset_snapshot_ref="snapshot-complete",
+            symbols=("nvda", "AAPL"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 28),
+            source_query_digest=build_source_query_digest({"window": "identity"}),
+            feature_schema_hash="feature-schema-v1",
+            cost_model_hash="cost-model-v1",
+            strategy_family="hpairs-v1",
+        )
+        self.assertEqual(complete["status"], "complete")
+        self.assertEqual(complete["missing_components"], [])
+        self.assertEqual(complete["components"]["symbol_universe"], ["AAPL", "NVDA"])
 
     def test_materialize_manifest_session_window_follows_new_york_dst(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4760,6 +4760,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             queue_payload["replay_tape"]["strategy_family"], "hpairs-frontier-family"
         )
         self.assertEqual(
+            queue_payload["replay_tape"]["cache_identity"]["status"], "complete"
+        )
+        self.assertFalse(
+            queue_payload["replay_tape"]["cache_identity"]["missing_components"]
+        )
+        self.assertEqual(
             [entry["frontier_bucket"] for entry in queue_payload["entries"]],
             [
                 "exploitation",
@@ -4782,6 +4788,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             first_entry["reproducibility_metadata"]["feature_schema_hash"],
             "feature-schema-frontier",
+        )
+        self.assertEqual(
+            first_entry["reproducibility_metadata"]["cache_identity"]["status"],
+            "complete",
         )
         self.assertEqual(
             first_entry["reproducibility_metadata"]["preview_score"],


### PR DESCRIPTION
## Summary

- Added explicit replay tape cache identity diagnostics that include dataset snapshot, symbol universe, date range, source query digest, feature schema hash, cost model hash, and strategy family without synthesizing missing values.
- Surfaced cache identity diagnostics and blockers through fast replay preview manifests, replay tape receipts, and bounded SIM target queue reproducibility metadata.
- Extended H-PAIRS frontier tests to cover max-six exact replay narrowing, exploitation/exploration split, deterministic cache identity behavior, missing identity blockers, and non-authority SIM queue output.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass after installing the missing local build-essential compiler toolchain needed to build crosshair in this Coder image)
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` (pass: 209 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (pass)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no separate documentation or release-note update was needed for this internal Torghut diagnostics tranche.
