### PR TITLE
chore(agents): bump chart for schedule suspend

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.23
+version: 0.9.24
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.23
+version: 0.9.24
 name: agents
 displayName: Agents Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Bumps the Agents Helm chart version from `0.9.23` to `0.9.24`.
- Unblocks chart publishing after PR #9509 changed the chart contents by adding `Schedule.spec.suspend`.
- Keeps the release fix limited to metadata required by the existing publish guard.

## Related Issues

None

## Testing

- `helm lint charts/agents`
- `scripts/agents/validate-agents.sh`
- `bunx oxfmt --check charts/agents/Chart.yaml charts/agents/artifacthub-pkg.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
