### PR TITLE
fix(torghut): block hpairs target entries with open exposure

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -2879,14 +2879,40 @@ class SimpleTradingPipeline(TradingPipeline):
                     symbols,
                 )
                 continue
+            blocked_open_exposure_symbols: list[str] = []
             for symbol in symbols:
-                action = symbol_actions.get(symbol, _target_probe_action(target))
-                if action == "sell" and not settings.trading_allow_shorts:
-                    continue
                 if self._paper_route_target_symbol_has_open_position(
                     positions,
                     symbol,
                 ):
+                    blocked_open_exposure_symbols.append(symbol)
+                    continue
+                if (
+                    session is not None
+                    and self._paper_route_target_symbol_has_open_strategy_exposure(
+                        session=session,
+                        strategy=strategy,
+                        symbol=symbol,
+                        account_label=self.account_label,
+                        window_start=window_start,
+                    )
+                ):
+                    blocked_open_exposure_symbols.append(symbol)
+            if blocked_open_exposure_symbols and pair_balance_state == "balanced":
+                logger.warning(
+                    "Skipping balanced paper-route pair target because existing "
+                    "strategy exposure is still open strategy=%s symbols=%s "
+                    "blocked_symbols=%s",
+                    strategy.name,
+                    symbols,
+                    blocked_open_exposure_symbols,
+                )
+                continue
+            for symbol in symbols:
+                action = symbol_actions.get(symbol, _target_probe_action(target))
+                if action == "sell" and not settings.trading_allow_shorts:
+                    continue
+                if symbol in blocked_open_exposure_symbols:
                     continue
                 if (
                     session is not None
@@ -2964,6 +2990,57 @@ class SimpleTradingPipeline(TradingPipeline):
                     )
                 )
         return decisions
+
+    @staticmethod
+    def _paper_route_target_symbol_has_open_strategy_exposure(
+        *,
+        session: Session,
+        strategy: Strategy,
+        symbol: str,
+        account_label: str,
+        window_start: datetime,
+    ) -> bool:
+        strategy_id = getattr(strategy, "id", None)
+        normalized_symbol = symbol.strip().upper()
+        if strategy_id is None or not normalized_symbol:
+            return False
+
+        guard_start = window_start - _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK
+        try:
+            rows = session.execute(
+                select(Execution.side, Execution.filled_qty)
+                .join(TradeDecision, Execution.trade_decision_id == TradeDecision.id)
+                .where(
+                    Execution.alpaca_account_label == account_label,
+                    TradeDecision.alpaca_account_label == account_label,
+                    TradeDecision.strategy_id == strategy_id,
+                    Execution.symbol == normalized_symbol,
+                    TradeDecision.symbol == normalized_symbol,
+                    Execution.filled_qty > 0,
+                    Execution.status.in_(("filled", "partially_filled")),
+                    Execution.created_at >= guard_start,
+                )
+            ).all()
+        except Exception:
+            logger.exception(
+                "Failed to inspect paper-route target strategy exposure "
+                "strategy_id=%s symbol=%s account_label=%s",
+                strategy_id,
+                normalized_symbol,
+                account_label,
+            )
+            return True
+
+        signed_qty = Decimal("0")
+        for side, filled_qty in rows:
+            qty = _optional_decimal(filled_qty)
+            if qty is None or qty <= 0:
+                continue
+            if str(side or "").strip().lower() == "sell":
+                signed_qty -= qty
+            else:
+                signed_qty += qty
+        return abs(signed_qty) > _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON
 
     @staticmethod
     def _paper_route_target_symbol_has_open_profit_proof_exposure(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -6193,7 +6193,7 @@ class TestTradingPipeline(TestCase):
 
         self.assertEqual([decision.symbol for decision in decisions], ["AAPL"])
 
-    def test_paper_route_target_source_decisions_skip_db_profit_proof_exposure(
+    def test_paper_route_target_source_decisions_skip_db_strategy_exposure(
         self,
     ) -> None:
         from app import config
@@ -6309,7 +6309,123 @@ class TestTradingPipeline(TestCase):
                     positions=[],
                 )
 
-        self.assertEqual([decision.symbol for decision in decisions], ["AMZN"])
+        self.assertEqual(decisions, [])
+
+    def test_paper_route_target_strategy_exposure_helper_fails_closed(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid4(),
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        mock_session = Mock(spec=Session)
+        mock_session.execute.side_effect = RuntimeError("database offline")
+
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_strategy_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol="AAPL",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+
+    def test_paper_route_target_strategy_exposure_helper_returns_false_without_key(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        mock_session = Mock(spec=Session)
+
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_strategy_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol="AAPL",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_strategy_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol=" ",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+        mock_session.execute.assert_not_called()
+
+    def test_paper_route_target_strategy_exposure_helper_ignores_noise(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid4(),
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        result = Mock()
+        result.all.return_value = [("buy", Decimal("0")), ("sell", None)]
+        mock_session = Mock(spec=Session)
+        mock_session.execute.return_value = result
+
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_strategy_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol="aapl",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+
+    def test_paper_route_target_strategy_exposure_helper_detects_buy_exposure(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid4(),
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        result = Mock()
+        result.all.return_value = [("buy", Decimal("3"))]
+        mock_session = Mock(spec=Session)
+        mock_session.execute.return_value = result
+
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_strategy_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol="aapl",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
 
     def test_paper_route_target_profit_proof_exposure_helper_fails_closed(
         self,
@@ -7835,6 +7951,121 @@ class TestTradingPipeline(TestCase):
                 ),
                 good_target,
             )
+
+    def test_paper_route_target_source_skips_pair_with_open_strategy_exposure(
+        self,
+    ) -> None:
+        from app import config
+
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = True
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "_is_market_session_open", lambda _now: True)
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="microbar_cross_sectional_pairs_v1",
+                universe_symbols=["AAPL", "AMZN"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AMZN",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "sell",
+                    "qty": "10",
+                    "event_ts": (window_start + timedelta(minutes=3)).isoformat(),
+                    "params": {
+                        "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+                        "profit_proof_eligible": False,
+                        "paper_route_probe": {
+                            "mode": "paper_route_acquisition",
+                            "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+                            "profit_proof_eligible": False,
+                        },
+                    },
+                },
+                rationale="paper-route-entry",
+                status="filled",
+                created_at=window_start + timedelta(minutes=3),
+            )
+            session.add(decision)
+            session.commit()
+            session.refresh(decision)
+            session.add(
+                Execution(
+                    trade_decision_id=decision.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    alpaca_order_id="paper-amzn-open",
+                    client_order_id="paper-amzn-open-client",
+                    symbol="AMZN",
+                    side="sell",
+                    order_type="market",
+                    time_in_force="day",
+                    submitted_qty=Decimal("10"),
+                    filled_qty=Decimal("10"),
+                    avg_fill_price=Decimal("272"),
+                    status="filled",
+                    raw_order={},
+                    created_at=window_start + timedelta(minutes=4),
+                    updated_at=window_start + timedelta(minutes=4),
+                )
+            )
+            session.commit()
+
+            target = {
+                "account_label": "TORGHUT_SIM",
+                "observed_stage": "paper",
+                "source_kind": "paper_route_probe_runtime_observed",
+                "candidate_id": "candidate-pairs-monday",
+                "hypothesis_id": "H-PAIRS-01",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                "strategy_lookup_names": [str(strategy.id), strategy.name],
+                "strategy_family": "microbar_cross_sectional_pairs",
+                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                "paper_route_probe_symbol_actions": {
+                    "AAPL": "buy",
+                    "AMZN": "sell",
+                },
+                "paper_route_probe_window_start": window_start.isoformat(),
+                "paper_route_probe_window_end": window_end.isoformat(),
+                "paper_route_probe_next_session_max_notional": "1000",
+                "bounded_evidence_collection_authorized": True,
+                "evidence_collection_ok": True,
+                "source_decision_readiness": {"ready": True, "blockers": []},
+            }
+            setattr(
+                pipeline,
+                "_external_paper_route_target_probe_symbols_cached",
+                lambda: ({"AAPL", "AMZN"}, None, [target]),
+            )
+            with patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=window_start + timedelta(minutes=5),
+            ):
+                decisions = pipeline._paper_route_target_source_decisions(
+                    strategies=[strategy],
+                    allowed_symbols=set(),
+                    positions=[],
+                    session=session,
+                )
+
+        self.assertEqual(decisions, [])
 
     def test_paper_decision_persists_external_target_lineage_existing_row(
         self,


### PR DESCRIPTION
## Summary

- Block paper-route target-source collection when the same strategy already has unresolved DB execution exposure on the target symbol.
- Skip the whole balanced H-PAIRS pair target when any leg has open strategy exposure, avoiding one-sided evidence collection.
- Add regression coverage for route-acquisition exposure and balanced-pair target suppression.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_target_source_skips_pair_with_open_strategy_exposure or paper_route_target_source_decisions or strategy_signal_paper_target'`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
