### PR TITLE
fix(torghut): preserve safe paper import plans

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5256,6 +5256,15 @@ def _merge_external_paper_route_target_plan(
     if load_error:
         gate["paper_route_target_plan_error"] = load_error
         if settings.trading_paper_route_target_plan_url:
+            if _paper_route_target_plan_cache_safe_for_live(local_plan):
+                gate.setdefault(
+                    "paper_route_target_plan_source",
+                    "local_runtime_ledger_paper_probation_import_plan",
+                )
+                gate["paper_route_target_plan_external_source"] = (
+                    "external_target_plan_url"
+                )
+                return gate
             gate["runtime_ledger_paper_probation_import_plan"] = {
                 "schema_version": local_plan.get("schema_version")
                 or "torghut.runtime-ledger-paper-probation-import-plan.v1",

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -9733,6 +9733,53 @@ class TestTradingApi(TestCase):
         finally:
             settings.trading_paper_route_target_plan_url = original_target_plan_url
 
+        safe_local_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "final_promotion_authorized": False,
+                "targets": [
+                    {
+                        "candidate_id": "safe-local",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_probe_symbols": ["AAPL"],
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                        "final_promotion_authorized": False,
+                    }
+                ],
+            }
+        }
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        try:
+            settings.trading_paper_route_target_plan_url = (
+                "http://torghut.example/paper-route-plan"
+            )
+            with patch(
+                "app.main._load_external_paper_route_target_plan",
+                return_value={"load_error": "paper_route_target_plan_timeout"},
+            ):
+                gate = _merge_external_paper_route_target_plan(safe_local_gate)
+            plan = gate["runtime_ledger_paper_probation_import_plan"]
+            self.assertEqual(
+                gate["paper_route_target_plan_error"],
+                "paper_route_target_plan_timeout",
+            )
+            self.assertEqual(
+                gate["paper_route_target_plan_source"],
+                "local_runtime_ledger_paper_probation_import_plan",
+            )
+            self.assertEqual(
+                gate["paper_route_target_plan_external_source"],
+                "external_target_plan_url",
+            )
+            self.assertEqual(plan["target_count"], 1)
+            self.assertEqual(plan["targets"][0]["candidate_id"], "safe-local")
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+
         original_target_plan_url = settings.trading_paper_route_target_plan_url
         try:
             settings.trading_paper_route_target_plan_url = (


### PR DESCRIPTION
## Summary

- Preserve a safe local TORGHUT_SIM paper-probation import plan when the external paper-route target-plan URL times out or fails.
- Keep external target-plan fetch errors visible on the gate while leaving promotion/final-promotion authority stripped.
- Add regression coverage so unsafe local plans still fail closed to zero targets, while safe evidence-collection plans remain auditable.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k merge_external_paper_route_target_plan_fails_closed -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
