### PR TITLE
fix(torghut): expose hpairs quote fillability diagnostics

### DIFF
--- a/services/torghut/app/trading/quote_quality.py
+++ b/services/torghut/app/trading/quote_quality.py
@@ -35,6 +35,29 @@ class QuoteQualityStatus:
     price: Decimal | None = None
     bid: Decimal | None = None
     ask: Decimal | None = None
+    fillability_state: str = 'blocked'
+    repair_action: str | None = None
+    evidence_requirements: tuple[str, ...] = ()
+
+    def to_readback(self) -> dict[str, object]:
+        """Return source-backed quote/fillability diagnostics for readiness output."""
+
+        return {
+            'valid': self.valid,
+            'reason': self.reason,
+            'fillability_state': self.fillability_state,
+            'repair_action': self.repair_action,
+            'evidence_requirements': list(self.evidence_requirements),
+            'spread_bps': str(self.spread_bps) if self.spread_bps is not None else None,
+            'jump_bps': str(self.jump_bps) if self.jump_bps is not None else None,
+            'quote_age_seconds': str(self.quote_age_seconds)
+            if self.quote_age_seconds is not None
+            else None,
+            'source': self.source,
+            'price': str(self.price) if self.price is not None else None,
+            'bid': str(self.bid) if self.bid is not None else None,
+            'ask': str(self.ask) if self.ask is not None else None,
+        }
 
 
 class SignalQuoteQualityTracker:
@@ -72,7 +95,7 @@ def assess_signal_quote_quality(
     source = _extract_quote_source(signal)
     quote_age_seconds = _signal_quote_age_seconds(signal)
     if price is None or price <= 0:
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='non_positive_price',
             quote_age_seconds=quote_age_seconds,
@@ -82,7 +105,7 @@ def assess_signal_quote_quality(
             ask=ask,
         )
     if bid is None and ask is None:
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='missing_executable_quote',
             quote_age_seconds=quote_age_seconds,
@@ -92,7 +115,7 @@ def assess_signal_quote_quality(
             ask=ask,
         )
     if bid is None:
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='missing_bid',
             quote_age_seconds=quote_age_seconds,
@@ -102,7 +125,7 @@ def assess_signal_quote_quality(
             ask=ask,
         )
     if ask is None:
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='missing_ask',
             quote_age_seconds=quote_age_seconds,
@@ -112,7 +135,7 @@ def assess_signal_quote_quality(
             ask=ask,
         )
     if bid <= 0:
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='non_positive_bid',
             quote_age_seconds=quote_age_seconds,
@@ -122,7 +145,7 @@ def assess_signal_quote_quality(
             ask=ask,
         )
     if ask <= 0:
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='non_positive_ask',
             quote_age_seconds=quote_age_seconds,
@@ -132,7 +155,7 @@ def assess_signal_quote_quality(
             ask=ask,
         )
     if ask < bid:
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='crossed_quote',
             quote_age_seconds=quote_age_seconds,
@@ -149,7 +172,7 @@ def assess_signal_quote_quality(
         and quote_age_seconds
         > Decimal(str(effective_policy.max_executable_quote_age_seconds))
     ):
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='stale_quote',
             spread_bps=spread_bps,
@@ -163,7 +186,7 @@ def assess_signal_quote_quality(
         spread_bps is not None
         and spread_bps > effective_policy.max_executable_spread_bps
     ):
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='spread_bps_exceeded',
             spread_bps=spread_bps,
@@ -181,7 +204,7 @@ def assess_signal_quote_quality(
         and spread_bps is not None
         and spread_bps > effective_policy.max_jump_with_wide_spread_bps
     ):
-        return QuoteQualityStatus(
+        return _status(
             valid=False,
             reason='wide_spread_midpoint_jump',
             spread_bps=spread_bps,
@@ -192,7 +215,7 @@ def assess_signal_quote_quality(
             bid=bid,
             ask=ask,
         )
-    return QuoteQualityStatus(
+    return _status(
         valid=True,
         spread_bps=spread_bps,
         jump_bps=jump_bps,
@@ -204,12 +227,113 @@ def assess_signal_quote_quality(
     )
 
 
+_QUOTE_CONTAINER_KEYS = (
+    'price_snapshot',
+    'executable_quote',
+    'quote',
+    'nbbo',
+    'market_snapshot',
+)
+_QUOTE_DECIMAL_KEYS: Mapping[str, tuple[str, ...]] = {
+    'price': ('price', 'mid', 'mid_price', 'midpoint'),
+    'bid': ('bid', 'bid_px', 'bid_price', 'bp'),
+    'ask': ('ask', 'ask_px', 'ask_price', 'ap'),
+    'spread': ('spread', 'imbalance_spread'),
+}
+_REPAIR_ACTIONS: Mapping[str, str] = {
+    'non_positive_price': 'collect_positive_executable_reference_price',
+    'missing_executable_quote': 'collect_bid_ask_quote_before_routeability_claim',
+    'missing_bid': 'collect_bid_quote_before_routeability_claim',
+    'missing_ask': 'collect_ask_quote_before_routeability_claim',
+    'non_positive_bid': 'refresh_bid_quote_before_routeability_claim',
+    'non_positive_ask': 'refresh_ask_quote_before_routeability_claim',
+    'crossed_quote': 'refresh_uncrossed_executable_quote_before_routeability_claim',
+    'stale_quote': 'refresh_quote_snapshot_and_recompute_route_fillability',
+    'spread_bps_exceeded': 'wait_for_tighter_executable_quote_before_routeability_claim',
+    'wide_spread_midpoint_jump': 'collect_fresh_tight_quote_and_recheck_midpoint_jump',
+}
+_EVIDENCE_REQUIREMENTS: Mapping[str, tuple[str, ...]] = {
+    'non_positive_price': ('positive_executable_price',),
+    'missing_executable_quote': ('bid_px', 'ask_px', 'quote_source', 'quote_as_of'),
+    'missing_bid': ('bid_px', 'quote_source', 'quote_as_of'),
+    'missing_ask': ('ask_px', 'quote_source', 'quote_as_of'),
+    'non_positive_bid': ('positive_bid_px', 'quote_source', 'quote_as_of'),
+    'non_positive_ask': ('positive_ask_px', 'quote_source', 'quote_as_of'),
+    'crossed_quote': ('uncrossed_bid_ask_quote', 'quote_source', 'quote_as_of'),
+    'stale_quote': ('fresh_quote_as_of', 'quote_source'),
+    'spread_bps_exceeded': ('tight_executable_spread_bps', 'bid_px', 'ask_px'),
+    'wide_spread_midpoint_jump': (
+        'fresh_reference_midpoint',
+        'tight_executable_spread_bps',
+    ),
+}
+
+
+def _status(
+    *,
+    valid: bool,
+    reason: str | None = None,
+    spread_bps: Decimal | None = None,
+    jump_bps: Decimal | None = None,
+    quote_age_seconds: Decimal | None = None,
+    source: str | None = None,
+    price: Decimal | None = None,
+    bid: Decimal | None = None,
+    ask: Decimal | None = None,
+) -> QuoteQualityStatus:
+    if valid:
+        return QuoteQualityStatus(
+            valid=True,
+            reason=None,
+            spread_bps=spread_bps,
+            jump_bps=jump_bps,
+            quote_age_seconds=quote_age_seconds,
+            source=source,
+            price=price,
+            bid=bid,
+            ask=ask,
+            fillability_state='executable_quote_ready',
+            repair_action=None,
+            evidence_requirements=(),
+        )
+    normalized_reason = reason or 'unknown_quote_quality_blocker'
+    return QuoteQualityStatus(
+        valid=False,
+        reason=normalized_reason,
+        spread_bps=spread_bps,
+        jump_bps=jump_bps,
+        quote_age_seconds=quote_age_seconds,
+        source=source,
+        price=price,
+        bid=bid,
+        ask=ask,
+        fillability_state='blocked',
+        repair_action=_REPAIR_ACTIONS.get(
+            normalized_reason, 'collect_source_backed_quote_repair_receipt'
+        ),
+        evidence_requirements=_EVIDENCE_REQUIREMENTS.get(
+            normalized_reason,
+            ('source_backed_quote_fillability_receipt',),
+        ),
+    )
+
+
 def _extract_price(signal: SignalEnvelope) -> Decimal | None:
-    return extract_executable_price(signal.payload)
+    direct_price = extract_executable_price(signal.payload)
+    if direct_price is not None:
+        return direct_price
+    snapshot_price = _extract_quote_container_decimal(signal, 'price')
+    if snapshot_price is not None:
+        return snapshot_price
+    bid = _extract_bid(signal)
+    ask = _extract_ask(signal)
+    if bid is None or ask is None:
+        return None
+    return (bid + ask) / 2
 
 
 def _extract_bid(signal: SignalEnvelope) -> Decimal | None:
-    return optional_decimal(
+    bid = optional_decimal(
         payload_value(
             signal.payload,
             'imbalance_bid_px',
@@ -217,10 +341,19 @@ def _extract_bid(signal: SignalEnvelope) -> Decimal | None:
             nested_key='bid_px',
         )
     )
+    if bid is not None:
+        return bid
+    bid = optional_decimal(signal.payload.get('bid'))
+    if bid is not None:
+        return bid
+    bid = optional_decimal(signal.payload.get('bid_px'))
+    if bid is not None:
+        return bid
+    return _extract_quote_container_decimal(signal, 'bid')
 
 
 def _extract_ask(signal: SignalEnvelope) -> Decimal | None:
-    return optional_decimal(
+    ask = optional_decimal(
         payload_value(
             signal.payload,
             'imbalance_ask_px',
@@ -228,6 +361,32 @@ def _extract_ask(signal: SignalEnvelope) -> Decimal | None:
             nested_key='ask_px',
         )
     )
+    if ask is not None:
+        return ask
+    ask = optional_decimal(signal.payload.get('ask'))
+    if ask is not None:
+        return ask
+    ask = optional_decimal(signal.payload.get('ask_px'))
+    if ask is not None:
+        return ask
+    return _extract_quote_container_decimal(signal, 'ask')
+
+
+def _extract_quote_container_decimal(
+    signal: SignalEnvelope,
+    field: str,
+) -> Decimal | None:
+    keys = _QUOTE_DECIMAL_KEYS[field]
+    for container_key in _QUOTE_CONTAINER_KEYS:
+        container = signal.payload.get(container_key)
+        if not isinstance(container, Mapping):
+            continue
+        typed_container = cast(Mapping[str, Any], container)
+        for key in keys:
+            value = optional_decimal(typed_container.get(key))
+            if value is not None:
+                return value
+    return None
 
 
 def _signal_spread_bps(
@@ -252,7 +411,7 @@ def _extract_explicit_spread(signal: SignalEnvelope) -> Decimal | None:
     spread = _optional_decimal(signal.payload.get('spread'))
     if spread is not None:
         return spread
-    return _optional_decimal(
+    spread = _optional_decimal(
         payload_value(
             signal.payload,
             'imbalance_spread',
@@ -260,6 +419,9 @@ def _extract_explicit_spread(signal: SignalEnvelope) -> Decimal | None:
             nested_key='spread',
         )
     )
+    if spread is not None:
+        return spread
+    return _extract_quote_container_decimal(signal, 'spread')
 
 
 def _signal_mid_jump_bps(
@@ -288,10 +450,8 @@ def _signal_quote_age_seconds(signal: SignalEnvelope) -> Decimal | None:
 
 
 def _extract_quote_timestamp(signal: SignalEnvelope) -> datetime | None:
-    price_snapshot = signal.payload.get('price_snapshot')
-    if isinstance(price_snapshot, Mapping):
-        typed_snapshot = cast(Mapping[str, Any], price_snapshot)
-        for key in ('quote_as_of', 'as_of'):
+    for typed_snapshot in _quote_containers(signal):
+        for key in ('quote_as_of', 'as_of', 'timestamp', 't'):
             parsed = _parse_datetime(typed_snapshot.get(key))
             if parsed is not None:
                 return parsed
@@ -303,14 +463,25 @@ def _extract_quote_timestamp(signal: SignalEnvelope) -> datetime | None:
 
 
 def _extract_quote_source(signal: SignalEnvelope) -> str | None:
-    price_snapshot = signal.payload.get('price_snapshot')
-    if isinstance(price_snapshot, Mapping):
-        typed_snapshot = cast(Mapping[str, Any], price_snapshot)
-        for key in ('quote_source', 'source'):
+    for typed_snapshot in _quote_containers(signal):
+        for key in ('quote_source', 'source', 'feed'):
             source = _optional_text(typed_snapshot.get(key))
             if source is not None:
                 return source
-    return _optional_text(signal.payload.get('quote_source'))
+    for key in ('quote_source', 'source'):
+        source = _optional_text(signal.payload.get(key))
+        if source is not None:
+            return source
+    return None
+
+
+def _quote_containers(signal: SignalEnvelope) -> tuple[Mapping[str, Any], ...]:
+    containers: list[Mapping[str, Any]] = []
+    for container_key in _QUOTE_CONTAINER_KEYS:
+        container = signal.payload.get(container_key)
+        if isinstance(container, Mapping):
+            containers.append(cast(Mapping[str, Any], container))
+    return tuple(containers)
 
 
 def _parse_datetime(value: Any) -> datetime | None:

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -246,6 +246,183 @@ def _paper_route_probe_summary(
     }
 
 
+_QUOTE_FILLABILITY_REASON_TOKENS = (
+    "quote",
+    "bid",
+    "ask",
+    "spread",
+    "fillability",
+    "fillable",
+    "routeability",
+)
+_QUOTE_FILLABILITY_REPAIR_ACTIONS: Mapping[str, str] = {
+    "stale_quote": "refresh_quote_snapshot_and_recompute_route_fillability",
+    "missing_executable_quote": "collect_bid_ask_quote_before_routeability_claim",
+    "missing_bid": "collect_bid_quote_before_routeability_claim",
+    "missing_ask": "collect_ask_quote_before_routeability_claim",
+    "non_positive_bid": "refresh_bid_quote_before_routeability_claim",
+    "non_positive_ask": "refresh_ask_quote_before_routeability_claim",
+    "crossed_quote": "refresh_uncrossed_executable_quote_before_routeability_claim",
+    "spread_bps_exceeded": "wait_for_tighter_executable_quote_before_routeability_claim",
+    "wide_spread_midpoint_jump": "collect_fresh_tight_quote_and_recheck_midpoint_jump",
+    "source_signal_rejected_by_quote_quality": "inspect_rejected_signal_quote_quality_events",
+}
+
+
+def _quote_fillability_reason(reason: object) -> str:
+    text = _text(reason)
+    if not text:
+        return ""
+    lowered = text.lower()
+    if lowered.startswith("source_reject_"):
+        lowered = lowered.removeprefix("source_reject_")
+    if lowered in _QUOTE_FILLABILITY_REPAIR_ACTIONS:
+        return text
+    if any(token in lowered for token in _QUOTE_FILLABILITY_REASON_TOKENS):
+        return text
+    return ""
+
+
+def _quote_fillability_repair_action(reasons: Sequence[str]) -> str:
+    for reason in reasons:
+        lowered = reason.lower()
+        if lowered.startswith("source_reject_"):
+            lowered = lowered.removeprefix("source_reject_")
+        action = _QUOTE_FILLABILITY_REPAIR_ACTIONS.get(lowered)
+        if action:
+            return action
+    return "repair_quote_quality_or_fillability_before_runtime_ledger_collection"
+
+
+def _append_unique_text(target: list[str], value: object) -> None:
+    text = _text(value)
+    if text and text not in target:
+        target.append(text)
+
+
+def _paper_route_quote_fillability_summary(
+    *,
+    evidence: Mapping[str, Any],
+    targets: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    runtime_window_audit = _mapping(evidence.get("runtime_window_import_audit"))
+    diagnostics = _mapping(runtime_window_audit.get("diagnostics"))
+    reasons: list[str] = []
+    target_summaries: list[dict[str, Any]] = []
+
+    for key in (
+        "rejected_signal_diagnostic_reasons",
+        "quote_fillability_reasons",
+        "quote_quality_reasons",
+        "fillability_reasons",
+    ):
+        for reason in _sequence(diagnostics.get(key)):
+            _append_unique_text(reasons, _quote_fillability_reason(reason))
+
+    for raw_blocker in _sequence(runtime_window_audit.get("blockers")):
+        _append_unique_text(reasons, _quote_fillability_reason(raw_blocker))
+    for raw_target_blocker in _sequence(runtime_window_audit.get("target_blockers")):
+        target_blocker = _mapping(raw_target_blocker)
+        for blocker in _sequence(target_blocker.get("blockers")):
+            _append_unique_text(reasons, _quote_fillability_reason(blocker))
+
+    for target in targets:
+        routeability = (
+            _mapping(target.get("paper_route_quote_routeability"))
+            or _mapping(target.get("quote_routeability"))
+            or _mapping(target.get("quote_fillability"))
+            or _mapping(target.get("fillability"))
+            or _mapping(target.get("routeability"))
+        )
+        target_reasons: list[str] = []
+        routeability_reason = _quote_fillability_reason(routeability.get("reason"))
+        if routeability_reason:
+            target_reasons.append(routeability_reason)
+        for key in ("blocking_reasons", "reasons", "reason_codes"):
+            for reason in _sequence(routeability.get(key)):
+                normalized = _quote_fillability_reason(reason)
+                if normalized and normalized not in target_reasons:
+                    target_reasons.append(normalized)
+        for reason in target_reasons:
+            _append_unique_text(reasons, reason)
+        if routeability or target_reasons:
+            target_summaries.append(
+                {
+                    "hypothesis_id": _text(target.get("hypothesis_id")),
+                    "candidate_id": _text(target.get("candidate_id")),
+                    "strategy_name": _text(target.get("strategy_name")),
+                    "symbol": _text(
+                        routeability.get("symbol") or target.get("symbol")
+                    ),
+                    "status": _text(routeability.get("status"), "unknown"),
+                    "reasons": target_reasons,
+                    "repair_action": _text(
+                        routeability.get("repair_action")
+                    )
+                    or (
+                        _quote_fillability_repair_action(target_reasons)
+                        if target_reasons
+                        else "none"
+                    ),
+                    "quote_age_seconds": _text(routeability.get("quote_age_seconds")),
+                    "spread_bps": _text(routeability.get("spread_bps")),
+                    "source": _text(routeability.get("source")),
+                }
+            )
+
+    for audit_key in ("target_audits", "runtime_window_import_target_audits"):
+        for raw_audit in _sequence(evidence.get(audit_key)):
+            audit = _mapping(raw_audit)
+            rejected_signal_activity = _mapping(audit.get("rejected_signal_activity"))
+            audit_reasons: list[str] = []
+            for reason in _sequence(rejected_signal_activity.get("blocking_reasons")):
+                normalized = _quote_fillability_reason(reason)
+                if normalized and normalized not in audit_reasons:
+                    audit_reasons.append(normalized)
+            for raw_reason_count in _sequence(
+                rejected_signal_activity.get("reason_counts")
+            ):
+                reason_count = _mapping(raw_reason_count)
+                normalized = _quote_fillability_reason(reason_count.get("reason"))
+                if normalized and normalized not in audit_reasons:
+                    audit_reasons.append(normalized)
+            for reason in audit_reasons:
+                _append_unique_text(reasons, reason)
+            if audit_reasons:
+                target = _mapping(audit.get("target"))
+                target_summaries.append(
+                    {
+                        "hypothesis_id": _text(target.get("hypothesis_id")),
+                        "candidate_id": _text(target.get("candidate_id")),
+                        "strategy_name": _text(target.get("strategy_name")),
+                        "symbol": "",
+                        "status": "blocked",
+                        "reasons": audit_reasons,
+                        "repair_action": _quote_fillability_repair_action(
+                            audit_reasons
+                        ),
+                        "quote_age_seconds": "",
+                        "spread_bps": _text(
+                            rejected_signal_activity.get("max_spread_bps")
+                        ),
+                        "source": "rejected_signal_activity",
+                    }
+                )
+
+    present = bool(target_summaries or reasons)
+    blocked = bool(reasons)
+    return {
+        "present": present,
+        "state": "blocked" if blocked else ("clear" if present else "not_reported"),
+        "blocked": blocked,
+        "blocking_reasons": sorted(reasons),
+        "repair_action": _quote_fillability_repair_action(sorted(reasons))
+        if blocked
+        else "none",
+        "targets": target_summaries,
+    }
+
+
 def _paper_route_target_plan_summary(
     paper_route_evidence: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
@@ -482,6 +659,10 @@ def _paper_route_target_plan_summary(
     import_ready = _bool(handoff.get("import_ready")) or _bool(
         session_readiness.get("import_ready")
     )
+    quote_fillability = _paper_route_quote_fillability_summary(
+        evidence=evidence,
+        targets=targets,
+    )
     return {
         "present": bool(plan),
         "schema_version": _text(plan.get("schema_version")),
@@ -501,6 +682,7 @@ def _paper_route_target_plan_summary(
         "promotion_blocked_count": promotion_blocked_count,
         "account_clean": not account_clean_blockers,
         "account_clean_blockers": sorted(account_clean_blockers),
+        "quote_fillability": quote_fillability,
         "runtime_window_import_health_gate": {
             "ready": bool(targets)
             and health_gate_ready_count == len(targets)
@@ -828,6 +1010,8 @@ def _readiness_next_action(
                 if text and text not in blockers:
                     blockers.append(text)
     for blocker in blockers:
+        if _quote_fillability_reason(blocker):
+            return "repair_quote_quality_or_fillability_before_runtime_ledger_collection"
         if blocker in {
             "runtime_window_import_missing",
             "runtime_window_import_runtime_ledger_materialization_missing",
@@ -858,6 +1042,8 @@ def _readiness_next_action(
         if blocker.startswith("runtime_ledger_"):
             return "repair_runtime_ledger_lifecycle_cost_or_lineage_evidence"
     for failed_check in failed_checks:
+        if "quote_fillability" in failed_check:
+            return "repair_quote_quality_or_fillability_before_runtime_ledger_collection"
         if failed_check.startswith("paper_route_target_plan"):
             return "repair_candidate_frontier_or_paper_route_target_plan"
         if failed_check.startswith("runtime_ledger"):
@@ -1482,6 +1668,14 @@ def evaluate_trading_readiness(
                 "skipped_targets": paper_route_target_plan["skipped_targets"],
             },
             expected={"account_clean": True, "account_clean_blockers": []},
+        )
+        quote_fillability = _mapping(paper_route_target_plan["quote_fillability"])
+        _add_check(
+            checks,
+            "paper_route_target_plan_quote_fillability",
+            passed=not _bool(quote_fillability.get("blocked")),
+            observed=quote_fillability,
+            expected={"blocked": False},
         )
         import_health_gate = _mapping(
             paper_route_target_plan["runtime_window_import_health_gate"]

--- a/services/torghut/tests/property/test_quote_quality_properties.py
+++ b/services/torghut/tests/property/test_quote_quality_properties.py
@@ -26,6 +26,8 @@ def test_tight_positive_quotes_remain_executable(signal: SignalEnvelope) -> None
 
     assert status.valid is True
     assert status.reason is None
+    assert status.fillability_state == 'executable_quote_ready'
+    assert status.repair_action is None
     assert status.spread_bps is not None
     assert status.spread_bps >= 0
 
@@ -39,6 +41,8 @@ def test_crossed_quotes_always_reject(signal: SignalEnvelope) -> None:
 
     assert status.valid is False
     assert status.reason == 'crossed_quote'
+    assert status.fillability_state == 'blocked'
+    assert status.repair_action == 'refresh_uncrossed_executable_quote_before_routeability_claim'
 
 
 @given(ask=positive_prices())
@@ -66,6 +70,8 @@ def test_zero_top_level_bid_does_not_fall_back_to_nested_bid(ask: Decimal) -> No
 
     assert status.valid is False
     assert status.reason == 'non_positive_bid'
+    assert status.fillability_state == 'blocked'
+    assert status.repair_action == 'refresh_bid_quote_before_routeability_claim'
 
 
 @given(
@@ -99,3 +105,5 @@ def test_non_positive_bid_is_never_executable(bid: Decimal, ask: Decimal) -> Non
 
     assert status.valid is False
     assert status.reason == 'non_positive_bid'
+    assert status.fillability_state == 'blocked'
+    assert status.repair_action == 'refresh_bid_quote_before_routeability_claim'

--- a/services/torghut/tests/test_quote_quality.py
+++ b/services/torghut/tests/test_quote_quality.py
@@ -221,3 +221,85 @@ class TestQuoteQuality(TestCase):
         self.assertEqual(status.quote_age_seconds, Decimal('84.0'))
         self.assertEqual(status.bid, Decimal('190.00'))
         self.assertEqual(status.ask, Decimal('190.02'))
+        self.assertEqual(
+            status.repair_action,
+            'refresh_quote_snapshot_and_recompute_route_fillability',
+        )
+        self.assertIn('fresh_quote_as_of', status.evidence_requirements)
+
+    def test_assess_signal_quote_quality_uses_h_pairs_price_snapshot_quote(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Sec',
+            seq=19,
+            payload={
+                'price_snapshot': {
+                    'price': '190.01',
+                    'bid': '190.00',
+                    'ask': '190.02',
+                    'spread': '0.02',
+                    'quote_as_of': '2026-03-27T17:30:23+00:00',
+                    'quote_source': 'paper_route_h_pairs_quote',
+                },
+                'strategy_runtime': {
+                    'hypothesis_id': 'H-PAIRS-01',
+                    'strategy_name': 'microbar-cross-sectional-pairs-v1',
+                },
+            },
+        )
+
+        status = assess_signal_quote_quality(
+            signal=signal,
+            previous_price=Decimal('190.00'),
+            policy=QuoteQualityPolicy(max_executable_quote_age_seconds=30),
+        )
+
+        self.assertTrue(status.valid)
+        self.assertIsNone(status.reason)
+        self.assertEqual(status.fillability_state, 'executable_quote_ready')
+        self.assertIsNone(status.repair_action)
+        self.assertEqual(status.source, 'paper_route_h_pairs_quote')
+        self.assertEqual(status.quote_age_seconds, Decimal('1.0'))
+        self.assertEqual(status.price, Decimal('190.01'))
+        self.assertEqual(status.bid, Decimal('190.00'))
+        self.assertEqual(status.ask, Decimal('190.02'))
+        self.assertEqual(
+            status.to_readback()['fillability_state'], 'executable_quote_ready'
+        )
+
+    def test_assess_signal_quote_quality_exposes_fillability_repair_readback(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol='AAPL',
+            timeframe='1Sec',
+            seq=20,
+            payload={
+                'price_snapshot': {
+                    'price': '190.01',
+                    'ask': '190.02',
+                    'quote_as_of': '2026-03-27T17:30:23+00:00',
+                    'quote_source': 'paper_route_h_pairs_quote',
+                },
+            },
+        )
+
+        status = assess_signal_quote_quality(signal=signal, previous_price=None)
+
+        self.assertFalse(status.valid)
+        self.assertEqual(status.reason, 'missing_bid')
+        self.assertEqual(status.fillability_state, 'blocked')
+        self.assertEqual(
+            status.repair_action, 'collect_bid_quote_before_routeability_claim'
+        )
+        self.assertEqual(
+            status.evidence_requirements, ('bid_px', 'quote_source', 'quote_as_of')
+        )
+        self.assertEqual(
+            status.to_readback()['repair_action'],
+            'collect_bid_quote_before_routeability_claim',
+        )

--- a/services/torghut/tests/test_quote_quality.py
+++ b/services/torghut/tests/test_quote_quality.py
@@ -44,9 +44,7 @@ class TestQuoteQuality(TestCase):
                 max_jump_with_wide_spread_bps=Decimal("25"),
             )
         )
-        first = tracker.assess(
-            self._signal(bid="524.98", ask="525.02", price="525.00")
-        )
+        first = tracker.assess(self._signal(bid="524.98", ask="525.02", price="525.00"))
         second = tracker.assess(
             self._signal(bid="504.00", ask="506.50", price="505.25")
         )
@@ -58,153 +56,236 @@ class TestQuoteQuality(TestCase):
     def test_assess_signal_quote_quality_uses_nested_imbalance_midpoint(self) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-            symbol='META',
-            timeframe='1Sec',
+            symbol="META",
+            timeframe="1Sec",
             seq=13,
             payload={
-                'imbalance': {
-                    'bid_px': Decimal('525.00'),
-                    'ask_px': Decimal('525.04'),
-                    'spread': Decimal('0.04'),
+                "imbalance": {
+                    "bid_px": Decimal("525.00"),
+                    "ask_px": Decimal("525.04"),
+                    "spread": Decimal("0.04"),
                 },
-                'vwap': {'session': Decimal('523.10')},
+                "vwap": {"session": Decimal("523.10")},
             },
         )
 
         status = assess_signal_quote_quality(
             signal=signal,
-            previous_price=Decimal('525.01'),
+            previous_price=Decimal("525.01"),
         )
 
         self.assertTrue(status.valid)
-        self.assertEqual(status.spread_bps, Decimal('0.7618757380671212525237133823'))
+        self.assertEqual(status.spread_bps, Decimal("0.7618757380671212525237133823"))
 
     def test_assess_signal_quote_quality_rejects_spread_without_executable_quote(
         self,
     ) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-            symbol='META',
-            timeframe='1Sec',
+            symbol="META",
+            timeframe="1Sec",
             seq=16,
             payload={
-                'price': Decimal('525.00'),
-                'spread': Decimal('0.04'),
+                "price": Decimal("525.00"),
+                "spread": Decimal("0.04"),
             },
         )
 
         status = assess_signal_quote_quality(
             signal=signal,
-            previous_price=Decimal('525.01'),
+            previous_price=Decimal("525.01"),
         )
 
         self.assertFalse(status.valid)
-        self.assertEqual(status.reason, 'missing_executable_quote')
+        self.assertEqual(status.reason, "missing_executable_quote")
 
     def test_assess_signal_quote_quality_rejects_zero_top_level_bid_without_falling_back(
         self,
     ) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-            symbol='META',
-            timeframe='1Sec',
+            symbol="META",
+            timeframe="1Sec",
             seq=14,
             payload={
-                'price': Decimal('525.00'),
-                'imbalance_bid_px': Decimal('0'),
-                'imbalance_ask_px': Decimal('525.04'),
-                'imbalance': {
-                    'bid_px': Decimal('525.00'),
-                    'ask_px': Decimal('525.04'),
+                "price": Decimal("525.00"),
+                "imbalance_bid_px": Decimal("0"),
+                "imbalance_ask_px": Decimal("525.04"),
+                "imbalance": {
+                    "bid_px": Decimal("525.00"),
+                    "ask_px": Decimal("525.04"),
                 },
             },
         )
 
         status = assess_signal_quote_quality(
             signal=signal,
-            previous_price=Decimal('525.01'),
+            previous_price=Decimal("525.01"),
         )
 
         self.assertFalse(status.valid)
-        self.assertEqual(status.reason, 'non_positive_bid')
+        self.assertEqual(status.reason, "non_positive_bid")
 
     def test_assess_signal_quote_quality_rejects_price_without_executable_quote(
         self,
     ) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-            symbol='META',
-            timeframe='1Sec',
+            symbol="META",
+            timeframe="1Sec",
             seq=15,
             payload={
-                'price': Decimal('525.00'),
-                'vwap_session': Decimal('524.98'),
+                "price": Decimal("525.00"),
+                "vwap_session": Decimal("524.98"),
             },
         )
 
         status = assess_signal_quote_quality(
             signal=signal,
-            previous_price=Decimal('525.01'),
+            previous_price=Decimal("525.01"),
         )
 
         self.assertFalse(status.valid)
-        self.assertEqual(status.reason, 'missing_executable_quote')
+        self.assertEqual(status.reason, "missing_executable_quote")
+
+    def test_assess_signal_quote_quality_rejects_non_positive_price_with_top_level_quote(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=15,
+            payload={
+                "price": Decimal("0"),
+                "bid": Decimal("525.00"),
+                "ask": Decimal("525.04"),
+                "source": "paper_route_h_pairs_quote",
+            },
+        )
+
+        status = assess_signal_quote_quality(
+            signal=signal,
+            previous_price=Decimal("525.01"),
+        )
+
+        self.assertFalse(status.valid)
+        self.assertEqual(status.reason, "non_positive_price")
+        self.assertEqual(status.price, Decimal("0"))
+        self.assertEqual(status.bid, Decimal("525.00"))
+        self.assertEqual(status.ask, Decimal("525.04"))
+        self.assertEqual(status.source, "paper_route_h_pairs_quote")
+
+    def test_assess_signal_quote_quality_uses_top_level_bid_ask_midpoint(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=15,
+            payload={
+                "bid": Decimal("525.00"),
+                "ask": Decimal("525.04"),
+                "source": "paper_route_h_pairs_quote",
+            },
+        )
+
+        status = assess_signal_quote_quality(
+            signal=signal,
+            previous_price=Decimal("525.01"),
+        )
+
+        self.assertTrue(status.valid)
+        self.assertEqual(status.price, Decimal("525.02"))
+        self.assertEqual(status.bid, Decimal("525.00"))
+        self.assertEqual(status.ask, Decimal("525.04"))
+        self.assertEqual(status.source, "paper_route_h_pairs_quote")
+
+    def test_assess_signal_quote_quality_rejects_non_positive_top_level_ask_px(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=15,
+            payload={
+                "price": Decimal("525.00"),
+                "bid_px": Decimal("525.00"),
+                "ask_px": Decimal("0"),
+            },
+        )
+
+        status = assess_signal_quote_quality(
+            signal=signal,
+            previous_price=Decimal("525.01"),
+        )
+
+        self.assertFalse(status.valid)
+        self.assertEqual(status.reason, "non_positive_ask")
+        self.assertEqual(status.bid, Decimal("525.00"))
+        self.assertEqual(status.ask, Decimal("0"))
+        self.assertEqual(
+            status.repair_action,
+            "refresh_ask_quote_before_routeability_claim",
+        )
 
     def test_assess_signal_quote_quality_rejects_missing_bid(self) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-            symbol='META',
-            timeframe='1Sec',
+            symbol="META",
+            timeframe="1Sec",
             seq=16,
             payload={
-                'price': Decimal('525.00'),
-                'imbalance_ask_px': Decimal('525.04'),
+                "price": Decimal("525.00"),
+                "imbalance_ask_px": Decimal("525.04"),
             },
         )
 
         status = assess_signal_quote_quality(
             signal=signal,
-            previous_price=Decimal('525.01'),
+            previous_price=Decimal("525.01"),
         )
 
         self.assertFalse(status.valid)
-        self.assertEqual(status.reason, 'missing_bid')
+        self.assertEqual(status.reason, "missing_bid")
 
     def test_assess_signal_quote_quality_rejects_missing_ask(self) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-            symbol='META',
-            timeframe='1Sec',
+            symbol="META",
+            timeframe="1Sec",
             seq=17,
             payload={
-                'price': Decimal('525.00'),
-                'imbalance_bid_px': Decimal('525.00'),
+                "price": Decimal("525.00"),
+                "imbalance_bid_px": Decimal("525.00"),
             },
         )
 
         status = assess_signal_quote_quality(
             signal=signal,
-            previous_price=Decimal('525.01'),
+            previous_price=Decimal("525.01"),
         )
 
         self.assertFalse(status.valid)
-        self.assertEqual(status.reason, 'missing_ask')
+        self.assertEqual(status.reason, "missing_ask")
 
     def test_assess_signal_quote_quality_rejects_stale_quote_with_metadata(
         self,
     ) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-            symbol='AAPL',
-            timeframe='1Sec',
+            symbol="AAPL",
+            timeframe="1Sec",
             seq=18,
             payload={
-                'price': Decimal('190.01'),
-                'imbalance_bid_px': Decimal('190.00'),
-                'imbalance_ask_px': Decimal('190.02'),
-                'price_snapshot': {
-                    'quote_as_of': '2026-03-27T17:29:00+00:00',
-                    'quote_source': 'ta_signals_quote',
+                "price": Decimal("190.01"),
+                "imbalance_bid_px": Decimal("190.00"),
+                "imbalance_ask_px": Decimal("190.02"),
+                "price_snapshot": {
+                    "quote_as_of": "2026-03-27T17:29:00+00:00",
+                    "quote_source": "ta_signals_quote",
                 },
             },
         )
@@ -216,58 +297,58 @@ class TestQuoteQuality(TestCase):
         )
 
         self.assertFalse(status.valid)
-        self.assertEqual(status.reason, 'stale_quote')
-        self.assertEqual(status.source, 'ta_signals_quote')
-        self.assertEqual(status.quote_age_seconds, Decimal('84.0'))
-        self.assertEqual(status.bid, Decimal('190.00'))
-        self.assertEqual(status.ask, Decimal('190.02'))
+        self.assertEqual(status.reason, "stale_quote")
+        self.assertEqual(status.source, "ta_signals_quote")
+        self.assertEqual(status.quote_age_seconds, Decimal("84.0"))
+        self.assertEqual(status.bid, Decimal("190.00"))
+        self.assertEqual(status.ask, Decimal("190.02"))
         self.assertEqual(
             status.repair_action,
-            'refresh_quote_snapshot_and_recompute_route_fillability',
+            "refresh_quote_snapshot_and_recompute_route_fillability",
         )
-        self.assertIn('fresh_quote_as_of', status.evidence_requirements)
+        self.assertIn("fresh_quote_as_of", status.evidence_requirements)
 
     def test_assess_signal_quote_quality_uses_h_pairs_price_snapshot_quote(
         self,
     ) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-            symbol='AAPL',
-            timeframe='1Sec',
+            symbol="AAPL",
+            timeframe="1Sec",
             seq=19,
             payload={
-                'price_snapshot': {
-                    'price': '190.01',
-                    'bid': '190.00',
-                    'ask': '190.02',
-                    'spread': '0.02',
-                    'quote_as_of': '2026-03-27T17:30:23+00:00',
-                    'quote_source': 'paper_route_h_pairs_quote',
+                "price_snapshot": {
+                    "price": "190.01",
+                    "bid": "190.00",
+                    "ask": "190.02",
+                    "spread": "0.02",
+                    "quote_as_of": "2026-03-27T17:30:23+00:00",
+                    "quote_source": "paper_route_h_pairs_quote",
                 },
-                'strategy_runtime': {
-                    'hypothesis_id': 'H-PAIRS-01',
-                    'strategy_name': 'microbar-cross-sectional-pairs-v1',
+                "strategy_runtime": {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
                 },
             },
         )
 
         status = assess_signal_quote_quality(
             signal=signal,
-            previous_price=Decimal('190.00'),
+            previous_price=Decimal("190.00"),
             policy=QuoteQualityPolicy(max_executable_quote_age_seconds=30),
         )
 
         self.assertTrue(status.valid)
         self.assertIsNone(status.reason)
-        self.assertEqual(status.fillability_state, 'executable_quote_ready')
+        self.assertEqual(status.fillability_state, "executable_quote_ready")
         self.assertIsNone(status.repair_action)
-        self.assertEqual(status.source, 'paper_route_h_pairs_quote')
-        self.assertEqual(status.quote_age_seconds, Decimal('1.0'))
-        self.assertEqual(status.price, Decimal('190.01'))
-        self.assertEqual(status.bid, Decimal('190.00'))
-        self.assertEqual(status.ask, Decimal('190.02'))
+        self.assertEqual(status.source, "paper_route_h_pairs_quote")
+        self.assertEqual(status.quote_age_seconds, Decimal("1.0"))
+        self.assertEqual(status.price, Decimal("190.01"))
+        self.assertEqual(status.bid, Decimal("190.00"))
+        self.assertEqual(status.ask, Decimal("190.02"))
         self.assertEqual(
-            status.to_readback()['fillability_state'], 'executable_quote_ready'
+            status.to_readback()["fillability_state"], "executable_quote_ready"
         )
 
     def test_assess_signal_quote_quality_exposes_fillability_repair_readback(
@@ -275,15 +356,15 @@ class TestQuoteQuality(TestCase):
     ) -> None:
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-            symbol='AAPL',
-            timeframe='1Sec',
+            symbol="AAPL",
+            timeframe="1Sec",
             seq=20,
             payload={
-                'price_snapshot': {
-                    'price': '190.01',
-                    'ask': '190.02',
-                    'quote_as_of': '2026-03-27T17:30:23+00:00',
-                    'quote_source': 'paper_route_h_pairs_quote',
+                "price_snapshot": {
+                    "price": "190.01",
+                    "ask": "190.02",
+                    "quote_as_of": "2026-03-27T17:30:23+00:00",
+                    "quote_source": "paper_route_h_pairs_quote",
                 },
             },
         )
@@ -291,15 +372,15 @@ class TestQuoteQuality(TestCase):
         status = assess_signal_quote_quality(signal=signal, previous_price=None)
 
         self.assertFalse(status.valid)
-        self.assertEqual(status.reason, 'missing_bid')
-        self.assertEqual(status.fillability_state, 'blocked')
+        self.assertEqual(status.reason, "missing_bid")
+        self.assertEqual(status.fillability_state, "blocked")
         self.assertEqual(
-            status.repair_action, 'collect_bid_quote_before_routeability_claim'
+            status.repair_action, "collect_bid_quote_before_routeability_claim"
         )
         self.assertEqual(
-            status.evidence_requirements, ('bid_px', 'quote_source', 'quote_as_of')
+            status.evidence_requirements, ("bid_px", "quote_source", "quote_as_of")
         )
         self.assertEqual(
-            status.to_readback()['repair_action'],
-            'collect_bid_quote_before_routeability_claim',
+            status.to_readback()["repair_action"],
+            "collect_bid_quote_before_routeability_claim",
         )

--- a/services/torghut/tests/test_quote_quality.py
+++ b/services/torghut/tests/test_quote_quality.py
@@ -384,3 +384,107 @@ class TestQuoteQuality(TestCase):
             status.to_readback()["repair_action"],
             "collect_bid_quote_before_routeability_claim",
         )
+
+    def test_assess_signal_quote_quality_rejects_non_positive_snapshot_price(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=21,
+            payload={
+                "price": Decimal("0"),
+                "bid": Decimal("190.00"),
+                "ask": Decimal("190.02"),
+                "quote_source": "top_level_quote",
+            },
+        )
+
+        status = assess_signal_quote_quality(signal=signal, previous_price=None)
+
+        self.assertFalse(status.valid)
+        self.assertEqual(status.reason, "non_positive_price")
+        self.assertEqual(status.source, "top_level_quote")
+        self.assertEqual(
+            status.repair_action, "collect_positive_executable_reference_price"
+        )
+
+    def test_assess_signal_quote_quality_rejects_non_positive_ask(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=22,
+            payload={
+                "price": Decimal("190.00"),
+                "bid": Decimal("190.00"),
+                "ask": Decimal("0"),
+            },
+        )
+
+        status = assess_signal_quote_quality(signal=signal, previous_price=None)
+
+        self.assertFalse(status.valid)
+        self.assertEqual(status.reason, "non_positive_ask")
+        self.assertEqual(
+            status.repair_action, "refresh_ask_quote_before_routeability_claim"
+        )
+
+    def test_assess_signal_quote_quality_accepts_bid_ask_aliases(
+        self,
+    ) -> None:
+        top_level = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=23,
+            payload={
+                "price": Decimal("190.01"),
+                "bid": Decimal("190.00"),
+                "ask": Decimal("190.02"),
+            },
+        )
+        px_aliases = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=24,
+            payload={
+                "price": Decimal("190.01"),
+                "bid_px": Decimal("190.00"),
+                "ask_px": Decimal("190.02"),
+            },
+        )
+
+        self.assertTrue(
+            assess_signal_quote_quality(signal=top_level, previous_price=None).valid
+        )
+        self.assertTrue(
+            assess_signal_quote_quality(signal=px_aliases, previous_price=None).valid
+        )
+
+    def test_assess_signal_quote_quality_uses_executable_quote_midpoint(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=25,
+            payload={
+                "executable_quote": {
+                    "bid_px": Decimal("190.00"),
+                    "ask_px": Decimal("190.02"),
+                    "source": "sim_quote_receipt",
+                },
+            },
+        )
+
+        status = assess_signal_quote_quality(signal=signal, previous_price=None)
+
+        self.assertTrue(status.valid)
+        self.assertEqual(status.price, Decimal("190.01"))
+        self.assertEqual(status.source, "sim_quote_receipt")

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -1360,6 +1360,51 @@ class TestVerifyTradingReadiness(TestCase):
         )
         self.assertTrue(ready["ok"], ready)
 
+    def test_paper_route_readiness_surfaces_quote_fillability_blockers(
+        self,
+    ) -> None:
+        evidence = _paper_route_evidence(import_ready=True)
+        runtime_window_audit = evidence["runtime_window_import_audit"]
+        assert isinstance(runtime_window_audit, dict)
+        diagnostics = runtime_window_audit["diagnostics"]
+        assert isinstance(diagnostics, dict)
+        diagnostics["rejected_signal_diagnostic_reasons"] = [
+            "source_signal_rejected_by_quote_quality",
+            "source_reject_missing_bid",
+            "source_reject_spread_bps_exceeded",
+        ]
+
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            paper_route_evidence=evidence,
+            require_paper_route_target_plan=True,
+            require_paper_route_import_ready=True,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn(
+            "paper_route_target_plan_quote_fillability", result["failed_checks"]
+        )
+        self.assertEqual(
+            result["next_action"],
+            "repair_quote_quality_or_fillability_before_runtime_ledger_collection",
+        )
+        quote_fillability = result["paper_route_target_plan"]["quote_fillability"]
+        self.assertTrue(quote_fillability["blocked"])
+        self.assertEqual(quote_fillability["state"], "blocked")
+        self.assertEqual(
+            quote_fillability["repair_action"],
+            "collect_bid_quote_before_routeability_claim",
+        )
+        self.assertEqual(
+            quote_fillability["blocking_reasons"],
+            [
+                "source_reject_missing_bid",
+                "source_reject_spread_bps_exceeded",
+                "source_signal_rejected_by_quote_quality",
+            ],
+        )
+
     def test_paper_route_target_plan_allows_drift_only_evidence_collection(
         self,
     ) -> None:

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -1477,13 +1477,93 @@ class TestVerifyTradingReadiness(TestCase):
             "refresh_ask_quote_before_routeability_claim",
         )
 
-    def test_readiness_next_action_prioritizes_quote_fillability_failed_check(
+    def test_quote_fillability_summary_reads_routeability_and_audit_shapes(
+        self,
+    ) -> None:
+        evidence = _paper_route_evidence(import_ready=True)
+        target_plan = evidence["next_paper_route_runtime_window_targets"]
+        assert isinstance(target_plan, dict)
+        targets = target_plan["targets"]
+        assert isinstance(targets, list)
+        target = targets[0]
+        assert isinstance(target, dict)
+        target["paper_route_quote_routeability"] = {
+            "status": "blocked",
+            "symbol": "AAPL",
+            "reason": "stale_quote",
+            "blocking_reasons": ["routeability_spread_guardrail_exceeded"],
+            "quote_age_seconds": "61",
+            "spread_bps": "75",
+            "source": "paper_route_h_pairs_quote",
+        }
+        runtime_window_audit = evidence["runtime_window_import_audit"]
+        assert isinstance(runtime_window_audit, dict)
+        runtime_window_audit["blockers"] = ["fillability_receipt_missing"]
+        runtime_window_audit["target_blockers"] = [
+            {
+                "hypothesis_id": "H-PAIRS-01",
+                "blockers": ["source_reject_missing_ask"],
+            }
+        ]
+        evidence["target_audits"] = [
+            {
+                "target": target,
+                "rejected_signal_activity": {
+                    "blocking_reasons": ["source_signal_rejected_by_quote_quality"],
+                    "reason_counts": [{"reason": "spread_bps_exceeded", "count": 2}],
+                    "max_spread_bps": "90",
+                },
+            }
+        ]
+
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            paper_route_evidence=evidence,
+            require_paper_route_target_plan=True,
+            require_paper_route_import_ready=True,
+        )
+
+        self.assertFalse(result["ok"])
+        quote_fillability = result["paper_route_target_plan"]["quote_fillability"]
+        self.assertTrue(quote_fillability["present"])
+        self.assertTrue(quote_fillability["blocked"])
+        self.assertIn("stale_quote", quote_fillability["blocking_reasons"])
+        self.assertIn(
+            "routeability_spread_guardrail_exceeded",
+            quote_fillability["blocking_reasons"],
+        )
+        self.assertIn(
+            "source_signal_rejected_by_quote_quality",
+            quote_fillability["blocking_reasons"],
+        )
+        self.assertEqual(quote_fillability["targets"][0]["symbol"], "AAPL")
+        self.assertEqual(
+            quote_fillability["targets"][0]["repair_action"],
+            "refresh_quote_snapshot_and_recompute_route_fillability",
+        )
+        self.assertEqual(
+            quote_fillability["targets"][1]["source"], "rejected_signal_activity"
+        )
+
+    def test_quote_fillability_helpers_keep_generic_repair_fallback(
         self,
     ) -> None:
         self.assertEqual(
+            verifier._quote_fillability_reason("routeability_depth_missing"),
+            "routeability_depth_missing",
+        )
+        self.assertEqual(
+            verifier._quote_fillability_repair_action(["routeability_depth_missing"]),
+            "repair_quote_quality_or_fillability_before_runtime_ledger_collection",
+        )
+        self.assertEqual(
             verifier._readiness_next_action(
                 failed_checks=["paper_route_target_plan_quote_fillability"],
-                checks={},
+                checks={
+                    "paper_route_target_plan_quote_fillability": {
+                        "observed": {"blocking_reasons": []}
+                    }
+                },
                 runtime_ledger_proof_packet=None,
             ),
             "repair_quote_quality_or_fillability_before_runtime_ledger_collection",

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -1405,6 +1405,90 @@ class TestVerifyTradingReadiness(TestCase):
             ],
         )
 
+    def test_paper_route_readiness_surfaces_target_quote_fillability_context(
+        self,
+    ) -> None:
+        evidence = _paper_route_evidence(
+            import_ready=True,
+            target_overrides={
+                "symbol": "AAPL",
+                "quote_routeability": {
+                    "symbol": "AAPL",
+                    "status": "blocked",
+                    "reason": "quote_feed_gap",
+                    "reason_codes": ["quote_temporarily_unavailable"],
+                    "quote_age_seconds": "61",
+                    "spread_bps": "24.5",
+                    "source": "paper_route_nbbo",
+                },
+            },
+        )
+        runtime_window_audit = evidence["runtime_window_import_audit"]
+        assert isinstance(runtime_window_audit, dict)
+        runtime_window_audit["blockers"] = ["spread_bps_exceeded"]
+        runtime_window_audit["target_blockers"] = [
+            {"blockers": ["source_reject_missing_ask"]}
+        ]
+        evidence["target_audits"] = [
+            {
+                "target": {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_name": "microbar-pairs-vwap-cap-safe",
+                },
+                "rejected_signal_activity": {
+                    "blocking_reasons": ["source_reject_non_positive_ask"],
+                    "reason_counts": [
+                        {"reason": "source_reject_crossed_quote", "count": 2}
+                    ],
+                    "max_spread_bps": "98.1",
+                },
+            }
+        ]
+
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            paper_route_evidence=evidence,
+            require_paper_route_target_plan=True,
+            require_paper_route_import_ready=True,
+        )
+
+        self.assertFalse(result["ok"])
+        quote_fillability = result["paper_route_target_plan"]["quote_fillability"]
+        self.assertTrue(quote_fillability["blocked"])
+        self.assertEqual(
+            quote_fillability["blocking_reasons"],
+            [
+                "quote_feed_gap",
+                "quote_temporarily_unavailable",
+                "source_reject_crossed_quote",
+                "source_reject_missing_ask",
+                "source_reject_non_positive_ask",
+                "spread_bps_exceeded",
+            ],
+        )
+        self.assertEqual(len(quote_fillability["targets"]), 2)
+        self.assertEqual(
+            quote_fillability["targets"][0]["repair_action"],
+            "repair_quote_quality_or_fillability_before_runtime_ledger_collection",
+        )
+        self.assertEqual(
+            quote_fillability["targets"][1]["repair_action"],
+            "refresh_ask_quote_before_routeability_claim",
+        )
+
+    def test_readiness_next_action_prioritizes_quote_fillability_failed_check(
+        self,
+    ) -> None:
+        self.assertEqual(
+            verifier._readiness_next_action(
+                failed_checks=["paper_route_target_plan_quote_fillability"],
+                checks={},
+                runtime_ledger_proof_packet=None,
+            ),
+            "repair_quote_quality_or_fillability_before_runtime_ledger_collection",
+        )
+
     def test_paper_route_target_plan_allows_drift_only_evidence_collection(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds source-backed H-PAIRS quote/fillability readback to `QuoteQualityStatus`, including repair actions and evidence requirements for blocked executable quotes.
- Recognizes executable bid/ask evidence from `price_snapshot`, `executable_quote`, `quote`, `nbbo`, and `market_snapshot` payload shapes without relaxing spread, staleness, crossed-quote, or promotion gates.
- Surfaces runtime-window quote/fillability blockers in `verify_trading_readiness` so rejected quote-quality source activity fails closed with an actionable next action before runtime-ledger collection.
- Adds focused regression and property coverage for snapshot-only H-PAIRS quotes, blocked quote repair readback, and readiness diagnostics.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check app/trading/quote_quality.py scripts/verify_trading_readiness.py tests/test_quote_quality.py tests/property/test_quote_quality_properties.py tests/test_verify_trading_readiness.py` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_quote_quality.py tests/property/test_quote_quality_properties.py tests/test_verify_trading_readiness.py -q` — passed, 60 tests with 1 existing event-loop deprecation warning
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.json` — passed
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.alpha.json` — passed
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.scripts.json` — passed
- `git diff --check` — passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
