### PR TITLE
feat(torghut): add hpairs exact replay handoff lineage

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -236,6 +236,10 @@ class FastReplayPreviewResult:
                 "dataset_snapshot_ref": self.replay_tape_manifest.dataset_snapshot_ref,
                 "content_sha256": self.replay_tape_manifest.content_sha256,
                 "replay_cache_key": self.replay_tape_manifest.replay_cache_key,
+                "source_query_digest": self.replay_tape_manifest.source_query_digest,
+                "source_table_versions": dict(
+                    self.replay_tape_manifest.source_table_versions
+                ),
                 "feature_schema_hash": self.replay_tape_manifest.feature_schema_hash,
                 "cost_model_hash": self.replay_tape_manifest.cost_model_hash,
                 "strategy_family": self.replay_tape_manifest.strategy_family,

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6752,11 +6752,21 @@ def _bounded_sim_target_queue_metadata(
     ]
     entries: list[dict[str, Any]] = []
     for index, row in enumerate(selected_rows, start=1):
+        candidate_spec_id = _string(row.get("candidate_spec_id"))
+        frontier_bucket = _string(row.get("frontier_bucket"))
+        handoff_lineage = _fast_replay_exact_handoff_lineage(
+            row=row,
+            replay_tape_manifest=replay_tape_manifest,
+            queue_priority=index,
+            candidate_spec_id=candidate_spec_id,
+            frontier_bucket=frontier_bucket,
+        )
+        handoff_lineage_hash = _string(handoff_lineage.get("lineage_hash"))
         entries.append(
             {
                 "queue_priority": index,
-                "candidate_spec_id": _string(row.get("candidate_spec_id")),
-                "frontier_bucket": _string(row.get("frontier_bucket")),
+                "candidate_spec_id": candidate_spec_id,
+                "frontier_bucket": frontier_bucket,
                 "preview_rank": row.get("rank"),
                 "preview_score": row.get("preview_score"),
                 "observed_post_cost_expectancy_bps": row.get(
@@ -6770,6 +6780,10 @@ def _bounded_sim_target_queue_metadata(
                     "dataset_snapshot_ref": replay_tape_manifest.dataset_snapshot_ref,
                     "replay_tape_content_sha256": replay_tape_manifest.content_sha256,
                     "replay_cache_key": replay_tape_manifest.replay_cache_key,
+                    "source_query_digest": replay_tape_manifest.source_query_digest,
+                    "source_table_versions": dict(
+                        replay_tape_manifest.source_table_versions
+                    ),
                     "feature_schema_hash": replay_tape_manifest.feature_schema_hash,
                     "cost_model_hash": replay_tape_manifest.cost_model_hash,
                     "strategy_family": replay_tape_manifest.strategy_family,
@@ -6778,7 +6792,10 @@ def _bounded_sim_target_queue_metadata(
                     ),
                     "preview_score": row.get("preview_score"),
                     "frontier_bucket": row.get("frontier_bucket"),
+                    "handoff_lineage_hash": handoff_lineage_hash,
                 },
+                "exact_replay_handoff_lineage": handoff_lineage,
+                "handoff_lineage_hash": handoff_lineage_hash,
                 "cost_impact_lineage": row.get("cost_impact_lineage"),
                 "adv_capacity_context": row.get("adv_capacity_context"),
                 "lineage_blockers": list(
@@ -6798,7 +6815,7 @@ def _bounded_sim_target_queue_metadata(
             }
         )
     return {
-        "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v1",
+        "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v2",
         "status": "metadata_only_preview_to_exact_replay_queue",
         "authority": "not_promotion_proof",
         "prefilter_only": True,
@@ -6833,6 +6850,8 @@ def _bounded_sim_target_queue_metadata(
             "dataset_snapshot_ref": replay_tape_manifest.dataset_snapshot_ref,
             "content_sha256": replay_tape_manifest.content_sha256,
             "replay_cache_key": replay_tape_manifest.replay_cache_key,
+            "source_query_digest": replay_tape_manifest.source_query_digest,
+            "source_table_versions": dict(replay_tape_manifest.source_table_versions),
             "feature_schema_hash": replay_tape_manifest.feature_schema_hash,
             "cost_model_hash": replay_tape_manifest.cost_model_hash,
             "strategy_family": replay_tape_manifest.strategy_family,
@@ -6843,8 +6862,54 @@ def _bounded_sim_target_queue_metadata(
         "exploration_slots": exploration_slots,
         "exact_replay_candidate_count": len(entries),
         "candidate_spec_ids": [entry["candidate_spec_id"] for entry in entries],
+        "handoff_lineage_hashes": [
+            entry["handoff_lineage_hash"] for entry in entries
+        ],
         "entries": entries,
     }
+
+
+def _fast_replay_exact_handoff_lineage(
+    *,
+    row: Mapping[str, Any],
+    replay_tape_manifest: ReplayTapeManifest,
+    queue_priority: int,
+    candidate_spec_id: str,
+    frontier_bucket: str,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": "torghut.fast-replay-exact-handoff-lineage.v1",
+        "status": "preview_only_exact_replay_handoff",
+        "authority": "not_promotion_proof",
+        "prefilter_only": True,
+        "promotion_proof": False,
+        "proof_authority": False,
+        "promotion_authority": False,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "candidate_spec_id": candidate_spec_id,
+        "queue_priority": queue_priority,
+        "frontier_bucket": frontier_bucket,
+        "preview_rank": row.get("rank"),
+        "preview_score": row.get("preview_score"),
+        "proof_semantics_label": row.get("proof_semantics_label"),
+        "replay_tape": {
+            "dataset_snapshot_ref": replay_tape_manifest.dataset_snapshot_ref,
+            "content_sha256": replay_tape_manifest.content_sha256,
+            "replay_cache_key": replay_tape_manifest.replay_cache_key,
+            "source_query_digest": replay_tape_manifest.source_query_digest,
+            "source_table_versions": dict(replay_tape_manifest.source_table_versions),
+            "feature_schema_hash": replay_tape_manifest.feature_schema_hash,
+            "cost_model_hash": replay_tape_manifest.cost_model_hash,
+            "strategy_family": replay_tape_manifest.strategy_family,
+            "cache_identity": replay_tape_manifest.cache_identity_diagnostics(),
+        },
+        "cost_impact_lineage": row.get("cost_impact_lineage"),
+        "hpairs_microstructure_prefilter": row.get("hpairs_microstructure_prefilter")
+        or row.get("microstructure_prefilter"),
+    }
+    payload["lineage_hash"] = build_source_query_digest(payload)
+    return payload
 
 
 def _maybe_materialize_epoch_replay_tape(

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -108,6 +108,7 @@ class TestFastReplayPreview(TestCase):
                     symbol="BBB", offset=3, price="98", ofi="-0.20", stress=True
                 ),
             ]
+            source_query_digest = build_source_query_digest({"window": "fast"})
             manifest = materialize_signal_tape(
                 rows=rows,
                 tape_path=Path(tmpdir) / "tape.jsonl",
@@ -115,7 +116,8 @@ class TestFastReplayPreview(TestCase):
                 symbols=("AAA", "BBB"),
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
-                source_query_digest=build_source_query_digest({"window": "fast"}),
+                source_query_digest=source_query_digest,
+                source_table_versions={"signals": "v1"},
             )
 
         preview = build_fast_replay_preview(
@@ -170,6 +172,12 @@ class TestFastReplayPreview(TestCase):
         self.assertIn("source_backed_adv_missing", row_payload["risk_flags"])
         self.assertEqual(
             payload["replay_tape"]["dataset_snapshot_ref"], "snapshot-fast"
+        )
+        self.assertEqual(
+            payload["replay_tape"]["source_query_digest"], source_query_digest
+        )
+        self.assertEqual(
+            payload["replay_tape"]["source_table_versions"], {"signals": "v1"}
         )
         self.assertIn("feature_schema_hash", payload["replay_tape"])
         self.assertIn("cost_model_hash", payload["replay_tape"])

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4670,6 +4670,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 )
                 for index, symbol in enumerate(["NVDA", "AAPL", "INTC"] * 3)
             ]
+            source_query_digest = build_source_query_digest({"window": "frontier"})
             materialize_signal_tape(
                 rows=rows,
                 tape_path=tape_path,
@@ -4677,10 +4678,11 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 symbols=("NVDA", "AAPL", "INTC"),
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
-                source_query_digest=build_source_query_digest({"window": "frontier"}),
+                source_query_digest=source_query_digest,
                 feature_schema_hash="feature-schema-frontier",
                 cost_model_hash="cost-model-frontier",
                 strategy_family="hpairs-frontier-family",
+                source_table_versions={"signals": "v1"},
             )
             specs = [
                 self._candidate_spec(f"spec-frontier-{index}") for index in range(8)
@@ -4760,6 +4762,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             queue_payload["replay_tape"]["strategy_family"], "hpairs-frontier-family"
         )
         self.assertEqual(
+            queue_payload["replay_tape"]["source_query_digest"], source_query_digest
+        )
+        self.assertEqual(
+            queue_payload["replay_tape"]["source_table_versions"], {"signals": "v1"}
+        )
+        self.assertEqual(
             queue_payload["replay_tape"]["cache_identity"]["status"], "complete"
         )
         self.assertFalse(
@@ -4790,6 +4798,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "feature-schema-frontier",
         )
         self.assertEqual(
+            first_entry["reproducibility_metadata"]["source_query_digest"],
+            source_query_digest,
+        )
+        self.assertEqual(
+            first_entry["reproducibility_metadata"]["source_table_versions"],
+            {"signals": "v1"},
+        )
+        self.assertEqual(
             first_entry["reproducibility_metadata"]["cache_identity"]["status"],
             "complete",
         )
@@ -4799,6 +4815,33 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertIn("target_implied_notional_context", first_entry)
         self.assertIn("cost_impact_lineage", first_entry)
+        self.assertIn("exact_replay_handoff_lineage", first_entry)
+        self.assertIn(
+            first_entry["handoff_lineage_hash"],
+            queue_payload["handoff_lineage_hashes"],
+        )
+        self.assertEqual(
+            first_entry["exact_replay_handoff_lineage"]["lineage_hash"],
+            first_entry["handoff_lineage_hash"],
+        )
+        self.assertEqual(
+            first_entry["exact_replay_handoff_lineage"]["replay_tape"][
+                "source_query_digest"
+            ],
+            source_query_digest,
+        )
+        self.assertEqual(
+            first_entry["exact_replay_handoff_lineage"]["replay_tape"][
+                "cost_model_hash"
+            ],
+            "cost-model-frontier",
+        )
+        self.assertFalse(
+            first_entry["exact_replay_handoff_lineage"]["promotion_allowed"]
+        )
+        self.assertFalse(
+            first_entry["exact_replay_handoff_lineage"]["final_promotion_allowed"]
+        )
         self.assertEqual(
             first_entry["adv_capacity_context"]["status"], "missing_source_backed_adv"
         )


### PR DESCRIPTION
## Summary

- Added deterministic exact-replay handoff lineage hashes to the bounded H-PAIRS fast-replay SIM target queue so exact replay can dedupe and audit preview-ranked candidates without treating preview output as proof.
- Preserved replay tape source query digest and source table versions in preview manifests, queue metadata, and per-candidate reproducibility metadata alongside content, feature, cost-model, and strategy-family hashes.
- Extended focused fast-replay/autoresearch tests to verify the six-candidate cap, proof/promotion separation, and source/cost/replay lineage propagation.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (passes after installing missing system `build-essential` compiler toolchain required by frozen `crosshair-tool` build)
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` (209 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_run_whitepaper_autoresearch_profit_target.py` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (0 errors)
- `git diff --check` (passed)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
