### PR TITLE
fix(torghut): allow bounded hpairs paper signal collection

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1748,7 +1748,6 @@ def _next_paper_route_runtime_window_targets(
         )
         evidence_collection_blockers = _unique_text_items(
             [
-                *health_gate_blockers,
                 *_unique_text_items(source_decision_readiness.get("blockers")),
                 *account_pre_session_blockers,
                 *clean_window_baseline_blockers,
@@ -1908,6 +1907,7 @@ def _next_paper_route_runtime_window_targets(
                     "paper_route_runtime_ledger_import_pending",
                     *_unique_text_items(target.get("candidate_blockers")),
                     *evidence_collection_blockers,
+                    *health_gate_blockers,
                     *health_gate_promotion_blockers,
                 ]
             ),

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -291,6 +291,7 @@ def _bounded_sim_collection_metadata_from_decision(
     for key in (
         "paper_route_target_plan_source_decision",
         "paper_route_target_plan",
+        "strategy_signal_paper",
         "paper_route_probe",
         "paper_route_probe_exit",
     ):
@@ -3274,6 +3275,20 @@ class SimpleTradingPipeline(TradingPipeline):
                 != "paper_route_probe_runtime_observed"
             ):
                 continue
+            if _target_requires_bounded_sim_collection_gate(target):
+                blockers = _bounded_sim_collection_blockers(
+                    target,
+                    account_label=self.account_label,
+                )
+                if blockers:
+                    logger.warning(
+                        "Skipping strategy-signal paper authority because bounded SIM "
+                        "collection is not authorized strategy=%s symbol=%s blockers=%s",
+                        strategy.name if strategy is not None else decision.strategy_id,
+                        symbol,
+                        ",".join(blockers),
+                    )
+                    continue
             if not _target_truthy(target.get("paper_probation_authorized")):
                 continue
             return target
@@ -3317,6 +3332,32 @@ class SimpleTradingPipeline(TradingPipeline):
             "dataset_snapshot_ref",
         ):
             value = _safe_text(target.get(key))
+            if value is not None:
+                metadata[key] = value
+        for key in _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS:
+            value = _safe_text(target.get(key))
+            if value is not None:
+                metadata[key] = value
+        for key in _BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS:
+            value = _target_bool(target.get(key))
+            if value is not None:
+                metadata[key] = value
+        for key in _BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS:
+            value = target.get(key)
+            if isinstance(value, Mapping):
+                metadata[key] = dict(cast(Mapping[str, Any], value))
+        for key in _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS:
+            values = _lineage_text_values(target.get(key))
+            if values:
+                metadata[key] = values
+        symbols = _lineage_text_values(target.get("paper_route_probe_symbols"))
+        if symbols:
+            metadata["paper_route_probe_symbols"] = symbols
+        for key in (
+            "paper_route_probe_pair_balance_required",
+            "paper_route_probe_pair_balance_state",
+        ):
+            value = target.get(key)
             if value is not None:
                 metadata[key] = value
         if window is not None:
@@ -3756,12 +3797,12 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         paper_route_probe_applied = False
         if proof_floor_block_reason is not None:
+            collection_metadata = _bounded_sim_collection_metadata_from_decision(
+                decision,
+                account_label=self.account_label,
+                trading_mode=settings.trading_mode,
+            )
             if not settings.trading_simple_submit_enabled:
-                collection_metadata = _bounded_sim_collection_metadata_from_decision(
-                    decision,
-                    account_label=self.account_label,
-                    trading_mode=settings.trading_mode,
-                )
                 if collection_metadata is None:
                     self._block_decision_submission(
                         session=session,
@@ -3783,6 +3824,7 @@ class SimpleTradingPipeline(TradingPipeline):
             if settings.trading_mode == "paper" and (
                 self._paper_route_probe_exit_metadata(decision) is not None
                 or _paper_route_probe_entry_metadata(decision.params) is not None
+                or collection_metadata is not None
             ):
                 paper_route_probe_applied = True
             if not paper_route_probe_applied:

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -10,11 +10,11 @@ from decimal import Decimal, ROUND_DOWN
 from typing import Any, Literal, Optional, cast
 from uuid import UUID
 
-from sqlalchemy import select  # pyright: ignore[reportUnknownVariableType]
+from sqlalchemy import desc, select  # pyright: ignore[reportUnknownVariableType]
 from sqlalchemy.orm import Session
 
 from ...config import settings
-from ...models import Execution, Strategy, TradeDecision
+from ...models import Execution, PositionSnapshot, Strategy, TradeDecision
 from ...strategies.catalog import extract_catalog_metadata
 from ..autonomy import DriftThresholds, detect_drift
 from ..empirical_jobs import build_empirical_jobs_status
@@ -87,6 +87,9 @@ _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS = (
     "runtime_window_import_health_gate_blockers",
     "paper_route_account_pre_session_blockers",
     "paper_route_hpairs_symbol_blockers",
+)
+_BOUNDED_SIM_COLLECTION_ALLOWED_HEALTH_GATE_BLOCKERS = frozenset(
+    {"evidence_continuity_not_ok"}
 )
 _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS = (
     "account_label",
@@ -255,7 +258,14 @@ def _bounded_sim_collection_blockers(
     if _safe_text(target.get("paper_route_probe_pair_balance_state")) == "imbalanced":
         blockers.append("paper_route_probe_pair_imbalanced")
     for key in _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS:
-        blockers.extend(_lineage_text_values(target.get(key)))
+        field_blockers = _lineage_text_values(target.get(key))
+        if key == "runtime_window_import_health_gate_blockers":
+            field_blockers = [
+                blocker
+                for blocker in field_blockers
+                if blocker not in _BOUNDED_SIM_COLLECTION_ALLOWED_HEALTH_GATE_BLOCKERS
+            ]
+        blockers.extend(field_blockers)
     return list(dict.fromkeys(blockers))
 
 
@@ -826,6 +836,16 @@ class SimpleTradingPipeline(TradingPipeline):
                 positions=positions,
                 allowed_symbols=allowed_symbols,
             )
+            if self._paper_route_target_plan_reserves_account(
+                allowed_symbols=allowed_symbols
+            ):
+                logger.info(
+                    "Skipping regular simple-lane signal processing while bounded "
+                    "paper-route evidence collection owns account=%s",
+                    self.account_label,
+                )
+                self.ingestor.commit_cursor(session, batch)
+                return
             quality_signals = self._quality_gate_signals(
                 signals=batch.signals,
                 strategies=strategies,
@@ -2861,6 +2881,16 @@ class SimpleTradingPipeline(TradingPipeline):
                 symbols = [symbol for symbol in symbols if symbol in strategy_symbols]
             symbol_actions = _target_probe_symbol_actions(target, symbols)
             pair_balance_state = _target_pair_balance_state(target, symbol_actions)
+            if _target_requires_bounded_sim_collection_gate(
+                target
+            ) and self._paper_route_target_account_has_open_exposure(positions):
+                logger.warning(
+                    "Skipping paper-route target source collection because account "
+                    "is not flat for bounded SIM evidence strategy=%s symbols=%s",
+                    strategy.name,
+                    symbols,
+                )
+                continue
             if pair_balance_state == "imbalanced":
                 logger.warning(
                     "Skipping imbalanced paper-route pair target strategy=%s symbols=%s actions=%s",
@@ -2992,6 +3022,47 @@ class SimpleTradingPipeline(TradingPipeline):
                 )
         return decisions
 
+    def _paper_route_target_plan_reserves_account(
+        self,
+        *,
+        allowed_symbols: set[str],
+    ) -> bool:
+        if settings.trading_mode != "paper":
+            return False
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return False
+        now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+        if not self._is_market_session_open(now):
+            return False
+        target_symbols, target_plan_error, target_plan_targets = (
+            self._external_paper_route_target_probe_symbols_cached()
+        )
+        if target_plan_error or not target_symbols:
+            return False
+        normalized_allowed = {
+            symbol.strip().upper() for symbol in allowed_symbols if symbol.strip()
+        }
+        for target in target_plan_targets:
+            if not _target_requires_bounded_sim_collection_gate(target):
+                continue
+            if not _bounded_sim_collection_authorized(
+                target,
+                account_label=self.account_label,
+            ):
+                continue
+            window = _target_probe_window(target)
+            if window is None:
+                continue
+            window_start, window_end = window
+            if now < window_start or now >= window_end:
+                continue
+            symbols = _target_symbols(target) & target_symbols
+            if normalized_allowed:
+                symbols = {symbol for symbol in symbols if symbol in normalized_allowed}
+            if symbols:
+                return True
+        return False
+
     @staticmethod
     def _paper_route_target_symbol_has_open_strategy_exposure(
         *,
@@ -3009,7 +3080,7 @@ class SimpleTradingPipeline(TradingPipeline):
         guard_start = window_start - _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK
         try:
             rows = session.execute(
-                select(Execution.side, Execution.filled_qty)
+                select(Execution.side, Execution.filled_qty, Execution.created_at)
                 .join(TradeDecision, Execution.trade_decision_id == TradeDecision.id)
                 .where(
                     Execution.alpaca_account_label == account_label,
@@ -3033,7 +3104,11 @@ class SimpleTradingPipeline(TradingPipeline):
             return True
 
         signed_qty = Decimal("0")
-        for side, filled_qty in rows:
+        latest_fill_at: datetime | None = None
+        for row in rows:
+            side = row[0]
+            filled_qty = row[1]
+            created_at = row[2] if len(row) > 2 else None
             qty = _optional_decimal(filled_qty)
             if qty is None or qty <= 0:
                 continue
@@ -3041,7 +3116,61 @@ class SimpleTradingPipeline(TradingPipeline):
                 signed_qty -= qty
             else:
                 signed_qty += qty
-        return abs(signed_qty) > _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON
+            if isinstance(created_at, datetime):
+                latest_fill_at = (
+                    created_at
+                    if latest_fill_at is None or created_at > latest_fill_at
+                    else latest_fill_at
+                )
+        if abs(signed_qty) <= _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON:
+            return False
+        if SimpleTradingPipeline._paper_route_target_symbol_has_flat_repair_snapshot(
+            session=session,
+            account_label=account_label,
+            symbol=normalized_symbol,
+            after=latest_fill_at,
+        ):
+            return False
+        return True
+
+    @staticmethod
+    def _paper_route_target_symbol_has_flat_repair_snapshot(
+        *,
+        session: Session,
+        account_label: str,
+        symbol: str,
+        after: datetime | None,
+    ) -> bool:
+        if after is None:
+            return False
+        try:
+            row = session.execute(
+                select(PositionSnapshot.positions, PositionSnapshot.as_of)
+                .where(
+                    PositionSnapshot.alpaca_account_label == account_label,
+                    PositionSnapshot.as_of >= after,
+                )
+                .order_by(desc(PositionSnapshot.as_of))
+                .limit(1)
+            ).first()
+        except Exception:
+            logger.exception(
+                "Failed to inspect paper-route flat repair snapshot symbol=%s account_label=%s",
+                symbol,
+                account_label,
+            )
+            return False
+        if row is None:
+            return False
+        positions = row[0]
+        if not isinstance(positions, Sequence) or isinstance(
+            positions, (bytes, bytearray, str)
+        ):
+            return False
+        return not SimpleTradingPipeline._paper_route_target_symbol_has_open_position(
+            cast(Sequence[Mapping[str, Any]], positions),
+            symbol,
+        )
 
     @staticmethod
     def _paper_route_target_symbol_has_open_profit_proof_exposure(
@@ -3129,6 +3258,22 @@ class SimpleTradingPipeline(TradingPipeline):
         for position in positions:
             if str(position.get("symbol") or "").strip().upper() != normalized_symbol:
                 continue
+            for qty_key in ("qty", "quantity", "qty_available"):
+                qty = _optional_decimal(position.get(qty_key))
+                if qty is not None and qty != 0:
+                    return True
+            market_value = _optional_decimal(position.get("market_value"))
+            if market_value is not None and market_value != 0:
+                return True
+        return False
+
+    @staticmethod
+    def _paper_route_target_account_has_open_exposure(
+        positions: Sequence[Mapping[str, Any]] | None,
+    ) -> bool:
+        if not positions:
+            return False
+        for position in positions:
             for qty_key in ("qty", "quantity", "qty_available"):
                 qty = _optional_decimal(position.get(qty_key))
                 if qty is not None and qty != 0:

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1189,6 +1189,101 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(clean_readiness["clean_target_count"], 1)
         self.assertEqual(clean_readiness["blockers"], [])
 
+    def test_clean_baseline_allows_collection_when_health_gate_blocks_promotion(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="paper-route-candidate-v1",
+                    description="clean baseline source strategy",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                )
+            )
+            self._add_account_position_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                as_of=generated_at - timedelta(seconds=30),
+                positions=[],
+            )
+            session.commit()
+
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": "false",
+                    "continuity_reason": "signal_continuity_missing",
+                    "drift_ok": "false",
+                    "drift_reason": "drift_live_promotion_ineligible",
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-clean-but-not-promotable",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "paper-route-candidate-v1",
+                                "account_label": "TORGHUT_REPLAY",
+                                "source_kind": "durable_runtime_ledger_bucket",
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+                                "dataset_snapshot_ref": "dataset://paper-route",
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_active_symbols": [],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 2,
+                        "eligible_symbols": ["AAPL", "AMZN"],
+                        "blocking_reasons": [],
+                    },
+                },
+                generated_at=generated_at,
+            )
+
+        target = payload["next_paper_route_runtime_window_targets"]["targets"][0]
+        self.assertEqual(
+            target["runtime_window_import_health_gate"]["blockers"],
+            ["evidence_continuity_not_ok"],
+        )
+        self.assertEqual(
+            target["runtime_window_import_promotion_blockers"],
+            ["drift_checks_not_ok"],
+        )
+        self.assertTrue(target["evidence_collection_ok"])
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertIn("evidence_continuity_not_ok", target["candidate_blockers"])
+        self.assertIn(
+            "evidence_continuity_not_ok",
+            target["runtime_ledger_target_metadata_blockers"],
+        )
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+
     def test_missing_clean_baseline_blocks_bounded_collection_readiness(self) -> None:
         generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8565,6 +8565,187 @@ class TestTradingPipeline(TestCase):
 
         self.assertTrue(reserves)
 
+    def test_run_once_commits_and_skips_regular_signals_when_target_reserves_account(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 6, 1, 14, 30, tzinfo=timezone.utc),
+            symbol="NVDA",
+            payload={"price": Decimal("100")},
+            timeframe="1Min",
+        )
+        ingestor = FakeIngestor([signal])
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "session_factory", self.session_local)
+        setattr(pipeline, "state", TradingState())
+        setattr(pipeline, "ingestor", ingestor)
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        setattr(pipeline, "_label_mature_rejected_signal_outcome_events", lambda: None)
+        setattr(pipeline, "_prepare_run_once", lambda _session: [strategy])
+        setattr(
+            pipeline,
+            "_capture_runtime_window_account_snapshot_if_due",
+            lambda _session: None,
+        )
+        setattr(
+            pipeline,
+            "_warm_session_context_from_open",
+            lambda _session, *, strategies: None,
+        )
+        setattr(pipeline, "_record_ingest_window", lambda _batch: None)
+        setattr(
+            pipeline,
+            "_build_run_context",
+            lambda _session: ({}, {}, [], {"AAPL", "AMZN"}),
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_probe_exit_decisions",
+            lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_target_source_decisions",
+            lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
+            "_paper_route_target_plan_reserves_account",
+            lambda *, allowed_symbols: True,
+        )
+        setattr(
+            pipeline,
+            "_quality_gate_signals",
+            Mock(side_effect=AssertionError("regular signal path should be skipped")),
+        )
+
+        pipeline.run_once()
+
+        self.assertEqual(ingestor.committed_batches, 1)
+
+    def test_paper_route_target_plan_reservation_rejects_unusable_targets(self) -> None:
+        from app import config
+
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        now = window_start + timedelta(minutes=5)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        base_target = {
+            "account_label": "TORGHUT_SIM",
+            "observed_stage": "paper",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "candidate_id": "candidate-pairs-monday",
+            "hypothesis_id": "H-PAIRS-01",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+            "bounded_evidence_collection_authorized": True,
+            "evidence_collection_ok": True,
+            "source_decision_readiness": {"ready": True, "blockers": []},
+        }
+        targets = [
+            {
+                **base_target,
+                "paper_route_account_pre_session_blockers": [
+                    "unlinked_order_events_present"
+                ],
+            },
+            {**base_target, "paper_route_probe_window_start": None},
+            {
+                **base_target,
+                "paper_route_probe_window_start": (
+                    window_start + timedelta(days=1)
+                ).isoformat(),
+                "paper_route_probe_window_end": (
+                    window_end + timedelta(days=1)
+                ).isoformat(),
+            },
+            base_target,
+        ]
+        setattr(
+            pipeline,
+            "_external_paper_route_target_probe_symbols_cached",
+            lambda: ({"AAPL", "AMZN"}, None, targets),
+        )
+
+        with patch(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            return_value=now,
+        ):
+            setattr(pipeline, "_is_market_session_open", lambda _now: False)
+            self.assertFalse(
+                pipeline._paper_route_target_plan_reserves_account(
+                    allowed_symbols=set()
+                )
+            )
+            setattr(pipeline, "_is_market_session_open", lambda _now: True)
+            self.assertFalse(
+                pipeline._paper_route_target_plan_reserves_account(
+                    allowed_symbols={"MSFT"}
+                )
+            )
+
+    def test_paper_route_flat_repair_snapshot_handles_query_and_shape_failures(
+        self,
+    ) -> None:
+        class RaisingSession:
+            def execute(self, *_args: object, **_kwargs: object) -> object:
+                raise RuntimeError("snapshot query failed")
+
+        class ResultWithStringPositions:
+            def first(self) -> tuple[str, datetime]:
+                return (
+                    "not-a-position-list",
+                    datetime(2026, 6, 1, tzinfo=timezone.utc),
+                )
+
+        class StringPositionsSession:
+            def execute(
+                self, *_args: object, **_kwargs: object
+            ) -> ResultWithStringPositions:
+                return ResultWithStringPositions()
+
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_symbol_has_flat_repair_snapshot(
+                session=cast(Session, RaisingSession()),
+                account_label="TORGHUT_SIM",
+                symbol="AMZN",
+                after=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            )
+        )
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_symbol_has_flat_repair_snapshot(
+                session=cast(Session, StringPositionsSession()),
+                account_label="TORGHUT_SIM",
+                symbol="AMZN",
+                after=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            )
+        )
+
+    def test_paper_route_account_exposure_detects_market_value(self) -> None:
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_target_account_has_open_exposure(
+                [{"symbol": "NVDA", "qty": "0", "market_value": "10"}]
+            )
+        )
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_account_has_open_exposure(
+                [{"symbol": "NVDA", "qty": "0", "market_value": "0"}]
+            )
+        )
+
     def test_paper_decision_persists_external_target_lineage_existing_row(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8301,6 +8301,10 @@ class TestTradingPipeline(TestCase):
                 "bounded_evidence_collection_authorized": True,
                 "evidence_collection_ok": True,
                 "source_decision_readiness": {"ready": True, "blockers": []},
+                "runtime_window_import_health_gate_blockers": [
+                    "evidence_continuity_not_ok"
+                ],
+                "runtime_window_import_promotion_blockers": ["drift_checks_not_ok"],
             }
             setattr(
                 pipeline,
@@ -8319,6 +8323,247 @@ class TestTradingPipeline(TestCase):
                 )
 
         self.assertEqual(decisions, [])
+
+    def test_paper_route_target_source_allows_flat_repaired_strategy_exposure(
+        self,
+    ) -> None:
+        from app import config
+
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = True
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "_is_market_session_open", lambda _now: True)
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="microbar_cross_sectional_pairs_v1",
+                universe_symbols=["AAPL", "AMZN"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AMZN",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "sell",
+                    "qty": "10",
+                    "event_ts": (
+                        window_start - timedelta(days=3) + timedelta(minutes=3)
+                    ).isoformat(),
+                    "params": {
+                        "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+                        "profit_proof_eligible": False,
+                    },
+                },
+                rationale="paper-route-entry",
+                status="filled",
+                created_at=window_start - timedelta(days=3) + timedelta(minutes=3),
+            )
+            session.add(decision)
+            session.commit()
+            session.refresh(decision)
+            session.add(
+                Execution(
+                    trade_decision_id=decision.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    alpaca_order_id="paper-amzn-stale-open",
+                    client_order_id="paper-amzn-stale-open-client",
+                    symbol="AMZN",
+                    side="sell",
+                    order_type="market",
+                    time_in_force="day",
+                    submitted_qty=Decimal("10"),
+                    filled_qty=Decimal("10"),
+                    avg_fill_price=Decimal("272"),
+                    status="filled",
+                    raw_order={},
+                    created_at=window_start - timedelta(days=3) + timedelta(minutes=2),
+                    updated_at=window_start - timedelta(days=3) + timedelta(minutes=2),
+                )
+            )
+            session.add(
+                PositionSnapshot(
+                    alpaca_account_label="TORGHUT_SIM",
+                    as_of=window_start - timedelta(minutes=5),
+                    equity=Decimal("100000"),
+                    cash=Decimal("100000"),
+                    buying_power=Decimal("200000"),
+                    positions=[],
+                )
+            )
+            session.commit()
+
+            target = {
+                "account_label": "TORGHUT_SIM",
+                "observed_stage": "paper",
+                "source_kind": "paper_route_probe_runtime_observed",
+                "candidate_id": "candidate-pairs-monday",
+                "hypothesis_id": "H-PAIRS-01",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                "strategy_lookup_names": [str(strategy.id), strategy.name],
+                "strategy_family": "microbar_cross_sectional_pairs",
+                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                "paper_route_probe_symbol_actions": {
+                    "AAPL": "buy",
+                    "AMZN": "sell",
+                },
+                "paper_route_probe_window_start": window_start.isoformat(),
+                "paper_route_probe_window_end": window_end.isoformat(),
+                "paper_route_probe_next_session_max_notional": "1000",
+                "bounded_evidence_collection_authorized": True,
+                "evidence_collection_ok": True,
+                "source_decision_readiness": {"ready": True, "blockers": []},
+                "runtime_window_import_health_gate_blockers": [
+                    "evidence_continuity_not_ok"
+                ],
+                "runtime_window_import_promotion_blockers": ["drift_checks_not_ok"],
+            }
+            setattr(
+                pipeline,
+                "_external_paper_route_target_probe_symbols_cached",
+                lambda: ({"AAPL", "AMZN"}, None, [target]),
+            )
+            with patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=window_start + timedelta(minutes=5),
+            ):
+                decisions = pipeline._paper_route_target_source_decisions(
+                    strategies=[strategy],
+                    allowed_symbols=set(),
+                    positions=[],
+                    session=session,
+                )
+
+        self.assertEqual(
+            [(decision.symbol, decision.action) for decision in decisions],
+            [("AAPL", "buy"), ("AMZN", "sell")],
+        )
+
+    def test_paper_route_target_source_skips_pair_when_account_not_flat(
+        self,
+    ) -> None:
+        from app import config
+
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = True
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "_is_market_session_open", lambda _now: True)
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="microbar_cross_sectional_pairs_v1",
+                universe_symbols=["AAPL", "AMZN"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+            target = {
+                "account_label": "TORGHUT_SIM",
+                "observed_stage": "paper",
+                "source_kind": "paper_route_probe_runtime_observed",
+                "candidate_id": "candidate-pairs-monday",
+                "hypothesis_id": "H-PAIRS-01",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                "strategy_lookup_names": [str(strategy.id), strategy.name],
+                "strategy_family": "microbar_cross_sectional_pairs",
+                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                "paper_route_probe_symbol_actions": {
+                    "AAPL": "buy",
+                    "AMZN": "sell",
+                },
+                "paper_route_probe_window_start": window_start.isoformat(),
+                "paper_route_probe_window_end": window_end.isoformat(),
+                "paper_route_probe_next_session_max_notional": "1000",
+                "bounded_evidence_collection_authorized": True,
+                "evidence_collection_ok": True,
+                "source_decision_readiness": {"ready": True, "blockers": []},
+            }
+            setattr(
+                pipeline,
+                "_external_paper_route_target_probe_symbols_cached",
+                lambda: ({"AAPL", "AMZN"}, None, [target]),
+            )
+            with patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=window_start + timedelta(minutes=5),
+            ):
+                decisions = pipeline._paper_route_target_source_decisions(
+                    strategies=[strategy],
+                    allowed_symbols=set(),
+                    positions=[{"symbol": "NVDA", "qty": "1", "side": "long"}],
+                    session=session,
+                )
+
+        self.assertEqual(decisions, [])
+
+    def test_paper_route_target_plan_reserves_account_for_collection(self) -> None:
+        from app import config
+
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "_is_market_session_open", lambda _now: True)
+        target = {
+            "account_label": "TORGHUT_SIM",
+            "observed_stage": "paper",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "candidate_id": "candidate-pairs-monday",
+            "hypothesis_id": "H-PAIRS-01",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+            "bounded_evidence_collection_authorized": True,
+            "evidence_collection_ok": True,
+            "source_decision_readiness": {"ready": True, "blockers": []},
+            "runtime_window_import_health_gate_blockers": [
+                "evidence_continuity_not_ok"
+            ],
+            "runtime_window_import_promotion_blockers": ["drift_checks_not_ok"],
+        }
+        setattr(
+            pipeline,
+            "_external_paper_route_target_probe_symbols_cached",
+            lambda: ({"AAPL", "AMZN"}, None, [target]),
+        )
+
+        with patch(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            return_value=window_start + timedelta(minutes=5),
+        ):
+            reserves = pipeline._paper_route_target_plan_reserves_account(
+                allowed_symbols=set()
+            )
+
+        self.assertTrue(reserves)
 
     def test_paper_decision_persists_external_target_lineage_existing_row(
         self,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3485,6 +3485,20 @@ class TestTradingPipeline(TestCase):
             target=target,
             strategy=strategy,
         )
+        blocked_metadata = SimpleTradingPipeline._strategy_signal_paper_metadata(
+            decision=base_decision,
+            target={
+                **target,
+                "paper_route_account_pre_session_blockers": [
+                    "unlinked_order_events_present",
+                ],
+            },
+            strategy=strategy,
+        )
+        self.assertEqual(
+            blocked_metadata.get("paper_route_account_pre_session_blockers"),
+            ["unlinked_order_events_present"],
+        )
         decision = base_decision.model_copy(
             update={
                 "params": {
@@ -8135,6 +8149,17 @@ class TestTradingPipeline(TestCase):
             ("missing hypothesis", good_decision, [make_target(hypothesis_id=None)]),
             ("wrong stage", good_decision, [make_target(observed_stage="backtest")]),
             ("wrong source kind", good_decision, [make_target(source_kind="manual")]),
+            (
+                "bounded collection blockers",
+                good_decision,
+                [
+                    make_target(
+                        paper_route_account_pre_session_blockers=[
+                            "unlinked_order_events_present"
+                        ]
+                    )
+                ],
+            ),
             (
                 "probation unauthorized",
                 good_decision,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -66,6 +66,7 @@ from app.trading.risk import RiskEngine
 from app.trading.scheduler.pipeline import TradingPipeline
 from app.trading.scheduler.simple_pipeline import (
     SimpleTradingPipeline,
+    _bounded_sim_collection_metadata_from_decision,
     _paper_route_probe_entry_metadata,
     _paper_route_probe_lineage_from_params,
     _parse_target_datetime,
@@ -3415,6 +3416,149 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(target_window.get("source_hypothesis_ids"), ["H-PAIRS-01"])
         self.assertEqual(scoped_row.status, "planned")
         self.assertNotIn("submission_block_reason", scoped_json)
+
+    def test_strategy_signal_paper_collection_bypasses_repair_only_floor(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 1, 14, 30, tzinfo=timezone.utc)
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = "http://torghut.test/plan"
+
+        strategy_id = uuid4()
+        strategy = Strategy(
+            id=strategy_id,
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded strategy-signal collection",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("75000"),
+        )
+        target: dict[str, Any] = {
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "hypothesis_id": "H-PAIRS-01",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": strategy.name,
+            "runtime_strategy_name": strategy.name,
+            "strategy_lookup_names": [str(strategy_id), strategy.name],
+            "account_label": "TORGHUT_SIM",
+            "source_account_label": "TORGHUT_REPLAY",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_pair_balance_state": "balanced",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+            "evidence_collection_ok": True,
+            "canary_collection_authorized": True,
+            "bounded_evidence_collection_authorized": True,
+            "bounded_live_paper_collection_authorized": True,
+            "bounded_evidence_collection_scope": "paper_route_probe_next_session_only",
+            "bounded_evidence_collection_blockers": [],
+            "runtime_window_import_health_gate_blockers": [],
+            "paper_route_account_pre_session_blockers": [],
+            "paper_route_hpairs_symbol_blockers": [],
+            "source_decision_readiness": {"ready": True, "blockers": []},
+            "paper_probation_authorized": True,
+        }
+        base_decision = StrategyDecision(
+            strategy_id=str(strategy_id),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("1"),
+            rationale="bounded strategy-signal paper collection",
+            params={"price": "100"},
+        )
+        metadata = SimpleTradingPipeline._strategy_signal_paper_metadata(
+            decision=base_decision,
+            target=target,
+            strategy=strategy,
+        )
+        decision = base_decision.model_copy(
+            update={
+                "params": {
+                    "price": "100",
+                    "paper_route_target_plan": metadata,
+                    "strategy_signal_paper": metadata,
+                    "source_decision_mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+                    "profit_proof_eligible": True,
+                }
+            }
+        )
+        proof_floor = {
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "market_window": {"session_open": True},
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+        }
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+
+        with self.session_local() as session:
+            row = TradeDecision(
+                strategy_id=strategy_id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json=decision.model_dump(mode="json"),
+                status="planned",
+            )
+            session.add(row)
+            session.commit()
+
+            with (
+                patch.object(
+                    pipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=({"AAPL", "AMZN"}, None, [target]),
+                ),
+                patch.object(
+                    SimpleTradingPipeline,
+                    "_profitability_proof_floor",
+                    return_value=proof_floor,
+                ),
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=now,
+                ),
+            ):
+                self.assertTrue(
+                    pipeline._is_trading_submission_allowed(
+                        session=session,
+                        decision=decision,
+                        decision_row=row,
+                    )
+                )
+
+            session.refresh(row)
+            row_json = cast(dict[str, Any], row.decision_json)
+
+        self.assertEqual(row.status, "planned")
+        self.assertNotIn("submission_block_reason", row_json)
 
     def test_simple_pipeline_retry_metadata_requires_prior_profit_floor_block(
         self,
@@ -7558,7 +7702,7 @@ class TestTradingPipeline(TestCase):
             reconciler=Reconciler(),
             universe_resolver=UniverseResolver(),
             state=TradingState(),
-            account_label="paper",
+            account_label="TORGHUT_SIM",
             session_factory=self.session_local,
         )
         with self.session_local() as session:
@@ -7605,6 +7749,27 @@ class TestTradingPipeline(TestCase):
                             "dataset_snapshot_ref": (
                                 "portfolio-profit-autoresearch-500-v1"
                             ),
+                            "account_label": "TORGHUT_SIM",
+                            "source_account_label": "TORGHUT_REPLAY",
+                            "runtime_strategy_name": (
+                                "microbar-cross-sectional-pairs-v1"
+                            ),
+                            "evidence_collection_ok": True,
+                            "canary_collection_authorized": True,
+                            "bounded_evidence_collection_authorized": True,
+                            "bounded_live_paper_collection_authorized": True,
+                            "bounded_evidence_collection_scope": (
+                                "paper_route_probe_next_session_only"
+                            ),
+                            "bounded_evidence_collection_blockers": [],
+                            "runtime_window_import_health_gate_blockers": [],
+                            "paper_route_account_pre_session_blockers": [],
+                            "paper_route_hpairs_symbol_blockers": [],
+                            "paper_route_probe_pair_balance_state": "balanced",
+                            "source_decision_readiness": {
+                                "ready": True,
+                                "blockers": [],
+                            },
                             "paper_probation_authorized": True,
                         }
                     ]
@@ -7640,7 +7805,27 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(
             target_plan.get("source_decision_mode"), "strategy_signal_paper"
         )
+        self.assertEqual(target_plan.get("account_label"), "TORGHUT_SIM")
+        self.assertEqual(
+            target_plan.get("bounded_evidence_collection_scope"),
+            "paper_route_probe_next_session_only",
+        )
         self.assertTrue(target_plan.get("profit_proof_eligible"))
+        self.assertIsNotNone(
+            _bounded_sim_collection_metadata_from_decision(
+                StrategyDecision(
+                    strategy_id=params.get("strategy_id", ""),
+                    symbol="AAPL",
+                    event_ts=datetime(2026, 5, 28, 15, 30, tzinfo=timezone.utc),
+                    timeframe="1Sec",
+                    action="sell",
+                    qty=Decimal("1"),
+                    params=params,
+                ),
+                account_label="TORGHUT_SIM",
+                trading_mode="paper",
+            )
+        )
         self.assertNotIn("paper_route_probe", params)
         self.assertNotIn("paper_route_target_plan_source_decision", params)
 
@@ -7670,7 +7855,7 @@ class TestTradingPipeline(TestCase):
             reconciler=Reconciler(),
             universe_resolver=UniverseResolver(),
             state=TradingState(),
-            account_label="paper",
+            account_label="TORGHUT_SIM",
             session_factory=self.session_local,
         )
         with self.session_local() as session:
@@ -7736,6 +7921,27 @@ class TestTradingPipeline(TestCase):
                             "dataset_snapshot_ref": (
                                 "portfolio-profit-autoresearch-500-v1"
                             ),
+                            "account_label": "TORGHUT_SIM",
+                            "source_account_label": "TORGHUT_REPLAY",
+                            "runtime_strategy_name": (
+                                "microbar-cross-sectional-pairs-v1"
+                            ),
+                            "evidence_collection_ok": True,
+                            "canary_collection_authorized": True,
+                            "bounded_evidence_collection_authorized": True,
+                            "bounded_live_paper_collection_authorized": True,
+                            "bounded_evidence_collection_scope": (
+                                "paper_route_probe_next_session_only"
+                            ),
+                            "bounded_evidence_collection_blockers": [],
+                            "runtime_window_import_health_gate_blockers": [],
+                            "paper_route_account_pre_session_blockers": [],
+                            "paper_route_hpairs_symbol_blockers": [],
+                            "paper_route_probe_pair_balance_state": "balanced",
+                            "source_decision_readiness": {
+                                "ready": True,
+                                "blockers": [],
+                            },
                             "paper_probation_authorized": True,
                         }
                     ],
@@ -7798,7 +8004,7 @@ class TestTradingPipeline(TestCase):
             reconciler=Reconciler(),
             universe_resolver=UniverseResolver(),
             state=TradingState(),
-            account_label="paper",
+            account_label="TORGHUT_SIM",
             session_factory=self.session_local,
         )
         strategy = Strategy(
@@ -7834,8 +8040,25 @@ class TestTradingPipeline(TestCase):
                 "candidate_id": "candidate-pairs-a",
                 "hypothesis_id": "H-PAIRS-01",
                 "observed_stage": "paper",
+                "account_label": "TORGHUT_SIM",
+                "source_account_label": "TORGHUT_REPLAY",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
                 "strategy_lookup_names": [str(strategy.id), strategy.name],
                 "source_kind": "paper_route_probe_runtime_observed",
+                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                "evidence_collection_ok": True,
+                "canary_collection_authorized": True,
+                "bounded_evidence_collection_authorized": True,
+                "bounded_live_paper_collection_authorized": True,
+                "bounded_evidence_collection_scope": (
+                    "paper_route_probe_next_session_only"
+                ),
+                "bounded_evidence_collection_blockers": [],
+                "runtime_window_import_health_gate_blockers": [],
+                "paper_route_account_pre_session_blockers": [],
+                "paper_route_hpairs_symbol_blockers": [],
+                "paper_route_probe_pair_balance_state": "balanced",
+                "source_decision_readiness": {"ready": True, "blockers": []},
                 "paper_probation_authorized": "yes",
             }
             target.update(overrides)
@@ -7901,7 +8124,12 @@ class TestTradingPipeline(TestCase):
             (
                 "strategy mismatch",
                 good_decision,
-                [make_target(strategy_lookup_names=["other-strategy"])],
+                [
+                    make_target(
+                        strategy_lookup_names=["other-strategy"],
+                        runtime_strategy_name="other-strategy",
+                    )
+                ],
             ),
             ("missing candidate", good_decision, [make_target(candidate_id=None)]),
             ("missing hypothesis", good_decision, [make_target(hypothesis_id=None)]),


### PR DESCRIPTION
## Summary

- Preserve bounded H-PAIRS collection metadata on strategy-signal paper decisions and require bounded collection authorization before assigning paper authority.
- Allow clean TORGHUT_SIM H-PAIRS evidence collection while continuity/drift still block promotion, keeping those blockers on candidate/proof metadata.
- Reserve the TORGHUT_SIM account for bounded paper-route collection windows and skip normal simple-lane signals so unrelated positions cannot contaminate the proof window.
- Treat later flat position snapshots as repair evidence for stale DB strategy exposure, while still blocking collection when the account has any open exposure.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_clean_baseline_allows_collection_when_health_gate_blocks_promotion tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_target_source_skips_pair_with_open_strategy_exposure tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_target_source_allows_flat_repaired_strategy_exposure tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_target_source_skips_pair_when_account_not_flat tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_target_plan_reserves_account_for_collection -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_pipeline.py -q`
- `uv run --frozen pytest tests/test_trading_scheduler_safety.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/scheduler/simple_pipeline.py tests/test_paper_route_evidence.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py app/trading/scheduler/simple_pipeline.py tests/test_paper_route_evidence.py tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
