### PR TITLE
fix(torghut): expose runtime ledger profit distance

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -141,6 +141,10 @@ from .trading.paper_route_evidence import (
 from .trading.runtime_cost_authority import (
     cost_basis_counts_have_non_promotion_grade_costs,
 )
+from .trading.runtime_ledger_source_authority import (
+    build_runtime_ledger_profit_distance_readback,
+    runtime_ledger_promotion_source_authority_blockers,
+)
 from .trading.proof_floor import build_profitability_proof_floor_receipt
 from .trading.quality_adjusted_profit_frontier import (
     build_quality_adjusted_profit_frontier,
@@ -2659,6 +2663,12 @@ def trading_status() -> dict[str, object]:
         llm_evaluation = _load_llm_evaluation(session)
         tca_summary = _load_tca_summary(session, scheduler=scheduler)
         tigerbeetle_ledger = _build_tigerbeetle_ledger_status(session)
+        runtime_ledger_portfolio_summary = _daily_runtime_ledger_portfolio_summary(
+            session=session,
+            account_label=settings.trading_account_label,
+            stage_scope="live" if settings.trading_mode == "live" else "paper",
+            observed_at=datetime.now(timezone.utc),
+        )
     market_context_status = scheduler.market_context_status()
     hypothesis_payload, hypothesis_summary, hypothesis_dependency_quorum = (
         _build_hypothesis_runtime_payload(
@@ -2952,6 +2962,12 @@ def trading_status() -> dict[str, object]:
         "running": state.running,
         "live_submission_gate": live_submission_gate,
         "tigerbeetle_ledger": tigerbeetle_ledger,
+        "portfolio_runtime_ledger_summary": runtime_ledger_portfolio_summary,
+        "runtime_ledger_profit_distance_readback": (
+            runtime_ledger_portfolio_summary.get(
+                "runtime_ledger_profit_distance_readback"
+            )
+        ),
         "profit_lease_projection": live_submission_gate.get("profit_lease_projection"),
         "proof_floor": proof_floor,
         "renewal_bond_profit_escrow": renewal_bond_profit_escrow,
@@ -3924,6 +3940,7 @@ def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> b
         and not cost_basis_counts_have_non_promotion_grade_costs(
             payload_json.get("cost_basis_counts")
         )
+        and not runtime_ledger_promotion_source_authority_blockers(payload_json)
         and not blockers
     )
 
@@ -4015,6 +4032,58 @@ def _daily_runtime_ledger_portfolio_summary(
         (row.filled_notional for row in evidence_rows),
         Decimal("0"),
     )
+    closed_trade_count = sum(
+        max(0, int(row.closed_trade_count or 0)) for row in evidence_rows
+    )
+    open_position_count = sum(
+        max(0, int(row.open_position_count or 0)) for row in evidence_rows
+    )
+    source_authority_blockers: list[str] = []
+    source_authority_bucket_count = 0
+    for row in rows:
+        raw_payload = cast(object, row.payload_json)
+        payload = (
+            {
+                str(key): item
+                for key, item in cast(Mapping[object, object], raw_payload).items()
+            }
+            if isinstance(raw_payload, Mapping)
+            else {}
+        )
+        row_source_blockers = runtime_ledger_promotion_source_authority_blockers(
+            payload
+        )
+        if row_source_blockers:
+            for blocker in row_source_blockers:
+                if blocker not in source_authority_blockers:
+                    source_authority_blockers.append(blocker)
+        else:
+            source_authority_bucket_count += 1
+    net_pnl_by_day = {
+        day_start.date().isoformat(): str(net_pnl),
+    }
+    filled_notional_by_day = {
+        day_start.date().isoformat(): str(filled_notional),
+    }
+    daily_summary = {
+        "runtime_ledger_observed_trading_day_count": 1 if rows else 0,
+        "runtime_ledger_net_pnl_by_trading_day": net_pnl_by_day if rows else {},
+        "runtime_ledger_mean_daily_net_pnl_after_costs": str(net_pnl),
+        "runtime_ledger_median_daily_net_pnl_after_costs": str(net_pnl),
+        "runtime_ledger_p10_daily_net_pnl_after_costs": str(net_pnl),
+        "runtime_ledger_worst_day_net_pnl_after_costs": str(net_pnl),
+        "runtime_ledger_max_intraday_drawdown": "0",
+        "runtime_ledger_avg_daily_filled_notional": str(filled_notional),
+        "runtime_ledger_filled_notional_by_trading_day": filled_notional_by_day
+        if rows
+        else {},
+        "runtime_ledger_closed_trade_count_by_day": {
+            day_start.date().isoformat(): closed_trade_count,
+        }
+        if rows
+        else {},
+        "runtime_ledger_filled_notional": str(filled_notional),
+    }
     candidate_ids = sorted(
         {
             str(row.candidate_id).strip()
@@ -4027,6 +4096,22 @@ def _daily_runtime_ledger_portfolio_summary(
         blockers.append("portfolio_runtime_ledger_summary_missing")
     elif not evidence_rows:
         blockers.append("portfolio_runtime_ledger_summary_not_evidence_grade")
+    for blocker in source_authority_blockers:
+        if blocker not in blockers:
+            blockers.append(blocker)
+    profit_distance_readback = build_runtime_ledger_profit_distance_readback(
+        summary=daily_summary,
+        candidate_id=",".join(candidate_ids) if candidate_ids else None,
+        observed_stage=stage if stage in {"paper", "live"} else None,
+        runtime_ledger_bucket_count=len(rows),
+        evidence_grade_runtime_ledger_bucket_count=len(evidence_rows),
+        source_authority_bucket_count=source_authority_bucket_count,
+        source_authority_blockers=source_authority_blockers,
+        blockers=blockers,
+        total_filled_notional=filled_notional,
+        total_closed_trade_count=closed_trade_count,
+        open_position_count=open_position_count,
+    )
     return {
         "summary_basis": "runtime_ledger_daily_stage_account_scope",
         "day_start": day_start.isoformat(),
@@ -4040,6 +4125,11 @@ def _daily_runtime_ledger_portfolio_summary(
         "evidence_grade_bucket_count": len(evidence_rows),
         "post_cost_net_pnl_per_day": str(net_pnl),
         "filled_notional": str(filled_notional),
+        "closed_trade_count": closed_trade_count,
+        "open_position_count": open_position_count,
+        "source_authority_bucket_count": source_authority_bucket_count,
+        "source_authority_blockers": source_authority_blockers,
+        "runtime_ledger_profit_distance_readback": profit_distance_readback,
         "candidate_ids": candidate_ids,
         "db_row_refs": [str(row.id) for row in evidence_rows],
         "blockers": blockers,

--- a/services/torghut/app/trading/completion.py
+++ b/services/torghut/app/trading/completion.py
@@ -1,3 +1,4 @@
+# fmt: off
 """Traceability helpers for doc 29 completion gates."""
 
 from __future__ import annotations
@@ -28,7 +29,10 @@ from .runtime_cost_authority import (
     is_non_promotion_grade_runtime_cost_basis,
 )
 from .runtime_ledger import POST_COST_PNL_BASIS
-from .runtime_ledger_source_authority import runtime_ledger_promotion_source_authority_blockers
+from .runtime_ledger_source_authority import (
+    build_runtime_ledger_profit_distance_readback,
+    runtime_ledger_promotion_source_authority_blockers,
+)
 
 
 def _runtime_matrix_path() -> Path:
@@ -751,27 +755,33 @@ def _runtime_ledger_bucket_summary(
     total_cost_amount = sum((row.cost_amount for row in rows), Decimal('0'))
     cost_basis_counts: dict[str, int] = {}
     source_authority_blockers: list[str] = []
+    source_authority_bucket_count = 0
     for row in rows:
         payload = _runtime_ledger_bucket_promotion_payload(row)
+        row_source_authority_blockers = runtime_ledger_promotion_source_authority_blockers(payload)
+        if not row_source_authority_blockers:
+            source_authority_bucket_count += 1
         for cost_basis, count in _as_dict(payload.get('cost_basis_counts')).items():
             key = _as_text(cost_basis)
             if key is None:
                 continue
             cost_basis_counts[key] = cost_basis_counts.get(key, 0) + _safe_int(count)
-        for blocker in runtime_ledger_promotion_source_authority_blockers(payload):
+        for blocker in row_source_authority_blockers:
             if blocker not in source_authority_blockers:
                 source_authority_blockers.append(blocker)
     expectancy_bps = (
         float((total_net_pnl / total_filled_notional) * Decimal('10000')) if total_filled_notional > 0 else 0.0
     )
     daily_summary = _runtime_ledger_daily_summary(rows)
+    closed_trade_count = sum(max(0, _safe_int(row.closed_trade_count)) for row in rows)
+    open_position_count = sum(max(0, _safe_int(row.open_position_count)) for row in rows)
     return {
         'runtime_ledger_bucket_count': len(rows),
         'runtime_ledger_fill_count': sum(max(0, _safe_int(row.fill_count)) for row in rows),
         'runtime_ledger_submitted_order_count': sum(max(0, _safe_int(row.submitted_order_count)) for row in rows),
-        'runtime_ledger_closed_trade_count': sum(max(0, _safe_int(row.closed_trade_count)) for row in rows),
-        'runtime_ledger_closed_round_trip_count': sum(max(0, _safe_int(row.closed_trade_count)) for row in rows),
-        'runtime_ledger_open_position_count': sum(max(0, _safe_int(row.open_position_count)) for row in rows),
+        'runtime_ledger_closed_trade_count': closed_trade_count,
+        'runtime_ledger_closed_round_trip_count': closed_trade_count,
+        'runtime_ledger_open_position_count': open_position_count,
         'runtime_ledger_filled_notional': float(total_filled_notional),
         'runtime_ledger_cost_amount': float(total_cost_amount),
         'runtime_ledger_cost_basis_counts': cost_basis_counts,
@@ -787,11 +797,26 @@ def _runtime_ledger_bucket_summary(
                 if (schema_version := _as_text(row.ledger_schema_version)) is not None
             }
         ),
-        'runtime_ledger_source_authority_bucket_count': len(rows)
-        if not source_authority_blockers
-        else 0,
+        'runtime_ledger_source_authority_bucket_count': source_authority_bucket_count,
         'runtime_ledger_source_authority_blockers': source_authority_blockers,
         'runtime_ledger_authority_blockers': [],
+        'runtime_ledger_profit_distance_readback': build_runtime_ledger_profit_distance_readback(
+            summary={
+                **daily_summary,
+                'runtime_ledger_filled_notional': str(total_filled_notional),
+            },
+            candidate_id=_as_text(rows[0].candidate_id) if rows else None,
+            observed_stage=_as_text(rows[0].observed_stage) if rows else None,
+            runtime_ledger_bucket_count=len(rows),
+            evidence_grade_runtime_ledger_bucket_count=sum(
+                1 for row in rows if _runtime_ledger_bucket_is_promotion_grade(row)
+            ),
+            source_authority_bucket_count=source_authority_bucket_count,
+            source_authority_blockers=source_authority_blockers,
+            total_filled_notional=total_filled_notional,
+            total_closed_trade_count=closed_trade_count,
+            open_position_count=open_position_count,
+        ),
         **daily_summary,
         'db_row_refs': [str(row.id) for row in rows],
     }
@@ -842,6 +867,9 @@ def _runtime_ledger_daily_summary(
         ),
         'runtime_ledger_max_intraday_drawdown': str(max_intraday_drawdown),
         'runtime_ledger_avg_daily_filled_notional': str(avg_daily_filled_notional),
+        'runtime_ledger_filled_notional_by_trading_day': {
+            day: str(filled_notional_by_day[day]) for day in trading_days
+        },
         'runtime_ledger_closed_trade_count_by_day': {day: closed_trade_count_by_day[day] for day in trading_days},
     }
 

--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -384,7 +384,9 @@ def _filled_notional_present(bucket: Mapping[str, object]) -> bool:
 def _explicit_cost_basis_present(bucket: Mapping[str, object]) -> bool:
     if is_non_promotion_grade_runtime_cost_basis(bucket.get("cost_basis")):
         return False
-    if cost_basis_counts_have_non_promotion_grade_costs(bucket.get("cost_basis_counts")):
+    if cost_basis_counts_have_non_promotion_grade_costs(
+        bucket.get("cost_basis_counts")
+    ):
         return False
     if cost_basis_counts_have_non_promotion_grade_costs(
         bucket.get("post_cost_basis_counts")
@@ -395,13 +397,16 @@ def _explicit_cost_basis_present(bucket: Mapping[str, object]) -> bool:
     )
     if _positive_mapping_value_count(cost_basis_counts) > 0:
         return True
-    return _text(
-        bucket.get("cost_basis")
-        or bucket.get("cost_source")
-        or bucket.get("fee_basis")
-        or bucket.get("commission_basis")
-        or bucket.get("broker_fee_basis")
-    ) is not None
+    return (
+        _text(
+            bucket.get("cost_basis")
+            or bucket.get("cost_source")
+            or bucket.get("fee_basis")
+            or bucket.get("commission_basis")
+            or bucket.get("broker_fee_basis")
+        )
+        is not None
+    )
 
 
 def _explicit_cost_amount_present(bucket: Mapping[str, object]) -> bool:
@@ -565,16 +570,20 @@ def runtime_ledger_promotion_source_authority_blockers(
     if _source_window_gap_count(bucket) > 0:
         blockers.append(ORDER_FEED_SOURCE_WINDOW_GAP_BLOCKER)
     lifecycle_complete = _truthy_flag(bucket.get("order_feed_lifecycle_complete"))
-    if lifecycle_complete is False or _source_window_classification_count(
-        bucket,
-        "unlinked_execution",
-        "unlinked_decision",
-        "missing_order_identity",
-        "missing_trade_update_payload",
-        "malformed_json",
-        "out_of_scope_account",
-        "failed_unhandled",
-    ) > 0:
+    if (
+        lifecycle_complete is False
+        or _source_window_classification_count(
+            bucket,
+            "unlinked_execution",
+            "unlinked_decision",
+            "missing_order_identity",
+            "missing_trade_update_payload",
+            "malformed_json",
+            "out_of_scope_account",
+            "failed_unhandled",
+        )
+        > 0
+    ):
         blockers.append(ORDER_FEED_LIFECYCLE_MISSING_BLOCKER)
     economics_complete = _truthy_flag(bucket.get("execution_economics_complete"))
     economics_required = _truthy_flag(
@@ -585,15 +594,13 @@ def runtime_ledger_promotion_source_authority_blockers(
         economics_required is True and not _execution_economics_present(bucket)
     ):
         blockers.append(EXECUTION_ECONOMICS_MISSING_BLOCKER)
-    if (
-        not _promotion_grade_source_materialization_present(bucket)
-        or _non_promotion_authority_marker_present(bucket.get("source_materialization"))
-    ):
+    if not _promotion_grade_source_materialization_present(
+        bucket
+    ) or _non_promotion_authority_marker_present(bucket.get("source_materialization")):
         blockers.append(RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER)
-    if (
-        not _promotion_grade_authority_marker_present(bucket)
-        or _non_promotion_derivation_present(bucket)
-    ):
+    if not _promotion_grade_authority_marker_present(
+        bucket
+    ) or _non_promotion_derivation_present(bucket):
         blockers.append(RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER)
     return list(dict.fromkeys(blockers))
 
@@ -602,6 +609,214 @@ def runtime_ledger_promotion_source_authority_present(
     bucket: Mapping[str, object],
 ) -> bool:
     return not runtime_ledger_promotion_source_authority_blockers(bucket)
+
+
+def _decimal_or_zero(value: object) -> Decimal:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return Decimal("0")
+    return parsed if parsed.is_finite() else Decimal("0")
+
+
+def _decimal_text(value: Decimal) -> str:
+    text = format(value, "f")
+    return text.rstrip("0").rstrip(".") if "." in text else text
+
+
+def _mapping_text_decimal(value: object) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        str(key): _decimal_text(_decimal_or_zero(item))
+        for key, item in cast(Mapping[object, object], value).items()
+    }
+
+
+def _mapping_text_int(value: object) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        str(key): _nonnegative_int(item)
+        for key, item in cast(Mapping[object, object], value).items()
+    }
+
+
+def _unique_texts(value: Sequence[str] | object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    items: list[str] = []
+    for item in cast(Sequence[object], value):
+        text = _text(item)
+        if text is not None and text not in items:
+            items.append(text)
+    return items
+
+
+def _append_unique(items: list[str], additions: Sequence[str]) -> None:
+    for item in additions:
+        text = _text(item)
+        if text is not None and text not in items:
+            items.append(text)
+
+
+def build_runtime_ledger_profit_distance_readback(
+    *,
+    summary: Mapping[str, object],
+    candidate_id: str | None = None,
+    observed_stage: str | None = None,
+    required_daily_net_pnl: Decimal = Decimal("500"),
+    runtime_ledger_bucket_count: int = 0,
+    evidence_grade_runtime_ledger_bucket_count: int = 0,
+    source_authority_bucket_count: int = 0,
+    source_authority_blockers: Sequence[str] = (),
+    blockers: Sequence[str] = (),
+    total_filled_notional: Decimal | None = None,
+    total_closed_trade_count: int | None = None,
+    open_position_count: int | None = None,
+) -> dict[str, object]:
+    """Build a row-backed distance-to-authority readback for operators.
+
+    This helper intentionally reports distance and blockers only. It does not
+    grant authority; callers still need their strict source-backed gates.
+    """
+
+    mean_daily_net_pnl = _decimal_or_zero(
+        summary.get("runtime_ledger_mean_daily_net_pnl_after_costs")
+    )
+    median_daily_net_pnl = _decimal_or_zero(
+        summary.get("runtime_ledger_median_daily_net_pnl_after_costs")
+    )
+    p10_daily_net_pnl = _decimal_or_zero(
+        summary.get("runtime_ledger_p10_daily_net_pnl_after_costs")
+    )
+    worst_day_net_pnl = _decimal_or_zero(
+        summary.get("runtime_ledger_worst_day_net_pnl_after_costs")
+    )
+    max_drawdown = _decimal_or_zero(summary.get("runtime_ledger_max_intraday_drawdown"))
+    avg_daily_filled_notional = _decimal_or_zero(
+        summary.get("runtime_ledger_avg_daily_filled_notional")
+    )
+    resolved_total_filled_notional = (
+        total_filled_notional
+        if total_filled_notional is not None
+        else _decimal_or_zero(summary.get("runtime_ledger_filled_notional"))
+    )
+    resolved_closed_trade_count = (
+        total_closed_trade_count
+        if total_closed_trade_count is not None
+        else _nonnegative_int(summary.get("runtime_ledger_closed_trade_count"))
+    )
+    resolved_open_position_count = (
+        open_position_count
+        if open_position_count is not None
+        else _nonnegative_int(summary.get("runtime_ledger_open_position_count"))
+    )
+    missing_daily_net_pnl = max(
+        Decimal("0"),
+        required_daily_net_pnl - mean_daily_net_pnl,
+    )
+    missing_median_daily_net_pnl = max(
+        Decimal("0"),
+        required_daily_net_pnl - median_daily_net_pnl,
+    )
+    missing_p10_daily_net_pnl = max(
+        Decimal("0"),
+        required_daily_net_pnl - p10_daily_net_pnl,
+    )
+    missing_worst_day_net_pnl = max(
+        Decimal("0"),
+        required_daily_net_pnl - worst_day_net_pnl,
+    )
+    resolved_blockers = _unique_texts(blockers)
+    resolved_source_blockers = _unique_texts(source_authority_blockers)
+    _append_unique(resolved_blockers, resolved_source_blockers)
+    if runtime_ledger_bucket_count <= 0:
+        _append_unique(resolved_blockers, ["runtime_ledger_rows_missing"])
+    if source_authority_bucket_count < runtime_ledger_bucket_count:
+        _append_unique(resolved_blockers, ["runtime_ledger_source_authority_blocked"])
+    if resolved_open_position_count > 0:
+        _append_unique(resolved_blockers, ["runtime_ledger_open_positions_present"])
+    if mean_daily_net_pnl < required_daily_net_pnl:
+        _append_unique(
+            resolved_blockers,
+            ["runtime_ledger_mean_daily_net_pnl_after_costs_below_target"],
+        )
+    next_blocking_reason = resolved_blockers[0] if resolved_blockers else None
+    symbol_concentration = {
+        "share": summary.get("runtime_ledger_symbol_concentration_share"),
+        "basis": summary.get("runtime_ledger_symbol_concentration_basis"),
+        "net_pnl_by_symbol": _mapping_text_decimal(
+            summary.get("runtime_ledger_net_pnl_by_symbol")
+        ),
+    }
+    drawdown: dict[str, object] = {"absolute": _decimal_text(max_drawdown)}
+    drawdown_pct = summary.get("runtime_ledger_drawdown_pct_equity")
+    if drawdown_pct is not None:
+        drawdown["percent_equity"] = _decimal_text(_decimal_or_zero(drawdown_pct))
+        drawdown["percent_equity_source"] = summary.get(
+            "runtime_ledger_drawdown_pct_equity_source"
+        )
+    return {
+        "schema_version": "torghut.runtime-ledger-profit-distance-readback.v1",
+        "candidate_id": candidate_id,
+        "observed_stage": observed_stage,
+        "required_daily_net_pnl": _decimal_text(required_daily_net_pnl),
+        "observed_mean_daily_net_pnl": _decimal_text(mean_daily_net_pnl),
+        "observed_median_daily_net_pnl": _decimal_text(median_daily_net_pnl),
+        "observed_p10_daily_net_pnl": _decimal_text(p10_daily_net_pnl),
+        "observed_worst_day_net_pnl": _decimal_text(worst_day_net_pnl),
+        "daily_post_cost_distribution": _mapping_text_decimal(
+            summary.get("runtime_ledger_net_pnl_by_trading_day")
+        ),
+        "max_drawdown": drawdown,
+        "best_day_share": (
+            _decimal_text(
+                _decimal_or_zero(summary.get("runtime_ledger_best_day_share"))
+            )
+            if summary.get("runtime_ledger_best_day_share") is not None
+            else None
+        ),
+        "symbol_concentration": symbol_concentration,
+        "pair_concentration": symbol_concentration,
+        "filled_notional": {
+            "total": _decimal_text(resolved_total_filled_notional),
+            "average_daily": _decimal_text(avg_daily_filled_notional),
+            "by_trading_day": _mapping_text_decimal(
+                summary.get("runtime_ledger_filled_notional_by_trading_day")
+            ),
+        },
+        "closed_trade_count": resolved_closed_trade_count,
+        "closed_trade_count_by_day": _mapping_text_int(
+            summary.get("runtime_ledger_closed_trade_count_by_day")
+        ),
+        "open_position_count": resolved_open_position_count,
+        "source_authority": {
+            "bucket_count": runtime_ledger_bucket_count,
+            "evidence_grade_bucket_count": evidence_grade_runtime_ledger_bucket_count,
+            "source_backed_bucket_count": source_authority_bucket_count,
+            "blocked_bucket_count": max(
+                0,
+                runtime_ledger_bucket_count - source_authority_bucket_count,
+            ),
+            "blockers": resolved_source_blockers,
+        },
+        "blockers": resolved_blockers,
+        "missing_to_target": {
+            "daily_net_pnl": _decimal_text(missing_daily_net_pnl),
+            "median_daily_net_pnl": _decimal_text(missing_median_daily_net_pnl),
+            "p10_daily_net_pnl": _decimal_text(missing_p10_daily_net_pnl),
+            "worst_day_net_pnl": _decimal_text(missing_worst_day_net_pnl),
+            "source_authority_bucket_count": max(
+                0,
+                runtime_ledger_bucket_count - source_authority_bucket_count,
+            ),
+        },
+        "next_blocking_reason": next_blocking_reason,
+        "authority_readback_state": "blocked"
+        if resolved_blockers
+        else "distance_satisfied",
+    }
 
 
 __all__ = [
@@ -617,6 +832,7 @@ __all__ = [
     "RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER",
     "RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER",
     "RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER",
+    "build_runtime_ledger_profit_distance_readback",
     "runtime_ledger_promotion_source_authority_blockers",
     "runtime_ledger_promotion_source_authority_present",
     "runtime_ledger_source_authority_blockers",

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -47,6 +47,7 @@ from .runtime_decision_authority import (
 )
 from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
 from .runtime_ledger_source_authority import (
+    build_runtime_ledger_profit_distance_readback,
     runtime_ledger_promotion_source_authority_blockers,
 )
 from .tigerbeetle_journal import (
@@ -1462,6 +1463,8 @@ def _runtime_window_import_readback_from_rows(
     metric_rows: Sequence[StrategyHypothesisMetricWindow],
     promotion_rows: Sequence[StrategyPromotionDecision],
     ledger_rows: Sequence[StrategyRuntimeLedgerBucket],
+    runtime_ledger_daily_summary: Mapping[str, Any],
+    proof_blocker_codes: Sequence[str],
 ) -> dict[str, Any]:
     evidence_grade_ledger_rows = [
         row
@@ -1472,8 +1475,19 @@ def _runtime_window_import_readback_from_rows(
     authority_classes: list[str] = []
     source_materializations: list[str] = []
     blockers: list[str] = []
+    source_authority_blockers: list[str] = []
+    source_authority_bucket_count = 0
     for row in ledger_rows:
         payload_json = _mapping(row.payload_json)
+        row_source_blockers = runtime_ledger_promotion_source_authority_blockers(
+            payload_json
+        )
+        if row_source_blockers:
+            for blocker in row_source_blockers:
+                if blocker not in source_authority_blockers:
+                    source_authority_blockers.append(blocker)
+        else:
+            source_authority_bucket_count += 1
         for ref in _string_list(payload_json.get("source_refs")):
             if ref not in source_refs:
                 source_refs.append(ref)
@@ -1542,6 +1556,31 @@ def _runtime_window_import_readback_from_rows(
         "authority_classes": authority_classes,
         "source_materializations": source_materializations,
         "runtime_ledger_blockers": blockers,
+        "runtime_ledger_profit_distance_readback": build_runtime_ledger_profit_distance_readback(
+            summary={
+                **runtime_ledger_daily_summary,
+                "runtime_ledger_filled_notional": str(
+                    sum((row.filled_notional for row in ledger_rows), Decimal("0"))
+                ),
+            },
+            candidate_id=candidate_id,
+            observed_stage=observed_stage,
+            runtime_ledger_bucket_count=len(ledger_rows),
+            evidence_grade_runtime_ledger_bucket_count=len(evidence_grade_ledger_rows),
+            source_authority_bucket_count=source_authority_bucket_count,
+            source_authority_blockers=source_authority_blockers,
+            blockers=[*blockers, *proof_blocker_codes],
+            total_filled_notional=sum(
+                (row.filled_notional for row in ledger_rows),
+                Decimal("0"),
+            ),
+            total_closed_trade_count=sum(
+                max(0, int(row.closed_trade_count or 0)) for row in ledger_rows
+            ),
+            open_position_count=sum(
+                max(0, int(row.open_position_count or 0)) for row in ledger_rows
+            ),
+        ),
     }
 
 
@@ -2274,6 +2313,9 @@ def _runtime_ledger_daily_summary_from_observed_buckets(
         ),
         "runtime_ledger_max_intraday_drawdown": str(max_intraday_drawdown),
         "runtime_ledger_avg_daily_filled_notional": str(avg_daily_filled_notional),
+        "runtime_ledger_filled_notional_by_trading_day": {
+            day: str(filled_notional_by_day[day]) for day in trading_days
+        },
         "runtime_ledger_closed_trade_count_by_day": {
             day: closed_trade_count_by_day[day] for day in trading_days
         },
@@ -2912,7 +2954,23 @@ def persist_observed_runtime_windows(
         metric_rows=metric_window_rows,
         promotion_rows=[promotion_decision_row],
         ledger_rows=runtime_ledger_rows,
+        runtime_ledger_daily_summary=runtime_ledger_daily_summary,
+        proof_blocker_codes=[
+            str(item.get("blocker"))
+            for item in proof_blockers
+            if str(item.get("blocker") or "").strip()
+        ],
     )
+    runtime_ledger_profit_distance_readback = cast(
+        dict[str, Any],
+        runtime_import_readback.get("runtime_ledger_profit_distance_readback") or {},
+    )
+    promotion_decision_row.payload_json = {
+        **_mapping(promotion_decision_row.payload_json),
+        "runtime_ledger_profit_distance_readback": (
+            runtime_ledger_profit_distance_readback
+        ),
+    }
     runtime_materialization_target.update(
         {
             "proof_status": proof_status,
@@ -2920,6 +2978,9 @@ def persist_observed_runtime_windows(
             "materialized": not proof_blockers,
             "materialization_blockers": materialization_blockers,
             "readback": runtime_import_readback,
+            "runtime_ledger_profit_distance_readback": (
+                runtime_ledger_profit_distance_readback
+            ),
             **materialization_counts,
             "metric_window_ids": [str(row.id) for row in metric_window_rows],
             "promotion_decision_id": str(promotion_decision_row.id),
@@ -2961,6 +3022,9 @@ def persist_observed_runtime_windows(
         "runtime_ledger_filled_notional": str(runtime_ledger_filled_notional),
         "runtime_ledger_net_strategy_pnl_after_costs": str(
             runtime_ledger_net_strategy_pnl_after_costs
+        ),
+        "runtime_ledger_profit_distance_readback": (
+            runtime_ledger_profit_distance_readback
         ),
         **runtime_ledger_daily_summary,
         "latest_three_within_budget": latest_three_budget_ok,

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1012,6 +1012,16 @@ def _runtime_import_target_materialization_ref(
             ),
             "source_refs": _text_list(readback.get("source_refs")),
         }
+        profit_distance_readback = _mapping(
+            readback.get("runtime_ledger_profit_distance_readback")
+        )
+        if profit_distance_readback:
+            ref["readback"]["runtime_ledger_profit_distance_readback"] = dict(
+                profit_distance_readback
+            )
+            ref["runtime_ledger_profit_distance_readback"] = dict(
+                profit_distance_readback
+            )
     if tigerbeetle_refs:
         ref["tigerbeetle"] = tigerbeetle_refs
     return {key: value for key, value in ref.items() if value not in ("", [], None)}

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -284,6 +284,38 @@ def _runtime_import(
             ]
             if authoritative
             else [],
+            "runtime_ledger_profit_distance_readback": {
+                "schema_version": "torghut.runtime-ledger-profit-distance-readback.v1",
+                "required_daily_net_pnl": "500",
+                "observed_mean_daily_net_pnl": "650" if authoritative else "0",
+                "observed_median_daily_net_pnl": "650" if authoritative else "0",
+                "observed_p10_daily_net_pnl": "650" if authoritative else "0",
+                "observed_worst_day_net_pnl": "650" if authoritative else "0",
+                "daily_post_cost_distribution": {
+                    "2026-05-26": "650" if authoritative else "0"
+                },
+                "max_drawdown": {"absolute": "0"},
+                "best_day_share": "1" if authoritative else None,
+                "symbol_concentration": {"share": None, "basis": None},
+                "pair_concentration": {"share": None, "basis": None},
+                "filled_notional": {
+                    "total": "50000" if authoritative else "0",
+                    "average_daily": "50000" if authoritative else "0",
+                    "by_trading_day": {"2026-05-26": "50000" if authoritative else "0"},
+                },
+                "closed_trade_count": 1 if authoritative else 0,
+                "open_position_count": 0,
+                "source_authority": {
+                    "bucket_count": 1 if authoritative else 0,
+                    "evidence_grade_bucket_count": 1 if authoritative else 0,
+                    "source_backed_bucket_count": 1 if authoritative else 0,
+                    "blocked_bucket_count": 0,
+                    "blockers": [],
+                },
+                "blockers": [],
+                "missing_to_target": {"daily_net_pnl": "0" if authoritative else "500"},
+                "next_blocking_reason": None,
+            },
         }
     if authoritative:
         target_payload["tigerbeetle"] = {
@@ -2099,6 +2131,12 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 "postgres:execution_order_events",
                 "postgres:order_feed_source_windows",
             ],
+        )
+        self.assertEqual(
+            materialization["materialized_targets"][0][
+                "runtime_ledger_profit_distance_readback"
+            ]["observed_mean_daily_net_pnl"],
+            "650",
         )
 
     def test_packet_blocks_authority_when_runtime_import_readback_missing(self) -> None:

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -1,3 +1,4 @@
+# fmt: off
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -27,6 +28,7 @@ from app.trading.completion import (
     _p10_decimal,
     _runtime_ledger_bucket_matches_window,
     _runtime_ledger_bucket_refs_for_windows,
+    _runtime_ledger_bucket_summary,
     _runtime_ledger_daily_summary,
     _runtime_ledger_trading_day_key,
     build_completion_trace,
@@ -765,9 +767,109 @@ class TestCompletionTrace(TestCase):
         self.assertEqual(summary['runtime_ledger_max_intraday_drawdown'], '130')
         self.assertEqual(summary['runtime_ledger_avg_daily_filled_notional'], '800')
         self.assertEqual(
+            summary['runtime_ledger_filled_notional_by_trading_day'],
+            {'2026-03-06': '1500', '2026-03-09': '100'},
+        )
+        self.assertEqual(
             summary['runtime_ledger_closed_trade_count_by_day'],
             {'2026-03-06': 2, '2026-03-09': 0},
         )
+
+    def test_runtime_ledger_bucket_summary_readback_blocks_empty_rows(self) -> None:
+        summary = _runtime_ledger_bucket_summary([])
+
+        readback = summary['runtime_ledger_profit_distance_readback']
+        self.assertEqual(readback['required_daily_net_pnl'], '500')
+        self.assertEqual(readback['observed_mean_daily_net_pnl'], '0')
+        self.assertEqual(readback['source_authority']['bucket_count'], 0)
+        self.assertIn('runtime_ledger_rows_missing', readback['blockers'])
+        self.assertEqual(readback['authority_readback_state'], 'blocked')
+
+    def test_runtime_ledger_bucket_summary_readback_blocks_aggregate_only_rows(
+        self,
+    ) -> None:
+        row = _runtime_ledger_bucket(
+            run_id='aggregate-only',
+            bucket_started_at=datetime(2026, 3, 6, 14, 30),
+            bucket_ended_at=datetime(2026, 3, 6, 15, 0),
+            payload_json={'source': 'aggregate-window-import'},
+        )
+        row.net_strategy_pnl_after_costs = Decimal('800')
+
+        summary = _runtime_ledger_bucket_summary([row])
+
+        readback = summary['runtime_ledger_profit_distance_readback']
+        self.assertEqual(readback['observed_mean_daily_net_pnl'], '800')
+        self.assertEqual(readback['source_authority']['source_backed_bucket_count'], 0)
+        self.assertEqual(readback['missing_to_target']['daily_net_pnl'], '0')
+        self.assertEqual(
+            readback['missing_to_target']['source_authority_bucket_count'],
+            1,
+        )
+        self.assertIn('runtime_ledger_source_authority_blocked', readback['blockers'])
+        self.assertEqual(readback['authority_readback_state'], 'blocked')
+
+    def test_runtime_ledger_bucket_summary_readback_reports_pnl_distance(
+        self,
+    ) -> None:
+        row = _runtime_ledger_bucket(
+            run_id='source-backed-insufficient',
+            bucket_started_at=datetime(2026, 3, 6, 14, 30),
+            bucket_ended_at=datetime(2026, 3, 6, 15, 0),
+        )
+        row.net_strategy_pnl_after_costs = Decimal('120')
+
+        summary = _runtime_ledger_bucket_summary([row])
+
+        readback = summary['runtime_ledger_profit_distance_readback']
+        self.assertEqual(readback['source_authority']['source_backed_bucket_count'], 1)
+        self.assertEqual(readback['observed_mean_daily_net_pnl'], '120')
+        self.assertEqual(readback['missing_to_target']['daily_net_pnl'], '380')
+        self.assertEqual(
+            readback['next_blocking_reason'],
+            'runtime_ledger_mean_daily_net_pnl_after_costs_below_target',
+        )
+
+    def test_runtime_ledger_bucket_summary_readback_reports_close_to_target(
+        self,
+    ) -> None:
+        row = _runtime_ledger_bucket(
+            run_id='source-backed-close',
+            bucket_started_at=datetime(2026, 3, 6, 14, 30),
+            bucket_ended_at=datetime(2026, 3, 6, 15, 0),
+        )
+        row.net_strategy_pnl_after_costs = Decimal('499.99')
+
+        summary = _runtime_ledger_bucket_summary([row])
+
+        readback = summary['runtime_ledger_profit_distance_readback']
+        self.assertEqual(readback['observed_mean_daily_net_pnl'], '499.99')
+        self.assertEqual(readback['missing_to_target']['daily_net_pnl'], '0.01')
+        self.assertEqual(readback['authority_readback_state'], 'blocked')
+
+    def test_runtime_ledger_bucket_summary_readback_satisfies_distance_when_source_backed(
+        self,
+    ) -> None:
+        row = _runtime_ledger_bucket(
+            run_id='source-backed-passing',
+            bucket_started_at=datetime(2026, 3, 6, 14, 30),
+            bucket_ended_at=datetime(2026, 3, 6, 15, 0),
+        )
+        row.net_strategy_pnl_after_costs = Decimal('620')
+        row.filled_notional = Decimal('125000')
+        row.closed_trade_count = 7
+
+        summary = _runtime_ledger_bucket_summary([row])
+
+        readback = summary['runtime_ledger_profit_distance_readback']
+        self.assertEqual(readback['observed_mean_daily_net_pnl'], '620')
+        self.assertEqual(readback['missing_to_target']['daily_net_pnl'], '0')
+        self.assertEqual(readback['filled_notional']['total'], '125000')
+        self.assertEqual(readback['closed_trade_count'], 7)
+        self.assertEqual(readback['open_position_count'], 0)
+        self.assertEqual(readback['source_authority']['source_backed_bucket_count'], 1)
+        self.assertEqual(readback['blockers'], [])
+        self.assertEqual(readback['authority_readback_state'], 'distance_satisfied')
 
     def test_runtime_ledger_bucket_match_requires_full_event_time_containment(
         self,

--- a/services/torghut/tests/test_evidence_epochs.py
+++ b/services/torghut/tests/test_evidence_epochs.py
@@ -38,6 +38,40 @@ from app.trading.evidence_receipts import (
 from app.trading.scheduler import TradingScheduler
 
 
+def _runtime_ledger_source_authority_payload() -> dict[str, object]:
+    return {
+        "source_window_start": "2026-05-29T14:30:00+00:00",
+        "source_window_end": "2026-05-29T15:00:00+00:00",
+        "source_refs": [
+            "postgres:trade_decisions",
+            "postgres:executions",
+            "postgres:execution_order_events",
+            "postgres:order_feed_source_windows",
+        ],
+        "source_row_counts": {
+            "trade_decisions": 2,
+            "executions": 2,
+            "execution_order_events": 2,
+            "order_feed_source_windows": 2,
+        },
+        "trade_decision_ids": ["decision-buy", "decision-sell"],
+        "execution_ids": ["execution-buy", "execution-sell"],
+        "execution_order_event_ids": ["event-fill-buy", "event-fill-sell"],
+        "source_window_ids": ["source-window-buy", "source-window-sell"],
+        "source_offsets": [
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100},
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 101},
+        ],
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
+        "authority_reason": "event_sourced_runtime_ledger_profit_proof",
+        "filled_notional": "1000",
+        "cost_amount": "1",
+        "cost_basis_counts": {"alpaca_2026_equity_fee_schedule": 2},
+        "cost_model_hash_counts": {"cost": 2},
+    }
+
+
 class TestEvidenceEpochs(TestCase):
     def test_env_json_string_list_accepts_json_and_fail_closed_values(self) -> None:
         with patch.dict(
@@ -329,6 +363,7 @@ class TestEvidenceEpochs(TestCase):
                         cost_model_hash_counts={"cost": 2},
                         lineage_hash_counts={"lineage": 2},
                         blockers_json=[],
+                        payload_json=_runtime_ledger_source_authority_payload(),
                     )
                 )
             session.commit()
@@ -412,6 +447,7 @@ class TestEvidenceEpochs(TestCase):
                     cost_model_hash_counts={"cost": 2},
                     lineage_hash_counts={"lineage": 2},
                     blockers_json=["runtime_ledger_stage_not_live"],
+                    payload_json=_runtime_ledger_source_authority_payload(),
                 )
             )
             session.commit()

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest import TestCase
 
 from app.trading.runtime_ledger_source_authority import (
+    build_runtime_ledger_profit_distance_readback,
     runtime_ledger_promotion_source_authority_blockers,
     runtime_ledger_promotion_source_authority_present,
     runtime_ledger_source_authority_blockers,
@@ -108,6 +109,53 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "runtime_ledger_source_window_missing",
                 "runtime_ledger_source_refs_missing",
             ],
+        )
+
+    def test_profit_distance_readback_normalizes_optional_fields(self) -> None:
+        readback = build_runtime_ledger_profit_distance_readback(
+            summary={
+                "runtime_ledger_mean_daily_net_pnl_after_costs": "not-a-decimal",
+                "runtime_ledger_median_daily_net_pnl_after_costs": "501",
+                "runtime_ledger_p10_daily_net_pnl_after_costs": "450",
+                "runtime_ledger_worst_day_net_pnl_after_costs": "400",
+                "runtime_ledger_max_intraday_drawdown": "25",
+                "runtime_ledger_avg_daily_filled_notional": "1000",
+                "runtime_ledger_net_pnl_by_trading_day": {"2026-05-29": "501"},
+                "runtime_ledger_filled_notional_by_trading_day": {"2026-05-29": "1000"},
+                "runtime_ledger_closed_trade_count_by_day": "missing",
+                "runtime_ledger_drawdown_pct_equity": "0.025",
+                "runtime_ledger_drawdown_pct_equity_source": "runtime_equity_snapshots",
+            },
+            runtime_ledger_bucket_count=1,
+            evidence_grade_runtime_ledger_bucket_count=1,
+            source_authority_bucket_count=1,
+            source_authority_blockers="not-a-sequence",
+            total_filled_notional=None,
+            total_closed_trade_count=3,
+            open_position_count=0,
+        )
+
+        self.assertEqual(readback["observed_mean_daily_net_pnl"], "0")
+        self.assertEqual(readback["filled_notional"]["total"], "0")
+        self.assertEqual(readback["closed_trade_count_by_day"], {})
+        self.assertEqual(readback["max_drawdown"]["percent_equity"], "0.025")
+        self.assertEqual(readback["source_authority"]["blockers"], [])
+        self.assertEqual(
+            readback["next_blocking_reason"],
+            "runtime_ledger_mean_daily_net_pnl_after_costs_below_target",
+        )
+
+    def test_promotion_source_authority_accepts_scalar_cost_basis_authority(
+        self,
+    ) -> None:
+        self.assertEqual(
+            runtime_ledger_promotion_source_authority_blockers(
+                _source_backed_payload(
+                    cost_basis="alpaca_2026_equity_fee_schedule",
+                    cost_basis_counts={},
+                )
+            ),
+            [],
         )
 
     def test_promotion_source_authority_requires_row_level_runtime_lineage(
@@ -658,7 +706,10 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
         }
 
         range_blockers = runtime_ledger_promotion_source_authority_blockers(
-            {**base, "source_window_gap_ranges": [{"start_offset": 41, "end_offset": 41}]}
+            {
+                **base,
+                "source_window_gap_ranges": [{"start_offset": 41, "end_offset": 41}],
+            }
         )
         mapping_blockers = runtime_ledger_promotion_source_authority_blockers(
             {
@@ -744,7 +795,9 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             runtime_ledger_filled_notional="1000",
         )
 
-        self.assertEqual(runtime_ledger_promotion_source_authority_blockers(payload), [])
+        self.assertEqual(
+            runtime_ledger_promotion_source_authority_blockers(payload), []
+        )
 
     def test_promotion_source_authority_rejects_non_promotion_cost_basis_inputs(
         self,
@@ -777,4 +830,6 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             cost_model_hash="broker-cost-v1",
         )
 
-        self.assertEqual(runtime_ledger_promotion_source_authority_blockers(payload), [])
+        self.assertEqual(
+            runtime_ledger_promotion_source_authority_blockers(payload), []
+        )

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1926,10 +1926,30 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(summary["runtime_ledger_p10_daily_net_pnl_after_costs"], "0")
         self.assertEqual(summary["runtime_ledger_worst_day_net_pnl_after_costs"], "0")
         self.assertEqual(summary["runtime_ledger_avg_daily_filled_notional"], "5000")
+        self.assertEqual(
+            summary["runtime_ledger_filled_notional_by_trading_day"],
+            {"2026-03-06": "10000", "2026-03-09": "0"},
+        )
+        readback = summary["runtime_ledger_profit_distance_readback"]
+        self.assertEqual(readback["required_daily_net_pnl"], "500")
+        self.assertEqual(readback["observed_mean_daily_net_pnl"], "300")
+        self.assertEqual(readback["missing_to_target"]["daily_net_pnl"], "200")
+        self.assertEqual(
+            readback["daily_post_cost_distribution"],
+            {"2026-03-06": "600", "2026-03-09": "0"},
+        )
+        self.assertEqual(readback["filled_notional"]["average_daily"], "5000")
+        self.assertEqual(readback["source_authority"]["source_backed_bucket_count"], 1)
         assert decision.payload_json is not None
         self.assertEqual(
             decision.payload_json["runtime_ledger_mean_daily_net_pnl_after_costs"],
             "300",
+        )
+        self.assertEqual(
+            decision.payload_json["runtime_ledger_profit_distance_readback"][
+                "missing_to_target"
+            ]["daily_net_pnl"],
+            "200",
         )
         assert ledger_bucket.payload_json is not None
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Added a runtime-ledger profit-distance readback object that reports the explicit gap to the honest $500/day post-cost target from real source-backed rows.
- Surfaced the readback through runtime window import payloads, completion summaries, trading status, and proof-packet references without weakening strict source-authority gates.
- Tightened source-authority bucket accounting so aggregate-only/runtime-unbacked rows stay blocked while still reporting observed PnL distance.
- Added focused row-fixture coverage for empty rows, aggregate-only rows, insufficient PnL, near-target PnL, and passing source-backed distance readbacks.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_runtime_ledger_source_authority.py tests/test_completion_trace.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_evidence_epochs.py -q` — passed (181 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/completion.py app/trading/runtime_ledger_source_authority.py app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_completion_trace.py tests/test_evidence_epochs.py tests/test_runtime_ledger_source_authority.py tests/test_runtime_window_import.py` — passed
- `cd services/torghut && uv run --frozen ruff format --check app/main.py app/trading/completion.py app/trading/runtime_ledger_source_authority.py app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_completion_trace.py tests/test_evidence_epochs.py tests/test_runtime_ledger_source_authority.py tests/test_runtime_window_import.py` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_runtime_ledger_source_authority.py tests/test_completion_trace.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_evidence_epochs.py --cov --cov-branch --cov-fail-under=0 --cov-report=xml -q && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main` — passed (93.81% changed-line coverage)
- `git diff --check` — passed

## Screenshots (if applicable)

N/A — backend/runtime-ledger readback change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no separate documentation or release note is required for this runtime status/readback change.
