### PR TITLE
feat(torghut): harden hpairs frontier fanout

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -148,6 +148,16 @@ _DEFAULT_FAST_REPLAY_PREVIEW_TOP_K = 48
 _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP = 6
 _DEFAULT_FAST_REPLAY_EXPLOITATION_SLOTS = 4
 _DEFAULT_FAST_REPLAY_EXPLORATION_SLOTS = 2
+_UNSAFE_NEXT_EPOCH_REMEDIATION_FLAG_MARKERS = (
+    "agentrun",
+    "agent-run",
+    "broker",
+    "fanout",
+    "kubectl",
+    "kubernetes",
+    "live-trading",
+    "promotion",
+)
 _DEFAULT_CLICKHOUSE_HTTP_URL = (
     "http://torghut-clickhouse.torghut.svc.cluster.local:8123"
 )
@@ -3621,6 +3631,14 @@ def _flag_int(value: Any) -> int | None:
         return None
 
 
+def _unsafe_next_epoch_remediation_flag(key: str) -> bool:
+    normalized = key.strip().lower()
+    return any(
+        marker in normalized
+        for marker in _UNSAFE_NEXT_EPOCH_REMEDIATION_FLAG_MARKERS
+    )
+
+
 def _decimal_arg_or_default(
     args: argparse.Namespace,
     name: str,
@@ -3684,9 +3702,26 @@ def _profitability_next_epoch_plan(
         flags["--real-replay-shard-timeout-seconds"] = str(
             real_replay_shard_timeout_seconds
         )
-    real_replay_shard_workers = _int_arg(
+    capped_runtime_flags: list[dict[str, str]] = []
+    requested_real_replay_shard_workers = _int_arg(
         args, "real_replay_shard_workers", _DEFAULT_REAL_REPLAY_SHARD_WORKERS
     )
+    real_replay_shard_workers = max(
+        1,
+        min(
+            requested_real_replay_shard_workers,
+            _DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+        ),
+    )
+    if real_replay_shard_workers != requested_real_replay_shard_workers:
+        capped_runtime_flags.append(
+            {
+                "flag": "--real-replay-shard-workers",
+                "requested_value": str(requested_real_replay_shard_workers),
+                "capped_value": str(real_replay_shard_workers),
+                "reason": "capped_to_local_worker_limit_no_kubernetes_fanout",
+            }
+        )
     if real_replay_shard_workers > 1:
         flags["--real-replay-shard-workers"] = str(real_replay_shard_workers)
     real_replay_failed_spec_retries = _int_arg(
@@ -3731,9 +3766,37 @@ def _profitability_next_epoch_plan(
             action_name = _string(action.get("action"))
             for key, value in _mapping(action.get("recommended_flags")).items():
                 if key.startswith("--") and _string(value):
+                    if _unsafe_next_epoch_remediation_flag(key):
+                        rejected_recommended_flags.append(
+                            {
+                                "action": action_name,
+                                "flag": key,
+                                "current_value": str(flags.get(key, "")),
+                                "recommended_value": _string(value),
+                                "reason": "rejected_unsafe_cluster_fanout_or_promotion_flag",
+                            }
+                        )
+                        continue
                     current_value = flags.get(key)
                     current_int = _flag_int(current_value)
                     recommended_int = _flag_int(value)
+                    if (
+                        key == "--real-replay-shard-workers"
+                        and (
+                            recommended_int is None
+                            or recommended_int > _DEFAULT_REAL_REPLAY_SHARD_WORKERS
+                        )
+                    ):
+                        rejected_recommended_flags.append(
+                            {
+                                "action": action_name,
+                                "flag": key,
+                                "current_value": str(current_value or ""),
+                                "recommended_value": _string(value),
+                                "reason": "rejected_broad_replay_worker_fanout",
+                            }
+                        )
+                        continue
                     if key in monotonic_int_flags and recommended_int is None:
                         rejected_recommended_flags.append(
                             {
@@ -3788,10 +3851,18 @@ def _profitability_next_epoch_plan(
         "direct_candidate_specs_artifacts": direct_candidate_specs_artifacts,
         "applied_recommended_flags": applied_recommended_flags,
         "rejected_recommended_flags": rejected_recommended_flags,
+        "capped_runtime_flags": capped_runtime_flags,
         "no_fast_path_policy": {
             "target_net_pnl_per_day_is_fixed": str(target),
             "replay_mode": "real",
+            "no_kubernetes_fanout": True,
+            "max_generated_real_replay_shard_workers": (
+                _DEFAULT_REAL_REPLAY_SHARD_WORKERS
+            ),
             "monotonic_search_flags": sorted(monotonic_int_flags),
+            "unsafe_remediation_flag_markers": sorted(
+                _UNSAFE_NEXT_EPOCH_REMEDIATION_FLAG_MARKERS
+            ),
             "allowed_decreases": [
                 (
                     "timeout remediation may reduce "

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -10429,6 +10429,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                         "recommended_flags": {
                             "--top-k": "not-a-number",
                             "--max-total-frontier-candidates": "48",
+                            "--kubernetes-fanout": "32",
+                            "--real-replay-shard-workers": "16",
                         },
                     }
                 ]
@@ -10448,7 +10450,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(plan["flags"]["--real-replay-timeout-seconds"], "7200")
         self.assertEqual(plan["flags"]["--real-replay-shard-size"], "2")
         self.assertEqual(plan["flags"]["--real-replay-shard-timeout-seconds"], "900")
-        self.assertEqual(plan["flags"]["--real-replay-shard-workers"], "3")
+        self.assertEqual(plan["flags"]["--real-replay-shard-workers"], "2")
         self.assertEqual(plan["flags"]["--real-replay-failed-spec-retries"], "2")
         self.assertEqual(plan["flags"]["--real-replay-retry-timeout-seconds"], "1800")
         self.assertEqual(
@@ -10469,6 +10471,40 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             },
             plan["rejected_recommended_flags"],
         )
+        self.assertIn(
+            {
+                "action": "increase_breadth_and_portfolio_diversity",
+                "flag": "--kubernetes-fanout",
+                "current_value": "",
+                "recommended_value": "32",
+                "reason": "rejected_unsafe_cluster_fanout_or_promotion_flag",
+            },
+            plan["rejected_recommended_flags"],
+        )
+        self.assertIn(
+            {
+                "action": "increase_breadth_and_portfolio_diversity",
+                "flag": "--real-replay-shard-workers",
+                "current_value": "2",
+                "recommended_value": "16",
+                "reason": "rejected_broad_replay_worker_fanout",
+            },
+            plan["rejected_recommended_flags"],
+        )
+        self.assertIn(
+            {
+                "flag": "--real-replay-shard-workers",
+                "requested_value": "3",
+                "capped_value": "2",
+                "reason": "capped_to_local_worker_limit_no_kubernetes_fanout",
+            },
+            plan["capped_runtime_flags"],
+        )
+        self.assertTrue(plan["no_fast_path_policy"]["no_kubernetes_fanout"])
+        self.assertEqual(
+            plan["no_fast_path_policy"]["max_generated_real_replay_shard_workers"], 2
+        )
+        self.assertNotIn("--kubernetes-fanout", plan["flags"])
 
     def test_train_ranker_script_main_writes_model_and_scores(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Hardened Torghut next-epoch command generation so remediation cannot inject Kubernetes/AgentRun/broker/promotion/fanout flags.
- Capped generated `--real-replay-shard-workers` at the local safe worker default and recorded capped runtime flag metadata.
- Added regression coverage proving unsafe fanout flags are rejected while bounded H-PAIRS replay frontier commands remain local and non-promotional.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (initial run failed because `cc` was missing; installed `build-essential`; rerun passed)
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` (209 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (passed)
- `git diff --check` (passed)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
