### PR TITLE
fix(torghut): discard dirty paper runtime windows

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -460,6 +460,102 @@ class RuntimeWindowImportTarget:
     target_dsn_env: str = ""
 
 
+def _runtime_window_target_plan_import_blocked_result(
+    *,
+    target: RuntimeWindowImportTarget,
+    candidate_id: str,
+    manifest_path: Path,
+    window_start: datetime,
+    window_end: datetime,
+    window_selection: str,
+) -> dict[str, Any] | None:
+    target_metadata = _as_dict(target.target_metadata)
+    state = _as_text(target_metadata.get("runtime_window_import_audit_state"))
+    if state not in RUNTIME_WINDOW_TARGET_PLAN_IMPORT_BLOCKED_STATES:
+        return None
+    if not _runtime_window_target_is_paper_route_collection(
+        target=target, target_metadata=target_metadata
+    ):
+        return None
+
+    blockers = [state]
+    for key in (
+        "runtime_window_import_audit_blockers",
+        "runtime_window_import_audit_target_blockers",
+        "runtime_ledger_target_metadata_blockers",
+        "runtime_window_import_health_gate_blockers",
+        "candidate_blockers",
+    ):
+        blockers.extend(_as_text_list(target_metadata.get(key)))
+    blocker_codes = list(dict.fromkeys(blockers))
+    remediation_by_state = {
+        "import_due_account_contamination_detected": (
+            "Discard this paper window for proof, isolate the paper account, and "
+            "collect a fresh clean session before runtime-ledger import."
+        ),
+        "import_due_account_state_not_clean": (
+            "Reset or flatten the paper account, persist a clean pre-session "
+            "snapshot, and collect a fresh clean session before runtime-ledger import."
+        ),
+        "import_due_source_activity_missing": (
+            "Repair target-plan/source activity collection and collect a fresh "
+            "source-backed session before runtime-ledger import."
+        ),
+    }
+    remediation = remediation_by_state.get(
+        state,
+        "Repair the target-plan import audit blockers before runtime-ledger import.",
+    )
+    proof_blockers = [
+        {
+            "blocker": blocker,
+            "hypothesis_id": target.hypothesis_id,
+            "candidate_id": candidate_id,
+            "observed_stage": target.observed_stage,
+            "window_start": _utc_iso(window_start),
+            "window_end": _utc_iso(window_end),
+            "runtime_window_import_audit_state": state,
+            "remediation": remediation,
+        }
+        for blocker in blocker_codes
+    ]
+    return {
+        "status": "blocked",
+        "reason": f"runtime_window_target_plan_import_blocked:{state}",
+        "window_start": _utc_iso(window_start),
+        "window_end": _utc_iso(window_end),
+        "window_selection": window_selection,
+        "hypothesis_id": target.hypothesis_id,
+        "candidate_id": candidate_id,
+        "strategy_name": target.strategy_name,
+        "account_label": target.account_label,
+        "source_account_label": target.source_account_label or target.account_label,
+        "source_dsn_env": target.source_dsn_env,
+        "target_dsn_env": target.target_dsn_env,
+        "source_kind": target.source_kind,
+        "artifact_refs": [str(manifest_path), *target.artifact_refs],
+        "target_metadata": target_metadata,
+        "proof_status": "blocked",
+        "proof_blockers": proof_blockers,
+        "summary": None,
+    }
+
+
+def _runtime_window_target_is_paper_route_collection(
+    *,
+    target: RuntimeWindowImportTarget,
+    target_metadata: Mapping[str, Any],
+) -> bool:
+    source_kind = target.source_kind.strip().lower().replace("-", "_")
+    handoff = str(target_metadata.get("handoff") or "").strip()
+    return (
+        source_kind.startswith("paper_route")
+        or handoff == "next_paper_route_runtime_window_import"
+        or bool(target_metadata.get("paper_probation_authorized"))
+        or bool(_as_text_list(target_metadata.get("paper_route_probe_symbols")))
+    )
+
+
 def _parse_runtime_window_target_spec(spec: str) -> dict[str, str]:
     text = spec.strip()
     if not text:
@@ -2347,6 +2443,16 @@ def _run_runtime_window_import_target(
             "proof_blockers": proof_blockers,
             "summary": None,
         }
+    blocked_result = _runtime_window_target_plan_import_blocked_result(
+        target=target,
+        candidate_id=candidate_id,
+        manifest_path=manifest_path,
+        window_start=window_start,
+        window_end=window_end,
+        window_selection=window_selection,
+    )
+    if blocked_result is not None:
+        return blocked_result
     delay_depth_report_ref = _runtime_manifest_delay_depth_stress_report_ref(
         target=target,
         runtime_manifest=runtime_manifest,

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -2237,6 +2237,123 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertTrue(payload["summary"]["audit_only"])
         self.assertFalse(payload["summary"]["would_persist"])
 
+    def test_runtime_window_import_discards_contaminated_target_plan_window(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="c88421d619759b2cfaa6f4d0",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            target_dsn_env="SIM_DB_DSN",
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            account_label="TORGHUT_SIM",
+            source_account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            target_metadata={
+                "runtime_window_import_audit_state": (
+                    "import_due_account_contamination_detected"
+                ),
+                "runtime_window_import_audit_blockers": [
+                    "paper_route_account_contamination_detected",
+                    "unlinked_order_events_present",
+                    "foreign_order_events_present",
+                ],
+            },
+        )
+        args = SimpleNamespace(runtime_window_target_plan_settlement_seconds=3600)
+
+        with patch.object(
+            renewal.subprocess,
+            "run",
+            side_effect=AssertionError("dirty paper windows must not import"),
+        ) as run_mock:
+            payload = renewal._run_runtime_window_import_target(
+                args=args,
+                target=target,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                window_start=window_start,
+                window_end=window_end,
+                now=datetime(2026, 6, 1, 21, 5, tzinfo=timezone.utc),
+            )
+
+        run_mock.assert_not_called()
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["proof_status"], "blocked")
+        self.assertEqual(
+            payload["reason"],
+            "runtime_window_target_plan_import_blocked:"
+            "import_due_account_contamination_detected",
+        )
+        blocker_codes = [item["blocker"] for item in payload["proof_blockers"]]
+        self.assertEqual(
+            blocker_codes,
+            [
+                "import_due_account_contamination_detected",
+                "paper_route_account_contamination_detected",
+                "unlinked_order_events_present",
+                "foreign_order_events_present",
+            ],
+        )
+        self.assertIsNone(payload["summary"])
+
+    def test_runtime_window_import_blocked_result_ignores_source_collection_targets(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        window_start = datetime(2026, 5, 13, 15, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 13, 16, 0, tzinfo=timezone.utc)
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-TSMOM-LIQ-01",
+            candidate_id="ca4e6e3c7d639e3363dc5860",
+            observed_stage="paper",
+            strategy_family="intraday_tsmom",
+            source_dsn_env="SIM_DB_DSN",
+            target_dsn_env="SIM_DB_DSN",
+            strategy_name="intraday-tsmom-v2",
+            account_label="TORGHUT_REPLAY",
+            source_account_label="TORGHUT_REPLAY",
+            dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            source_manifest_ref="config/trading/hypotheses/h-tsmom-liq-01.json",
+            source_kind="runtime_ledger_source_collection_candidate",
+            delay_adjusted_depth_stress_report_ref="",
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            target_metadata={
+                "runtime_window_import_audit_state": (
+                    "import_due_account_contamination_detected"
+                ),
+                "runtime_window_import_audit_blockers": [
+                    "paper_route_account_contamination_detected",
+                ],
+                "handoff": "runtime_ledger_source_collection_import",
+            },
+        )
+
+        self.assertIsNone(
+            renewal._runtime_window_target_plan_import_blocked_result(
+                target=target,
+                candidate_id=target.candidate_id,
+                manifest_path=manifest_path,
+                window_start=window_start,
+                window_end=window_end,
+                window_selection="target_plan_window",
+            )
+        )
+
     def test_runtime_window_import_passes_probation_metadata_and_artifacts(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Stops empirical renewal from invoking runtime-window import for paper-route target-plan windows already marked dirty by the import audit.
- Returns a structured blocked renewal result with proof blockers and remediation for contaminated, account-dirty, or source-missing paper windows.
- Keeps source-collection targets from being suppressed by paper-route contamination state unless they are actually paper-route collection targets.
- Adds regression coverage for contaminated paper-window discard behavior and combined-plan source-collection safety.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'runtime_window_import_discards_contaminated_target_plan_window or runtime_window_import_blocked_result_ignores_source_collection_targets or runtime_window_target_plan_payload_marks_contaminated_import_audit or runtime_window_target_plan_payload_blocks_contaminated_import_audit_without_targets'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'account_contamination_blocks_runtime_window_import or active_window_contamination_blocks_target_plan_collection'`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
