### PR TITLE
chore(torghut): promote image 4eb8dcf6

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.586.0-280-gf3cc6a5ad
+              value: v0.586.0-288-g4eb8dcf66
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f3cc6a5ad99f8f1e6e208ead36fafbdc45d84183
+              value: 4eb8dcf66a29485b82c5cb7c067b0416f05a4f2e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.586.0-280-gf3cc6a5ad
+              value: v0.586.0-288-g4eb8dcf66
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f3cc6a5ad99f8f1e6e208ead36fafbdc45d84183
+              value: 4eb8dcf66a29485b82c5cb7c067b0416f05a4f2e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -127,7 +127,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+                  value: sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-01T19:04:23Z"
+        client.knative.dev/updateTimestamp: "2026-06-01T19:47:30Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           ports:
             - name: http1
               containerPort: 8181
@@ -529,11 +529,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.586.0-280-gf3cc6a5ad
+              value: v0.586.0-288-g4eb8dcf66
             - name: TORGHUT_COMMIT
-              value: f3cc6a5ad99f8f1e6e208ead36fafbdc45d84183
+              value: 4eb8dcf66a29485b82c5cb7c067b0416f05a4f2e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+              value: sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-01T19:04:23Z"
+        client.knative.dev/updateTimestamp: "2026-06-01T19:47:30Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           ports:
             - name: http1
               containerPort: 8181
@@ -371,11 +371,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.586.0-280-gf3cc6a5ad
+              value: v0.586.0-288-g4eb8dcf66
             - name: TORGHUT_COMMIT
-              value: f3cc6a5ad99f8f1e6e208ead36fafbdc45d84183
+              value: 4eb8dcf66a29485b82c5cb7c067b0416f05a4f2e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+              value: sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -113,6 +113,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+                  value: sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- Promotes the Torghut image built from origin/main commit `4eb8dcf66a29485b82c5cb7c067b0416f05a4f2e`.
- Updates Torghut GitOps manifests from digest `sha256:8c65590baa2fffe2d1e76014318f87e710866dc87986429e8703c6704562c7aa` to `sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405`.
- Keeps this change limited to rollout plumbing; it does not alter trading, runtime-ledger, routeability, or profitability gates.

## Related Issues

None

## Testing

- `torghut-build-push` run `26777329425` passed for `4eb8dcf66a29485b82c5cb7c067b0416f05a4f2e` and produced digest `sha256:4e0e5e0ab2c0eb0e30e1d6791030ddfb873df2521b313bcaadd7eb14391c3405`.
- `torghut-ci` run `26777329393` passed for source commit `4eb8dcf66a29485b82c5cb7c067b0416f05a4f2e`.
- `bash scripts/kubeconform.sh argocd/applications/torghut` passed locally: 107 resources found, 50 valid, 57 skipped.
- `bash scripts/kubeconform.sh argocd/applications/torghut-options` passed locally: 23 resources found, 14 valid, 9 skipped.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.