### PR TITLE
fix(torghut): block contaminated paper-route collection

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1651,6 +1651,16 @@ def _next_paper_route_runtime_window_targets(
         clean_window_baseline_blockers = _unique_text_items(
             clean_window_baseline_state.get("blockers")
         )
+        account_contamination_state = _account_contamination_audit(
+            session,
+            account_label=PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+            symbols=target_probe_symbols,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        account_contamination_blockers = _unique_text_items(
+            account_contamination_state.get("blockers")
+        )
         if account_pre_session_blockers and require_clean_pre_session:
             skipped_targets.append(
                 {
@@ -1751,6 +1761,7 @@ def _next_paper_route_runtime_window_targets(
                 *_unique_text_items(source_decision_readiness.get("blockers")),
                 *account_pre_session_blockers,
                 *clean_window_baseline_blockers,
+                *account_contamination_blockers,
                 *(
                     ["paper_route_probe_pair_imbalanced"]
                     if pair_balance_state == "imbalanced"
@@ -1833,8 +1844,14 @@ def _next_paper_route_runtime_window_targets(
             "paper_route_clean_window_baseline_blockers": (
                 clean_window_baseline_blockers
             ),
+            "paper_route_account_contamination_state": account_contamination_state,
+            "paper_route_account_contamination_blockers": (
+                account_contamination_blockers
+            ),
             "paper_route_clean_window_state": (
-                "clean_window_collection_ready"
+                "contaminated_window_discarded"
+                if account_contamination_blockers
+                else "clean_window_collection_ready"
                 if not clean_window_baseline_blockers
                 else "clean_window_required"
             ),

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -86,7 +86,14 @@ _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS = (
     "bounded_evidence_collection_blockers",
     "runtime_window_import_health_gate_blockers",
     "paper_route_account_pre_session_blockers",
+    "paper_route_account_contamination_blockers",
     "paper_route_hpairs_symbol_blockers",
+)
+_BOUNDED_SIM_COLLECTION_RESERVATION_BLOCKERS = frozenset(
+    {
+        "paper_route_account_contamination_detected",
+        "unlinked_order_events_present",
+    }
 )
 _BOUNDED_SIM_COLLECTION_ALLOWED_HEALTH_GATE_BLOCKERS = frozenset(
     {"evidence_continuity_not_ok"}
@@ -298,6 +305,17 @@ def _bounded_sim_collection_authorized(
     account_label: str | None,
 ) -> bool:
     return not _bounded_sim_collection_blockers(target, account_label=account_label)
+
+
+def _bounded_sim_collection_reserves_account(
+    target: Mapping[str, Any],
+    *,
+    account_label: str | None,
+) -> bool:
+    blockers = _bounded_sim_collection_blockers(target, account_label=account_label)
+    if not blockers:
+        return True
+    return bool(_BOUNDED_SIM_COLLECTION_RESERVATION_BLOCKERS.intersection(blockers))
 
 
 def _target_requires_bounded_sim_collection_gate(target: Mapping[str, Any]) -> bool:
@@ -3161,7 +3179,7 @@ class SimpleTradingPipeline(TradingPipeline):
         for target in target_plan_targets:
             if not _target_requires_bounded_sim_collection_gate(target):
                 continue
-            if not _bounded_sim_collection_authorized(
+            if not _bounded_sim_collection_reserves_account(
                 target,
                 account_label=self.account_label,
             ):

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5973,6 +5973,117 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "contaminated_window_discarded",
         )
 
+    def test_active_window_contamination_blocks_target_plan_collection(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 18, 5, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="active-contamination-proof-strategy",
+                description="active paper account contamination fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="active-external-autonomous-trader-event",
+                    source_topic="alpaca.trade_updates",
+                    source_partition=0,
+                    source_offset=42,
+                    alpaca_account_label="TORGHUT_SIM",
+                    event_ts=window_start + timedelta(minutes=20),
+                    symbol="AAPL",
+                    alpaca_order_id="active-external-order-1",
+                    client_order_id="autonomous-trader-AAPL-cover-active-1",
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("101"),
+                    raw_event={"source": "external_autonomous_trader"},
+                    execution_id=None,
+                    trade_decision_id=None,
+                )
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
+            session.commit()
+
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": (
+                            "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                        ),
+                        "target_count": "1",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-CONTAMINATION",
+                                "candidate_id": "candidate-contamination",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy.name,
+                                "strategy_id": "active_contamination_strategy@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": (
+                                    "config/trading/hypotheses/h-contamination.json"
+                                ),
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=now,
+            )
+
+        target = payload["next_paper_route_runtime_window_targets"]["targets"][0]
+        self.assertFalse(target["evidence_collection_ok"])
+        self.assertFalse(target["canary_collection_authorized"])
+        self.assertFalse(target["bounded_live_paper_collection_authorized"])
+        self.assertEqual(
+            target["paper_route_clean_window_state"],
+            "contaminated_window_discarded",
+        )
+        self.assertIn(
+            "paper_route_account_contamination_detected",
+            target["paper_route_account_contamination_blockers"],
+        )
+        self.assertIn(
+            "unlinked_order_events_present",
+            target["bounded_evidence_collection_blockers"],
+        )
+
     def test_account_window_start_positions_block_runtime_window_import(
         self,
     ) -> None:

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -449,6 +449,57 @@ def test_bounded_paper_route_authorized_without_live_simple_submit_enabled() -> 
         settings.trading_emergency_stop_enabled = emergency_stop_before
 
 
+def test_contaminated_bounded_window_still_reserves_paper_account(monkeypatch) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    try:
+        settings.trading_mode = 'paper'
+        settings.trading_simple_paper_route_probe_enabled = True
+        now = datetime(2026, 6, 1, 18, 0, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            paper_route_probe_window_start='2026-06-01T13:30:00+00:00',
+            paper_route_probe_window_end='2026-06-01T20:00:00+00:00',
+            evidence_collection_ok=False,
+            canary_collection_authorized=False,
+            bounded_evidence_collection_authorized=False,
+            bounded_live_paper_collection_authorized=False,
+            bounded_evidence_collection_blockers=[
+                'paper_route_account_contamination_detected',
+                'unlinked_order_events_present',
+            ],
+            paper_route_account_contamination_blockers=[
+                'paper_route_account_contamination_detected',
+                'unlinked_order_events_present',
+            ],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = 'TORGHUT_SIM'
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+            {'AAPL', 'AMZN'},
+            None,
+            [target],
+        )
+        monkeypatch.setattr(
+            'app.trading.scheduler.simple_pipeline.trading_now',
+            lambda account_label=None: now,
+        )
+
+        blockers = _bounded_sim_collection_blockers(
+            target,
+            account_label='TORGHUT_SIM',
+        )
+
+        assert 'bounded_sim_collection_evidence_collection_not_ready' in blockers
+        assert 'paper_route_account_contamination_detected' in blockers
+        assert pipeline._paper_route_target_plan_reserves_account(
+            allowed_symbols={'AAPL', 'AMZN'},
+        )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+
+
 def test_bounded_paper_route_execution_metadata_keeps_live_capital_closed() -> None:
     target = _bounded_hpairs_target(source_account_label='PA3SX7FYNUTF')
     strategy = Strategy(


### PR DESCRIPTION
## Summary

- Propagate active paper-account contamination into paper-route target plans.
- Mark contaminated targets as not evidence-collection-ready and not canary-authorized.
- Keep the bounded SIM paper account reserved during an active contaminated window so regular simple-lane processing does not add more non-authority orders.
- Add regressions for target-plan contamination blocking and account reservation behavior.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_simple_pipeline.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "contamination or builder_exports_next_paper_route_runtime_window_targets or source_activity_is_scoped_to_target_account_and_probe_symbols"`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/scheduler/simple_pipeline.py tests/test_paper_route_evidence.py tests/test_simple_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
