### PR TITLE
fix(torghut): require exclusive renewal target plan

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -66,10 +66,9 @@ spec:
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \
+                    --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \
-                    --runtime-window-targets-from-latest-autoresearch \
-                    --runtime-window-targets-from-registry \
                     --runtime-window-hypothesis-id H-PAIRS-01 \
                     --runtime-window-candidate-id c88421d619759b2cfaa6f4d0 \
                     --runtime-window-strategy-family microbar_cross_sectional_pairs \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1597,11 +1597,11 @@ class TestLiveConfigManifestContract(TestCase):
             "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
-        self.assertNotIn("--runtime-window-target-plan-exclusive", args)
+        self.assertIn("--runtime-window-target-plan-exclusive", args)
         self.assertIn("--runtime-window-target-plan-required", args)
         self.assertIn("--runtime-window-target-plan-settlement-seconds 3600", args)
-        self.assertIn("--runtime-window-targets-from-latest-autoresearch", args)
-        self.assertIn("--runtime-window-targets-from-registry", args)
+        self.assertNotIn("--runtime-window-targets-from-latest-autoresearch", args)
+        self.assertNotIn("--runtime-window-targets-from-registry", args)
         self.assertIn(
             "--strategy-spec-ref microbar_cross_sectional_pairs_v1@research", args
         )


### PR DESCRIPTION
## Summary

- Requires `torghut-empirical-promotion-renewal` to use the exclusive runtime-window target-plan path.
- Removes stale autoresearch and registry fallback flags from the renewal CronJob.
- Updates the live manifest contract test so exclusive target-plan collection remains required.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`
- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut | rg -C 2 'runtime-window-target-plan-exclusive|runtime-window-targets-from'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
