### PR TITLE
fix(torghut): persist order feed source evidence

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import logging
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Callable, Mapping, cast
@@ -134,7 +134,15 @@ class OrderFeedIngestor:
             self._reconcile_tigerbeetle_if_enabled(session)
             session.commit()
         if durable_any and commit_allowed:
-            _commit_consumer(consumer)
+            if _consumer_commit_enabled():
+                if _commit_consumer(consumer):
+                    counters["consumer_commits_total"] += 1
+            else:
+                counters["consumer_commit_skipped_total"] += 1
+                logger.info(
+                    "Order-feed Kafka commit skipped: assignment_mode=%s db_cursor_authority=true",
+                    settings.trading_order_feed_assignment_mode,
+                )
         return counters
 
     def _reconcile_tigerbeetle_if_enabled(self, session: Session) -> None:
@@ -168,6 +176,8 @@ class OrderFeedIngestor:
             "failed_unhandled_total": 0,
             "apply_updates_total": 0,
             "consumer_errors_total": 0,
+            "consumer_commits_total": 0,
+            "consumer_commit_skipped_total": 0,
             "cursor_updates_total": 0,
         }
 
@@ -225,10 +235,34 @@ class OrderFeedIngestor:
             if normalized.event is not None
             else _coerce_int(getattr(record, "offset", None))
         )
-        out_of_scope_account = (
-            normalized.event is not None
+        event = normalized.event
+        account_alias_payload: dict[str, str] | None = None
+        if (
+            event is not None
             and normalized.account_label_explicit
-            and normalized.event.alpaca_account_label != self._default_account_label
+            and event.alpaca_account_label != self._default_account_label
+        ):
+            aliased_event = _event_with_default_account_label_if_in_scope(
+                session,
+                event,
+                default_account_label=self._default_account_label,
+            )
+            if aliased_event is not None:
+                account_alias_payload = {
+                    "source_account_label": event.alpaca_account_label,
+                    "canonical_account_label": self._default_account_label,
+                    "basis": "matched_order_identity",
+                }
+                event = aliased_event
+                normalized = NormalizationResult(
+                    event=event,
+                    drop_reason=None,
+                    account_label_explicit=normalized.account_label_explicit,
+                )
+        out_of_scope_account = (
+            event is not None
+            and normalized.account_label_explicit
+            and event.alpaca_account_label != self._default_account_label
         )
         source_window = _create_order_feed_source_window(
             session,
@@ -239,13 +273,17 @@ class OrderFeedIngestor:
             alpaca_account_label=(
                 self._default_account_label
                 if out_of_scope_account
-                else normalized.event.alpaca_account_label
-                if normalized.event is not None
+                else event.alpaca_account_label
+                if event is not None
                 else self._default_account_label
             ),
         )
         if source_window is not None:
             counters["source_windows_total"] += 1
+            if account_alias_payload is not None:
+                source_window.payload_json = {
+                    "account_label_alias": account_alias_payload,
+                }
 
         try:
             if out_of_scope_account:
@@ -307,6 +345,7 @@ class OrderFeedIngestor:
                     source_window,
                     persisted=persisted,
                     duplicate=duplicate,
+                    account_label_alias=account_alias_payload,
                 )
             if duplicate:
                 cursor_updated = _upsert_cursor_and_count(
@@ -513,14 +552,13 @@ class OrderFeedIngestor:
 
         manual_assignment = settings.trading_order_feed_assignment_mode == "manual"
         topics = [] if manual_assignment else settings.trading_order_feed_topics
+        group_id = None if manual_assignment else _kafka_consumer_group_id()
         return cast(
             Any,
             KafkaConsumer(
                 *topics,
                 bootstrap_servers=settings.trading_order_feed_bootstrap_server_list,
-                group_id=None
-                if manual_assignment
-                else settings.trading_order_feed_group_id,
+                group_id=group_id,
                 client_id=settings.trading_order_feed_client_id,
                 enable_auto_commit=False,
                 auto_offset_reset=settings.trading_order_feed_auto_offset_reset,
@@ -660,6 +698,7 @@ def _classify_source_window_event(
     *,
     persisted: ExecutionOrderEvent,
     duplicate: bool,
+    account_label_alias: dict[str, str] | None = None,
 ) -> None:
     source_window.first_event_ts = persisted.event_ts
     source_window.last_event_ts = persisted.event_ts
@@ -667,10 +706,13 @@ def _classify_source_window_event(
         source_window.status = "duplicate"
         source_window.status_reason = "duplicate_event_fingerprint"
         source_window.duplicate_count = 1
-        source_window.payload_json = {
+        payload: dict[str, Any] = {
             "classification": "duplicate",
             "classification_counts": {"duplicate": 1},
         }
+        if account_label_alias is not None:
+            payload["account_label_alias"] = account_label_alias
+        source_window.payload_json = payload
         return
     source_window.status = "inserted"
     source_window.inserted_count = 1
@@ -681,10 +723,13 @@ def _classify_source_window_event(
     if persisted.trade_decision_id is None:
         source_window.unlinked_decision_count = 1
         classification_counts["unlinked_decision"] = 1
-    source_window.payload_json = {
+    payload = {
         "classification": "inserted",
         "classification_counts": classification_counts,
     }
+    if account_label_alias is not None:
+        payload["account_label_alias"] = account_label_alias
+    source_window.payload_json = payload
 
 
 def normalize_order_feed_record(
@@ -797,6 +842,112 @@ def normalize_order_feed_record(
         event=event,
         drop_reason=None,
         account_label_explicit=explicit_account_label is not None,
+    )
+
+
+def _event_with_default_account_label_if_in_scope(
+    session: Session,
+    event: NormalizedOrderEvent,
+    *,
+    default_account_label: str,
+) -> NormalizedOrderEvent | None:
+    """Canonicalize broker-account labels only when local order identity proves scope.
+
+    Some paper broker streams identify the account by broker account id while
+    Torghut's runtime proof labels the same lane as ``TORGHUT_SIM``. Treat the
+    broker id as an alias only when a submitted local execution or decision with
+    the same order identity already exists under the default account label. This
+    keeps true cross-account events fail-closed as out-of-scope.
+    """
+
+    if not default_account_label or event.alpaca_account_label == default_account_label:
+        return event
+    if not _order_identity_matches_account_scope(
+        session,
+        event,
+        account_label=default_account_label,
+    ):
+        return None
+
+    raw_event = coerce_json_payload(event.raw_event)
+    if isinstance(raw_event, Mapping):
+        aliased_raw_event: dict[str, Any] = {
+            str(key): value
+            for key, value in cast(Mapping[object, Any], raw_event).items()
+        }
+    else:
+        aliased_raw_event = {"payload": raw_event}
+    aliased_raw_event["_torghut_account_label_alias"] = {
+        "source_account_label": event.alpaca_account_label,
+        "canonical_account_label": default_account_label,
+        "basis": "matched_order_identity",
+    }
+    return replace(
+        event,
+        event_fingerprint=_fingerprint_normalized_order_event(
+            event,
+            account_label=default_account_label,
+        ),
+        alpaca_account_label=default_account_label,
+        raw_event=coerce_json_payload(aliased_raw_event),
+    )
+
+
+def _fingerprint_normalized_order_event(
+    event: NormalizedOrderEvent,
+    *,
+    account_label: str | None = None,
+) -> str:
+    fingerprint_input = {
+        "alpaca_account_label": account_label or event.alpaca_account_label,
+        "alpaca_order_id": event.alpaca_order_id,
+        "client_order_id": event.client_order_id,
+        "event_type": event.event_type,
+        "status": event.status,
+        "event_ts": event.event_ts.isoformat() if event.event_ts else None,
+        "feed_seq": event.feed_seq,
+        "qty": str(event.qty) if event.qty is not None else None,
+        "filled_qty": str(event.filled_qty) if event.filled_qty is not None else None,
+        "avg_fill_price": (
+            str(event.avg_fill_price) if event.avg_fill_price is not None else None
+        ),
+    }
+    return hashlib.sha256(
+        json.dumps(fingerprint_input, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+def _order_identity_matches_account_scope(
+    session: Session,
+    event: NormalizedOrderEvent,
+    *,
+    account_label: str,
+) -> bool:
+    clauses: list[ColumnElement[bool]] = []
+    if event.alpaca_order_id:
+        clauses.append(
+            (Execution.alpaca_order_id == event.alpaca_order_id)
+            & (Execution.alpaca_account_label == account_label)
+        )
+    if event.client_order_id:
+        clauses.append(
+            (Execution.client_order_id == event.client_order_id)
+            & (Execution.alpaca_account_label == account_label)
+        )
+    if clauses and session.scalar(select(exists().where(or_(*clauses)))):
+        return True
+
+    if not event.client_order_id:
+        return False
+    return bool(
+        session.scalar(
+            select(
+                exists().where(
+                    TradeDecision.decision_hash == event.client_order_id,
+                    TradeDecision.alpaca_account_label == account_label,
+                )
+            )
+        )
     )
 
 
@@ -2035,6 +2186,14 @@ def _order_feed_cursor_consumer_group() -> str:
     return client_id or "torghut-order-feed"
 
 
+def _kafka_consumer_group_id() -> str:
+    return _order_feed_cursor_consumer_group()
+
+
+def _consumer_commit_enabled() -> bool:
+    return settings.trading_order_feed_assignment_mode == "group"
+
+
 def _latest_persisted_source_offsets(session: Session) -> dict[tuple[str, int], int]:
     consumer_group = _order_feed_cursor_consumer_group()
     cursor_rows = session.execute(
@@ -2253,14 +2412,16 @@ def _update_trade_decision_from_execution(
     session.add(decision)
 
 
-def _commit_consumer(consumer: Any) -> None:
+def _commit_consumer(consumer: Any) -> bool:
     run_commit = cast(Callable[[], Any] | None, getattr(consumer, "commit", None))
     if run_commit is None:
-        return
+        return False
     try:
         run_commit()
+        return True
     except Exception as exc:  # pragma: no cover - external Kafka failure
         logger.warning("Order-feed consumer commit failed: %s", exc)
+        return False
 
 
 __all__ = [

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -908,6 +908,62 @@ class TestOrderFeed(TestCase):
         assert normalized.event is not None
         self.assertEqual(normalized.event.alpaca_account_label, "paper-c")
 
+    def test_sim_broker_account_label_alias_links_to_torghut_sim_scope(
+        self,
+    ) -> None:
+        record = FakeRecord(
+            value=(
+                b'{"channel":"trade_updates","account_label":"PA3SX7FYNUTF",'
+                b'"payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+                b'"account_label":"PA3SX7FYNUTF",'
+                b'"order":{"id":"sim-order-1","client_order_id":"sim-client-1",'
+                b'"symbol":"AAPL","status":"filled","qty":"1","filled_qty":"1",'
+                b'"filled_avg_price":"190.2","alpaca_account_label":"PA3SX7FYNUTF"}},'
+                b'"seq":10}'
+            ),
+            offset=26,
+        )
+        consumer = FakeConsumer([record])
+        ingestor = OrderFeedIngestor(
+            consumer_factory=lambda: consumer,
+            default_account_label="TORGHUT_SIM",
+        )
+
+        with Session(self.engine) as session:
+            execution = self._seed_execution(
+                session,
+                account_label="TORGHUT_SIM",
+                order_id="sim-order-1",
+                client_order_id="sim-client-1",
+            )
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+
+            counters = ingestor.ingest_once(session)
+            event = session.execute(select(ExecutionOrderEvent)).scalar_one()
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(counters["events_persisted_total"], 1)
+        self.assertEqual(counters["out_of_scope_account_total"], 0)
+        self.assertEqual(counters["apply_updates_total"], 1)
+        self.assertEqual(event.alpaca_account_label, "TORGHUT_SIM")
+        self.assertEqual(event.execution_id, execution_id)
+        self.assertEqual(event.trade_decision_id, trade_decision_id)
+        self.assertEqual(
+            event.raw_event["_torghut_account_label_alias"]["source_account_label"],
+            "PA3SX7FYNUTF",
+        )
+        self.assertEqual(source_window.alpaca_account_label, "TORGHUT_SIM")
+        self.assertEqual(source_window.status, "inserted")
+        self.assertEqual(
+            source_window.payload_json["account_label_alias"],
+            {
+                "source_account_label": "PA3SX7FYNUTF",
+                "canonical_account_label": "TORGHUT_SIM",
+                "basis": "matched_order_identity",
+            },
+        )
+
     def test_build_consumer_applies_kafka_security_kwargs(self) -> None:
         captured_kwargs: dict[str, object] = {}
         original_security_protocol = settings.trading_order_feed_security_protocol
@@ -940,6 +996,36 @@ class TestOrderFeed(TestCase):
         self.assertEqual(captured_kwargs.get("sasl_mechanism"), "SCRAM-SHA-512")
         self.assertEqual(captured_kwargs.get("sasl_plain_username"), "user")
         self.assertEqual(captured_kwargs.get("sasl_plain_password"), "secret")
+
+    def test_build_consumer_group_mode_falls_back_to_client_id_group(self) -> None:
+        captured_kwargs: dict[str, object] = {}
+        original_group_id = settings.trading_order_feed_group_id
+        original_client_id = settings.trading_order_feed_client_id
+        original_assignment_mode = settings.trading_order_feed_assignment_mode
+        try:
+            settings.trading_order_feed_assignment_mode = "group"
+            settings.trading_order_feed_group_id = " "
+            settings.trading_order_feed_client_id = "paper-route-client"
+
+            class _FakeKafkaConsumer:
+                def __init__(self, *topics: str, **kwargs: object) -> None:
+                    captured_kwargs["topics"] = list(topics)
+                    captured_kwargs.update(kwargs)
+
+            with patch.dict(
+                "sys.modules",
+                {"kafka": SimpleNamespace(KafkaConsumer=_FakeKafkaConsumer)},
+            ):
+                OrderFeedIngestor._build_consumer()
+        finally:
+            settings.trading_order_feed_group_id = original_group_id
+            settings.trading_order_feed_client_id = original_client_id
+            settings.trading_order_feed_assignment_mode = original_assignment_mode
+
+        self.assertEqual(
+            captured_kwargs.get("topics"), ["torghut.trade-updates.v1"]
+        )
+        self.assertEqual(captured_kwargs.get("group_id"), "paper-route-client")
 
     def test_build_consumer_disables_group_subscription_for_manual_assignment(
         self,
@@ -1995,6 +2081,40 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.start_offset, 31)
         self.assertEqual(source_window.end_offset, 31)
         self.assertEqual(source_window.broker_high_watermark, 37)
+        self.assertEqual(source_window.status, "inserted")
+
+    def test_manual_assignment_skips_kafka_commit_after_durable_cursor_update(
+        self,
+    ) -> None:
+        settings.trading_order_feed_assignment_mode = "manual"
+        settings.trading_order_feed_auto_offset_reset = "earliest"
+        record = FakeRecord(
+            value=(
+                b'{"channel":"trade_updates","payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+                b'"order":{"id":"order-1","client_order_id":"client-1","symbol":"AAPL","status":"filled",'
+                b'"qty":"1","filled_qty":"1","filled_avg_price":"190.2"}},"seq":10}'
+            ),
+            offset=32,
+        )
+        consumer = FakeManualConsumer(
+            [record],
+            partitions={"torghut.trade-updates.v1": {0}},
+        )
+        ingestor = OrderFeedIngestor(consumer_factory=lambda: consumer)
+
+        with Session(self.engine) as session:
+            self._seed_execution(session)
+            counters = ingestor.ingest_once(session)
+            cursor = session.execute(select(OrderFeedConsumerCursor)).scalar_one()
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(counters["events_persisted_total"], 1)
+        self.assertEqual(counters["cursor_updates_total"], 1)
+        self.assertEqual(counters["consumer_commits_total"], 0)
+        self.assertEqual(counters["consumer_commit_skipped_total"], 1)
+        self.assertEqual(consumer.commit_calls, 0)
+        self.assertEqual(cursor.high_watermark_offset, 32)
+        self.assertEqual(source_window.assignment_mode, "manual")
         self.assertEqual(source_window.status, "inserted")
 
     def test_invalid_json_is_durably_classified_before_cursor_advance(self) -> None:


### PR DESCRIPTION
## Summary

- Keeps manual-assignment order-feed ingestion DB-cursor authoritative by skipping Kafka commits explicitly, with counters/logging instead of `Requires group_id` commit failures.
- Uses a valid fallback Kafka consumer group in group mode when `TRADING_ORDER_FEED_GROUP_ID` is blank.
- Canonicalizes proven broker account aliases to `TORGHUT_SIM` only when local execution or decision order identity proves scope, while keeping true cross-account events fail-closed.
- Adds regression coverage for alias linking, commit setup, durable cursor/source-window classification, and manual commit skip semantics.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
