### PR TITLE
fix(torghut): revision TigerBeetle execution TCA refs

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from decimal import Decimal
+import hashlib
 from types import TracebackType
 from typing import Any, Self, cast
 
@@ -469,6 +470,86 @@ def _submitted_pending_key(event: ExecutionOrderEvent) -> str:
     return f"{event.alpaca_account_label}:{source_id}"
 
 
+def _economic_decimal_text(value: object) -> str:
+    if value is None:
+        return "null"
+    return format(Decimal(str(value)).normalize(), "f")
+
+
+def _economic_text(value: object) -> str:
+    if isinstance(value, Decimal):
+        return _economic_decimal_text(value)
+    if value is None:
+        return "null"
+    return str(value).strip()
+
+
+def _source_revision_id(source_id: object, economic_event_key: str) -> str:
+    normalized_source_id = str(source_id).strip()
+    digest = hashlib.sha256(economic_event_key.encode("utf-8")).hexdigest()[:32]
+    return f"{normalized_source_id}:{digest}"
+
+
+def execution_economic_event_key(execution: Execution) -> str:
+    """Return the immutable economics key represented by an execution ref."""
+
+    return "|".join(
+        (
+            "execution_fill",
+            str(execution.id),
+            _economic_text(execution.alpaca_account_label),
+            _economic_text(execution.symbol),
+            _economic_text(execution.side),
+            _economic_text(execution.trade_decision_id),
+            _economic_text(execution.alpaca_order_id),
+            _economic_text(execution.client_order_id),
+            _economic_decimal_text(execution.filled_qty),
+            _economic_decimal_text(execution.avg_fill_price),
+        )
+    )
+
+
+def execution_source_id(execution: Execution) -> str:
+    return _source_revision_id(execution.id, execution_economic_event_key(execution))
+
+
+def execution_tca_metric_economic_event_key(metric: ExecutionTCAMetric) -> str:
+    """Return the immutable economics key represented by an execution TCA ref."""
+
+    return "|".join(
+        (
+            "execution_tca_metric",
+            str(metric.id),
+            _economic_text(metric.execution_id),
+            _economic_text(metric.trade_decision_id),
+            _economic_text(metric.strategy_id),
+            _economic_text(metric.alpaca_account_label),
+            _economic_text(metric.symbol),
+            _economic_text(metric.side),
+            _economic_decimal_text(metric.arrival_price),
+            _economic_decimal_text(metric.avg_fill_price),
+            _economic_decimal_text(metric.filled_qty),
+            _economic_decimal_text(metric.signed_qty),
+            _economic_decimal_text(metric.shortfall_notional),
+            _economic_decimal_text(metric.slippage_bps),
+            _economic_decimal_text(metric.realized_shortfall_bps),
+            _economic_decimal_text(metric.expected_shortfall_bps_p50),
+            _economic_decimal_text(metric.expected_shortfall_bps_p95),
+            _economic_decimal_text(metric.divergence_bps),
+            _economic_decimal_text(metric.churn_qty),
+            _economic_decimal_text(metric.churn_ratio),
+            _economic_text(metric.simulator_version),
+        )
+    )
+
+
+def execution_tca_metric_source_id(metric: ExecutionTCAMetric) -> str:
+    return _source_revision_id(
+        metric.id,
+        execution_tca_metric_economic_event_key(metric),
+    )
+
+
 def submitted_pending_transfer_id(event: ExecutionOrderEvent) -> int:
     return stable_u128(
         "torghut.tigerbeetle.submitted_pending",
@@ -486,11 +567,17 @@ def event_transfer_id(event: ExecutionOrderEvent, transfer_kind: str) -> int:
 
 
 def execution_transfer_id(execution: Execution) -> int:
-    return stable_u128("torghut.tigerbeetle.execution_fill", str(execution.id))
+    return stable_u128(
+        "torghut.tigerbeetle.execution_fill",
+        execution_economic_event_key(execution),
+    )
 
 
 def execution_cost_transfer_id(metric: ExecutionTCAMetric) -> int:
-    return stable_u128("torghut.tigerbeetle.execution_cost", str(metric.id))
+    return stable_u128(
+        "torghut.tigerbeetle.execution_cost",
+        execution_tca_metric_economic_event_key(metric),
+    )
 
 
 def runtime_ledger_transfer_id(bucket: StrategyRuntimeLedgerBucket) -> int:
@@ -1294,7 +1381,11 @@ class TigerBeetleLedgerJournal:
                 "source_refs": [
                     f"postgres:executions:{execution.id}",
                 ],
-                "economic_event_key": f"execution:{execution.id}:fill_notional",
+                "source_row_id": str(execution.id),
+                "source_economic_fingerprint": execution_source_id(execution).split(
+                    ":", 1
+                )[1],
+                "economic_event_key": execution_economic_event_key(execution),
                 "alpaca_order_id": execution.alpaca_order_id,
                 "client_order_id": execution.client_order_id,
                 "filled_qty": str(execution.filled_qty),
@@ -1329,17 +1420,18 @@ class TigerBeetleLedgerJournal:
             execution_id=metric.execution_id,
             execution_tca_metric_id=metric.id,
             source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
-            source_id=str(metric.id),
+            source_id=execution_tca_metric_source_id(metric),
             payload_json={
                 "source": SOURCE_TYPE_EXECUTION_TCA_METRIC,
                 "source_refs": [
                     f"postgres:execution_tca_metrics:{metric.id}",
                     f"postgres:executions:{metric.execution_id}",
                 ],
-                "economic_event_key": (
-                    f"execution:{metric.execution_id}:tca_metric:{metric.id}:"
-                    "execution_cost"
-                ),
+                "source_row_id": str(metric.id),
+                "source_economic_fingerprint": execution_tca_metric_source_id(
+                    metric
+                ).split(":", 1)[1],
+                "economic_event_key": execution_tca_metric_economic_event_key(metric),
                 "shortfall_notional": str(metric.shortfall_notional),
                 "realized_shortfall_bps": str(metric.realized_shortfall_bps),
                 "simulator_version": metric.simulator_version,

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -32,6 +32,7 @@ from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION_ORDER_EVENT,
     SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+    execution_tca_metric_source_id,
     build_order_event_transfer_plan,
     build_runtime_ledger_bucket_transfer_plan,
     runtime_ledger_amount_source,
@@ -293,8 +294,9 @@ def _payload_string_list(payload: Mapping[str, object], key: str) -> list[str]:
 def _uuid_or_none(value: str | None) -> UUID | None:
     if not value:
         return None
+    uuid_text = value.split(":", 1)[0]
     try:
-        return UUID(value)
+        return UUID(uuid_text)
     except ValueError:
         return None
 
@@ -350,10 +352,30 @@ def _archived_runtime_ledger_amount_micros(
         return None
 
 
+def _archived_source_amount_micros(ref: TigerBeetleTransferRef) -> Decimal | None:
+    if ref.source_type not in {SOURCE_TYPE_EXECUTION, SOURCE_TYPE_EXECUTION_TCA_METRIC}:
+        return None
+    payload = _payload_mapping(ref)
+    if ":" not in str(ref.source_id or "") and not payload.get(
+        "source_economic_fingerprint"
+    ):
+        return None
+    raw_amount = payload.get("amount_source")
+    if raw_amount is None:
+        return None
+    try:
+        return _usd_to_micros(Decimal(str(raw_amount)))
+    except (InvalidOperation, ValueError):
+        return None
+
+
 def _expected_source_amount_micros(
     session: Session,
     ref: TigerBeetleTransferRef,
 ) -> Decimal | None:
+    archived_amount = _archived_source_amount_micros(ref)
+    if archived_amount is not None:
+        return archived_amount
     source_uuid = _uuid_or_none(ref.source_id)
     if source_uuid is None:
         return None
@@ -1055,7 +1077,7 @@ def reconcile_tigerbeetle_transfers(
             session,
             settings_obj=settings_obj,
             source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
-            source_id=str(metric.id),
+            source_id=execution_tca_metric_source_id(metric),
             transfer_kind=TRANSFER_KIND_EXECUTION_COST,
         ):
             continue
@@ -1065,7 +1087,7 @@ def reconcile_tigerbeetle_transfers(
             {
                 "blocker": BLOCKER_UNLINKED_COST,
                 "source_type": SOURCE_TYPE_EXECUTION_TCA_METRIC,
-                "source_id": str(metric.id),
+                "source_id": execution_tca_metric_source_id(metric),
                 "execution_id": str(metric.execution_id),
             },
         )

--- a/services/torghut/app/trading/tigerbeetle_runtime_ledger_parity.py
+++ b/services/torghut/app/trading/tigerbeetle_runtime_ledger_parity.py
@@ -36,6 +36,7 @@ from app.trading.tigerbeetle_journal import (
     build_execution_tca_metric_transfer_plan,
     build_execution_transfer_plan,
     build_runtime_ledger_bucket_transfer_plan,
+    execution_tca_metric_source_id,
 )
 from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_EXECUTION_COST,
@@ -188,7 +189,7 @@ def _select_sources(
             _ParitySource(
                 family=TRANSFER_KIND_EXECUTION_COST,
                 source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
-                source_id=str(metric.id),
+                source_id=execution_tca_metric_source_id(metric),
                 account_label=metric.alpaca_account_label,
                 candidate_id=None,
                 plan=plan,

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, cast
 
-from sqlalchemy import String, create_engine, select
+from sqlalchemy import String, create_engine, or_, select
 from sqlalchemy.orm import sessionmaker
 
 from app.config import Settings
@@ -147,7 +147,10 @@ def _source_ref_exists(
         .where(
             TigerBeetleTransferRef.cluster_id == settings_obj.tigerbeetle_cluster_id,
             TigerBeetleTransferRef.source_type == source_type,
-            TigerBeetleTransferRef.source_id == source_id_column,
+            or_(
+                TigerBeetleTransferRef.source_id == source_id_column,
+                TigerBeetleTransferRef.source_id.like(source_id_column + ":%"),
+            ),
             TigerBeetleTransferRef.transfer_kind == transfer_kind,
         )
         .exists()

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -44,10 +44,13 @@ from app.trading.tigerbeetle_journal import (
     _transfer_ref_mismatches,
     _transfer_spec,
     build_order_event_transfer_plan,
+    execution_economic_event_key,
     submitted_pending_transfer_id,
     event_transfer_id,
     execution_cost_transfer_id,
     execution_transfer_id,
+    execution_tca_metric_economic_event_key,
+    execution_tca_metric_source_id,
     runtime_ledger_transfer_id,
     tigerbeetle_runtime_ledger_journal_payload,
 )
@@ -453,6 +456,11 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(ref.transfer_kind, TRANSFER_KIND_EXECUTION_FILL)
             self.assertEqual(ref.transfer_id, str(execution_transfer_id(execution)))
             self.assertEqual(ref.amount, Decimal("190250000"))
+            self.assertEqual(ref.payload_json["source_row_id"], str(execution.id))
+            self.assertEqual(
+                ref.payload_json["economic_event_key"],
+                execution_economic_event_key(execution),
+            )
             self.assertIn(int(ref.transfer_id), client.transfers)
 
     def test_cost_source_writes_real_tca_metric_ref(self) -> None:
@@ -485,7 +493,7 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertIsNotNone(ref)
             assert ref is not None
             self.assertEqual(ref.source_type, "execution_tca_metric")
-            self.assertEqual(ref.source_id, str(metric.id))
+            self.assertEqual(ref.source_id, execution_tca_metric_source_id(metric))
             self.assertEqual(ref.execution_tca_metric_id, metric.id)
             self.assertEqual(ref.transfer_kind, TRANSFER_KIND_EXECUTION_COST)
             self.assertEqual(ref.transfer_id, str(execution_cost_transfer_id(metric)))
@@ -499,8 +507,9 @@ class TestTigerBeetleLedgerJournal(TestCase):
             )
             self.assertEqual(
                 ref.payload_json["economic_event_key"],
-                f"execution:{metric.execution_id}:tca_metric:{metric.id}:execution_cost",
+                execution_tca_metric_economic_event_key(metric),
             )
+            self.assertEqual(ref.payload_json["source_row_id"], str(metric.id))
             self.assertEqual(ref.payload_json["amount_source"], "0.25")
             self.assertEqual(ref.payload_json["ledger"], LEDGER_USD_MICRO)
             self.assertEqual(ref.payload_json["code"], 2011)
@@ -540,6 +549,65 @@ class TestTigerBeetleLedgerJournal(TestCase):
             refs = session.execute(select(TigerBeetleTransferRef)).scalars().all()
             self.assertEqual(len(refs), 1)
             self.assertEqual(len(client.transfers), 1)
+
+    def test_cost_source_changed_economics_create_distinct_revision_ref(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(
+                session, fingerprint="fingerprint-cost-revision"
+            )
+            metric = ExecutionTCAMetric(
+                execution_id=event.execution_id,
+                trade_decision_id=event.trade_decision_id,
+                strategy_id=event.trade_decision.strategy_id
+                if event.trade_decision
+                else None,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.25"),
+                realized_shortfall_bps=Decimal("1.3"),
+                computed_at=datetime.now(timezone.utc),
+            )
+            session.add(metric)
+            session.flush()
+            client = FakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            first = journal.journal_execution_tca_metric(session, metric)
+            self.assertIsNotNone(first)
+            assert first is not None
+            first_transfer_id = first.transfer_id
+            first_source_id = first.source_id
+            metric.shortfall_notional = Decimal("0.40")
+            metric.realized_shortfall_bps = Decimal("2.1")
+            session.add(metric)
+            session.flush()
+            second = journal.journal_execution_tca_metric(session, metric)
+
+            self.assertIsNotNone(second)
+            assert second is not None
+            self.assertNotEqual(second.transfer_id, first_transfer_id)
+            self.assertNotEqual(second.source_id, first_source_id)
+            self.assertEqual(second.amount, Decimal("400000"))
+            refs = (
+                session.execute(
+                    select(TigerBeetleTransferRef).where(
+                        TigerBeetleTransferRef.source_type
+                        == "execution_tca_metric"
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            self.assertEqual(len(refs), 2)
+            self.assertEqual(len(client.transfers), 2)
 
     def test_cost_source_same_ref_different_payload_is_blocked(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -1238,6 +1238,14 @@ class TestTigerBeetleReconcile(TestCase):
         self.assertEqual(_payload_int({}, "value"), 0)
         self.assertIsNone(_uuid_or_none(None))
         self.assertIsNone(_uuid_or_none("not-a-uuid"))
+        self.assertEqual(
+            str(
+                _uuid_or_none(
+                    "6f767a53-6b44-428a-bd85-2f662642f637:revision"
+                )
+            ),
+            "6f767a53-6b44-428a-bd85-2f662642f637",
+        )
         self.assertIsNone(_usd_to_micros(None))
         self.assertIsNone(_usd_to_micros(Decimal("0")))
         self.assertIsNone(_usd_to_micros(Decimal("0.0000001")))
@@ -1334,8 +1342,21 @@ class TestTigerBeetleReconcile(TestCase):
                 amount=Decimal("250000"),
                 status="created",
                 source_type="execution_tca_metric",
-                source_id=str(metric.id),
+                source_id=f"{metric.id}:revision",
             )
+            archived_cost_ref = TigerBeetleTransferRef(
+                cluster_id=2001,
+                transfer_id="2005",
+                transfer_kind="execution_cost",
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_EXECUTION_FILL,
+                amount=Decimal("250000"),
+                status="created",
+                source_type="execution_tca_metric",
+                source_id=f"{metric.id}:archived",
+                payload_json={"amount_source": "0.25"},
+            )
+            metric.shortfall_notional = Decimal("0.75")
             runtime_ref = TigerBeetleTransferRef(
                 cluster_id=2001,
                 transfer_id="2002",
@@ -1371,7 +1392,11 @@ class TestTigerBeetleReconcile(TestCase):
             )
 
             self.assertEqual(
-                _expected_source_amount_micros(session, cost_ref), Decimal("250000")
+                _expected_source_amount_micros(session, cost_ref), Decimal("750000")
+            )
+            self.assertEqual(
+                _expected_source_amount_micros(session, archived_cost_ref),
+                Decimal("250000"),
             )
             self.assertEqual(
                 _expected_source_amount_micros(session, runtime_ref), Decimal("500000")

--- a/services/torghut/tests/test_tigerbeetle_runtime_ledger_parity.py
+++ b/services/torghut/tests/test_tigerbeetle_runtime_ledger_parity.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.config import Settings
+from app.models import Base, Execution, ExecutionTCAMetric
+from app.trading.tigerbeetle_client import FakeTigerBeetleClient
+from app.trading.tigerbeetle_journal import (
+    TigerBeetleLedgerJournal,
+    execution_tca_metric_source_id,
+)
+from app.trading.tigerbeetle_runtime_ledger_parity import (
+    PARITY_STATUS_PASS,
+    audit_tigerbeetle_runtime_ledger_parity,
+)
+
+
+def _settings() -> Settings:
+    return Settings(
+        TORGHUT_TIGERBEETLE_ENABLED=True,
+        TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
+        TORGHUT_TIGERBEETLE_REQUIRED=True,
+        TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED=True,
+    )
+
+
+class TestTigerBeetleRuntimeLedgerParity(TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine('sqlite+pysqlite:///:memory:', future=True)
+        Base.metadata.create_all(self.engine)
+
+    def test_parity_reads_revisioned_tca_ref_after_same_metric_retry(self) -> None:
+        with Session(self.engine) as session:
+            execution = Execution(
+                alpaca_account_label='paper',
+                alpaca_order_id='order-parity-revision',
+                client_order_id='client-parity-revision',
+                symbol='AAPL',
+                side='buy',
+                order_type='market',
+                time_in_force='day',
+                submitted_qty=Decimal('1'),
+                filled_qty=Decimal('1'),
+                avg_fill_price=Decimal('190.25'),
+                status='filled',
+                raw_order={'id': 'order-parity-revision'},
+            )
+            session.add(execution)
+            session.flush()
+            metric = ExecutionTCAMetric(
+                execution_id=execution.id,
+                alpaca_account_label='paper',
+                symbol='AAPL',
+                side='buy',
+                filled_qty=Decimal('1'),
+                signed_qty=Decimal('1'),
+                shortfall_notional=Decimal('0.25'),
+                realized_shortfall_bps=Decimal('1.3'),
+                computed_at=datetime.now(timezone.utc),
+            )
+            session.add(metric)
+            session.flush()
+            client = FakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(settings_obj=_settings(), client=client)
+
+            self.assertIsNotNone(journal.journal_execution(session, execution))
+            first = journal.journal_execution_tca_metric(session, metric)
+            self.assertIsNotNone(first)
+            metric.shortfall_notional = Decimal('0.40')
+            metric.realized_shortfall_bps = Decimal('2.1')
+            session.add(metric)
+            session.flush()
+            second = journal.journal_execution_tca_metric(session, metric)
+
+            self.assertIsNotNone(second)
+            assert second is not None
+            self.assertEqual(second.source_id, execution_tca_metric_source_id(metric))
+            payload = audit_tigerbeetle_runtime_ledger_parity(
+                session,
+                settings_obj=_settings(),
+                client=client,
+                limit=1,
+            )
+
+        self.assertTrue(payload['ok'])
+        self.assertEqual(payload['parity_status'], PARITY_STATUS_PASS)
+        samples = payload['samples']
+        assert isinstance(samples, list)
+        self.assertEqual(samples[0]['source_id'], second.source_id)
+        self.assertEqual(samples[0]['expected_amount_micros'], '400000')


### PR DESCRIPTION
## Summary

- Derives TigerBeetle execution-fill and execution-TCA transfer refs from immutable economic event keys instead of mutable row UUIDs alone.
- Stores revisioned source IDs plus source row and economic fingerprint metadata so retries are idempotent only for matching economics and source lineage.
- Updates reconciliation/parity/readback helpers to resolve revisioned source IDs without masking non-revisioned source mismatches.
- Adds regression coverage for same-event idempotency, changed TCA economics producing distinct refs, and runtime-ledger parity readback.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_runtime_ledger_parity.py tests/test_journal_tigerbeetle_order_events.py tests/test_verify_tigerbeetle_ledger.py tests/test_audit_tigerbeetle_runtime_ledger_parity.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_client.py app/trading/tigerbeetle_ids.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py app/trading/tigerbeetle_runtime_ledger_parity.py scripts/journal_tigerbeetle_order_events.py scripts/verify_tigerbeetle_ledger.py scripts/audit_tigerbeetle_runtime_ledger_parity.py tests/test_tigerbeetle_client.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_runtime_ledger_parity.py tests/test_journal_tigerbeetle_order_events.py tests/test_verify_tigerbeetle_ledger.py tests/test_audit_tigerbeetle_runtime_ledger_parity.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
