### PR TITLE
feat(torghut): enrich hpairs frontier prefilter metadata

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -5827,6 +5827,10 @@ def compile_candidate_specs(
                             "deterministic_microbar_order_flow_fallback_with_explicit_blockers"
                         ),
                         "horizon_ofi_microbars": [3, 12, 36],
+                        "macro_window_concentration_metadata": True,
+                        "impact_capacity_lineage": (
+                            "square_root_power_law_prefilter_only_requires_source_backed_adv"
+                        ),
                         "ranking_authority": "candidate_discovery_prefilter_only",
                     }
                     parameter_space["hpairs_microstructure_prefilter"] = {

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -81,6 +81,12 @@ class FastReplayPreviewRow:
         notional_blocked = required_daily_notional is None
         lineage_blockers = _lineage_blockers_for_row(self)
         risk_flags = _risk_flags_for_row(self, lineage_blockers=lineage_blockers)
+        prefilter_capacity_lineage = _mapping(
+            self.microstructure_prefilter.get("impact_capacity_lineage")
+        )
+        prefilter_macro_window_stress = _mapping(
+            self.microstructure_prefilter.get("macro_window_stress")
+        )
         return {
             "schema_version": FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION,
             "candidate_spec_id": self.candidate_spec_id,
@@ -116,6 +122,8 @@ class FastReplayPreviewRow:
             "frontier_bucket": self.frontier_bucket,
             "microstructure_prefilter": dict(self.microstructure_prefilter),
             "hpairs_microstructure_prefilter": dict(self.microstructure_prefilter),
+            "hpairs_macro_window_stress": prefilter_macro_window_stress,
+            "hpairs_impact_capacity_lineage": prefilter_capacity_lineage,
             "proof_source": HPAIRS_PREFILTER_PROOF_SOURCE,
             "hpairs_prefilter_proof_semantics_label": HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
             "observed_post_cost_expectancy_bps": str(observed_post_cost_expectancy_bps),
@@ -143,6 +151,7 @@ class FastReplayPreviewRow:
                 "status": "preview_prefilter_only",
                 "source": "manifest_verified_replay_tape",
                 "cost_basis": "signed_return_minus_spread_plus_square_root_impact_penalty",
+                "impact_model": "square_root_power_law_capacity_proxy",
                 "median_spread_bps": str(self.median_spread_bps),
                 "impact_liquidity_penalty_bps": str(self.impact_liquidity_penalty_bps),
                 "square_root_impact_capacity_penalty_bps": str(
@@ -151,7 +160,9 @@ class FastReplayPreviewRow:
                 "observed_post_cost_expectancy_bps": str(
                     observed_post_cost_expectancy_bps
                 ),
+                "hpairs_prefilter_impact_capacity_lineage": prefilter_capacity_lineage,
             },
+            "impact_capacity_lineage": prefilter_capacity_lineage,
             "adv_capacity_context": {
                 "status": "missing_source_backed_adv",
                 "source": "missing_external_adv_source",
@@ -594,12 +605,19 @@ def _score_candidate_spec(
     )
     if hpairs_prefilter_score is not None:
         preview_score = preview_score * 0.65 + hpairs_prefilter_score * 0.35
+    macro_window_stress = _mapping(microstructure_prefilter.get("macro_window_stress"))
+    macro_window_concentration = _float_or_none(
+        macro_window_stress.get("concentration")
+    )
+    if macro_window_concentration is not None:
+        preview_score -= macro_window_concentration * 6.0
     exploration_score = (
         cluster_lob_activity_score * 4.0
         + abs(ofi_decay_alignment_score) * 5.0
         + liquidity_regime_score * 2.0
         + coverage_score * 6.0
         - macro_stress_veto_score * 8.0
+        - (macro_window_concentration or 0.0) * 3.0
         - conformal_tail_risk_penalty_bps * 0.04
         - square_root_impact_capacity_penalty_bps * 0.08
     )
@@ -1111,6 +1129,12 @@ def _lineage_blockers_for_row(row: FastReplayPreviewRow) -> tuple[str, ...]:
     if _observed_post_cost_expectancy_bps(row) <= 0:
         blockers.append("positive_post_cost_expectancy_missing")
         blockers.append("target_implied_notional_blocked_non_positive_expectancy")
+    source_input_blockers = row.microstructure_prefilter.get("source_input_blockers")
+    if isinstance(source_input_blockers, Sequence) and not isinstance(
+        source_input_blockers, (str, bytes, bytearray)
+    ):
+        if source_input_blockers:
+            blockers.append("hpairs_prefilter_source_inputs_missing")
     return tuple(blockers)
 
 

--- a/services/torghut/app/trading/discovery/microstructure_prefilter.py
+++ b/services/torghut/app/trading/discovery/microstructure_prefilter.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timezone
 from decimal import Decimal
 from math import exp, isfinite, log, sqrt
@@ -60,6 +60,12 @@ class MicrostructureCandidatePrefilterRow:
     horizon_ofi_features: Mapping[str, Any]
     cluster_behavior: Mapping[str, Any]
     regime_stress_veto: Mapping[str, Any]
+    macro_window_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    impact_capacity_lineage: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
     proof_source: str = HPAIRS_PREFILTER_PROOF_SOURCE
     proof_semantics_label: str = HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL
     promotion_allowed: bool = False
@@ -87,6 +93,11 @@ class MicrostructureCandidatePrefilterRow:
             "horizon_ofi_features": dict(self.horizon_ofi_features),
             "cluster_behavior": dict(self.cluster_behavior),
             "regime_stress_veto": dict(self.regime_stress_veto),
+            "macro_window_stress": dict(self.macro_window_stress),
+            "impact_capacity_lineage": dict(self.impact_capacity_lineage),
+            "source_input_blockers": list(
+                _source_input_blockers(self.blockers, self.warnings)
+            ),
             "proof_source": self.proof_source,
             "proof_semantics_label": self.proof_semantics_label,
             "promotion_allowed": self.promotion_allowed,
@@ -128,6 +139,8 @@ class MicrostructurePrefilterResult:
                 "horizon_specific_ofi_shock_memory_prefilter",
                 "microbar_order_flow_fallback_when_lob_absent",
                 "regime_stress_veto_metadata",
+                "macro_window_concentration_stress_metadata",
+                "square_root_power_law_impact_capacity_lineage",
                 "bounded_exploitation_plus_exploration_handoff",
             ],
             "requested_top_k": self.requested_top_k,
@@ -159,6 +172,7 @@ class _SymbolMicrostructureStats:
     horizon_features: Mapping[str, Any]
     cluster_behavior: Mapping[str, Any]
     regime_stress_veto: Mapping[str, Any]
+    stress_values: tuple[float, ...]
 
 
 def build_hpairs_microstructure_prefilter(
@@ -332,6 +346,7 @@ def _build_symbol_microstructure_stats(
             returns_bps=returns,
             volume_values=volume_values,
             stress_values=stress_values,
+            row_count=len(ordered),
         )
         stats[symbol] = _SymbolMicrostructureStats(
             symbol=symbol,
@@ -352,6 +367,7 @@ def _build_symbol_microstructure_stats(
             horizon_features=horizon_features,
             cluster_behavior=cluster_behavior,
             regime_stress_veto=regime_stress_veto,
+            stress_values=tuple(stress_values),
         )
     return stats
 
@@ -405,6 +421,14 @@ def _score_spec(
             horizon_ofi_features=_empty_horizon_features(),
             cluster_behavior=_empty_cluster_behavior(),
             regime_stress_veto=_empty_regime_stress_veto(),
+            macro_window_stress=_empty_macro_window_stress(),
+            impact_capacity_lineage=_impact_capacity_lineage(
+                spec=spec,
+                median_price=0.0,
+                median_volume=0.0,
+                median_spread_bps=0.0,
+                capacity_penalty_bps=0.0,
+            ),
         )
 
     direction = _candidate_direction(spec)
@@ -431,14 +455,15 @@ def _score_spec(
             for stat in matched
         ),
     )
+    merged_stress_values = tuple(
+        value for stat in matched for value in stat.stress_values
+    )
     regime_stress_veto = _regime_stress_veto(
         spread_values=spread_values,
         returns_bps=returns,
         volume_values=volume_values,
-        stress_values=[
-            float(stat.regime_stress_veto.get("input_stress_score") or 0.0)
-            for stat in matched
-        ],
+        stress_values=merged_stress_values,
+        row_count=matched_row_count,
     )
     if float(regime_stress_veto["veto_score"]) >= 0.65:
         blockers.add("regime_stress_veto_active")
@@ -457,13 +482,22 @@ def _score_spec(
     cluster_score = float(cluster_behavior["cluster_score"])
     stress_veto = float(regime_stress_veto["veto_score"])
     microprice_alignment = direction * _mean(microprice_bias)
+    median_price = _weighted_average(
+        tuple((stat.median_price, stat.row_count) for stat in matched)
+    )
+    median_volume = _percentile(volume_values, 50.0)
     capacity_penalty = _capacity_penalty_bps(
         spec=spec,
-        median_price=_weighted_average(
-            tuple((stat.median_price, stat.row_count) for stat in matched)
-        ),
-        median_volume=_percentile(volume_values, 50.0),
+        median_price=median_price,
+        median_volume=median_volume,
         median_spread_bps=median_spread_bps,
+    )
+    impact_capacity_lineage = _impact_capacity_lineage(
+        spec=spec,
+        median_price=median_price,
+        median_volume=median_volume,
+        median_spread_bps=median_spread_bps,
+        capacity_penalty_bps=capacity_penalty,
     )
     exploitation_score = (
         signed_return_bps
@@ -512,6 +546,8 @@ def _score_spec(
         horizon_ofi_features=horizon_features,
         cluster_behavior=cluster_behavior,
         regime_stress_veto=regime_stress_veto,
+        macro_window_stress=_macro_window_stress_from_regime(regime_stress_veto),
+        impact_capacity_lineage=impact_capacity_lineage,
     )
 
 
@@ -586,6 +622,8 @@ def _with_rank_and_bucket(
         horizon_ofi_features=row.horizon_ofi_features,
         cluster_behavior=row.cluster_behavior,
         regime_stress_veto=row.regime_stress_veto,
+        macro_window_stress=row.macro_window_stress,
+        impact_capacity_lineage=row.impact_capacity_lineage,
     )
 
 
@@ -620,6 +658,17 @@ def _source_field_diagnostics(
     if not stress_values:
         warnings.add("missing_regime_stress_veto_fields")
     return tuple(sorted(blockers)), tuple(sorted(warnings))
+
+
+def _source_input_blockers(
+    blockers: Sequence[str], warnings: Sequence[str]
+) -> tuple[str, ...]:
+    """Surface missing input blockers separately from permanent authority blockers."""
+
+    prefixes = ("missing_", "insufficient_")
+    return tuple(
+        sorted({item for item in (*blockers, *warnings) if item.startswith(prefixes)})
+    )
 
 
 def _horizon_ofi_features(values: NDArray[np.float64]) -> dict[str, Any]:
@@ -749,10 +798,20 @@ def _regime_stress_veto(
     returns_bps: NDArray[np.float64],
     volume_values: NDArray[np.float64],
     stress_values: Sequence[float],
+    row_count: int,
 ) -> dict[str, Any]:
     spread_tail_bps = _percentile(spread_values, 95.0)
     return_tail_bps = _percentile(np.abs(returns_bps), 95.0)
     liquidity_score = _volume_score(volume_values)
+    bounded_row_count = max(0, int(row_count))
+    stress_sample_count = len(stress_values)
+    stress_active_count = sum(1 for value in stress_values if value > 0.0)
+    macro_window_concentration = (
+        stress_sample_count / bounded_row_count if bounded_row_count > 0 else 0.0
+    )
+    macro_window_active_share = (
+        stress_active_count / bounded_row_count if bounded_row_count > 0 else 0.0
+    )
     input_stress_score = (
         float(np.clip(_mean(np.asarray(stress_values, dtype=np.float64)), 0.0, 1.0))
         if stress_values
@@ -780,6 +839,10 @@ def _regime_stress_veto(
         "veto_score": str(_decimal(veto_score)),
         "veto_active": veto_score >= 0.65,
         "input_stress_score": str(_decimal(input_stress_score)),
+        "macro_window_sample_count": stress_sample_count,
+        "macro_window_active_count": stress_active_count,
+        "macro_window_concentration": str(_decimal(macro_window_concentration)),
+        "macro_window_active_share": str(_decimal(macro_window_active_share)),
         "spread_tail_bps": str(_decimal(spread_tail_bps)),
         "return_tail_abs_bps": str(_decimal(return_tail_bps)),
         "liquidity_score": str(_decimal(liquidity_score)),
@@ -795,11 +858,40 @@ def _empty_regime_stress_veto() -> dict[str, Any]:
         "veto_score": "0",
         "veto_active": False,
         "input_stress_score": "0",
+        "macro_window_sample_count": 0,
+        "macro_window_active_count": 0,
+        "macro_window_concentration": "0",
+        "macro_window_active_share": "0",
         "spread_tail_bps": "0",
         "return_tail_abs_bps": "0",
         "liquidity_score": "0",
         "source": "missing_regime_stress_fields",
     }
+
+
+def _macro_window_stress_from_regime(
+    regime_stress_veto: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "status": regime_stress_veto.get("status", "missing_inputs"),
+        "concentration": str(
+            regime_stress_veto.get("macro_window_concentration") or "0"
+        ),
+        "active_share": str(regime_stress_veto.get("macro_window_active_share") or "0"),
+        "sample_count": int(regime_stress_veto.get("macro_window_sample_count") or 0),
+        "active_count": int(regime_stress_veto.get("macro_window_active_count") or 0),
+        "stress_score": str(regime_stress_veto.get("input_stress_score") or "0"),
+        "veto_score": str(regime_stress_veto.get("veto_score") or "0"),
+        "veto_active": bool(regime_stress_veto.get("veto_active")),
+        "source": regime_stress_veto.get("source", "missing_regime_stress_fields"),
+        "prefilter_only": True,
+        "proof_authority": False,
+        "promotion_authority": False,
+    }
+
+
+def _empty_macro_window_stress() -> dict[str, Any]:
+    return _macro_window_stress_from_regime(_empty_regime_stress_veto())
 
 
 def _extract_price(signal: SignalEnvelope, *, source_fields: set[str]) -> float | None:
@@ -1073,6 +1165,50 @@ def _capacity_penalty_bps(
             sqrt(max(0.0, participation)) * 100.0 + median_spread_bps * 0.25, 0.0, 500.0
         )
     )
+
+
+def _impact_capacity_lineage(
+    *,
+    spec: CandidateSpec,
+    median_price: float,
+    median_volume: float,
+    median_spread_bps: float,
+    capacity_penalty_bps: float,
+) -> dict[str, Any]:
+    """Return square-root/power-law impact context as non-authoritative metadata."""
+
+    notional = _candidate_notional(spec)
+    dollar_volume = max(0.0, median_price) * max(0.0, median_volume)
+    participation_rate_proxy = notional / dollar_volume if dollar_volume > 0.0 else None
+    blockers: list[str] = []
+    if notional <= 0.0:
+        blockers.append("candidate_notional_missing")
+    if median_price <= 0.0:
+        blockers.append("median_price_missing")
+    if median_volume <= 0.0:
+        blockers.append("median_volume_missing")
+    return {
+        "schema_version": "torghut.hpairs-impact-capacity-lineage.v1",
+        "status": "available"
+        if dollar_volume > 0.0 and notional > 0.0
+        else "missing_inputs",
+        "model": "square_root_power_law_impact_proxy",
+        "source": "replay_tape_price_volume_spread_fields",
+        "candidate_notional": str(_decimal(notional)),
+        "median_price": str(_decimal(median_price)),
+        "median_volume": str(_decimal(median_volume)),
+        "dollar_volume_proxy": str(_decimal(dollar_volume)),
+        "participation_rate_proxy": str(_decimal(participation_rate_proxy))
+        if participation_rate_proxy is not None
+        else None,
+        "median_spread_bps": str(_decimal(median_spread_bps)),
+        "capacity_penalty_bps": str(_decimal(capacity_penalty_bps)),
+        "blockers": blockers,
+        "prefilter_only": True,
+        "proof_authority": False,
+        "promotion_authority": False,
+        "requires_source_backed_adv": True,
+    }
 
 
 def _volume_score(values: NDArray[np.float64]) -> float:

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -3634,8 +3634,7 @@ def _flag_int(value: Any) -> int | None:
 def _unsafe_next_epoch_remediation_flag(key: str) -> bool:
     normalized = key.strip().lower()
     return any(
-        marker in normalized
-        for marker in _UNSAFE_NEXT_EPOCH_REMEDIATION_FLAG_MARKERS
+        marker in normalized for marker in _UNSAFE_NEXT_EPOCH_REMEDIATION_FLAG_MARKERS
     )
 
 
@@ -3780,12 +3779,9 @@ def _profitability_next_epoch_plan(
                     current_value = flags.get(key)
                     current_int = _flag_int(current_value)
                     recommended_int = _flag_int(value)
-                    if (
-                        key == "--real-replay-shard-workers"
-                        and (
-                            recommended_int is None
-                            or recommended_int > _DEFAULT_REAL_REPLAY_SHARD_WORKERS
-                        )
+                    if key == "--real-replay-shard-workers" and (
+                        recommended_int is None
+                        or recommended_int > _DEFAULT_REAL_REPLAY_SHARD_WORKERS
                     ):
                         rejected_recommended_flags.append(
                             {
@@ -6649,6 +6645,18 @@ def _apply_fast_replay_preview_narrowing(
                 updated["hpairs_microstructure_behavior_bucket"] = _mapping(
                     microstructure_prefilter.get("cluster_behavior")
                 ).get("behavior_bucket")
+                updated["hpairs_microstructure_macro_window_stress"] = _mapping(
+                    microstructure_prefilter.get("macro_window_stress")
+                )
+                updated["hpairs_microstructure_impact_capacity_lineage"] = _mapping(
+                    microstructure_prefilter.get("impact_capacity_lineage")
+                )
+                updated["hpairs_microstructure_source_input_blockers"] = list(
+                    cast(
+                        Sequence[Any],
+                        microstructure_prefilter.get("source_input_blockers") or (),
+                    )
+                )
                 updated["hpairs_microstructure_proof_source"] = (
                     microstructure_prefilter.get("proof_source")
                 )
@@ -6824,6 +6832,11 @@ def _bounded_sim_target_queue_metadata(
                 "exact_replay_handoff_lineage": handoff_lineage,
                 "handoff_lineage_hash": handoff_lineage_hash,
                 "cost_impact_lineage": row.get("cost_impact_lineage"),
+                "impact_capacity_lineage": row.get("impact_capacity_lineage"),
+                "hpairs_macro_window_stress": row.get("hpairs_macro_window_stress"),
+                "hpairs_impact_capacity_lineage": row.get(
+                    "hpairs_impact_capacity_lineage"
+                ),
                 "adv_capacity_context": row.get("adv_capacity_context"),
                 "lineage_blockers": list(
                     cast(Sequence[Any], row.get("lineage_blockers") or ())
@@ -6889,9 +6902,7 @@ def _bounded_sim_target_queue_metadata(
         "exploration_slots": exploration_slots,
         "exact_replay_candidate_count": len(entries),
         "candidate_spec_ids": [entry["candidate_spec_id"] for entry in entries],
-        "handoff_lineage_hashes": [
-            entry["handoff_lineage_hash"] for entry in entries
-        ],
+        "handoff_lineage_hashes": [entry["handoff_lineage_hash"] for entry in entries],
         "entries": entries,
     }
 

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -163,6 +163,17 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn("observed_post_cost_expectancy_bps", row_payload)
         self.assertIn("cost_impact_lineage", row_payload)
+        self.assertIn("impact_capacity_lineage", row_payload)
+        self.assertEqual(
+            row_payload["cost_impact_lineage"]["impact_model"],
+            "square_root_power_law_capacity_proxy",
+        )
+        self.assertEqual(
+            row_payload["impact_capacity_lineage"]["model"],
+            "square_root_power_law_impact_proxy",
+        )
+        self.assertIn("hpairs_macro_window_stress", row_payload)
+        self.assertFalse(row_payload["hpairs_macro_window_stress"]["proof_authority"])
         self.assertEqual(
             row_payload["adv_capacity_context"]["status"], "missing_source_backed_adv"
         )

--- a/services/torghut/tests/test_microstructure_prefilter.py
+++ b/services/torghut/tests/test_microstructure_prefilter.py
@@ -146,6 +146,16 @@ class MicrostructurePrefilterTest(TestCase):
             payload["warnings"],
         )
         self.assertEqual(payload["horizon_ofi_features"]["status"], "missing_inputs")
+        self.assertIn(
+            "missing_price_return_microbar_fields",
+            payload["source_input_blockers"],
+        )
+        self.assertEqual(payload["macro_window_stress"]["status"], "missing_inputs")
+        self.assertEqual(payload["impact_capacity_lineage"]["status"], "missing_inputs")
+        self.assertIn(
+            "median_price_missing",
+            payload["impact_capacity_lineage"]["blockers"],
+        )
         self.assertEqual(payload["proof_source"], HPAIRS_PREFILTER_PROOF_SOURCE)
 
     def test_prefilter_metadata_never_grants_promotion_authority(self) -> None:
@@ -234,4 +244,13 @@ class MicrostructurePrefilterTest(TestCase):
         self.assertEqual(payload["cluster_behavior"]["source"], "cluster_lob_fields")
         self.assertIn("behavior_bucket", payload["cluster_behavior"])
         self.assertEqual(payload["regime_stress_veto"]["status"], "available")
+        self.assertEqual(payload["macro_window_stress"]["status"], "available")
+        self.assertEqual(payload["macro_window_stress"]["sample_count"], 3)
+        self.assertFalse(payload["macro_window_stress"]["proof_authority"])
+        self.assertEqual(
+            payload["impact_capacity_lineage"]["model"],
+            "square_root_power_law_impact_proxy",
+        )
+        self.assertEqual(payload["impact_capacity_lineage"]["status"], "available")
+        self.assertFalse(payload["impact_capacity_lineage"]["proof_authority"])
         self.assertEqual(payload["proof_source"], "prefilter_only")

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4835,6 +4835,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertIn("target_implied_notional_context", first_entry)
         self.assertIn("cost_impact_lineage", first_entry)
+        self.assertIn("impact_capacity_lineage", first_entry)
+        self.assertIn("hpairs_macro_window_stress", first_entry)
+        self.assertIn("hpairs_impact_capacity_lineage", first_entry)
         self.assertIn("exact_replay_handoff_lineage", first_entry)
         self.assertIn(
             first_entry["handoff_lineage_hash"],
@@ -4878,6 +4881,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertIn(
             "horizon_ofi_features",
+            first_entry["hpairs_microstructure_prefilter"],
+        )
+        self.assertIn(
+            "macro_window_stress",
+            first_entry["hpairs_microstructure_prefilter"],
+        )
+        self.assertIn(
+            "impact_capacity_lineage",
             first_entry["hpairs_microstructure_prefilter"],
         )
 
@@ -6478,7 +6489,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             updated.objective_scorecard["executable_replay_artifact_ref"],
             str(approval_replay_path),
         )
-        self.assertNotIn("exact_replay_ledger_artifact_ref", updated.objective_scorecard)
+        self.assertNotIn(
+            "exact_replay_ledger_artifact_ref", updated.objective_scorecard
+        )
         self.assertNotIn(
             "exact_replay_ledger_artifact_row_count",
             updated.objective_scorecard,


### PR DESCRIPTION
## Summary

- Added deterministic H-PAIRS macro-window concentration/stress metadata alongside the existing regime stress veto so frontier ranking can penalize clustered macro/news windows without granting authority.
- Added square-root/power-law impact capacity lineage to microstructure prefilter rows and fast replay payloads, including candidate notional, dollar-volume proxy, participation-rate proxy, source blockers, and explicit non-authority flags.
- Propagated the new metadata into staged replay frontier selection rows and bounded SIM target queue entries for exact-replay handoff traceability.
- Extended focused regressions for microstructure prefilter, fast replay, and staged frontier queue metadata.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_replay_ledger_ranker.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_candidate_specs.py tests/test_microstructure_prefilter.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/microstructure_prefilter.py app/trading/discovery/fast_replay.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_microstructure_prefilter.py tests/test_fast_replay.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/microstructure_prefilter.py app/trading/discovery/fast_replay.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_microstructure_prefilter.py tests/test_fast_replay.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A; backend ranking metadata and tests only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
