### PR TITLE
fix(torghut): avoid runtime import readback rollback

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -1447,82 +1447,22 @@ def _runtime_ledger_bucket_payloads(payload: Mapping[str, Any]) -> list[dict[str
     return [single_payload] if single_payload else []
 
 
-def _candidate_filter(column: Any, candidate_id: str | None) -> ColumnElement[bool]:
-    if candidate_id is None:
-        return column.is_(None)
-    return column == candidate_id
-
-
 def _row_ref(table_name: str, row_id: Any) -> str:
     return f"{table_name}:{row_id}"
 
 
-def _runtime_window_import_readback(
+def _runtime_window_import_readback_from_rows(
     *,
-    session: Session,
     run_id: str,
     candidate_id: str | None,
     hypothesis_id: str,
     observed_stage: str,
     window_start: datetime,
     window_end: datetime,
+    metric_rows: Sequence[StrategyHypothesisMetricWindow],
+    promotion_rows: Sequence[StrategyPromotionDecision],
+    ledger_rows: Sequence[StrategyRuntimeLedgerBucket],
 ) -> dict[str, Any]:
-    metric_rows = (
-        session.execute(
-            select(StrategyHypothesisMetricWindow)
-            .where(
-                StrategyHypothesisMetricWindow.run_id == run_id,
-                _candidate_filter(
-                    StrategyHypothesisMetricWindow.candidate_id, candidate_id
-                ),
-                StrategyHypothesisMetricWindow.hypothesis_id == hypothesis_id,
-                StrategyHypothesisMetricWindow.observed_stage == observed_stage,
-            )
-            .order_by(
-                StrategyHypothesisMetricWindow.window_started_at,
-                StrategyHypothesisMetricWindow.window_ended_at,
-                StrategyHypothesisMetricWindow.id,
-            )
-        )
-        .scalars()
-        .all()
-    )
-    promotion_rows = (
-        session.execute(
-            select(StrategyPromotionDecision)
-            .where(
-                StrategyPromotionDecision.run_id == run_id,
-                _candidate_filter(StrategyPromotionDecision.candidate_id, candidate_id),
-                StrategyPromotionDecision.hypothesis_id == hypothesis_id,
-                StrategyPromotionDecision.promotion_target == observed_stage,
-            )
-            .order_by(
-                StrategyPromotionDecision.created_at, StrategyPromotionDecision.id
-            )
-        )
-        .scalars()
-        .all()
-    )
-    ledger_rows = (
-        session.execute(
-            select(StrategyRuntimeLedgerBucket)
-            .where(
-                StrategyRuntimeLedgerBucket.run_id == run_id,
-                _candidate_filter(
-                    StrategyRuntimeLedgerBucket.candidate_id, candidate_id
-                ),
-                StrategyRuntimeLedgerBucket.hypothesis_id == hypothesis_id,
-                StrategyRuntimeLedgerBucket.observed_stage == observed_stage,
-            )
-            .order_by(
-                StrategyRuntimeLedgerBucket.bucket_started_at,
-                StrategyRuntimeLedgerBucket.bucket_ended_at,
-                StrategyRuntimeLedgerBucket.id,
-            )
-        )
-        .scalars()
-        .all()
-    )
     evidence_grade_ledger_rows = [
         row
         for row in ledger_rows
@@ -2958,14 +2898,20 @@ def persist_observed_runtime_windows(
             )
     proof_status = "blocked" if proof_blockers else "ok"
     tigerbeetle_proof_refs = _runtime_ledger_tigerbeetle_proof_refs(runtime_ledger_rows)
-    runtime_import_readback = _runtime_window_import_readback(
-        session=session,
+    # Build readback from flushed rows in the current unit of work instead of
+    # re-querying broad governance tables before commit. Large SIM ledgers can
+    # make those scans slow enough for the import job to be killed, rolling back
+    # otherwise-valid source-backed buckets to zero durable rows.
+    runtime_import_readback = _runtime_window_import_readback_from_rows(
         run_id=run_id,
         candidate_id=candidate_id,
         hypothesis_id=hypothesis_id,
         observed_stage=observed_stage,
         window_start=import_window_start,
         window_end=import_window_end,
+        metric_rows=metric_window_rows,
+        promotion_rows=[promotion_decision_row],
+        ledger_rows=runtime_ledger_rows,
     )
     runtime_materialization_target.update(
         {

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1738,6 +1738,20 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(readback["runtime_ledger_closed_trade_count"], 1)
         self.assertEqual(readback["runtime_ledger_open_position_count"], 0)
         self.assertEqual(readback["runtime_ledger_filled_notional"], "200")
+        self.assertEqual(
+            readback["runtime_ledger_bucket_refs"],
+            [
+                "strategy_runtime_ledger_buckets:"
+                f"{summary['runtime_materialization_target']['runtime_ledger_bucket_ids'][0]}"
+            ],
+        )
+        self.assertEqual(
+            readback["evidence_grade_runtime_ledger_bucket_refs"],
+            [
+                "strategy_runtime_ledger_buckets:"
+                f"{summary['runtime_materialization_target']['evidence_grade_runtime_ledger_bucket_ids'][0]}"
+            ],
+        )
         self.assertIn("postgres:trade_decisions", readback["source_refs"])
         self.assertIn(
             "runtime_order_feed_execution_source", readback["authority_classes"]
@@ -3138,6 +3152,10 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(target["promotion_decision_count"], 1)
         self.assertEqual(target["runtime_ledger_bucket_count"], 0)
         self.assertEqual(target["evidence_grade_runtime_ledger_bucket_count"], 0)
+        self.assertEqual(target["readback"]["runtime_ledger_bucket_count"], 0)
+        self.assertEqual(
+            target["readback"]["evidence_grade_runtime_ledger_bucket_count"], 0
+        )
         self.assertIn(
             "runtime_window_import_runtime_ledger_bucket_missing",
             target["materialization_blockers"],


### PR DESCRIPTION
## Summary

- Diagnosed the zero-bucket path as a pre-commit import readback hazard: the import materialized rows, then re-queried broad governance tables before commit; slow SIM readback scans can outlive the job deadline and roll back otherwise-valid runtime buckets.
- Reworked runtime-window import readback to use the flushed metric, promotion, and runtime-ledger rows already in the current unit of work, preserving source-backed proof gates while avoiding rollback-prone table scans.
- Tightened runtime-window import tests for positive source-backed bucket readback refs and negative claimed-proof-without-ledger readback counts.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — pass
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_runtime_ledger.py tests/test_assemble_runtime_ledger_proof_packet.py -q` — pass (273 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_window_import.py tests/test_runtime_window_import.py` — pass
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — pass
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — pass
- `git diff --check` — pass
- Read-only live diagnosis: `curl http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan` showed the 2026-06-01 paper-route import deferred until 2026-06-01T21:00:00Z settlement; read-only SIM DB counts showed recent trade/order activity but zero `strategy_runtime_ledger_buckets` before the post-settlement import.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
