### PR TITLE
feat(torghut): record tigerbeetle runtime ledger parity

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -49,7 +49,15 @@ from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
 from .runtime_ledger_source_authority import (
     runtime_ledger_promotion_source_authority_blockers,
 )
-from .tigerbeetle_journal import TigerBeetleLedgerJournal
+from .tigerbeetle_journal import (
+    TIGERBEETLE_BLOCKER_JOURNAL_DISABLED,
+    TIGERBEETLE_BLOCKER_JOURNAL_ENTRY_UNAVAILABLE,
+    TIGERBEETLE_BLOCKER_JOURNAL_ERROR,
+    TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_NON_AUTHORITY_BLOCKED,
+    TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
+    TigerBeetleLedgerJournal,
+    tigerbeetle_runtime_ledger_journal_payload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1734,6 +1742,17 @@ def _tigerbeetle_account_refs_for_ids(
     )
 
 
+def _tigerbeetle_account_refs_for_transfer_ref(
+    session: Session,
+    ref: TigerBeetleTransferRef,
+) -> list[TigerBeetleAccountRef]:
+    return _tigerbeetle_account_refs_for_ids(
+        session=session,
+        cluster_ids=[ref.cluster_id],
+        account_ids=_tigerbeetle_transfer_account_ids(ref),
+    )
+
+
 def _tigerbeetle_refs_for_ledger_payload(
     session: Session,
     ledger_payload: Mapping[str, Any],
@@ -1952,20 +1971,125 @@ def _journal_tigerbeetle_runtime_ledger_bucket(
     row: StrategyRuntimeLedgerBucket,
 ) -> None:
     if not settings.tigerbeetle_enabled or not settings.tigerbeetle_journal_enabled:
+        _mark_runtime_ledger_bucket_tigerbeetle_journal(
+            session,
+            row,
+            ref=None,
+            status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_NON_AUTHORITY_BLOCKED,
+            blockers=[TIGERBEETLE_BLOCKER_JOURNAL_DISABLED],
+        )
         return
     session.flush()
     try:
         with TigerBeetleLedgerJournal() as journal, session.begin_nested():
-            journal.journal_runtime_ledger_bucket(session, row)
+            ref = journal.journal_runtime_ledger_bucket(session, row)
     except Exception as exc:
         if settings.tigerbeetle_required:
             raise
+        _mark_runtime_ledger_bucket_tigerbeetle_journal(
+            session,
+            row,
+            ref=None,
+            status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_NON_AUTHORITY_BLOCKED,
+            blockers=[TIGERBEETLE_BLOCKER_JOURNAL_ERROR],
+            error=f"{type(exc).__name__}: {exc}",
+        )
         logger.warning(
             "TigerBeetle runtime-ledger journal failed for bucket_id=%s run_id=%s: %s",
             row.id,
             row.run_id,
             exc,
         )
+        return
+    if ref is None:
+        _mark_runtime_ledger_bucket_tigerbeetle_journal(
+            session,
+            row,
+            ref=None,
+            status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_NON_AUTHORITY_BLOCKED,
+            blockers=[TIGERBEETLE_BLOCKER_JOURNAL_ENTRY_UNAVAILABLE],
+        )
+        return
+    _mark_runtime_ledger_bucket_tigerbeetle_journal(
+        session,
+        row,
+        ref=ref,
+        status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
+        blockers=[],
+    )
+
+
+def _mark_runtime_ledger_bucket_tigerbeetle_journal(
+    session: Session,
+    row: StrategyRuntimeLedgerBucket,
+    *,
+    ref: TigerBeetleTransferRef | None,
+    status: str,
+    blockers: Sequence[str],
+    error: str | None = None,
+) -> None:
+    account_refs = (
+        _tigerbeetle_account_refs_for_transfer_ref(session, ref)
+        if ref is not None
+        else []
+    )
+    journal_payload = tigerbeetle_runtime_ledger_journal_payload(
+        bucket=row,
+        ref=ref,
+        status=status,
+        blockers=blockers,
+        account_refs=account_refs,
+        error=error,
+    )
+    existing_payload = _mapping(row.payload_json)
+    source_refs = _string_list(existing_payload.get("source_refs"))
+    for source_ref in _string_list(journal_payload.get("source_refs")):
+        if source_ref not in source_refs:
+            source_refs.append(source_ref)
+    source_row_counts = _mapping(existing_payload.get("source_row_counts"))
+    if ref is not None:
+        source_row_counts["tigerbeetle_transfer_refs"] = 1
+        source_row_counts["tigerbeetle_account_refs"] = len(account_refs)
+    existing_tigerbeetle_refs = _mapping(existing_payload.get("tigerbeetle"))
+    tigerbeetle_refs = (
+        journal_payload
+        if ref is not None or not existing_tigerbeetle_refs
+        else existing_tigerbeetle_refs
+    )
+    tigerbeetle_account_ids = (
+        journal_payload["account_ids"]
+        if ref is not None
+        else existing_payload.get("tigerbeetle_account_ids")
+        or tigerbeetle_refs.get("account_ids")
+        or journal_payload["account_ids"]
+    )
+    tigerbeetle_account_keys = (
+        journal_payload["account_keys"]
+        if ref is not None
+        else existing_payload.get("tigerbeetle_account_keys")
+        or tigerbeetle_refs.get("account_keys")
+        or journal_payload["account_keys"]
+    )
+    tigerbeetle_transfer_ids = (
+        journal_payload["transfer_ids"]
+        if ref is not None
+        else existing_payload.get("tigerbeetle_transfer_ids")
+        or tigerbeetle_refs.get("transfer_ids")
+        or journal_payload["transfer_ids"]
+    )
+    row.payload_json = {
+        **existing_payload,
+        "source_refs": source_refs,
+        "source_row_counts": source_row_counts,
+        "tigerbeetle_journal_parity": journal_payload,
+        "tigerbeetle": tigerbeetle_refs,
+        "tigerbeetle_account_ids": tigerbeetle_account_ids,
+        "tigerbeetle_account_keys": tigerbeetle_account_keys,
+        "tigerbeetle_transfer_ids": tigerbeetle_transfer_ids,
+        "tigerbeetle_non_authority_blockers": journal_payload["authority_blockers"],
+    }
+    session.add(row)
+    session.flush()
 
 
 def _runtime_ledger_daily_summary_from_observed_buckets(

--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -57,6 +57,25 @@ SOURCE_TYPE_EXECUTION = "execution"
 SOURCE_TYPE_EXECUTION_ORDER_EVENT = "execution_order_event"
 SOURCE_TYPE_EXECUTION_TCA_METRIC = "execution_tca_metric"
 SOURCE_TYPE_RUNTIME_LEDGER_BUCKET = "strategy_runtime_ledger_bucket"
+TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_PARITY_SCHEMA_VERSION = (
+    "torghut.tigerbeetle-runtime-ledger-journal-parity.v1"
+)
+TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS = "pass"
+TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_NON_AUTHORITY_BLOCKED = (
+    "non_authority_blocked"
+)
+TIGERBEETLE_BLOCKER_JOURNAL_DISABLED = "tigerbeetle_journal_disabled"
+TIGERBEETLE_BLOCKER_JOURNAL_ENTRY_UNAVAILABLE = "tigerbeetle_journal_entry_unavailable"
+TIGERBEETLE_BLOCKER_JOURNAL_ERROR = "tigerbeetle_journal_error"
+TIGERBEETLE_AUTHORITY_BLOCKER_ACCOUNTING_ONLY = (
+    "tigerbeetle_accounting_parity_not_promotion_authority"
+)
+TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_REFS_MISSING = (
+    "runtime_ledger_source_refs_missing"
+)
+TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_WINDOW_REFS_MISSING = (
+    "runtime_ledger_source_window_refs_missing"
+)
 
 
 def _official_status_name(value: object) -> str | None:
@@ -125,6 +144,151 @@ def _lookup_payload_decimal(
 
 def _nested_mapping(value: object) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _payload_text_list(value: object) -> list[str]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items = cast(Sequence[object], value)
+        return [text for item in items if (text := str(item).strip())]
+    text = str(value).strip() if value is not None else ""
+    return [text] if text else []
+
+
+def runtime_ledger_bucket_source_authority_blockers(
+    bucket: StrategyRuntimeLedgerBucket,
+) -> list[str]:
+    """Return source-window blockers that keep TigerBeetle parity non-authoritative.
+
+    TigerBeetle is a deterministic double-entry accounting mirror. Runtime-ledger
+    source rows and source-window refs remain the promotion authority for honest
+    PnL proof, so the journal records explicitly carry blockers when that source
+    context is not present on the persisted bucket payload.
+    """
+
+    payload = _nested_mapping(bucket.payload_json)
+    source_refs = [
+        source_ref
+        for source_ref in [
+            *(_payload_text_list(payload.get("source_refs"))),
+            *(_payload_text_list(payload.get("runtime_ledger_source_refs"))),
+        ]
+        if "tigerbeetle" not in source_ref
+        and "strategy_runtime_ledger_buckets" not in source_ref
+    ]
+    source_row_counts = _nested_mapping(payload.get("source_row_counts"))
+    source_window_refs = [
+        *(_payload_text_list(payload.get("source_window_refs"))),
+        *(_payload_text_list(payload.get("runtime_ledger_source_window_refs"))),
+        *(_payload_text_list(payload.get("source_window_id"))),
+    ]
+    has_source_rows = bool(source_refs) or any(
+        _positive_payload_count(value)
+        for key, value in source_row_counts.items()
+        if str(key).startswith(
+            (
+                "execution",
+                "runtime_ledger",
+                "strategy_runtime",
+                "trade_decision",
+            )
+        )
+    )
+    blockers = [TIGERBEETLE_AUTHORITY_BLOCKER_ACCOUNTING_ONLY]
+    if not has_source_rows:
+        blockers.append(
+            TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_REFS_MISSING
+        )
+    if not source_window_refs:
+        blockers.append(
+            TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_WINDOW_REFS_MISSING
+        )
+    return blockers
+
+
+def _positive_payload_count(value: object) -> bool:
+    try:
+        return Decimal(str(value or "0")) > 0
+    except Exception:
+        return False
+
+
+def tigerbeetle_runtime_ledger_journal_payload(
+    *,
+    bucket: StrategyRuntimeLedgerBucket,
+    ref: TigerBeetleTransferRef | None,
+    status: str,
+    blockers: Sequence[str] = (),
+    account_refs: Sequence[TigerBeetleAccountRef] = (),
+    error: str | None = None,
+) -> dict[str, object]:
+    """Build stable bucket metadata for TigerBeetle journal parity.
+
+    The payload is intentionally explicit that TigerBeetle is not the final
+    promotion authority. It gives proof assemblers durable refs when present and
+    gives readiness checks deterministic non-authority blockers when journaling is
+    disabled, skipped, or degraded.
+    """
+
+    account_ids: list[str] = []
+    transfer_ids: list[str] = []
+    source_refs = [f"postgres:strategy_runtime_ledger_buckets:{bucket.id}"]
+    cluster_ids: list[int] = []
+    transfer_payload: Mapping[str, object] = {}
+    if ref is not None:
+        transfer_ids.append(ref.transfer_id)
+        source_refs.append(f"postgres:tigerbeetle_transfer_refs:{ref.id}")
+        cluster_ids.append(ref.cluster_id)
+        transfer_payload = _nested_mapping(ref.payload_json)
+        for key in ("debit_account_id", "credit_account_id"):
+            raw_account_id = transfer_payload.get(key)
+            if raw_account_id is not None:
+                account_id = str(raw_account_id)
+                if account_id not in account_ids:
+                    account_ids.append(account_id)
+    for account_ref in account_refs:
+        if account_ref.account_id not in account_ids:
+            account_ids.append(account_ref.account_id)
+        if account_ref.cluster_id not in cluster_ids:
+            cluster_ids.append(account_ref.cluster_id)
+
+    return coerce_json_payload(
+        {
+            "schema_version": (
+                TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_PARITY_SCHEMA_VERSION
+            ),
+            "status": status,
+            "journal_record_available": ref is not None,
+            "authority": "accounting_parity_only",
+            "promotion_authority": False,
+            "overrides_runtime_ledger_authority": False,
+            "blockers": sorted({str(item) for item in blockers if str(item)}),
+            "authority_blockers": runtime_ledger_bucket_source_authority_blockers(
+                bucket
+            ),
+            "error": error,
+            "runtime_ledger_bucket_id": str(bucket.id),
+            "cluster_ids": sorted(cluster_ids),
+            "account_count": len(account_refs),
+            "account_ids": sorted(account_ids),
+            "account_keys": sorted({row.account_key for row in account_refs}),
+            "transfer_count": len(transfer_ids),
+            "transfer_ids": sorted(transfer_ids),
+            "source_refs": source_refs,
+            "transfer": {
+                "cluster_id": ref.cluster_id,
+                "transfer_id": ref.transfer_id,
+                "transfer_kind": ref.transfer_kind,
+                "ledger": ref.ledger,
+                "code": ref.code,
+                "amount": str(ref.amount),
+                "status": ref.status,
+                "debit_account_id": transfer_payload.get("debit_account_id"),
+                "credit_account_id": transfer_payload.get("credit_account_id"),
+            }
+            if ref is not None
+            else None,
+        }
+    )
 
 
 FILL_POST_EVENT_TYPES = {"fill", "filled", "partial_fill", "partially_filled"}

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import String, create_engine, select
 from sqlalchemy.orm import sessionmaker
@@ -26,8 +27,10 @@ from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION_ORDER_EVENT,
     SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+    TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
     TigerBeetleLedgerJournal,
     build_order_event_transfer_plan,
+    tigerbeetle_runtime_ledger_journal_payload,
 )
 from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_EXECUTION_COST,
@@ -268,6 +271,10 @@ def _journal_source_batch(
             if ref is None:
                 batch["skipped"] = int(batch["skipped"]) + 1
             else:
+                if source == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET and isinstance(
+                    ref, TigerBeetleTransferRef
+                ):
+                    _attach_runtime_bucket_journal_payload(row, ref)
                 batch["journaled"] = int(batch["journaled"]) + 1
         except Exception as exc:
             batch["failed"] = int(batch["failed"]) + 1
@@ -285,6 +292,52 @@ def _journal_source_batch(
                     }
                 )
     return batch
+
+
+def _attach_runtime_bucket_journal_payload(
+    row: StrategyRuntimeLedgerBucket,
+    ref: TigerBeetleTransferRef,
+) -> None:
+    journal_payload = tigerbeetle_runtime_ledger_journal_payload(
+        bucket=row,
+        ref=ref,
+        status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
+    )
+    existing_payload = (
+        dict(row.payload_json) if isinstance(row.payload_json, dict) else {}
+    )
+    source_refs = [
+        str(item)
+        for item in existing_payload.get("source_refs", [])
+        if str(item).strip()
+    ]
+    raw_journal_source_refs = journal_payload.get("source_refs")
+    journal_source_refs = (
+        cast(Sequence[object], raw_journal_source_refs)
+        if isinstance(raw_journal_source_refs, Sequence)
+        and not isinstance(raw_journal_source_refs, (str, bytes, bytearray))
+        else ()
+    )
+    for source_ref in journal_source_refs:
+        if isinstance(source_ref, str) and source_ref not in source_refs:
+            source_refs.append(source_ref)
+    source_row_counts = (
+        dict(existing_payload.get("source_row_counts", {}))
+        if isinstance(existing_payload.get("source_row_counts"), dict)
+        else {}
+    )
+    source_row_counts["tigerbeetle_transfer_refs"] = 1
+    row.payload_json = {
+        **existing_payload,
+        "source_refs": source_refs,
+        "source_row_counts": source_row_counts,
+        "tigerbeetle_journal_parity": journal_payload,
+        "tigerbeetle": journal_payload,
+        "tigerbeetle_account_ids": journal_payload["account_ids"],
+        "tigerbeetle_account_keys": journal_payload["account_keys"],
+        "tigerbeetle_transfer_ids": journal_payload["transfer_ids"],
+        "tigerbeetle_non_authority_blockers": journal_payload["authority_blockers"],
+    }
 
 
 def _error_summary(exc: Exception) -> str:

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -22,6 +22,10 @@ NEXT_PAPER_ROUTE_TARGET_PLAN_SCHEMA_VERSION = (
 RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION = (
     "torghut.runtime-ledger-live-paper-proof-packet.v1"
 )
+TIGERBEETLE_RUNTIME_LEDGER_PARITY_SCHEMA_VERSION = (
+    "torghut.tigerbeetle-runtime-ledger-parity.v1"
+)
+TIGERBEETLE_PARITY_STATUS_PASS = "pass"
 DOC29_LIVE_SCALE_GATE = "live_scale_observed"
 REQUIRED_RUNTIME_WINDOW_TARGET_PLAN_FLAGS = (
     "--runtime-window-import",
@@ -752,6 +756,56 @@ def _add_runtime_ledger_proof_packet_check(
     )
 
 
+def _add_tigerbeetle_parity_check(
+    checks: dict[str, dict[str, Any]],
+    tigerbeetle_parity: Mapping[str, Any] | None,
+) -> None:
+    parity = _mapping(tigerbeetle_parity)
+    totals = _mapping(parity.get("totals"))
+    read_only_contract = _mapping(parity.get("read_only_contract"))
+    blockers = [
+        text for item in _sequence(parity.get("blockers")) if (text := _text(item))
+    ]
+    schema_version = _text(parity.get("schema_version"))
+    parity_status = _text(parity.get("parity_status"))
+    checked_source_count = _int(totals.get("checked_source_count"))
+    accounting_only = (
+        read_only_contract.get("generates_proof") is False
+        and read_only_contract.get("synthesizes_fills") is False
+        and read_only_contract.get("overrides_runtime_ledger_authority") is False
+    )
+    _add_check(
+        checks,
+        "tigerbeetle_runtime_ledger_parity",
+        passed=(
+            bool(parity)
+            and schema_version == TIGERBEETLE_RUNTIME_LEDGER_PARITY_SCHEMA_VERSION
+            and parity.get("ok") is True
+            and parity_status == TIGERBEETLE_PARITY_STATUS_PASS
+            and checked_source_count > 0
+            and not blockers
+            and accounting_only
+        ),
+        observed={
+            "present": bool(parity),
+            "schema_version": schema_version,
+            "ok": parity.get("ok"),
+            "parity_status": parity_status,
+            "checked_source_count": checked_source_count,
+            "blockers": blockers,
+            "read_only_contract": read_only_contract,
+        },
+        expected={
+            "schema_version": TIGERBEETLE_RUNTIME_LEDGER_PARITY_SCHEMA_VERSION,
+            "ok": True,
+            "parity_status": TIGERBEETLE_PARITY_STATUS_PASS,
+            "checked_source_count": ">0",
+            "blockers": [],
+            "read_only_contract.overrides_runtime_ledger_authority": False,
+        },
+    )
+
+
 def _readiness_next_action(
     *,
     failed_checks: Sequence[str],
@@ -762,6 +816,8 @@ def _readiness_next_action(
     packet_next_action = _text(packet.get("next_action"))
     if "runtime_ledger_proof_packet_authority" in failed_checks and packet_next_action:
         return packet_next_action
+    if "tigerbeetle_runtime_ledger_parity" in failed_checks:
+        return "repair_tigerbeetle_journal_parity_without_using_as_profit_authority"
     blockers: list[str] = []
     for check_name in failed_checks:
         check = _mapping(checks.get(check_name))
@@ -945,6 +1001,7 @@ def evaluate_trading_readiness(
     completion_status: Mapping[str, Any] | None = None,
     paper_route_evidence: Mapping[str, Any] | None = None,
     runtime_ledger_proof_packet: Mapping[str, Any] | None = None,
+    tigerbeetle_parity: Mapping[str, Any] | None = None,
     profile: str = "paper",
     min_routeable_symbols: int = 2,
     min_decisions: int = 0,
@@ -959,6 +1016,7 @@ def evaluate_trading_readiness(
     require_paper_route_import_ready: bool = False,
     require_runtime_ledger_profit_proof: bool = False,
     require_runtime_ledger_proof_packet: bool = False,
+    require_tigerbeetle_parity: bool = False,
     allow_paper_route_preopen_evidence_collection: bool = False,
 ) -> dict[str, Any]:
     """Return a strict readiness verdict from a Torghut trading status payload."""
@@ -1405,6 +1463,8 @@ def evaluate_trading_readiness(
             checks,
             runtime_ledger_proof_packet,
         )
+    if require_tigerbeetle_parity:
+        _add_tigerbeetle_parity_check(checks, tigerbeetle_parity)
 
     paper_route_preopen_evidence_collection = (
         _paper_route_preopen_evidence_collection_ready(
@@ -1450,6 +1510,7 @@ def evaluate_trading_readiness(
         runtime_ledger_proof_packet=runtime_ledger_proof_packet,
     )
     packet_summary = _mapping(runtime_ledger_proof_packet)
+    tigerbeetle_parity_summary = _mapping(tigerbeetle_parity)
     return {
         "schema_version": SCHEMA_VERSION,
         "ok": not failed_checks,
@@ -1471,9 +1532,7 @@ def evaluate_trading_readiness(
         },
         "runtime_ledger_proof_packet": {
             "required": require_runtime_ledger_proof_packet,
-            "schema_version": _text(
-                packet_summary.get("schema_version")
-            ),
+            "schema_version": _text(packet_summary.get("schema_version")),
             "proof_mode": _text(packet_summary.get("proof_mode")),
             "final_authority_ok": packet_summary.get("final_authority_ok"),
             "capital_promotion_allowed": packet_summary.get(
@@ -1481,6 +1540,12 @@ def evaluate_trading_readiness(
             ),
             "evidence_collection_ok": packet_summary.get("evidence_collection_ok"),
             "next_action": _text(packet_summary.get("next_action")),
+        },
+        "tigerbeetle_parity": {
+            "required": require_tigerbeetle_parity,
+            "schema_version": _text(tigerbeetle_parity_summary.get("schema_version")),
+            "parity_status": _text(tigerbeetle_parity_summary.get("parity_status")),
+            "ok": tigerbeetle_parity_summary.get("ok"),
         },
     }
 
@@ -1523,6 +1588,16 @@ def _parser() -> argparse.ArgumentParser:
     runtime_ledger_packet_source.add_argument(
         "--runtime-ledger-proof-packet-url",
         help="URL returning an assemble_runtime_ledger_proof_packet.py JSON payload.",
+    )
+    tigerbeetle_parity_source = parser.add_mutually_exclusive_group(required=False)
+    tigerbeetle_parity_source.add_argument(
+        "--tigerbeetle-parity-file",
+        type=Path,
+        help="Path to an audit_tigerbeetle_runtime_ledger_parity.py JSON payload.",
+    )
+    tigerbeetle_parity_source.add_argument(
+        "--tigerbeetle-parity-url",
+        help="URL returning a TigerBeetle/runtime-ledger parity payload.",
     )
     parser.add_argument(
         "--profile", choices=("paper", "live", "either"), default="paper"
@@ -1574,6 +1649,14 @@ def _parser() -> argparse.ArgumentParser:
         help="Require canonical runtime-ledger proof packet promotion authority.",
     )
     parser.add_argument(
+        "--require-tigerbeetle-parity",
+        action="store_true",
+        help=(
+            "Require TigerBeetle journal parity to pass as an accounting-only "
+            "companion check; this never satisfies runtime-ledger proof authority."
+        ),
+    )
+    parser.add_argument(
         "--allow-paper-route-preopen-evidence-collection",
         action="store_true",
         help=(
@@ -1610,6 +1693,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         url=args.runtime_ledger_proof_packet_url,
         timeout_seconds=args.timeout_seconds,
     )
+    tigerbeetle_parity = _load_optional_json_object(
+        path=args.tigerbeetle_parity_file,
+        url=args.tigerbeetle_parity_url,
+        timeout_seconds=args.timeout_seconds,
+    )
     min_runtime_ledger_net_pnl = _decimal(args.min_runtime_ledger_net_pnl)
     if min_runtime_ledger_net_pnl is None:
         raise SystemExit(
@@ -1626,6 +1714,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         completion_status=completion_status,
         paper_route_evidence=paper_route_evidence,
         runtime_ledger_proof_packet=runtime_ledger_proof_packet,
+        tigerbeetle_parity=tigerbeetle_parity,
         profile=str(args.profile),
         min_routeable_symbols=max(0, int(args.min_routeable_symbols)),
         min_decisions=max(0, int(args.min_decisions)),
@@ -1648,6 +1737,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         require_runtime_ledger_proof_packet=bool(
             args.require_runtime_ledger_proof_packet
         ),
+        require_tigerbeetle_parity=bool(args.require_tigerbeetle_parity),
         allow_paper_route_preopen_evidence_collection=bool(
             args.allow_paper_route_preopen_evidence_collection
         ),

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -267,6 +267,99 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(payload["failed"], 0)
         self.assertTrue(payload["fail_on_degraded"])
 
+    def test_process_rows_attaches_runtime_bucket_journal_payload(self) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        observed_at = datetime.now(timezone.utc)
+        with Session(self.engine) as session:
+            bucket = StrategyRuntimeLedgerBucket(
+                run_id="runtime-run-journal-attach",
+                candidate_id="candidate",
+                hypothesis_id="hypothesis",
+                observed_stage="paper",
+                bucket_started_at=observed_at,
+                bucket_ended_at=observed_at,
+                account_label="paper",
+                runtime_strategy_name="demo-runtime",
+                strategy_family="demo",
+                fill_count=1,
+                decision_count=1,
+                submitted_order_count=1,
+                cancelled_order_count=0,
+                rejected_order_count=0,
+                unfilled_order_count=0,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("190.25"),
+                gross_strategy_pnl=Decimal("3.00"),
+                cost_amount=Decimal("0.50"),
+                net_strategy_pnl_after_costs=Decimal("2.50"),
+                post_cost_expectancy_bps=Decimal("12.50"),
+                ledger_schema_version="torghut.runtime-ledger.v1",
+                pnl_basis="post_cost",
+                payload_json={
+                    "source_refs": ["postgres:execution_order_events:event-1"],
+                    "source_row_counts": {"execution_order_events": 1},
+                    "source_window_refs": ["kafka:torghut.trade-updates.v1:0:1-2"],
+                },
+            )
+            session.add(bucket)
+            session.flush()
+            ref = TigerBeetleTransferRef(
+                cluster_id=settings_obj.tigerbeetle_cluster_id,
+                transfer_id="340282366920938463463374607431768211",
+                transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_FILL_POST,
+                amount=Decimal("2500000"),
+                status="created",
+                runtime_ledger_bucket_id=bucket.id,
+                source_type=script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                source_id=str(bucket.id),
+                payload_json={
+                    "debit_account_id": "100100100100100100100100100100100101",
+                    "credit_account_id": "100100100100100100100100100100100102",
+                },
+            )
+            session.add(ref)
+            session.flush()
+
+            batch = script._journal_source_batch(
+                session,
+                args=argparse.Namespace(dry_run=False),
+                source=script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                rows=[bucket],
+                journal_one=lambda row: ref,
+            )
+
+        self.assertEqual(batch["journaled"], 1)
+        self.assertEqual(batch["failed"], 0)
+        payload = bucket.payload_json
+        self.assertIsInstance(payload, dict)
+        self.assertIn("postgres:execution_order_events:event-1", payload["source_refs"])
+        self.assertIn(
+            f"postgres:strategy_runtime_ledger_buckets:{bucket.id}",
+            payload["source_refs"],
+        )
+        self.assertIn(
+            f"postgres:tigerbeetle_transfer_refs:{ref.id}",
+            payload["source_refs"],
+        )
+        self.assertEqual(
+            payload["source_row_counts"]["tigerbeetle_transfer_refs"],
+            1,
+        )
+        self.assertEqual(
+            payload["tigerbeetle_transfer_ids"],
+            ["340282366920938463463374607431768211"],
+        )
+        self.assertEqual(
+            payload["tigerbeetle_journal_parity"]["status"],
+            "pass",
+        )
+        self.assertFalse(
+            payload["tigerbeetle_journal_parity"]["promotion_authority"],
+        )
+
     def test_select_unlinked_events_filters_to_journalable_account_rows(self) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1836,11 +1836,15 @@ class TestRuntimeWindowImport(TestCase):
 
         summary = _runtime_ledger_daily_summary_from_observed_buckets(buckets)
 
+        self.assertEqual(summary["runtime_ledger_observed_trading_day_count"], 2)
         self.assertEqual(
             summary["runtime_ledger_net_pnl_by_trading_day"]["2026-03-06"], "-30"
         )
         self.assertEqual(
             summary["runtime_ledger_mean_daily_net_pnl_after_costs"], "-10"
+        )
+        self.assertEqual(
+            summary["runtime_ledger_median_daily_net_pnl_after_costs"], "-10"
         )
         self.assertEqual(summary["runtime_ledger_p10_daily_net_pnl_after_costs"], "-30")
         self.assertEqual(summary["runtime_ledger_max_intraday_drawdown"], "130")

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -22,6 +22,7 @@ from app.models import (
     TigerBeetleTransferRef,
     VNextDatasetSnapshot,
 )
+from app.trading.tigerbeetle_client import FakeTigerBeetleClient
 from app.trading.runtime_cost_authority import (
     cost_basis_counts_have_non_promotion_grade_costs,
 )
@@ -212,6 +213,15 @@ class TestRuntimeWindowImport(TestCase):
                     level="WARNING",
                 ):
                     _journal_tigerbeetle_runtime_ledger_bucket(session, row)
+            session.refresh(row)
+            parity = row.payload_json["tigerbeetle_journal_parity"]
+            self.assertEqual(parity["status"], "non_authority_blocked")
+            self.assertEqual(parity["blockers"], ["tigerbeetle_journal_error"])
+            self.assertFalse(parity["promotion_authority"])
+            self.assertIn(
+                "tigerbeetle_accounting_parity_not_promotion_authority",
+                row.payload_json["tigerbeetle_non_authority_blockers"],
+            )
 
             with (
                 patch.object(
@@ -236,6 +246,125 @@ class TestRuntimeWindowImport(TestCase):
             ):
                 with self.assertRaisesRegex(RuntimeError, "journal failed"):
                     _journal_tigerbeetle_runtime_ledger_bucket(session, row)
+
+    def test_runtime_bucket_journal_records_durable_tigerbeetle_refs(self) -> None:
+        with self.session_local() as session:
+            row = StrategyRuntimeLedgerBucket(
+                run_id="run-journal-success",
+                candidate_id="cand",
+                hypothesis_id="hyp",
+                observed_stage="paper",
+                bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                account_label="TORGHUT_SIM",
+                runtime_strategy_name="strategy",
+                fill_count=2,
+                decision_count=2,
+                submitted_order_count=2,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("200"),
+                gross_strategy_pnl=Decimal("1"),
+                cost_amount=Decimal("0.20"),
+                net_strategy_pnl_after_costs=Decimal("0.80"),
+                post_cost_expectancy_bps=Decimal("40"),
+                pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                payload_json={
+                    "source_refs": ["postgres:execution_order_events:event-1"],
+                    "source_window_refs": ["postgres:source_windows:window-1"],
+                },
+            )
+            session.add(row)
+            session.flush()
+            fake_client = FakeTigerBeetleClient()
+
+            with (
+                patch.object(
+                    runtime_window_import_module.settings,
+                    "tigerbeetle_enabled",
+                    True,
+                ),
+                patch.object(
+                    runtime_window_import_module.settings,
+                    "tigerbeetle_journal_enabled",
+                    True,
+                ),
+                patch.object(
+                    runtime_window_import_module.settings,
+                    "tigerbeetle_required",
+                    False,
+                ),
+                patch(
+                    "app.trading.tigerbeetle_journal.create_tigerbeetle_client",
+                    return_value=fake_client,
+                ),
+            ):
+                _journal_tigerbeetle_runtime_ledger_bucket(session, row)
+
+            session.refresh(row)
+            payload = row.payload_json
+            parity = payload["tigerbeetle_journal_parity"]
+            self.assertEqual(parity["status"], "pass")
+            self.assertEqual(parity["blockers"], [])
+            self.assertFalse(parity["promotion_authority"])
+            self.assertEqual(parity["transfer_count"], 1)
+            self.assertEqual(len(payload["tigerbeetle_transfer_ids"]), 1)
+            self.assertEqual(len(fake_client.transfers), 1)
+            self.assertIn(
+                "postgres:tigerbeetle_transfer_refs",
+                " ".join(payload["source_refs"]),
+            )
+
+    def test_runtime_bucket_journal_disabled_records_non_authority_blocker(
+        self,
+    ) -> None:
+        with self.session_local() as session:
+            row = StrategyRuntimeLedgerBucket(
+                run_id="run-journal-disabled",
+                candidate_id="cand",
+                hypothesis_id="hyp",
+                observed_stage="paper",
+                bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                account_label="TORGHUT_SIM",
+                runtime_strategy_name="strategy",
+                fill_count=2,
+                decision_count=2,
+                submitted_order_count=2,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("200"),
+                gross_strategy_pnl=Decimal("1"),
+                cost_amount=Decimal("0.20"),
+                net_strategy_pnl_after_costs=Decimal("0.80"),
+                post_cost_expectancy_bps=Decimal("40"),
+                pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                payload_json={},
+            )
+            session.add(row)
+            session.flush()
+
+            with (
+                patch.object(
+                    runtime_window_import_module.settings,
+                    "tigerbeetle_enabled",
+                    False,
+                ),
+                patch.object(
+                    runtime_window_import_module.settings,
+                    "tigerbeetle_journal_enabled",
+                    True,
+                ),
+            ):
+                _journal_tigerbeetle_runtime_ledger_bucket(session, row)
+
+            session.refresh(row)
+            parity = row.payload_json["tigerbeetle_journal_parity"]
+            self.assertEqual(parity["status"], "non_authority_blocked")
+            self.assertEqual(parity["blockers"], ["tigerbeetle_journal_disabled"])
+            self.assertEqual(parity["transfer_ids"], [])
 
     def test_build_regular_session_buckets_counts_session_samples(self) -> None:
         buckets = build_regular_session_buckets(

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -27,6 +27,10 @@ from app.models import (
 )
 from app.trading.tigerbeetle_client import FakeTigerBeetleClient
 from app.trading.tigerbeetle_journal import (
+    TIGERBEETLE_AUTHORITY_BLOCKER_ACCOUNTING_ONLY,
+    TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_REFS_MISSING,
+    TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_WINDOW_REFS_MISSING,
+    TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
     TigerBeetleLedgerJournal,
     _account_specs,
     _event_amount_usd,
@@ -43,6 +47,7 @@ from app.trading.tigerbeetle_journal import (
     execution_cost_transfer_id,
     execution_transfer_id,
     runtime_ledger_transfer_id,
+    tigerbeetle_runtime_ledger_journal_payload,
 )
 from app.trading.tigerbeetle_ids import u128_decimal
 from app.trading.tigerbeetle_ledger_model import (
@@ -487,6 +492,10 @@ class TestTigerBeetleLedgerJournal(TestCase):
     def test_runtime_bucket_source_writes_real_runtime_ledger_ref(self) -> None:
         with Session(self.engine) as session:
             bucket = _runtime_bucket()
+            bucket.payload_json = {
+                "source_refs": ["postgres:execution_order_events:event-1"],
+                "source_window_refs": ["postgres:source_windows:window-1"],
+            }
             session.add(bucket)
             session.flush()
             client = FakeTigerBeetleClient()
@@ -506,6 +515,25 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(ref.amount, Decimal("2500000"))
             self.assertEqual(ref.payload_json["pnl_direction"], "profit")
             self.assertEqual(ref.payload_json["signed_amount_micros"], 2500000)
+            parity = tigerbeetle_runtime_ledger_journal_payload(
+                bucket=bucket,
+                ref=ref,
+                status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
+            )
+            self.assertEqual(parity["status"], "pass")
+            self.assertFalse(parity["promotion_authority"])
+            self.assertIn(
+                TIGERBEETLE_AUTHORITY_BLOCKER_ACCOUNTING_ONLY,
+                parity["authority_blockers"],
+            )
+            self.assertNotIn(
+                TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_REFS_MISSING,
+                parity["authority_blockers"],
+            )
+            self.assertNotIn(
+                TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_WINDOW_REFS_MISSING,
+                parity["authority_blockers"],
+            )
             transfer = client.transfers[int(ref.transfer_id)]
             self.assertEqual(
                 ref.payload_json["debit_account_id"],
@@ -515,6 +543,39 @@ class TestTigerBeetleLedgerJournal(TestCase):
                 ref.payload_json["credit_account_id"],
                 str(getattr(transfer, "credit_account_id")),
             )
+
+    def test_runtime_bucket_journal_payload_marks_aggregate_only_non_authority(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket()
+            bucket.payload_json = {"source": "aggregate-only-fixture"}
+            session.add(bucket)
+            session.flush()
+            client = FakeTigerBeetleClient()
+
+            ref = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            ).journal_runtime_ledger_bucket(session, bucket)
+
+        self.assertIsNotNone(ref)
+        assert ref is not None
+        parity = tigerbeetle_runtime_ledger_journal_payload(
+            bucket=bucket,
+            ref=ref,
+            status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
+        )
+        self.assertFalse(parity["promotion_authority"])
+        self.assertFalse(parity["overrides_runtime_ledger_authority"])
+        self.assertIn(
+            TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_REFS_MISSING,
+            parity["authority_blockers"],
+        )
+        self.assertIn(
+            TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_WINDOW_REFS_MISSING,
+            parity["authority_blockers"],
+        )
 
     def test_negative_runtime_bucket_reverses_transfer_direction(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -37,6 +37,7 @@ from app.trading.tigerbeetle_journal import (
     _lookup_payload_decimal,
     _order_event_precedes,
     _persist_account_refs,
+    _positive_payload_count,
     _result_status,
     _transfer_attr,
     _transfer_flag,
@@ -575,6 +576,70 @@ class TestTigerBeetleLedgerJournal(TestCase):
         self.assertIn(
             TIGERBEETLE_AUTHORITY_BLOCKER_RUNTIME_LEDGER_SOURCE_WINDOW_REFS_MISSING,
             parity["authority_blockers"],
+        )
+
+    def test_source_authority_count_parser_rejects_invalid_values(self) -> None:
+        self.assertFalse(_positive_payload_count("not-a-number"))
+
+    def test_runtime_bucket_journal_payload_merges_transfer_account_refs(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket()
+            session.add(bucket)
+            session.flush()
+            ref = TigerBeetleTransferRef(
+                cluster_id=2001,
+                transfer_id="340282366920938463463374607431768210",
+                transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+                ledger=LEDGER_USD_MICRO,
+                code=2001,
+                amount=Decimal("2500000"),
+                status="created",
+                runtime_ledger_bucket_id=bucket.id,
+                payload_json={
+                    "debit_account_id": "100100100100100100100100100100100101",
+                    "credit_account_id": "100100100100100100100100100100100102",
+                },
+            )
+            duplicate_cash_ref = TigerBeetleAccountRef(
+                cluster_id=2001,
+                account_id="100100100100100100100100100100100101",
+                account_key="TORGHUT_SIM:cash",
+                ledger=840001,
+                code=1001,
+                account_label="paper",
+            )
+            missing_fee_ref = TigerBeetleAccountRef(
+                cluster_id=2002,
+                account_id="100100100100100100100100100100100103",
+                account_key="TORGHUT_SIM:fees",
+                ledger=840001,
+                code=1003,
+                account_label="paper",
+            )
+            session.add_all([ref, duplicate_cash_ref, missing_fee_ref])
+            session.flush()
+
+            parity = tigerbeetle_runtime_ledger_journal_payload(
+                bucket=bucket,
+                ref=ref,
+                status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
+                account_refs=[duplicate_cash_ref, missing_fee_ref],
+            )
+
+        self.assertEqual(parity["cluster_ids"], [2001, 2002])
+        self.assertEqual(
+            parity["account_ids"],
+            [
+                "100100100100100100100100100100100101",
+                "100100100100100100100100100100100102",
+                "100100100100100100100100100100100103",
+            ],
+        )
+        self.assertEqual(
+            parity["account_keys"],
+            ["TORGHUT_SIM:cash", "TORGHUT_SIM:fees"],
         )
 
     def test_negative_runtime_bucket_reverses_transfer_direction(self) -> None:

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -304,6 +304,33 @@ def _runtime_ledger_proof_packet(
     }
 
 
+def _tigerbeetle_parity(
+    *,
+    ok: bool = True,
+    parity_status: str = "pass",
+    source_count: int = 3,
+    blockers: list[str] | None = None,
+    overrides_runtime_ledger_authority: bool = False,
+) -> dict[str, object]:
+    return {
+        "schema_version": verifier.TIGERBEETLE_RUNTIME_LEDGER_PARITY_SCHEMA_VERSION,
+        "ok": ok,
+        "parity_status": parity_status,
+        "blockers": blockers or [],
+        "totals": {
+            "checked_source_count": source_count,
+            "checked_ref_count": source_count,
+            "checked_actual_transfer_count": source_count,
+        },
+        "read_only_contract": {
+            "generates_proof": False,
+            "synthesizes_fills": False,
+            "overrides_runtime_ledger_authority": (overrides_runtime_ledger_authority),
+            "writes_database": False,
+        },
+    }
+
+
 class _JsonHandler(BaseHTTPRequestHandler):
     payload: ClassVar[object] = {}
 
@@ -428,6 +455,67 @@ class TestVerifyTradingReadiness(TestCase):
             result["runtime_ledger_proof_packet"]["schema_version"],
             verifier.RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
         )
+
+    def test_tigerbeetle_parity_can_be_required_as_accounting_only_gate(
+        self,
+    ) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            tigerbeetle_parity=_tigerbeetle_parity(),
+            require_tigerbeetle_parity=True,
+        )
+
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["failed_checks"], [])
+        self.assertEqual(result["tigerbeetle_parity"]["parity_status"], "pass")
+
+    def test_tigerbeetle_parity_requirement_fails_closed_on_degraded_or_authority_claim(
+        self,
+    ) -> None:
+        degraded = evaluate_trading_readiness(
+            _ready_status(),
+            tigerbeetle_parity=_tigerbeetle_parity(
+                ok=False,
+                parity_status="blocked",
+                blockers=["tigerbeetle_parity_entry_missing"],
+            ),
+            require_tigerbeetle_parity=True,
+        )
+
+        self.assertFalse(degraded["ok"])
+        self.assertIn(
+            "tigerbeetle_runtime_ledger_parity",
+            degraded["failed_checks"],
+        )
+        self.assertEqual(
+            degraded["next_action"],
+            "repair_tigerbeetle_journal_parity_without_using_as_profit_authority",
+        )
+
+        synthetic = evaluate_trading_readiness(
+            _ready_status(),
+            tigerbeetle_parity=_tigerbeetle_parity(
+                overrides_runtime_ledger_authority=True
+            ),
+            require_tigerbeetle_parity=True,
+        )
+        self.assertFalse(synthetic["ok"])
+        self.assertIn("tigerbeetle_runtime_ledger_parity", synthetic["failed_checks"])
+
+    def test_tigerbeetle_parity_does_not_replace_runtime_ledger_authority(
+        self,
+    ) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            tigerbeetle_parity=_tigerbeetle_parity(),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            require_runtime_ledger_profit_proof=True,
+            require_tigerbeetle_parity=True,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("completion_status_present", result["failed_checks"])
+        self.assertNotIn("tigerbeetle_runtime_ledger_parity", result["failed_checks"])
 
     def test_runtime_ledger_proof_packet_fails_closed_when_blocked(self) -> None:
         result = evaluate_trading_readiness(


### PR DESCRIPTION
## Summary

- Adds deterministic TigerBeetle runtime-ledger journal parity metadata on durable runtime buckets, including transfer/account refs and explicit accounting-only authority flags.
- Records non-authority blockers when TigerBeetle journaling is disabled, skipped, or optionally degraded, while preserving runtime-ledger source-window/source-ref authority.
- Backfills runtime bucket TigerBeetle refs from the journal script and adds an optional readiness parity gate that fails closed without treating TigerBeetle as promotion proof.
- Narrow scope note: `services/torghut/app/trading/runtime_window_import.py` is touched because it is the production write path that persists runtime-ledger buckets and invokes TigerBeetle journaling.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — pass
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_journal.py tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_ledger_bucket_journal_failure_respects_required_flag tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_bucket_journal_records_durable_tigerbeetle_refs tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_bucket_journal_disabled_records_non_authority_blocker tests/test_verify_trading_readiness.py tests/test_audit_tigerbeetle_runtime_ledger_parity.py tests/test_journal_tigerbeetle_order_events.py -q` — pass (107 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tigerbeetle_journal.py app/trading/runtime_window_import.py scripts/journal_tigerbeetle_order_events.py scripts/verify_trading_readiness.py tests/test_tigerbeetle_journal.py tests/test_runtime_window_import.py tests/test_verify_trading_readiness.py` — pass
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_journal.py app/trading/runtime_window_import.py scripts/journal_tigerbeetle_order_events.py scripts/verify_trading_readiness.py tests/test_tigerbeetle_journal.py tests/test_runtime_window_import.py tests/test_verify_trading_readiness.py` — pass
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — pass
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — pass
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — pass

## Screenshots (if applicable)

N/A — backend/runtime ledger and CLI readiness changes only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
