### PR TITLE
fix(torghut): scope hpairs evidence universe

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -428,6 +428,8 @@ class HypothesisManifest(BaseModel):
     required_feature_sets: list[str] = Field(default_factory=list)
     required_dependency_capabilities: list[str] = Field(default_factory=list)
     segment_dependencies: list[str] = Field(default_factory=list)
+    evidence_universe_symbols: list[str] = Field(default_factory=list)
+    require_pair_balance: bool = False
     expected_gross_edge_bps: Decimal
     max_allowed_slippage_bps: Decimal
     min_sample_count_for_live_canary: int
@@ -444,6 +446,7 @@ class HypothesisManifest(BaseModel):
         "required_feature_sets",
         "required_dependency_capabilities",
         "segment_dependencies",
+        "evidence_universe_symbols",
         "paper_probation_candidate_ids",
         "rollback_triggers",
         "promotion_gates",
@@ -480,6 +483,19 @@ class HypothesisManifest(BaseModel):
             return None
         normalized = value.strip()
         return normalized or None
+
+    @field_validator("evidence_universe_symbols")
+    @classmethod
+    def _normalize_symbol_universe(cls, value: list[str]) -> list[str]:
+        symbols: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            symbol = item.strip().upper()
+            if not symbol or symbol in seen:
+                continue
+            seen.add(symbol)
+            symbols.append(symbol)
+        return symbols
 
 
 @dataclass(frozen=True)
@@ -775,6 +791,23 @@ def _route_tca_bool(value: object) -> bool | None:
     return _optional_bool(value)
 
 
+def _manifest_pair_contract_blockers(manifest: HypothesisManifest) -> tuple[str, ...]:
+    if "pairs" not in manifest.strategy_family and "pairs" not in manifest.lane_id:
+        return ()
+
+    blockers: list[str] = []
+    symbols = tuple(manifest.evidence_universe_symbols)
+    if not symbols:
+        blockers.append("evidence_universe_symbols_missing")
+    elif len(symbols) < 2:
+        blockers.append("evidence_universe_symbol_count_below_pair_minimum")
+    elif len(symbols) % 2 != 0:
+        blockers.append("pair_universe_unbalanced")
+    if not manifest.require_pair_balance:
+        blockers.append("pair_balance_not_declared")
+    return tuple(blockers)
+
+
 def _route_tca_target_blockers(
     row: Mapping[str, Any],
     *,
@@ -950,6 +983,7 @@ def _resolve_tca_readiness_inputs(
     *,
     max_allowed_slippage_bps: Decimal,
     route_symbol_filter_enabled: bool,
+    target_scope_symbols: Sequence[str] = (),
     hypothesis_id: str | None = None,
     candidate_id: str | None = None,
     strategy_family: str | None = None,
@@ -984,11 +1018,19 @@ def _resolve_tca_readiness_inputs(
         for item in _sequence(tca_summary.get("symbol_breakdown"))
         if isinstance(item, Mapping)
     ]
-    scope_symbols = tuple(
+    summary_scope_symbols = tuple(
         str(item).strip().upper()
         for item in _sequence(tca_summary.get("scope_symbols"))
         if str(item).strip()
     )
+    manifest_scope_symbols = tuple(
+        dict.fromkeys(
+            str(item).strip().upper()
+            for item in target_scope_symbols
+            if str(item).strip()
+        )
+    )
+    scope_symbols = manifest_scope_symbols or summary_scope_symbols
     scope_symbol_set = set(scope_symbols)
     if not rows and not scope_symbols:
         return aggregate
@@ -1012,6 +1054,10 @@ def _resolve_tca_readiness_inputs(
     for row in rows:
         symbol = str(row.get("symbol") or "").strip().upper()
         if not symbol:
+            continue
+        if manifest_scope_symbols and symbol not in scope_symbol_set:
+            excluded_symbol_count += 1
+            route_blockers.append("route_tca_out_of_scope_symbol")
             continue
         seen_symbols.add(symbol)
         order_count = max(0, _optional_int(row.get("order_count")) or 0)
@@ -1854,10 +1900,12 @@ def compile_hypothesis_runtime_statuses(
 
     statuses: list[dict[str, object]] = []
     for manifest in registry.items:
+        pair_contract_blockers = _manifest_pair_contract_blockers(manifest)
         tca_inputs = _resolve_tca_readiness_inputs(
             tca_summary,
             max_allowed_slippage_bps=manifest.max_allowed_slippage_bps,
             route_symbol_filter_enabled=route_symbol_filter_enabled,
+            target_scope_symbols=manifest.evidence_universe_symbols,
             hypothesis_id=manifest.hypothesis_id,
             candidate_id=manifest.candidate_id,
             strategy_family=manifest.strategy_family,
@@ -2018,6 +2066,7 @@ def compile_hypothesis_runtime_statuses(
                 f"dependency_capability_unknown:{capability}"
                 for capability in sorted(unknown_dependency_capabilities)
             )
+        reasons.extend(pair_contract_blockers)
 
         if (
             manifest.initial_state == "blocked"
@@ -2148,6 +2197,10 @@ def compile_hypothesis_runtime_statuses(
             ),
             "tca_age_minutes": tca_age_minutes,
             "market_session_open": market_session_open,
+            "evidence_universe_symbols": list(manifest.evidence_universe_symbols),
+            "evidence_universe_symbol_count": len(manifest.evidence_universe_symbols),
+            "pair_balance_required": manifest.require_pair_balance,
+            "pair_contract_blockers": list(pair_contract_blockers),
             "avg_abs_slippage_bps": _decimal_to_string(tca_inputs.avg_abs_slippage_bps),
             "runtime_ledger_proof_present": runtime_ledger_inputs.proof_present,
             "runtime_ledger_candidate_id": runtime_ledger_inputs.candidate_id,
@@ -2292,6 +2345,20 @@ def compile_hypothesis_runtime_statuses(
                     "strategy_id": manifest.strategy_id or manifest.strategy_family,
                     "lane_id": manifest.lane_id,
                     "strategy_family": manifest.strategy_family,
+                    **(
+                        {
+                            "evidence_universe_symbols": list(
+                                manifest.evidence_universe_symbols
+                            )
+                        }
+                        if manifest.evidence_universe_symbols
+                        else {}
+                    ),
+                    **(
+                        {"require_pair_balance": True}
+                        if manifest.require_pair_balance
+                        else {}
+                    ),
                 },
             }
         )

--- a/services/torghut/config/trading/hypotheses/h-pairs-01.json
+++ b/services/torghut/config/trading/hypotheses/h-pairs-01.json
@@ -12,6 +12,8 @@
   "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
   "initial_state": "blocked",
   "market_regimes": ["R2", "R3", "R5"],
+  "evidence_universe_symbols": ["AAPL", "AMZN"],
+  "require_pair_balance": true,
   "required_feature_sets": ["microstructure", "cross_sectional_rank", "tca"],
   "required_dependency_capabilities": ["drift_governance", "feature_coverage", "signal_continuity"],
   "segment_dependencies": ["execution", "empirical", "ta-core"],

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -607,6 +607,248 @@ class TestHypothesisReadiness(TestCase):
         self.assertIn("runtime_ledger_stage_not_live", liq["reasons"])
         self.assertNotIn("runtime_ledger_candidate_id_mismatch", liq["reasons"])
 
+    def test_hpairs_manifest_declares_balanced_evidence_universe(self) -> None:
+        registry = load_hypothesis_registry()
+        hpairs_manifest = next(
+            item for item in registry.items if item.hypothesis_id == "H-PAIRS-01"
+        )
+
+        self.assertEqual(hpairs_manifest.evidence_universe_symbols, ["AAPL", "AMZN"])
+        self.assertTrue(hpairs_manifest.require_pair_balance)
+
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=_state(
+                feature_rows=5,
+                drift_checks=3,
+                evidence_checks=2,
+                signal_lag_seconds=15,
+                evidence_report={
+                    "ok": True,
+                    "checked_at": "2026-06-01T19:45:00+00:00",
+                },
+            ),
+            tca_summary={
+                "account_label": "TORGHUT_SIM",
+                "order_count": 2,
+                "avg_abs_slippage_bps": "3",
+                "last_computed_at": "2026-06-01T19:50:00+00:00",
+                "scope_symbols": ["AAPL", "AMZN"],
+                "symbol_breakdown": [
+                    {
+                        "symbol": "AAPL",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "3",
+                        "last_computed_at": "2026-06-01T19:50:00+00:00",
+                    },
+                    {
+                        "symbol": "AMZN",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "3",
+                        "last_computed_at": "2026-06-01T19:50:00+00:00",
+                    },
+                ],
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-PAIRS-01",
+                submitted_order_count=120,
+                post_cost_expectancy_bps="12",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 6, 1, 19, 55, tzinfo=timezone.utc),
+            market_session_open=True,
+            route_symbol_filter_enabled=True,
+        )
+        hpairs = next(
+            item for item in statuses if item["hypothesis_id"] == "H-PAIRS-01"
+        )
+
+        self.assertEqual(
+            hpairs["lineage_ref"]["evidence_universe_symbols"], ["AAPL", "AMZN"]
+        )
+        self.assertTrue(hpairs["lineage_ref"]["require_pair_balance"])
+        observed = hpairs["observed"]
+        self.assertEqual(observed["evidence_universe_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(observed["evidence_universe_symbol_count"], 2)
+        self.assertEqual(observed["pair_contract_blockers"], [])
+
+    def test_hpairs_route_tca_ignores_unrelated_tsmom_symbols_without_lineage(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=_state(
+                feature_rows=2770,
+                drift_checks=3,
+                evidence_checks=2,
+                signal_lag_seconds=14,
+                evidence_report={
+                    "ok": True,
+                    "checked_at": "2026-06-01T19:15:00+00:00",
+                },
+            ),
+            tca_summary={
+                "account_label": "TORGHUT_SIM",
+                "order_count": 4,
+                "avg_abs_slippage_bps": "12",
+                "avg_realized_shortfall_bps": "1",
+                "last_computed_at": "2026-06-01T19:16:00+00:00",
+                "scope_symbols": ["AAPL", "AMZN", "INTC", "NVDA"],
+                "symbol_breakdown": [
+                    {
+                        "symbol": "AAPL",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "4",
+                        "avg_realized_shortfall_bps": "1",
+                        "last_computed_at": "2026-06-01T19:16:00+00:00",
+                    },
+                    {
+                        "symbol": "AMZN",
+                        "order_count": 0,
+                        "avg_abs_slippage_bps": None,
+                        "avg_realized_shortfall_bps": None,
+                        "last_computed_at": None,
+                    },
+                    {
+                        "symbol": "INTC",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "2",
+                        "avg_realized_shortfall_bps": "1",
+                        "last_computed_at": "2026-06-01T19:16:00+00:00",
+                    },
+                    {
+                        "symbol": "NVDA",
+                        "order_count": 1,
+                        "avg_abs_slippage_bps": "2",
+                        "avg_realized_shortfall_bps": "1",
+                        "last_computed_at": "2026-06-01T19:16:00+00:00",
+                    },
+                ],
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-PAIRS-01",
+                submitted_order_count=120,
+                post_cost_expectancy_bps="12",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 6, 1, 19, 17, tzinfo=timezone.utc),
+            market_session_open=True,
+            route_symbol_filter_enabled=True,
+        )
+
+        hpairs = next(
+            item for item in statuses if item["hypothesis_id"] == "H-PAIRS-01"
+        )
+        observed = hpairs["observed"]
+        self.assertEqual(observed["route_tca_symbols"], ["AAPL"])
+        self.assertEqual(observed["route_tca_repair_symbols"], ["AMZN"])
+        self.assertEqual(observed["route_tca_excluded_symbol_count"], 2)
+        self.assertIn(
+            "route_tca_out_of_scope_symbol",
+            observed["route_tca_blocking_reason_codes"],
+        )
+        diagnostic_symbols = [
+            diagnostic["symbol"]
+            for diagnostic in observed["route_tca_symbol_diagnostics"]
+        ]
+        self.assertEqual(diagnostic_symbols, ["AAPL", "AMZN"])
+
+    def test_pairs_manifest_fails_closed_without_balanced_evidence_universe(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "h-pairs-incomplete.json"
+            manifest_path.write_text(
+                json.dumps(
+                    _hypothesis_manifest_payload(
+                        hypothesis_id="H-PAIRS-INCOMPLETE",
+                        lane_id="microbar-cross-sectional-pairs",
+                        strategy_family="microbar_cross_sectional_pairs",
+                        required_dependency_capabilities=[],
+                        candidate_id="candidate-h-pairs-incomplete",
+                        strategy_id="microbar_cross_sectional_pairs_v1@research",
+                        initial_state="blocked",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            registry = load_hypothesis_registry(path_value=str(manifest_path))
+
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=_state(
+                feature_rows=5,
+                drift_checks=3,
+                evidence_checks=2,
+                signal_lag_seconds=15,
+                evidence_report={
+                    "ok": True,
+                    "checked_at": "2026-06-01T19:45:00+00:00",
+                },
+            ),
+            tca_summary={
+                "account_label": "TORGHUT_SIM",
+                "order_count": 2,
+                "avg_abs_slippage_bps": "3",
+                "last_computed_at": "2026-06-01T19:50:00+00:00",
+                "scope_symbols": ["AAPL", "AMZN"],
+            },
+            runtime_ledger_summary={
+                "by_hypothesis": {
+                    "H-PAIRS-INCOMPLETE": {
+                        "hypothesis_id": "H-PAIRS-INCOMPLETE",
+                        "candidate_id": "candidate-h-pairs-incomplete",
+                        "observed_stage": "live",
+                        "bucket_started_at": "2026-06-01T19:00:00+00:00",
+                        "bucket_ended_at": "2026-06-01T19:45:00+00:00",
+                        "strategy_family": "microbar_cross_sectional_pairs",
+                        "fill_count": 120,
+                        "submitted_order_count": 120,
+                        "closed_trade_count": 60,
+                        "open_position_count": 0,
+                        "filled_notional": "100000",
+                        "net_strategy_pnl_after_costs": "100",
+                        "post_cost_expectancy_bps": "12",
+                        "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+                        "pnl_basis": POST_COST_PNL_BASIS,
+                        "execution_policy_hash_counts": {"policy-sha": 1},
+                        "cost_model_hash_counts": {"cost-sha": 1},
+                        "lineage_hash_counts": {"lineage-sha": 1},
+                    }
+                }
+            },
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 6, 1, 19, 55, tzinfo=timezone.utc),
+            market_session_open=True,
+            route_symbol_filter_enabled=True,
+        )
+
+        hpairs = statuses[0]
+        self.assertFalse(hpairs["promotion_eligible"])
+        self.assertEqual(hpairs["state"], "blocked")
+        self.assertIn("evidence_universe_symbols_missing", hpairs["reasons"])
+        self.assertIn("pair_balance_not_declared", hpairs["reasons"])
+        self.assertEqual(
+            hpairs["observed"]["pair_contract_blockers"],
+            ["evidence_universe_symbols_missing", "pair_balance_not_declared"],
+        )
+
     def test_compile_hypothesis_runtime_statuses_prefers_target_live_bucket_over_newer_paper(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Added a manifest-declared H-PAIRS evidence universe (`AAPL`, `AMZN`) with a required pair-balance contract.
- Scoped hypothesis route/TCA readiness to the manifest evidence universe so aggregate H-TSMOM/INTC/NVDA symbol rows cannot become H-PAIRS repair/proof inputs.
- Added fail-closed H-PAIRS pair-contract blockers and regression coverage for clean lineage, out-of-scope contamination rejection, and incomplete pair config.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_hypotheses.py -k "hpairs_manifest_declares_balanced_evidence_universe or hpairs_route_tca_ignores_unrelated_tsmom_symbols_without_lineage or pairs_manifest_fails_closed_without_balanced_evidence_universe or compile_hypothesis_runtime_statuses_selects_clean_current_hpairs_route_tca or compile_hypothesis_runtime_statuses_rejects_non_authority_hpairs_route_tca"`
- `cd services/torghut && uv run --frozen pytest tests/test_hypotheses.py`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -k "enabled_paper_sleeves_are_chip_universe_with_safe_profiles"`
- `cd services/torghut && uv run --frozen ruff check app/trading/hypotheses.py tests/test_hypotheses.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend/config evidence-lane change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
