### PR TITLE
fix(torghut): materialize bounded hpairs paper targets

### DIFF
--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -5,9 +5,35 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from hashlib import sha256
 from http.client import HTTPConnection, HTTPSConnection
 from typing import Any, cast
 from urllib.parse import urlsplit
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..config import settings
+from ..models import Strategy, TradeDecision, coerce_json_payload
+from .runtime_decision_authority import (
+    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+    source_decision_mode_is_profit_proof_eligible,
+)
+
+
+PAPER_ROUTE_MATERIALIZATION_SCHEMA_VERSION = (
+    "torghut.paper-route-target-materialization.v1"
+)
+PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL = "TORGHUT_SIM"
+PAPER_ROUTE_MATERIALIZATION_STAGE = "bounded_paper_collection"
+PAPER_ROUTE_MATERIALIZATION_SOURCE = "paper_route_target_plan_materializer"
+PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS = (
+    "paper_route_bounded_collection_only",
+    "runtime_ledger_live_or_live_paper_required",
+    "paper_route_runtime_ledger_import_pending",
+)
 
 
 def _to_str_map(value: object) -> dict[str, Any]:
@@ -152,8 +178,492 @@ def paper_route_target_plan_probe_symbols(plan: Mapping[str, Any]) -> set[str]:
     return symbols
 
 
+def _safe_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _safe_decimal(value: object) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def _decimal_text(value: Decimal) -> str:
+    return format(value, "f")
+
+
+def _positive_decimal_from_fields(
+    payload: Mapping[str, Any],
+    fields: Sequence[str],
+) -> Decimal:
+    for field in fields:
+        value = _safe_decimal(payload.get(field))
+        if value > 0:
+            return value
+    return Decimal("0")
+
+
+def _text_items(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [
+        str(item).strip()
+        for item in cast(Sequence[object], value)
+        if str(item).strip()
+    ]
+
+
+def _target_symbol_actions(target: Mapping[str, Any]) -> dict[str, str]:
+    raw_actions = _to_str_map(target.get("paper_route_probe_symbol_actions"))
+    actions: dict[str, str] = {}
+    for raw_symbol, raw_action in raw_actions.items():
+        symbol = str(raw_symbol).strip().upper()
+        action = str(raw_action).strip().lower()
+        if symbol and action in {"buy", "sell"}:
+            actions[symbol] = action
+    return actions
+
+
+def _target_symbol_quantities(target: Mapping[str, Any]) -> dict[str, Decimal]:
+    quantities: dict[str, Decimal] = {}
+    for field in (
+        "paper_route_probe_symbol_quantities",
+        "target_symbol_quantities",
+        "symbol_quantities",
+    ):
+        raw_quantities = _to_str_map(target.get(field))
+        for raw_symbol, raw_quantity in raw_quantities.items():
+            symbol = str(raw_symbol).strip().upper()
+            quantity = _safe_decimal(raw_quantity)
+            if symbol and quantity > 0:
+                quantities[symbol] = quantity
+    fallback_quantity = _positive_decimal_from_fields(
+        target,
+        (
+            "target_quantity",
+            "paper_route_probe_target_quantity",
+            "qty",
+            "quantity",
+        ),
+    )
+    if fallback_quantity > 0:
+        for symbol in _target_symbol_actions(target):
+            quantities.setdefault(symbol, fallback_quantity)
+    return quantities
+
+
+def _target_notional(target: Mapping[str, Any]) -> Decimal:
+    return _positive_decimal_from_fields(
+        target,
+        (
+            "target_notional",
+            "paper_route_probe_target_notional",
+            "paper_route_probe_effective_max_notional",
+            "bounded_evidence_collection_max_notional",
+            "paper_route_probe_next_session_max_notional",
+            "max_notional",
+        ),
+    )
+
+
+def _target_quantity(target: Mapping[str, Any]) -> Decimal:
+    explicit_quantity = _positive_decimal_from_fields(
+        target,
+        (
+            "target_quantity",
+            "paper_route_probe_target_quantity",
+            "qty",
+            "quantity",
+        ),
+    )
+    if explicit_quantity > 0:
+        return explicit_quantity
+    return sum(_target_symbol_quantities(target).values(), Decimal("0"))
+
+
+def _configured_bounded_collection_limit(
+    *,
+    bounded_notional_limit: Decimal | int | float | str | None,
+) -> Decimal:
+    if bounded_notional_limit is not None:
+        return _safe_decimal(bounded_notional_limit)
+    return _safe_decimal(settings.trading_simple_paper_route_probe_max_notional)
+
+
+def _clean_window_baseline_blockers(target: Mapping[str, Any]) -> list[str]:
+    state = _to_str_map(target.get("paper_route_clean_window_baseline_state"))
+    blockers = _text_items(target.get("paper_route_clean_window_baseline_blockers"))
+    if not blockers:
+        blockers = _text_items(state.get("blockers"))
+    baseline_state = _safe_text(state.get("state"))
+    if baseline_state != "clean":
+        blockers.append("paper_route_clean_window_baseline_missing_or_dirty")
+    if _safe_text(target.get("paper_route_clean_window_state")) not in {
+        "clean_window_collection_ready",
+        "clean",
+    }:
+        blockers.append("paper_route_clean_window_gate_not_passed")
+    return sorted(dict.fromkeys(blockers))
+
+
+def _target_identity(
+    target: Mapping[str, Any],
+    *,
+    target_index: int,
+) -> dict[str, Any]:
+    source_plan_ref = (
+        _safe_text(target.get("source_plan_ref"))
+        or _safe_text(target.get("source_plan_id"))
+        or _safe_text(target.get("source_manifest_ref"))
+        or _safe_text(target.get("paper_route_target_plan_source"))
+    )
+    bounded_collection_stage = (
+        _safe_text(target.get("bounded_collection_stage"))
+        or _safe_text(target.get("evidence_collection_stage"))
+        or _safe_text(target.get("observed_stage"))
+    )
+    return {
+        "schema_version": "torghut.paper-route-target-identity.v1",
+        "target_index": target_index,
+        "hypothesis_id": _safe_text(target.get("hypothesis_id")),
+        "candidate_id": _safe_text(target.get("candidate_id")),
+        "runtime_strategy_name": _safe_text(target.get("runtime_strategy_name"))
+        or _safe_text(target.get("strategy_name")),
+        "strategy_name": _safe_text(target.get("strategy_name")),
+        "strategy_id": _safe_text(target.get("strategy_id")),
+        "account_label": _safe_text(target.get("account_label")),
+        "source_plan_ref": source_plan_ref,
+        "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
+        "target_notional": _decimal_text(_target_notional(target)),
+        "target_quantity": _decimal_text(_target_quantity(target)),
+        "target_symbol_quantities": {
+            symbol: _decimal_text(quantity)
+            for symbol, quantity in sorted(_target_symbol_quantities(target).items())
+        },
+        "bounded_collection_stage": bounded_collection_stage,
+        "window_start": _safe_text(target.get("window_start"))
+        or _safe_text(target.get("paper_route_probe_window_start")),
+        "window_end": _safe_text(target.get("window_end"))
+        or _safe_text(target.get("paper_route_probe_window_end")),
+        "source_kind": _safe_text(target.get("source_kind")),
+        "paper_route_probe_symbols": sorted(_target_symbol_actions(target)),
+    }
+
+
+def _target_identity_blockers(identity: Mapping[str, Any]) -> list[str]:
+    required = (
+        "hypothesis_id",
+        "candidate_id",
+        "runtime_strategy_name",
+        "account_label",
+        "source_plan_ref",
+        "target_notional",
+        "target_quantity",
+        "bounded_collection_stage",
+    )
+    blockers = [
+        f"paper_route_target_identity_{field}_missing"
+        for field in required
+        if not _safe_text(identity.get(field))
+        or (field == "target_notional" and _safe_decimal(identity.get(field)) <= 0)
+        or (field == "target_quantity" and _safe_decimal(identity.get(field)) <= 0)
+    ]
+    if _safe_text(identity.get("account_label")) != PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL:
+        blockers.append("paper_route_target_torghut_sim_account_required")
+    if _safe_text(identity.get("bounded_collection_stage")) not in {
+        "paper",
+        PAPER_ROUTE_MATERIALIZATION_STAGE,
+        "bounded_live_paper_collection",
+    }:
+        blockers.append("paper_route_target_bounded_collection_stage_required")
+    return blockers
+
+
+def _target_materialization_blockers(
+    target: Mapping[str, Any],
+    *,
+    identity: Mapping[str, Any],
+    bounded_notional_limit: Decimal,
+) -> list[str]:
+    blockers = _target_identity_blockers(identity)
+    blockers.extend(_clean_window_baseline_blockers(target))
+    if not bool(target.get("evidence_collection_ok")):
+        blockers.append("paper_route_evidence_collection_gate_not_passed")
+    if not bool(target.get("bounded_evidence_collection_authorized")):
+        blockers.append("paper_route_bounded_collection_not_authorized")
+    target_notional = _safe_decimal(identity.get("target_notional"))
+    if bounded_notional_limit <= 0:
+        blockers.append("paper_route_bounded_collection_limit_missing")
+    elif target_notional > bounded_notional_limit:
+        blockers.append("paper_route_target_notional_exceeds_bounded_collection_limit")
+    actions = _target_symbol_actions(target)
+    quantities = _target_symbol_quantities(target)
+    if not actions:
+        blockers.append("paper_route_target_symbol_actions_missing")
+    missing_quantity_symbols = sorted(symbol for symbol in actions if symbol not in quantities)
+    if missing_quantity_symbols:
+        blockers.append("paper_route_target_symbol_quantities_missing")
+    return sorted(dict.fromkeys(blockers))
+
+
+def _paper_route_decision_hash(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _paper_route_decision_payload(
+    *,
+    target: Mapping[str, Any],
+    identity: Mapping[str, Any],
+    symbol: str,
+    action: str,
+    quantity: Decimal,
+    target_notional: Decimal,
+    generated_at: datetime,
+) -> dict[str, Any]:
+    source_decision_mode = BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+    return {
+        "schema_version": PAPER_ROUTE_MATERIALIZATION_SCHEMA_VERSION,
+        "source": PAPER_ROUTE_MATERIALIZATION_SOURCE,
+        "source_decision_mode": source_decision_mode,
+        "source_decision_mode_profit_proof_eligible": (
+            source_decision_mode_is_profit_proof_eligible(source_decision_mode)
+        ),
+        "profit_proof_eligible_scope": "bounded_paper_collection_only",
+        "hypothesis_id": identity.get("hypothesis_id"),
+        "candidate_id": identity.get("candidate_id"),
+        "runtime_strategy_name": identity.get("runtime_strategy_name"),
+        "strategy_name": identity.get("strategy_name"),
+        "account_label": identity.get("account_label"),
+        "source_plan_ref": identity.get("source_plan_ref"),
+        "source_manifest_ref": identity.get("source_manifest_ref"),
+        "target_plan_identity": identity,
+        "symbol": symbol,
+        "action": action,
+        "qty": _decimal_text(quantity),
+        "target_quantity": _decimal_text(quantity),
+        "target_notional": _decimal_text(target_notional),
+        "bounded_collection_stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
+        "bounded_evidence_collection_max_notional": _safe_text(
+            target.get("bounded_evidence_collection_max_notional")
+        )
+        or _safe_text(target.get("paper_route_probe_effective_max_notional")),
+        "order_type": "market",
+        "time_in_force": "day",
+        "timeframe": "1Min",
+        "event_ts": generated_at.isoformat(),
+        "submission_stage": "bounded_paper_route_materialized",
+        "paper_route_order_submission": {
+            "schema_version": "torghut.paper-route-order-submission.v1",
+            "account_label": PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+            "symbol": symbol,
+            "side": action,
+            "qty": _decimal_text(quantity),
+            "target_notional": _decimal_text(target_notional),
+            "order_type": "market",
+            "time_in_force": "day",
+            "live_capital_routing_enabled": False,
+            "submission_enabled": False,
+            "submission_authority": "bounded_paper_collection_only",
+        },
+        "capital_promotion_allowed": False,
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "final_promotion_blockers": list(
+            PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS
+        ),
+        "live_capital_routing_enabled": False,
+        "route_submission_enabled": False,
+        "params": {
+            "paper_route_target_plan_materialized": True,
+            "source_decision_mode": source_decision_mode,
+            "candidate_id": identity.get("candidate_id"),
+            "hypothesis_id": identity.get("hypothesis_id"),
+            "runtime_strategy_name": identity.get("runtime_strategy_name"),
+            "source_plan_ref": identity.get("source_plan_ref"),
+            "target_notional": _decimal_text(target_notional),
+            "target_quantity": _decimal_text(quantity),
+            "bounded_collection_stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
+            "live_capital_routing_enabled": False,
+        },
+    }
+
+
+def materialize_bounded_paper_route_target_plan(
+    session: Session,
+    plan: Mapping[str, Any],
+    *,
+    generated_at: datetime | None = None,
+    bounded_notional_limit: Decimal | int | float | str | None = None,
+) -> dict[str, Any]:
+    """Persist bounded paper-route target decisions without enabling live routing."""
+
+    event_ts = generated_at or datetime.now(timezone.utc)
+    if event_ts.tzinfo is None:
+        event_ts = event_ts.replace(tzinfo=timezone.utc)
+    event_ts = event_ts.astimezone(timezone.utc)
+    limit = _configured_bounded_collection_limit(
+        bounded_notional_limit=bounded_notional_limit
+    )
+    materialized_decisions: list[dict[str, Any]] = []
+    route_submissions: list[dict[str, Any]] = []
+    blocked_targets: list[dict[str, Any]] = []
+    for target_index, target in enumerate(paper_route_target_plan_targets(plan)):
+        identity = _target_identity(target, target_index=target_index)
+        blockers = _target_materialization_blockers(
+            target,
+            identity=identity,
+            bounded_notional_limit=limit,
+        )
+        if blockers:
+            blocked_targets.append(
+                {
+                    "target_index": target_index,
+                    "hypothesis_id": identity.get("hypothesis_id"),
+                    "candidate_id": identity.get("candidate_id"),
+                    "blockers": blockers,
+                    "target_identity": identity,
+                }
+            )
+            continue
+        strategy_name = _safe_text(identity.get("runtime_strategy_name"))
+        strategy = (
+            session.execute(select(Strategy).where(Strategy.name == strategy_name))
+            .scalars()
+            .first()
+        )
+        if strategy is None:
+            blocked_targets.append(
+                {
+                    "target_index": target_index,
+                    "hypothesis_id": identity.get("hypothesis_id"),
+                    "candidate_id": identity.get("candidate_id"),
+                    "blockers": ["paper_route_target_strategy_missing"],
+                    "target_identity": identity,
+                }
+            )
+            continue
+
+        target_notional = _safe_decimal(identity.get("target_notional"))
+        for symbol, action in _target_symbol_actions(target).items():
+            quantity = _target_symbol_quantities(target)[symbol]
+            payload = _paper_route_decision_payload(
+                target=target,
+                identity=identity,
+                symbol=symbol,
+                action=action,
+                quantity=quantity,
+                target_notional=target_notional,
+                generated_at=event_ts,
+            )
+            digest = _paper_route_decision_hash(
+                {
+                    "source": PAPER_ROUTE_MATERIALIZATION_SOURCE,
+                    "account_label": PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+                    "symbol": symbol,
+                    "action": action,
+                    "qty": _decimal_text(quantity),
+                    "target_identity": identity,
+                }
+            )
+            existing = (
+                session.execute(
+                    select(TradeDecision).where(
+                        TradeDecision.decision_hash == digest,
+                        TradeDecision.alpaca_account_label
+                        == PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if existing is None:
+                existing = TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label=PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+                    symbol=symbol,
+                    timeframe="1Min",
+                    decision_json=coerce_json_payload(payload),
+                    rationale=(
+                        "bounded H-PAIRS paper-route target materialization; "
+                        "live-capital routing disabled"
+                    ),
+                    decision_hash=digest,
+                    status="planned",
+                    created_at=event_ts,
+                )
+                session.add(existing)
+                session.flush()
+            route_submission = dict(
+                cast(Mapping[str, Any], payload["paper_route_order_submission"])
+            )
+            route_submission["client_order_id"] = digest
+            route_submission["trade_decision_id"] = str(existing.id)
+            route_submissions.append(route_submission)
+            materialized_decisions.append(
+                {
+                    "trade_decision_id": str(existing.id),
+                    "decision_hash": digest,
+                    "symbol": symbol,
+                    "action": action,
+                    "qty": _decimal_text(quantity),
+                    "target_notional": _decimal_text(target_notional),
+                    "source_decision_mode": (
+                        BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+                    ),
+                    "target_identity": identity,
+                    "promotion_allowed": False,
+                    "final_promotion_authorized": False,
+                    "live_capital_routing_enabled": False,
+                }
+            )
+
+    return {
+        "schema_version": PAPER_ROUTE_MATERIALIZATION_SCHEMA_VERSION,
+        "source": PAPER_ROUTE_MATERIALIZATION_SOURCE,
+        "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+        "source_decision_mode_profit_proof_eligible": (
+            source_decision_mode_is_profit_proof_eligible(
+                BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+            )
+        ),
+        "profit_proof_eligible_scope": "bounded_paper_collection_only",
+        "account_label": PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+        "bounded_collection_stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
+        "bounded_notional_limit": _decimal_text(limit),
+        "target_count": len(paper_route_target_plan_targets(plan)),
+        "materialized_decision_count": len(materialized_decisions),
+        "route_submission_count": len(route_submissions),
+        "blocked_target_count": len(blocked_targets),
+        "blocked": bool(blocked_targets),
+        "blockers": sorted(
+            {
+                blocker
+                for item in blocked_targets
+                for blocker in cast(Sequence[str], item.get("blockers", []))
+            }
+        ),
+        "decisions": materialized_decisions,
+        "route_submissions": route_submissions,
+        "capital_promotion_allowed": False,
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "live_capital_routing_enabled": False,
+        "blocked_targets": blocked_targets,
+    }
+
+
 __all__ = [
     "fetch_paper_route_target_plan_url",
+    "materialize_bounded_paper_route_target_plan",
     "mapping_items",
     "paper_route_target_plan_from_payload",
     "paper_route_target_plan_probe_symbols",

--- a/services/torghut/app/trading/runtime_decision_authority.py
+++ b/services/torghut/app/trading/runtime_decision_authority.py
@@ -7,6 +7,9 @@ from typing import Any, cast
 
 ROUTE_ACQUISITION_SOURCE_DECISION_MODE = "route_acquisition_probe"
 STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE = "strategy_signal_paper"
+BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE = (
+    "bounded_paper_route_collection"
+)
 LIVE_STRATEGY_SIGNAL_SOURCE_DECISION_MODE = "live_strategy_signal"
 SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER = (
     "source_decision_mode_not_profit_proof_eligible"
@@ -22,8 +25,18 @@ _ROUTE_ACQUISITION_ALIASES = frozenset(
         ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
     }
 )
+_BOUNDED_PAPER_ROUTE_COLLECTION_ALIASES = frozenset(
+    {
+        "bounded_paper_route",
+        "bounded_paper_route_source_decision",
+        "bounded_paper_route_target_plan_source_decision",
+        "bounded_live_paper_route_collection",
+        BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+    }
+)
 PROFIT_PROOF_ELIGIBLE_SOURCE_DECISION_MODES = frozenset(
     {
+        BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
         STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
         LIVE_STRATEGY_SIGNAL_SOURCE_DECISION_MODE,
     }
@@ -36,6 +49,8 @@ def normalize_source_decision_mode(value: object) -> str | None:
         return None
     if text in _ROUTE_ACQUISITION_ALIASES:
         return ROUTE_ACQUISITION_SOURCE_DECISION_MODE
+    if text in _BOUNDED_PAPER_ROUTE_COLLECTION_ALIASES:
+        return BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
     return text
 
 
@@ -71,6 +86,7 @@ def source_decision_mode_counts_have_profit_proof_modes(value: Any) -> bool:
 
 
 __all__ = [
+    "BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE",
     "LIVE_STRATEGY_SIGNAL_SOURCE_DECISION_MODE",
     "PROFIT_PROOF_ELIGIBLE_SOURCE_DECISION_MODES",
     "ROUTE_ACQUISITION_SOURCE_DECISION_MODE",

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -4,10 +4,11 @@ import json
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import patch
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -27,6 +28,14 @@ from app.models import (
     TradeDecision,
 )
 from app.trading.hypotheses import JangarDependencyQuorumStatus
+from app.trading.paper_route_target_plan import (
+    materialize_bounded_paper_route_target_plan,
+)
+from app.trading.runtime_decision_authority import (
+    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+    ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+    source_decision_mode_is_profit_proof_eligible,
+)
 from app.trading.submission_council import (
     _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT,
     _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
@@ -422,6 +431,225 @@ class TestSubmissionCouncil(TestCase):
             "status": "healthy",
             "source_url": "http://jangar.test/api/torghut/trading/control-plane/quant/health?account=paper&window=15m",
         }
+
+    def _hpairs_clean_target_plan(self) -> dict[str, Any]:
+        return {
+            "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+            "source": "paper_route_evidence_audit",
+            "purpose": "next_session_paper_route_runtime_window_evidence_collection",
+            "promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "targets": [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "account_label": "TORGHUT_SIM",
+                    "source_plan_ref": "paper-route-plan:c88421d619759b2cfaa6f4d0",
+                    "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                    "target_notional": "20",
+                    "bounded_collection_stage": "paper",
+                    "evidence_collection_stage": "paper",
+                    "window_start": "2026-06-01T13:30:00+00:00",
+                    "window_end": "2026-06-01T20:00:00+00:00",
+                    "paper_route_probe_symbol_actions": {
+                        "AAPL": "buy",
+                        "AMZN": "sell",
+                    },
+                    "paper_route_probe_symbol_quantities": {
+                        "AAPL": "0.10",
+                        "AMZN": "0.10",
+                    },
+                    "paper_route_clean_window_state": "clean_window_collection_ready",
+                    "paper_route_clean_window_baseline_state": {
+                        "state": "clean",
+                        "blockers": [],
+                    },
+                    "paper_route_clean_window_baseline_blockers": [],
+                    "evidence_collection_ok": True,
+                    "bounded_evidence_collection_authorized": True,
+                    "capital_promotion_allowed": False,
+                    "promotion_allowed": False,
+                    "final_promotion_authorized": False,
+                    "final_promotion_allowed": False,
+                }
+            ],
+        }
+
+    def test_hpairs_target_plan_materializes_auditable_source_decisions(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        generated_at = datetime(2026, 6, 1, 13, 35, tzinfo=timezone.utc)
+        with session_local() as session:
+            session.add(
+                Strategy(
+                    name="microbar-cross-sectional-pairs-v1",
+                    description="H-PAIRS bounded paper materialization fixture",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_notional_per_trade=Decimal("20"),
+                )
+            )
+            session.commit()
+
+            result = materialize_bounded_paper_route_target_plan(
+                session,
+                self._hpairs_clean_target_plan(),
+                generated_at=generated_at,
+                bounded_notional_limit=Decimal("25"),
+            )
+            session.commit()
+
+            rows = list(
+                session.execute(
+                    select(TradeDecision).order_by(TradeDecision.symbol.asc())
+                ).scalars()
+            )
+
+        self.assertFalse(result["promotion_allowed"])
+        self.assertFalse(result["final_promotion_authorized"])
+        self.assertFalse(result["live_capital_routing_enabled"])
+        self.assertEqual(result["materialized_decision_count"], 2)
+        self.assertEqual(result["route_submission_count"], 2)
+        self.assertEqual(result["blocked_target_count"], 0)
+        self.assertEqual(
+            result["source_decision_mode"],
+            BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+        )
+        self.assertEqual(len(rows), 2)
+        self.assertEqual([row.symbol for row in rows], ["AAPL", "AMZN"])
+        for row in rows:
+            payload = row.decision_json
+            self.assertEqual(row.alpaca_account_label, "TORGHUT_SIM")
+            self.assertEqual(row.status, "planned")
+            self.assertEqual(
+                payload["source_decision_mode"],
+                BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+            )
+            self.assertEqual(payload["hypothesis_id"], "H-PAIRS-01")
+            self.assertEqual(payload["candidate_id"], "c88421d619759b2cfaa6f4d0")
+            self.assertEqual(
+                payload["runtime_strategy_name"],
+                "microbar-cross-sectional-pairs-v1",
+            )
+            self.assertEqual(payload["account_label"], "TORGHUT_SIM")
+            self.assertEqual(
+                payload["source_plan_ref"],
+                "paper-route-plan:c88421d619759b2cfaa6f4d0",
+            )
+            self.assertEqual(payload["target_notional"], "20")
+            self.assertEqual(
+                payload["bounded_collection_stage"],
+                "bounded_paper_collection",
+            )
+            self.assertFalse(payload["promotion_allowed"])
+            self.assertFalse(payload["final_promotion_authorized"])
+            self.assertFalse(payload["live_capital_routing_enabled"])
+            route_submission = payload["paper_route_order_submission"]
+            self.assertFalse(route_submission["submission_enabled"])
+            self.assertFalse(route_submission["live_capital_routing_enabled"])
+            self.assertEqual(route_submission["account_label"], "TORGHUT_SIM")
+            self.assertEqual(
+                payload["target_plan_identity"]["hypothesis_id"],
+                "H-PAIRS-01",
+            )
+            self.assertEqual(
+                payload["target_plan_identity"]["candidate_id"],
+                "c88421d619759b2cfaa6f4d0",
+            )
+            self.assertEqual(payload["target_plan_identity"]["target_notional"], "20")
+            self.assertEqual(payload["target_plan_identity"]["target_quantity"], "0.20")
+            self.assertEqual(
+                payload["target_plan_identity"]["target_symbol_quantities"],
+                {"AAPL": "0.10", "AMZN": "0.10"},
+            )
+
+    def test_hpairs_target_plan_materialization_blocks_dirty_incomplete_or_unbounded_targets(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        plan = self._hpairs_clean_target_plan()
+        target_template = cast(list[dict[str, Any]], plan["targets"])[0]
+        dirty_target = dict(target_template)
+        dirty_target["paper_route_clean_window_baseline_state"] = {
+            "state": "blocked",
+            "blockers": ["paper_route_account_contamination_detected"],
+        }
+        missing_target = dict(target_template)
+        missing_target.pop("paper_route_clean_window_baseline_state")
+        wrong_account_target = dict(target_template)
+        wrong_account_target["account_label"] = "paper"
+        unbounded_target = dict(target_template)
+        unbounded_target["target_notional"] = "250"
+
+        with session_local() as session:
+            result = materialize_bounded_paper_route_target_plan(
+                session,
+                {
+                    **plan,
+                    "targets": [
+                        dirty_target,
+                        missing_target,
+                        wrong_account_target,
+                        unbounded_target,
+                    ],
+                },
+                generated_at=datetime(2026, 6, 1, 13, 35, tzinfo=timezone.utc),
+                bounded_notional_limit=Decimal("25"),
+            )
+            row_count = session.execute(
+                select(func.count()).select_from(TradeDecision)
+            ).scalar_one()
+
+        self.assertEqual(result["materialized_decision_count"], 0)
+        self.assertEqual(result["blocked_target_count"], 4)
+        self.assertEqual(row_count, 0)
+        self.assertIn("paper_route_account_contamination_detected", result["blockers"])
+        self.assertIn(
+            "paper_route_clean_window_baseline_missing_or_dirty",
+            result["blockers"],
+        )
+        self.assertIn(
+            "paper_route_target_torghut_sim_account_required",
+            result["blockers"],
+        )
+        self.assertIn(
+            "paper_route_target_notional_exceeds_bounded_collection_limit",
+            result["blockers"],
+        )
+        self.assertFalse(result["promotion_allowed"])
+        self.assertFalse(result["final_promotion_authorized"])
+        self.assertFalse(result["live_capital_routing_enabled"])
+
+    def test_source_decision_mode_profit_proof_scope_is_bounded_paper_only(
+        self,
+    ) -> None:
+        self.assertFalse(
+            source_decision_mode_is_profit_proof_eligible(
+                ROUTE_ACQUISITION_SOURCE_DECISION_MODE
+            )
+        )
+        self.assertTrue(
+            source_decision_mode_is_profit_proof_eligible(
+                BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+            )
+        )
 
     def test_load_latest_runtime_ledger_summary_uses_latest_bucket_per_hypothesis(
         self,


### PR DESCRIPTION
## Summary

- Added bounded H-PAIRS paper-route target materialization that turns clean target-plan entries into auditable `TradeDecision` rows and disabled paper order-submission intents.
- Added strict target gating for clean-window baseline, TORGHUT_SIM account identity, complete H-PAIRS/source-plan identity, per-symbol quantities, and bounded notional limits.
- Added a bounded paper-route source decision mode that is source-proof eligible only for bounded paper collection while keeping promotion and live-capital routing disabled.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_completion_trace.py tests/test_trading_api.py tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_target_plan.py app/trading/submission_council.py app/trading/completion.py app/trading/runtime_decision_authority.py tests/test_submission_council.py tests/test_completion_trace.py tests/test_trading_api.py tests/test_paper_route_evidence.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A; backend-only Torghut trading materialization change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
