### PR TITLE
fix(torghut): scope bounded ingest before audit repair

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -1151,7 +1151,7 @@ class SimpleTradingPipeline(TradingPipeline):
         for target in targets:
             if not _target_requires_bounded_sim_collection_gate(target):
                 continue
-            if not _bounded_sim_collection_authorized(
+            if not _bounded_sim_collection_reserves_account(
                 target,
                 account_label=self.account_label,
             ):

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -706,6 +706,58 @@ def test_target_account_audit_unavailable_still_reserves_paper_account(
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
 
 
+def test_target_account_audit_unavailable_still_scopes_signal_ingest(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    try:
+        settings.trading_mode = 'paper'
+        settings.trading_simple_paper_route_probe_enabled = True
+        now = datetime(2026, 6, 1, 18, 0, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            paper_route_probe_window_start='2026-06-01T13:30:00+00:00',
+            paper_route_probe_window_end='2026-06-01T20:00:00+00:00',
+            evidence_collection_ok=False,
+            canary_collection_authorized=False,
+            bounded_evidence_collection_authorized=False,
+            bounded_live_paper_collection_authorized=False,
+            bounded_evidence_collection_blockers=[
+                'paper_route_target_account_audit_unavailable',
+            ],
+            paper_route_target_account_audit_blockers=[
+                'paper_route_target_account_audit_unavailable',
+            ],
+        )
+        strategy = Strategy(
+            name='microbar-cross-sectional-pairs-v1',
+            description='metadata fixture',
+            enabled=True,
+            base_timeframe='1Sec',
+            universe_type='static',
+            universe_symbols=['AAPL', 'AMZN'],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = 'TORGHUT_SIM'
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+            {'AAPL', 'AMZN', 'MSFT'},
+            None,
+            [target],
+        )
+        monkeypatch.setattr(
+            'app.trading.scheduler.simple_pipeline.trading_now',
+            lambda account_label=None: now,
+        )
+
+        scope = pipeline._bounded_paper_route_signal_scope([strategy])
+
+        assert scope == ({'AAPL', 'AMZN'}, {'1Sec'})
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+
+
 def test_bounded_paper_route_execution_metadata_keeps_live_capital_closed() -> None:
     target = _bounded_hpairs_target(source_account_label='PA3SX7FYNUTF')
     strategy = Strategy(


### PR DESCRIPTION
## Summary

- Keeps bounded paper-route signal ingest scoped when a target reserves the paper account because target-account audit evidence is not available yet.
- Preserves the later fail-closed authorization gate: decisions still require the runtime account snapshot to repair the audit before source collection.
- Adds regression coverage for audit-unavailable H-PAIRS targets polling only their target symbols and timeframe.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_simple_pipeline.py -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'simple_pipeline_blocks_unscoped_order_during_bounded_target_window or bounded_signal_scope_skips_unusable_targets_before_valid_target or strategy_signal_paper_collection_bypasses_repair_only_floor or strategy_signal_paper_collection_reopens_prior_profit_floor_block or strategy_signal_paper_target_rejects_unqualified_targets or matching_paper_target_signal_gets_strategy_signal_paper_authority or strategy_signal_paper_uses_next_target_plan_over_closed_import_plan or run_once_blocks_bounded_target_decisions_when_signal_ingest_times_out or run_once_scopes_hpairs_signal_ingest_and_emits_candidate_decisions'`
- `uv run --frozen pytest tests/test_simple_pipeline.py tests/test_trading_pipeline.py -q`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py tests/test_trading_pipeline.py`
- `git -c core.fsmonitor=false diff --check`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
