### PR TITLE
fix(torghut): require runtime import readback proof

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -1439,6 +1439,164 @@ def _runtime_ledger_bucket_payloads(payload: Mapping[str, Any]) -> list[dict[str
     return [single_payload] if single_payload else []
 
 
+def _candidate_filter(column: Any, candidate_id: str | None) -> ColumnElement[bool]:
+    if candidate_id is None:
+        return column.is_(None)
+    return column == candidate_id
+
+
+def _row_ref(table_name: str, row_id: Any) -> str:
+    return f"{table_name}:{row_id}"
+
+
+def _runtime_window_import_readback(
+    *,
+    session: Session,
+    run_id: str,
+    candidate_id: str | None,
+    hypothesis_id: str,
+    observed_stage: str,
+    window_start: datetime,
+    window_end: datetime,
+) -> dict[str, Any]:
+    metric_rows = (
+        session.execute(
+            select(StrategyHypothesisMetricWindow)
+            .where(
+                StrategyHypothesisMetricWindow.run_id == run_id,
+                _candidate_filter(
+                    StrategyHypothesisMetricWindow.candidate_id, candidate_id
+                ),
+                StrategyHypothesisMetricWindow.hypothesis_id == hypothesis_id,
+                StrategyHypothesisMetricWindow.observed_stage == observed_stage,
+            )
+            .order_by(
+                StrategyHypothesisMetricWindow.window_started_at,
+                StrategyHypothesisMetricWindow.window_ended_at,
+                StrategyHypothesisMetricWindow.id,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    promotion_rows = (
+        session.execute(
+            select(StrategyPromotionDecision)
+            .where(
+                StrategyPromotionDecision.run_id == run_id,
+                _candidate_filter(StrategyPromotionDecision.candidate_id, candidate_id),
+                StrategyPromotionDecision.hypothesis_id == hypothesis_id,
+                StrategyPromotionDecision.promotion_target == observed_stage,
+            )
+            .order_by(
+                StrategyPromotionDecision.created_at, StrategyPromotionDecision.id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    ledger_rows = (
+        session.execute(
+            select(StrategyRuntimeLedgerBucket)
+            .where(
+                StrategyRuntimeLedgerBucket.run_id == run_id,
+                _candidate_filter(
+                    StrategyRuntimeLedgerBucket.candidate_id, candidate_id
+                ),
+                StrategyRuntimeLedgerBucket.hypothesis_id == hypothesis_id,
+                StrategyRuntimeLedgerBucket.observed_stage == observed_stage,
+            )
+            .order_by(
+                StrategyRuntimeLedgerBucket.bucket_started_at,
+                StrategyRuntimeLedgerBucket.bucket_ended_at,
+                StrategyRuntimeLedgerBucket.id,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    evidence_grade_ledger_rows = [
+        row
+        for row in ledger_rows
+        if _persisted_runtime_ledger_bucket_evidence_grade(row)
+    ]
+    source_refs: list[str] = []
+    authority_classes: list[str] = []
+    source_materializations: list[str] = []
+    blockers: list[str] = []
+    for row in ledger_rows:
+        payload_json = _mapping(row.payload_json)
+        for ref in _string_list(payload_json.get("source_refs")):
+            if ref not in source_refs:
+                source_refs.append(ref)
+        if (authority_class := _text(payload_json.get("authority_class"))) is not None:
+            if authority_class not in authority_classes:
+                authority_classes.append(authority_class)
+        if (
+            source_materialization := _text(payload_json.get("source_materialization"))
+        ) is not None:
+            if source_materialization not in source_materializations:
+                source_materializations.append(source_materialization)
+        for blocker in _string_list(row.blockers_json):
+            if blocker not in blockers:
+                blockers.append(blocker)
+    return {
+        "schema_version": "torghut.runtime-window-import-readback.v1",
+        "run_id": run_id,
+        "candidate_id": candidate_id,
+        "hypothesis_id": hypothesis_id,
+        "observed_stage": observed_stage,
+        "window_start": window_start.isoformat(),
+        "window_end": window_end.isoformat(),
+        "metric_window_count": len(metric_rows),
+        "promotion_decision_count": len(promotion_rows),
+        "runtime_ledger_bucket_count": len(ledger_rows),
+        "evidence_grade_runtime_ledger_bucket_count": len(evidence_grade_ledger_rows),
+        "runtime_ledger_fill_count": sum(
+            max(0, int(row.fill_count or 0)) for row in ledger_rows
+        ),
+        "runtime_ledger_submitted_order_count": sum(
+            max(0, int(row.submitted_order_count or 0)) for row in ledger_rows
+        ),
+        "runtime_ledger_closed_trade_count": sum(
+            max(0, int(row.closed_trade_count or 0)) for row in ledger_rows
+        ),
+        "runtime_ledger_open_position_count": sum(
+            max(0, int(row.open_position_count or 0)) for row in ledger_rows
+        ),
+        "runtime_ledger_filled_notional": str(
+            sum((row.filled_notional for row in ledger_rows), Decimal("0"))
+        ),
+        "runtime_ledger_cost_amount": str(
+            sum((row.cost_amount for row in ledger_rows), Decimal("0"))
+        ),
+        "runtime_ledger_net_strategy_pnl_after_costs": str(
+            sum(
+                (row.net_strategy_pnl_after_costs for row in ledger_rows),
+                Decimal("0"),
+            )
+        ),
+        "metric_window_refs": [
+            _row_ref("strategy_hypothesis_metric_windows", row.id)
+            for row in metric_rows
+        ],
+        "promotion_decision_refs": [
+            _row_ref("strategy_promotion_decisions", row.id) for row in promotion_rows
+        ],
+        "runtime_ledger_bucket_refs": [
+            _row_ref("strategy_runtime_ledger_buckets", row.id) for row in ledger_rows
+        ],
+        "evidence_grade_runtime_ledger_bucket_refs": [
+            _row_ref("strategy_runtime_ledger_buckets", row.id)
+            for row in evidence_grade_ledger_rows
+        ],
+        "source_refs": source_refs,
+        "authority_classes": authority_classes,
+        "source_materializations": source_materializations,
+        "runtime_ledger_blockers": blockers,
+    }
+
+
 def _runtime_ledger_bucket_replacement_scopes(
     *,
     buckets: Sequence[ObservedRuntimeBucket],
@@ -2676,12 +2834,22 @@ def persist_observed_runtime_windows(
             )
     proof_status = "blocked" if proof_blockers else "ok"
     tigerbeetle_proof_refs = _runtime_ledger_tigerbeetle_proof_refs(runtime_ledger_rows)
+    runtime_import_readback = _runtime_window_import_readback(
+        session=session,
+        run_id=run_id,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+        observed_stage=observed_stage,
+        window_start=import_window_start,
+        window_end=import_window_end,
+    )
     runtime_materialization_target.update(
         {
             "proof_status": proof_status,
             "proof_blockers": proof_blockers,
             "materialized": not proof_blockers,
             "materialization_blockers": materialization_blockers,
+            "readback": runtime_import_readback,
             **materialization_counts,
             "metric_window_ids": [str(row.id) for row in metric_window_rows],
             "promotion_decision_id": str(promotion_decision_row.id),
@@ -2736,6 +2904,7 @@ def persist_observed_runtime_windows(
             current_runtime_ledger_bucket_replacement_count
         ),
         "replaced_runtime_ledger_bucket_count": replaced_runtime_ledger_bucket_count,
+        "runtime_window_import_readback": runtime_import_readback,
         "runtime_materialization_target": runtime_materialization_target,
         "runtime_observation": runtime_payload,
         "delay_adjusted_depth_stress": delay_depth_stress_summary,

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -941,6 +941,10 @@ def _runtime_import_target_materialization_ref(
         materialization_target,
         observation,
     )
+    readback = _runtime_import_readback_payload(
+        summary=summary,
+        target=materialization_target,
+    )
     ref: dict[str, Any] = {
         "materialized": materialized,
         "candidate_id": first_text("candidate_id"),
@@ -985,6 +989,29 @@ def _runtime_import_target_materialization_ref(
         ),
         "blockers": list(blockers),
     }
+    if readback:
+        ref["readback"] = {
+            "schema_version": _text(readback.get("schema_version")),
+            "metric_window_count": _int(readback.get("metric_window_count")),
+            "promotion_decision_count": _int(readback.get("promotion_decision_count")),
+            "runtime_ledger_bucket_count": _int(
+                readback.get("runtime_ledger_bucket_count")
+            ),
+            "evidence_grade_runtime_ledger_bucket_count": _int(
+                readback.get("evidence_grade_runtime_ledger_bucket_count")
+            ),
+            "metric_window_refs": _text_list(readback.get("metric_window_refs")),
+            "promotion_decision_refs": _text_list(
+                readback.get("promotion_decision_refs")
+            ),
+            "runtime_ledger_bucket_refs": _text_list(
+                readback.get("runtime_ledger_bucket_refs")
+            ),
+            "evidence_grade_runtime_ledger_bucket_refs": _text_list(
+                readback.get("evidence_grade_runtime_ledger_bucket_refs")
+            ),
+            "source_refs": _text_list(readback.get("source_refs")),
+        }
     if tigerbeetle_refs:
         ref["tigerbeetle"] = tigerbeetle_refs
     return {key: value for key, value in ref.items() if value not in ("", [], None)}
@@ -1065,6 +1092,80 @@ def _runtime_import_materialization_metadata_blockers(
     ]
 
 
+def _runtime_import_readback_payload(
+    *,
+    summary: Mapping[str, Any],
+    target: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    nested = _mapping(target.get("readback"))
+    if nested:
+        return nested
+    return _mapping(summary.get("runtime_window_import_readback"))
+
+
+def _runtime_import_readback_blockers(
+    *,
+    target: Mapping[str, Any],
+    readback: Mapping[str, Any],
+    profit_proof_count: int,
+) -> list[str]:
+    if not readback:
+        return ["runtime_window_import_readback_missing"]
+
+    blockers: list[str] = []
+    count_pairs = (
+        (
+            "metric_window_count",
+            "runtime_window_import_metric_window_readback_mismatch",
+        ),
+        (
+            "promotion_decision_count",
+            "runtime_window_import_promotion_decision_readback_mismatch",
+        ),
+        (
+            "runtime_ledger_bucket_count",
+            "runtime_window_import_runtime_ledger_bucket_readback_mismatch",
+        ),
+        (
+            "evidence_grade_runtime_ledger_bucket_count",
+            "runtime_window_import_evidence_grade_runtime_ledger_bucket_readback_mismatch",
+        ),
+    )
+    for key, blocker in count_pairs:
+        if _int(target.get(key)) != _int(readback.get(key)):
+            blockers.append(blocker)
+
+    ref_pairs = (
+        (
+            "metric_window_ids",
+            "metric_window_refs",
+            "runtime_window_import_metric_window_refs_readback_mismatch",
+        ),
+        (
+            "runtime_ledger_bucket_ids",
+            "runtime_ledger_bucket_refs",
+            "runtime_window_import_runtime_ledger_bucket_refs_readback_mismatch",
+        ),
+        (
+            "evidence_grade_runtime_ledger_bucket_ids",
+            "evidence_grade_runtime_ledger_bucket_refs",
+            "runtime_window_import_evidence_grade_runtime_ledger_bucket_refs_readback_mismatch",
+        ),
+    )
+    for target_key, readback_key, blocker in ref_pairs:
+        target_refs = _text_list(target.get(target_key))
+        readback_refs = _text_list(readback.get(readback_key))
+        if len(readback_refs) < len(target_refs):
+            blockers.append(blocker)
+    if _text(target.get("promotion_decision_id")) and not _text_list(
+        readback.get("promotion_decision_refs")
+    ):
+        blockers.append("runtime_window_import_promotion_decision_ref_readback_missing")
+    if profit_proof_count > 0 and not _text_list(readback.get("source_refs")):
+        blockers.append("runtime_window_import_readback_source_refs_missing")
+    return list(dict.fromkeys(blockers))
+
+
 def _runtime_import_target_surface_blockers(
     *,
     summary: Mapping[str, Any],
@@ -1109,6 +1210,13 @@ def _runtime_import_target_surface_blockers(
         blockers.extend(
             _runtime_import_target_blocker_codes(target.get("proof_blockers"))
         )
+    blockers.extend(
+        _runtime_import_readback_blockers(
+            target=target,
+            readback=_runtime_import_readback_payload(summary=summary, target=target),
+            profit_proof_count=profit_proof_count,
+        )
+    )
     return list(dict.fromkeys(blockers))
 
 
@@ -2034,8 +2142,12 @@ def build_runtime_ledger_proof_packet(
             runtime_summary.get("runtime_ledger_closed_trade_count"),
         )
     )
-    open_position_count_present = "runtime_ledger_open_position_count" in runtime_summary
-    open_position_count = _int(runtime_summary.get("runtime_ledger_open_position_count"))
+    open_position_count_present = (
+        "runtime_ledger_open_position_count" in runtime_summary
+    )
+    open_position_count = _int(
+        runtime_summary.get("runtime_ledger_open_position_count")
+    )
     filled_notional = _decimal(runtime_summary.get("runtime_ledger_filled_notional"))
     cost_amount = _decimal(runtime_summary.get("runtime_ledger_cost_amount"))
     net_pnl = _decimal(
@@ -2113,7 +2225,9 @@ def build_runtime_ledger_proof_packet(
     ledger_schema_versions = _text_list(
         runtime_summary.get("runtime_ledger_schema_versions")
     )
-    cost_basis_counts = _mapping(runtime_summary.get("runtime_ledger_cost_basis_counts"))
+    cost_basis_counts = _mapping(
+        runtime_summary.get("runtime_ledger_cost_basis_counts")
+    )
     cost_model_hash_count = _int(
         runtime_summary.get("runtime_ledger_cost_model_hash_count")
     )
@@ -2193,8 +2307,12 @@ def build_runtime_ledger_proof_packet(
             authority_mechanical_blockers.append(
                 "runtime_ledger_open_position_count_nonzero"
             )
-        if cost_amount is None or (not cost_basis_counts and cost_model_hash_count <= 0):
-            authority_mechanical_blockers.append("runtime_ledger_explicit_costs_missing")
+        if cost_amount is None or (
+            not cost_basis_counts and cost_model_hash_count <= 0
+        ):
+            authority_mechanical_blockers.append(
+                "runtime_ledger_explicit_costs_missing"
+            )
         if source_authority_bucket_count < max(1, bucket_count):
             authority_mechanical_blockers.append(
                 "runtime_ledger_source_authority_missing"
@@ -2230,9 +2348,7 @@ def build_runtime_ledger_proof_packet(
         },
         expected={
             "min_closed_round_trips": min_runtime_ledger_closed_round_trips,
-            "min_filled_notional": _decimal_text(
-                min_runtime_ledger_filled_notional
-            ),
+            "min_filled_notional": _decimal_text(min_runtime_ledger_filled_notional),
             "open_position_count": 0,
             "explicit_costs": True,
             "source_backed_runtime_ledger_refs": True,

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -212,6 +212,7 @@ def _runtime_import(
     proof_blockers: list[str] | None = None,
     authoritative: bool = True,
     materialization_target: bool = True,
+    readback: bool = True,
 ) -> dict[str, object]:
     blocker_payloads = [{"blocker": blocker} for blocker in proof_blockers or []]
     target_payload: dict[str, object] = {
@@ -246,6 +247,44 @@ def _runtime_import(
         "proof_blockers": blocker_payloads,
         "materialized": authoritative and proof_status == "ok" and not blocker_payloads,
     }
+    if readback:
+        target_payload["readback"] = {
+            "schema_version": "torghut.runtime-window-import-readback.v1",
+            "run_id": "runtime-import-run-1",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "hypothesis_id": "H-PAIRS-01",
+            "observed_stage": "paper",
+            "window_start": "2026-05-26T13:30:00+00:00",
+            "window_end": "2026-05-26T20:00:00+00:00",
+            "metric_window_count": 1,
+            "promotion_decision_count": 1,
+            "runtime_ledger_bucket_count": 1 if authoritative else 0,
+            "evidence_grade_runtime_ledger_bucket_count": 1 if authoritative else 0,
+            "metric_window_refs": [
+                "strategy_hypothesis_metric_windows:metric-window-1"
+            ],
+            "promotion_decision_refs": [
+                "strategy_promotion_decisions:promotion-decision-1"
+            ],
+            "runtime_ledger_bucket_refs": [
+                "strategy_runtime_ledger_buckets:runtime-ledger-bucket-1"
+            ]
+            if authoritative
+            else [],
+            "evidence_grade_runtime_ledger_bucket_refs": [
+                "strategy_runtime_ledger_buckets:runtime-ledger-bucket-1"
+            ]
+            if authoritative
+            else [],
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ]
+            if authoritative
+            else [],
+        }
     if authoritative:
         target_payload["tigerbeetle"] = {
             "schema_version": "torghut.tigerbeetle-runtime-ledger-proof-refs.v1",
@@ -301,6 +340,8 @@ def _runtime_import(
     }
     if materialization_target:
         summary["runtime_materialization_target"] = target_payload
+    if readback:
+        summary["runtime_window_import_readback"] = target_payload["readback"]
     return {
         "status": "ok",
         "proof_status": proof_status,
@@ -931,7 +972,8 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertFalse(result["final_authority_ok"])
         self.assertIn("runtime_window_import_missing", result["blockers"])
         self.assertEqual(
-            result["next_action"], "run_runtime_window_import_from_paper_route_target_plan"
+            result["next_action"],
+            "run_runtime_window_import_from_paper_route_target_plan",
         )
 
     def test_smoke_packet_cannot_grant_promotion_authority(self) -> None:
@@ -1245,7 +1287,9 @@ class TestRuntimeLedgerProofPacket(TestCase):
                     ),
                 },
             )
-            self.assertRegex(local_payload["artifact"]["payload_sha256"], r"^[0-9a-f]{64}$")
+            self.assertRegex(
+                local_payload["artifact"]["payload_sha256"], r"^[0-9a-f]{64}$"
+            )
             lineage = local_payload["evidence"]["runtime_window_import"]["lineage"]
             self.assertEqual(
                 lineage["run_id"],
@@ -1968,7 +2012,9 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertIn("runtime_ledger_post_cost_expectancy_not_positive", blockers)
         self.assertIn("runtime_ledger_net_pnl_below_target", blockers)
         self.assertIn("runtime_ledger_trading_days_below_target", blockers)
-        self.assertIn("runtime_ledger_mean_daily_net_pnl_after_costs_below_floor", blockers)
+        self.assertIn(
+            "runtime_ledger_mean_daily_net_pnl_after_costs_below_floor", blockers
+        )
         self.assertIn(
             "keep_promotion_blocked_until_live_gate_and_proof_floor_pass",
             result["required_actions"],
@@ -2039,6 +2085,81 @@ class TestRuntimeLedgerProofPacket(TestCase):
             "c88421d619759b2cfaa6f4d0",
         )
         self.assertTrue(materialization["materialized_targets"][0]["materialized"])
+        self.assertEqual(
+            materialization["materialized_targets"][0]["readback"][
+                "runtime_ledger_bucket_refs"
+            ],
+            ["strategy_runtime_ledger_buckets:runtime-ledger-bucket-1"],
+        )
+        self.assertEqual(
+            materialization["materialized_targets"][0]["readback"]["source_refs"],
+            [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+        )
+
+    def test_packet_blocks_authority_when_runtime_import_readback_missing(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(readback=False),
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(materialization["materialized_target_count"], 0)
+        self.assertEqual(materialization["unmaterialized_target_count"], 1)
+        self.assertIn(
+            "runtime_window_import_readback_missing", materialization["blockers"]
+        )
+        self.assertIn(
+            "runtime_window_import_readback_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+
+    def test_packet_blocks_authority_when_runtime_import_readback_lacks_source_refs(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        target = runtime_import["imports"][0]["summary"][
+            "runtime_materialization_target"
+        ]
+        assert isinstance(target, dict)
+        readback = target["readback"]
+        assert isinstance(readback, dict)
+        readback["source_refs"] = []
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertIn(
+            "runtime_window_import_readback_source_refs_missing",
+            materialization["blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_readback_source_refs_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
 
     def test_packet_blocks_runtime_import_profit_proof_blockers(self) -> None:
         runtime_import = _runtime_import()
@@ -2611,6 +2732,26 @@ class TestRuntimeLedgerProofPacket(TestCase):
                         "evidence_grade_runtime_ledger_bucket_ids": [
                             "runtime-ledger-bucket-1"
                         ],
+                        "readback": {
+                            "schema_version": "torghut.runtime-window-import-readback.v1",
+                            "metric_window_count": 1,
+                            "promotion_decision_count": 1,
+                            "runtime_ledger_bucket_count": 1,
+                            "evidence_grade_runtime_ledger_bucket_count": 1,
+                            "metric_window_refs": [
+                                "strategy_hypothesis_metric_windows:metric-window-1"
+                            ],
+                            "promotion_decision_refs": [
+                                "strategy_promotion_decisions:promotion-decision-1"
+                            ],
+                            "runtime_ledger_bucket_refs": [
+                                "strategy_runtime_ledger_buckets:runtime-ledger-bucket-1"
+                            ],
+                            "evidence_grade_runtime_ledger_bucket_refs": [
+                                "strategy_runtime_ledger_buckets:runtime-ledger-bucket-1"
+                            ],
+                            "source_refs": ["postgres:executions"],
+                        },
                     },
                 },
             },

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1461,6 +1461,97 @@ class TestRuntimeWindowImport(TestCase):
         )
         self.assertNotIn("runtime_ledger_readback_source", ledger_rows[0].payload_json)
 
+    def test_persist_source_backed_paper_window_returns_deterministic_readback(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc),
+                    datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+                    6,
+                )
+            ],
+            decision_times=[
+                datetime(2026, 6, 1, 13, 41, tzinfo=timezone.utc),
+                datetime(2026, 6, 1, 13, 45, tzinfo=timezone.utc),
+            ],
+            execution_times=[
+                datetime(2026, 6, 1, 13, 42, tzinfo=timezone.utc),
+                datetime(2026, 6, 1, 13, 46, tzinfo=timezone.utc),
+            ],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 6, 1, 13, 46, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("40"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        bucket_started_at="2026-06-01T13:41:00+00:00",
+                        bucket_ended_at="2026-06-01T13:46:00+00:00",
+                        source_window_start="2026-06-01T13:41:00+00:00",
+                        source_window_end="2026-06-01T13:46:00+00:00",
+                        account_label="TORGHUT_SIM",
+                        strategy_id="microbar-cross-sectional-pairs-v1",
+                        cost_basis_counts={"broker_reported_commission_and_fees": 2},
+                        net_strategy_pnl_after_costs="0.80",
+                    ),
+                    **_runtime_pnl_basis(),
+                }
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-hpairs-source-backed-readback",
+                candidate_id="cand-hpairs-source-backed",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=buckets,
+                runtime_observation_payload={
+                    "authoritative": True,
+                    "authority_reason": "runtime_ledger_profit_proof",
+                    "promotion_authority": "runtime_ledger",
+                    "runtime_ledger_profit_proof_present": True,
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "source_kind": "runtime_ledger_source_collection_candidate",
+                },
+            )
+            session.commit()
+
+        readback = summary["runtime_window_import_readback"]
+        self.assertEqual(
+            readback["schema_version"], "torghut.runtime-window-import-readback.v1"
+        )
+        self.assertEqual(readback["metric_window_count"], 1)
+        self.assertEqual(readback["promotion_decision_count"], 1)
+        self.assertEqual(readback["runtime_ledger_bucket_count"], 1)
+        self.assertEqual(readback["evidence_grade_runtime_ledger_bucket_count"], 1)
+        self.assertEqual(readback["runtime_ledger_closed_trade_count"], 1)
+        self.assertEqual(readback["runtime_ledger_open_position_count"], 0)
+        self.assertEqual(readback["runtime_ledger_filled_notional"], "200")
+        self.assertIn("postgres:trade_decisions", readback["source_refs"])
+        self.assertIn(
+            "runtime_order_feed_execution_source", readback["authority_classes"]
+        )
+        self.assertEqual(summary["proof_status"], "ok")
+        self.assertEqual(summary["proof_blockers"], [])
+        self.assertFalse(summary["promotion_allowed"])
+        self.assertIn(
+            "paper_stage_evidence_collection_only",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertEqual(
+            summary["runtime_materialization_target"]["readback"], readback
+        )
+
     def test_persist_observed_runtime_windows_uses_notional_weighted_ledger_summary(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Added deterministic runtime-window import readback metadata for persisted metric windows, promotion decisions, runtime-ledger buckets, source refs, lifecycle counts, and authority classes.
- Made runtime-ledger proof packets require import readback/source-ref metadata before authority materialization can pass.
- Added regressions for source-backed H-PAIRS paper imports, missing readback fail-closed behavior, and missing source-ref readback blockers.

## Related Issues

None

## Testing

- `uv run ruff format app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run ruff check app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run pytest tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_import_hypothesis_runtime_windows.py::TestImportHypothesisRuntimeWindows::test_runtime_observation_authority_keeps_simulation_replay_only -q`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run pyright --project pyrightconfig.scripts.json`
- `uv sync --frozen --extra dev` could not complete in this workspace because `crosshair-tool` requires a C compiler and `cc` is not installed; targeted pytest/ruff/pyright were run with the locked pyright version installed directly.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
