### PR TITLE
fix(torghut): stabilize paper route evidence collection

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -220,6 +220,7 @@ _ALPACA_HEALTH_CACHE_LOCK = Lock()
 _ALPACA_HEALTH_STATE: dict[str, object] = {}
 _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS = 600
 _PAPER_ROUTE_TARGET_PLAN_SUCCESS_CACHE_LOCK = Lock()
+_PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL = "TORGHUT_SIM"
 _paper_route_target_plan_success_cache: tuple[dict[str, Any], float] | None = None
 
 
@@ -4692,11 +4693,11 @@ def trading_paper_route_target_plan(
     market_context_status: Mapping[str, Any] | None = None
     hypothesis_payload: Mapping[str, Any] | None = None
 
-    live_submission_gate = (
-        None
-        if settings.trading_mode == "live"
-        else _paper_route_cached_live_submission_gate(scheduler)
+    live_submission_gate = _paper_route_cached_live_submission_gate(
+        scheduler,
+        require_bounded_sim_targets=settings.trading_mode == "live",
     )
+    loaded_full_live_gate = False
     if live_submission_gate is None:
         empirical_jobs = _empirical_jobs_status()
         quant_evidence = load_quant_evidence_status(
@@ -4722,6 +4723,7 @@ def trading_paper_route_target_plan(
             ),
             quant_health_status=quant_evidence,
         )
+        loaded_full_live_gate = True
     live_submission_gate = _merge_external_paper_route_target_plan(
         cast(Mapping[str, Any], live_submission_gate)
     )
@@ -4732,7 +4734,7 @@ def trading_paper_route_target_plan(
         state=scheduler.state,
         session=session,
     )
-    if settings.trading_mode == "live":
+    if settings.trading_mode == "live" and loaded_full_live_gate:
         assert empirical_jobs is not None
         assert quant_evidence is not None
         assert tca_summary is not None
@@ -4821,15 +4823,57 @@ def _paper_route_target_plan_probe_notional(
     return _decimal_to_string(max(positive_values))
 
 
+def _paper_route_target_plan_truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float | Decimal):
+        return bool(value)
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _paper_route_target_plan_cache_safe_for_live(
+    plan: Mapping[str, Any],
+) -> bool:
+    targets = _paper_route_target_plan_targets(plan)
+    if not targets:
+        return False
+    for key in (
+        "promotion_allowed",
+        "final_promotion_allowed",
+        "final_promotion_authorized",
+    ):
+        if _paper_route_target_plan_truthy(plan.get(key)):
+            return False
+    for target in targets:
+        target_account = str(
+            target.get("account_label") or target.get("source_account_label") or ""
+        ).strip()
+        if target_account != _PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL:
+            return False
+        for key in (
+            "promotion_allowed",
+            "final_promotion_allowed",
+            "final_promotion_authorized",
+        ):
+            if _paper_route_target_plan_truthy(target.get(key)):
+                return False
+    return True
+
+
 def _paper_route_cached_live_submission_gate(
     scheduler: object,
+    *,
+    require_bounded_sim_targets: bool = False,
 ) -> dict[str, object] | None:
     cached_gate = getattr(scheduler, "_last_live_submission_gate", None)
     if not isinstance(cached_gate, Mapping):
         return None
     gate = dict(cast(Mapping[str, object], cached_gate))
-    if not _paper_route_target_plan_targets(
-        _paper_route_target_plan_from_payload(gate)
+    plan = _paper_route_target_plan_from_payload(gate)
+    if not _paper_route_target_plan_targets(plan):
+        return None
+    if require_bounded_sim_targets and not _paper_route_target_plan_cache_safe_for_live(
+        plan
     ):
         return None
     gate.setdefault("paper_route_target_plan_source", "cached_live_submission_gate")
@@ -4930,9 +4974,11 @@ def _paper_route_probe_book_from_target_plan(
         return None
     market_session_open = cast(bool | None, getattr(state, "market_session_open", None))
     blocking_reasons: list[str] = []
+    if settings.trading_mode != "paper":
+        blocking_reasons.append("not_paper_mode")
     if market_session_open is not True:
         blocking_reasons.append("market_session_closed")
-    active = configured_enabled and market_session_open is True
+    active = configured_enabled and market_session_open is True and not blocking_reasons
     effective_max_notional = next_session_max_notional if active else "0"
     active_symbols = eligible_symbols if active else []
     return {

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -108,6 +108,9 @@ _BOUNDED_SIM_COLLECTION_LINEAGE_BOOL_KEYS = (
     "evidence_collection_ok",
 )
 _BOUNDED_SIM_COLLECTION_LINEAGE_MAPPING_KEYS = ("source_decision_readiness",)
+_FLATTEN_CLOSE_DECISION_SCHEMA_VERSION = (
+    "torghut.paper-account-flatten-close-decision.v1"
+)
 
 
 def _safe_int(value: object) -> int:
@@ -1066,8 +1069,16 @@ class SimpleTradingPipeline(TradingPipeline):
         decision_json = decision_row.decision_json
         if not isinstance(decision_json, Mapping):
             return None
+        decision_payload = cast(Mapping[str, Any], decision_json)
+        if (
+            str(decision_payload.get("schema_version") or "").strip()
+            == _FLATTEN_CLOSE_DECISION_SCHEMA_VERSION
+            or str(decision_payload.get("flatten_lineage_role") or "").strip()
+            == "close"
+        ):
+            return None
         try:
-            return StrategyDecision.model_validate(decision_json)
+            return StrategyDecision.model_validate(decision_payload)
         except Exception:
             logger.warning(
                 "Skipping paper route probe retry with invalid decision payload decision_id=%s",

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -502,6 +502,7 @@ def _close_decision_payload(
     order_type: str,
     limit_price: Decimal | None,
     lineage: FlattenSourceLineage,
+    generated_at: datetime,
 ) -> dict[str, Any]:
     lineage_status = (
         LINEAGE_LINKED_STATUS if lineage.has_source_lineage else LINEAGE_UNLINKED_STATUS
@@ -538,7 +539,10 @@ def _close_decision_payload(
         "source_trade_decision_id": source_trade_decision_id,
         "source_execution_id": source_execution_id,
         "client_order_id": client_order_id,
+        "strategy_id": str(lineage.strategy_id or FLATTEN_CLEANUP_STRATEGY_NAME),
         "symbol": position.symbol,
+        "event_ts": generated_at.isoformat(),
+        "timeframe": "event",
         "action": position.close_side,
         "qty": str(position.close_qty),
         "order_type": order_type,
@@ -557,6 +561,7 @@ def _persist_close_decision(
     client_order_id: str,
     order_type: str,
     limit_price: Decimal | None,
+    generated_at: datetime,
 ) -> tuple[TradeDecision, FlattenSourceLineage]:
     lineage = _source_lineage(
         session, account_label=account_label, symbol=position.symbol
@@ -567,6 +572,7 @@ def _persist_close_decision(
         order_type=order_type,
         limit_price=limit_price,
         lineage=lineage,
+        generated_at=generated_at,
     )
     stmt = select(TradeDecision).where(
         TradeDecision.decision_hash == client_order_id,
@@ -749,6 +755,7 @@ def flatten_paper_account_positions(
                         client_order_id=client_order_id,
                         order_type=order_type,
                         limit_price=limit_price,
+                        generated_at=generated_at,
                     )
                 except Exception as exc:
                     lineage_session.rollback()

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -15,6 +15,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
 from app.models import Base, Execution, ExecutionOrderEvent, Strategy, TradeDecision
+from app.trading.models import StrategyDecision
 from scripts import flatten_paper_account_positions as flatten_script
 from scripts.flatten_paper_account_positions import (
     flatten_paper_account_positions,
@@ -327,6 +328,13 @@ class TestFlattenPaperAccountPositions(TestCase):
                 decision_json["schema_version"],
                 "torghut.paper-account-flatten-close-decision.v1",
             )
+            StrategyDecision.model_validate(decision_json)
+            self.assertEqual(decision_json["strategy_id"], str(strategy.id))
+            self.assertEqual(
+                decision_json["event_ts"],
+                "2026-06-01T13:35:00+00:00",
+            )
+            self.assertEqual(decision_json["timeframe"], "event")
             self.assertEqual(
                 decision_json["source_candidate_ids"],
                 ["c88421d619759b2cfaa6f4d0"],
@@ -388,6 +396,16 @@ class TestFlattenPaperAccountPositions(TestCase):
             self.assertEqual(
                 decision_json["flatten_lineage_status"], "unlinked_no_source_lineage"
             )
+            StrategyDecision.model_validate(decision_json)
+            self.assertEqual(
+                decision_json["strategy_id"],
+                str(close_decision.strategy_id),
+            )
+            self.assertEqual(
+                decision_json["event_ts"],
+                "2026-06-01T13:40:00+00:00",
+            )
+            self.assertEqual(decision_json["timeframe"], "event")
             self.assertEqual(decision_json["source_candidate_ids"], [])
             self.assertFalse(decision_json["profit_proof_eligible"])
             close_execution = session.execute(
@@ -464,6 +482,7 @@ class TestFlattenPaperAccountPositions(TestCase):
                 client_order_id=second_client_order_id,
                 order_type="market",
                 limit_price=None,
+                generated_at=generated_at,
             )
             reused_decision, _ = flatten_script._persist_close_decision(
                 session,
@@ -472,6 +491,7 @@ class TestFlattenPaperAccountPositions(TestCase):
                 client_order_id=second_client_order_id,
                 order_type="market",
                 limit_price=None,
+                generated_at=generated_at,
             )
 
             self.assertEqual(first_payload["lineage_result_count"], 1)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7799,6 +7799,118 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
+    def test_live_paper_route_target_plan_uses_bounded_sim_cached_gate_fast_path(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        original_trading_mode = settings.trading_mode
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        settings.trading_mode = "live"
+        settings.trading_paper_route_target_plan_url = None
+        self.addCleanup(setattr, settings, "trading_mode", original_trading_mode)
+        self.addCleanup(
+            setattr,
+            settings,
+            "trading_paper_route_target_plan_url",
+            original_target_plan_url,
+        )
+        target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "account_label": "TORGHUT_SIM",
+            "source_kind": "runtime_ledger_paper_probation_candidates",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_probation_authorized": True,
+            "bounded_evidence_collection_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "max_notional": "0",
+        }
+        cached_gate = {
+            "allowed": False,
+            "reason": "simple_submit_disabled",
+            "blocked_reasons": [
+                "alpha_readiness_not_promotion_eligible",
+                "simple_submit_disabled",
+            ],
+            "promotion_eligible_total": 0,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "skipped_target_count": 0,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "final_promotion_authorized": False,
+                "targets": [target],
+            },
+        }
+        fake_scheduler = SimpleNamespace(
+            state=SimpleNamespace(market_session_open=True),
+            _last_live_submission_gate=cached_gate,
+        )
+        try:
+            app.state.trading_scheduler = fake_scheduler
+            with (
+                patch(
+                    "app.main._empirical_jobs_status",
+                    side_effect=AssertionError("empirical jobs should not load"),
+                ),
+                patch(
+                    "app.main.load_quant_evidence_status",
+                    side_effect=AssertionError("quant evidence should not load"),
+                ),
+                patch(
+                    "app.main._load_tca_summary",
+                    side_effect=AssertionError("TCA summary should not load"),
+                ),
+                patch(
+                    "app.main._build_hypothesis_runtime_payload",
+                    side_effect=AssertionError("hypothesis payload should not load"),
+                ),
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    side_effect=AssertionError("live gate should use cache"),
+                ),
+                patch(
+                    "app.main._build_profitability_proof_floor_payload",
+                    side_effect=AssertionError("proof floor should not run"),
+                ),
+                patch(
+                    "app.main._build_simple_lane_status_payload",
+                    return_value={
+                        "paper_route_probe_enabled": True,
+                        "paper_route_probe_max_notional": "75000",
+                    },
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-target-plan")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(payload["target_count"], 1)
+            self.assertEqual(
+                payload["live_submission_gate"]["paper_route_target_plan_source"],
+                "cached_live_submission_gate",
+            )
+            self.assertFalse(payload["summary"]["promotion_authority"]["allowed"])
+            self.assertFalse(payload["paper_route_probe"]["active"])
+            self.assertIn(
+                "not_paper_mode",
+                payload["paper_route_probe"]["blocking_reasons"],
+            )
+        finally:
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
     def test_live_paper_route_target_plan_bypasses_cached_gate_scope(
         self,
     ) -> None:
@@ -8265,6 +8377,9 @@ class TestTradingApi(TestCase):
         )
 
     def test_paper_route_cached_gate_requires_target_plan(self) -> None:
+        self.assertFalse(main_module._paper_route_target_plan_truthy(0))
+        self.assertTrue(main_module._paper_route_target_plan_truthy(1))
+        self.assertFalse(main_module._paper_route_target_plan_cache_safe_for_live({}))
         self.assertIsNone(
             main_module._paper_route_cached_live_submission_gate(
                 SimpleNamespace(_last_live_submission_gate=None)
@@ -8273,6 +8388,55 @@ class TestTradingApi(TestCase):
         self.assertIsNone(
             main_module._paper_route_cached_live_submission_gate(
                 SimpleNamespace(_last_live_submission_gate={"allowed": False})
+            )
+        )
+        unsafe_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "promotion_allowed": True,
+                "final_promotion_allowed": False,
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_probe_symbols": ["AAPL"],
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ],
+            }
+        }
+        self.assertIsNone(
+            main_module._paper_route_cached_live_submission_gate(
+                SimpleNamespace(_last_live_submission_gate=unsafe_gate),
+                require_bounded_sim_targets=True,
+            )
+        )
+        unsafe_target_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_probe_symbols": ["AAPL"],
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                        "final_promotion_authorized": "yes",
+                    }
+                ],
+            }
+        }
+        self.assertIsNone(
+            main_module._paper_route_cached_live_submission_gate(
+                SimpleNamespace(_last_live_submission_gate=unsafe_target_gate),
+                require_bounded_sim_targets=True,
             )
         )
 

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3911,6 +3911,37 @@ class TestTradingPipeline(TestCase):
         self.assertIsNone(
             SimpleTradingPipeline._trade_decision_from_retry_row(invalid_row)
         )
+        flatten_close_row = TradeDecision(
+            strategy_id=strategy_id,
+            alpaca_account_label="paper",
+            symbol="BITO",
+            timeframe="event",
+            decision_json={
+                "schema_version": "torghut.paper-account-flatten-close-decision.v1",
+                "flatten_lineage_role": "close",
+                "action": "sell",
+                "qty": "1000",
+            },
+            status="submitted",
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._trade_decision_from_retry_row(flatten_close_row)
+        )
+        flatten_role_only_row = TradeDecision(
+            strategy_id=strategy_id,
+            alpaca_account_label="paper",
+            symbol="BITO",
+            timeframe="event",
+            decision_json={
+                "flatten_lineage_role": "close",
+                "action": "sell",
+                "qty": "1000",
+            },
+            status="submitted",
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._trade_decision_from_retry_row(flatten_role_only_row)
+        )
 
         event_ts = datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc)
         decision = StrategyDecision(


### PR DESCRIPTION
## Summary

- Added a bounded `TORGHUT_SIM` cache fast path for the live paper-route target-plan endpoint so the SIM collector does not need the full live proof-floor rebuild on each internal fetch.
- Kept the endpoint fail-closed by rejecting promotional or non-SIM cached targets and marking route probes inactive with `not_paper_mode` outside paper mode.
- Persisted paper-account flatten close decisions with strategy, event timestamp, and timeframe fields, and excluded flatten cleanup close rows from route-retry processing.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py tests/test_flatten_paper_account_positions.py tests/test_trading_pipeline.py -q`
- `uv run --frozen ruff format --check app/main.py app/trading/scheduler/simple_pipeline.py scripts/flatten_paper_account_positions.py tests/test_trading_api.py tests/test_trading_pipeline.py tests/test_flatten_paper_account_positions.py`
- `uv run --frozen ruff check app/main.py app/trading/scheduler/simple_pipeline.py scripts/flatten_paper_account_positions.py tests/test_trading_api.py tests/test_trading_pipeline.py tests/test_flatten_paper_account_positions.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
