### PR TITLE
fix(torghut): isolate paper-route contamination windows

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -268,14 +268,20 @@ def _account_contamination_audit_unavailable(
         "window_start": _isoformat(window_start),
         "window_end": _isoformat(window_end),
         "contaminated": None,
+        "order_event_count": 0,
         "unlinked_order_event_count": 0,
+        "foreign_linked_order_event_count": 0,
+        "target_linked_order_event_count": 0,
         "client_order_id_count": 0,
         "sample_client_order_ids": [],
         "symbol_counts": {},
         "event_type_counts": {},
         "status_counts": {},
+        "foreign_strategy_counts": {},
         "last_event_at": None,
+        "reason": "target_account_audit_unavailable",
         "blockers": [],
+        "sample_order_event_refs": [],
         "source_audit_blockers": [PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER],
     }
 
@@ -525,6 +531,20 @@ def _safe_decimal(value: object) -> Decimal:
     return Decimal("0")
 
 
+def _account_contamination_reason(
+    *,
+    unlinked_order_event_count: int,
+    foreign_linked_order_event_count: int,
+) -> str:
+    if unlinked_order_event_count and foreign_linked_order_event_count:
+        return "unlinked_and_foreign_account_order_events_present"
+    if unlinked_order_event_count:
+        return "unlinked_account_order_events_present"
+    if foreign_linked_order_event_count:
+        return "foreign_account_order_events_present"
+    return "target_window_account_order_events_clean"
+
+
 def _decimal_text(value: object) -> str:
     amount = _safe_decimal(value)
     text = format(amount, "f")
@@ -596,6 +616,27 @@ def _order_event_activity_timestamp() -> Any:
 
 def _order_event_activity_at(row: ExecutionOrderEvent) -> datetime | None:
     return row.event_ts or row.created_at
+
+
+def _order_event_sample_ref(row: ExecutionOrderEvent) -> dict[str, object]:
+    decision = row.trade_decision
+    strategy_name = _safe_text(
+        getattr(getattr(decision, "strategy", None), "name", None)
+    )
+    return {
+        "event_fingerprint": _safe_text(row.event_fingerprint),
+        "source_topic": _safe_text(row.source_topic),
+        "source_partition": row.source_partition,
+        "source_offset": row.source_offset,
+        "event_ts": _isoformat(_order_event_activity_at(row)),
+        "symbol": _safe_text(row.symbol),
+        "alpaca_order_id": _safe_text(row.alpaca_order_id),
+        "client_order_id": _safe_text(row.client_order_id),
+        "event_type": _safe_text(row.event_type),
+        "status": _safe_text(row.status),
+        "trade_decision_id": row.trade_decision_id,
+        "strategy_name": strategy_name,
+    }
 
 
 def _order_event_is_fill(row: ExecutionOrderEvent) -> bool:
@@ -2307,6 +2348,61 @@ def _next_paper_route_runtime_window_targets(
         clean_window_baseline_summary_state = "clean"
     else:
         clean_window_baseline_summary_state = "unknown"
+    account_contamination_items = [
+        item
+        for target in planned_targets
+        if (item := _as_mapping(target.get("paper_route_account_contamination_state")))
+    ]
+    account_contamination_blockers = sorted(
+        {
+            blocker
+            for item in account_contamination_items
+            for blocker in _unique_text_items(item.get("blockers"))
+        }
+    )
+    account_contamination_contaminated_count = sum(
+        1
+        for item in account_contamination_items
+        if bool(item.get("contaminated")) or _unique_text_items(item.get("blockers"))
+    )
+    account_contamination_clean_count = sum(
+        1
+        for item in account_contamination_items
+        if not bool(item.get("contaminated"))
+        and not _unique_text_items(item.get("blockers"))
+    )
+    account_contamination_sample_client_order_ids = _unique_text_items(
+        [
+            client_order_id
+            for item in account_contamination_items
+            for client_order_id in _as_sequence(item.get("sample_client_order_ids"))
+        ]
+    )[:10]
+    account_contamination_sample_order_event_refs: list[dict[str, Any]] = []
+    seen_account_contamination_sample_refs: set[tuple[str | None, str | None]] = set()
+    for item in account_contamination_items:
+        for raw_ref in _as_sequence(item.get("sample_order_event_refs")):
+            ref = _as_mapping(raw_ref)
+            key = (
+                _safe_text(ref.get("event_fingerprint")),
+                _safe_text(ref.get("client_order_id")),
+            )
+            if key in seen_account_contamination_sample_refs:
+                continue
+            seen_account_contamination_sample_refs.add(key)
+            account_contamination_sample_order_event_refs.append(ref)
+            if len(account_contamination_sample_order_event_refs) >= 10:
+                break
+        if len(account_contamination_sample_order_event_refs) >= 10:
+            break
+    if not account_contamination_items:
+        account_contamination_summary_state = "no_targets"
+    elif account_contamination_contaminated_count:
+        account_contamination_summary_state = "contaminated_window_discarded"
+    elif account_contamination_clean_count == len(account_contamination_items):
+        account_contamination_summary_state = "clean"
+    else:
+        account_contamination_summary_state = "unknown"
     return {
         "schema_version": NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION,
         "source": "paper_route_evidence_audit",
@@ -2399,6 +2495,32 @@ def _next_paper_route_runtime_window_targets(
             "clean_target_count": clean_window_baseline_clean_count,
             "blocked_target_count": clean_window_baseline_blocked_count,
             "blockers": clean_window_baseline_blockers,
+        },
+        "account_contamination_readiness": {
+            "schema_version": "torghut.paper-route-account-contamination-readiness-summary.v1",
+            "state": account_contamination_summary_state,
+            "target_count": len(account_contamination_items),
+            "clean_target_count": account_contamination_clean_count,
+            "contaminated_target_count": account_contamination_contaminated_count,
+            "order_event_count": sum(
+                _safe_int(item.get("order_event_count"))
+                for item in account_contamination_items
+            ),
+            "unlinked_order_event_count": sum(
+                _safe_int(item.get("unlinked_order_event_count"))
+                for item in account_contamination_items
+            ),
+            "foreign_linked_order_event_count": sum(
+                _safe_int(item.get("foreign_linked_order_event_count"))
+                for item in account_contamination_items
+            ),
+            "target_linked_order_event_count": sum(
+                _safe_int(item.get("target_linked_order_event_count"))
+                for item in account_contamination_items
+            ),
+            "blockers": account_contamination_blockers,
+            "sample_client_order_ids": account_contamination_sample_client_order_ids,
+            "sample_order_event_refs": account_contamination_sample_order_event_refs,
         },
         "paper_route_probe": {
             "configured_enabled": bool(probe.get("configured_enabled")),
@@ -3251,7 +3373,9 @@ def _account_contamination_audit(
             "status_counts": {},
             "foreign_strategy_counts": {},
             "last_event_at": None,
+            "reason": "account_label_missing",
             "blockers": [],
+            "sample_order_event_refs": [],
         }
     order_event_activity_ts = _order_event_activity_timestamp()
     strategy_filters = [name for name in strategy_lookup_names if name]
@@ -3319,6 +3443,10 @@ def _account_contamination_audit(
         status_counts[_safe_text(row.status) or "missing"] += 1
     contaminating_rows = [*unlinked_rows, *foreign_linked_rows]
     last_event_row = contaminating_rows[0] if contaminating_rows else rows[0] if rows else None
+    reason = _account_contamination_reason(
+        unlinked_order_event_count=len(unlinked_rows),
+        foreign_linked_order_event_count=len(foreign_linked_rows),
+    )
     return {
         "schema_version": "torghut.paper-route-account-contamination-audit.v1",
         "scope": "target_window_account_symbol_order_events",
@@ -3340,7 +3468,11 @@ def _account_contamination_audit(
         "last_event_at": _isoformat(
             _order_event_activity_at(last_event_row) if last_event_row is not None else None
         ),
+        "reason": reason,
         "blockers": blockers,
+        "sample_order_event_refs": [
+            _order_event_sample_ref(row) for row in contaminating_rows[:10]
+        ],
     }
 
 
@@ -4747,7 +4879,9 @@ def _evidence_window_contract(
     account_state_blockers = _unique_text_items(account_state.get("blockers"))
     if contamination_blockers:
         state = "contaminated_window_discarded"
-        reason = "unlinked_account_order_events_present"
+        reason = _safe_text(account_contamination.get("reason")) or (
+            "account_order_events_present"
+        )
     elif account_state_blockers:
         state = "clean_window_required"
         reason = "window_start_account_state_not_clean"
@@ -4782,6 +4916,10 @@ def _evidence_window_contract(
         "sample_client_order_ids": _unique_text_items(
             account_contamination.get("sample_client_order_ids")
         ),
+        "sample_order_event_refs": [
+            _as_mapping(item)
+            for item in _as_sequence(account_contamination.get("sample_order_event_refs"))
+        ],
         "sample_positions": [
             _as_mapping(item)
             for item in _as_sequence(account_state.get("sample_positions"))
@@ -5628,8 +5766,17 @@ def _runtime_window_target_blockers(
                 },
                 "account_contamination": {
                     "contaminated": bool(account_contamination.get("contaminated")),
+                    "order_event_count": _safe_int(
+                        account_contamination.get("order_event_count")
+                    ),
                     "unlinked_order_event_count": _safe_int(
                         account_contamination.get("unlinked_order_event_count")
+                    ),
+                    "foreign_linked_order_event_count": _safe_int(
+                        account_contamination.get("foreign_linked_order_event_count")
+                    ),
+                    "target_linked_order_event_count": _safe_int(
+                        account_contamination.get("target_linked_order_event_count")
                     ),
                     "client_order_id_count": _safe_int(
                         account_contamination.get("client_order_id_count")
@@ -5637,9 +5784,16 @@ def _runtime_window_target_blockers(
                     "sample_client_order_ids": _unique_text_items(
                         account_contamination.get("sample_client_order_ids")
                     ),
+                    "sample_order_event_refs": [
+                        _as_mapping(item)
+                        for item in _as_sequence(
+                            account_contamination.get("sample_order_event_refs")
+                        )
+                    ],
                     "last_event_at": _safe_text(
                         account_contamination.get("last_event_at")
                     ),
+                    "reason": _safe_text(account_contamination.get("reason")),
                 },
                 "account_state": {
                     "state": _safe_text(account_state.get("state")),

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -2395,14 +2395,13 @@ def _next_paper_route_runtime_window_targets(
                 break
         if len(account_contamination_sample_order_event_refs) >= 10:
             break
+    account_contamination_summary_state = "unknown"
     if not account_contamination_items:
         account_contamination_summary_state = "no_targets"
     elif account_contamination_contaminated_count:
         account_contamination_summary_state = "contaminated_window_discarded"
     elif account_contamination_clean_count == len(account_contamination_items):
         account_contamination_summary_state = "clean"
-    else:
-        account_contamination_summary_state = "unknown"
     return {
         "schema_version": NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION,
         "source": "paper_route_evidence_audit",
@@ -2427,11 +2426,7 @@ def _next_paper_route_runtime_window_targets(
         "session_readiness": session_readiness,
         "collection_session_readiness": {
             "schema_version": "torghut.paper-route-collection-session-readiness.v1",
-            "state": (
-                "ready"
-                if not collection_session_blockers
-                else "blocked"
-            ),
+            "state": ("ready" if not collection_session_blockers else "blocked"),
             "blockers": collection_session_blockers,
         },
         "runtime_window_import_handoff": {
@@ -3080,7 +3075,9 @@ def _strategy_source_activity(
                     )
                 ).scalars()
             )
-            tca_truncated = len(queried_tca_rows) > PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+            tca_truncated = (
+                len(queried_tca_rows) > PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+            )
             tca_rows = queried_tca_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT]
         except SQLAlchemyError as exc:
             _rollback_after_source_activity_error(
@@ -3124,7 +3121,12 @@ def _strategy_source_activity(
     if tca_sample_count <= 0 and complete_fill_order_event_count <= 0:
         missing_reasons.append("source_tca_missing")
     missing_reasons.extend(lineage_blockers)
-    if decision_truncated or execution_truncated or order_event_truncated or tca_truncated:
+    if (
+        decision_truncated
+        or execution_truncated
+        or order_event_truncated
+        or tca_truncated
+    ):
         missing_reasons.append("source_activity_readback_truncated")
     lifecycle_summary = _source_activity_lifecycle_summary(
         execution_rows=execution_rows,
@@ -3138,8 +3140,7 @@ def _strategy_source_activity(
         str(row.id) for row in execution_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
     ]
     order_lifecycle_refs = [
-        str(row.id)
-        for row in order_event_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
+        str(row.id) for row in order_event_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
     ]
     tca_metric_refs = [
         str(row.id) for row in tca_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
@@ -3215,8 +3216,7 @@ def _strategy_source_activity(
         "readback_state": readback_state,
         "stage_presence": {
             "source_decisions_present": decision_count > 0,
-            "submitted_lifecycle_present": execution_count > 0
-            or order_event_count > 0,
+            "submitted_lifecycle_present": execution_count > 0 or order_event_count > 0,
             "fills_present": filled_execution_count > 0
             or fill_order_event_count > 0
             or complete_fill_order_event_count > 0,
@@ -3442,7 +3442,9 @@ def _account_contamination_audit(
         event_type_counts[_safe_text(row.event_type) or "missing"] += 1
         status_counts[_safe_text(row.status) or "missing"] += 1
     contaminating_rows = [*unlinked_rows, *foreign_linked_rows]
-    last_event_row = contaminating_rows[0] if contaminating_rows else rows[0] if rows else None
+    last_event_row = (
+        contaminating_rows[0] if contaminating_rows else rows[0] if rows else None
+    )
     reason = _account_contamination_reason(
         unlinked_order_event_count=len(unlinked_rows),
         foreign_linked_order_event_count=len(foreign_linked_rows),
@@ -3466,7 +3468,9 @@ def _account_contamination_audit(
         "status_counts": dict(sorted(status_counts.items())),
         "foreign_strategy_counts": dict(sorted(foreign_strategy_counts.items())),
         "last_event_at": _isoformat(
-            _order_event_activity_at(last_event_row) if last_event_row is not None else None
+            _order_event_activity_at(last_event_row)
+            if last_event_row is not None
+            else None
         ),
         "reason": reason,
         "blockers": blockers,
@@ -4790,9 +4794,9 @@ def _target_evidence_readback_diagnostics(
     source_decisions_present = bool(stage_presence.get("source_decisions_present")) or (
         decision_count > 0
     )
-    submitted_lifecycle_present = bool(
-        stage_presence.get("submitted_lifecycle_present")
-    ) or execution_count > 0
+    submitted_lifecycle_present = (
+        bool(stage_presence.get("submitted_lifecycle_present")) or execution_count > 0
+    )
     fills_present = (
         bool(stage_presence.get("fills_present"))
         or filled_execution_count > 0
@@ -4831,7 +4835,9 @@ def _target_evidence_readback_diagnostics(
             ),
             *(
                 ["promotion_decision_not_allowed"]
-                if not bool(_as_mapping(promotion_decisions.get("latest")).get("allowed"))
+                if not bool(
+                    _as_mapping(promotion_decisions.get("latest")).get("allowed")
+                )
                 and _safe_int(promotion_decisions.get("decision_count")) > 0
                 else []
             ),
@@ -4853,7 +4859,9 @@ def _target_evidence_readback_diagnostics(
         "final_promotion_authority_blocked": not bool(
             target.get("final_promotion_allowed")
         ),
-        "promotion_decision_count": _safe_int(promotion_decisions.get("decision_count")),
+        "promotion_decision_count": _safe_int(
+            promotion_decisions.get("decision_count")
+        ),
         "promotion_decision_allowed_count": _safe_int(
             promotion_decisions.get("allowed_count")
         ),
@@ -4918,7 +4926,9 @@ def _evidence_window_contract(
         ),
         "sample_order_event_refs": [
             _as_mapping(item)
-            for item in _as_sequence(account_contamination.get("sample_order_event_refs"))
+            for item in _as_sequence(
+                account_contamination.get("sample_order_event_refs")
+            )
         ],
         "sample_positions": [
             _as_mapping(item)
@@ -6602,12 +6612,12 @@ def build_paper_route_evidence_audit(
     next_target_audits = [
         _target_audit_fail_closed(
             session,
-                raw_target=target,
-                probe=probe,
-                generated_at=resolved_generated_at,
-                lookback_hours=effective_lookback_hours,
-                error_source="paper_route_next_target_audit",
-            )
+            raw_target=target,
+            probe=probe,
+            generated_at=resolved_generated_at,
+            lookback_hours=effective_lookback_hours,
+            error_source="paper_route_next_target_audit",
+        )
         for target in _as_mapping_items(next_targets.get("targets"))
     ]
     runtime_window_import_plan = next_targets

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -521,12 +521,16 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 require_source_lineage=True,
             )
 
-        self.assertEqual(activity["raw_decision_count"], PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT)
+        self.assertEqual(
+            activity["raw_decision_count"], PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+        )
         self.assertEqual(
             activity["lineage_matched_decision_count"],
             PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
         )
-        self.assertEqual(len(activity["decision_refs"]), PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT)
+        self.assertEqual(
+            len(activity["decision_refs"]), PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT
+        )
         self.assertEqual(activity["readback_state"], "source_decisions_present")
         self.assertTrue(activity["stage_presence"]["source_decisions_present"])
         self.assertFalse(activity["stage_presence"]["submitted_lifecycle_present"])
@@ -6706,6 +6710,264 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(
             contamination_readiness["sample_order_event_refs"][0]["client_order_id"],
             "tsmom-AAPL-foreign-linked-1",
+        )
+
+    def test_account_contamination_summary_deduplicates_and_caps_order_event_refs(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 18, 5, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            first_strategy = Strategy(
+                name="hpairs-overlap-aapl",
+                description="overlap target fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            second_strategy = Strategy(
+                name="hpairs-overlap-pair",
+                description="overlap target pair fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            foreign_strategy = Strategy(
+                name="intraday-tsmom-overlap",
+                description="foreign paper account fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AMZN"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add_all([first_strategy, second_strategy, foreign_strategy])
+            session.flush()
+            foreign_decision = TradeDecision(
+                strategy_id=foreign_strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AMZN",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-foreign",
+                    "hypothesis_id": "H-FOREIGN",
+                },
+                rationale="foreign linked overlap contamination fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=49),
+                executed_at=window_start + timedelta(minutes=50),
+            )
+            session.add(foreign_decision)
+            session.flush()
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="overlap-foreign-amzn-event",
+                    source_topic="alpaca.trade_updates",
+                    source_partition=0,
+                    source_offset=90,
+                    alpaca_account_label="TORGHUT_SIM",
+                    event_ts=window_start + timedelta(minutes=50),
+                    symbol="AMZN",
+                    alpaca_order_id="overlap-foreign-amzn-order",
+                    client_order_id="tsmom-AMZN-foreign-overlap",
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("101"),
+                    raw_event={"source": "foreign_tsmom_strategy"},
+                    execution_id=None,
+                    trade_decision_id=foreign_decision.id,
+                )
+            )
+            for index in range(5):
+                session.add(
+                    ExecutionOrderEvent(
+                        event_fingerprint=f"overlap-unlinked-aapl-event-{index}",
+                        source_topic="alpaca.trade_updates",
+                        source_partition=0,
+                        source_offset=100 + index,
+                        alpaca_account_label="TORGHUT_SIM",
+                        event_ts=window_start + timedelta(minutes=40, seconds=index),
+                        symbol="AAPL",
+                        alpaca_order_id=f"overlap-unlinked-aapl-order-{index}",
+                        client_order_id=f"external-AAPL-overlap-{index}",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("101"),
+                        raw_event={"source": "external_unlinked_aapl"},
+                        execution_id=None,
+                        trade_decision_id=None,
+                    )
+                )
+            for index in range(5):
+                session.add(
+                    ExecutionOrderEvent(
+                        event_fingerprint=f"overlap-unlinked-amzn-event-{index}",
+                        source_topic="alpaca.trade_updates",
+                        source_partition=0,
+                        source_offset=200 + index,
+                        alpaca_account_label="TORGHUT_SIM",
+                        event_ts=window_start + timedelta(minutes=20, seconds=index),
+                        symbol="AMZN",
+                        alpaca_order_id=f"overlap-unlinked-amzn-order-{index}",
+                        client_order_id=f"external-AMZN-overlap-{index}",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("101"),
+                        raw_event={"source": "external_unlinked_amzn"},
+                        execution_id=None,
+                        trade_decision_id=None,
+                    )
+                )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
+            session.commit()
+
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": True,
+                    "continuity_reason": "signal_continuity_nominal",
+                    "drift_ok": True,
+                    "drift_reason": "drift_live_promotion_eligible",
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": (
+                            "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                        ),
+                        "target_count": "2",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-OVERLAP-AAPL",
+                                "candidate_id": "candidate-overlap-aapl",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": first_strategy.name,
+                                "strategy_id": "hpairs_overlap_aapl@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": (
+                                    "config/trading/hypotheses/overlap-aapl.json"
+                                ),
+                                "paper_route_probe_scope_authority": (
+                                    "external_target_plan"
+                                ),
+                                "paper_route_probe_symbols": ["AAPL"],
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            },
+                            {
+                                "hypothesis_id": "H-OVERLAP-PAIR",
+                                "candidate_id": "candidate-overlap-pair",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": second_strategy.name,
+                                "strategy_id": "hpairs_overlap_pair@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": (
+                                    "config/trading/hypotheses/overlap-pair.json"
+                                ),
+                                "paper_route_probe_scope_authority": (
+                                    "external_target_plan"
+                                ),
+                                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            },
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_active_symbols": ["AAPL", "AMZN"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                        "eligible_symbols": ["AAPL", "AMZN"],
+                    },
+                },
+                generated_at=now,
+            )
+
+        plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(plan["target_count"], 2)
+        first_target, second_target = plan["targets"]
+        self.assertEqual(
+            first_target["paper_route_account_contamination_state"]["reason"],
+            "unlinked_account_order_events_present",
+        )
+        self.assertEqual(
+            second_target["paper_route_account_contamination_state"]["reason"],
+            "unlinked_and_foreign_account_order_events_present",
+        )
+        contamination_readiness = plan["account_contamination_readiness"]
+        self.assertEqual(
+            contamination_readiness["state"], "contaminated_window_discarded"
+        )
+        self.assertEqual(contamination_readiness["target_count"], 2)
+        self.assertEqual(contamination_readiness["contaminated_target_count"], 2)
+        self.assertEqual(contamination_readiness["unlinked_order_event_count"], 15)
+        self.assertEqual(contamination_readiness["foreign_linked_order_event_count"], 1)
+        sample_refs = contamination_readiness["sample_order_event_refs"]
+        self.assertEqual(len(sample_refs), 10)
+        sample_keys = {
+            (item["event_fingerprint"], item["client_order_id"]) for item in sample_refs
+        }
+        self.assertEqual(len(sample_keys), 10)
+        self.assertNotIn(
+            ("overlap-foreign-amzn-event", "tsmom-AMZN-foreign-overlap"),
+            sample_keys,
+        )
+        self.assertEqual(
+            sum(
+                1
+                for item in sample_refs
+                if str(item["event_fingerprint"]).startswith(
+                    "overlap-unlinked-aapl-event"
+                )
+            ),
+            5,
+        )
+        self.assertEqual(
+            sum(
+                1
+                for item in sample_refs
+                if str(item["event_fingerprint"]).startswith(
+                    "overlap-unlinked-amzn-event"
+                )
+            ),
+            5,
         )
 
     def test_account_window_start_positions_block_runtime_window_import(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -27,6 +27,7 @@ from app.trading.paper_route_evidence import (
     PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT,
     PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
     RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
+    _account_contamination_reason,
     _account_pre_session_snapshot_audit,
     _account_window_start_snapshot_audit,
     _balanced_pair_probe_symbol_actions,
@@ -69,6 +70,17 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
         self.assertEqual(actions, {"AAPL": "buy", "AMZN": "sell"})
         self.assertEqual(_pair_probe_balance_state(actions), "balanced")
+
+    def test_account_contamination_reason_reports_mixed_foreign_and_unlinked(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _account_contamination_reason(
+                unlinked_order_event_count=1,
+                foreign_linked_order_event_count=1,
+            ),
+            "unlinked_and_foreign_account_order_events_present",
+        )
 
     def test_balanced_pair_probe_accepts_explicit_true_and_short_alias(self) -> None:
         actions = _balanced_pair_probe_symbol_actions(
@@ -1464,6 +1476,79 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(clean_readiness["state"], "clean")
         self.assertEqual(clean_readiness["clean_target_count"], 1)
         self.assertEqual(clean_readiness["blockers"], [])
+
+    def test_older_contaminated_window_does_not_poison_later_clean_target_window(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 26, 13, 35, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="paper-route-candidate-v1",
+                    description="clean isolated target window source strategy",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                )
+            )
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="older-contaminated-window-aapl-fill",
+                    source_topic="alpaca.trade_updates",
+                    source_partition=0,
+                    source_offset=41,
+                    alpaca_account_label="TORGHUT_SIM",
+                    event_ts=window_start - timedelta(days=1),
+                    symbol="AAPL",
+                    alpaca_order_id="older-contaminated-order-1",
+                    client_order_id="intraday-tsmom-AAPL-older-contamination-1",
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("101"),
+                    raw_event={"source": "older_intraday_tsmom_window"},
+                    execution_id=None,
+                    trade_decision_id=None,
+                )
+            )
+            self._add_account_position_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                as_of=window_start - timedelta(minutes=5),
+                positions=[],
+            )
+            session.commit()
+
+            payload = self._build_basic_paper_route_target_plan(
+                session,
+                generated_at=generated_at,
+            )
+
+        plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        contamination = target["paper_route_account_contamination_state"]
+        self.assertFalse(contamination["contaminated"])
+        self.assertEqual(contamination["order_event_count"], 0)
+        self.assertEqual(contamination["unlinked_order_event_count"], 0)
+        self.assertEqual(contamination["sample_client_order_ids"], [])
+        self.assertEqual(contamination["sample_order_event_refs"], [])
+        contamination_readiness = plan["account_contamination_readiness"]
+        self.assertEqual(contamination_readiness["state"], "clean")
+        self.assertEqual(contamination_readiness["clean_target_count"], 1)
+        self.assertEqual(contamination_readiness["contaminated_target_count"], 0)
+        self.assertEqual(contamination_readiness["unlinked_order_event_count"], 0)
+        self.assertEqual(contamination_readiness["blockers"], [])
+        self.assertEqual(
+            target["paper_route_clean_window_state"], "clean_window_collection_ready"
+        )
+        self.assertTrue(target["evidence_collection_ok"])
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
 
     def test_target_account_audit_unavailable_blocks_collection_readiness(
         self,
@@ -6276,15 +6361,27 @@ class TestPaperRouteEvidenceAudit(TestCase):
             contamination["sample_client_order_ids"],
             ["autonomous-trader-AAPL-cover-external-1"],
         )
+        self.assertEqual(
+            contamination["reason"], "unlinked_account_order_events_present"
+        )
+        self.assertEqual(
+            contamination["sample_order_event_refs"][0]["event_fingerprint"],
+            "external-autonomous-trader-order-event",
+        )
         self.assertIn(
             "paper_route_account_contamination_detected",
             audit["readiness"]["blockers"],
         )
         contract = audit["evidence_window_contract"]
         self.assertEqual(contract["state"], "contaminated_window_discarded")
+        self.assertEqual(contract["reason"], "unlinked_account_order_events_present")
         self.assertFalse(contract["proof_allowed"])
         self.assertFalse(contract["promotion_allowed"])
         self.assertFalse(contract["final_promotion_allowed"])
+        self.assertEqual(
+            contract["sample_order_event_refs"][0]["client_order_id"],
+            "autonomous-trader-AAPL-cover-external-1",
+        )
         import_audit = payload["runtime_window_import_audit"]
         self.assertEqual(
             import_audit["state"], "import_due_account_contamination_detected"
@@ -6303,6 +6400,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "client_order_id_count"
             ],
             1,
+        )
+        self.assertEqual(
+            import_audit["target_blockers"][0]["account_contamination"][
+                "sample_order_event_refs"
+            ][0]["event_fingerprint"],
+            "external-autonomous-trader-order-event",
         )
         target_plan_import_audit = target_plan_payload["runtime_window_import_audit"]
         self.assertEqual(
@@ -6427,6 +6530,22 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertIn(
             "unlinked_order_events_present",
             target["bounded_evidence_collection_blockers"],
+        )
+        contamination_readiness = payload["next_paper_route_runtime_window_targets"][
+            "account_contamination_readiness"
+        ]
+        self.assertEqual(
+            contamination_readiness["state"], "contaminated_window_discarded"
+        )
+        self.assertEqual(contamination_readiness["contaminated_target_count"], 1)
+        self.assertEqual(contamination_readiness["unlinked_order_event_count"], 1)
+        self.assertEqual(
+            contamination_readiness["sample_client_order_ids"],
+            ["autonomous-trader-AAPL-cover-active-1"],
+        )
+        self.assertEqual(
+            contamination_readiness["sample_order_event_refs"][0]["event_fingerprint"],
+            "active-external-autonomous-trader-event",
         )
 
     def test_active_window_foreign_linked_order_events_block_target_plan_collection(
@@ -6564,10 +6683,29 @@ class TestPaperRouteEvidenceAudit(TestCase):
             contamination["foreign_strategy_counts"],
             {"intraday-tsmom-profit-v3": 1},
         )
+        self.assertEqual(
+            contamination["reason"], "foreign_account_order_events_present"
+        )
+        self.assertEqual(
+            contamination["sample_order_event_refs"][0]["strategy_name"],
+            "intraday-tsmom-profit-v3",
+        )
         self.assertFalse(target["evidence_collection_ok"])
         self.assertIn(
             "foreign_order_events_present",
             target["bounded_evidence_collection_blockers"],
+        )
+        contamination_readiness = payload["next_paper_route_runtime_window_targets"][
+            "account_contamination_readiness"
+        ]
+        self.assertEqual(
+            contamination_readiness["state"], "contaminated_window_discarded"
+        )
+        self.assertEqual(contamination_readiness["contaminated_target_count"], 1)
+        self.assertEqual(contamination_readiness["foreign_linked_order_event_count"], 1)
+        self.assertEqual(
+            contamination_readiness["sample_order_event_refs"][0]["client_order_id"],
+            "tsmom-AAPL-foreign-linked-1",
         )
 
     def test_account_window_start_positions_block_runtime_window_import(


### PR DESCRIPTION
## Summary

- Adds explicit paper-route account contamination readback reasons, sample order-event references, and plan-level contamination readiness counters.
- Keeps clean target-scoped windows eligible for bounded evidence collection while contaminated active windows are marked `contaminated_window_discarded`.
- Extends H-PAIRS regression coverage for older-window isolation, active unlinked contamination, and foreign linked strategy contamination without enabling final promotion authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_simple_pipeline.py tests/test_verify_trading_readiness.py tests/test_run_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
