### PR TITLE
feat(torghut): add hpairs zero evidence diagnostics

### DIFF
--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, Sequence, Set
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
@@ -31,6 +31,8 @@ from app.models import (
     TradeDecision,
 )
 from app.trading.runtime_authority_verifier import (
+    AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER,
+    AUTHORITY_BUCKET_BLOCKERS_PRESENT,
     AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER,
     AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER,
     AUTHORITY_EVIDENCE_MISSING_BLOCKER,
@@ -41,6 +43,7 @@ from app.trading.runtime_authority_verifier import (
     AUTHORITY_MEDIAN_PNL_BLOCKER,
     AUTHORITY_OPEN_POSITIONS_BLOCKER,
     AUTHORITY_P10_PNL_BLOCKER,
+    AUTHORITY_READ_ERROR_BLOCKER,
     AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
     AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
     AUTHORITY_TRADING_DAYS_BLOCKER,
@@ -75,6 +78,9 @@ ECONOMICS_MISSING = 'economics_missing'
 SOURCE_REFS_MISSING = 'source_refs_missing'
 OPEN_POSITIONS = 'open_positions'
 AUTHORITY_DISTRIBUTION_MISSING = 'authority_distribution_missing'
+LADDER_PASS = 'pass'
+LADDER_MISSING = 'missing'
+LADDER_BLOCKED = 'blocked'
 
 _SOURCE_REF_BLOCKERS = frozenset(
     {
@@ -98,6 +104,7 @@ _DISTRIBUTION_BLOCKERS = frozenset(
         AUTHORITY_MEDIAN_PNL_BLOCKER,
         AUTHORITY_P10_PNL_BLOCKER,
         AUTHORITY_WORST_DAY_BLOCKER,
+        AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER,
         AUTHORITY_FILLED_NOTIONAL_BLOCKER,
         AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER,
     }
@@ -185,6 +192,14 @@ def build_source_proof_census(
     blockers = _census_blockers(rows, totals, ledger_report, read_error=read_error)
     missing_source_ref_categories = _missing_source_ref_categories(blockers)
     missing_requirement_categories = _missing_requirement_categories(blockers)
+    blocker_ladder = _blocker_ladder(
+        totals,
+        daily,
+        ledger_report,
+        blockers,
+        observed_stage=identity.observed_stage,
+        source_kind=source_kind,
+    )
     classification = _classify_verdict(totals, blockers)
     return {
         'schema_version': SCHEMA_VERSION,
@@ -204,6 +219,9 @@ def build_source_proof_census(
             'read_only': True,
             'writes_proof': False,
             'modifies_rows': False,
+            'runtime_stage': identity.observed_stage,
+            'replay_outputs_count_as_runtime_proof': False,
+            'synthetic_proof_created': False,
         },
         'totals': totals,
         'daily': daily,
@@ -214,10 +232,12 @@ def build_source_proof_census(
         },
         'missing_source_ref_categories': missing_source_ref_categories,
         'missing_requirement_categories': missing_requirement_categories,
+        'blocker_ladder': blocker_ladder,
         'blockers': blockers,
         'verdict': {
             'classification': classification,
             'authority_candidate_ready': classification == AUTHORITY_CANDIDATE_READY,
+            'next_blocker': _next_ladder_blocker(blocker_ladder),
             'next_action': _next_action(classification),
         },
     }
@@ -618,6 +638,223 @@ def _missing_requirement_categories(blockers: Sequence[str]) -> dict[str, bool]:
         'source_offsets': RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in blocker_set,
         'tca_cost_rows': AUTHORITY_EXPLICIT_COSTS_BLOCKER in blocker_set,
     }
+
+
+def _blocker_ladder(
+    totals: Mapping[str, object],
+    daily: Sequence[Mapping[str, object]],
+    ledger_report: Mapping[str, object],
+    blockers: Sequence[str],
+    *,
+    observed_stage: str | None,
+    source_kind: str,
+) -> list[dict[str, object]]:
+    """Return a compact, ordered read-only ladder that points at the next missing proof input."""
+
+    aggregate = _mapping(ledger_report.get('aggregate'))
+    daily_ledger = [_mapping(item) for item in _sequence(ledger_report.get('trading_days'))]
+    daily_pnl_blockers = {
+        AUTHORITY_TRADING_DAYS_BLOCKER,
+        AUTHORITY_MEAN_PNL_BLOCKER,
+        AUTHORITY_MEDIAN_PNL_BLOCKER,
+        AUTHORITY_P10_PNL_BLOCKER,
+        AUTHORITY_WORST_DAY_BLOCKER,
+        AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER,
+    }
+    return [
+        _ladder_step(
+            'decisions',
+            blockers=blockers,
+            step_blockers={
+                AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+                RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+            },
+            present=_int(totals.get('trade_decision_count')) > 0,
+            observed={
+                'source_trade_decision_count': _int(totals.get('trade_decision_count')),
+                'runtime_ledger_decision_count': _sum_daily_int(daily_ledger, 'decision_count'),
+                'observed_stage': observed_stage,
+            },
+            next_action='run the strategy through paper/live routing until durable TradeDecision rows exist',
+        ),
+        _ladder_step(
+            'executions',
+            blockers=blockers,
+            step_blockers={AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER, RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER},
+            present=_int(totals.get('filled_execution_count')) > 0,
+            observed={
+                'source_execution_count': _int(totals.get('execution_count')),
+                'source_filled_execution_count': _int(totals.get('filled_execution_count')),
+                'runtime_ledger_fill_count': _sum_daily_int(daily_ledger, 'fill_count'),
+            },
+            next_action='connect decisions to broker fills before relying on any replay-only result',
+        ),
+        _ladder_step(
+            'order_feed_lifecycle',
+            blockers=blockers,
+            step_blockers={
+                ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+                RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+            },
+            present=_int(totals.get('linked_order_event_fill_count')) > 0,
+            observed={
+                'execution_order_event_count': _int(totals.get('execution_order_event_count')),
+                'fill_lifecycle_event_count': _int(totals.get('fill_lifecycle_event_count')),
+                'linked_order_event_fill_count': _int(totals.get('linked_order_event_fill_count')),
+                'runtime_submitted_order_count': _sum_daily_int(daily_ledger, 'submitted_order_count'),
+            },
+            next_action='materialize order-feed fill lifecycle events linked to executions and decisions',
+        ),
+        _ladder_step(
+            'source_windows_and_refs',
+            blockers=blockers,
+            step_blockers=_SOURCE_REF_BLOCKERS,
+            present=_int(totals.get('source_window_count')) > 0
+            and _int(totals.get('execution_order_events_with_source_window_count'))
+            >= _int(totals.get('execution_order_event_count'))
+            and _int(totals.get('execution_order_events_with_source_offset_count'))
+            >= _int(totals.get('execution_order_event_count')),
+            observed={
+                'source_window_count': _int(totals.get('source_window_count')),
+                'events_with_source_window_count': _int(
+                    totals.get('execution_order_events_with_source_window_count')
+                ),
+                'events_with_source_offset_count': _int(totals.get('execution_order_events_with_source_offset_count')),
+                'runtime_source_authority_bucket_count': _int(totals.get('blocker_free_runtime_ledger_bucket_count')),
+            },
+            next_action='backfill runtime-ledger source windows, offsets, refs, materialization, and authority class',
+        ),
+        _ladder_step(
+            'runtime_ledger_buckets',
+            blockers=blockers,
+            step_blockers={
+                AUTHORITY_EVIDENCE_MISSING_BLOCKER,
+                AUTHORITY_READ_ERROR_BLOCKER,
+                AUTHORITY_BUCKET_BLOCKERS_PRESENT,
+            },
+            present=_int(totals.get('runtime_ledger_bucket_count')) > 0,
+            observed={
+                'runtime_ledger_bucket_count': _int(totals.get('runtime_ledger_bucket_count')),
+                'blocker_free_runtime_ledger_bucket_count': _int(
+                    totals.get('blocker_free_runtime_ledger_bucket_count')
+                ),
+                'source_kind': source_kind,
+                'read_only': True,
+                'writes_proof': False,
+            },
+            next_action='emit durable runtime-ledger buckets from paper/live runtime rows without synthetic proof',
+        ),
+        _ladder_step(
+            'closed_round_trips',
+            blockers=blockers,
+            step_blockers={AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER, AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER},
+            present=_int(totals.get('closed_trade_count')) > 0,
+            observed={
+                'closed_round_trip_count': _int(totals.get('closed_trade_count')),
+                'authority_min_closed_round_trips': _int(aggregate.get('authority_min_closed_round_trips')),
+            },
+            next_action='wait for source-backed entry and exit fills that close round trips',
+        ),
+        _ladder_step(
+            'open_positions',
+            blockers=blockers,
+            step_blockers={AUTHORITY_OPEN_POSITIONS_BLOCKER},
+            present=_int(totals.get('open_position_count')) == 0,
+            observed={'open_position_count': _int(totals.get('open_position_count'))},
+            next_action='flatten or let paper/live positions close before promotion',
+        ),
+        _ladder_step(
+            'explicit_costs',
+            blockers=blockers,
+            step_blockers={AUTHORITY_EXPLICIT_COSTS_BLOCKER, EXECUTION_ECONOMICS_MISSING_BLOCKER},
+            present=_int(totals.get('tca_cost_row_count')) > 0
+            and _int(totals.get('explicit_cost_runtime_ledger_bucket_count')) > 0,
+            observed={
+                'tca_cost_row_count': _int(totals.get('tca_cost_row_count')),
+                'explicit_cost_runtime_ledger_bucket_count': _int(
+                    totals.get('explicit_cost_runtime_ledger_bucket_count')
+                ),
+                'total_explicit_costs': _text(aggregate.get('total_explicit_costs'), default='0'),
+            },
+            next_action='record broker/TCA costs and promotion-grade runtime cost bases for every bucket',
+        ),
+        _ladder_step(
+            'filled_notional',
+            blockers=blockers,
+            step_blockers={AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER, AUTHORITY_FILLED_NOTIONAL_BLOCKER},
+            present=_decimal(totals.get('filled_notional')) > 0,
+            observed={
+                'filled_notional': _text(totals.get('filled_notional'), default='0'),
+                'buckets_with_filled_notional_count': _int(
+                    totals.get('runtime_ledger_buckets_with_filled_notional_count')
+                ),
+                'authority_min_filled_notional': _text(aggregate.get('authority_min_filled_notional'), default='0'),
+            },
+            next_action='accumulate source-backed filled notional, not replay-only simulated volume',
+        ),
+        _ladder_step(
+            'daily_post_cost_pnl',
+            blockers=blockers,
+            step_blockers=daily_pnl_blockers,
+            present=len(daily) > 0,
+            observed={
+                'trading_day_count': _int(totals.get('trading_day_count')),
+                'post_cost_pnl': _text(totals.get('post_cost_pnl'), default='0'),
+                'mean_daily_net_pnl_after_costs': _text(
+                    aggregate.get('mean_daily_net_pnl_after_costs'), default='0'
+                ),
+                'median_daily_net_pnl_after_costs': _text(
+                    aggregate.get('median_daily_net_pnl_after_costs'), default='0'
+                ),
+                'p10_daily_net_pnl_after_costs': _text(aggregate.get('p10_daily_net_pnl_after_costs'), default='0'),
+                'worst_day_net_pnl_after_costs': _text(
+                    aggregate.get('worst_day_net_pnl_after_costs'), default='0'
+                ),
+            },
+            next_action='continue source-backed paper/live runtime until post-cost daily PnL clears gates',
+        ),
+    ]
+
+
+def _ladder_step(
+    step: str,
+    *,
+    blockers: Sequence[str],
+    step_blockers: Set[str],
+    present: bool,
+    observed: Mapping[str, object],
+    next_action: str,
+) -> dict[str, object]:
+    blocker_codes = sorted(code for code in blockers if code in step_blockers)
+    if blocker_codes:
+        status = LADDER_BLOCKED
+    elif present:
+        status = LADDER_PASS
+    else:
+        status = LADDER_MISSING
+    return {
+        'step': step,
+        'status': status,
+        'observed': dict(observed),
+        'blocker_codes': blocker_codes,
+        'next_action': next_action if status != LADDER_PASS else None,
+    }
+
+
+def _next_ladder_blocker(ladder: Sequence[Mapping[str, object]]) -> dict[str, object] | None:
+    for step in ladder:
+        if step.get('status') != LADDER_PASS:
+            return {
+                'step': step.get('step'),
+                'status': step.get('status'),
+                'blocker_codes': list(_sequence(step.get('blocker_codes'))),
+                'next_action': step.get('next_action'),
+            }
+    return None
+
+
+def _sum_daily_int(daily: Sequence[Mapping[str, object]], key: str) -> int:
+    return sum(_int(item.get(key)) for item in daily)
 
 
 def _classify_verdict(totals: Mapping[str, object], blockers: Sequence[str]) -> str:

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -186,6 +186,16 @@ def _report(payload: dict[str, object]) -> dict[str, object]:
     )
 
 
+def _ladder_step(report: dict[str, object], step: str) -> dict[str, object]:
+    ladder = report['blocker_ladder']
+    assert isinstance(ladder, list)
+    for item in ladder:
+        assert isinstance(item, dict)
+        if item['step'] == step:
+            return item
+    raise AssertionError(f'missing ladder step {step}')
+
+
 def test_full_source_backed_census_is_authority_candidate_ready() -> None:
     report = _report(_fixture())
 
@@ -206,6 +216,13 @@ def test_full_source_backed_census_is_authority_candidate_ready() -> None:
     assert report['totals']['closed_trade_count'] == 400
     assert report['totals']['filled_notional'] == '12000000'
     assert report['totals']['post_cost_pnl'] == '12000'
+    assert report['source']['runtime_stage'] == 'paper'
+    assert report['source']['replay_outputs_count_as_runtime_proof'] is False
+    assert report['source']['synthetic_proof_created'] is False
+    assert report['verdict']['next_blocker'] is None
+    assert _ladder_step(report, 'source_windows_and_refs')['status'] == census.LADDER_PASS
+    assert _ladder_step(report, 'runtime_ledger_buckets')['status'] == census.LADDER_PASS
+    assert _ladder_step(report, 'daily_post_cost_pnl')['status'] == census.LADDER_PASS
 
 
 def test_missing_decisions_reports_exact_trade_decision_ref_gap() -> None:
@@ -327,6 +344,36 @@ def test_empty_fixture_has_no_source_activity_verdict() -> None:
 
     assert report['verdict']['classification'] == census.NO_SOURCE_ACTIVITY
     assert report['totals']['runtime_ledger_bucket_count'] == 0
+    assert _ladder_step(report, 'decisions')['status'] == census.LADDER_BLOCKED
+    assert report['verdict']['next_blocker'] == {
+        'step': 'decisions',
+        'status': census.LADDER_BLOCKED,
+        'blocker_codes': [
+            AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+            RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+        ],
+        'next_action': 'run the strategy through paper/live routing until durable TradeDecision rows exist',
+    }
+
+
+def test_partial_evidence_ladder_points_at_order_feed_lifecycle() -> None:
+    full = _fixture()
+    payload = {
+        'trade_decisions': full['trade_decisions'],
+        'executions': full['executions'],
+        'execution_order_events': [],
+        'execution_tca_metrics': [],
+        'order_feed_source_windows': [],
+        'runtime_ledger_buckets': [],
+    }
+
+    report = _report(payload)
+
+    assert _ladder_step(report, 'decisions')['status'] == census.LADDER_PASS
+    assert _ladder_step(report, 'executions')['status'] == census.LADDER_PASS
+    assert _ladder_step(report, 'order_feed_lifecycle')['status'] == census.LADDER_BLOCKED
+    assert report['verdict']['next_blocker']['step'] == 'order_feed_lifecycle'
+    assert census.ORDER_FEED_LIFECYCLE_MISSING_BLOCKER in report['verdict']['next_blocker']['blocker_codes']
 
 
 def test_too_few_source_backed_days_are_distribution_missing() -> None:


### PR DESCRIPTION
## Summary

- Adds a compact read-only blocker ladder to the H-PAIRS source-proof census JSON for decisions, executions, order-feed lifecycle, source refs, runtime-ledger buckets, closed round trips, open positions, explicit costs, filled notional, and daily post-cost PnL.
- Keeps live/paper runtime evidence, replay output, and proof materialization boundaries explicit without creating synthetic proof or mutating source rows.
- Extends tests to cover zero evidence, partial evidence, and source-backed runtime bucket presence.

## Related Issues

None

## Testing

- PASS: `uv run --frozen --with pytest --with hypothesis pytest tests/test_audit_hpairs_source_proof_census.py`
- PASS: `uv run --frozen --with ruff ruff check scripts/audit_hpairs_source_proof_census.py tests/test_audit_hpairs_source_proof_census.py`
- PASS: `git diff --check`
- PASS: `uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- PASS: `uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- PASS: `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen --with pyright pyright --project pyrightconfig.json`
- LOCAL ENV NOTE: `uv sync --frozen --extra dev` could not complete because this workspace lacks `cc` while building `crosshair-tool`; the focused validation above installs only the required runners with `uv --with`.

## Screenshots (if applicable)

N/A (CLI JSON diagnostics only).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
