### PR TITLE
fix(torghut): bound options freshness readiness checks

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -513,7 +513,7 @@ class Settings(BaseSettings):
         ),
     )
     trading_options_catalog_freshness_cache_seconds: int = Field(
-        default=0,
+        default=30,
         alias="TRADING_OPTIONS_CATALOG_FRESHNESS_CACHE_SECONDS",
         description=(
             "Short in-process cache TTL for options catalog freshness summaries. "

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6386,19 +6386,10 @@ LIMIT 200
         reason_codes = ["options_catalog_freshness_summary_unavailable"]
         if _sqlalchemy_error_indicates_statement_timeout(exc):
             reason_codes.append("options_catalog_freshness_query_timeout")
-            return _store_options_catalog_freshness_summary(
-                scoped_symbols,
-                {
-                    "status": "unavailable",
-                    "scope": "route_symbols" if scoped_symbols else "global",
-                    "route_symbols": list(scoped_symbols),
-                    "reason_codes": reason_codes,
-                },
-            )
         bounded_payload = _load_bounded_options_catalog_freshness_summary(
             session,
             scoped_symbols,
-            reason="options_catalog_freshness_summary_unavailable",
+            reason=reason_codes[-1],
         )
         if bounded_payload is not None:
             return _store_options_catalog_freshness_summary(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -733,7 +733,7 @@ class TestTradingApi(TestCase):
         self.assertEqual(second["status"], "unavailable")
         self.assertEqual(first["route_symbols"], ["AAPL"])
         self.assertEqual(second["route_symbols"], ["AAPL"])
-        self.assertEqual(len(fake_session.calls), 1)
+        self.assertEqual(len(fake_session.calls), 2)
         self.assertIn(
             "options_catalog_freshness_query_timeout",
             first["reason_codes"],
@@ -747,7 +747,7 @@ class TestTradingApi(TestCase):
         self.assertEqual(first_cache["hit"], False)
         self.assertEqual(second_cache["hit"], True)
 
-    def test_options_catalog_freshness_summary_skips_bounded_fallback_on_timeout(
+    def test_options_catalog_freshness_summary_falls_back_to_bounded_on_timeout(
         self,
     ) -> None:
         fake_session = _TimedOutAggregateOptionsFreshnessSession()
@@ -757,11 +757,15 @@ class TestTradingApi(TestCase):
             route_symbols=["AAPL", "MSFT"],
         )
 
-        self.assertEqual(payload["status"], "unavailable")
+        self.assertEqual(payload["status"], "current")
         self.assertEqual(payload["scope"], "route_symbols")
         self.assertEqual(payload["route_symbols"], ["AAPL", "MSFT"])
+        self.assertTrue(payload["bounded"])
+        self.assertFalse(payload["coverage_exact"])
+        self.assertFalse(payload["active_contracts_exact"])
+        self.assertEqual(payload["active_contracts"], 2)
         self.assertIn(
-            "options_catalog_freshness_summary_unavailable",
+            "options_catalog_freshness_bounded_route_scope",
             payload["reason_codes"],
         )
         self.assertIn(
@@ -770,7 +774,7 @@ class TestTradingApi(TestCase):
         )
         self.assertEqual(
             sum("LIMIT 1" in sql for sql, _params in fake_session.calls),
-            0,
+            2,
         )
 
     def test_options_catalog_freshness_summary_expires_cached_route_scope(


### PR DESCRIPTION
## Summary

- Bound route-scoped options catalog freshness after aggregate query timeouts with a non-exact fallback instead of returning only unavailable status.
- Preserve honest evidence semantics by marking fallback payloads as bounded and non-exact with timeout reason codes.
- Default the in-process options freshness cache to 30 seconds so repeated readiness/status probes do not hammer the same slow aggregate path.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_api.py -k options_catalog_freshness_summary -q`
- `uv run --frozen pytest tests/test_trading_api.py -q`
- `uv run --frozen ruff format --check app/config.py app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/config.py app/main.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
