### PR TITLE
fix(torghut): repair execution TCA cost lineage

### DIFF
--- a/services/torghut/app/trading/tca.py
+++ b/services/torghut/app/trading/tca.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import hashlib
+import json
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -34,6 +36,60 @@ ADAPTIVE_PARTICIPATION_TIGHTEN = Decimal("0.75")
 ADAPTIVE_PARTICIPATION_RELAX = Decimal("1.0")
 ADAPTIVE_EXECUTION_SLOWDOWN = Decimal("1.40")
 ADAPTIVE_EXECUTION_SPEEDUP = Decimal("0.85")
+EXECUTION_TCA_COST_LINEAGE_SCHEMA_VERSION = "torghut.execution-tca-cost-lineage.v1"
+POST_COST_PNL_BASIS = "realized_strategy_pnl_after_explicit_costs"
+
+_EXPLICIT_COST_AMOUNT_KEYS = (
+    "cost_amount",
+    "explicit_cost",
+    "explicit_cost_amount",
+    "commission",
+    "fees",
+    "fee_amount",
+    "broker_fee",
+    "total_fees",
+    "total_fee_amount",
+)
+_COST_BASIS_KEYS = (
+    "cost_basis",
+    "cost_source",
+    "fee_basis",
+    "commission_basis",
+    "broker_fee_basis",
+)
+_EXECUTION_POLICY_HASH_KEYS = (
+    "execution_policy_hash",
+    "execution_policy_sha256",
+    "policy_hash",
+)
+_EXECUTION_POLICY_PAYLOAD_KEYS = (
+    "execution_policy",
+    "execution_policy_context",
+    "execution_advisor",
+    "_execution_advice_provenance",
+)
+_COST_MODEL_HASH_KEYS = (
+    "cost_model_hash",
+    "fee_model_hash",
+    "cost_model_sha256",
+)
+_COST_MODEL_PAYLOAD_KEYS = (
+    "cost_model",
+    "cost_model_config",
+    "transaction_cost_model",
+    "fee_model",
+    "fees_model",
+)
+_LINEAGE_HASH_KEYS = (
+    "lineage_hash",
+    "candidate_lineage_hash",
+    "replay_lineage_hash",
+    "candidate_evaluation_key",
+    "replay_data_hash",
+    "replay_tape_content_sha256",
+    "dataset_snapshot_hash",
+    "source_query_digest",
+)
 
 
 @dataclass(frozen=True)
@@ -147,6 +203,12 @@ def upsert_execution_tca_metric(
         signed_qty=signed_qty,
         filled_qty=filled_qty,
     )
+    _repair_execution_tca_cost_lineage(
+        execution=execution,
+        decision=decision,
+        filled_qty=filled_qty,
+        avg_fill_price=avg_fill_price,
+    )
 
     existing = session.execute(
         select(ExecutionTCAMetric).where(
@@ -202,6 +264,282 @@ def upsert_execution_tca_metric(
     session.add(existing)
     _journal_tigerbeetle_execution_cost(session, execution, existing)
     return existing
+
+
+def _repair_execution_tca_cost_lineage(
+    *,
+    execution: Execution,
+    decision: TradeDecision | None,
+    filled_qty: Decimal,
+    avg_fill_price: Decimal | None,
+) -> dict[str, object]:
+    """Attach deterministic runtime-ledger cost lineage to execution audit JSON.
+
+    The repair is intentionally conservative: it computes filled notional only
+    from persisted fill quantity and average fill price, accepts explicit costs
+    only from persisted execution/order payload fields, and records missing or
+    ambiguous source evidence as blockers instead of fabricating authority.
+    """
+
+    audit_payload = _mapping_from_any(execution.execution_audit_json)
+    raw_order_payload = _mapping_from_any(execution.raw_order)
+    decision_payload = _mapping_from_any(decision.decision_json if decision else None)
+    source_payloads = _lineage_source_payloads(
+        raw_order_payload,
+        audit_payload,
+        decision_payload,
+    )
+    blockers: list[str] = []
+    source_fields: dict[str, object] = {}
+
+    filled_notional: Decimal | None = None
+    if filled_qty > 0 and avg_fill_price is not None and avg_fill_price > 0:
+        filled_notional = filled_qty * avg_fill_price
+        source_fields["filled_notional"] = [
+            "executions.filled_qty",
+            "executions.avg_fill_price",
+        ]
+    else:
+        blockers.append("filled_notional_missing")
+
+    cost_amount, cost_basis, cost_source_field = _resolve_explicit_cost(source_payloads)
+    if cost_amount is None:
+        blockers.append("explicit_cost_missing")
+    elif cost_basis is None:
+        blockers.append("cost_basis_missing")
+    else:
+        source_fields["explicit_cost"] = cost_source_field
+
+    execution_policy_hashes = _hash_candidates(
+        source_payloads,
+        hash_keys=_EXECUTION_POLICY_HASH_KEYS,
+        payload_keys=_EXECUTION_POLICY_PAYLOAD_KEYS,
+    )
+    if len(execution_policy_hashes) == 0:
+        blockers.append("execution_policy_hash_missing")
+    elif len(execution_policy_hashes) > 1:
+        blockers.append("execution_policy_hash_ambiguous")
+    execution_policy_hash = (
+        next(iter(execution_policy_hashes))
+        if len(execution_policy_hashes) == 1
+        else None
+    )
+
+    cost_model_hashes = _hash_candidates(
+        source_payloads,
+        hash_keys=_COST_MODEL_HASH_KEYS,
+        payload_keys=_COST_MODEL_PAYLOAD_KEYS,
+    )
+    if (
+        len(cost_model_hashes) == 0
+        and cost_amount is not None
+        and cost_basis is not None
+        and cost_source_field is not None
+    ):
+        cost_model_hashes.add(
+            _stable_payload_digest(
+                {
+                    "cost_basis": cost_basis,
+                    "kind": "explicit_cost_source",
+                    "source_field": cost_source_field,
+                }
+            )
+        )
+    if len(cost_model_hashes) == 0:
+        blockers.append("cost_model_hash_missing")
+    elif len(cost_model_hashes) > 1:
+        blockers.append("cost_model_hash_ambiguous")
+    cost_model_hash = (
+        next(iter(cost_model_hashes)) if len(cost_model_hashes) == 1 else None
+    )
+
+    lineage_hash = _resolve_lineage_hash(
+        source_payloads=source_payloads,
+        execution=execution,
+        decision=decision,
+    )
+    blockers = _dedupe_texts(blockers)
+    source_backed = not blockers
+    lineage_payload: dict[str, object] = {
+        "schema_version": EXECUTION_TCA_COST_LINEAGE_SCHEMA_VERSION,
+        "status": "source_backed" if source_backed else "blocked",
+        "source_backed": source_backed,
+        "promotion_authority": False,
+        "promotion_authority_reason": "lineage_dimension_only_not_promotion_authority",
+        "blockers": blockers,
+        "pnl_basis": POST_COST_PNL_BASIS,
+        "filled_notional": str(filled_notional)
+        if filled_notional is not None
+        else None,
+        "filled_notional_basis": "execution_filled_qty_x_avg_fill_price"
+        if filled_notional is not None
+        else None,
+        "explicit_cost_amount": str(cost_amount) if cost_amount is not None else None,
+        "cost_basis": cost_basis,
+        "execution_policy_hash": execution_policy_hash,
+        "cost_model_hash": cost_model_hash,
+        "lineage_hash": lineage_hash,
+        "source_fields": source_fields,
+    }
+
+    repaired_audit = dict(audit_payload)
+    repaired_audit["runtime_ledger_lineage"] = lineage_payload
+    repaired_audit["execution_tca_cost_lineage"] = lineage_payload
+    if filled_notional is not None:
+        repaired_audit["filled_notional"] = str(filled_notional)
+    if cost_amount is not None:
+        repaired_audit["cost_amount"] = str(cost_amount)
+    if cost_basis is not None:
+        repaired_audit["cost_basis"] = cost_basis
+    if execution_policy_hash is not None:
+        repaired_audit["execution_policy_hash"] = execution_policy_hash
+    if cost_model_hash is not None:
+        repaired_audit["cost_model_hash"] = cost_model_hash
+    repaired_audit["lineage_hash"] = lineage_hash
+    repaired_audit["pnl_basis"] = POST_COST_PNL_BASIS
+    execution.execution_audit_json = repaired_audit
+    return lineage_payload
+
+
+def _mapping_from_any(value: object | None) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        return {}
+    mapping = cast(Mapping[object, object], value)
+    return {str(key): item for key, item in mapping.items()}
+
+
+def _lineage_source_payloads(
+    *values: Mapping[str, object],
+) -> list[Mapping[str, object]]:
+    payloads: list[Mapping[str, object]] = []
+
+    def append_payload(value: object, *, depth: int) -> None:
+        if not isinstance(value, Mapping):
+            return
+        mapping = cast(Mapping[object, object], value)
+        payload = {str(item_key): item for item_key, item in mapping.items()}
+        payloads.append(payload)
+        if depth <= 0:
+            return
+        for nested in payload.values():
+            if isinstance(nested, Mapping):
+                append_payload(cast(Mapping[object, object], nested), depth=depth - 1)
+
+    for value in values:
+        append_payload(value, depth=4)
+    return payloads
+
+
+def _resolve_explicit_cost(
+    payloads: Collection[Mapping[str, object]],
+) -> tuple[Decimal | None, str | None, str | None]:
+    missing_basis_candidate: tuple[Decimal, str] | None = None
+    for payload in payloads:
+        for key in _EXPLICIT_COST_AMOUNT_KEYS:
+            amount = _non_negative_decimal(payload.get(key))
+            if amount is None:
+                continue
+            basis = _text_from_payload(payload, *_COST_BASIS_KEYS)
+            if basis is None:
+                basis = _default_cost_basis_for_field(key)
+            if basis is None:
+                missing_basis_candidate = (amount, key)
+                continue
+            return amount, basis, key
+    if missing_basis_candidate is not None:
+        amount, key = missing_basis_candidate
+        return amount, None, key
+    return None, None, None
+
+
+def _default_cost_basis_for_field(key: str) -> str | None:
+    normalized = key.strip().lower()
+    if normalized == "commission":
+        return "broker_reported_commission"
+    if normalized in {
+        "fees",
+        "fee_amount",
+        "broker_fee",
+        "total_fees",
+        "total_fee_amount",
+    }:
+        return "broker_reported_fees"
+    return None
+
+
+def _hash_candidates(
+    payloads: Collection[Mapping[str, object]],
+    *,
+    hash_keys: Collection[str],
+    payload_keys: Collection[str],
+) -> set[str]:
+    candidates: set[str] = set()
+    for payload in payloads:
+        for key in hash_keys:
+            text = _text_from_payload(payload, key)
+            if text is not None:
+                candidates.add(text)
+        for key in payload_keys:
+            value = payload.get(key)
+            if value is not None and (digest := _stable_payload_digest(value)):
+                candidates.add(digest)
+    return candidates
+
+
+def _resolve_lineage_hash(
+    *,
+    source_payloads: Collection[Mapping[str, object]],
+    execution: Execution,
+    decision: TradeDecision | None,
+) -> str:
+    explicit_hashes = _hash_candidates(
+        source_payloads,
+        hash_keys=_LINEAGE_HASH_KEYS,
+        payload_keys=("lineage", "candidate_lineage", "source_lineage"),
+    )
+    if len(explicit_hashes) == 1:
+        return next(iter(explicit_hashes))
+    return _stable_payload_digest(
+        {
+            "alpaca_account_label": execution.alpaca_account_label,
+            "alpaca_order_id": execution.alpaca_order_id,
+            "client_order_id": execution.client_order_id,
+            "decision_hash": decision.decision_hash if decision is not None else None,
+            "execution_id": str(execution.id),
+            "trade_decision_id": str(execution.trade_decision_id)
+            if execution.trade_decision_id
+            else None,
+        }
+    )
+
+
+def _stable_payload_digest(value: object) -> str:
+    body = json.dumps(value, default=str, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _text_from_payload(payload: Mapping[str, object], *keys: str) -> str | None:
+    for key in keys:
+        text = str(payload.get(key) or "").strip()
+        if text:
+            return text
+    return None
+
+
+def _non_negative_decimal(value: object | None) -> Decimal | None:
+    parsed = _decimal_or_none(value)
+    if parsed is None or parsed < 0:
+        return None
+    return parsed
+
+
+def _dedupe_texts(values: Collection[str]) -> list[str]:
+    deduped: list[str] = []
+    for value in values:
+        text = value.strip()
+        if text and text not in deduped:
+            deduped.append(text)
+    return deduped
 
 
 def _journal_tigerbeetle_execution_cost(
@@ -288,6 +626,7 @@ def refresh_execution_tca_metrics(
             "limit": bounded_limit,
             "account_label": normalized_account_label or None,
             "stale_before": stale_before.isoformat() if stale_before else None,
+            "runtime_ledger_lineage": _execution_lineage_summary(executions),
         }
 
     refreshed = 0
@@ -295,6 +634,7 @@ def refresh_execution_tca_metrics(
         upsert_execution_tca_metric(session, execution)
         refreshed += 1
 
+    lineage_summary = _execution_lineage_summary(executions)
     return {
         "selected": len(executions),
         "refreshed": refreshed,
@@ -302,6 +642,7 @@ def refresh_execution_tca_metrics(
         "limit": bounded_limit,
         "account_label": normalized_account_label or None,
         "stale_before": stale_before.isoformat() if stale_before else None,
+        "runtime_ledger_lineage": lineage_summary,
     }
 
 
@@ -387,6 +728,12 @@ def build_tca_gate_inputs(
         account_label=normalized_account_label,
         symbols=normalized_symbols,
     )
+    runtime_ledger_lineage = _build_tca_runtime_ledger_lineage_summary(
+        session,
+        strategy_id=strategy_id,
+        account_label=normalized_account_label,
+        symbols=normalized_symbols,
+    )
     return {
         "account_label": normalized_account_label or None,
         "scope_symbols": list(normalized_symbols),
@@ -429,6 +776,7 @@ def build_tca_gate_inputs(
         "latest_execution_created_at": latest_execution_created_at,
         "unsettled_execution_count": unsettled_execution_count,
         "symbol_breakdown": symbol_breakdown,
+        "runtime_ledger_lineage": runtime_ledger_lineage,
     }
 
 
@@ -464,6 +812,103 @@ def _tca_execution_coverage_stmt(
     if symbols:
         stmt = stmt.where(Execution.symbol.in_(symbols))
     return stmt
+
+
+def _build_tca_runtime_ledger_lineage_summary(
+    session: Session,
+    *,
+    strategy_id: str | None,
+    account_label: str,
+    symbols: tuple[str, ...],
+) -> dict[str, object]:
+    stmt = (
+        select(Execution)
+        .join(ExecutionTCAMetric, ExecutionTCAMetric.execution_id == Execution.id)
+        .where(
+            Execution.avg_fill_price.is_not(None),
+            Execution.filled_qty > 0,
+        )
+    )
+    if strategy_id:
+        stmt = stmt.where(ExecutionTCAMetric.strategy_id == strategy_id)
+    if account_label:
+        stmt = stmt.where(Execution.alpaca_account_label == account_label)
+    if symbols:
+        stmt = stmt.where(Execution.symbol.in_(symbols))
+    return _execution_lineage_summary(session.execute(stmt).scalars().all())
+
+
+def _execution_lineage_summary(executions: Collection[Execution]) -> dict[str, object]:
+    blocker_counts: dict[str, int] = {}
+    source_backed_count = 0
+    filled_notional_count = 0
+    explicit_cost_count = 0
+    execution_policy_hash_count = 0
+    cost_model_hash_count = 0
+    post_cost_pnl_basis_count = 0
+    sample_blockers: list[dict[str, object]] = []
+    for execution in executions:
+        audit_payload = _mapping_from_any(execution.execution_audit_json)
+        lineage = _mapping_from_any(
+            audit_payload.get("runtime_ledger_lineage")
+            or audit_payload.get("execution_tca_cost_lineage")
+        )
+        blockers = [
+            str(item).strip()
+            for item in cast(Collection[object], lineage.get("blockers") or [])
+            if str(item).strip()
+        ]
+        if not lineage:
+            blockers = ["runtime_tca_cost_lineage_readback_missing"]
+        if lineage.get("source_backed") is True and not blockers:
+            source_backed_count += 1
+        if lineage.get("filled_notional") is not None:
+            filled_notional_count += 1
+        if lineage.get("explicit_cost_amount") is not None:
+            explicit_cost_count += 1
+        if lineage.get("execution_policy_hash") is not None:
+            execution_policy_hash_count += 1
+        if lineage.get("cost_model_hash") is not None:
+            cost_model_hash_count += 1
+        if lineage.get("pnl_basis") == POST_COST_PNL_BASIS:
+            post_cost_pnl_basis_count += 1
+        for blocker in blockers:
+            blocker_counts[blocker] = blocker_counts.get(blocker, 0) + 1
+        if blockers and len(sample_blockers) < 10:
+            sample_blockers.append(
+                {
+                    "execution_id": str(execution.id),
+                    "alpaca_order_id": execution.alpaca_order_id,
+                    "symbol": execution.symbol,
+                    "blockers": blockers,
+                }
+            )
+
+    execution_count = len(executions)
+    blockers = sorted(blocker_counts)
+    return {
+        "schema_version": EXECUTION_TCA_COST_LINEAGE_SCHEMA_VERSION,
+        "status": "source_backed"
+        if execution_count > 0
+        and source_backed_count == execution_count
+        and not blockers
+        else "blocked"
+        if execution_count > 0
+        else "missing",
+        "promotion_authority": False,
+        "promotion_authority_reason": "lineage_dimension_only_not_promotion_authority",
+        "execution_count": execution_count,
+        "source_backed_count": source_backed_count,
+        "blocked_count": max(0, execution_count - source_backed_count),
+        "filled_notional_count": filled_notional_count,
+        "explicit_cost_count": explicit_cost_count,
+        "execution_policy_hash_count": execution_policy_hash_count,
+        "cost_model_hash_count": cost_model_hash_count,
+        "post_cost_pnl_basis_count": post_cost_pnl_basis_count,
+        "blockers": blockers,
+        "blocker_counts": dict(sorted(blocker_counts.items())),
+        "sample_blockers": sample_blockers,
+    }
 
 
 def _normalize_tca_symbols(symbols: Collection[str] | None) -> tuple[str, ...]:

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -995,6 +995,86 @@ def _add_runtime_ledger_profit_proof_checks(
     )
 
 
+def _execution_tca_lineage_summary(tca_source_ref: Mapping[str, Any]) -> dict[str, Any]:
+    lineage = _mapping(
+        tca_source_ref.get("runtime_ledger_lineage")
+        or tca_source_ref.get("execution_tca_cost_lineage")
+    )
+    if not lineage:
+        return {
+            "present": False,
+            "status": "missing",
+            "schema_version": None,
+            "promotion_authority": False,
+            "execution_count": 0,
+            "source_backed_count": 0,
+            "blocked_count": 0,
+            "blockers": ["runtime_tca_cost_lineage_readback_missing"],
+            "blocker_counts": {
+                "runtime_tca_cost_lineage_readback_missing": 1,
+            },
+        }
+    blockers = [
+        _text(item) for item in _sequence(lineage.get("blockers")) if _text(item)
+    ]
+    return {
+        "present": True,
+        "schema_version": _text(lineage.get("schema_version")),
+        "status": _text(lineage.get("status")),
+        "promotion_authority": lineage.get("promotion_authority") is True,
+        "promotion_authority_reason": _text(lineage.get("promotion_authority_reason")),
+        "execution_count": _int(lineage.get("execution_count")),
+        "source_backed_count": _int(lineage.get("source_backed_count")),
+        "blocked_count": _int(lineage.get("blocked_count")),
+        "filled_notional_count": _int(lineage.get("filled_notional_count")),
+        "explicit_cost_count": _int(lineage.get("explicit_cost_count")),
+        "execution_policy_hash_count": _int(lineage.get("execution_policy_hash_count")),
+        "cost_model_hash_count": _int(lineage.get("cost_model_hash_count")),
+        "post_cost_pnl_basis_count": _int(lineage.get("post_cost_pnl_basis_count")),
+        "blockers": blockers,
+        "blocker_counts": _mapping(lineage.get("blocker_counts")),
+        "sample_blockers": list(_sequence(lineage.get("sample_blockers"))),
+    }
+
+
+def _add_execution_tca_lineage_check(
+    checks: dict[str, dict[str, Any]],
+    lineage: Mapping[str, Any],
+) -> None:
+    execution_count = _int(lineage.get("execution_count"))
+    source_backed_count = _int(lineage.get("source_backed_count"))
+    blockers = [
+        _text(item) for item in _sequence(lineage.get("blockers")) if _text(item)
+    ]
+    _add_check(
+        checks,
+        "execution_tca_cost_lineage_source_backed",
+        passed=(
+            lineage.get("present") is True
+            and lineage.get("schema_version") == "torghut.execution-tca-cost-lineage.v1"
+            and lineage.get("status") == "source_backed"
+            and execution_count > 0
+            and source_backed_count == execution_count
+            and _int(lineage.get("filled_notional_count")) == execution_count
+            and _int(lineage.get("explicit_cost_count")) == execution_count
+            and _int(lineage.get("execution_policy_hash_count")) == execution_count
+            and _int(lineage.get("cost_model_hash_count")) == execution_count
+            and _int(lineage.get("post_cost_pnl_basis_count")) == execution_count
+            and lineage.get("promotion_authority") is False
+            and not blockers
+        ),
+        observed=lineage,
+        expected={
+            "schema_version": "torghut.execution-tca-cost-lineage.v1",
+            "status": "source_backed",
+            "execution_count": ">0",
+            "source_backed_count": "execution_count",
+            "promotion_authority": False,
+            "blockers": [],
+        },
+    )
+
+
 def evaluate_trading_readiness(
     status: Mapping[str, Any],
     *,
@@ -1154,6 +1234,7 @@ def evaluate_trading_readiness(
     )
 
     tca_source_ref = _mapping(dimensions.get("execution_tca", {}).get("source_ref"))
+    execution_tca_lineage = _execution_tca_lineage_summary(tca_source_ref)
     symbol_routes = _mapping(tca_source_ref.get("symbol_routes"))
     routeable_symbol_count = _int(symbol_routes.get("routeable_symbol_count"))
     blocked_symbol_count = _int(symbol_routes.get("blocked_symbol_count"))
@@ -1185,6 +1266,8 @@ def evaluate_trading_readiness(
         expected=0,
         detail=symbol_routes.get("missing_symbols") or [],
     )
+    if require_runtime_ledger_profit_proof or require_runtime_ledger_proof_packet:
+        _add_execution_tca_lineage_check(checks, execution_tca_lineage)
 
     route_board = _mapping(status.get("route_reacquisition_board"))
     route_board_summary = _mapping(route_board.get("summary"))
@@ -1523,6 +1606,7 @@ def evaluate_trading_readiness(
         "paper_route_preopen_evidence_collection": (
             paper_route_preopen_evidence_collection
         ),
+        "execution_tca_lineage": execution_tca_lineage,
         "completion_profit_proof": {
             "required": require_runtime_ledger_profit_proof,
             "gate_id": DOC29_LIVE_SCALE_GATE,

--- a/services/torghut/tests/test_execution_tca.py
+++ b/services/torghut/tests/test_execution_tca.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+from unittest import TestCase
+
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.models import Base, Execution, ExecutionTCAMetric, Strategy, TradeDecision
+from app.trading.tca import (
+    build_tca_gate_inputs,
+    refresh_execution_tca_metrics,
+    upsert_execution_tca_metric,
+)
+
+
+class TestExecutionTcaCostLineage(TestCase):
+    def setUp(self) -> None:
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        Base.metadata.create_all(engine)
+        self.session_local = sessionmaker(
+            bind=engine, expire_on_commit=False, future=True
+        )
+
+    def test_upsert_repairs_source_backed_cost_lineage(self) -> None:
+        with self.session_local() as session:
+            strategy = self._insert_strategy(session)
+            decision = self._insert_decision(
+                session,
+                strategy,
+                decision_hash="source-backed-decision",
+                execution_policy={"version": "adaptive-limit-v1", "max_bps": "12"},
+            )
+            execution = self._insert_execution(
+                session,
+                decision,
+                order_id="source-backed-order",
+                raw_order={
+                    "commission": "0.02",
+                    "cost_model": {
+                        "source": "broker_reported_commission",
+                        "version": "alpaca-paper-explicit",
+                    },
+                },
+            )
+
+            metric = upsert_execution_tca_metric(session, execution)
+            session.flush()
+            lineage = self._lineage(execution)
+            tca_inputs = build_tca_gate_inputs(
+                session,
+                strategy_id=str(strategy.id),
+                account_label="paper",
+                symbols=["AAPL"],
+            )
+
+        self.assertEqual(metric.execution_id, execution.id)
+        self.assertEqual(lineage["status"], "source_backed")
+        self.assertEqual(lineage["blockers"], [])
+        self.assertEqual(lineage["filled_notional"], "1000")
+        self.assertEqual(lineage["explicit_cost_amount"], "0.02")
+        self.assertEqual(lineage["cost_basis"], "broker_reported_commission")
+        self.assertIsInstance(lineage["execution_policy_hash"], str)
+        self.assertIsInstance(lineage["cost_model_hash"], str)
+        self.assertFalse(lineage["promotion_authority"])
+        runtime_lineage = tca_inputs["runtime_ledger_lineage"]
+        assert isinstance(runtime_lineage, dict)
+        self.assertEqual(runtime_lineage["status"], "source_backed")
+        self.assertEqual(runtime_lineage["source_backed_count"], 1)
+        self.assertEqual(runtime_lineage["explicit_cost_count"], 1)
+
+    def test_upsert_blocks_missing_explicit_cost_without_inference(self) -> None:
+        with self.session_local() as session:
+            strategy = self._insert_strategy(session)
+            decision = self._insert_decision(
+                session,
+                strategy,
+                decision_hash="missing-cost-decision",
+                execution_policy={"version": "adaptive-limit-v1"},
+            )
+            execution = self._insert_execution(
+                session,
+                decision,
+                order_id="missing-cost-order",
+                raw_order={"cost_model": {"version": "present-but-no-cost"}},
+            )
+
+            upsert_execution_tca_metric(session, execution)
+            session.flush()
+            lineage = self._lineage(execution)
+
+        self.assertEqual(lineage["status"], "blocked")
+        self.assertIn("explicit_cost_missing", lineage["blockers"])
+        self.assertEqual(lineage["filled_notional"], "1000")
+        self.assertIsNone(lineage["explicit_cost_amount"])
+
+    def test_upsert_blocks_ambiguous_policy_and_cost_model_hashes(self) -> None:
+        with self.session_local() as session:
+            strategy = self._insert_strategy(session)
+            decision = self._insert_decision(
+                session,
+                strategy,
+                decision_hash="ambiguous-hash-decision",
+                execution_policy=None,
+            )
+            execution = self._insert_execution(
+                session,
+                decision,
+                order_id="ambiguous-hash-order",
+                execution_audit_json={
+                    "execution_policy_hash": "policy-a",
+                    "cost_model_hash": "cost-a",
+                },
+                raw_order={
+                    "commission": "0.02",
+                    "execution_policy_hash": "policy-b",
+                    "cost_model_hash": "cost-b",
+                },
+            )
+
+            upsert_execution_tca_metric(session, execution)
+            session.flush()
+            lineage = self._lineage(execution)
+
+        self.assertEqual(lineage["status"], "blocked")
+        self.assertIn("execution_policy_hash_ambiguous", lineage["blockers"])
+        self.assertIn("cost_model_hash_ambiguous", lineage["blockers"])
+        self.assertIsNone(lineage["execution_policy_hash"])
+        self.assertIsNone(lineage["cost_model_hash"])
+
+    def test_refresh_is_idempotent_for_audit_lineage(self) -> None:
+        with self.session_local() as session:
+            strategy = self._insert_strategy(session)
+            decision = self._insert_decision(
+                session,
+                strategy,
+                decision_hash="idempotent-refresh-decision",
+                execution_policy={"version": "adaptive-limit-v1"},
+            )
+            execution = self._insert_execution(
+                session,
+                decision,
+                order_id="idempotent-refresh-order",
+                raw_order={
+                    "commission": "0.02",
+                    "cost_model": {"source": "broker_reported_commission"},
+                },
+            )
+            session.commit()
+
+            first = refresh_execution_tca_metrics(session, limit=10)
+            session.commit()
+            first_audit = dict(execution.execution_audit_json)
+
+            second = refresh_execution_tca_metrics(session, limit=10)
+            session.commit()
+            second_audit = dict(execution.execution_audit_json)
+            metric_count = session.scalar(select(func.count(ExecutionTCAMetric.id)))
+
+        self.assertEqual(first["selected"], 1)
+        self.assertEqual(first["refreshed"], 1)
+        self.assertEqual(second["selected"], 1)
+        self.assertEqual(second["refreshed"], 1)
+        self.assertEqual(first_audit, second_audit)
+        self.assertEqual(metric_count, 1)
+
+    def _insert_strategy(self, session: Session) -> Strategy:
+        strategy = Strategy(
+            name="execution-tca-lineage-test",
+            description="test",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+        )
+        session.add(strategy)
+        session.commit()
+        session.refresh(strategy)
+        return strategy
+
+    def _insert_decision(
+        self,
+        session: Session,
+        strategy: Strategy,
+        *,
+        decision_hash: str,
+        execution_policy: dict[str, object] | None,
+    ) -> TradeDecision:
+        params: dict[str, object] = {"price": "100"}
+        if execution_policy is not None:
+            params["execution_policy"] = execution_policy
+        decision = TradeDecision(
+            strategy_id=strategy.id,
+            alpaca_account_label="paper",
+            symbol="AAPL",
+            timeframe="1Min",
+            decision_json={
+                "strategy_id": str(strategy.id),
+                "symbol": "AAPL",
+                "action": "buy",
+                "qty": "10",
+                "params": params,
+            },
+            rationale="test",
+            status="submitted",
+            decision_hash=decision_hash,
+        )
+        session.add(decision)
+        session.flush()
+        return decision
+
+    def _insert_execution(
+        self,
+        session: Session,
+        decision: TradeDecision,
+        *,
+        order_id: str,
+        raw_order: dict[str, object],
+        execution_audit_json: dict[str, object] | None = None,
+    ) -> Execution:
+        execution = Execution(
+            trade_decision_id=decision.id,
+            alpaca_order_id=order_id,
+            client_order_id=f"client-{order_id}",
+            symbol="AAPL",
+            side="buy",
+            order_type="market",
+            time_in_force="day",
+            submitted_qty=Decimal("10"),
+            filled_qty=Decimal("10"),
+            avg_fill_price=Decimal("100"),
+            status="filled",
+            alpaca_account_label="paper",
+            execution_expected_adapter="alpaca",
+            execution_actual_adapter="alpaca",
+            execution_audit_json=execution_audit_json,
+            raw_order={
+                "id": order_id,
+                "filled_at": datetime(2026, 6, 1, tzinfo=timezone.utc).isoformat(),
+                **raw_order,
+            },
+        )
+        session.add(execution)
+        session.flush()
+        return execution
+
+    def _lineage(self, execution: Execution) -> dict[str, Any]:
+        audit = execution.execution_audit_json
+        assert isinstance(audit, dict)
+        lineage = audit["runtime_ledger_lineage"]
+        assert isinstance(lineage, dict)
+        return lineage

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -61,7 +61,26 @@ def _ready_status() -> dict[str, object]:
                             ],
                             "blocked_symbols": [],
                             "missing_symbols": [],
-                        }
+                        },
+                        "runtime_ledger_lineage": {
+                            "schema_version": "torghut.execution-tca-cost-lineage.v1",
+                            "status": "source_backed",
+                            "promotion_authority": False,
+                            "promotion_authority_reason": (
+                                "lineage_dimension_only_not_promotion_authority"
+                            ),
+                            "execution_count": 2,
+                            "source_backed_count": 2,
+                            "blocked_count": 0,
+                            "filled_notional_count": 2,
+                            "explicit_cost_count": 2,
+                            "execution_policy_hash_count": 2,
+                            "cost_model_hash_count": 2,
+                            "post_cost_pnl_basis_count": 2,
+                            "blockers": [],
+                            "blocker_counts": {},
+                            "sample_blockers": [],
+                        },
                     },
                 },
             ],
@@ -439,6 +458,75 @@ class TestVerifyTradingReadiness(TestCase):
             "runtime_ledger_post_cost_expectancy_positive",
         ):
             self.assertIn(check_name, weak["failed_checks"])
+
+    def test_runtime_ledger_profit_proof_requires_tca_cost_lineage_readback(
+        self,
+    ) -> None:
+        status = _ready_status()
+        proof_floor = status["proof_floor"]
+        assert isinstance(proof_floor, dict)
+        dimensions = proof_floor["proof_dimensions"]
+        assert isinstance(dimensions, list)
+        for dimension in dimensions:
+            if (
+                isinstance(dimension, dict)
+                and dimension.get("dimension") == "execution_tca"
+            ):
+                source_ref = dimension["source_ref"]
+                assert isinstance(source_ref, dict)
+                source_ref["runtime_ledger_lineage"] = {
+                    "schema_version": "torghut.execution-tca-cost-lineage.v1",
+                    "status": "blocked",
+                    "promotion_authority": False,
+                    "execution_count": 1,
+                    "source_backed_count": 0,
+                    "blocked_count": 1,
+                    "filled_notional_count": 1,
+                    "explicit_cost_count": 0,
+                    "execution_policy_hash_count": 1,
+                    "cost_model_hash_count": 1,
+                    "post_cost_pnl_basis_count": 1,
+                    "blockers": ["explicit_cost_missing"],
+                    "blocker_counts": {"explicit_cost_missing": 1},
+                    "sample_blockers": [
+                        {
+                            "execution_id": "exec-1",
+                            "blockers": ["explicit_cost_missing"],
+                        }
+                    ],
+                }
+
+        result = evaluate_trading_readiness(
+            status,
+            completion_status=_completion_status(),
+            require_runtime_ledger_profit_proof=True,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn(
+            "execution_tca_cost_lineage_source_backed",
+            result["failed_checks"],
+        )
+        self.assertEqual(
+            result["execution_tca_lineage"]["blockers"],
+            ["explicit_cost_missing"],
+        )
+
+    def test_tca_cost_lineage_readback_does_not_replace_runtime_authority(
+        self,
+    ) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            require_runtime_ledger_profit_proof=True,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("completion_status_present", result["failed_checks"])
+        self.assertNotIn(
+            "execution_tca_cost_lineage_source_backed",
+            result["failed_checks"],
+        )
 
     def test_runtime_ledger_proof_packet_can_be_required_as_final_authority(
         self,


### PR DESCRIPTION
## Summary

- Adds deterministic execution TCA/runtime-ledger cost lineage repair during TCA metric upsert and refresh, backed only by persisted execution/order/decision fields.
- Writes structured source-backed or blocked lineage metadata for filled notional, explicit cost amount/basis, execution policy hash, cost model hash, lineage hash, and post-cost PnL basis.
- Exposes aggregate TCA lineage readback and verifies it as a required evidence dimension when runtime-ledger profit proof or proof packets are required, without making TCA lineage promotion authority.
- Adds regression coverage for source-backed explicit costs, missing explicit costs, ambiguous policy/cost hashes, idempotent refresh, and readiness readback behavior.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_tca.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_tca.py tests/test_tca_adaptive_policy.py tests/test_refresh_execution_tca_metrics_script.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/tca.py scripts/refresh_execution_tca_metrics.py scripts/verify_trading_readiness.py tests/test_execution_tca.py tests/test_tca_adaptive_policy.py tests/test_refresh_execution_tca_metrics_script.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tca.py scripts/refresh_execution_tca_metrics.py scripts/verify_trading_readiness.py tests/test_execution_tca.py tests/test_tca_adaptive_policy.py tests/test_refresh_execution_tca_metrics_script.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
