### PR TITLE
fix(torghut): bound paper-route evidence readback

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -131,6 +131,10 @@ from .trading.paper_route_target_plan import (
     paper_route_target_plan_from_payload as _shared_paper_route_target_plan_from_payload,
 )
 from .trading.paper_route_evidence import (
+    DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+    DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+    MAX_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+    MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
     build_paper_route_evidence_audit,
     build_paper_route_target_plan_payload,
 )
@@ -4609,6 +4613,18 @@ def trading_runtime_profitability(
 
 @app.get("/trading/paper-route-evidence")
 def trading_paper_route_evidence(
+    lookback_hours: int = Query(
+        DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+        ge=1,
+        le=MAX_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+        description="Bounded fallback lookback window for targets without explicit windows.",
+    ),
+    target_limit: int = Query(
+        DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+        ge=1,
+        le=MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+        description="Maximum number of paper-route targets to audit.",
+    ),
     session: Session = Depends(get_session),
 ) -> JSONResponse:
     """Return target-by-target paper-route evidence collection status."""
@@ -4672,6 +4688,8 @@ def trading_paper_route_evidence(
         session,
         live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
         route_reacquisition_book=route_reacquisition_book,
+        lookback_hours=lookback_hours,
+        target_limit=target_limit,
         target_account_audit_available=settings.trading_mode == "paper",
     )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -83,6 +83,10 @@ RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet
 RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
 RUNTIME_LEDGER_PROOF_PACKET_ARTIFACT_PREFIX = "runtime-ledger-proof-packets/{run_id}"
 RUNTIME_LEDGER_SUMMARY_ROW_LIMIT = 50
+PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT = 100
+PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT = 25
+MAX_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 168
+MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
 PAPER_ROUTE_EVIDENCE_QUERY_TIMEOUT_MS = 5000
 US_EQUITIES_TIMEZONE = "America/New_York"
 US_EQUITIES_OPEN = time(hour=9, minute=30)
@@ -488,6 +492,13 @@ def _safe_int(value: object) -> int:
         except ValueError:
             return 0
     return 0
+
+
+def _bounded_int(value: object, *, default: int, minimum: int, maximum: int) -> int:
+    parsed = _safe_int(value)
+    if parsed <= 0:
+        parsed = default
+    return max(minimum, min(parsed, maximum))
 
 
 def _safe_decimal(value: object) -> Decimal:
@@ -2434,6 +2445,23 @@ def _unavailable_source_activity(
         "fill_order_event_count": 0,
         "complete_fill_order_event_count": 0,
         "tca_sample_count": 0,
+        "readback_state": "query_unavailable",
+        "stage_presence": {
+            "source_decisions_present": raw_decision_count > 0,
+            "submitted_lifecycle_present": False,
+            "fills_present": False,
+            "source_refs_present": False,
+            "runtime_execution_economics_present": False,
+        },
+        "query_limits": {
+            "row_limit": PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
+            "ref_limit": PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT,
+            "decision_truncated": False,
+            "execution_truncated": False,
+            "order_event_truncated": False,
+            "tca_truncated": False,
+            "truncated_sources": [],
+        },
         "last_decision_at": None,
         "last_execution_at": None,
         "last_order_event_at": None,
@@ -2575,6 +2603,30 @@ def _source_activity_lifecycle_summary(
     }
 
 
+def _source_activity_readback_state(
+    *,
+    decision_count: int,
+    execution_count: int,
+    filled_execution_count: int,
+    fill_order_event_count: int,
+    complete_fill_order_event_count: int,
+    tca_sample_count: int,
+) -> str:
+    if tca_sample_count > 0:
+        return "source_execution_economics_present"
+    if (
+        filled_execution_count > 0
+        or fill_order_event_count > 0
+        or complete_fill_order_event_count > 0
+    ):
+        return "source_fills_present"
+    if execution_count > 0:
+        return "submitted_lifecycle_present"
+    if decision_count > 0:
+        return "source_decisions_present"
+    return "no_source_activity"
+
+
 def _strategy_source_activity(
     session: Session,
     *,
@@ -2621,6 +2673,23 @@ def _strategy_source_activity(
             "fill_order_event_count": 0,
             "complete_fill_order_event_count": 0,
             "tca_sample_count": 0,
+            "readback_state": "no_source_activity",
+            "stage_presence": {
+                "source_decisions_present": False,
+                "submitted_lifecycle_present": False,
+                "fills_present": False,
+                "source_refs_present": False,
+                "runtime_execution_economics_present": False,
+            },
+            "query_limits": {
+                "row_limit": PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
+                "ref_limit": PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT,
+                "decision_truncated": False,
+                "execution_truncated": False,
+                "order_event_truncated": False,
+                "tca_truncated": False,
+                "truncated_sources": [],
+            },
             "last_decision_at": None,
             "last_execution_at": None,
             "last_order_event_at": None,
@@ -2648,13 +2717,20 @@ def _strategy_source_activity(
         )
     if symbol_filters:
         decision_stmt = decision_stmt.where(TradeDecision.symbol.in_(symbol_filters))
+    decision_truncated = False
     try:
         _maybe_set_paper_route_audit_statement_timeout(session)
-        decision_rows = list(
+        queried_decision_rows = list(
             session.execute(
-                decision_stmt.order_by(TradeDecision.created_at.desc()).limit(500)
+                decision_stmt.order_by(TradeDecision.created_at.desc()).limit(
+                    PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT + 1
+                )
             ).scalars()
         )
+        decision_truncated = (
+            len(queried_decision_rows) > PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+        )
+        decision_rows = queried_decision_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT]
     except SQLAlchemyError as exc:
         _rollback_after_source_activity_error(
             session,
@@ -2710,11 +2786,19 @@ def _strategy_source_activity(
             execution_stmt = execution_stmt.where(Execution.symbol.in_(symbol_filters))
         try:
             _maybe_set_paper_route_audit_statement_timeout(session)
-            execution_rows = list(
+            queried_execution_rows = list(
                 session.execute(
-                    execution_stmt.order_by(execution_activity_ts.desc()).limit(500)
+                    execution_stmt.order_by(execution_activity_ts.desc()).limit(
+                        PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT + 1
+                    )
                 ).scalars()
             )
+            execution_truncated = (
+                len(queried_execution_rows) > PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+            )
+            execution_rows = queried_execution_rows[
+                :PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+            ]
         except SQLAlchemyError as exc:
             _rollback_after_source_activity_error(
                 session,
@@ -2734,6 +2818,8 @@ def _strategy_source_activity(
                 raw_decision_count=raw_decision_count,
                 lineage_matched_decision_count=len(decision_rows),
             )
+    else:
+        execution_truncated = False
     order_event_rows: list[ExecutionOrderEvent] = []
     if decision_ids:
         order_event_activity_ts = _order_event_activity_timestamp()
@@ -2753,11 +2839,19 @@ def _strategy_source_activity(
             )
         try:
             _maybe_set_paper_route_audit_statement_timeout(session)
-            order_event_rows = list(
+            queried_order_event_rows = list(
                 session.execute(
-                    order_event_stmt.order_by(order_event_activity_ts.desc()).limit(500)
+                    order_event_stmt.order_by(order_event_activity_ts.desc()).limit(
+                        PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT + 1
+                    )
                 ).scalars()
             )
+            order_event_truncated = (
+                len(queried_order_event_rows) > PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+            )
+            order_event_rows = queried_order_event_rows[
+                :PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+            ]
         except SQLAlchemyError as exc:
             _rollback_after_source_activity_error(
                 session,
@@ -2777,6 +2871,8 @@ def _strategy_source_activity(
                 raw_decision_count=raw_decision_count,
                 lineage_matched_decision_count=len(decision_rows),
             )
+    else:
+        order_event_truncated = False
     tca_rows: list[ExecutionTCAMetric] = []
     if decision_ids:
         tca_stmt = (
@@ -2797,11 +2893,15 @@ def _strategy_source_activity(
             tca_stmt = tca_stmt.where(ExecutionTCAMetric.symbol.in_(symbol_filters))
         try:
             _maybe_set_paper_route_audit_statement_timeout(session)
-            tca_rows = list(
+            queried_tca_rows = list(
                 session.execute(
-                    tca_stmt.order_by(ExecutionTCAMetric.computed_at.desc()).limit(500)
+                    tca_stmt.order_by(ExecutionTCAMetric.computed_at.desc()).limit(
+                        PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT + 1
+                    )
                 ).scalars()
             )
+            tca_truncated = len(queried_tca_rows) > PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+            tca_rows = queried_tca_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT]
         except SQLAlchemyError as exc:
             _rollback_after_source_activity_error(
                 session,
@@ -2821,6 +2921,8 @@ def _strategy_source_activity(
                 raw_decision_count=raw_decision_count,
                 lineage_matched_decision_count=len(decision_rows),
             )
+    else:
+        tca_truncated = False
     decision_count = len(decision_rows)
     execution_count = len(execution_rows)
     tca_sample_count = len(tca_rows)
@@ -2842,15 +2944,26 @@ def _strategy_source_activity(
     if tca_sample_count <= 0 and complete_fill_order_event_count <= 0:
         missing_reasons.append("source_tca_missing")
     missing_reasons.extend(lineage_blockers)
+    if decision_truncated or execution_truncated or order_event_truncated or tca_truncated:
+        missing_reasons.append("source_activity_readback_truncated")
     lifecycle_summary = _source_activity_lifecycle_summary(
         execution_rows=execution_rows,
         order_event_rows=order_event_rows,
         tca_rows=tca_rows,
     )
-    decision_refs = [str(row.id) for row in decision_rows]
-    execution_refs = [str(row.id) for row in execution_rows]
-    order_lifecycle_refs = [str(row.id) for row in order_event_rows]
-    tca_metric_refs = [str(row.id) for row in tca_rows]
+    decision_refs = [
+        str(row.id) for row in decision_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
+    ]
+    execution_refs = [
+        str(row.id) for row in execution_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
+    ]
+    order_lifecycle_refs = [
+        str(row.id)
+        for row in order_event_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
+    ]
+    tca_metric_refs = [
+        str(row.id) for row in tca_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
+    ]
     source_reference_blockers = _unique_text_items(
         [
             *(["source_decision_refs_missing"] if not decision_refs else []),
@@ -2867,7 +2980,33 @@ def _strategy_source_activity(
         [
             *_unique_text_items(lifecycle_summary.get("blockers")),
             *source_reference_blockers,
+            *(
+                ["source_activity_readback_truncated"]
+                if decision_truncated
+                or execution_truncated
+                or order_event_truncated
+                or tca_truncated
+                else []
+            ),
         ]
+    )
+    truncated_sources = [
+        source
+        for source, truncated in (
+            ("trade_decisions", decision_truncated),
+            ("executions", execution_truncated),
+            ("execution_order_events", order_event_truncated),
+            ("execution_tca_metrics", tca_truncated),
+        )
+        if truncated
+    ]
+    readback_state = _source_activity_readback_state(
+        decision_count=decision_count,
+        execution_count=execution_count,
+        filled_execution_count=filled_execution_count,
+        fill_order_event_count=fill_order_event_count,
+        complete_fill_order_event_count=complete_fill_order_event_count,
+        tca_sample_count=tca_sample_count,
     )
     return {
         "strategy_name": strategy_name,
@@ -2893,6 +3032,32 @@ def _strategy_source_activity(
         "complete_fill_order_event_count": complete_fill_order_event_count,
         "tca_sample_count": tca_sample_count,
         "submitted_order_count": execution_count,
+        "readback_state": readback_state,
+        "stage_presence": {
+            "source_decisions_present": decision_count > 0,
+            "submitted_lifecycle_present": execution_count > 0
+            or order_event_count > 0,
+            "fills_present": filled_execution_count > 0
+            or fill_order_event_count > 0
+            or complete_fill_order_event_count > 0,
+            "source_refs_present": bool(
+                decision_refs
+                or execution_refs
+                or order_lifecycle_refs
+                or tca_metric_refs
+            ),
+            "runtime_execution_economics_present": tca_sample_count > 0
+            or complete_fill_order_event_count > 0,
+        },
+        "query_limits": {
+            "row_limit": PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
+            "ref_limit": PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT,
+            "decision_truncated": decision_truncated,
+            "execution_truncated": execution_truncated,
+            "order_event_truncated": order_event_truncated,
+            "tca_truncated": tca_truncated,
+            "truncated_sources": truncated_sources,
+        },
         "source_lifecycle": lifecycle_summary,
         "source_lifecycle_blockers": source_lifecycle_blockers,
         "last_decision_at": _isoformat(
@@ -2950,6 +3115,23 @@ def _database_unavailable_source_activity(
         "fill_order_event_count": 0,
         "complete_fill_order_event_count": 0,
         "tca_sample_count": 0,
+        "readback_state": "query_unavailable",
+        "stage_presence": {
+            "source_decisions_present": False,
+            "submitted_lifecycle_present": False,
+            "fills_present": False,
+            "source_refs_present": False,
+            "runtime_execution_economics_present": False,
+        },
+        "query_limits": {
+            "row_limit": PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
+            "ref_limit": PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT,
+            "decision_truncated": False,
+            "execution_truncated": False,
+            "order_event_truncated": False,
+            "tca_truncated": False,
+            "truncated_sources": [],
+        },
         "last_decision_at": None,
         "last_execution_at": None,
         "last_order_event_at": None,
@@ -4350,6 +4532,109 @@ def _source_backed_import_ready_metadata(
     }
 
 
+def _target_evidence_readback_diagnostics(
+    *,
+    target: Mapping[str, object],
+    source_activity: Mapping[str, object],
+    runtime_ledger: Mapping[str, object],
+    promotion_decisions: Mapping[str, object],
+    readiness_blockers: Sequence[str],
+) -> dict[str, object]:
+    stage_presence = _as_mapping(source_activity.get("stage_presence"))
+    decision_count = _safe_int(source_activity.get("decision_count"))
+    execution_count = _safe_int(source_activity.get("execution_count"))
+    filled_execution_count = _safe_int(source_activity.get("filled_execution_count"))
+    fill_order_event_count = _safe_int(source_activity.get("fill_order_event_count"))
+    complete_fill_order_event_count = _safe_int(
+        source_activity.get("complete_fill_order_event_count")
+    )
+    tca_sample_count = _safe_int(source_activity.get("tca_sample_count"))
+    runtime_bucket_count = _safe_int(runtime_ledger.get("bucket_count"))
+    evidence_grade_runtime_bucket_count = _safe_int(
+        runtime_ledger.get("evidence_grade_bucket_count")
+    )
+    source_decisions_present = bool(stage_presence.get("source_decisions_present")) or (
+        decision_count > 0
+    )
+    submitted_lifecycle_present = bool(
+        stage_presence.get("submitted_lifecycle_present")
+    ) or execution_count > 0
+    fills_present = (
+        bool(stage_presence.get("fills_present"))
+        or filled_execution_count > 0
+        or fill_order_event_count > 0
+        or complete_fill_order_event_count > 0
+    )
+    source_refs_present = bool(stage_presence.get("source_refs_present")) or bool(
+        _unique_text_items(source_activity.get("decision_refs"))
+        or _unique_text_items(source_activity.get("execution_refs"))
+        or _unique_text_items(source_activity.get("order_lifecycle_refs"))
+        or _unique_text_items(source_activity.get("tca_metric_refs"))
+    )
+    runtime_buckets_present = runtime_bucket_count > 0
+    if evidence_grade_runtime_bucket_count > 0:
+        state = "evidence_grade_runtime_buckets_present"
+    elif runtime_buckets_present:
+        state = "runtime_buckets_present"
+    elif tca_sample_count > 0:
+        state = "source_execution_economics_present"
+    elif fills_present:
+        state = "source_fills_present"
+    elif submitted_lifecycle_present:
+        state = "submitted_lifecycle_present"
+    elif source_decisions_present:
+        state = "source_decisions_present"
+    else:
+        state = "no_source_activity"
+    promotion_authority_blockers = _unique_text_items(
+        [
+            *readiness_blockers,
+            *_unique_text_items(runtime_ledger.get("blockers")),
+            *(
+                ["final_promotion_authority_blocked"]
+                if not bool(target.get("final_promotion_allowed"))
+                else []
+            ),
+            *(
+                ["promotion_decision_not_allowed"]
+                if not bool(_as_mapping(promotion_decisions.get("latest")).get("allowed"))
+                and _safe_int(promotion_decisions.get("decision_count")) > 0
+                else []
+            ),
+        ]
+    )
+    return {
+        "schema_version": "torghut.paper-route-evidence-readback-diagnostics.v1",
+        "state": state,
+        "source_decisions_present": source_decisions_present,
+        "submitted_lifecycle_present": submitted_lifecycle_present,
+        "fills_or_executions_present": fills_present,
+        "source_refs_present": source_refs_present,
+        "runtime_buckets_present": runtime_buckets_present,
+        "evidence_grade_runtime_buckets_present": (
+            evidence_grade_runtime_bucket_count > 0
+        ),
+        "runtime_bucket_count": runtime_bucket_count,
+        "evidence_grade_runtime_bucket_count": evidence_grade_runtime_bucket_count,
+        "final_promotion_authority_blocked": not bool(
+            target.get("final_promotion_allowed")
+        ),
+        "promotion_decision_count": _safe_int(promotion_decisions.get("decision_count")),
+        "promotion_decision_allowed_count": _safe_int(
+            promotion_decisions.get("allowed_count")
+        ),
+        "query_unavailable": bool(source_activity.get("query_unavailable")),
+        "query_limits": {
+            "source_activity": _as_mapping(source_activity.get("query_limits")),
+            "runtime_ledger": {
+                "row_limit": _safe_int(runtime_ledger.get("query_limit")),
+                "truncated": bool(runtime_ledger.get("truncated")),
+            },
+        },
+        "blockers": promotion_authority_blockers,
+    }
+
+
 def _evidence_window_contract(
     *,
     target: Mapping[str, object],
@@ -4524,6 +4809,13 @@ def _target_audit(
         account_contamination=account_contamination,
         account_state=account_state,
     )
+    evidence_readback = _target_evidence_readback_diagnostics(
+        target=target,
+        source_activity=source_activity,
+        runtime_ledger=runtime_ledger,
+        promotion_decisions=promotion_decisions,
+        readiness_blockers=blockers,
+    )
     return {
         "target": target,
         "window": {
@@ -4535,6 +4827,7 @@ def _target_audit(
         "account_state": account_state,
         "account_close_state": account_close_state,
         "evidence_window_contract": evidence_window_contract,
+        "evidence_readback": evidence_readback,
         "source_backed_import_ready_metadata": _source_backed_import_ready_metadata(
             target=target,
             source_activity=source_activity,
@@ -4704,6 +4997,28 @@ def _database_unavailable_target_audit(
         "state": "database_unavailable",
         "db_load_error": error_payload,
     }
+    runtime_ledger = {
+        "bucket_count": 0,
+        "evidence_grade_bucket_count": 0,
+        "non_evidence_grade_bucket_count": 0,
+        "returned_bucket_count": 0,
+        "query_limit": RUNTIME_LEDGER_SUMMARY_ROW_LIMIT,
+        "truncated": False,
+        "filled_notional": "0",
+        "net_strategy_pnl_after_costs": "0",
+        "closed_trade_count": 0,
+        "open_position_count": 0,
+        "blockers": [PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER, source_blocker],
+        "db_load_error": error_payload,
+    }
+    promotion_decisions = {
+        "decision_count": 0,
+        "allowed_count": 0,
+        "latest": None,
+        "db_row_refs": [],
+        "blockers": [PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER, source_blocker],
+        "db_load_error": error_payload,
+    }
     return {
         "target": target,
         "window": {
@@ -4739,6 +5054,13 @@ def _database_unavailable_target_audit(
             "account_label": _safe_text(target.get("account_label")),
             "blockers": [PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER, source_blocker],
         },
+        "evidence_readback": _target_evidence_readback_diagnostics(
+            target=target,
+            source_activity=source_activity,
+            runtime_ledger=runtime_ledger,
+            promotion_decisions=promotion_decisions,
+            readiness_blockers=blockers,
+        ),
         "source_backed_import_ready_metadata": {
             "schema_version": "torghut.paper-route-source-backed-import-ready.v1",
             "ready": False,
@@ -4750,19 +5072,7 @@ def _database_unavailable_target_audit(
             "blocking_reasons": [PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER],
             "db_load_error": error_payload,
         },
-        "runtime_ledger": {
-            "bucket_count": 0,
-            "evidence_grade_bucket_count": 0,
-            "non_evidence_grade_bucket_count": 0,
-            "returned_bucket_count": 0,
-            "query_limit": RUNTIME_LEDGER_SUMMARY_ROW_LIMIT,
-            "filled_notional": "0",
-            "net_strategy_pnl_after_costs": "0",
-            "closed_trade_count": 0,
-            "open_position_count": 0,
-            "blockers": [PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER, source_blocker],
-            "db_load_error": error_payload,
-        },
+        "runtime_ledger": runtime_ledger,
         "hypothesis_windows": {
             "window_count": 0,
             "decision_count": 0,
@@ -4776,14 +5086,7 @@ def _database_unavailable_target_audit(
             "blockers": [PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER, source_blocker],
             "db_load_error": error_payload,
         },
-        "promotion_decisions": {
-            "decision_count": 0,
-            "allowed_count": 0,
-            "latest": None,
-            "db_row_refs": [],
-            "blockers": [PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER, source_blocker],
-            "db_load_error": error_payload,
-        },
+        "promotion_decisions": promotion_decisions,
         "readiness": {
             "state": "evidence_collection_blocked",
             "evidence_collection_ok": False,
@@ -5975,10 +6278,22 @@ def build_paper_route_evidence_audit(
     """Build a target-by-target audit for paper-route evidence collection."""
 
     resolved_generated_at = generated_at or datetime.now(timezone.utc)
+    effective_lookback_hours = _bounded_int(
+        lookback_hours,
+        default=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+        minimum=1,
+        maximum=MAX_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+    )
+    effective_target_limit = _bounded_int(
+        target_limit,
+        default=DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+        minimum=1,
+        maximum=MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+    )
     plan = _as_mapping(
         live_submission_gate.get("runtime_ledger_paper_probation_import_plan")
     )
-    targets = _as_mapping_items(plan.get("targets"))[: max(0, target_limit)]
+    targets = _as_mapping_items(plan.get("targets"))[:effective_target_limit]
     probe = _paper_route_probe_summary(
         route_reacquisition_book,
         target_plan=plan,
@@ -5996,7 +6311,7 @@ def build_paper_route_evidence_audit(
             raw_target=target,
             probe=probe,
             generated_at=resolved_generated_at,
-            lookback_hours=lookback_hours,
+            lookback_hours=effective_lookback_hours,
             error_source="paper_route_source_target_audit",
         )
         for target in targets
@@ -6027,12 +6342,12 @@ def build_paper_route_evidence_audit(
     next_target_audits = [
         _target_audit_fail_closed(
             session,
-            raw_target=target,
-            probe=probe,
-            generated_at=resolved_generated_at,
-            lookback_hours=lookback_hours,
-            error_source="paper_route_next_target_audit",
-        )
+                raw_target=target,
+                probe=probe,
+                generated_at=resolved_generated_at,
+                lookback_hours=effective_lookback_hours,
+                error_source="paper_route_next_target_audit",
+            )
         for target in _as_mapping_items(next_targets.get("targets"))
     ]
     runtime_window_import_plan = next_targets
@@ -6048,7 +6363,7 @@ def build_paper_route_evidence_audit(
                 raw_target=target,
                 probe=probe,
                 generated_at=resolved_generated_at,
-                lookback_hours=lookback_hours,
+                lookback_hours=effective_lookback_hours,
                 error_source="paper_route_runtime_window_import_target_audit",
             )
             for target in _as_mapping_items(latest_closed_targets.get("targets"))
@@ -6082,12 +6397,33 @@ def build_paper_route_evidence_audit(
     )
     if not targets:
         summary_blockers.append("paper_probation_import_plan_missing")
+    readback_items = [
+        _as_mapping(audit.get("evidence_readback")) for audit in target_audits
+    ]
+    source_activity_limits = [
+        _as_mapping(_as_mapping(audit.get("source_activity")).get("query_limits"))
+        for audit in target_audits
+    ]
+    truncated_source_names = sorted(
+        {
+            source
+            for limits in source_activity_limits
+            for source in _unique_text_items(limits.get("truncated_sources"))
+        }
+    )
     return {
         "schema_version": PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION,
         "generated_at": _isoformat(resolved_generated_at),
         "window": {
-            "lookback_hours": lookback_hours,
-            "target_limit": target_limit,
+            "lookback_hours": effective_lookback_hours,
+            "requested_lookback_hours": lookback_hours,
+            "max_lookback_hours": MAX_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+            "target_limit": effective_target_limit,
+            "requested_target_limit": target_limit,
+            "max_target_limit": MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+            "source_activity_row_limit": PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
+            "source_activity_ref_limit": PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT,
+            "runtime_ledger_row_limit": RUNTIME_LEDGER_SUMMARY_ROW_LIMIT,
         },
         "live_submission_gate": {
             "allowed": bool(live_submission_gate.get("allowed")),
@@ -6175,6 +6511,50 @@ def build_paper_route_evidence_audit(
                 )
                 for audit in target_audits
             ),
+            "readback": {
+                "schema_version": "torghut.paper-route-evidence-readback-summary.v1",
+                "target_count": len(readback_items),
+                "no_source_activity_count": sum(
+                    int(item.get("state") == "no_source_activity")
+                    for item in readback_items
+                ),
+                "source_decisions_present_count": sum(
+                    int(bool(item.get("source_decisions_present")))
+                    for item in readback_items
+                ),
+                "submitted_lifecycle_present_count": sum(
+                    int(bool(item.get("submitted_lifecycle_present")))
+                    for item in readback_items
+                ),
+                "fills_or_executions_present_count": sum(
+                    int(bool(item.get("fills_or_executions_present")))
+                    for item in readback_items
+                ),
+                "source_refs_present_count": sum(
+                    int(bool(item.get("source_refs_present")))
+                    for item in readback_items
+                ),
+                "runtime_buckets_present_count": sum(
+                    int(bool(item.get("runtime_buckets_present")))
+                    for item in readback_items
+                ),
+                "evidence_grade_runtime_buckets_present_count": sum(
+                    int(bool(item.get("evidence_grade_runtime_buckets_present")))
+                    for item in readback_items
+                ),
+                "final_promotion_authority_blocked_count": sum(
+                    int(bool(item.get("final_promotion_authority_blocked")))
+                    for item in readback_items
+                ),
+                "query_unavailable_count": sum(
+                    int(bool(item.get("query_unavailable"))) for item in readback_items
+                ),
+                "truncated_source_activity_count": sum(
+                    int(bool(_unique_text_items(limits.get("truncated_sources"))))
+                    for limits in source_activity_limits
+                ),
+                "truncated_source_activity_sources": truncated_source_names,
+            },
             "promotion_allowed_count": sum(
                 int(
                     bool(
@@ -6276,6 +6656,8 @@ def build_paper_route_evidence_audit(
 __all__ = [
     "DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS",
     "NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION",
+    "MAX_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS",
+    "MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT",
     "PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION",
     "PAPER_ROUTE_TARGET_PLAN_PAYLOAD_SCHEMA_VERSION",
     "PAPER_ROUTE_RUNTIME_WINDOW_IMPORT_AUDIT_SCHEMA_VERSION",

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -24,6 +24,8 @@ from app.models import (
     TradeDecision,
 )
 from app.trading.paper_route_evidence import (
+    PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT,
+    PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
     RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
     _account_pre_session_snapshot_audit,
     _account_window_start_snapshot_audit,
@@ -454,6 +456,277 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(activity["missing_reasons"], ["source_tca_unavailable"])
         self.assertEqual(activity["raw_decision_count"], 1)
         self.assertEqual(activity["lineage_matched_decision_count"], 1)
+
+    def test_source_activity_noisy_dataset_is_bounded_and_reports_truncation(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc)
+        window_end = window_start + timedelta(hours=1)
+        strategy_name = "paper-route-noisy-readback"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="noisy bounded readback fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            for index in range(PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT + 7):
+                session.add(
+                    TradeDecision(
+                        strategy_id=strategy.id,
+                        alpaca_account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        timeframe="1Min",
+                        decision_json={
+                            "action": "buy",
+                            "qty": "1",
+                            "candidate_id": "candidate-noisy-readback",
+                            "hypothesis_id": "H-NOISY-READBACK",
+                        },
+                        rationale="bounded noisy source readback",
+                        status="planned",
+                        created_at=window_start + timedelta(seconds=index),
+                        executed_at=None,
+                    )
+                )
+            session.commit()
+
+            activity = _strategy_source_activity(
+                session,
+                strategy_name=strategy_name,
+                account_label="TORGHUT_SIM",
+                symbols=["AAPL"],
+                window_start=window_start,
+                window_end=window_end,
+                candidate_id="candidate-noisy-readback",
+                hypothesis_id="H-NOISY-READBACK",
+                require_source_lineage=True,
+            )
+
+        self.assertEqual(activity["raw_decision_count"], PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT)
+        self.assertEqual(
+            activity["lineage_matched_decision_count"],
+            PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
+        )
+        self.assertEqual(len(activity["decision_refs"]), PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT)
+        self.assertEqual(activity["readback_state"], "source_decisions_present")
+        self.assertTrue(activity["stage_presence"]["source_decisions_present"])
+        self.assertFalse(activity["stage_presence"]["submitted_lifecycle_present"])
+        self.assertEqual(
+            activity["query_limits"]["truncated_sources"], ["trade_decisions"]
+        )
+        self.assertTrue(activity["query_limits"]["decision_truncated"])
+        self.assertIn("source_executions_missing", activity["missing_reasons"])
+
+    def test_evidence_readback_diagnostics_distinguish_source_lifecycle_and_blockers(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc)
+        window_end = window_start + timedelta(hours=1)
+        event_at = window_start + timedelta(minutes=5)
+        strategy_name = "paper-route-diagnostic-readback"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="diagnostic readback fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-diagnostic-readback",
+                    "hypothesis_id": "H-DIAGNOSTIC-READBACK",
+                },
+                rationale="diagnostic source-backed readback",
+                status="executed",
+                created_at=event_at,
+                executed_at=event_at,
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="diagnostic-readback-order",
+                client_order_id="diagnostic-readback-client",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=event_at,
+                updated_at=event_at,
+                last_update_at=event_at,
+            )
+            session.add(execution)
+            session.flush()
+            session.add_all(
+                [
+                    ExecutionOrderEvent(
+                        event_fingerprint="diagnostic-readback-fill",
+                        source_topic="trade_updates",
+                        source_partition=0,
+                        source_offset=501,
+                        alpaca_account_label="TORGHUT_SIM",
+                        feed_seq=501,
+                        event_ts=event_at,
+                        symbol="AAPL",
+                        alpaca_order_id="diagnostic-readback-order",
+                        client_order_id="diagnostic-readback-client",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        filled_qty_delta=Decimal("1"),
+                        filled_notional_delta=Decimal("100"),
+                        avg_fill_price=Decimal("100"),
+                        raw_event={"event": "fill", "side": "buy"},
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        created_at=event_at,
+                    ),
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        side="buy",
+                        arrival_price=Decimal("99"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=Decimal("1"),
+                        slippage_bps=Decimal("5"),
+                        shortfall_notional=Decimal("1"),
+                        realized_shortfall_bps=Decimal("5"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=event_at,
+                        created_at=event_at,
+                        updated_at=event_at,
+                    ),
+                    StrategyRuntimeLedgerBucket(
+                        run_id="diagnostic-readback-ledger",
+                        candidate_id="candidate-diagnostic-readback",
+                        hypothesis_id="H-DIAGNOSTIC-READBACK",
+                        observed_stage="paper",
+                        bucket_started_at=window_start,
+                        bucket_ended_at=window_end,
+                        account_label="TORGHUT_SIM",
+                        runtime_strategy_name=strategy_name,
+                        strategy_family="microbar_pairs",
+                        fill_count=1,
+                        decision_count=1,
+                        submitted_order_count=1,
+                        closed_trade_count=0,
+                        open_position_count=1,
+                        filled_notional=Decimal("100"),
+                        gross_strategy_pnl=Decimal("1"),
+                        cost_amount=Decimal("0.25"),
+                        net_strategy_pnl_after_costs=Decimal("0.75"),
+                        post_cost_expectancy_bps=Decimal("75"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy": 1},
+                        cost_model_hash_counts={"cost": 1},
+                        lineage_hash_counts={"lineage": 1},
+                        blockers_json=["paper_route_missing_close"],
+                    ),
+                    StrategyPromotionDecision(
+                        run_id="diagnostic-readback-ledger",
+                        candidate_id="candidate-diagnostic-readback",
+                        hypothesis_id="H-DIAGNOSTIC-READBACK",
+                        promotion_target="paper",
+                        state="blocked",
+                        allowed=False,
+                        reason_summary="paper_probation_evidence_collection_only",
+                    ),
+                ]
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-DIAGNOSTIC-READBACK",
+                                "candidate_id": "candidate-diagnostic-readback",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": "config/trading/hypotheses/h-diagnostic.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_allowed": False,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=window_end + timedelta(minutes=5),
+            )
+
+        diagnostic = payload["targets"][0]["evidence_readback"]
+        self.assertEqual(diagnostic["state"], "runtime_buckets_present")
+        self.assertTrue(diagnostic["source_decisions_present"])
+        self.assertTrue(diagnostic["submitted_lifecycle_present"])
+        self.assertTrue(diagnostic["fills_or_executions_present"])
+        self.assertTrue(diagnostic["source_refs_present"])
+        self.assertTrue(diagnostic["runtime_buckets_present"])
+        self.assertTrue(diagnostic["final_promotion_authority_blocked"])
+        self.assertIn("final_promotion_authority_blocked", diagnostic["blockers"])
+        self.assertIn("paper_route_missing_close", diagnostic["blockers"])
+        summary = payload["summary"]["readback"]
+        self.assertEqual(summary["source_decisions_present_count"], 1)
+        self.assertEqual(summary["submitted_lifecycle_present_count"], 1)
+        self.assertEqual(summary["fills_or_executions_present_count"], 1)
+        self.assertEqual(summary["runtime_buckets_present_count"], 1)
+        self.assertEqual(summary["final_promotion_authority_blocked_count"], 1)
 
     def _add_flat_account_start_snapshot(
         self,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7547,12 +7547,16 @@ class TestTradingApi(TestCase):
                     return_value=proof_floor,
                 ),
             ):
-                response = self.client.get("/trading/paper-route-evidence")
+                response = self.client.get(
+                    "/trading/paper-route-evidence?lookback_hours=24&target_limit=1"
+                )
             self.assertEqual(response.status_code, 200)
             payload = response.json()
             self.assertEqual(
                 payload["schema_version"], "torghut.paper-route-evidence.v1"
             )
+            self.assertEqual(payload["window"]["lookback_hours"], 24)
+            self.assertEqual(payload["window"]["target_limit"], 1)
             self.assertEqual(payload["summary"]["target_count"], 1)
             self.assertEqual(payload["summary"]["target_with_runtime_ledger_count"], 1)
             self.assertEqual(payload["summary"]["target_with_source_activity_count"], 0)


### PR DESCRIPTION
## Summary

- Bound paper-route evidence readback with capped endpoint query params for fallback lookback and target count.
- Limit source activity row/ref samples, expose truncation diagnostics, and fail closed when bounded readback is incomplete.
- Add per-target and summary evidence-readback diagnostics for source decisions, submitted lifecycle, fills, refs, runtime buckets, and final promotion authority blockers.
- Cover noisy bounded datasets and endpoint query wiring with regression tests.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_simple_pipeline.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py app/main.py tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_simple_pipeline.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
