### PR TITLE
fix(torghut): enable bounded hpairs paper route collection

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -394,6 +394,21 @@ def _target_probe_action(target: Mapping[str, Any]) -> Literal["buy", "sell"]:
     return "buy"
 
 
+def _target_probe_cap(target: Mapping[str, Any]) -> Decimal | None:
+    for key in (
+        "paper_route_probe_next_session_max_notional",
+        "bounded_evidence_collection_max_notional",
+        "paper_route_probe_effective_max_notional",
+        "paper_route_probe_target_notional",
+        "target_notional",
+        "max_notional",
+    ):
+        cap = _optional_decimal(target.get(key))
+        if cap is not None and cap > 0:
+            return cap
+    return None
+
+
 def _target_probe_exit_minute_after_open(
     target: Mapping[str, Any],
 ) -> tuple[int | None, bool]:
@@ -2955,9 +2970,7 @@ class SimpleTradingPipeline(TradingPipeline):
             window_start, window_end = window
             if now < window_start or now >= window_end:
                 continue
-            target_cap = _optional_decimal(
-                target.get("paper_route_probe_next_session_max_notional")
-            )
+            target_cap = _target_probe_cap(target)
             if target_cap is None or target_cap <= 0:
                 continue
             strategy = self._paper_route_target_strategy(target, strategies)
@@ -3126,7 +3139,7 @@ class SimpleTradingPipeline(TradingPipeline):
                     StrategyDecision(
                         strategy_id=str(strategy.id),
                         symbol=symbol,
-                        event_ts=window_start,
+                        event_ts=now,
                         timeframe=timeframe,
                         action=action,
                         qty=Decimal("1"),

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1603,6 +1603,15 @@ _RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS = (
     "runtime_ledger_source_window_evidence_pending",
     "live_runtime_ledger_required",
 )
+_HPAIRS_BOUNDED_COLLECTION_HYPOTHESIS_ID = "H-PAIRS-01"
+_HPAIRS_BOUNDED_COLLECTION_CANDIDATE_ID = "c88421d619759b2cfaa6f4d0"
+_BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_KIND = "paper_route_probe_runtime_observed"
+_BOUNDED_PAPER_ROUTE_COLLECTION_SCOPE = "paper_route_probe_next_session_only"
+_BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS = (
+    "bounded_paper_route_evidence_collection_only",
+    "paper_route_runtime_ledger_import_pending",
+    "live_runtime_ledger_required",
+)
 
 
 def _runtime_ledger_paper_probation_eligible(
@@ -1979,6 +1988,191 @@ def _runtime_ledger_paper_probation_import_plan(
         "targets": targets,
         "skipped_targets": skipped_targets,
     }
+
+
+def _runtime_ledger_import_plan_has_target(
+    plan: Mapping[str, object],
+    *,
+    hypothesis_id: str,
+    candidate_id: str,
+) -> bool:
+    for target in cast(Sequence[object], plan.get("targets") or []):
+        if not isinstance(target, Mapping):
+            continue
+        typed_target = cast(Mapping[str, object], target)
+        if (
+            _safe_text(typed_target.get("hypothesis_id")) == hypothesis_id
+            and _safe_text(typed_target.get("candidate_id")) == candidate_id
+        ):
+            return True
+    return False
+
+
+def _bounded_paper_route_manifest_collection_targets(
+    registry_items: Sequence[Mapping[str, object]],
+    *,
+    existing_plan: Mapping[str, object],
+) -> list[dict[str, object]]:
+    """Return bounded manifest-seeded source collection targets.
+
+    Runtime-ledger repair candidates are intentionally strict and require
+    existing filled paper activity. H-PAIRS can get stuck before that first
+    source-backed row exists, so seed only the known H-PAIRS paper-route
+    collection handoff from source-controlled registry metadata. The returned
+    targets are collection-only: they do not grant promotion authority or live
+    capital routing, and the downstream paper-route target-plan audit still
+    applies source-strategy, account-cleanliness, dependency, and runtime-window
+    readiness gates before the scheduler can submit paper orders.
+    """
+
+    targets: list[dict[str, object]] = []
+    for item in registry_items:
+        hypothesis_id = _safe_text(item.get("hypothesis_id"))
+        candidate_id = _safe_text(item.get("candidate_id"))
+        if (
+            hypothesis_id != _HPAIRS_BOUNDED_COLLECTION_HYPOTHESIS_ID
+            or candidate_id != _HPAIRS_BOUNDED_COLLECTION_CANDIDATE_ID
+        ):
+            continue
+        if _runtime_ledger_import_plan_has_target(
+            existing_plan,
+            hypothesis_id=hypothesis_id,
+            candidate_id=candidate_id,
+        ):
+            continue
+
+        strategy_id = _safe_text(item.get("strategy_id"))
+        manifest_strategy_name = _runtime_ledger_paper_probation_strategy_name(item)
+        strategy_family = _safe_text(item.get("strategy_family"))
+        source_manifest_ref = _hypothesis_manifest_ref(hypothesis_id)
+        missing = [
+            field
+            for field, value in (
+                ("strategy_family", strategy_family),
+                ("strategy_name", manifest_strategy_name),
+                ("source_manifest_ref", source_manifest_ref),
+            )
+            if value is None
+        ]
+        if missing:
+            continue
+
+        strategy_lookup_names = _strategy_lookup_names(
+            item.get("strategy_lookup_names"),
+            manifest_strategy_name,
+            strategy_names_from_strategy_id(strategy_id),
+            derived_strategy_name_from_strategy_id(strategy_id),
+        )
+        targets.append(
+            {
+                "hypothesis_id": hypothesis_id,
+                "candidate_id": candidate_id,
+                "observed_stage": "paper",
+                "strategy_family": strategy_family,
+                "strategy_name": manifest_strategy_name,
+                "strategy_id": strategy_id or "",
+                "runtime_strategy_name": manifest_strategy_name,
+                "strategy_lookup_names": strategy_lookup_names,
+                "account_label": "TORGHUT_SIM",
+                "source_account_label": "TORGHUT_SIM",
+                "account_stage_runtime_identity": {
+                    "account_label": "TORGHUT_SIM",
+                    "source_account_label": "TORGHUT_SIM",
+                    "observed_stage": "paper",
+                    "runtime_strategy_name": manifest_strategy_name,
+                    "source_kind": _BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_KIND,
+                },
+                "source_dsn_env": "SIM_DB_DSN",
+                "target_dsn_env": "SIM_DB_DSN",
+                "dataset_snapshot_ref": _safe_text(item.get("dataset_snapshot_ref"))
+                or "",
+                "source_manifest_ref": source_manifest_ref,
+                "source_kind": _BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_KIND,
+                "paper_probation_authorized": True,
+                "paper_probation_authorization_scope": "evidence_collection_only",
+                "source_collection_authorized": True,
+                "source_collection_authorization_scope": (
+                    "bounded_paper_route_source_decision_collection_only"
+                ),
+                "source_collection_reason_codes": [
+                    "runtime_ledger_source_decisions_missing",
+                    "bounded_paper_route_manifest_seed",
+                ],
+                "proof_mode": "probation",
+                "evidence_collection_ok": True,
+                "canary_collection_authorized": True,
+                "bounded_live_paper_collection_authorized": True,
+                "bounded_evidence_collection_authorized": True,
+                "bounded_evidence_collection_scope": (
+                    _BOUNDED_PAPER_ROUTE_COLLECTION_SCOPE
+                ),
+                "capital_promotion_allowed": False,
+                "final_authority_ok": False,
+                "evidence_collection_stage": "paper",
+                "probation_allowed": True,
+                "probation_reason": "bounded_paper_route_source_activity_needed",
+                "promotion_allowed": False,
+                "final_promotion_authorized": False,
+                "final_promotion_allowed": False,
+                "final_promotion_blockers": list(
+                    _BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS
+                ),
+                "candidate_blockers": [
+                    "runtime_ledger_source_decisions_missing",
+                    "paper_route_runtime_ledger_import_pending",
+                ],
+                "runtime_ledger_target_metadata_blockers": list(
+                    _BOUNDED_PAPER_ROUTE_COLLECTION_PROMOTION_BLOCKERS
+                ),
+                "handoff": "next_paper_route_runtime_window_import",
+                "promotion_gate": "runtime_ledger_live_or_live_paper_required",
+                "selected_by": "hypothesis_manifest_bounded_paper_route_collection",
+                "selection_reason": "source_decisions_missing_for_bounded_paper_route",
+                "max_notional": "0",
+            }
+        )
+    return targets
+
+
+def _with_bounded_paper_route_manifest_collection_targets(
+    plan: Mapping[str, object],
+    *,
+    registry_items: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    merged_plan = dict(plan)
+    manifest_targets = _bounded_paper_route_manifest_collection_targets(
+        registry_items,
+        existing_plan=merged_plan,
+    )
+    if not manifest_targets:
+        return merged_plan
+
+    targets = [
+        dict(cast(Mapping[str, object], target))
+        for target in cast(Sequence[object], merged_plan.get("targets") or [])
+        if isinstance(target, Mapping)
+    ]
+    targets.extend(manifest_targets)
+    merged_plan["targets"] = targets
+    merged_plan["target_count"] = len(targets)
+    merged_plan["manifest_bounded_collection_target_count"] = len(manifest_targets)
+    merged_plan["source_collection_target_count"] = _safe_int(
+        merged_plan.get("source_collection_target_count")
+    ) + len(manifest_targets)
+    merged_plan["evidence_collection_ok"] = bool(targets)
+    merged_plan["canary_collection_authorized"] = any(
+        bool(target.get("canary_collection_authorized")) for target in targets
+    )
+    merged_plan["bounded_live_paper_collection_authorized"] = any(
+        bool(target.get("bounded_live_paper_collection_authorized"))
+        for target in targets
+    )
+    merged_plan["capital_promotion_allowed"] = False
+    merged_plan["final_authority_ok"] = False
+    merged_plan["promotion_allowed"] = False
+    merged_plan["final_promotion_authorized"] = False
+    merged_plan["final_promotion_allowed"] = False
+    return merged_plan
 
 
 def _paper_probation_eligible_total_with_runtime_ledger(
@@ -3729,6 +3923,12 @@ def build_live_submission_gate_payload(
             ]
         )
     )
+    runtime_ledger_paper_probation_import_plan = (
+        _with_bounded_paper_route_manifest_collection_targets(
+            runtime_ledger_paper_probation_import_plan,
+            registry_items=registry_item_payloads,
+        )
+    )
     evidence_rows = (
         [dict(item) for item in promotion_certificate_evidence]
         if promotion_certificate_evidence is not None
@@ -3899,7 +4099,11 @@ def build_live_submission_gate_payload(
         blocked_reasons.append("alpha_readiness_not_promotion_eligible")
         if runtime_ledger_paper_probation_candidates:
             blocked_reasons.append("paper_probation_evidence_collection_only")
-        if runtime_ledger_source_collection_candidates:
+        if runtime_ledger_source_collection_candidates or _safe_int(
+            runtime_ledger_paper_probation_import_plan.get(
+                "manifest_bounded_collection_target_count"
+            )
+        ):
             blocked_reasons.append("runtime_ledger_source_collection_pending")
     if empirical_ready is False:
         blocked_reasons.append("empirical_jobs_not_ready")

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -2027,6 +2027,106 @@ class TestSubmissionCouncil(TestCase):
         self.assertTrue(target["source_collection_authorized"])
         self.assertFalse(target["promotion_allowed"])
 
+    def test_live_gate_seeds_hpairs_bounded_collection_target_without_source_rows(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+        class _RegistryItem:
+            hypothesis_id = "H-PAIRS-01"
+
+            def model_dump(self, *, mode: str = "json") -> dict[str, object]:
+                return {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "lane_id": "microbar_cross_sectional_pairs",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                }
+
+        registry = SimpleNamespace(
+            loaded=True,
+            path="test-registry",
+            errors=[],
+            items=[_RegistryItem()],
+        )
+
+        with session_local() as session:
+            with patch(
+                "app.trading.submission_council.load_hypothesis_registry",
+                return_value=registry,
+            ):
+                gate = build_live_submission_gate_payload(
+                    SimpleNamespace(
+                        market_session_open=True,
+                        last_autonomy_promotion_eligible=False,
+                        last_autonomy_promotion_action=None,
+                        drift_live_promotion_eligible=False,
+                        last_market_context_freshness_seconds=45,
+                        metrics=SimpleNamespace(
+                            feature_batch_rows_total=9,
+                            feature_null_rate={"price": 0.0},
+                            feature_staleness_ms_p95=250,
+                            feature_duplicate_ratio=0.0,
+                            decision_state_total={},
+                        ),
+                    ),
+                    hypothesis_summary={
+                        "summary": {
+                            "promotion_eligible_total": 0,
+                            "capital_stage_totals": {"shadow": 1},
+                            "dependency_quorum": {
+                                "decision": "allow",
+                                "reasons": [],
+                                "message": "ready",
+                            },
+                        },
+                        "items": [],
+                    },
+                    empirical_jobs_status={"ready": True, "status": "healthy"},
+                    dspy_runtime_status={"mode": "inactive"},
+                    quant_health_status=self._healthy_quant_status(),
+                    promotion_certificate_evidence=[],
+                    session=session,
+                )
+
+        self.assertFalse(gate["allowed"])
+        self.assertFalse(gate["runtime_ledger_paper_probation_candidates"])
+        self.assertFalse(gate["runtime_ledger_source_collection_candidates"])
+        self.assertIn(
+            "runtime_ledger_source_collection_pending", gate["blocked_reasons"]
+        )
+        import_plan = gate["runtime_ledger_paper_probation_import_plan"]
+        self.assertEqual(import_plan["target_count"], 1)
+        self.assertEqual(import_plan["manifest_bounded_collection_target_count"], 1)
+        self.assertTrue(import_plan["bounded_live_paper_collection_authorized"])
+        self.assertFalse(import_plan["promotion_allowed"])
+        self.assertFalse(import_plan["final_promotion_allowed"])
+        target = import_plan["targets"][0]
+        self.assertEqual(target["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(target["candidate_id"], "c88421d619759b2cfaa6f4d0")
+        self.assertEqual(target["account_label"], "TORGHUT_SIM")
+        self.assertEqual(target["source_kind"], "paper_route_probe_runtime_observed")
+        self.assertEqual(
+            target["runtime_strategy_name"], "microbar-cross-sectional-pairs-v1"
+        )
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertTrue(target["source_collection_authorized"])
+        self.assertFalse(target["capital_promotion_allowed"])
+        self.assertFalse(target["final_promotion_authorized"])
+        self.assertIn(
+            "runtime_ledger_source_decisions_missing",
+            target["candidate_blockers"],
+        )
+
     def test_metric_window_activity_rejects_tca_proxy_expectancy(self) -> None:
         metric_window = SimpleNamespace(
             market_session_count=3,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8657,6 +8657,167 @@ class TestTradingPipeline(TestCase):
             [("AAPL", "buy"), ("AMZN", "sell")],
         )
 
+    def test_bounded_hpairs_target_source_records_decisions_and_executions(
+        self,
+    ) -> None:
+        from app import config
+
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        now = window_start + timedelta(minutes=15)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_simple_max_notional_per_order = 1000.0
+        config.settings.trading_simple_max_notional_per_symbol = 1000.0
+
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="microbar_cross_sectional_pairs_v1",
+                universe_symbols=["AAPL", "AMZN"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            target = {
+                "account_label": "TORGHUT_SIM",
+                "observed_stage": "paper",
+                "source_kind": "paper_route_probe_runtime_observed",
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "hypothesis_id": "H-PAIRS-01",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                "strategy_lookup_names": [str(strategy.id), strategy.name],
+                "strategy_family": "microbar_cross_sectional_pairs",
+                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                "paper_route_probe_symbol_actions": {
+                    "AAPL": "buy",
+                    "AMZN": "sell",
+                },
+                "paper_route_probe_window_start": window_start.isoformat(),
+                "paper_route_probe_window_end": window_end.isoformat(),
+                "paper_route_probe_next_session_max_notional": "0",
+                "bounded_evidence_collection_max_notional": "500",
+                "max_notional": "0",
+                "bounded_evidence_collection_authorized": True,
+                "bounded_live_paper_collection_authorized": True,
+                "bounded_evidence_collection_scope": "paper_route_probe_next_session_only",
+                "evidence_collection_ok": True,
+                "source_decision_readiness": {"ready": True, "blockers": []},
+                "runtime_window_import_health_gate_blockers": [
+                    "evidence_continuity_not_ok"
+                ],
+                "paper_route_account_pre_session_blockers": [],
+                "paper_route_hpairs_symbol_blockers": [],
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "final_promotion_authorized": False,
+            }
+            proof_floor = {
+                "route_state": "repair_only",
+                "capital_state": "zero_notional",
+                "max_notional": "0",
+                "market_window": {"session_open": True},
+                "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+            }
+
+            def priced_decision(
+                decision: StrategyDecision, signal_price: object = None
+            ) -> tuple[StrategyDecision, MarketSnapshot | None]:
+                del signal_price
+                params = dict(decision.params)
+                params["price"] = Decimal("100")
+                return decision.model_copy(update={"params": params}), None
+
+            with (
+                patch.object(
+                    pipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=({"AAPL", "AMZN"}, None, [target]),
+                ),
+                patch.object(
+                    SimpleTradingPipeline,
+                    "_profitability_proof_floor",
+                    return_value=proof_floor,
+                ),
+                patch.object(
+                    pipeline,
+                    "_ensure_decision_price",
+                    side_effect=priced_decision,
+                ),
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=now,
+                ),
+                patch(
+                    "app.trading.scheduler.pipeline.trading_now",
+                    return_value=now,
+                ),
+            ):
+                pipeline._process_paper_route_target_source_decisions(
+                    session=session,
+                    strategies=[strategy],
+                    account=alpaca_client.get_account(),
+                    positions=[],
+                    allowed_symbols={"AAPL", "AMZN"},
+                )
+
+            decisions = session.execute(
+                select(TradeDecision).order_by(TradeDecision.symbol)
+            ).scalars().all()
+            executions = session.execute(
+                select(Execution).order_by(Execution.symbol)
+            ).scalars().all()
+
+        self.assertEqual([decision.symbol for decision in decisions], ["AAPL", "AMZN"])
+        self.assertEqual(
+            [decision.status for decision in decisions], ["submitted", "submitted"]
+        )
+        self.assertEqual(
+            [execution.symbol for execution in executions], ["AAPL", "AMZN"]
+        )
+        self.assertEqual(len(alpaca_client.submitted), 2)
+        for decision in decisions:
+            payload = cast(dict[str, Any], decision.decision_json)
+            params = cast(dict[str, Any], payload.get("params") or {})
+            metadata = cast(
+                dict[str, Any], params.get("paper_route_target_plan") or {}
+            )
+            self.assertEqual(
+                metadata.get("paper_route_probe_next_session_max_notional"), "500"
+            )
+            self.assertFalse(params.get("promotion_allowed"))
+            self.assertFalse(params.get("final_promotion_allowed"))
+            self.assertFalse(params.get("final_promotion_authorized"))
+            self.assertEqual(params.get("execution_account_label"), "TORGHUT_SIM")
+
     def test_paper_route_target_source_skips_pair_when_account_not_flat(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Seeds the known H-PAIRS-01 bounded paper-route source-collection handoff from registry metadata when no prior source rows/runtime-ledger targets exist yet.
- Keeps the seeded handoff collection-only: TORGHUT_SIM paper route, zero live-capital authority, and promotion/final-promotion gates explicitly false.
- Lets the scheduler honor positive bounded evidence caps even when promotion max_notional remains zero, and records fresh event timestamps so late-session probes are not immediately recovered as stale.
- Adds regression coverage for target-plan materialization plus bounded H-PAIRS paper source decisions/executions while preserving blocked final promotion.

## Related Issues

None

## Testing

- Pass: `cd services/torghut && uv sync --frozen --extra dev`
- Pass: `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_completion_trace.py -q`
- Pass: `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py app/trading/submission_council.py app/trading/paper_route_evidence.py app/trading/completion.py tests/test_trading_pipeline.py tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_completion_trace.py`
- Pass: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- Pass: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- Pass: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- Pass: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
