### PR TITLE
fix(torghut): require source refs for runtime ledger materialization

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -96,6 +96,15 @@ _DIAGNOSTIC_EXPECTANCY_SUPPRESSING_BLOCKERS = frozenset(
         "runtime_ledger_cost_basis_non_promotion_grade",
     }
 )
+_SOURCE_REF_BLOCKER_SOURCE_WINDOW_MISSING = "runtime_ledger_source_window_ids_missing"
+_SOURCE_REF_BLOCKER_TRADE_DECISION_MISSING = (
+    "runtime_ledger_trade_decision_refs_missing"
+)
+_SOURCE_REF_BLOCKER_EXECUTION_MISSING = "runtime_ledger_execution_refs_missing"
+_SOURCE_REF_BLOCKER_EXECUTION_ORDER_EVENT_MISSING = (
+    "runtime_ledger_execution_order_event_refs_missing"
+)
+_SOURCE_REF_BLOCKER_SOURCE_OFFSETS_MISSING = "runtime_ledger_source_offsets_missing"
 
 
 @dataclass(frozen=True)
@@ -183,6 +192,11 @@ class _NormalizedFill:
     fill_quantity_basis: str | None = None
     lifecycle_only: bool = False
     order_feed_lifecycle_source: bool = False
+    execution_id: str | None = None
+    execution_order_event_id: str | None = None
+    source_window_id: str | None = None
+    source_offset_present: bool = False
+    source_materialization: str | None = None
 
     @property
     def is_usable_fill(self) -> bool:
@@ -442,6 +456,7 @@ def _build_bucket(
                 lineage_hash_counter=lineage_hash_counter,
             )
         )
+        blockers.extend(_source_materialization_blockers(lifecycle_rows))
 
     unique_blockers = _dedupe(blockers)
     post_cost_expectancy_bps: Decimal | None = None
@@ -578,6 +593,30 @@ def _order_lifecycle_blockers(
     if len(lineage_hash_counter) > 1:
         blockers.append("proof_lineage_hash_ambiguous")
     return blockers
+
+
+def _source_materialization_blockers(
+    lifecycle_rows: Sequence[_NormalizedFill],
+) -> list[str]:
+    """Fail closed on order-feed source rows missing row-level runtime refs."""
+
+    blockers: list[str] = []
+    for row in lifecycle_rows:
+        if row.source_materialization not in _PROMOTION_GRADE_SOURCE_MATERIALIZATIONS:
+            continue
+        if row.event_type not in _SUBMITTED_ORDER_EVENTS | _FILL_EVENTS:
+            continue
+        if row.execution_order_event_id is None:
+            blockers.append(_SOURCE_REF_BLOCKER_EXECUTION_ORDER_EVENT_MISSING)
+        if row.decision_id is None:
+            blockers.append(_SOURCE_REF_BLOCKER_TRADE_DECISION_MISSING)
+        if row.event_type in _FILL_EVENTS and row.execution_id is None:
+            blockers.append(_SOURCE_REF_BLOCKER_EXECUTION_MISSING)
+        if row.source_window_id is None:
+            blockers.append(_SOURCE_REF_BLOCKER_SOURCE_WINDOW_MISSING)
+        if not row.source_offset_present:
+            blockers.append(_SOURCE_REF_BLOCKER_SOURCE_OFFSETS_MISSING)
+    return _dedupe(blockers)
 
 
 def _apply_fill_to_position(
@@ -767,6 +806,19 @@ def _normalize_fill_row(
     decision_id = _coerce_text(
         _row_value(row, "decision_id", "trade_decision_id", "decision_hash")
     )
+    execution_id = _coerce_text(
+        _row_value(row, "execution_id", "execution_correlation_id")
+    )
+    execution_order_event_id = _coerce_text(
+        _row_value(row, "execution_order_event_id", "event_fingerprint")
+    )
+    source_window_id = _coerce_text(
+        _row_value(row, "source_window_id", "runtime_ledger_source_window_id")
+    )
+    source_offset_present = _source_offset_present(row)
+    source_materialization = _coerce_text(
+        _row_value(row, "source_materialization", "source")
+    )
     order_id = _coerce_text(
         _row_value(
             row,
@@ -857,6 +909,11 @@ def _normalize_fill_row(
         event_type=event_type,
         decision_id=decision_id,
         order_id=order_id,
+        execution_id=execution_id,
+        execution_order_event_id=execution_order_event_id,
+        source_window_id=source_window_id,
+        source_offset_present=source_offset_present,
+        source_materialization=source_materialization,
         execution_policy_hash=execution_policy_hash,
         cost_model_hash=cost_model_hash,
         lineage_hash=lineage_hash,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2309,6 +2309,19 @@ def _runtime_lifecycle_ledger_row(
             "source_offset",
         ),
     }
+    if _source_authority_order_event_row(row):
+        ledger_row["source"] = "execution_order_event"
+        ledger_row["source_materialization"] = "execution_order_events"
+        for key in (
+            "execution_order_event_id",
+            "execution_id",
+            "source_topic",
+            "source_partition",
+            "source_offset",
+            "source_window_id",
+        ):
+            if row.get(key) is not None:
+                ledger_row[key] = row[key]
     if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
         side = _first_text(row, "side", "action", "order_side")
         source_authority_order_event = _source_authority_order_event_row(row)
@@ -2440,7 +2453,6 @@ def _runtime_lifecycle_ledger_row(
             ledger_row["cost_basis"] = cost_basis
         if _cost_basis_is_alpaca_fee_schedule(cost_basis):
             ledger_row["cost_model_hash"] = _alpaca_2026_equity_fee_schedule_hash()
-        ledger_row["source"] = "execution_order_event"
     return ledger_row
 
 
@@ -2452,6 +2464,39 @@ def _runtime_order_id(row: Mapping[str, object]) -> str | None:
         "client_order_id",
         "execution_correlation_id",
     )
+
+
+def _execution_id_by_order_id(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[str, str]:
+    ids_by_order_id: dict[str, set[str]] = {}
+    for row in rows:
+        order_id = _runtime_order_id(row)
+        execution_id = _first_text(row, "execution_id")
+        if order_id is None or execution_id is None:
+            continue
+        ids_by_order_id.setdefault(order_id, set()).add(execution_id)
+    return {
+        order_id: next(iter(execution_ids))
+        for order_id, execution_ids in ids_by_order_id.items()
+        if len(execution_ids) == 1
+    }
+
+
+def _with_linked_execution_id(
+    row: Mapping[str, object],
+    *,
+    execution_id_by_order_id: Mapping[str, str],
+) -> dict[str, object]:
+    payload = dict(row)
+    if _first_text(payload, "execution_id") is not None:
+        return payload
+    order_id = _runtime_order_id(payload)
+    if order_id is not None and (
+        execution_id := execution_id_by_order_id.get(order_id)
+    ):
+        payload["execution_id"] = execution_id
+    return payload
 
 
 def _execution_row_has_fill(row: Mapping[str, object]) -> bool:
@@ -3511,6 +3556,24 @@ def _build_realized_strategy_pnl_rows(
         for row in carry_in_execution_rows or []
         if (execution_id := _first_text(row, "execution_id"))
     }
+    execution_id_by_order_id = _execution_id_by_order_id(execution_rows)
+    carry_in_execution_id_by_order_id = _execution_id_by_order_id(
+        carry_in_execution_rows or []
+    )
+    order_lifecycle_rows = [
+        _with_linked_execution_id(
+            row,
+            execution_id_by_order_id=execution_id_by_order_id,
+        )
+        for row in order_lifecycle_rows or []
+    ]
+    carry_in_order_lifecycle_rows = [
+        _with_linked_execution_id(
+            row,
+            execution_id_by_order_id=carry_in_execution_id_by_order_id,
+        )
+        for row in carry_in_order_lifecycle_rows or []
+    ]
     for row in decision_lifecycle_rows or []:
         lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type="decision")
         if lifecycle_row is None:
@@ -3519,7 +3582,7 @@ def _build_realized_strategy_pnl_rows(
         event_time = lifecycle_row.get("executed_at")
         if isinstance(event_time, datetime):
             event_times.append(event_time)
-    for row in order_lifecycle_rows or []:
+    for row in order_lifecycle_rows:
         event_type = _runtime_ledger_event_type(
             {str(key): value for key, value in row.items()}
         )
@@ -3576,7 +3639,7 @@ def _build_realized_strategy_pnl_rows(
         lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type="decision")
         if lifecycle_row is not None:
             carry_in_ledger_rows.append(lifecycle_row)
-    for row in carry_in_order_lifecycle_rows or []:
+    for row in carry_in_order_lifecycle_rows:
         event_type = _runtime_ledger_event_type(
             {str(key): value for key, value in row.items()}
         )

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -4880,6 +4880,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
         )
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
+        self.assertEqual(
+            bucket["execution_ids"],
+            ["execution-buy", "execution-sell"],
+        )
 
     def test_source_backed_round_trip_materializes_alpaca_payload_delta_when_columns_missing(
         self,

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -1079,6 +1079,11 @@ def test_linked_order_feed_fill_materializes_fill_economics_lineage() -> None:
                 "executed_at": _ts(1),
                 "decision_id": "decision-buy",
                 "order_id": "execution-buy",
+                "execution_order_event_id": "event-new-buy",
+                "source_window_id": "window-buy",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 6,
             },
             {
                 **common,
@@ -1093,6 +1098,11 @@ def test_linked_order_feed_fill_materializes_fill_economics_lineage() -> None:
                 "executed_at": _ts(3),
                 "decision_id": "decision-sell",
                 "order_id": "execution-sell",
+                "execution_order_event_id": "event-new-sell",
+                "source_window_id": "window-sell",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 7,
             },
             {
                 **common,
@@ -1104,7 +1114,7 @@ def test_linked_order_feed_fill_materializes_fill_economics_lineage() -> None:
                 "source_window_id": "window-buy",
                 "source_topic": "alpaca.trade_updates",
                 "source_partition": 0,
-                "source_offset": 7,
+                "source_offset": 8,
                 "side": "buy",
                 "quantity": "1",
                 "avg_fill_price": "100",
@@ -1122,7 +1132,7 @@ def test_linked_order_feed_fill_materializes_fill_economics_lineage() -> None:
                 "source_window_id": "window-sell",
                 "source_topic": "alpaca.trade_updates",
                 "source_partition": 0,
-                "source_offset": 8,
+                "source_offset": 9,
                 "side": "sell",
                 "quantity": "1",
                 "avg_fill_price": "101",
@@ -1145,6 +1155,105 @@ def test_linked_order_feed_fill_materializes_fill_economics_lineage() -> None:
     assert bucket.cost_basis_counts == {"broker_reported_commission_and_fees": 2}
     assert bucket.cost_model_hash_counts == {"broker-cost-v1": 2}
     assert bucket.post_cost_expectancy_bps is not None
+
+
+def test_source_materialized_fill_requires_execution_refs_for_authority() -> None:
+    common = {
+        "account_label": "paper",
+        "strategy_id": "strategy-1",
+        "symbol": "NVDA",
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
+        "execution_policy_hash": "policy",
+        "cost_model_hash": "broker-cost-v1",
+        "lineage_hash": "lineage",
+    }
+
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(0),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(1),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+                "execution_order_event_id": "event-new-buy",
+                "source_window_id": "window-buy",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 6,
+            },
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(2),
+                "decision_id": "decision-sell",
+                "order_id": "order-sell",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(3),
+                "decision_id": "decision-sell",
+                "order_id": "order-sell",
+                "execution_order_event_id": "event-new-sell",
+                "source_window_id": "window-sell",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 7,
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(4),
+                "execution_order_event_id": "event-buy",
+                "trade_decision_id": "decision-buy",
+                "source_window_id": "window-buy",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 8,
+                "order_id": "order-buy",
+                "side": "buy",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "100",
+                "explicit_cost_amount": "0.25",
+                "broker_fee_basis": "broker_reported_commission_and_fees",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(5),
+                "execution_order_event_id": "event-sell",
+                "trade_decision_id": "decision-sell",
+                "source_window_id": "window-sell",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 9,
+                "order_id": "order-sell",
+                "side": "sell",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "101",
+                "broker_fee": "0.25",
+                "broker_fee_basis": "broker_reported_commission_and_fees",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.closed_trade_count == 1
+    assert bucket.diagnostic_closed_trade_expectancy_bps is not None
+    assert bucket.post_cost_expectancy_bps is None
+    assert "runtime_ledger_execution_refs_missing" in bucket.blockers
 
 
 def test_linked_order_feed_fill_accepts_structured_source_offsets_mapping() -> None:


### PR DESCRIPTION
## Summary

- Fail closed promotion-grade runtime-ledger materialization when source-backed order lifecycle rows lack execution-order-event refs, trade-decision refs, fill execution refs, source-window IDs, or source offsets.
- Thread execution-order-event source metadata and unambiguous linked execution IDs into runtime-window import ledger rows before bucket materialization.
- Add regression coverage for missing source execution refs and positive source-backed execution ID readback.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger.py app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
