### PR TITLE
fix(torghut): mark bounded paper targets proof eligible

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -33,6 +33,7 @@ from ..models import (
 )
 from .runtime_cost_authority import cost_basis_counts_have_non_promotion_grade_costs
 from .runtime_decision_authority import (
+    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
     ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
     normalize_source_decision_mode,
     source_decision_mode_is_profit_proof_eligible,
@@ -2054,6 +2055,15 @@ def _next_paper_route_runtime_window_targets(
             and _safe_decimal(next_notional) > 0
             and bool(target_probe_symbols)
         )
+        bounded_collection_authorized = bool(canary_collection_authorized)
+        source_decision_mode = (
+            BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+            if bounded_collection_authorized
+            else ROUTE_ACQUISITION_SOURCE_DECISION_MODE
+        )
+        profit_proof_eligible = source_decision_mode_is_profit_proof_eligible(
+            source_decision_mode
+        )
         planned_target: dict[str, object] = {
             "hypothesis_id": hypothesis_id,
             "candidate_id": candidate_id,
@@ -2181,8 +2191,10 @@ def _next_paper_route_runtime_window_targets(
             "canary_collection_authorized": canary_collection_authorized,
             "capital_promotion_allowed": False,
             "final_authority_ok": False,
-            "bounded_evidence_collection_authorized": canary_collection_authorized,
-            "bounded_live_paper_collection_authorized": (canary_collection_authorized),
+            "bounded_evidence_collection_authorized": bounded_collection_authorized,
+            "bounded_live_paper_collection_authorized": (
+                bounded_collection_authorized
+            ),
             "bounded_evidence_collection_scope": (
                 "paper_route_probe_next_session_only"
             ),
@@ -2193,8 +2205,9 @@ def _next_paper_route_runtime_window_targets(
             "probation_reason": "paper_route_probe_next_session_runtime_window",
             "selection_reason": "paper_route_probe_next_session_evidence_collection",
             "selected_by": "paper_route_evidence_audit",
-            "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
-            "profit_proof_eligible": False,
+            "source_decision_mode": source_decision_mode,
+            "source_decision_mode_profit_proof_eligible": profit_proof_eligible,
+            "profit_proof_eligible": profit_proof_eligible,
             "promotion_allowed": False,
             "final_promotion_authorized": False,
             "final_promotion_allowed": False,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1474,6 +1474,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(target["paper_route_clean_window_baseline_blockers"], [])
         self.assertTrue(target["evidence_collection_ok"])
         self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(
+            target["source_decision_mode"], "bounded_paper_route_collection"
+        )
+        self.assertTrue(target["source_decision_mode_profit_proof_eligible"])
+        self.assertTrue(target["profit_proof_eligible"])
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_allowed"])
         clean_readiness = plan["clean_window_baseline_readiness"]
@@ -1551,6 +1556,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertTrue(target["evidence_collection_ok"])
         self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(
+            target["source_decision_mode"], "bounded_paper_route_collection"
+        )
+        self.assertTrue(target["source_decision_mode_profit_proof_eligible"])
+        self.assertTrue(target["profit_proof_eligible"])
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_allowed"])
 
@@ -1607,6 +1617,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(target["canary_collection_authorized"])
         self.assertFalse(target["bounded_evidence_collection_authorized"])
         self.assertFalse(target["bounded_live_paper_collection_authorized"])
+        self.assertEqual(target["source_decision_mode"], "route_acquisition_probe")
+        self.assertFalse(target["source_decision_mode_profit_proof_eligible"])
+        self.assertFalse(target["profit_proof_eligible"])
         self.assertEqual(plan["target_account_audit_readiness"]["state"], "unavailable")
 
     def test_clean_baseline_allows_collection_when_health_gate_blocks_promotion(
@@ -1697,6 +1710,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertTrue(target["evidence_collection_ok"])
         self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(
+            target["source_decision_mode"], "bounded_paper_route_collection"
+        )
+        self.assertTrue(target["source_decision_mode_profit_proof_eligible"])
+        self.assertTrue(target["profit_proof_eligible"])
         self.assertIn("evidence_continuity_not_ok", target["candidate_blockers"])
         self.assertIn(
             "evidence_continuity_not_ok",
@@ -2994,8 +3012,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target["source_collection_reason_codes"],
             ["source_window_evidence_collection_pending"],
         )
-        self.assertEqual(target["source_decision_mode"], "route_acquisition_probe")
-        self.assertFalse(target["profit_proof_eligible"])
+        self.assertEqual(
+            target["source_decision_mode"], "bounded_paper_route_collection"
+        )
+        self.assertTrue(target["source_decision_mode_profit_proof_eligible"])
+        self.assertTrue(target["profit_proof_eligible"])
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_authorized"])
         self.assertFalse(target["final_promotion_allowed"])
@@ -3017,9 +3038,10 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertTrue(summary_target["pair_balance_required"])
         self.assertEqual(summary_target["pair_balance_state"], "balanced")
         self.assertEqual(
-            summary_target["source_decision_mode"], "route_acquisition_probe"
+            summary_target["source_decision_mode"],
+            "bounded_paper_route_collection",
         )
-        self.assertFalse(summary_target["profit_proof_eligible"])
+        self.assertTrue(summary_target["profit_proof_eligible"])
 
     def test_hpairs_next_window_requires_aapl_amzn_pair_legs(self) -> None:
         generated_at = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

- Marks clean bounded paper-route collection targets with `bounded_paper_route_collection` source-decision mode.
- Exposes `source_decision_mode_profit_proof_eligible` and `profit_proof_eligible` only when bounded collection is actually authorized.
- Keeps blocked or unavailable collection targets in `route_acquisition_probe` mode with proof eligibility disabled.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'flat_clean_baseline_allows_bounded_collection_readiness or older_contaminated_window_does_not_poison_later_clean_target_window or target_account_audit_unavailable_blocks_collection_readiness or clean_baseline_allows_collection_when_health_gate_blocks_promotion or hpairs_next_window_scopes_probe_symbols_to_strategy_universe'`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_submission_council.py -k source_decision_mode_profit_proof_scope_is_bounded_paper_only`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
