### PR TITLE
fix(torghut): repair paper-route collection readiness

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -96,8 +96,17 @@ PROMOTION_ONLY_READINESS_BLOCKERS = frozenset(
     {
         "paper_probation_evidence_collection_only",
         "paper_route_evidence_audit_stripped_promotion_authority",
+        "paper_route_runtime_ledger_import_pending",
+        "bounded_paper_route_evidence_collection_only",
+        "runtime_ledger_source_collection_only",
+        "runtime_ledger_source_window_evidence_pending",
         "runtime_ledger_stage_not_live",
         "live_runtime_ledger_required",
+        "runtime_ledger_bucket_missing",
+        "runtime_ledger_evidence_grade_bucket_missing",
+        "hypothesis_window_missing",
+        "promotion_decision_missing",
+        "promotion_decision_not_allowed",
     }
 )
 CLEAN_WINDOW_BASELINE_SCHEMA_VERSION = "torghut.paper-route-clean-window-baseline.v1"
@@ -726,6 +735,37 @@ def _paper_route_session_readiness(
         ),
         "import_blockers": import_blockers,
     }
+
+
+def _paper_route_collection_session_blockers(
+    session_readiness: Mapping[str, object],
+) -> list[str]:
+    """Return blockers for submitting bounded paper collection in this window.
+
+    Import readiness and collection readiness are intentionally not identical:
+    an open window blocks import because it is not closed yet, but it is the
+    only time a bounded live-paper collection target may submit. Before the
+    open and after the close, report a machine-readable collection blocker
+    instead of allowing ambiguous "ready" target state.
+    """
+
+    state = _safe_text(session_readiness.get("state")) or "unknown"
+    if state == "collecting_session_evidence":
+        return []
+    if state == "waiting_for_session_open":
+        return ["paper_route_session_window_not_open"]
+    if state == "window_closed_settlement_pending":
+        return ["paper_route_session_settlement_pending"]
+    if state == "window_closed_import_ready":
+        return ["paper_route_session_window_closed"]
+    if state == "window_closed_import_blocked":
+        blockers = [
+            blocker
+            for blocker in _unique_text_items(session_readiness.get("import_blockers"))
+            if blocker != "paper_route_session_window_not_closed"
+        ]
+        return blockers or ["paper_route_session_window_closed"]
+    return ["paper_route_session_state_unknown"]
 
 
 def _paper_route_probe_summary(
@@ -1598,6 +1638,9 @@ def _next_paper_route_runtime_window_targets(
         for item in _as_sequence(session_readiness.get("import_blockers"))
         if str(item).strip()
     ]
+    collection_session_blockers = _paper_route_collection_session_blockers(
+        session_readiness
+    )
     import_handoff = {
         "runner": "scripts/renew_latest_empirical_promotion_jobs.py",
         "target_plan_endpoint": PAPER_ROUTE_TARGET_PLAN_ENDPOINT,
@@ -1836,6 +1879,10 @@ def _next_paper_route_runtime_window_targets(
                 symbols=target_probe_symbols,
                 window_start=window_start,
                 window_end=window_end,
+                strategy_lookup_names=strategy_lookup_names,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                require_source_lineage=_target_requires_source_lineage(target),
             )
             if target_account_audit_available
             else _account_contamination_audit_unavailable(
@@ -1945,6 +1992,7 @@ def _next_paper_route_runtime_window_targets(
         )
         evidence_collection_blockers = _unique_text_items(
             [
+                *collection_session_blockers,
                 *_unique_text_items(source_decision_readiness.get("blockers")),
                 *target_account_audit_blockers,
                 *account_pre_session_blockers,
@@ -2070,6 +2118,7 @@ def _next_paper_route_runtime_window_targets(
                 session_readiness.get("state")
             )
             or "unknown",
+            "paper_route_session_collection_blockers": collection_session_blockers,
             "paper_route_session_import_ready": import_ready,
             "paper_route_session_import_blockers": import_blockers,
             "paper_route_runtime_window_import_not_before": _safe_text(
@@ -2280,6 +2329,15 @@ def _next_paper_route_runtime_window_targets(
             "end": _isoformat(window_end),
         },
         "session_readiness": session_readiness,
+        "collection_session_readiness": {
+            "schema_version": "torghut.paper-route-collection-session-readiness.v1",
+            "state": (
+                "ready"
+                if not collection_session_blockers
+                else "blocked"
+            ),
+            "blockers": collection_session_blockers,
+        },
         "runtime_window_import_handoff": {
             **import_handoff,
             "target_count": len(planned_targets),
@@ -3164,6 +3222,10 @@ def _account_contamination_audit(
     symbols: Sequence[str],
     window_start: datetime,
     window_end: datetime,
+    strategy_lookup_names: Sequence[str] = (),
+    candidate_id: str | None = None,
+    hypothesis_id: str | None = None,
+    require_source_lineage: bool = False,
 ) -> dict[str, object]:
     symbol_filters = [
         str(item).strip().upper() for item in symbols if str(item).strip()
@@ -3178,22 +3240,26 @@ def _account_contamination_audit(
             "window_start": _isoformat(window_start),
             "window_end": _isoformat(window_end),
             "contaminated": False,
+            "order_event_count": 0,
             "unlinked_order_event_count": 0,
+            "foreign_linked_order_event_count": 0,
+            "target_linked_order_event_count": 0,
             "client_order_id_count": 0,
             "sample_client_order_ids": [],
             "symbol_counts": {},
             "event_type_counts": {},
             "status_counts": {},
+            "foreign_strategy_counts": {},
             "last_event_at": None,
             "blockers": [],
         }
     order_event_activity_ts = _order_event_activity_timestamp()
+    strategy_filters = [name for name in strategy_lookup_names if name]
     stmt = (
         select(ExecutionOrderEvent)
         .where(ExecutionOrderEvent.alpaca_account_label == account_label)
         .where(order_event_activity_ts >= window_start)
         .where(order_event_activity_ts < window_end)
-        .where(ExecutionOrderEvent.trade_decision_id.is_(None))
     )
     if symbol_filters:
         stmt = stmt.where(ExecutionOrderEvent.symbol.in_(symbol_filters))
@@ -3203,24 +3269,56 @@ def _account_contamination_audit(
             stmt.order_by(order_event_activity_ts.desc()).limit(500)
         ).scalars()
     )
-    if rows:
+    target_linked_rows: list[ExecutionOrderEvent] = []
+    foreign_linked_rows: list[ExecutionOrderEvent] = []
+    unlinked_rows: list[ExecutionOrderEvent] = []
+    foreign_strategy_counts: Counter[str] = Counter()
+    for row in rows:
+        decision = row.trade_decision
+        if decision is None:
+            unlinked_rows.append(row)
+            continue
+        strategy_name = _safe_text(
+            getattr(getattr(decision, "strategy", None), "name", None)
+        )
+        strategy_matches = not strategy_filters or strategy_name in strategy_filters
+        lineage_matches = (
+            _source_decision_lineage_matches(
+                decision,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+            )
+            if require_source_lineage
+            else True
+        )
+        if strategy_matches and lineage_matches:
+            target_linked_rows.append(row)
+            continue
+        foreign_linked_rows.append(row)
+        foreign_strategy_counts[strategy_name or "missing"] += 1
+    if unlinked_rows or foreign_linked_rows:
         blockers.extend(
             [
                 "paper_route_account_contamination_detected",
-                "unlinked_order_events_present",
             ]
         )
+    if unlinked_rows:
+        blockers.append("unlinked_order_events_present")
+    if foreign_linked_rows:
+        blockers.append("foreign_order_events_present")
     client_order_ids: list[str] = []
     symbol_counts: Counter[str] = Counter()
     event_type_counts: Counter[str] = Counter()
     status_counts: Counter[str] = Counter()
-    for row in rows:
+    for row in [*unlinked_rows, *foreign_linked_rows]:
         if client_order_id := _safe_text(row.client_order_id):
             if client_order_id not in client_order_ids:
                 client_order_ids.append(client_order_id)
         symbol_counts[_safe_text(row.symbol) or "missing"] += 1
         event_type_counts[_safe_text(row.event_type) or "missing"] += 1
         status_counts[_safe_text(row.status) or "missing"] += 1
+    contaminating_rows = [*unlinked_rows, *foreign_linked_rows]
+    last_event_row = contaminating_rows[0] if contaminating_rows else rows[0] if rows else None
     return {
         "schema_version": "torghut.paper-route-account-contamination-audit.v1",
         "scope": "target_window_account_symbol_order_events",
@@ -3228,15 +3326,19 @@ def _account_contamination_audit(
         "symbols": symbol_filters,
         "window_start": _isoformat(window_start),
         "window_end": _isoformat(window_end),
-        "contaminated": bool(rows),
-        "unlinked_order_event_count": len(rows),
+        "contaminated": bool(unlinked_rows or foreign_linked_rows),
+        "order_event_count": len(rows),
+        "unlinked_order_event_count": len(unlinked_rows),
+        "foreign_linked_order_event_count": len(foreign_linked_rows),
+        "target_linked_order_event_count": len(target_linked_rows),
         "client_order_id_count": len(client_order_ids),
         "sample_client_order_ids": client_order_ids[:10],
         "symbol_counts": dict(sorted(symbol_counts.items())),
         "event_type_counts": dict(sorted(event_type_counts.items())),
         "status_counts": dict(sorted(status_counts.items())),
+        "foreign_strategy_counts": dict(sorted(foreign_strategy_counts.items())),
         "last_event_at": _isoformat(
-            _order_event_activity_at(rows[0]) if rows else None
+            _order_event_activity_at(last_event_row) if last_event_row is not None else None
         ),
         "blockers": blockers,
     }
@@ -4741,6 +4843,10 @@ def _target_audit(
         symbols=_target_probe_symbols(target, probe),
         window_start=window_start,
         window_end=window_end,
+        strategy_lookup_names=strategy_lookup_names,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+        require_source_lineage=_target_requires_source_lineage(target),
     )
     account_state = _account_window_start_snapshot_audit(
         session,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1419,7 +1419,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
 
     def test_flat_clean_baseline_allows_bounded_collection_readiness(self) -> None:
-        generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
+        generated_at = datetime(2026, 5, 26, 13, 35, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
         with Session(self.engine) as session:
             session.add(
                 Strategy(
@@ -1434,7 +1435,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             self._add_account_position_snapshot(
                 session,
                 account_label="TORGHUT_SIM",
-                as_of=generated_at - timedelta(seconds=30),
+                as_of=window_start - timedelta(minutes=5),
                 positions=[],
             )
             session.commit()
@@ -1467,7 +1468,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
     def test_target_account_audit_unavailable_blocks_collection_readiness(
         self,
     ) -> None:
-        generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
+        generated_at = datetime(2026, 5, 26, 13, 35, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
         with Session(self.engine) as session:
             session.add(
                 Strategy(
@@ -1482,7 +1484,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             self._add_account_position_snapshot(
                 session,
                 account_label="TORGHUT_SIM",
-                as_of=generated_at - timedelta(seconds=30),
+                as_of=window_start - timedelta(minutes=5),
                 positions=[],
             )
             session.commit()
@@ -1521,7 +1523,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
     def test_clean_baseline_allows_collection_when_health_gate_blocks_promotion(
         self,
     ) -> None:
-        generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
+        generated_at = datetime(2026, 5, 26, 13, 35, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
         with Session(self.engine) as session:
             session.add(
                 Strategy(
@@ -1536,7 +1539,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             self._add_account_position_snapshot(
                 session,
                 account_label="TORGHUT_SIM",
-                as_of=generated_at - timedelta(seconds=30),
+                as_of=window_start - timedelta(minutes=5),
                 positions=[],
             )
             session.commit()
@@ -2577,6 +2580,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(
             summary_target["bounded_evidence_collection_blockers"],
             [
+                "paper_route_session_window_not_open",
                 "source_strategy_missing",
                 "paper_route_clean_window_baseline_snapshot_pending",
             ],
@@ -2723,6 +2727,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             [
                 "paper_route_runtime_ledger_import_pending",
                 "custom_runtime_blocker",
+                "paper_route_session_window_not_open",
                 "source_strategy_missing",
                 "paper_route_clean_window_baseline_snapshot_pending",
             ],
@@ -2735,7 +2740,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
     def test_next_paper_route_targets_surface_source_decision_readiness(
         self,
     ) -> None:
-        generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
+        generated_at = datetime(2026, 5, 26, 13, 35, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
         with Session(self.engine) as session:
             session.add(
                 Strategy(
@@ -2751,7 +2757,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             self._add_account_position_snapshot(
                 session,
                 account_label="TORGHUT_SIM",
-                as_of=generated_at - timedelta(seconds=30),
+                as_of=window_start - timedelta(minutes=5),
                 positions=[],
             )
             session.commit()
@@ -4121,6 +4127,16 @@ class TestPaperRouteEvidenceAudit(TestCase):
             settlement_target["paper_route_runtime_window_import_not_before"],
             "2026-05-26T21:00:00+00:00",
         )
+        self.assertFalse(settlement_target["evidence_collection_ok"])
+        self.assertFalse(settlement_target["bounded_evidence_collection_authorized"])
+        self.assertEqual(
+            settlement_target["paper_route_session_collection_blockers"],
+            ["paper_route_session_settlement_pending"],
+        )
+        self.assertIn(
+            "paper_route_session_settlement_pending",
+            settlement_target["bounded_evidence_collection_blockers"],
+        )
 
         import_payload = build(datetime(2026, 5, 26, 21, tzinfo=timezone.utc))
         import_readiness = import_payload["next_paper_route_runtime_window_targets"][
@@ -5163,12 +5179,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(readiness["evidence_collection_ok"])
         self.assertFalse(readiness["capital_promotion_allowed"])
         self.assertFalse(readiness["final_authority_ok"])
-        for blocker in (
-            "source_tca_missing",
-            "runtime_ledger_bucket_missing",
+        self.assertIn("source_tca_missing", readiness["evidence_collection_blockers"])
+        self.assertIn("runtime_ledger_bucket_missing", readiness["blockers"])
+        self.assertIn(
             "runtime_ledger_evidence_grade_bucket_missing",
-        ):
-            self.assertIn(blocker, readiness["evidence_collection_blockers"])
+            readiness["blockers"],
+        )
         self.assertFalse(readiness["promotion_authority"]["allowed"])
         self.assertFalse(readiness["promotion_authority"]["final_authority_ok"])
 
@@ -6413,6 +6429,147 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target["bounded_evidence_collection_blockers"],
         )
 
+    def test_active_window_foreign_linked_order_events_block_target_plan_collection(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 18, 5, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            target_strategy = Strategy(
+                name="hpairs-target-contamination-strategy",
+                description="target bounded paper route strategy",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            foreign_strategy = Strategy(
+                name="intraday-tsmom-profit-v3",
+                description="foreign paper account strategy",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add_all([target_strategy, foreign_strategy])
+            session.flush()
+            foreign_decision = TradeDecision(
+                strategy_id=foreign_strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-tsmom",
+                    "hypothesis_id": "H-TSMOM-LIQ",
+                },
+                rationale="foreign linked paper route contamination fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=5),
+                executed_at=window_start + timedelta(minutes=6),
+            )
+            session.add(foreign_decision)
+            session.flush()
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="foreign-linked-tsmom-paper-event",
+                    source_topic="alpaca.trade_updates",
+                    source_partition=0,
+                    source_offset=43,
+                    alpaca_account_label="TORGHUT_SIM",
+                    event_ts=window_start + timedelta(minutes=20),
+                    symbol="AAPL",
+                    alpaca_order_id="foreign-linked-order-1",
+                    client_order_id="tsmom-AAPL-foreign-linked-1",
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("101"),
+                    raw_event={"source": "foreign_tsmom_strategy"},
+                    execution_id=None,
+                    trade_decision_id=foreign_decision.id,
+                )
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
+            session.commit()
+
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": (
+                            "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                        ),
+                        "target_count": "1",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-hpairs",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": target_strategy.name,
+                                "strategy_id": "hpairs_target_strategy@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": (
+                                    "config/trading/hypotheses/h-pairs-01.json"
+                                ),
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_active_symbols": ["AAPL", "AMZN"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                        "eligible_symbols": ["AAPL", "AMZN"],
+                    },
+                },
+                generated_at=now,
+            )
+
+        target = payload["next_paper_route_runtime_window_targets"]["targets"][0]
+        contamination = target["paper_route_account_contamination_state"]
+        self.assertTrue(contamination["contaminated"])
+        self.assertEqual(contamination["unlinked_order_event_count"], 0)
+        self.assertEqual(contamination["foreign_linked_order_event_count"], 1)
+        self.assertEqual(contamination["target_linked_order_event_count"], 0)
+        self.assertEqual(
+            contamination["foreign_strategy_counts"],
+            {"intraday-tsmom-profit-v3": 1},
+        )
+        self.assertFalse(target["evidence_collection_ok"])
+        self.assertIn(
+            "foreign_order_events_present",
+            target["bounded_evidence_collection_blockers"],
+        )
+
     def test_account_window_start_positions_block_runtime_window_import(
         self,
     ) -> None:
@@ -7362,9 +7519,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(runtime_ledger["evidence_grade_bucket_count"], 0)
         self.assertIn(
             "runtime_ledger_bucket_missing",
-            payload["targets"][0]["readiness"]["evidence_collection_blockers"],
+            payload["targets"][0]["readiness"]["blockers"],
         )
         self.assertIn(
             "runtime_ledger_evidence_grade_bucket_missing",
-            payload["targets"][0]["readiness"]["evidence_collection_blockers"],
+            payload["targets"][0]["readiness"]["blockers"],
         )


### PR DESCRIPTION
## Summary

- Split bounded paper-route collection readiness from final promotion authority so live-paper collection only opens during the active session while final promotion remains blocked without source-backed runtime-ledger proof.
- Added machine-readable collection-session blockers for pre-open, settlement-pending, and closed/import-ready states, plus target/summary readback fields.
- Expanded account contamination detection to block both unlinked order events and linked foreign-strategy order events in the target account/window.
- Added regressions for settlement-pending collection blocks, foreign linked contamination, collection-ready/promotion-blocked target plans, and promotion-only blockers staying out of collection readiness.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_completion_trace.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/submission_council.py app/trading/completion.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_completion_trace.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
