### PR TITLE
fix(torghut): harden tigerbeetle tca cost refs

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -72,6 +72,12 @@ _NON_PROMOTION_SOURCE_MARKERS = frozenset(
         "simulation_source_replay_only",
     }
 )
+_TIGERBEETLE_EXECUTION_COST_JOURNAL_FAILURE_BLOCKER = (
+    "tigerbeetle_execution_cost_journal_failed"
+)
+_TIGERBEETLE_JOURNAL_SUCCESS_STATUSES = frozenset(
+    {"", "pass", "passed", "success", "succeeded", "journaled", "created", "exists"}
+)
 _DIAGNOSTIC_EXPECTANCY_SUPPRESSING_BLOCKERS = frozenset(
     {
         "runtime_fills_missing",
@@ -806,6 +812,7 @@ def _normalize_fill_row(
         blockers.append("tca_shortfall_not_runtime_pnl")
     if _is_non_promotion_runtime_source_row(row):
         blockers.append("runtime_source_not_promotion_authority")
+    blockers.extend(_tigerbeetle_journal_blockers(row))
     if executed_at is None and event_type != "diagnostic":
         blockers.append("executed_at_missing")
     if event_type in _FILL_EVENTS and not lifecycle_only:
@@ -1111,6 +1118,42 @@ def _has_tca_pnl_shortcut(row: RuntimeLedgerFill | Mapping[str, object]) -> bool
         and _row_value(row, "shortfall_notional", "realized_pnl_proxy_notional")
         is not None
     )
+
+
+def _tigerbeetle_journal_blockers(
+    row: RuntimeLedgerFill | Mapping[str, object],
+) -> list[str]:
+    blockers: list[str] = []
+    for key in (
+        "tigerbeetle_journal_blockers",
+        "tigerbeetle_journal_blocker",
+        "tigerbeetle_execution_cost_journal_blockers",
+        "tigerbeetle_execution_cost_journal_blocker",
+    ):
+        value = _row_value(row, key)
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            for item in cast(Sequence[object], value):
+                blocker = str(item).strip()
+                if blocker:
+                    blockers.append(blocker)
+        elif value is not None and str(value).strip():
+            blockers.append(str(value).strip())
+
+    status = _coerce_text(
+        _row_value(
+            row,
+            "tigerbeetle_execution_cost_journal_status",
+            "tigerbeetle_journal_status",
+        )
+    )
+    if (
+        status is not None
+        and status.lower().replace("-", "_") not in _TIGERBEETLE_JOURNAL_SUCCESS_STATUSES
+    ):
+        blockers.append(_TIGERBEETLE_EXECUTION_COST_JOURNAL_FAILURE_BLOCKER)
+    return _dedupe(blockers)
 
 
 def _group_key(row: _NormalizedFill, group_by: Sequence[str]) -> tuple[str | None, ...]:

--- a/services/torghut/app/trading/tca.py
+++ b/services/torghut/app/trading/tca.py
@@ -15,7 +15,11 @@ from sqlalchemy.orm import Session
 from ..config import settings
 from ..models import Execution, ExecutionTCAMetric, TradeDecision
 from .prices import resolve_execution_reference_price
-from .tigerbeetle_journal import TigerBeetleLedgerJournal
+from .tigerbeetle_journal import (
+    TIGERBEETLE_BLOCKER_JOURNAL_ERROR,
+    TIGERBEETLE_BLOCKER_TRANSFER_REF_CONFLICT,
+    TigerBeetleLedgerJournal,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -215,11 +219,23 @@ def _journal_tigerbeetle_execution_cost(
     except Exception as exc:
         if settings.tigerbeetle_required:
             raise
+        blocker = (
+            TIGERBEETLE_BLOCKER_TRANSFER_REF_CONFLICT
+            if TIGERBEETLE_BLOCKER_TRANSFER_REF_CONFLICT in str(exc)
+            else TIGERBEETLE_BLOCKER_JOURNAL_ERROR
+        )
         logger.warning(
-            "TigerBeetle execution/TCA journal failed for execution_id=%s metric_id=%s: %s",
+            "TigerBeetle execution/TCA journal failed for execution_id=%s metric_id=%s blocker=%s: %s",
             execution.id,
             metric.id,
+            blocker,
             exc,
+            extra={
+                "tigerbeetle_execution_cost_journal_status": "blocked",
+                "tigerbeetle_execution_cost_journal_blocker": blocker,
+                "tigerbeetle_execution_id": str(execution.id),
+                "tigerbeetle_execution_tca_metric_id": str(metric.id),
+            },
         )
 
 

--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -67,6 +67,7 @@ TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_NON_AUTHORITY_BLOCKED = (
 TIGERBEETLE_BLOCKER_JOURNAL_DISABLED = "tigerbeetle_journal_disabled"
 TIGERBEETLE_BLOCKER_JOURNAL_ENTRY_UNAVAILABLE = "tigerbeetle_journal_entry_unavailable"
 TIGERBEETLE_BLOCKER_JOURNAL_ERROR = "tigerbeetle_journal_error"
+TIGERBEETLE_BLOCKER_TRANSFER_REF_CONFLICT = "tigerbeetle_transfer_ref_conflict"
 TIGERBEETLE_AUTHORITY_BLOCKER_ACCOUNTING_ONLY = (
     "tigerbeetle_accounting_parity_not_promotion_authority"
 )
@@ -880,6 +881,46 @@ def _transfer_matches(
     )
 
 
+def _transfer_ref_mismatches(
+    ref: TigerBeetleTransferRef,
+    expected: TigerBeetleTransferSpec,
+) -> list[str]:
+    mismatches: list[str] = []
+    if ref.transfer_id != u128_decimal(expected.transfer_id):
+        mismatches.append("transfer_id")
+    if ref.transfer_kind != expected.transfer_kind:
+        mismatches.append("transfer_kind")
+    if ref.amount != Decimal(expected.amount):
+        mismatches.append("amount")
+    if ref.ledger != expected.ledger:
+        mismatches.append("ledger")
+    if ref.code != expected.code:
+        mismatches.append("code")
+    payload = _nested_mapping(ref.payload_json)
+    expected_debit = u128_decimal(expected.debit_account_id)
+    expected_credit = u128_decimal(expected.credit_account_id)
+    if payload.get("debit_account_id") not in {None, expected_debit}:
+        mismatches.append("debit_account_id")
+    if payload.get("credit_account_id") not in {None, expected_credit}:
+        mismatches.append("credit_account_id")
+    if expected.pending_id:
+        expected_pending = u128_decimal(expected.pending_id)
+        if payload.get("pending_id") not in {None, expected_pending}:
+            mismatches.append("pending_id")
+    return mismatches
+
+
+def _assert_transfer_ref_matches(
+    ref: TigerBeetleTransferRef,
+    expected: TigerBeetleTransferSpec,
+) -> None:
+    mismatches = _transfer_ref_mismatches(ref, expected)
+    if mismatches:
+        raise RuntimeError(
+            f"{TIGERBEETLE_BLOCKER_TRANSFER_REF_CONFLICT}:{','.join(mismatches)}"
+        )
+
+
 def _source_transfer_spec(
     *,
     transfer_id: int,
@@ -1084,61 +1125,68 @@ class TigerBeetleLedgerJournal:
         payload_json: Mapping[str, object],
     ) -> TigerBeetleTransferRef:
         transfer_id_text = u128_decimal(transfer_spec.transfer_id)
-        existing = session.execute(
+        source_existing = session.execute(
             select(TigerBeetleTransferRef).where(
                 TigerBeetleTransferRef.cluster_id
                 == self._settings.tigerbeetle_cluster_id,
-                TigerBeetleTransferRef.transfer_id == transfer_id_text,
+                TigerBeetleTransferRef.source_type == source_type,
+                TigerBeetleTransferRef.source_id == source_id,
+                TigerBeetleTransferRef.transfer_kind == transfer_spec.transfer_kind,
             )
         ).scalar_one_or_none()
+        if source_existing is not None:
+            _assert_transfer_ref_matches(source_existing, transfer_spec)
+            existing = source_existing
+        else:
+            existing = session.execute(
+                select(TigerBeetleTransferRef).where(
+                    TigerBeetleTransferRef.cluster_id
+                    == self._settings.tigerbeetle_cluster_id,
+                    TigerBeetleTransferRef.transfer_id == transfer_id_text,
+                )
+            ).scalar_one_or_none()
         if existing is not None:
-            if (
-                existing.transfer_kind == transfer_spec.transfer_kind
-                and existing.amount == Decimal(transfer_spec.amount)
-                and existing.code == transfer_spec.code
-                and existing.ledger == transfer_spec.ledger
-            ):
-                if existing.trade_decision_id is None:
-                    existing.trade_decision_id = cast(Any, trade_decision_id)
-                if existing.execution_id is None:
-                    existing.execution_id = cast(Any, execution_id)
-                if existing.execution_order_event_id is None:
-                    existing.execution_order_event_id = cast(
-                        Any,
-                        execution_order_event_id,
-                    )
-                if existing.execution_tca_metric_id is None:
-                    existing.execution_tca_metric_id = cast(
-                        Any,
-                        execution_tca_metric_id,
-                    )
-                if existing.runtime_ledger_bucket_id is None:
-                    existing.runtime_ledger_bucket_id = cast(
-                        Any,
-                        runtime_ledger_bucket_id,
-                    )
-                if existing.source_type is None:
-                    existing.source_type = source_type
-                if existing.source_id is None:
-                    existing.source_id = source_id
-                if existing.event_fingerprint is None:
-                    existing.event_fingerprint = event_fingerprint
-                raw_existing_payload: object = existing.payload_json
-                existing_payload: Mapping[str, object] = (
-                    cast(Mapping[str, object], raw_existing_payload)
-                    if isinstance(raw_existing_payload, Mapping)
-                    else {}
+            _assert_transfer_ref_matches(existing, transfer_spec)
+            if existing.trade_decision_id is None:
+                existing.trade_decision_id = cast(Any, trade_decision_id)
+            if existing.execution_id is None:
+                existing.execution_id = cast(Any, execution_id)
+            if existing.execution_order_event_id is None:
+                existing.execution_order_event_id = cast(
+                    Any,
+                    execution_order_event_id,
                 )
-                existing.payload_json = coerce_json_payload(
-                    {
-                        **existing_payload,
-                        **payload_json,
-                    }
+            if existing.execution_tca_metric_id is None:
+                existing.execution_tca_metric_id = cast(
+                    Any,
+                    execution_tca_metric_id,
                 )
-                session.add(existing)
-                session.flush()
-                return existing
-            raise RuntimeError("tigerbeetle_transfer_ref_conflict")
+            if existing.runtime_ledger_bucket_id is None:
+                existing.runtime_ledger_bucket_id = cast(
+                    Any,
+                    runtime_ledger_bucket_id,
+                )
+            if existing.source_type is None:
+                existing.source_type = source_type
+            if existing.source_id is None:
+                existing.source_id = source_id
+            if existing.event_fingerprint is None:
+                existing.event_fingerprint = event_fingerprint
+            raw_existing_payload: object = existing.payload_json
+            existing_payload: Mapping[str, object] = (
+                cast(Mapping[str, object], raw_existing_payload)
+                if isinstance(raw_existing_payload, Mapping)
+                else {}
+            )
+            existing.payload_json = coerce_json_payload(
+                {
+                    **existing_payload,
+                    **payload_json,
+                }
+            )
+            session.add(existing)
+            session.flush()
+            return existing
 
         _persist_account_refs(
             session,
@@ -1243,11 +1291,19 @@ class TigerBeetleLedgerJournal:
             source_id=str(execution.id),
             payload_json={
                 "source": SOURCE_TYPE_EXECUTION,
+                "source_refs": [
+                    f"postgres:executions:{execution.id}",
+                ],
+                "economic_event_key": f"execution:{execution.id}:fill_notional",
                 "alpaca_order_id": execution.alpaca_order_id,
                 "client_order_id": execution.client_order_id,
                 "filled_qty": str(execution.filled_qty),
                 "avg_fill_price": str(execution.avg_fill_price),
+                "amount_source": str(plan.amount_source),
                 "notional_micros": transfer_spec.amount,
+                "transfer_id": u128_decimal(transfer_spec.transfer_id),
+                "ledger": transfer_spec.ledger,
+                "code": transfer_spec.code,
                 "debit_account_id": u128_decimal(transfer_spec.debit_account_id),
                 "credit_account_id": u128_decimal(transfer_spec.credit_account_id),
             },
@@ -1276,10 +1332,22 @@ class TigerBeetleLedgerJournal:
             source_id=str(metric.id),
             payload_json={
                 "source": SOURCE_TYPE_EXECUTION_TCA_METRIC,
+                "source_refs": [
+                    f"postgres:execution_tca_metrics:{metric.id}",
+                    f"postgres:executions:{metric.execution_id}",
+                ],
+                "economic_event_key": (
+                    f"execution:{metric.execution_id}:tca_metric:{metric.id}:"
+                    "execution_cost"
+                ),
                 "shortfall_notional": str(metric.shortfall_notional),
                 "realized_shortfall_bps": str(metric.realized_shortfall_bps),
                 "simulator_version": metric.simulator_version,
+                "amount_source": str(plan.amount_source),
                 "cost_micros": transfer_spec.amount,
+                "transfer_id": u128_decimal(transfer_spec.transfer_id),
+                "ledger": transfer_spec.ledger,
+                "code": transfer_spec.code,
                 "debit_account_id": u128_decimal(transfer_spec.debit_account_id),
                 "credit_account_id": u128_decimal(transfer_spec.credit_account_id),
             },

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -74,6 +74,47 @@ def test_closed_round_trip_pnl_uses_net_after_explicit_costs() -> None:
     )
 
 
+def test_tigerbeetle_execution_cost_journal_failure_blocks_authority() -> None:
+    bucket = _bucket(
+        [
+            {
+                "executed_at": _ts(1),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "cost_amount": "1.00",
+                "cost_basis": "broker_reported_commission_and_fees",
+                "tigerbeetle_execution_cost_journal_status": "blocked",
+                "tigerbeetle_execution_cost_journal_blockers": [
+                    "tigerbeetle_transfer_ref_conflict:amount",
+                    "",
+                ],
+            },
+            {
+                "executed_at": _ts(12),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "10",
+                "avg_fill_price": "110",
+                "cost_amount": "2.00",
+                "cost_basis": "broker_reported_commission_and_fees",
+                "tigerbeetle_execution_cost_journal_status": "created",
+            },
+        ]
+    )
+
+    assert "tigerbeetle_execution_cost_journal_failed" in bucket.blockers
+    assert "tigerbeetle_transfer_ref_conflict:amount" in bucket.blockers
+    assert bucket.cost_amount == Decimal("0")
+    assert bucket.net_strategy_pnl_after_costs == Decimal("0")
+    assert bucket.post_cost_expectancy_bps is None
+
+
 def test_partial_unclosed_positions_report_realized_pnl_but_block_expectancy() -> None:
     bucket = _bucket(
         [

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -41,6 +41,7 @@ from app.trading.tigerbeetle_journal import (
     _result_status,
     _transfer_attr,
     _transfer_flag,
+    _transfer_ref_mismatches,
     _transfer_spec,
     build_order_event_transfer_plan,
     submitted_pending_transfer_id,
@@ -489,6 +490,186 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(ref.transfer_kind, TRANSFER_KIND_EXECUTION_COST)
             self.assertEqual(ref.transfer_id, str(execution_cost_transfer_id(metric)))
             self.assertEqual(ref.amount, Decimal("250000"))
+            self.assertEqual(
+                ref.payload_json["source_refs"],
+                [
+                    f"postgres:execution_tca_metrics:{metric.id}",
+                    f"postgres:executions:{metric.execution_id}",
+                ],
+            )
+            self.assertEqual(
+                ref.payload_json["economic_event_key"],
+                f"execution:{metric.execution_id}:tca_metric:{metric.id}:execution_cost",
+            )
+            self.assertEqual(ref.payload_json["amount_source"], "0.25")
+            self.assertEqual(ref.payload_json["ledger"], LEDGER_USD_MICRO)
+            self.assertEqual(ref.payload_json["code"], 2011)
+            self.assertEqual(ref.payload_json["transfer_id"], ref.transfer_id)
+
+    def test_cost_source_retry_for_same_metric_is_idempotent(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(session, fingerprint="fingerprint-cost-retry")
+            metric = ExecutionTCAMetric(
+                execution_id=event.execution_id,
+                trade_decision_id=event.trade_decision_id,
+                strategy_id=event.trade_decision.strategy_id
+                if event.trade_decision
+                else None,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.25"),
+                realized_shortfall_bps=Decimal("1.3"),
+                computed_at=datetime.now(timezone.utc),
+            )
+            session.add(metric)
+            session.flush()
+            client = FakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            first = journal.journal_execution_tca_metric(session, metric)
+            second = journal.journal_execution_tca_metric(session, metric)
+
+            self.assertIsNotNone(first)
+            self.assertEqual(first, second)
+            refs = session.execute(select(TigerBeetleTransferRef)).scalars().all()
+            self.assertEqual(len(refs), 1)
+            self.assertEqual(len(client.transfers), 1)
+
+    def test_cost_source_same_ref_different_payload_is_blocked(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(
+                session, fingerprint="fingerprint-cost-payload-conflict"
+            )
+            metric = ExecutionTCAMetric(
+                execution_id=event.execution_id,
+                trade_decision_id=event.trade_decision_id,
+                strategy_id=event.trade_decision.strategy_id
+                if event.trade_decision
+                else None,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.25"),
+                realized_shortfall_bps=Decimal("1.3"),
+                computed_at=datetime.now(timezone.utc),
+            )
+            session.add(metric)
+            session.flush()
+            expected_transfer_id = str(execution_cost_transfer_id(metric))
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=expected_transfer_id,
+                    transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+                    ledger=LEDGER_USD_MICRO,
+                    code=2011,
+                    amount=Decimal("999"),
+                    status="created",
+                    execution_id=metric.execution_id,
+                    execution_tca_metric_id=metric.id,
+                    source_type="execution_tca_metric",
+                    source_id=str(metric.id),
+                    payload_json={
+                        "debit_account_id": "1",
+                        "credit_account_id": "2",
+                    },
+                )
+            )
+            session.flush()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "tigerbeetle_transfer_ref_conflict:.*amount.*debit_account_id.*credit_account_id",
+            ):
+                TigerBeetleLedgerJournal(
+                    settings_obj=_settings(), client=FakeTigerBeetleClient()
+                ).journal_execution_tca_metric(session, metric)
+
+    def test_cost_source_same_ref_different_currency_is_blocked(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(
+                session, fingerprint="fingerprint-cost-ledger-conflict"
+            )
+            metric = ExecutionTCAMetric(
+                execution_id=event.execution_id,
+                trade_decision_id=event.trade_decision_id,
+                strategy_id=event.trade_decision.strategy_id
+                if event.trade_decision
+                else None,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.25"),
+                realized_shortfall_bps=Decimal("1.3"),
+                computed_at=datetime.now(timezone.utc),
+            )
+            session.add(metric)
+            session.flush()
+            expected_transfer_id = str(execution_cost_transfer_id(metric))
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=expected_transfer_id,
+                    transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+                    ledger=LEDGER_USD_MICRO + 1,
+                    code=2011,
+                    amount=Decimal("250000"),
+                    status="created",
+                    execution_id=metric.execution_id,
+                    execution_tca_metric_id=metric.id,
+                    source_type="execution_tca_metric",
+                    source_id=str(metric.id),
+                    payload_json={},
+                )
+            )
+            session.flush()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "tigerbeetle_transfer_ref_conflict:ledger",
+            ):
+                TigerBeetleLedgerJournal(
+                    settings_obj=_settings(), client=FakeTigerBeetleClient()
+                ).journal_execution_tca_metric(session, metric)
+
+    def test_transfer_ref_mismatch_details_cover_identity_kind_code_and_pending(
+        self,
+    ) -> None:
+        expected = TigerBeetleTransferSpec(
+            transfer_id=123,
+            transfer_kind=TRANSFER_KIND_FILL_POST,
+            debit_account_id=11,
+            credit_account_id=22,
+            amount=1000,
+            ledger=LEDGER_USD_MICRO,
+            code=2001,
+            pending_id=456,
+        )
+        ref = TigerBeetleTransferRef(
+            cluster_id=2001,
+            transfer_id="999",
+            transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+            ledger=LEDGER_USD_MICRO,
+            code=2999,
+            amount=Decimal("1000"),
+            status="created",
+            payload_json={"pending_id": "999"},
+        )
+
+        self.assertEqual(
+            _transfer_ref_mismatches(ref, expected),
+            ["transfer_id", "transfer_kind", "code", "pending_id"],
+        )
 
     def test_runtime_bucket_source_writes_real_runtime_ledger_ref(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Harden TigerBeetle transfer-ref idempotency for execution/TCA cost journaling by validating existing refs against source identity plus immutable transfer payload fields.
- Preserve fail-closed conflict detection with precise `tigerbeetle_transfer_ref_conflict` with field-specific suffixes blockers for amount, account, ledger/currency, code, kind, transfer-id, and pending-id mismatches.
- Add TigerBeetle lineage metadata to execution and TCA cost transfer refs so runtime-ledger proof can link persisted refs back to Postgres source rows and economic events.
- Propagate TigerBeetle execution-cost journal failure metadata into runtime-ledger blockers so failed journaling cannot clear proof blockers or create authority-grade cost evidence.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_tca_adaptive_policy.py tests/test_refresh_execution_tca_metrics_script.py tests/test_tigerbeetle*.py tests/test_runtime_ledger.py -q`
- PASS: `cd services/torghut && uv run --frozen ruff check app/trading/tca.py app/trading/tigerbeetle_client.py app/trading/tigerbeetle_ids.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_ledger_model.py app/trading/tigerbeetle_reconcile.py app/trading/tigerbeetle_runtime_ledger_parity.py app/trading/runtime_ledger.py tests/test_tca_adaptive_policy.py tests/test_tigerbeetle_client.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_reconcile.py tests/test_runtime_ledger.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.