### PR TITLE
fix(torghut): fail closed on stale TigerBeetle reconciliation

### DIFF
--- a/docs/torghut/tigerbeetle-ledger-design.md
+++ b/docs/torghut/tigerbeetle-ledger-design.md
@@ -90,11 +90,26 @@ tigerbeetle_transfer_missing
 tigerbeetle_transfer_amount_mismatch
 tigerbeetle_transfer_code_mismatch
 tigerbeetle_transfer_ledger_mismatch
+tigerbeetle_transfer_debit_account_mismatch
+tigerbeetle_transfer_credit_account_mismatch
+tigerbeetle_postgres_ref_mismatch
+tigerbeetle_source_row_missing
+tigerbeetle_source_amount_mismatch
+tigerbeetle_runtime_ledger_direction_mismatch
+tigerbeetle_runtime_ledger_metadata_mismatch
+tigerbeetle_runtime_ledger_signed_refs_missing
+tigerbeetle_runtime_ledger_account_refs_missing
 tigerbeetle_unlinked_order_event
+tigerbeetle_unlinked_execution
+tigerbeetle_unlinked_execution_cost
+tigerbeetle_unlinked_runtime_ledger
 tigerbeetle_client_unavailable
+tigerbeetle_reconciliation_stale
 ```
 
-Readiness may fail closed on protocol or reconciliation blockers only when the corresponding `TORGHUT_TIGERBEETLE_REQUIRED` or `TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED` flag is enabled.
+Readiness may fail closed on protocol or reconciliation blockers only when the corresponding `TORGHUT_TIGERBEETLE_REQUIRED` or `TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED` flag is enabled. Stale reconciliation is explicit: `TORGHUT_TIGERBEETLE_RECONCILE_MAX_AGE_SECONDS` bounds the age of the latest reconciliation row, readiness reports the measured age, and stale rows produce `tigerbeetle_reconciliation_stale`.
+
+TigerBeetle evidence is supplementary durability/accounting evidence. It never sets `proof_authority` or `promotion_authority` by itself; final promotion still requires source-backed runtime-ledger/live-paper post-cost proof from the broker/order-feed/runtime sources.
 
 ## Production Topology
 

--- a/docs/torghut/tigerbeetle-ledger-runbook.md
+++ b/docs/torghut/tigerbeetle-ledger-runbook.md
@@ -58,7 +58,7 @@ For HTTP checks, inspect:
 - `/trading/health`: same readiness dependency payload
 - `/trading/status`: top-level `tigerbeetle_ledger`
 
-Optional protocol failures do not make Torghut unready while `TORGHUT_TIGERBEETLE_REQUIRED=false`. If `TORGHUT_TIGERBEETLE_REQUIRED=true`, protocol failure becomes a readiness blocker. If `TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED=true`, missing or degraded reconciliation becomes a readiness blocker.
+Optional protocol failures do not make Torghut unready while `TORGHUT_TIGERBEETLE_REQUIRED=false`. If `TORGHUT_TIGERBEETLE_REQUIRED=true`, protocol failure becomes a readiness blocker. If `TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED=true`, missing, degraded, or stale reconciliation becomes a readiness blocker. Staleness is controlled by `TORGHUT_TIGERBEETLE_RECONCILE_MAX_AGE_SECONDS` (default `3600`) and is exposed as `reconciliation_age_seconds`, `reconciliation_max_age_seconds`, `reconciliation_stale`, and the `tigerbeetle_reconciliation_stale` blocker.
 
 ## Reconciliation Semantics
 
@@ -76,8 +76,23 @@ Reconciliation blockers are proof blockers, not profitability claims:
 - `tigerbeetle_transfer_amount_mismatch`
 - `tigerbeetle_transfer_code_mismatch`
 - `tigerbeetle_transfer_ledger_mismatch`
+- `tigerbeetle_transfer_debit_account_mismatch`
+- `tigerbeetle_transfer_credit_account_mismatch`
+- `tigerbeetle_postgres_ref_mismatch`
+- `tigerbeetle_source_row_missing`
+- `tigerbeetle_source_amount_mismatch`
+- `tigerbeetle_runtime_ledger_direction_mismatch`
+- `tigerbeetle_runtime_ledger_metadata_mismatch`
+- `tigerbeetle_runtime_ledger_signed_refs_missing`
+- `tigerbeetle_runtime_ledger_account_refs_missing`
 - `tigerbeetle_unlinked_order_event`
+- `tigerbeetle_unlinked_execution`
+- `tigerbeetle_unlinked_execution_cost`
+- `tigerbeetle_unlinked_runtime_ledger`
 - `tigerbeetle_client_unavailable`
+- `tigerbeetle_reconciliation_stale`
+
+The journal job emits stable JSON with schema version `torghut.tigerbeetle-journal-order-events.v1`, top-level `ok`/`status`, per-source batch counts, sampled errors, and the reconciliation payload so proof packets and readiness readback can distinguish durable ledger evidence from degraded or stale ledger parity.
 
 ## Rollout Checklist
 

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -306,6 +306,14 @@ class Settings(BaseSettings):
         alias="TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED",
         description="Fail readiness when TigerBeetle reconciliation has blockers.",
     )
+    tigerbeetle_reconcile_max_age_seconds: int = Field(
+        default=3600,
+        alias="TORGHUT_TIGERBEETLE_RECONCILE_MAX_AGE_SECONDS",
+        description=(
+            "Maximum age of the latest TigerBeetle reconciliation run before "
+            "readiness marks ledger parity stale."
+        ),
+    )
     apca_api_key_id: Optional[str] = Field(default=None, alias="APCA_API_KEY_ID")
     apca_api_secret_key: Optional[str] = Field(
         default=None, alias="APCA_API_SECRET_KEY"
@@ -2660,6 +2668,10 @@ class Settings(BaseSettings):
             raise ValueError("TORGHUT_TIGERBEETLE_CLUSTER_ID must be > 0")
         if self.tigerbeetle_health_timeout_seconds <= 0:
             raise ValueError("TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS must be > 0")
+        if self.tigerbeetle_reconcile_max_age_seconds <= 0:
+            raise ValueError(
+                "TORGHUT_TIGERBEETLE_RECONCILE_MAX_AGE_SECONDS must be > 0"
+            )
         if self.tigerbeetle_enabled and not self.tigerbeetle_replica_addresses:
             raise ValueError(
                 "TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES is required when TigerBeetle is enabled"

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -180,6 +180,7 @@ from .trading.simulation_progress import (
 from .trading.time_source import trading_time_status
 from .trading.tigerbeetle_client import check_tigerbeetle_health
 from .trading.tigerbeetle_reconcile import (
+    BLOCKER_RECONCILIATION_STALE,
     latest_tigerbeetle_reconciliation_payload,
     tigerbeetle_ref_counts,
 )
@@ -547,6 +548,7 @@ def _readiness_dependency_cache_key(include_database_contract: bool) -> str:
             settings.tigerbeetle_enabled,
             settings.tigerbeetle_required,
             settings.tigerbeetle_reconcile_required,
+            settings.tigerbeetle_reconcile_max_age_seconds,
         )
     )
     return f"readyz:{trading_mode}:{cache_mode}:{int(include_database_contract)}:{tigerbeetle_mode}"
@@ -5471,12 +5473,35 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
             blockers.append("tigerbeetle_reconciliation_missing")
     else:
         reconciliation_ok = bool(latest_reconciliation.get("ok"))
+        reconciliation_age_seconds = _tigerbeetle_status_int(
+            latest_reconciliation.get("age_seconds")
+        )
+        reconciliation_max_age_seconds = max(
+            1,
+            int(settings.tigerbeetle_reconcile_max_age_seconds),
+        )
+        if reconciliation_age_seconds > reconciliation_max_age_seconds:
+            reconciliation_ok = False
+            blockers.append(BLOCKER_RECONCILIATION_STALE)
         raw_blockers = latest_reconciliation.get("blockers")
         if isinstance(raw_blockers, Sequence) and not isinstance(
             raw_blockers, (str, bytes, bytearray)
         ):
             blocker_items = cast(Sequence[object], raw_blockers)
             blockers.extend(str(item) for item in blocker_items)
+    reconciliation_age_seconds = (
+        _tigerbeetle_status_int(latest_reconciliation.get("age_seconds"))
+        if latest_reconciliation is not None
+        else None
+    )
+    reconciliation_max_age_seconds = max(
+        1,
+        int(settings.tigerbeetle_reconcile_max_age_seconds),
+    )
+    reconciliation_stale = (
+        reconciliation_age_seconds is not None
+        and reconciliation_age_seconds > reconciliation_max_age_seconds
+    )
     if runtime_ledger_missing_signed_ref_count:
         reconciliation_ok = False
         blockers.append("tigerbeetle_runtime_ledger_signed_refs_missing")
@@ -5500,6 +5525,9 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
         "ok": protocol_gate_ok and reconcile_gate_ok,
         "protocol_ok": bool(protocol.get("protocol_ok")),
         "reconciliation_ok": reconciliation_ok,
+        "reconciliation_age_seconds": reconciliation_age_seconds,
+        "reconciliation_max_age_seconds": reconciliation_max_age_seconds,
+        "reconciliation_stale": reconciliation_stale,
         "cluster_id": settings.tigerbeetle_cluster_id,
         "replica_addresses": protocol.get("replica_addresses", []),
         "last_error": protocol.get("last_error"),

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -72,6 +72,7 @@ BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING = (
     "tigerbeetle_runtime_ledger_account_refs_missing"
 )
 BLOCKER_CLIENT_UNAVAILABLE = "tigerbeetle_client_unavailable"
+BLOCKER_RECONCILIATION_STALE = "tigerbeetle_reconciliation_stale"
 SAMPLE_LIMIT = 50
 
 
@@ -281,14 +282,18 @@ def _payload_int(payload: Mapping[str, object], key: str) -> int:
 
 def _payload_string_list(payload: Mapping[str, object], key: str) -> list[str]:
     value = payload.get(key)
-    if isinstance(value, Sequence) and not isinstance(
-        value, (str, bytes, bytearray)
-    ):
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         items = cast(Sequence[object], value)
         return [str(item) for item in items if item is not None]
     if value is None:
         return []
     return [str(value)]
+
+
+def _as_aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _uuid_or_none(value: str | None) -> UUID | None:
@@ -476,9 +481,7 @@ def _runtime_ledger_ref_coverage(
         if ref.runtime_ledger_bucket_id is not None or ref.source_id
     }
     runtime_source_ids = [
-        str(ref.source_id)
-        for ref in runtime_refs
-        if ref.source_id is not None
+        str(ref.source_id) for ref in runtime_refs if ref.source_id is not None
     ][:sample_limit]
     runtime_transfer_ids = [str(ref.transfer_id) for ref in runtime_refs][:sample_limit]
     runtime_account_ids: list[str] = []
@@ -656,18 +659,27 @@ def _latest_run_payload(
         "runtime_ledger_signed_ref_count",
     ) or _payload_int(ref_counts, "runtime_ledger_signed_ref_count")
     source_row_missing_count = _payload_int(payload, "source_row_missing_count")
-    missing_source_row_count = _payload_int(
-        payload,
-        "missing_source_row_count",
-    ) or source_row_missing_count
+    missing_source_row_count = (
+        _payload_int(
+            payload,
+            "missing_source_row_count",
+        )
+        or source_row_missing_count
+    )
     mismatched_ref_count = _payload_int(payload, "mismatched_ref_count") or int(
         row.mismatched_transfer_count
+    )
+    observed_at = _as_aware_utc(row.finished_at or row.started_at)
+    age_seconds = max(
+        0,
+        int((datetime.now(timezone.utc) - observed_at).total_seconds()),
     )
     return {
         "schema_version": SCHEMA_VERSION,
         "ok": row.status == "ok",
         "cluster_id": row.cluster_id,
         "status": row.status,
+        "age_seconds": age_seconds,
         "account_ref_count": account_ref_count,
         "transfer_ref_count": transfer_ref_count,
         "checked_transfer_count": row.checked_transfer_count,

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -374,6 +374,8 @@ def _payload(
     )
     status = "ok" if failed == 0 and reconciliation_ok else "degraded"
     return {
+        "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
+        "ok": status == "ok",
         "status": status,
         "fail_on_degraded": bool(args.fail_on_degraded),
         "dry_run": bool(args.dry_run),

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -644,6 +644,11 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
 
         payload = json.loads(stdout.getvalue())
         self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            payload["schema_version"],
+            "torghut.tigerbeetle-journal-order-events.v1",
+        )
+        self.assertTrue(payload["ok"])
         self.assertEqual(payload["journaled"], 4)
         self.assertEqual(payload["failed"], 0)
         self.assertEqual(FakeJournal.instances[0].events, ["selected"])

--- a/services/torghut/tests/test_tigerbeetle_status.py
+++ b/services/torghut/tests/test_tigerbeetle_status.py
@@ -37,11 +37,15 @@ class TestTigerBeetleStatus(TestCase):
         self._orig_required = settings.tigerbeetle_required
         self._orig_journal_enabled = settings.tigerbeetle_journal_enabled
         self._orig_reconcile_required = settings.tigerbeetle_reconcile_required
+        self._orig_reconcile_max_age_seconds = (
+            settings.tigerbeetle_reconcile_max_age_seconds
+        )
         self._orig_timeout = settings.tigerbeetle_health_timeout_seconds
         settings.tigerbeetle_enabled = False
         settings.tigerbeetle_required = False
         settings.tigerbeetle_journal_enabled = False
         settings.tigerbeetle_reconcile_required = False
+        settings.tigerbeetle_reconcile_max_age_seconds = 3600
         settings.tigerbeetle_health_timeout_seconds = 1.0
 
     def tearDown(self) -> None:
@@ -49,6 +53,9 @@ class TestTigerBeetleStatus(TestCase):
         settings.tigerbeetle_required = self._orig_required
         settings.tigerbeetle_journal_enabled = self._orig_journal_enabled
         settings.tigerbeetle_reconcile_required = self._orig_reconcile_required
+        settings.tigerbeetle_reconcile_max_age_seconds = (
+            self._orig_reconcile_max_age_seconds
+        )
         settings.tigerbeetle_health_timeout_seconds = self._orig_timeout
 
     def test_disabled_tigerbeetle_status_is_non_blocking(self) -> None:
@@ -271,3 +278,45 @@ class TestTigerBeetleStatus(TestCase):
         latest_reconciliation = payload["latest_reconciliation"]
         assert isinstance(latest_reconciliation, dict)
         self.assertEqual(latest_reconciliation["ref_counts"], {"transfer_ref_count": 1})
+
+    def test_stale_reconciliation_is_fail_closed_when_required(self) -> None:
+        settings.tigerbeetle_enabled = True
+        settings.tigerbeetle_reconcile_required = True
+        settings.tigerbeetle_reconcile_max_age_seconds = 60
+        health = TigerBeetleHealth(
+            enabled=True,
+            required=False,
+            ok=True,
+            cluster_id=2001,
+            replica_addresses=["tb:3000"],
+            last_error=None,
+        )
+        stale_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            session.add(
+                TigerBeetleReconciliationRun(
+                    cluster_id=2001,
+                    started_at=stale_at,
+                    finished_at=stale_at,
+                    status="ok",
+                    checked_transfer_count=1,
+                    missing_transfer_count=0,
+                    mismatched_transfer_count=0,
+                    source_missing_count=0,
+                    payload_json={
+                        "blockers": [],
+                        "ref_counts": {"transfer_ref_count": 1},
+                    },
+                )
+            )
+            session.flush()
+            with patch("app.main.check_tigerbeetle_health", return_value=health):
+                payload = _build_tigerbeetle_ledger_status(session)
+
+        self.assertFalse(payload["ok"])
+        self.assertFalse(payload["reconciliation_ok"])
+        self.assertTrue(payload["reconciliation_stale"])
+        self.assertGreater(payload["reconciliation_age_seconds"], 60)
+        self.assertEqual(payload["reconciliation_max_age_seconds"], 60)
+        self.assertIn("tigerbeetle_reconciliation_stale", payload["blockers"])


### PR DESCRIPTION
## Summary

- Adds `TORGHUT_TIGERBEETLE_RECONCILE_MAX_AGE_SECONDS` and fail-closed readiness metadata for stale TigerBeetle reconciliation.
- Exposes reconciliation age/max/stale status plus the `tigerbeetle_reconciliation_stale` blocker in Torghut TigerBeetle readiness/status payloads.
- Adds a stable schema/`ok` surface to the TigerBeetle journal job JSON and documents the full reconciliation blocker vocabulary.
- Reinforces that TigerBeetle ledger refs are supplementary durability/accounting evidence, not proof or promotion authority by themselves.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed after installing the missing system compiler needed to build `crosshair-tool` in this workspace.
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_client.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_status.py tests/test_verify_tigerbeetle_ledger.py tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_runtime_ledger_parity.py -q` — passed, 125 tests.
- `cd services/torghut && uv run --frozen ruff check app/config.py app/main.py app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_status.py tests/test_journal_tigerbeetle_order_events.py` — passed.
- `cd services/torghut && uv run --frozen ruff format --check app/config.py app/main.py app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_status.py tests/test_journal_tigerbeetle_order_events.py` — passed after formatting `app/trading/tigerbeetle_reconcile.py`.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed, 0 errors.
- `git diff --check` — passed.

## Screenshots (if applicable)

N/A — backend readiness, script JSON, and documentation changes only.

## Breaking Changes

None. The new reconciliation max-age setting defaults to 3600 seconds and only fails readiness when TigerBeetle reconciliation is required.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
