### PR TITLE
fix(torghut): close strategy signal paper evidence loops

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -367,7 +367,9 @@ def _bounded_sim_collection_target_with_runtime_account_audit(
         "candidate_blockers",
     ):
         if key in normalized:
-            normalized[key] = _without_lineage_text_values(normalized.get(key), unavailable)
+            normalized[key] = _without_lineage_text_values(
+                normalized.get(key), unavailable
+            )
 
     evidence_blockers: list[str] = []
     for key in _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS:
@@ -388,8 +390,13 @@ def _bounded_sim_collection_target_with_runtime_account_audit(
             evidence_blockers.append("bounded_sim_collection_source_decision_not_ready")
         evidence_blockers.extend(_lineage_text_values(typed_readiness.get("blockers")))
     else:
-        evidence_blockers.append("bounded_sim_collection_source_decision_readiness_missing")
-    if _safe_text(normalized.get("paper_route_probe_pair_balance_state")) == "imbalanced":
+        evidence_blockers.append(
+            "bounded_sim_collection_source_decision_readiness_missing"
+        )
+    if (
+        _safe_text(normalized.get("paper_route_probe_pair_balance_state"))
+        == "imbalanced"
+    ):
         evidence_blockers.append("paper_route_probe_pair_imbalanced")
 
     if not list(dict.fromkeys(evidence_blockers)):
@@ -714,7 +721,7 @@ def _merge_unique_texts(target: list[str], values: Sequence[str]) -> None:
 
 def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[str, Any]:
     payloads: list[Mapping[str, Any]] = [params]
-    for key in ("paper_route_probe", "paper_route_probe_exit"):
+    for key in ("paper_route_probe", "paper_route_probe_exit", "strategy_signal_paper"):
         value = params.get(key)
         if isinstance(value, Mapping):
             payloads.append(cast(Mapping[str, Any], value))
@@ -840,6 +847,31 @@ def _paper_route_probe_entry_metadata(
     if _target_bool(probe_metadata.get("profit_proof_eligible")) is True:
         return None
     return probe_metadata
+
+
+def _strategy_signal_paper_entry_metadata(
+    params: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    source_decision_mode = normalize_source_decision_mode(
+        params.get("source_decision_mode")
+    )
+    if source_decision_mode != STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE:
+        return None
+    if _target_bool(params.get("profit_proof_eligible")) is not True:
+        return None
+
+    metadata = params.get("strategy_signal_paper")
+    if not isinstance(metadata, Mapping):
+        return None
+    metadata_mapping = cast(Mapping[str, Any], metadata)
+    metadata_mode = normalize_source_decision_mode(
+        metadata_mapping.get("source_decision_mode") or metadata_mapping.get("mode")
+    )
+    if metadata_mode not in {None, STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE}:
+        return None
+    if _target_bool(metadata_mapping.get("profit_proof_eligible")) is False:
+        return None
+    return metadata_mapping
 
 
 def _lineage_target_from_mapping(raw_target: Mapping[str, object]) -> dict[str, str]:
@@ -1675,7 +1707,14 @@ class SimpleTradingPipeline(TradingPipeline):
             if not isinstance(decision_json, Mapping):
                 continue
             params = decision.params
-            is_entry = _paper_route_probe_entry_metadata(params) is not None
+            probe_entry_metadata = _paper_route_probe_entry_metadata(params)
+            strategy_signal_entry_metadata = _strategy_signal_paper_entry_metadata(
+                params
+            )
+            is_entry = (
+                probe_entry_metadata is not None
+                or strategy_signal_entry_metadata is not None
+            )
             is_exit = isinstance(params.get("paper_route_probe_exit"), Mapping)
             if not is_entry and not is_exit:
                 continue
@@ -1715,9 +1754,16 @@ class SimpleTradingPipeline(TradingPipeline):
                     "sell_notional": Decimal("0"),
                     "latest_entry_at": None,
                     "exit_minute_after_open": None,
+                    "exit_source": None,
                     "paper_route_probe_lineage": {},
                 },
             )
+            if strategy_signal_entry_metadata is not None:
+                exposure["exit_source"] = "filled_strategy_signal_paper_executions"
+            elif (
+                probe_entry_metadata is not None and exposure.get("exit_source") is None
+            ):
+                exposure["exit_source"] = "filled_paper_route_probe_executions"
             lineage = _paper_route_probe_lineage_from_params(params)
             if lineage:
                 exposure_lineage = cast(
@@ -1804,10 +1850,14 @@ class SimpleTradingPipeline(TradingPipeline):
                 avg_entry_price = buy_notional / buy_qty
             elif net_qty < 0 and sell_qty > 0:
                 avg_entry_price = sell_notional / sell_qty
+            exit_source = (
+                _safe_text(exposure.get("exit_source"))
+                or "filled_paper_route_probe_executions"
+            )
             params: dict[str, Any] = {
                 "paper_route_probe_exit": {
                     "mode": "paper_route_exit",
-                    "source": "filled_paper_route_probe_executions",
+                    "source": exit_source,
                     "symbol": symbol,
                     "strategy_id": str(strategy.id),
                     "db_open_qty": str(exit_qty),

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -976,6 +976,46 @@ class TestTradingPipeline(TestCase):
             if profit_proof_eligible is not None:
                 params["profit_proof_eligible"] = profit_proof_eligible
                 paper_route_probe["profit_proof_eligible"] = profit_proof_eligible
+            if source_decision_mode == STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE:
+                strategy_signal_paper: dict[str, Any] = {
+                    "mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+                    "source": "test",
+                    "symbol": symbol,
+                    "strategy_id": str(strategy.id),
+                    "strategy_name": strategy.name,
+                    "source_decision_mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+                    "profit_proof_eligible": (
+                        profit_proof_eligible
+                        if profit_proof_eligible is not None
+                        else True
+                    ),
+                    "exit_minute_after_open": exit_minute_after_open,
+                }
+                if source_candidate_ids:
+                    strategy_signal_paper["source_candidate_ids"] = list(
+                        source_candidate_ids
+                    )
+                if source_hypothesis_ids:
+                    strategy_signal_paper["source_hypothesis_ids"] = list(
+                        source_hypothesis_ids
+                    )
+                if source_strategy_names:
+                    strategy_signal_paper["source_strategy_names"] = list(
+                        source_strategy_names
+                    )
+                if (
+                    source_candidate_ids
+                    or source_hypothesis_ids
+                    or source_strategy_names
+                ):
+                    strategy_signal_paper["paper_route_probe_lineage_targets"] = [
+                        dict(item)
+                        for item in paper_route_probe.get(
+                            "paper_route_probe_lineage_targets",
+                            [],
+                        )
+                    ]
+                params["strategy_signal_paper"] = strategy_signal_paper
             decision = StrategyDecision(
                 strategy_id=str(strategy.id),
                 symbol=symbol,
@@ -5184,7 +5224,7 @@ class TestTradingPipeline(TestCase):
             payload = cast(dict[str, Any], exit_row.decision_json)
             self.assertNotIn("max_notional_exceeded", payload.get("risk_reasons", []))
 
-    def test_simple_pipeline_does_not_close_strategy_signal_paper_as_probe_inventory(
+    def test_simple_pipeline_closes_strategy_signal_paper_with_linked_exit(
         self,
     ) -> None:
         self._seed_filled_paper_route_probe_entry(
@@ -5203,7 +5243,9 @@ class TestTradingPipeline(TestCase):
             now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
         )
 
-        self.assertEqual(alpaca_client.submitted, [])
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "sell")
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "2.0")
         with self.session_local() as session:
             decisions = (
                 session.execute(
@@ -5212,12 +5254,32 @@ class TestTradingPipeline(TestCase):
                 .scalars()
                 .all()
             )
-            self.assertEqual(len(decisions), 1)
-            payload = cast(dict[str, Any], decisions[0].decision_json)
+            self.assertEqual(len(decisions), 2)
+            payload = cast(dict[str, Any], decisions[-1].decision_json)
             params = cast(dict[str, Any], payload["params"])
+            exit_metadata = cast(dict[str, Any], params.get("paper_route_probe_exit"))
+
+            self.assertEqual(payload.get("action"), "sell")
             self.assertEqual(params["source_decision_mode"], "strategy_signal_paper")
             self.assertTrue(params["profit_proof_eligible"])
-            self.assertNotIn("paper_route_probe_exit", params)
+            self.assertEqual(exit_metadata.get("mode"), "paper_route_exit")
+            self.assertEqual(
+                exit_metadata.get("source"),
+                "filled_strategy_signal_paper_executions",
+            )
+            self.assertEqual(
+                exit_metadata.get("source_decision_mode"),
+                "strategy_signal_paper",
+            )
+            self.assertTrue(exit_metadata.get("profit_proof_eligible"))
+            self.assertEqual(
+                exit_metadata.get("source_candidate_ids"), ["cand-h-pairs"]
+            )
+            self.assertEqual(exit_metadata.get("source_hypothesis_ids"), ["H-PAIRS-01"])
+            self.assertEqual(
+                exit_metadata.get("source_strategy_names"),
+                ["microbar-cross-sectional-pairs-v1"],
+            )
 
     def test_paper_route_probe_entry_metadata_rejects_proof_and_non_probe_rows(
         self,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -66,9 +66,11 @@ from app.trading.risk import RiskEngine
 from app.trading.scheduler.pipeline import TradingPipeline
 from app.trading.scheduler.simple_pipeline import (
     SimpleTradingPipeline,
+    _bounded_sim_collection_target_with_runtime_account_audit,
     _bounded_sim_collection_metadata_from_decision,
     _paper_route_probe_entry_metadata,
     _paper_route_probe_lineage_from_params,
+    _strategy_signal_paper_entry_metadata,
     _parse_target_datetime,
     _safe_int,
     _target_probe_action,
@@ -5327,6 +5329,98 @@ class TestTradingPipeline(TestCase):
                 "source_decision_mode": "route_acquisition_probe",
             },
         )
+
+    def test_strategy_signal_paper_entry_metadata_rejects_incomplete_payloads(
+        self,
+    ) -> None:
+        base_params: dict[str, Any] = {
+            "source_decision_mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+            "profit_proof_eligible": True,
+            "strategy_signal_paper": {
+                "mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+                "profit_proof_eligible": True,
+            },
+        }
+
+        self.assertIsNotNone(_strategy_signal_paper_entry_metadata(base_params))
+        self.assertIsNone(
+            _strategy_signal_paper_entry_metadata(
+                {
+                    **base_params,
+                    "profit_proof_eligible": False,
+                }
+            )
+        )
+        self.assertIsNone(
+            _strategy_signal_paper_entry_metadata(
+                {
+                    "source_decision_mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+                    "profit_proof_eligible": True,
+                }
+            )
+        )
+        self.assertIsNone(
+            _strategy_signal_paper_entry_metadata(
+                {
+                    **base_params,
+                    "strategy_signal_paper": {
+                        "mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+                        "profit_proof_eligible": True,
+                    },
+                }
+            )
+        )
+        self.assertIsNone(
+            _strategy_signal_paper_entry_metadata(
+                {
+                    **base_params,
+                    "strategy_signal_paper": {
+                        "mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+                        "profit_proof_eligible": False,
+                    },
+                }
+            )
+        )
+
+    def test_runtime_account_audit_normalization_keeps_missing_readiness_blocked(
+        self,
+    ) -> None:
+        normalized = _bounded_sim_collection_target_with_runtime_account_audit(
+            {
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "account_label": "TORGHUT_SIM",
+                "observed_stage": "paper",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "source_kind": "paper_route_probe_runtime_observed",
+                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                "bounded_evidence_collection_blockers": [
+                    "paper_route_target_account_audit_unavailable"
+                ],
+                "paper_route_target_account_audit_blockers": [
+                    "paper_route_target_account_audit_unavailable"
+                ],
+                "evidence_collection_ok": False,
+                "canary_collection_authorized": False,
+                "bounded_evidence_collection_authorized": False,
+                "bounded_live_paper_collection_authorized": False,
+                "promotion_allowed": False,
+                "final_promotion_authorized": False,
+                "final_promotion_allowed": False,
+                "capital_promotion_allowed": False,
+            },
+            positions=[],
+            account_label="TORGHUT_SIM",
+        )
+
+        audit_state = cast(
+            Mapping[str, Any],
+            normalized["paper_route_target_account_audit_state"],
+        )
+        self.assertEqual(audit_state["state"], "available")
+        self.assertEqual(normalized["paper_route_target_account_audit_blockers"], [])
+        self.assertFalse(normalized["evidence_collection_ok"])
 
     def test_paper_route_probe_lineage_parses_profit_proof_eligibility(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
## Summary

- Adds a `strategy_signal_paper` entry detector to the paper-route exit generator so proof-eligible paper signal fills emit linked reducing exits.
- Carries strategy-signal candidate, hypothesis, strategy, and profit-proof lineage into the generated exit metadata.
- Updates the scheduler regression to assert a linked `filled_strategy_signal_paper_executions` close instead of relying on unlinked circuit-flat cleanup.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `gtimeout 120s uv run --frozen pytest -q tests/test_trading_pipeline.py::TestTradingPipeline::test_simple_pipeline_closes_strategy_signal_paper_with_linked_exit`
- `gtimeout 180s uv run --frozen pytest -q tests/test_trading_pipeline.py -k 'paper_route_probe_exit or strategy_signal_paper or paper_route_probe_lineage or closes_filled_paper_route_probe or closes_short_paper_route_probe or does_not_duplicate_paper_route_probe_exit'`
- `gtimeout 180s uv run --frozen pytest -q tests/test_trading_pipeline.py -k 'strategy_signal_paper_entry_metadata or runtime_account_audit_normalization_keeps_missing_readiness_blocked or paper_route_probe_exit or strategy_signal_paper or paper_route_probe_lineage or closes_filled_paper_route_probe or closes_short_paper_route_probe or does_not_duplicate_paper_route_probe_exit'`
- `uv run --frozen ruff format app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `gtimeout 300s uv run --frozen pytest -q tests/test_trading_pipeline.py` (236 passed)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
