### PR TITLE
fix(torghut): prefer clean paper route followup targets

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -6622,6 +6622,7 @@ def build_paper_route_target_plan_payload(
     )
     effective_target_plan: Mapping[str, Any] = {}
     for candidate_plan in (
+        next_clean_after_discard_targets,
         next_targets,
         source_targets,
         runtime_window_import_plan,

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -58,6 +58,9 @@ def paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, A
 
 def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     live_gate = _to_str_map(payload.get("live_submission_gate"))
+    next_clean_after_discard_plan = _to_str_map(
+        payload.get("next_clean_paper_route_runtime_window_targets_after_discard")
+    )
     runtime_window_plan = _to_str_map(payload.get("runtime_window_import_plan"))
     source_runtime_window_plan = _to_str_map(
         payload.get("source_runtime_window_import_plan")
@@ -66,6 +69,7 @@ def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str
         payload.get("next_paper_route_runtime_window_targets")
     )
     candidate_plans = [
+        next_clean_after_discard_plan,
         next_paper_route_plan,
         source_runtime_window_plan,
         runtime_window_plan,
@@ -213,9 +217,7 @@ def _text_items(value: object) -> list[str]:
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
         return []
     return [
-        str(item).strip()
-        for item in cast(Sequence[object], value)
-        if str(item).strip()
+        str(item).strip() for item in cast(Sequence[object], value) if str(item).strip()
     ]
 
 
@@ -374,7 +376,10 @@ def _target_identity_blockers(identity: Mapping[str, Any]) -> list[str]:
         or (field == "target_notional" and _safe_decimal(identity.get(field)) <= 0)
         or (field == "target_quantity" and _safe_decimal(identity.get(field)) <= 0)
     ]
-    if _safe_text(identity.get("account_label")) != PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL:
+    if (
+        _safe_text(identity.get("account_label"))
+        != PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL
+    ):
         blockers.append("paper_route_target_torghut_sim_account_required")
     if _safe_text(identity.get("bounded_collection_stage")) not in {
         "paper",
@@ -406,7 +411,9 @@ def _target_materialization_blockers(
     quantities = _target_symbol_quantities(target)
     if not actions:
         blockers.append("paper_route_target_symbol_actions_missing")
-    missing_quantity_symbols = sorted(symbol for symbol in actions if symbol not in quantities)
+    missing_quantity_symbols = sorted(
+        symbol for symbol in actions if symbol not in quantities
+    )
     if missing_quantity_symbols:
         blockers.append("paper_route_target_symbol_quantities_missing")
     return sorted(dict.fromkeys(blockers))

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -6487,6 +6487,24 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target_plan_payload["runtime_window_import_plan"]["purpose"],
             "next_clean_session_paper_route_runtime_window_collection_after_discard",
         )
+        self.assertEqual(
+            target_plan_payload["purpose"],
+            "next_clean_session_paper_route_runtime_window_collection_after_discard",
+        )
+        self.assertEqual(
+            target_plan_payload["targets"][0]["paper_route_probe_window_start"],
+            "2026-05-27T13:30:00+00:00",
+        )
+        self.assertEqual(
+            target_plan_payload["targets"][0]["paper_route_clean_window_state"],
+            "clean_window_required",
+        )
+        self.assertEqual(
+            target_plan_payload["targets"][0][
+                "paper_route_account_contamination_blockers"
+            ],
+            [],
+        )
 
     def test_active_window_contamination_blocks_target_plan_collection(self) -> None:
         window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -9081,6 +9081,48 @@ class TestTradingApi(TestCase):
             plan["targets"][0]["window_start"], "2026-06-01T13:30:00+00:00"
         )
 
+    def test_paper_route_target_plan_from_payload_prefers_clean_after_discard(
+        self,
+    ) -> None:
+        plan = _paper_route_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "next_clean_paper_route_runtime_window_targets_after_discard": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "purpose": "next_clean_session_paper_route_runtime_window_collection_after_discard",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "clean-followup-target",
+                            "window_start": "2026-06-02T13:30:00+00:00",
+                            "window_end": "2026-06-02T20:00:00+00:00",
+                            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        }
+                    ],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "purpose": "latest_closed_session_paper_route_runtime_window_import",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "contaminated-closed-target",
+                            "window_start": "2026-06-01T13:30:00+00:00",
+                            "window_end": "2026-06-01T20:00:00+00:00",
+                            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(plan["targets"][0]["candidate_id"], "clean-followup-target")
+        self.assertEqual(
+            plan["targets"][0]["window_start"], "2026-06-02T13:30:00+00:00"
+        )
+
     def test_paper_route_target_plan_from_payload_falls_back_to_source_plan(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Prefer `next_clean_paper_route_runtime_window_targets_after_discard` when exporting or parsing paper-route target plans.
- Keep contaminated latest/next window evidence visible in nested audit fields while steering collection/materialization at the clean follow-up window.
- Add regressions proving the target-plan payload and shared parser select the clean follow-up target after a dirty window is discarded.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'discard or contamination' tests/test_trading_api.py -k 'paper_route_target_plan_from_payload' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -k 'paper_route_target_plan or discard or contamination' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'strategy_signal_paper_uses_next_target_plan_over_closed_import_plan or paper_route_probe_context_honors_external_target_plan_scope or paper_route_target_plan_reserves_account_for_collection or paper_route_target_plan_reservation_rejects_unusable_targets' -q`
- `uv run --frozen ruff check app/trading/paper_route_target_plan.py app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen ruff format --check app/trading/paper_route_target_plan.py app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
