### PR TITLE
fix(torghut): bound options freshness by default

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -521,6 +521,15 @@ class Settings(BaseSettings):
             "preserving fail-closed evidence semantics."
         ),
     )
+    trading_options_catalog_freshness_exact_route_scope_enabled: bool = Field(
+        default=False,
+        alias="TRADING_OPTIONS_CATALOG_FRESHNESS_EXACT_ROUTE_SCOPE_ENABLED",
+        description=(
+            "Enable exact active-contract aggregation for route-scoped options catalog "
+            "freshness. Defaults off so readiness probes use explicitly non-exact "
+            "bounded reads instead of waiting for large catalog aggregates to time out."
+        ),
+    )
     trading_poll_ms: int = Field(default=5000, alias="TRADING_POLL_MS")
     trading_reconcile_ms: int = Field(default=15000, alias="TRADING_RECONCILE_MS")
     trading_order_feed_enabled: bool = Field(

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6251,6 +6251,33 @@ def _load_options_catalog_freshness_summary(
     cached_payload = _load_cached_options_catalog_freshness_summary(scoped_symbols)
     if cached_payload is not None:
         return cached_payload
+    if (
+        scoped_symbols
+        and not settings.trading_options_catalog_freshness_exact_route_scope_enabled
+    ):
+        reason_codes = [
+            "options_catalog_freshness_exact_route_scope_disabled",
+        ]
+        bounded_payload = _load_bounded_options_catalog_freshness_summary(
+            session,
+            scoped_symbols,
+            reason=reason_codes[-1],
+        )
+        if bounded_payload is not None:
+            return _store_options_catalog_freshness_summary(
+                scoped_symbols,
+                bounded_payload,
+            )
+        reason_codes.append("options_catalog_freshness_bounded_route_scope_unavailable")
+        return _store_options_catalog_freshness_summary(
+            scoped_symbols,
+            {
+                "status": "unavailable",
+                "scope": "route_symbols",
+                "route_symbols": list(scoped_symbols),
+                "reason_codes": reason_codes,
+            },
+        )
     try:
         session.execute(text("SET LOCAL statement_timeout = 500"))
         if scoped_symbols:

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -1070,6 +1070,7 @@ class TestConfig(TestCase):
             "trading_simple_submit_enabled",
             "trading_simple_order_feed_telemetry_enabled",
             "trading_simple_paper_route_probe_enabled",
+            "trading_options_catalog_freshness_exact_route_scope_enabled",
             "trading_empirical_jobs_health_required",
             "trading_jangar_quant_health_required",
             "tigerbeetle_enabled",

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -540,6 +540,18 @@ class TestTradingApi(TestCase):
             )
             session.commit()
 
+    def _enable_exact_options_catalog_route_scope(self) -> None:
+        original_exact_scope = (
+            settings.trading_options_catalog_freshness_exact_route_scope_enabled
+        )
+        settings.trading_options_catalog_freshness_exact_route_scope_enabled = True
+        self.addCleanup(
+            setattr,
+            settings,
+            "trading_options_catalog_freshness_exact_route_scope_enabled",
+            original_exact_scope,
+        )
+
     def test_forecast_service_status_uses_empirical_job_lineage_when_registry_empty(
         self,
     ) -> None:
@@ -615,6 +627,7 @@ class TestTradingApi(TestCase):
     def test_options_catalog_freshness_summary_includes_route_symbol_scope(
         self,
     ) -> None:
+        self._enable_exact_options_catalog_route_scope()
         fake_session = _OptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
@@ -643,6 +656,38 @@ class TestTradingApi(TestCase):
                 for sql, _params in fake_session.calls
             ),
             1,
+        )
+
+    def test_options_catalog_freshness_summary_uses_bounded_route_scope_by_default(
+        self,
+    ) -> None:
+        fake_session = _FallbackOptionsFreshnessSession()
+
+        payload = _load_options_catalog_freshness_summary(
+            fake_session,  # type: ignore[arg-type]
+            route_symbols=["AAPL", "MSFT"],
+        )
+
+        self.assertEqual(payload["scope"], "route_symbols")
+        self.assertEqual(payload["route_symbols"], ["AAPL", "MSFT"])
+        self.assertTrue(payload["bounded"])
+        self.assertFalse(payload["coverage_exact"])
+        self.assertFalse(payload["active_contracts_exact"])
+        self.assertEqual(payload["active_contracts"], 1)
+        self.assertIn(
+            "options_catalog_freshness_exact_route_scope_disabled",
+            payload["reason_codes"],
+        )
+        self.assertEqual(
+            sum(
+                "GROUP BY underlying_symbol" in sql
+                for sql, _params in fake_session.calls
+            ),
+            0,
+        )
+        self.assertEqual(
+            sum("LIMIT 1" in sql for sql, _params in fake_session.calls),
+            2,
         )
 
     def test_options_catalog_freshness_summary_uses_bounded_global_scan_without_route_scope(
@@ -733,11 +778,6 @@ class TestTradingApi(TestCase):
         self.assertEqual(second["status"], "unavailable")
         self.assertEqual(first["route_symbols"], ["AAPL"])
         self.assertEqual(second["route_symbols"], ["AAPL"])
-        self.assertEqual(len(fake_session.calls), 2)
-        self.assertIn(
-            "options_catalog_freshness_query_timeout",
-            first["reason_codes"],
-        )
         first_cache = first.get("cache")
         second_cache = second.get("cache")
         self.assertIsInstance(first_cache, dict)
@@ -746,10 +786,16 @@ class TestTradingApi(TestCase):
         assert isinstance(second_cache, dict)
         self.assertEqual(first_cache["hit"], False)
         self.assertEqual(second_cache["hit"], True)
+        self.assertEqual(len(fake_session.calls), 1)
+        self.assertIn(
+            "options_catalog_freshness_exact_route_scope_disabled",
+            first["reason_codes"],
+        )
 
     def test_options_catalog_freshness_summary_falls_back_to_bounded_on_timeout(
         self,
     ) -> None:
+        self._enable_exact_options_catalog_route_scope()
         fake_session = _TimedOutAggregateOptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
@@ -780,6 +826,7 @@ class TestTradingApi(TestCase):
     def test_options_catalog_freshness_summary_expires_cached_route_scope(
         self,
     ) -> None:
+        self._enable_exact_options_catalog_route_scope()
         original_cache_seconds = (
             settings.trading_options_catalog_freshness_cache_seconds
         )
@@ -824,6 +871,7 @@ class TestTradingApi(TestCase):
     def test_options_catalog_freshness_summary_falls_back_to_bounded_route_scope(
         self,
     ) -> None:
+        self._enable_exact_options_catalog_route_scope()
         fake_session = _FallbackOptionsFreshnessSession()
 
         payload = _load_options_catalog_freshness_summary(
@@ -860,6 +908,7 @@ class TestTradingApi(TestCase):
     def test_options_catalog_freshness_summary_rolls_back_before_bounded_fallback(
         self,
     ) -> None:
+        self._enable_exact_options_catalog_route_scope()
         fake_session = _FallbackOptionsFreshnessRequiresRollbackSession()
 
         payload = _load_options_catalog_freshness_summary(
@@ -879,6 +928,7 @@ class TestTradingApi(TestCase):
     def test_options_catalog_freshness_bounded_fallback_skips_blank_symbols(
         self,
     ) -> None:
+        self._enable_exact_options_catalog_route_scope()
         fake_session = _FallbackOptionsFreshnessBlankSymbolSession()
 
         payload = _load_options_catalog_freshness_summary(


### PR DESCRIPTION
## Summary

- Defaults route-scoped options catalog freshness to bounded per-symbol reads instead of exact active-contract aggregation.
- Keeps the payload honest by marking bounded route freshness as non-exact and adding an explicit `options_catalog_freshness_exact_route_scope_disabled` reason.
- Adds an opt-in setting for exact route-scope aggregation when a caller needs the slower authoritative count.
- Covers the default bounded path, timeout fallback path, cache behavior, and exact opt-in path in focused API tests.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k options_catalog_freshness_summary -q`
- `uv run --frozen pytest tests/test_trading_api.py -q`
- `uv run --frozen pytest tests/test_config.py::TestConfig::test_feature_flag_map_covers_all_boolean_runtime_gates -q`
- `uv run --frozen pytest -n auto --dist=worksteal --cov --cov-branch --cov-fail-under=0 --cov-report= <CI shard 3 test files>`
- `uv run --frozen ruff format --check app/config.py app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/config.py app/main.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Exact route-scoped active-contract aggregation is now opt-in with `TRADING_OPTIONS_CATALOG_FRESHNESS_EXACT_ROUTE_SCOPE_ENABLED=true`; default route freshness remains available but explicitly non-exact.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
