### PR TITLE
fix(torghut): separate route TCA repair from authority

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -667,8 +667,35 @@ class _TcaReadinessInputs:
     last_computed_at: datetime | None
     route_filter_applied: bool
     routeable_symbols: tuple[str, ...]
+    route_repair_symbols: tuple[str, ...]
     route_excluded_symbol_count: int
     route_missing_symbol_count: int
+    route_blocking_reason_codes: tuple[str, ...]
+    route_symbol_diagnostics: tuple[dict[str, object], ...]
+
+
+_NON_AUTHORITY_TCA_SOURCE_KINDS = {
+    EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+    "aggregate",
+    "aggregate_only",
+    "backtest",
+    "backtest_replay",
+    "exact_replay",
+    "exact_replay_ledger",
+    "exact_replay_ledger.v1",
+    "replay",
+    "replay_only",
+    "synthetic",
+}
+_NON_AUTHORITY_TCA_DECISION_MODES = {
+    "bounded_paper_collection",
+    "bounded_paper_route_collection",
+    "bounded_paper_route_collection_only",
+    "exact_replay",
+    "paper_route_probe",
+    "paper_route_probe_runtime_observed",
+    "replay_only",
+}
 
 
 @dataclass(frozen=True)
@@ -732,6 +759,141 @@ def _latest_tca_timestamp(rows: Sequence[Mapping[str, Any]]) -> datetime | None:
     return latest
 
 
+def _normalized_route_token(value: object) -> str | None:
+    text = _route_tca_text(value)
+    return text.lower().replace("-", "_") if text is not None else None
+
+
+def _route_tca_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _route_tca_bool(value: object) -> bool | None:
+    return _optional_bool(value)
+
+
+def _route_tca_target_blockers(
+    row: Mapping[str, Any],
+    *,
+    hypothesis_id: str | None,
+    candidate_id: str | None,
+    strategy_family: str | None,
+    account_label: str | None,
+) -> tuple[str, ...]:
+    blockers: list[str] = []
+    expected_hypothesis_id = _route_tca_text(hypothesis_id)
+    actual_hypothesis_id = _route_tca_text(row.get("hypothesis_id"))
+    if (
+        expected_hypothesis_id is not None
+        and actual_hypothesis_id is not None
+        and actual_hypothesis_id != expected_hypothesis_id
+    ):
+        blockers.append("route_tca_hypothesis_id_mismatch")
+
+    expected_candidate_id = _route_tca_text(candidate_id)
+    actual_candidate_id = _route_tca_text(row.get("candidate_id"))
+    if (
+        expected_candidate_id is not None
+        and actual_candidate_id is not None
+        and actual_candidate_id != expected_candidate_id
+    ):
+        blockers.append("route_tca_candidate_id_mismatch")
+
+    expected_strategy_family = _normalized_route_token(strategy_family)
+    actual_strategy_family = _normalized_route_token(row.get("strategy_family"))
+    if (
+        expected_strategy_family is not None
+        and actual_strategy_family is not None
+        and actual_strategy_family != expected_strategy_family
+    ):
+        blockers.append("route_tca_strategy_family_mismatch")
+
+    expected_account_label = _route_tca_text(account_label)
+    actual_account_label = _route_tca_text(row.get("account_label"))
+    if (
+        expected_account_label is not None
+        and actual_account_label is not None
+        and actual_account_label != expected_account_label
+    ):
+        blockers.append("route_tca_account_label_mismatch")
+
+    return tuple(blockers)
+
+
+def _route_tca_authority_blockers(row: Mapping[str, Any]) -> tuple[str, ...]:
+    blockers: list[str] = []
+    source_kind = _normalized_route_token(
+        row.get("source_kind")
+        or row.get("source")
+        or row.get("ledger_schema_version")
+        or row.get("schema_version")
+    )
+    if source_kind in _NON_AUTHORITY_TCA_SOURCE_KINDS:
+        blockers.append("route_tca_non_authority_source")
+    source_decision_mode = _normalized_route_token(row.get("source_decision_mode"))
+    if source_decision_mode in _NON_AUTHORITY_TCA_DECISION_MODES:
+        blockers.append("route_tca_non_authority_source_decision_mode")
+    profit_proof_eligible = _route_tca_bool(
+        row.get("source_decision_mode_profit_proof_eligible")
+    )
+    if source_decision_mode is not None and profit_proof_eligible is False:
+        blockers.append("route_tca_non_authority_source_decision_mode")
+    for key in ("aggregate_only", "replay_only", "synthetic", "non_authority"):
+        if _route_tca_bool(row.get(key)) is True:
+            blockers.append(f"route_tca_{key}")
+    state = _normalized_route_token(row.get("state") or row.get("source_state"))
+    if state in {"stale", "expired"}:
+        blockers.append("route_tca_stale")
+    return tuple(dict.fromkeys(blockers))
+
+
+def _route_tca_adverse_slippage(row: Mapping[str, Any]) -> Decimal | None:
+    realized_shortfall = _optional_decimal(row.get("avg_realized_shortfall_bps"))
+    if realized_shortfall is not None:
+        return max(realized_shortfall, Decimal("0"))
+    return _optional_decimal(row.get("avg_abs_slippage_bps"))
+
+
+def _route_tca_diagnostic(
+    *,
+    row: Mapping[str, Any],
+    symbol: str,
+    state: str,
+    blockers: Sequence[str],
+    route_adverse_slippage: Decimal | None,
+    max_allowed_slippage_bps: Decimal,
+) -> dict[str, object]:
+    diagnostic: dict[str, object] = {
+        "symbol": symbol,
+        "state": state,
+        "order_count": max(0, _optional_int(row.get("order_count")) or 0),
+        "blocking_reason_codes": list(dict.fromkeys(blockers)),
+        "max_avg_abs_slippage_bps": _decimal_to_string(max_allowed_slippage_bps),
+    }
+    for key in (
+        "avg_abs_slippage_bps",
+        "avg_realized_shortfall_bps",
+        "last_computed_at",
+        "candidate_id",
+        "hypothesis_id",
+        "strategy_family",
+        "account_label",
+        "source_kind",
+        "source_decision_mode",
+    ):
+        value = row.get(key)
+        if value is not None:
+            diagnostic[key] = value
+    if route_adverse_slippage is not None:
+        diagnostic["route_adverse_slippage_bps"] = _decimal_to_string(
+            route_adverse_slippage
+        )
+    return diagnostic
+
+
 def _resolve_delay_adjusted_depth_stress_inputs(
     *,
     state: object,
@@ -788,6 +950,10 @@ def _resolve_tca_readiness_inputs(
     *,
     max_allowed_slippage_bps: Decimal,
     route_symbol_filter_enabled: bool,
+    hypothesis_id: str | None = None,
+    candidate_id: str | None = None,
+    strategy_family: str | None = None,
+    account_label: str | None = None,
 ) -> _TcaReadinessInputs:
     aggregate_order_count = max(0, _optional_int(tca_summary.get("order_count")) or 0)
     aggregate_avg_abs_slippage = _coerce_decimal(
@@ -804,8 +970,11 @@ def _resolve_tca_readiness_inputs(
         last_computed_at=aggregate_last_computed_at,
         route_filter_applied=False,
         routeable_symbols=(),
+        route_repair_symbols=(),
         route_excluded_symbol_count=0,
         route_missing_symbol_count=0,
+        route_blocking_reason_codes=(),
+        route_symbol_diagnostics=(),
     )
     if not route_symbol_filter_enabled:
         return aggregate
@@ -815,25 +984,126 @@ def _resolve_tca_readiness_inputs(
         for item in _sequence(tca_summary.get("symbol_breakdown"))
         if isinstance(item, Mapping)
     ]
-    if not rows:
+    scope_symbols = tuple(
+        str(item).strip().upper()
+        for item in _sequence(tca_summary.get("scope_symbols"))
+        if str(item).strip()
+    )
+    scope_symbol_set = set(scope_symbols)
+    if not rows and not scope_symbols:
         return aggregate
 
     routeable_rows: list[Mapping[str, Any]] = []
+    route_repair_symbols: list[str] = []
+    route_repair_symbol_set: set[str] = set()
+    route_blockers: list[str] = []
+    diagnostics: list[dict[str, object]] = []
     missing_symbol_count = 0
     excluded_symbol_count = 0
+    seen_symbols: set[str] = set()
+
+    def append_repair_symbol(symbol: str) -> None:
+        normalized = symbol.strip().upper()
+        if not normalized or normalized in route_repair_symbol_set:
+            return
+        route_repair_symbol_set.add(normalized)
+        route_repair_symbols.append(normalized)
+
     for row in rows:
+        symbol = str(row.get("symbol") or "").strip().upper()
+        if not symbol:
+            continue
+        seen_symbols.add(symbol)
         order_count = max(0, _optional_int(row.get("order_count")) or 0)
+        scope_blockers: tuple[str, ...] = (
+            ("route_tca_out_of_scope_symbol",)
+            if scope_symbol_set and symbol not in scope_symbol_set
+            else ()
+        )
+        target_blockers = _route_tca_target_blockers(
+            row,
+            hypothesis_id=hypothesis_id,
+            candidate_id=candidate_id,
+            strategy_family=strategy_family,
+            account_label=account_label,
+        )
+        authority_blockers = _route_tca_authority_blockers(row)
+        row_blockers: list[str] = [
+            *scope_blockers,
+            *target_blockers,
+            *authority_blockers,
+        ]
+        avg_abs_slippage = _optional_decimal(row.get("avg_abs_slippage_bps"))
+        route_adverse_slippage = _route_tca_adverse_slippage(row)
         if order_count <= 0:
             missing_symbol_count += 1
+            row_blockers.append("execution_tca_symbol_missing")
+            if not scope_blockers and not target_blockers:
+                append_repair_symbol(symbol)
+            route_blockers.extend(row_blockers)
+            diagnostics.append(
+                _route_tca_diagnostic(
+                    row=row,
+                    symbol=symbol,
+                    state="missing",
+                    blockers=row_blockers,
+                    route_adverse_slippage=route_adverse_slippage,
+                    max_allowed_slippage_bps=max_allowed_slippage_bps,
+                )
+            )
             continue
-        avg_abs_slippage = _optional_decimal(row.get("avg_abs_slippage_bps"))
         if (
-            avg_abs_slippage is not None
+            not row_blockers
+            and avg_abs_slippage is not None
             and avg_abs_slippage <= max_allowed_slippage_bps
         ):
             routeable_rows.append(row)
+            diagnostics.append(
+                _route_tca_diagnostic(
+                    row=row,
+                    symbol=symbol,
+                    state="final_authority_routeable",
+                    blockers=(),
+                    route_adverse_slippage=route_adverse_slippage,
+                    max_allowed_slippage_bps=max_allowed_slippage_bps,
+                )
+            )
         else:
             excluded_symbol_count += 1
+            if avg_abs_slippage is None:
+                row_blockers.append("route_tca_slippage_missing")
+            elif avg_abs_slippage > max_allowed_slippage_bps:
+                row_blockers.append("route_tca_avg_abs_slippage_above_guardrail")
+            if not scope_blockers and not target_blockers:
+                append_repair_symbol(symbol)
+            route_blockers.extend(row_blockers)
+            diagnostics.append(
+                _route_tca_diagnostic(
+                    row=row,
+                    symbol=symbol,
+                    state="bounded_repair_only",
+                    blockers=row_blockers,
+                    route_adverse_slippage=route_adverse_slippage,
+                    max_allowed_slippage_bps=max_allowed_slippage_bps,
+                )
+            )
+
+    for symbol in scope_symbols:
+        if symbol in seen_symbols:
+            continue
+        missing_symbol_count += 1
+        append_repair_symbol(symbol)
+        route_blockers.append("execution_tca_symbol_missing")
+        diagnostics.append(
+            _route_tca_diagnostic(
+                row={},
+                symbol=symbol,
+                state="missing",
+                blockers=("execution_tca_symbol_missing",),
+                route_adverse_slippage=None,
+                max_allowed_slippage_bps=max_allowed_slippage_bps,
+            )
+        )
 
     routeable_symbols = tuple(
         str(row.get("symbol") or "").strip().upper()
@@ -851,8 +1121,11 @@ def _resolve_tca_readiness_inputs(
             last_computed_at=aggregate_last_computed_at,
             route_filter_applied=True,
             routeable_symbols=(),
+            route_repair_symbols=tuple(route_repair_symbols),
             route_excluded_symbol_count=excluded_symbol_count,
             route_missing_symbol_count=missing_symbol_count,
+            route_blocking_reason_codes=tuple(dict.fromkeys(route_blockers)),
+            route_symbol_diagnostics=tuple(diagnostics),
         )
 
     route_avg_abs_slippage = _weighted_decimal_average(
@@ -877,8 +1150,11 @@ def _resolve_tca_readiness_inputs(
         or aggregate_last_computed_at,
         route_filter_applied=True,
         routeable_symbols=routeable_symbols,
+        route_repair_symbols=tuple(route_repair_symbols),
         route_excluded_symbol_count=excluded_symbol_count,
         route_missing_symbol_count=missing_symbol_count,
+        route_blocking_reason_codes=tuple(dict.fromkeys(route_blockers)),
+        route_symbol_diagnostics=tuple(diagnostics),
     )
 
 
@@ -1582,6 +1858,10 @@ def compile_hypothesis_runtime_statuses(
             tca_summary,
             max_allowed_slippage_bps=manifest.max_allowed_slippage_bps,
             route_symbol_filter_enabled=route_symbol_filter_enabled,
+            hypothesis_id=manifest.hypothesis_id,
+            candidate_id=manifest.candidate_id,
+            strategy_family=manifest.strategy_family,
+            account_label=cast(str | None, tca_summary.get("account_label")),
         )
         runtime_ledger_inputs = _resolve_runtime_ledger_readiness_inputs(
             runtime_ledger_summary,
@@ -1919,8 +2199,31 @@ def compile_hypothesis_runtime_statuses(
                     "route_symbol_filter_enabled": True,
                     "route_tca_symbols": list(tca_inputs.routeable_symbols),
                     "route_tca_symbol_count": len(tca_inputs.routeable_symbols),
+                    "route_tca_repair_symbols": list(tca_inputs.route_repair_symbols),
+                    "route_tca_repair_symbol_count": len(
+                        tca_inputs.route_repair_symbols
+                    ),
                     "route_tca_excluded_symbol_count": tca_inputs.route_excluded_symbol_count,
                     "route_tca_missing_symbol_count": tca_inputs.route_missing_symbol_count,
+                    "route_tca_blocking_reason_codes": list(
+                        tca_inputs.route_blocking_reason_codes
+                    ),
+                    "route_tca_symbol_diagnostics": list(
+                        tca_inputs.route_symbol_diagnostics
+                    ),
+                    "bounded_route_evidence_collection_eligible": bool(
+                        tca_inputs.route_repair_symbols
+                    ),
+                    "bounded_route_evidence_collection_authority": (
+                        "repair_only_non_authority"
+                        if tca_inputs.route_repair_symbols
+                        else "none"
+                    ),
+                    "bounded_route_repair_action": (
+                        "collect_bounded_paper_route_source_rows_before_promotion"
+                        if tca_inputs.route_repair_symbols
+                        else "none"
+                    ),
                 }
             )
 

--- a/services/torghut/app/trading/route_reacquisition.py
+++ b/services/torghut/app/trading/route_reacquisition.py
@@ -14,8 +14,14 @@ SCHEMA_VERSION = "torghut.route-reacquisition-book.v1"
 ROUTE_REPAIR_AUDIT_RECEIPT_SCHEMA_VERSION = "torghut.route-repair-audit-receipt.v1"
 _PAPER_ROUTE_PROBE_REASONS = {
     "execution_tca_route_universe_empty",
+    "execution_tca_route_universe_exclusions_applied",
+    "execution_tca_route_universe_incomplete",
+    "execution_tca_slippage_guardrail_exceeded",
     "execution_tca_symbol_missing",
     "route_tca_passed_but_dependency_receipts_block_capital",
+    "route_tca_avg_abs_slippage_above_guardrail",
+    "route_tca_non_authority_source",
+    "route_tca_non_authority_source_decision_mode",
     "tca_evidence_stale",
     "stale_quote",
     "missing_bid_ask",
@@ -26,7 +32,7 @@ _PAPER_ROUTE_PROBE_REASONS = {
     "missing_close_flatten_handoff",
     "runtime_import_pending",
 }
-_PAPER_ROUTE_PROBE_STATES = {"missing", "probing"}
+_PAPER_ROUTE_PROBE_STATES = {"blocked", "missing", "probing"}
 
 
 def _text(value: object, default: str = "") -> str:

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -124,6 +124,8 @@ def _hypothesis_manifest_payload(
 def _runtime_ledger_summary(
     *hypothesis_ids: str,
     candidate_id: str | None = None,
+    bucket_started_at: str = "2026-03-06T15:00:00+00:00",
+    bucket_ended_at: str = "2026-03-06T15:55:00+00:00",
     submitted_order_count: int = 45,
     fill_count: int | None = None,
     closed_trade_count: int = 12,
@@ -142,8 +144,8 @@ def _runtime_ledger_summary(
                 or _MANIFEST_CANDIDATE_IDS.get(hypothesis_id)
                 or f"candidate-{hypothesis_id.lower()}",
                 "observed_stage": observed_stage,
-                "bucket_started_at": "2026-03-06T15:00:00+00:00",
-                "bucket_ended_at": "2026-03-06T15:55:00+00:00",
+                "bucket_started_at": bucket_started_at,
+                "bucket_ended_at": bucket_ended_at,
                 "strategy_family": _MANIFEST_STRATEGY_FAMILIES.get(hypothesis_id),
                 "fill_count": fill_count
                 if fill_count is not None
@@ -1320,6 +1322,261 @@ class TestHypothesisReadiness(TestCase):
         self.assertEqual(observed["avg_abs_slippage_bps"], "6")
         self.assertEqual(observed["runtime_ledger_post_cost_expectancy_bps"], "-1")
         self.assertEqual(observed["route_tca_symbols"], ["AAPL"])
+
+    def test_compile_hypothesis_runtime_statuses_keeps_non_authority_route_tca_out_of_final_authority(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=2770,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=14,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-06-01T19:15:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "account_label": "TORGHUT_SIM",
+                "order_count": 2,
+                "avg_abs_slippage_bps": "4",
+                "avg_realized_shortfall_bps": "1",
+                "last_computed_at": "2026-06-01T19:16:00+00:00",
+                "scope_symbols": ["AAPL", "AMZN"],
+                "symbol_breakdown": [
+                    {
+                        "symbol": "AAPL",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "4",
+                        "avg_realized_shortfall_bps": "1",
+                        "last_computed_at": "2026-06-01T19:16:00+00:00",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": _MANIFEST_CANDIDATE_IDS["H-PAIRS-01"],
+                        "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-PAIRS-01"],
+                        "account_label": "TORGHUT_SIM",
+                        "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+                    },
+                    {
+                        "symbol": "AMZN",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "4",
+                        "avg_realized_shortfall_bps": "1",
+                        "last_computed_at": "2026-06-01T19:16:00+00:00",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": _MANIFEST_CANDIDATE_IDS["H-PAIRS-01"],
+                        "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-PAIRS-01"],
+                        "account_label": "TORGHUT_SIM",
+                        "source_decision_mode": "bounded_paper_route_collection_only",
+                        "source_decision_mode_profit_proof_eligible": False,
+                    },
+                ],
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-PAIRS-01",
+                bucket_started_at="2026-06-01T19:00:00+00:00",
+                bucket_ended_at="2026-06-01T19:15:00+00:00",
+                submitted_order_count=120,
+                post_cost_expectancy_bps="12",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 6, 1, 19, 17, tzinfo=timezone.utc),
+            market_session_open=True,
+            route_symbol_filter_enabled=True,
+        )
+
+        hpairs = next(
+            item for item in statuses if item["hypothesis_id"] == "H-PAIRS-01"
+        )
+        observed = hpairs["observed"]
+        self.assertFalse(hpairs["promotion_eligible"])
+        self.assertIn("route_universe_empty", hpairs["reasons"])
+        self.assertEqual(observed["tca_order_count"], 0)
+        self.assertEqual(observed["route_tca_symbols"], [])
+        self.assertEqual(observed["route_tca_repair_symbols"], ["AAPL", "AMZN"])
+        self.assertTrue(observed["bounded_route_evidence_collection_eligible"])
+        self.assertEqual(
+            observed["bounded_route_evidence_collection_authority"],
+            "repair_only_non_authority",
+        )
+        self.assertIn(
+            "route_tca_non_authority_source",
+            observed["route_tca_blocking_reason_codes"],
+        )
+        self.assertIn(
+            "route_tca_non_authority_source_decision_mode",
+            observed["route_tca_blocking_reason_codes"],
+        )
+
+    def test_compile_hypothesis_runtime_statuses_selects_clean_current_hpairs_route_tca(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=2770,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=14,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-06-01T19:15:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "account_label": "TORGHUT_SIM",
+                "order_count": 2,
+                "avg_abs_slippage_bps": "4",
+                "avg_realized_shortfall_bps": "1",
+                "last_computed_at": "2026-06-01T19:16:00+00:00",
+                "scope_symbols": ["AAPL", "AMZN"],
+                "symbol_breakdown": [
+                    {
+                        "symbol": "AAPL",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "4",
+                        "avg_realized_shortfall_bps": "1",
+                        "last_computed_at": "2026-06-01T19:16:00+00:00",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": _MANIFEST_CANDIDATE_IDS["H-PAIRS-01"],
+                        "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-PAIRS-01"],
+                        "account_label": "TORGHUT_SIM",
+                        "source_kind": "live_paper_execution_tca",
+                    },
+                    {
+                        "symbol": "AMZN",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "4",
+                        "avg_realized_shortfall_bps": "1",
+                        "last_computed_at": "2026-06-01T19:16:00+00:00",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": _MANIFEST_CANDIDATE_IDS["H-PAIRS-01"],
+                        "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-PAIRS-01"],
+                        "account_label": "TORGHUT_SIM",
+                        "source_kind": "live_paper_execution_tca",
+                    },
+                ],
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-PAIRS-01",
+                bucket_started_at="2026-06-01T19:00:00+00:00",
+                bucket_ended_at="2026-06-01T19:15:00+00:00",
+                submitted_order_count=120,
+                post_cost_expectancy_bps="12",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 6, 1, 19, 17, tzinfo=timezone.utc),
+            market_session_open=True,
+            route_symbol_filter_enabled=True,
+        )
+
+        hpairs = next(
+            item for item in statuses if item["hypothesis_id"] == "H-PAIRS-01"
+        )
+        observed = hpairs["observed"]
+        self.assertEqual(observed["tca_order_count"], 2)
+        self.assertEqual(observed["route_tca_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(observed["route_tca_repair_symbols"], [])
+        self.assertNotIn("route_universe_empty", hpairs["reasons"])
+
+    def test_compile_hypothesis_runtime_statuses_keeps_high_slippage_hpairs_tca_repair_only(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=2770,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=14,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-06-01T19:15:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "account_label": "TORGHUT_SIM",
+                "order_count": 2,
+                "avg_abs_slippage_bps": "24.34",
+                "avg_realized_shortfall_bps": "24.34",
+                "last_computed_at": "2026-06-01T19:16:00+00:00",
+                "scope_symbols": ["AAPL", "AMZN"],
+                "symbol_breakdown": [
+                    {
+                        "symbol": "AAPL",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "24.34",
+                        "avg_realized_shortfall_bps": "24.34",
+                        "last_computed_at": "2026-06-01T19:16:00+00:00",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": _MANIFEST_CANDIDATE_IDS["H-PAIRS-01"],
+                        "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-PAIRS-01"],
+                        "account_label": "TORGHUT_SIM",
+                        "source_kind": "live_paper_execution_tca",
+                    },
+                    {
+                        "symbol": "AMZN",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "24.34",
+                        "avg_realized_shortfall_bps": "24.34",
+                        "last_computed_at": "2026-06-01T19:16:00+00:00",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": _MANIFEST_CANDIDATE_IDS["H-PAIRS-01"],
+                        "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-PAIRS-01"],
+                        "account_label": "TORGHUT_SIM",
+                        "source_kind": "live_paper_execution_tca",
+                    },
+                ],
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-PAIRS-01",
+                bucket_started_at="2026-06-01T19:00:00+00:00",
+                bucket_ended_at="2026-06-01T19:15:00+00:00",
+                submitted_order_count=120,
+                post_cost_expectancy_bps="12",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 6, 1, 19, 17, tzinfo=timezone.utc),
+            market_session_open=True,
+            route_symbol_filter_enabled=True,
+        )
+
+        hpairs = next(
+            item for item in statuses if item["hypothesis_id"] == "H-PAIRS-01"
+        )
+        observed = hpairs["observed"]
+        self.assertFalse(hpairs["promotion_eligible"])
+        self.assertEqual(hpairs["promotion_contract"]["max_avg_abs_slippage_bps"], "8")
+        self.assertIn("route_universe_empty", hpairs["reasons"])
+        self.assertEqual(observed["tca_order_count"], 0)
+        self.assertEqual(observed["route_tca_symbols"], [])
+        self.assertEqual(observed["route_tca_repair_symbols"], ["AAPL", "AMZN"])
+        self.assertIn(
+            "route_tca_avg_abs_slippage_above_guardrail",
+            observed["route_tca_blocking_reason_codes"],
+        )
 
     def test_compile_hypothesis_runtime_statuses_blocks_stale_tca_evidence(
         self,

--- a/services/torghut/tests/test_route_reacquisition.py
+++ b/services/torghut/tests/test_route_reacquisition.py
@@ -343,13 +343,18 @@ def test_route_book_surfaces_paper_route_probe_readiness_without_capital_authori
     assert probe["active"] is False
     assert probe["effective_max_notional"] == "0"
     assert probe["next_session_max_notional"] == "25.0"
-    assert probe["eligible_symbols"] == ["AMZN", "AAPL", "INTC"]
+    assert probe["eligible_symbols"] == ["AMZN", "NVDA", "AAPL", "INTC"]
     assert probe["active_symbols"] == []
     assert probe["blocking_reasons"] == ["session_closed"]
     assert probe["capital_authority"] == "none"
 
     summary = cast(Mapping[str, Any], book["summary"])
-    assert summary["paper_route_probe_eligible_symbols"] == ["AMZN", "AAPL", "INTC"]
+    assert summary["paper_route_probe_eligible_symbols"] == [
+        "AMZN",
+        "NVDA",
+        "AAPL",
+        "INTC",
+    ]
     assert summary["paper_route_probe_active_symbols"] == []
     assert summary["repair_candidate_symbols"] == ["NVDA", "AAPL", "INTC"]
 
@@ -762,8 +767,12 @@ def test_hpairs_route_repair_receipts_keep_pair_legs_separate_and_audit_only() -
     )
     records = cast(list[Mapping[str, Any]], book["records"])
     by_symbol = {record["symbol"]: record for record in records}
+    probe = cast(Mapping[str, Any], book["paper_route_probe"])
 
     assert list(by_symbol) == ["AAPL", "AMZN", "MSFT"]
+    assert probe["eligible_symbols"] == ["AAPL", "AMZN", "MSFT"]
+    assert probe["active"] is False
+    assert probe["blocking_reasons"] == ["session_closed"]
     assert by_symbol["AAPL"]["reason"] == "missing_bid_ask"
     assert by_symbol["AMZN"]["reason"] == "stale_quote"
     assert by_symbol["AAPL"]["repair_recommendation"] == (


### PR DESCRIPTION
## Summary

- Separates final route-TCA authority from bounded route-repair eligibility for H-PAIRS and other route-filtered hypotheses.
- Adds per-symbol route diagnostics for non-authority/exact-replay, out-of-scope, target-mismatch, missing, and high-slippage TCA rows while preserving final promotion gates.
- Allows blocked route-reacquisition rows to advertise bounded paper-route probe repair eligibility without capital or promotion authority.
- Adds regressions for non-authority TCA, clean AAPL/AMZN route selection, high-slippage repair-only handling, and blocked-row probe eligibility.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_hypotheses.py tests/test_route_reacquisition.py tests/test_routeability_repair_acceptance.py tests/test_profitability_proof_floor.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/hypotheses.py app/trading/route_reacquisition.py app/trading/route_reacquisition_board.py app/trading/routeability_repair_acceptance.py app/trading/paper_route_target_plan.py tests/test_hypotheses.py tests/test_route_reacquisition.py tests/test_routeability_repair_acceptance.py tests/test_profitability_proof_floor.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
