### PR TITLE
test(torghut): cover tigerbeetle unavailable blocker

### DIFF
--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -366,6 +366,77 @@ class TestRuntimeWindowImport(TestCase):
             self.assertEqual(parity["blockers"], ["tigerbeetle_journal_disabled"])
             self.assertEqual(parity["transfer_ids"], [])
 
+    def test_runtime_bucket_journal_unavailable_records_non_authority_blocker(
+        self,
+    ) -> None:
+        with self.session_local() as session:
+            row = StrategyRuntimeLedgerBucket(
+                run_id="run-journal-unavailable",
+                candidate_id="cand",
+                hypothesis_id="hyp",
+                observed_stage="paper",
+                bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                account_label="TORGHUT_SIM",
+                runtime_strategy_name="strategy",
+                fill_count=2,
+                decision_count=2,
+                submitted_order_count=2,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("200"),
+                gross_strategy_pnl=Decimal("1"),
+                cost_amount=Decimal("0.20"),
+                net_strategy_pnl_after_costs=Decimal("0.80"),
+                post_cost_expectancy_bps=Decimal("40"),
+                pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                payload_json={
+                    "source_refs": ["postgres:execution_order_events:event-1"],
+                    "source_window_refs": ["postgres:source_windows:window-1"],
+                    "tigerbeetle": {
+                        "account_ids": ["existing-account"],
+                        "account_keys": ["existing-key"],
+                        "transfer_ids": ["existing-transfer"],
+                    },
+                },
+            )
+            session.add(row)
+            session.flush()
+
+            with (
+                patch.object(
+                    runtime_window_import_module.settings,
+                    "tigerbeetle_enabled",
+                    True,
+                ),
+                patch.object(
+                    runtime_window_import_module.settings,
+                    "tigerbeetle_journal_enabled",
+                    True,
+                ),
+                patch.object(
+                    runtime_window_import_module.settings,
+                    "tigerbeetle_required",
+                    False,
+                ),
+                patch(
+                    "app.trading.runtime_window_import.TigerBeetleLedgerJournal.journal_runtime_ledger_bucket",
+                    return_value=None,
+                ),
+            ):
+                _journal_tigerbeetle_runtime_ledger_bucket(session, row)
+
+            session.refresh(row)
+            payload = row.payload_json
+            parity = payload["tigerbeetle_journal_parity"]
+            self.assertEqual(parity["status"], "non_authority_blocked")
+            self.assertEqual(
+                parity["blockers"], ["tigerbeetle_journal_entry_unavailable"]
+            )
+            self.assertEqual(payload["tigerbeetle_transfer_ids"], ["existing-transfer"])
+            self.assertEqual(payload["tigerbeetle_account_ids"], ["existing-account"])
+
     def test_build_regular_session_buckets_counts_session_samples(self) -> None:
         buckets = build_regular_session_buckets(
             window_start=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),


### PR DESCRIPTION
## Summary

- Adds focused coverage for the runtime-ledger TigerBeetle journal path when journaling is enabled but no durable transfer ref is returned.
- Verifies the bucket records the explicit `tigerbeetle_journal_entry_unavailable` non-authority blocker.
- Verifies existing TigerBeetle account/transfer refs remain intact when parity metadata is degraded.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format tests/test_runtime_window_import.py`
- `cd services/torghut && uv run --frozen ruff check tests/test_runtime_window_import.py`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_bucket_journal_unavailable_records_non_authority_blocker tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_bucket_journal_disabled_records_non_authority_blocker tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_bucket_journal_records_durable_tigerbeetle_refs -q`
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_journal.py tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_persist_observed_runtime_windows_creates_governance_rows tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_ledger_bucket_journal_failure_respects_required_flag tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_bucket_journal_records_durable_tigerbeetle_refs tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_bucket_journal_disabled_records_non_authority_blocker tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_bucket_journal_unavailable_records_non_authority_blocker tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_runtime_ledger_daily_summary_from_observed_buckets_tracks_drawdown tests/test_verify_trading_readiness.py tests/test_audit_tigerbeetle_runtime_ledger_parity.py tests/test_journal_tigerbeetle_order_events.py -q`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tigerbeetle_journal.py app/trading/runtime_window_import.py scripts/journal_tigerbeetle_order_events.py scripts/verify_trading_readiness.py tests/test_tigerbeetle_journal.py tests/test_runtime_window_import.py tests/test_verify_trading_readiness.py tests/test_journal_tigerbeetle_order_events.py && uv run --frozen ruff check app/trading/tigerbeetle_journal.py app/trading/runtime_window_import.py scripts/journal_tigerbeetle_order_events.py scripts/verify_trading_readiness.py tests/test_tigerbeetle_journal.py tests/test_runtime_window_import.py tests/test_verify_trading_readiness.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
