### PR TITLE
fix(torghut): clear route TCA and drift proof blockers

### DIFF
--- a/services/torghut/app/trading/proof_floor.py
+++ b/services/torghut/app/trading/proof_floor.py
@@ -401,6 +401,43 @@ def _tca_symbol_routes(
     return payload
 
 
+def _route_universe_adverse_slippage_clear(
+    symbol_routes: Mapping[str, Any],
+    *,
+    route_filter_enabled: bool,
+    aggregate_tca_reason: str,
+) -> bool:
+    if not route_filter_enabled:
+        return False
+    if aggregate_tca_reason != "execution_tca_slippage_guardrail_exceeded":
+        return False
+    scope_symbol_count = _int(symbol_routes.get("scope_symbol_count"))
+    routeable_symbol_count = _int(symbol_routes.get("routeable_symbol_count"))
+    if (
+        scope_symbol_count <= 0
+        or routeable_symbol_count <= 0
+        or routeable_symbol_count != scope_symbol_count
+        or _int(symbol_routes.get("blocked_symbol_count")) > 0
+        or _int(symbol_routes.get("missing_symbol_count")) > 0
+    ):
+        return False
+    route_guardrail = _decimal(
+        symbol_routes.get("route_slippage_guardrail_bps")
+    ) or _decimal(symbol_routes.get("slippage_guardrail_bps"))
+    if route_guardrail is None:
+        return False
+    for item in _sequence(symbol_routes.get("routeable_symbols")):
+        if not isinstance(item, Mapping):
+            return False
+        row = cast(Mapping[str, Any], item)
+        if row.get("route_slippage_basis") != "signed_realized_shortfall_bps":
+            return False
+        route_adverse_slippage = _decimal(row.get("route_adverse_slippage_bps"))
+        if route_adverse_slippage is None or route_adverse_slippage > route_guardrail:
+            return False
+    return True
+
+
 def _route_symbol_filter_enabled(
     simple_lane_status: Mapping[str, Any] | None,
 ) -> bool:
@@ -904,9 +941,31 @@ def build_profitability_proof_floor_receipt(
                 if route_filter_enabled
                 else "execution_tca_route_universe_incomplete"
             )
+        elif _route_universe_adverse_slippage_clear(
+            symbol_routes,
+            route_filter_enabled=route_filter_enabled,
+            aggregate_tca_reason=aggregate_tca_reason,
+        ):
+            tca_source_ref["route_universe_adverse_slippage"] = {
+                "state": "clear",
+                "enforcement": "route_symbol_filter",
+                "candidate_symbol_count": routeable_symbol_count,
+                "blocked_symbol_count": blocked_symbol_count,
+                "missing_symbol_count": missing_symbol_count,
+                "max_notional_for_adverse_symbols": "0",
+            }
+            route_universe_reason = (
+                "execution_tca_route_universe_adverse_slippage_clear"
+            )
         if route_universe_reason is not None:
             if route_universe_reason == "execution_tca_route_universe_empty":
                 tca_state = "fail"
+                tca_reason = route_universe_reason
+            elif (
+                route_universe_reason
+                == "execution_tca_route_universe_adverse_slippage_clear"
+            ):
+                tca_state = "pass"
                 tca_reason = route_universe_reason
             elif route_filter_enabled and aggregate_tca_reason in {
                 "fresh",
@@ -919,18 +978,22 @@ def build_profitability_proof_floor_receipt(
                 tca_reason = route_universe_reason
             if aggregate_tca_reason != "fresh":
                 tca_source_ref["aggregate_reason"] = aggregate_tca_reason
-            _add_repair(
-                repairs,
-                code="repair_route_universe",
-                dimension="route_universe",
-                action="exclude_missing_or_high_slippage_symbols_before_promotion",
-                reason=route_universe_reason,
-                priority=78,
-                expected_unblock_value=max(
-                    1,
-                    excluded_symbol_count,
-                ),
-            )
+            if (
+                route_universe_reason
+                != "execution_tca_route_universe_adverse_slippage_clear"
+            ):
+                _add_repair(
+                    repairs,
+                    code="repair_route_universe",
+                    dimension="route_universe",
+                    action="exclude_missing_or_high_slippage_symbols_before_promotion",
+                    reason=route_universe_reason,
+                    priority=78,
+                    expected_unblock_value=max(
+                        1,
+                        excluded_symbol_count,
+                    ),
+                )
     if tca_state != "pass":
         _add_repair(
             repairs,

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -1199,6 +1199,12 @@ class SimpleTradingPipeline(TradingPipeline):
                     self.state.metrics.drift_incident_reason_total.get(reason_code, 0)
                     + 1
                 )
+        else:
+            self.state.drift_active_incident_id = None
+            self.state.drift_active_reason_codes = []
+            self.state.drift_status = "stable"
+            self.state.drift_live_promotion_eligible = True
+            self.state.drift_live_promotion_reasons = []
 
     def _process_batch_signals(
         self,

--- a/services/torghut/tests/test_profitability_proof_floor.py
+++ b/services/torghut/tests/test_profitability_proof_floor.py
@@ -4,7 +4,10 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
-from app.trading.proof_floor import build_profitability_proof_floor_receipt
+from app.trading.proof_floor import (
+    _route_universe_adverse_slippage_clear,
+    build_profitability_proof_floor_receipt,
+)
 
 
 NOW = datetime(2026, 5, 6, 21, 27, tzinfo=timezone.utc)
@@ -1056,6 +1059,168 @@ def test_execution_tca_route_universe_uses_adverse_signed_shortfall() -> None:
     aapl_record = next(item for item in route_records if item["symbol"] == "AAPL")
     assert aapl_record["state"] == "routeable"
     assert aapl_record["route_adverse_slippage_bps"] == "0"
+
+
+def test_execution_tca_signed_adverse_clear_unblocks_aggregate_abs_slippage() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="TORGHUT_SIM",
+        torghut_revision="torghut-sim-00979",
+        trading_mode="paper",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "capital_stage": "paper",
+        },
+        hypothesis_payload=_healthy_hypothesis_payload(),
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary={
+            **_fresh_tca_summary(avg_abs_slippage_bps="29.9205222873469388"),
+            "scope_symbols": ["AAPL", "AMZN", "INTC", "NVDA"],
+            "scope_symbol_count": 4,
+            "symbol_breakdown": [
+                {
+                    "symbol": "AAPL",
+                    "order_count": 19,
+                    "avg_abs_slippage_bps": "10.0605907784615385",
+                    "avg_realized_shortfall_bps": "-3.7676291292307692",
+                    "max_abs_slippage_bps": "52.57029761",
+                    "last_computed_at": NOW.isoformat(),
+                },
+                {
+                    "symbol": "AMZN",
+                    "order_count": 24,
+                    "avg_abs_slippage_bps": "15.533415621",
+                    "avg_realized_shortfall_bps": "-12.782019899",
+                    "max_abs_slippage_bps": "109.74841602",
+                    "last_computed_at": NOW.isoformat(),
+                },
+                {
+                    "symbol": "INTC",
+                    "order_count": 9,
+                    "avg_abs_slippage_bps": "76.5197505133333333",
+                    "avg_realized_shortfall_bps": "-76.21408033",
+                    "max_abs_slippage_bps": "437.54186202",
+                    "last_computed_at": NOW.isoformat(),
+                },
+                {
+                    "symbol": "NVDA",
+                    "order_count": 14,
+                    "avg_abs_slippage_bps": "56.553109646",
+                    "avg_realized_shortfall_bps": "-56.064048032",
+                    "max_abs_slippage_bps": "524.38041507",
+                    "last_computed_at": NOW.isoformat(),
+                },
+            ],
+        },
+        simple_lane_status=_simple_lane_status(),
+        now=NOW,
+    )
+
+    tca_dimension = next(
+        item
+        for item in receipt["proof_dimensions"]
+        if item["dimension"] == "execution_tca"
+    )
+    source_ref = cast(Mapping[str, Any], tca_dimension["source_ref"])
+    symbol_routes = cast(Mapping[str, Any], source_ref["symbol_routes"])
+    adverse_clear = cast(
+        Mapping[str, Any], source_ref["route_universe_adverse_slippage"]
+    )
+
+    assert tca_dimension["state"] == "pass"
+    assert (
+        tca_dimension["reason"] == "execution_tca_route_universe_adverse_slippage_clear"
+    )
+    assert source_ref["aggregate_reason"] == "execution_tca_slippage_guardrail_exceeded"
+    assert symbol_routes["routeable_symbol_count"] == 4
+    assert symbol_routes["blocked_symbol_count"] == 0
+    assert symbol_routes["missing_symbol_count"] == 0
+    assert adverse_clear["state"] == "clear"
+    assert receipt["blocking_reasons"] == []
+    assert [
+        item["code"] for item in cast(list[Mapping[str, Any]], receipt["repair_ladder"])
+    ] == []
+
+
+def test_route_universe_adverse_slippage_clear_fails_closed() -> None:
+    base_symbol_routes: dict[str, object] = {
+        "scope_symbol_count": 1,
+        "routeable_symbol_count": 1,
+        "blocked_symbol_count": 0,
+        "missing_symbol_count": 0,
+        "slippage_guardrail_bps": "20",
+        "routeable_symbols": [
+            {
+                "symbol": "AAPL",
+                "route_slippage_basis": "signed_realized_shortfall_bps",
+                "route_adverse_slippage_bps": "0",
+            }
+        ],
+    }
+    cases: list[tuple[str, dict[str, object], bool]] = [
+        ("filter_disabled", base_symbol_routes, False),
+        (
+            "inconsistent_counts",
+            {**base_symbol_routes, "scope_symbol_count": 2},
+            True,
+        ),
+        (
+            "missing_guardrail",
+            {
+                key: value
+                for key, value in base_symbol_routes.items()
+                if key != "slippage_guardrail_bps"
+            },
+            True,
+        ),
+        (
+            "malformed_routeable_row",
+            {**base_symbol_routes, "routeable_symbols": ["AAPL"]},
+            True,
+        ),
+        (
+            "wrong_slippage_basis",
+            {
+                **base_symbol_routes,
+                "routeable_symbols": [
+                    {
+                        "symbol": "AAPL",
+                        "route_slippage_basis": "avg_abs_slippage_bps_fallback",
+                        "route_adverse_slippage_bps": "0",
+                    }
+                ],
+            },
+            True,
+        ),
+        (
+            "adverse_slippage_above_guardrail",
+            {
+                **base_symbol_routes,
+                "routeable_symbols": [
+                    {
+                        "symbol": "AAPL",
+                        "route_slippage_basis": "signed_realized_shortfall_bps",
+                        "route_adverse_slippage_bps": "25",
+                    }
+                ],
+            },
+            True,
+        ),
+    ]
+
+    for case_name, symbol_routes, route_filter_enabled in cases:
+        assert (
+            _route_universe_adverse_slippage_clear(
+                symbol_routes,
+                route_filter_enabled=route_filter_enabled,
+                aggregate_tca_reason="execution_tca_slippage_guardrail_exceeded",
+            )
+            is False
+        ), case_name
 
 
 def test_execution_tca_route_universe_requires_symbol_filter_before_unblock() -> None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -2464,8 +2464,8 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(pipeline.state.metrics.feature_quality_rejections_total, 0)
         self.assertEqual(pipeline.state.metrics.drift_detection_checks_total, 1)
         self.assertIsNotNone(pipeline.state.drift_last_detection_at)
-        self.assertFalse(pipeline.state.drift_live_promotion_eligible)
-        self.assertEqual(pipeline.state.drift_status, "unknown")
+        self.assertTrue(pipeline.state.drift_live_promotion_eligible)
+        self.assertEqual(pipeline.state.drift_status, "stable")
         with self.session_local() as session:
             decision = session.execute(select(TradeDecision)).scalar_one()
             execution = session.execute(select(Execution)).scalar_one()
@@ -2563,8 +2563,8 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(pipeline.state.metrics.feature_quality_rejections_total, 0)
         self.assertEqual(pipeline.state.metrics.drift_detection_checks_total, 1)
         self.assertIsNotNone(pipeline.state.drift_last_detection_at)
-        self.assertFalse(pipeline.state.drift_live_promotion_eligible)
-        self.assertEqual(pipeline.state.drift_status, "unknown")
+        self.assertTrue(pipeline.state.drift_live_promotion_eligible)
+        self.assertEqual(pipeline.state.drift_status, "stable")
         with self.session_local() as session:
             decision = session.execute(select(TradeDecision)).scalar_one()
             execution = session.execute(select(Execution)).scalar_one()
@@ -8830,12 +8830,16 @@ class TestTradingPipeline(TestCase):
                     allowed_symbols={"AAPL", "AMZN"},
                 )
 
-            decisions = session.execute(
-                select(TradeDecision).order_by(TradeDecision.symbol)
-            ).scalars().all()
-            executions = session.execute(
-                select(Execution).order_by(Execution.symbol)
-            ).scalars().all()
+            decisions = (
+                session.execute(select(TradeDecision).order_by(TradeDecision.symbol))
+                .scalars()
+                .all()
+            )
+            executions = (
+                session.execute(select(Execution).order_by(Execution.symbol))
+                .scalars()
+                .all()
+            )
 
         self.assertEqual([decision.symbol for decision in decisions], ["AAPL", "AMZN"])
         self.assertEqual(
@@ -8848,9 +8852,7 @@ class TestTradingPipeline(TestCase):
         for decision in decisions:
             payload = cast(dict[str, Any], decision.decision_json)
             params = cast(dict[str, Any], payload.get("params") or {})
-            metadata = cast(
-                dict[str, Any], params.get("paper_route_target_plan") or {}
-            )
+            metadata = cast(dict[str, Any], params.get("paper_route_target_plan") or {})
             self.assertEqual(
                 metadata.get("paper_route_probe_next_session_max_notional"), "500"
             )
@@ -9121,14 +9123,18 @@ class TestTradingPipeline(TestCase):
                 "_external_paper_route_target_probe_symbols_cached",
                 return_value=({"AAPL", "AMZN"}, None, [target]),
             ),
-            patch("app.trading.scheduler.simple_pipeline.trading_now", return_value=now),
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now", return_value=now
+            ),
             patch("app.trading.scheduler.pipeline.trading_now", return_value=now),
         ):
             pipeline.run_once()
 
         self.assertEqual(ingestor.fetch_scopes, [({"AAPL", "AMZN"}, {"1Sec"})])
         self.assertEqual(alpaca_client.submitted, [])
-        self.assertEqual(pipeline.state.last_ingest_reason, "clickhouse_signal_query_timeout")
+        self.assertEqual(
+            pipeline.state.last_ingest_reason, "clickhouse_signal_query_timeout"
+        )
         self.assertEqual(
             pipeline.state.last_signal_continuity_reason,
             "clickhouse_signal_query_timeout",
@@ -9219,7 +9225,9 @@ class TestTradingPipeline(TestCase):
             "source_decision_readiness": {"ready": True, "blockers": []},
             "paper_probation_authorized": True,
         }
-        ingestor = FakeIngestor(signals, cursor_at=now, cursor_seq=2, cursor_symbol="AMZN")
+        ingestor = FakeIngestor(
+            signals, cursor_at=now, cursor_seq=2, cursor_symbol="AMZN"
+        )
         alpaca_client = FakeAlpacaClient()
         pipeline = SimpleTradingPipeline(
             alpaca_client=alpaca_client,
@@ -9255,7 +9263,9 @@ class TestTradingPipeline(TestCase):
                     "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
                 },
             ),
-            patch("app.trading.scheduler.simple_pipeline.trading_now", return_value=now),
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now", return_value=now
+            ),
             patch("app.trading.scheduler.pipeline.trading_now", return_value=now),
             patch("app.trading.simulation.trading_now", return_value=now),
         ):
@@ -9280,7 +9290,9 @@ class TestTradingPipeline(TestCase):
                     dict[str, Any],
                     params.get("paper_route_target_plan"),
                 )
-                self.assertEqual(target_plan.get("candidate_id"), "candidate-pairs-monday")
+                self.assertEqual(
+                    target_plan.get("candidate_id"), "candidate-pairs-monday"
+                )
 
     def test_fetch_signal_batch_falls_back_for_legacy_ingestor_signature(self) -> None:
         class LegacyIngestor:
@@ -9376,12 +9388,16 @@ class TestTradingPipeline(TestCase):
         pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
         targets = [
             target(paper_route_account_pre_session_blockers=["not_flat"]),
-            target(paper_route_probe_window_start=None, paper_route_probe_window_end=None),
+            target(
+                paper_route_probe_window_start=None, paper_route_probe_window_end=None
+            ),
             target(
                 paper_route_probe_window_start=(
                     window_start - timedelta(days=1)
                 ).isoformat(),
-                paper_route_probe_window_end=(window_end - timedelta(days=1)).isoformat(),
+                paper_route_probe_window_end=(
+                    window_end - timedelta(days=1)
+                ).isoformat(),
             ),
             target(strategy_name="missing-strategy", runtime_strategy_name="missing"),
             target(),
@@ -9393,7 +9409,9 @@ class TestTradingPipeline(TestCase):
                 "_external_paper_route_target_probe_symbols_cached",
                 return_value=({"AAPL", "AMZN"}, None, targets),
             ),
-            patch("app.trading.scheduler.simple_pipeline.trading_now", return_value=now),
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now", return_value=now
+            ),
         ):
             scope = pipeline._bounded_paper_route_signal_scope([strategy])
 


### PR DESCRIPTION
## Summary

- Keeps aggregate absolute-slippage warnings visible while letting enforced route filters clear TCA when every scoped symbol has signed adverse slippage within guardrail.
- Marks clean simple-pipeline drift checks as `stable` and drift-promotion eligible so `drift_checks_not_ok` is not sticky after passing drift evidence.
- Adds explicit `route_universe_adverse_slippage` source evidence for the clear case.
- Covers the live SIM-shaped regression where all scoped signed shortfalls are favorable but aggregate absolute slippage is high.

## Related Issues

None

## Testing

- `uv run --frozen python -m pytest tests/test_profitability_proof_floor.py -k 'tca'`
- `uv run --frozen python -m pytest tests/test_profitability_proof_floor.py`
- `uv run --frozen python -m pytest tests/test_build_revenue_repair_digest.py -k 'tca or execution_tca or proof_floor'`
- `uv run --frozen python -m pytest tests/test_trading_api.py -k 'proof_floor or execution_tca'`
- `uv run --frozen python -m pytest tests/test_verify_trading_readiness.py -k 'tca or runtime_window or drift'`
- `uv run --frozen python -m pytest tests/test_trading_pipeline.py -k 'drift_check or detected_drift or direct_paper_order_uses_limit_order_when_configured or paper_order_updates_proof_counters'`
- `uv run --frozen python -m pytest tests/test_profitability_proof_floor.py tests/test_trading_pipeline.py -k 'tca or drift_check or detected_drift or direct_paper_order_uses_limit_order_when_configured or paper_order_updates_proof_counters'`
- `uv run --frozen python -m pytest tests/test_paper_route_evidence.py -k 'drift or runtime_window_import'`
- `uv run --frozen ruff format --check app/trading/proof_floor.py tests/test_profitability_proof_floor.py`
- `uv run --frozen ruff check app/trading/proof_floor.py tests/test_profitability_proof_floor.py`
- `uv run --frozen ruff format --check app/trading/proof_floor.py app/trading/scheduler/simple_pipeline.py tests/test_profitability_proof_floor.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/proof_floor.py app/trading/scheduler/simple_pipeline.py tests/test_profitability_proof_floor.py tests/test_trading_pipeline.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
