### PR TITLE
fix(torghut): repair bounded sim account audit readiness

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -103,6 +103,9 @@ _BOUNDED_SIM_COLLECTION_RESERVATION_BLOCKERS = frozenset(
         "unlinked_order_events_present",
     }
 )
+_PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER = (
+    "paper_route_target_account_audit_unavailable"
+)
 _BOUNDED_SIM_COLLECTION_ALLOWED_HEALTH_GATE_BLOCKERS = frozenset(
     {"evidence_continuity_not_ok"}
 )
@@ -254,6 +257,7 @@ def _bounded_sim_collection_blockers(
         blockers.append("bounded_sim_collection_authorization_missing")
     if not _target_truthy(target.get("evidence_collection_ok")):
         blockers.append("bounded_sim_collection_evidence_collection_not_ready")
+    blockers.extend(_bounded_sim_collection_account_audit_blockers(target))
     if (
         _target_truthy(target.get("promotion_allowed"))
         or _target_truthy(target.get("final_promotion_allowed"))
@@ -290,6 +294,110 @@ def _bounded_sim_collection_blockers(
             ]
         blockers.extend(field_blockers)
     return list(dict.fromkeys(blockers))
+
+
+def _bounded_sim_collection_account_audit_blockers(
+    target: Mapping[str, Any],
+) -> list[str]:
+    audit_state = target.get("paper_route_target_account_audit_state")
+    nested_blockers: list[str] = []
+    audit_available: bool | None = None
+    if isinstance(audit_state, Mapping):
+        typed_audit_state = cast(Mapping[str, Any], audit_state)
+        nested_blockers = _lineage_text_values(typed_audit_state.get("blockers"))
+        raw_available = _target_bool(typed_audit_state.get("audit_available"))
+        state = _safe_text(typed_audit_state.get("state"))
+        audit_available = (
+            bool(raw_available)
+            if raw_available is not None
+            else state == "available"
+            if state in {"available", "unavailable"}
+            else None
+        )
+
+    blockers = [
+        *nested_blockers,
+        *_lineage_text_values(target.get("paper_route_target_account_audit_blockers")),
+    ]
+    if blockers:
+        return blockers
+    if audit_available is True:
+        return []
+    if (
+        not isinstance(audit_state, Mapping)
+        and "paper_route_target_account_audit_blockers" not in target
+        and _PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER
+        not in _lineage_text_values(target.get("bounded_evidence_collection_blockers"))
+    ):
+        return []
+    return [_PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER]
+
+
+def _without_lineage_text_values(value: object, excluded: set[str]) -> list[str]:
+    return [item for item in _lineage_text_values(value) if item not in excluded]
+
+
+def _bounded_sim_collection_target_with_runtime_account_audit(
+    target: Mapping[str, Any],
+    *,
+    positions: Sequence[Mapping[str, Any]] | None,
+    account_label: str | None,
+) -> dict[str, Any]:
+    normalized = dict(target)
+    if positions is None:
+        return normalized
+
+    unavailable = {_PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER}
+    normalized["paper_route_target_account_audit_state"] = {
+        "schema_version": "torghut.paper-route-target-account-audit.v1",
+        "scope": "local_torghut_sim_paper_runtime_account_state",
+        "state": "available",
+        "account_label": _safe_text(account_label)
+        or _safe_text(target.get("account_label"))
+        or _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL,
+        "required_account_label": _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL,
+        "symbols": sorted(_target_symbols(target)),
+        "audit_available": True,
+        "blockers": [],
+        "source": "simple_pipeline_runtime_account_snapshot",
+    }
+    normalized["paper_route_target_account_audit_blockers"] = []
+    for key in (
+        "bounded_evidence_collection_blockers",
+        "candidate_blockers",
+    ):
+        if key in normalized:
+            normalized[key] = _without_lineage_text_values(normalized.get(key), unavailable)
+
+    evidence_blockers: list[str] = []
+    for key in _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS:
+        if key == "paper_route_target_account_audit_blockers":
+            continue
+        field_blockers = _lineage_text_values(normalized.get(key))
+        if key == "runtime_window_import_health_gate_blockers":
+            field_blockers = [
+                blocker
+                for blocker in field_blockers
+                if blocker not in _BOUNDED_SIM_COLLECTION_ALLOWED_HEALTH_GATE_BLOCKERS
+            ]
+        evidence_blockers.extend(field_blockers)
+    readiness = normalized.get("source_decision_readiness")
+    if isinstance(readiness, Mapping):
+        typed_readiness = cast(Mapping[str, Any], readiness)
+        if not _target_truthy(typed_readiness.get("ready")):
+            evidence_blockers.append("bounded_sim_collection_source_decision_not_ready")
+        evidence_blockers.extend(_lineage_text_values(typed_readiness.get("blockers")))
+    else:
+        evidence_blockers.append("bounded_sim_collection_source_decision_readiness_missing")
+    if _safe_text(normalized.get("paper_route_probe_pair_balance_state")) == "imbalanced":
+        evidence_blockers.append("paper_route_probe_pair_imbalanced")
+
+    if not list(dict.fromkeys(evidence_blockers)):
+        normalized["evidence_collection_ok"] = True
+        normalized["bounded_evidence_collection_authorized"] = True
+        normalized["bounded_live_paper_collection_authorized"] = True
+        normalized["canary_collection_authorized"] = True
+    return normalized
 
 
 def _bounded_sim_collection_runtime_account_aliases(
@@ -2982,9 +3090,12 @@ class SimpleTradingPipeline(TradingPipeline):
         }
         for key in (
             "source_decision_readiness",
+            "paper_route_target_account_audit_state",
+            "paper_route_target_account_audit_blockers",
             "bounded_evidence_collection_blockers",
             "runtime_window_import_health_gate_blockers",
             "paper_route_account_pre_session_blockers",
+            "paper_route_account_contamination_blockers",
             "paper_route_hpairs_symbol_blockers",
             "paper_route_probe_pair_balance_state",
         ):
@@ -3118,7 +3229,16 @@ class SimpleTradingPipeline(TradingPipeline):
         }
         decisions: list[StrategyDecision] = []
         seen: set[tuple[str, str, str, str]] = set()
-        for target in target_plan_targets:
+        for raw_target in target_plan_targets:
+            target = _bounded_sim_collection_target_with_runtime_account_audit(
+                raw_target,
+                positions=(
+                    positions
+                    if _target_requires_bounded_sim_collection_gate(raw_target)
+                    else None
+                ),
+                account_label=self.account_label,
+            )
             if _target_requires_bounded_sim_collection_gate(target):
                 collection_blockers = _bounded_sim_collection_blockers(
                     target,

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -286,7 +286,19 @@ def _bounded_hpairs_target(**overrides: object) -> dict[str, object]:
         'bounded_evidence_collection_scope': 'paper_route_probe_next_session_only',
         'bounded_evidence_collection_blockers': [],
         'runtime_window_import_health_gate_blockers': [],
+        'paper_route_target_account_audit_state': {
+            'schema_version': 'torghut.paper-route-target-account-audit.v1',
+            'scope': 'local_torghut_sim_paper_runtime_account_state',
+            'state': 'available',
+            'account_label': 'TORGHUT_SIM',
+            'required_account_label': 'TORGHUT_SIM',
+            'symbols': ['AAPL', 'AMZN'],
+            'audit_available': True,
+            'blockers': [],
+        },
+        'paper_route_target_account_audit_blockers': [],
         'paper_route_account_pre_session_blockers': [],
+        'paper_route_account_contamination_blockers': [],
         'paper_route_hpairs_symbol_blockers': [],
         'source_decision_readiness': {'ready': True, 'blockers': []},
         'promotion_allowed': False,
@@ -302,6 +314,10 @@ def test_bounded_sim_collection_authorizes_non_final_hpairs_target_only() -> Non
     target = _bounded_hpairs_target()
 
     assert _bounded_sim_collection_blockers(target, account_label='TORGHUT_SIM') == []
+    assert target['promotion_allowed'] is False
+    assert target['final_promotion_authorized'] is False
+    assert target['final_promotion_allowed'] is False
+    assert target['capital_promotion_allowed'] is False
 
     assert 'bounded_sim_collection_runtime_account_not_target' in (
         _bounded_sim_collection_blockers(target, account_label='TORGHUT_LIVE')
@@ -332,6 +348,145 @@ def test_bounded_sim_collection_blocks_missing_source_lineage_prerequisites() ->
     assert 'bounded_sim_collection_evidence_collection_not_ready' in blockers
     assert 'bounded_sim_collection_source_decision_not_ready' in blockers
     assert 'source_strategy_missing' in blockers
+
+
+def test_bounded_sim_collection_fails_closed_when_account_audit_missing() -> None:
+    target = _bounded_hpairs_target()
+    target.pop('paper_route_target_account_audit_state')
+    target['paper_route_target_account_audit_blockers'] = []
+
+    assert _bounded_sim_collection_blockers(target, account_label='TORGHUT_SIM') == [
+        'paper_route_target_account_audit_unavailable'
+    ]
+    assert target['promotion_allowed'] is False
+    assert target['final_promotion_authorized'] is False
+    assert target['final_promotion_allowed'] is False
+    assert target['capital_promotion_allowed'] is False
+
+
+def test_bounded_sim_collection_fails_closed_when_account_audit_unavailable() -> None:
+    target = _bounded_hpairs_target(
+        evidence_collection_ok=False,
+        canary_collection_authorized=False,
+        bounded_evidence_collection_authorized=False,
+        bounded_live_paper_collection_authorized=False,
+        bounded_evidence_collection_blockers=[
+            'paper_route_target_account_audit_unavailable',
+        ],
+        paper_route_target_account_audit_state={
+            'schema_version': 'torghut.paper-route-target-account-audit.v1',
+            'scope': 'local_torghut_sim_paper_runtime_account_state',
+            'state': 'unavailable',
+            'account_label': 'TORGHUT_SIM',
+            'required_account_label': 'TORGHUT_SIM',
+            'symbols': ['AAPL', 'AMZN'],
+            'audit_available': False,
+            'blockers': ['paper_route_target_account_audit_unavailable'],
+        },
+        paper_route_target_account_audit_blockers=[
+            'paper_route_target_account_audit_unavailable',
+        ],
+    )
+
+    blockers = _bounded_sim_collection_blockers(target, account_label='TORGHUT_SIM')
+
+    assert 'bounded_sim_collection_authorization_missing' in blockers
+    assert 'bounded_sim_collection_evidence_collection_not_ready' in blockers
+    assert 'paper_route_target_account_audit_unavailable' in blockers
+    assert target['promotion_allowed'] is False
+    assert target['final_promotion_authorized'] is False
+    assert target['final_promotion_allowed'] is False
+    assert target['capital_promotion_allowed'] is False
+
+
+def test_bounded_source_collection_authorizes_after_runtime_account_audit_readback(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    allow_shorts_before = settings.trading_allow_shorts
+    try:
+        settings.trading_mode = 'paper'
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_allow_shorts = True
+        now = datetime(2026, 6, 1, 18, 0, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            paper_route_probe_window_start='2026-06-01T13:30:00+00:00',
+            paper_route_probe_window_end='2026-06-01T20:00:00+00:00',
+            paper_route_probe_next_session_max_notional='25',
+            paper_route_probe_symbol_actions={'AAPL': 'buy', 'AMZN': 'sell'},
+            evidence_collection_ok=False,
+            canary_collection_authorized=False,
+            bounded_evidence_collection_authorized=False,
+            bounded_live_paper_collection_authorized=False,
+            bounded_evidence_collection_blockers=[
+                'paper_route_target_account_audit_unavailable',
+            ],
+            paper_route_target_account_audit_state={
+                'schema_version': 'torghut.paper-route-target-account-audit.v1',
+                'scope': 'local_torghut_sim_paper_runtime_account_state',
+                'state': 'unavailable',
+                'account_label': 'TORGHUT_SIM',
+                'required_account_label': 'TORGHUT_SIM',
+                'symbols': ['AAPL', 'AMZN'],
+                'audit_available': False,
+                'blockers': ['paper_route_target_account_audit_unavailable'],
+            },
+            paper_route_target_account_audit_blockers=[
+                'paper_route_target_account_audit_unavailable',
+            ],
+        )
+        strategy = Strategy(
+            name='microbar-cross-sectional-pairs-v1',
+            description='metadata fixture',
+            enabled=True,
+            base_timeframe='1Sec',
+            universe_type='static',
+            universe_symbols=['AAPL', 'AMZN'],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = 'TORGHUT_SIM'
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+            {'AAPL', 'AMZN'},
+            None,
+            [target],
+        )
+        monkeypatch.setattr(
+            'app.trading.scheduler.simple_pipeline.trading_now',
+            lambda account_label=None: now,
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[strategy],
+            allowed_symbols={'AAPL', 'AMZN'},
+            positions=[],
+            session=None,
+        )
+
+        assert {decision.symbol for decision in decisions} == {'AAPL', 'AMZN'}
+        for decision in decisions:
+            metadata = decision.params['paper_route_target_plan_source_decision']
+            assert metadata['bounded_evidence_collection_authorized'] is True
+            assert metadata['bounded_live_paper_collection_authorized'] is True
+            assert metadata['canary_collection_authorized'] is True
+            assert metadata['evidence_collection_ok'] is True
+            assert metadata['promotion_allowed'] is False
+            assert metadata['final_promotion_authorized'] is False
+            assert metadata['final_promotion_allowed'] is False
+            assert decision.params['final_authority_ok'] is False
+            audit_state = metadata['paper_route_target_account_audit_state']
+            assert audit_state['state'] == 'available'
+            assert audit_state['audit_available'] is True
+            assert metadata['paper_route_target_account_audit_blockers'] == []
+            assert (
+                'paper_route_target_account_audit_unavailable'
+                not in metadata['bounded_evidence_collection_blockers']
+            )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_allow_shorts = allow_shorts_before
 
 
 def test_bounded_sim_collection_accepts_declared_paper_account_alias() -> None:


### PR DESCRIPTION
## Summary

- Require bounded SIM paper-route targets with explicit target-account audit readiness to prove the audit is available before source collection can authorize.
- Recompute the target-account audit from the live runtime account position readback inside the simple pipeline when target-plan evidence reports the audit unavailable but the runtime readback is available.
- Keep bounded collection as evidence-only by preserving non-final promotion metadata and closed live-capital authority.
- Add regressions for audit-available authorization, missing/unavailable audit fail-closed blockers, runtime audit readback repair, and final authority staying blocked.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_simple_pipeline.py -q` — passed (13 passed, 1 warning)
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -q -k "bounded_signal_scope_skips_unusable_targets_before_valid_target or matching_paper_target_signal_gets_strategy_signal_paper_authority or run_once_scopes_hpairs_signal_ingest_and_emits_candidate_decisions or run_once_blocks_bounded_target_decisions_when_signal_ingest_times_out or strategy_signal_paper_collection_bypasses_repair_only_floor or strategy_signal_paper_collection_reopens_prior_profit_floor_block or strategy_signal_paper_target_rejects_unqualified_targets or strategy_signal_paper_uses_next_target_plan_over_closed_import_plan or simple_pipeline_blocks_unscoped_order_during_bounded_target_window"` — passed (9 passed, 225 deselected, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed
- `git diff --check` — passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
