### PR TITLE
fix(torghut): reopen bounded paper signal collection

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -3722,6 +3722,59 @@ class SimpleTradingPipeline(TradingPipeline):
             "previous_paper_route_probe_retry_attempts": retry_attempts,
         }
 
+    def _reopen_bounded_sim_collection_decision(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+    ) -> TradeDecision | None:
+        retry_metadata = self._paper_route_probe_retry_metadata(decision_row)
+        if retry_metadata is None:
+            return None
+        if self.executor.execution_exists(session, decision_row):
+            return None
+        collection_metadata = _bounded_sim_collection_metadata_from_decision(
+            decision,
+            account_label=self.account_label,
+            trading_mode=settings.trading_mode,
+        )
+        if collection_metadata is None:
+            return None
+        proof_floor = self._profitability_proof_floor(session=session)
+        if self._proof_floor_submission_block_reason(proof_floor) is None:
+            return None
+
+        decision_row.status = "planned"
+        decision_row.created_at = trading_now(account_label=self.account_label)
+        decision_json = dict(cast(Mapping[str, Any], decision_row.decision_json))
+        retry_attempts = _safe_int(
+            decision_json.get("paper_route_probe_retry_attempts")
+        )
+        decision_json["paper_route_probe_retry_attempts"] = retry_attempts + 1
+        decision_json["bounded_sim_collection_retry"] = {
+            **retry_metadata,
+            "submission_stage": "bounded_sim_collection_retry_pending",
+            "symbol": decision.symbol.strip().upper(),
+            "strategy_id": decision.strategy_id,
+            "collection_metadata": dict(collection_metadata),
+        }
+        decision_json["submission_stage"] = "bounded_sim_collection_retry_pending"
+        decision_json.pop("submission_block_reason", None)
+        decision_json.pop("submission_block_atomic", None)
+        decision_row.decision_json = decision_json
+        session.add(decision_row)
+        session.commit()
+        session.refresh(decision_row)
+        logger.warning(
+            "Reopening proof-floor-blocked decision for bounded SIM evidence collection strategy_id=%s decision_id=%s symbol=%s previous_reason=%s",
+            decision.strategy_id,
+            decision_row.id,
+            decision.symbol,
+            retry_metadata["previous_submission_block_reason"],
+        )
+        return decision_row
+
     def _ensure_pending_decision_row(
         self,
         *,
@@ -3758,6 +3811,13 @@ class SimpleTradingPipeline(TradingPipeline):
             session.add(decision_row)
             session.commit()
             session.refresh(decision_row)
+        reopened_bounded_collection = self._reopen_bounded_sim_collection_decision(
+            session=session,
+            decision=decision,
+            decision_row=decision_row,
+        )
+        if reopened_bounded_collection is not None:
+            return reopened_bounded_collection
         retry_metadata = self._paper_route_probe_retry_metadata(decision_row)
         if retry_metadata is None:
             return super()._ensure_pending_decision_row(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3574,6 +3574,179 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(row.status, "planned")
         self.assertNotIn("submission_block_reason", row_json)
 
+    def test_strategy_signal_paper_collection_reopens_prior_profit_floor_block(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 1, 14, 35, tzinfo=timezone.utc)
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 2
+        config.settings.trading_paper_route_target_plan_url = "http://torghut.test/plan"
+
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded strategy-signal collection",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("75000"),
+        )
+        target: dict[str, Any] = {
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "hypothesis_id": "H-PAIRS-01",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": strategy.name,
+            "runtime_strategy_name": strategy.name,
+            "strategy_lookup_names": [str(strategy.id), strategy.name],
+            "account_label": "TORGHUT_SIM",
+            "source_account_label": "TORGHUT_REPLAY",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_pair_balance_state": "balanced",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+            "evidence_collection_ok": True,
+            "canary_collection_authorized": True,
+            "bounded_evidence_collection_authorized": True,
+            "bounded_live_paper_collection_authorized": True,
+            "bounded_evidence_collection_scope": "paper_route_probe_next_session_only",
+            "bounded_evidence_collection_blockers": [],
+            "runtime_window_import_health_gate_blockers": [],
+            "paper_route_account_pre_session_blockers": [],
+            "paper_route_hpairs_symbol_blockers": [],
+            "source_decision_readiness": {"ready": True, "blockers": []},
+            "paper_probation_authorized": True,
+        }
+        decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("1"),
+            rationale="bounded strategy-signal paper collection",
+            params={"price": "100"},
+        )
+        proof_floor = {
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "market_window": {"session_open": True},
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+        }
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+
+        with self.session_local() as session:
+            session.add(strategy)
+            session.commit()
+            row = pipeline.executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "TORGHUT_SIM",
+            )
+            blocked_json = dict(cast(Mapping[str, Any], row.decision_json))
+            blocked_json["params"] = {
+                "price": "100",
+                "source_decision_mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+                "profit_proof_eligible": True,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "final_promotion_authorized": False,
+            }
+            blocked_json["submission_stage"] = "blocked_profitability_proof_floor"
+            blocked_json["submission_block_reason"] = (
+                "alpha_readiness_not_promotion_eligible"
+            )
+            blocked_json["profitability_proof_floor"] = proof_floor
+            row.status = "blocked"
+            row.decision_json = blocked_json
+            session.add(row)
+            session.commit()
+
+            with (
+                patch.object(
+                    pipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=({"AAPL", "AMZN"}, None, [target]),
+                ),
+                patch.object(
+                    SimpleTradingPipeline,
+                    "_profitability_proof_floor",
+                    return_value=proof_floor,
+                ),
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=now,
+                ),
+            ):
+                reopened = pipeline._ensure_pending_decision_row(
+                    session=session,
+                    decision=decision,
+                    strategy=strategy,
+                )
+
+            self.assertIsNotNone(reopened)
+            assert reopened is not None
+            session.refresh(reopened)
+            row_json = cast(dict[str, Any], reopened.decision_json)
+            params = cast(dict[str, Any], row_json.get("params"))
+            retry = cast(dict[str, Any], row_json.get("bounded_sim_collection_retry"))
+
+        self.assertEqual(reopened.status, "planned")
+        self.assertEqual(
+            row_json.get("submission_stage"),
+            "bounded_sim_collection_retry_pending",
+        )
+        self.assertNotIn("submission_block_reason", row_json)
+        self.assertEqual(row_json.get("paper_route_probe_retry_attempts"), 1)
+        self.assertEqual(
+            retry.get("previous_submission_block_reason"),
+            "alpha_readiness_not_promotion_eligible",
+        )
+        self.assertEqual(params.get("source_decision_mode"), "strategy_signal_paper")
+        self.assertFalse(params.get("promotion_allowed"))
+        self.assertFalse(params.get("final_promotion_allowed"))
+        self.assertFalse(params.get("final_promotion_authorized"))
+        self.assertIsNotNone(
+            _bounded_sim_collection_metadata_from_decision(
+                StrategyDecision(
+                    strategy_id=str(strategy.id),
+                    symbol="AAPL",
+                    event_ts=now,
+                    timeframe="1Sec",
+                    action="sell",
+                    qty=Decimal("1"),
+                    params=params,
+                ),
+                account_label="TORGHUT_SIM",
+                trading_mode="paper",
+            )
+        )
+
     def test_simple_pipeline_retry_metadata_requires_prior_profit_floor_block(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Reopens prior profit-floor-blocked bounded SIM collection decisions when a new scheduler pass attaches strict authorized paper collection metadata.
- Keeps the bypass paper-only and gated by TORGHUT_SIM account, clean collection readiness, bounded authorization, source lineage, and non-promotion flags.
- Adds regression coverage for the pre-rollout blocked strategy-signal paper row case that was preventing current-window H-PAIRS proof collection.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k "strategy_signal_paper_collection or matching_paper_target_signal"`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
