### PR TITLE
fix(torghut): expose hpairs signal drift readiness

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -109,6 +109,88 @@ def _optional_bool(value: object) -> bool | None:
     return None
 
 
+def _first_matching_reason(reasons: set[str], ordered: Sequence[str]) -> str | None:
+    for reason in ordered:
+        if reason in reasons:
+            return reason
+    return None
+
+
+def _bounded_route_evidence_collection_readiness(
+    *,
+    route_repair_symbols: Sequence[str],
+    requirements: HypothesisEntryRequirements,
+    signal_lag_seconds: int | None,
+    drift_detection_checks_total: int,
+    market_session_open: bool | None,
+) -> dict[str, object]:
+    """Return fail-closed H-PAIRS bounded-route liveness gates.
+
+    Route-repair eligibility only means there is a non-authority target worth
+    collecting. This readback keeps the live/SIM collector honest by separately
+    requiring a fresh signal window, materialized drift checks, and an open
+    market session before any bounded collection can be considered ready.
+    """
+
+    has_route_repair_symbols = bool(route_repair_symbols)
+    blockers: list[str] = []
+    if not has_route_repair_symbols:
+        blockers.append("bounded_route_repair_symbols_missing")
+
+    drift_checks_required = requirements.require_drift_checks
+    drift_checks_present = (
+        True if not drift_checks_required else drift_detection_checks_total > 0
+    )
+    if not drift_checks_present:
+        blockers.append("drift_checks_missing")
+
+    max_signal_lag_seconds = requirements.max_signal_lag_seconds
+    fresh_signal_window: bool | None = None
+    if max_signal_lag_seconds is not None:
+        if signal_lag_seconds is None:
+            blockers.append("signal_lag_unmeasured")
+        else:
+            fresh_signal_window = signal_lag_seconds <= max_signal_lag_seconds
+            if not fresh_signal_window:
+                blockers.append("signal_lag_exceeded")
+
+    if market_session_open is False:
+        blockers.append("market_session_closed")
+
+    blocker_set = set(blockers)
+    next_blocker = _first_matching_reason(
+        blocker_set,
+        (
+            "bounded_route_repair_symbols_missing",
+            "drift_checks_missing",
+            "signal_lag_unmeasured",
+            "signal_lag_exceeded",
+            "market_session_closed",
+        ),
+    )
+    next_action = {
+        "bounded_route_repair_symbols_missing": "wait_for_bounded_route_repair_target",
+        "drift_checks_missing": "materialize_drift_checks",
+        "signal_lag_unmeasured": "measure_signal_lag",
+        "signal_lag_exceeded": "wait_for_fresh_signal_window",
+        "market_session_closed": "wait_for_market_session_open",
+        None: "collect_bounded_paper_route_source_rows",
+    }[next_blocker]
+    ready = has_route_repair_symbols and not blockers
+
+    return {
+        "ready": ready,
+        "blockers": sorted(set(blockers)),
+        "next_action": next_action,
+        "fresh_signal_window": fresh_signal_window,
+        "signal_lag_seconds": signal_lag_seconds,
+        "max_signal_lag_seconds": max_signal_lag_seconds,
+        "drift_checks_present": drift_checks_present,
+        "drift_detection_checks_total": drift_detection_checks_total,
+        "market_session_open": market_session_open,
+    }
+
+
 def _parse_iso8601(value: object) -> datetime | None:
     if isinstance(value, datetime):
         parsed = value
@@ -2247,6 +2329,13 @@ def compile_hypothesis_runtime_statuses(
             "runtime_ledger_pnl_basis": runtime_ledger_inputs.pnl_basis,
         }
         if tca_inputs.route_filter_applied:
+            bounded_route_liveness = _bounded_route_evidence_collection_readiness(
+                route_repair_symbols=tca_inputs.route_repair_symbols,
+                requirements=requirements,
+                signal_lag_seconds=signal_lag_seconds,
+                drift_detection_checks_total=drift_detection_checks_total,
+                market_session_open=market_session_open,
+            )
             observed.update(
                 {
                     "route_symbol_filter_enabled": True,
@@ -2266,6 +2355,21 @@ def compile_hypothesis_runtime_statuses(
                     ),
                     "bounded_route_evidence_collection_eligible": bool(
                         tca_inputs.route_repair_symbols
+                    ),
+                    "bounded_route_evidence_collection_ready": bool(
+                        bounded_route_liveness["ready"]
+                    ),
+                    "bounded_route_evidence_collection_blockers": list(
+                        cast(
+                            Sequence[str],
+                            bounded_route_liveness["blockers"],
+                        )
+                    ),
+                    "bounded_route_evidence_collection_next_action": str(
+                        bounded_route_liveness["next_action"]
+                    ),
+                    "bounded_route_evidence_collection_liveness": dict(
+                        bounded_route_liveness
                     ),
                     "bounded_route_evidence_collection_authority": (
                         "repair_only_non_authority"

--- a/services/torghut/scripts/audit_hpairs_signal_liveness.py
+++ b/services/torghut/scripts/audit_hpairs_signal_liveness.py
@@ -18,57 +18,60 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
-DEFAULT_HPAIRS_HYPOTHESIS_ID = 'H-PAIRS-01'
-DEFAULT_HPAIRS_CANDIDATE_ID = 'c88421d619759b2cfaa6f4d0'
-DEFAULT_HPAIRS_RUNTIME_STRATEGY = 'microbar-cross-sectional-pairs-v1'
-DEFAULT_HPAIRS_ACCOUNT_LABEL = 'TORGHUT_SIM'
-DEFAULT_OBSERVED_STAGE = 'paper'
-HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION = 'torghut.hpairs-signal-liveness.v1'
+DEFAULT_HPAIRS_HYPOTHESIS_ID = "H-PAIRS-01"
+DEFAULT_HPAIRS_CANDIDATE_ID = "c88421d619759b2cfaa6f4d0"
+DEFAULT_HPAIRS_RUNTIME_STRATEGY = "microbar-cross-sectional-pairs-v1"
+DEFAULT_HPAIRS_ACCOUNT_LABEL = "TORGHUT_SIM"
+DEFAULT_OBSERVED_STAGE = "paper"
+HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION = "torghut.hpairs-signal-liveness.v1"
 
 NEXT_ACTIONS = (
-    'no_target',
-    'wrong_account',
-    'no_market_data',
-    'signal_below_threshold',
-    'risk_veto',
-    'route_disabled',
-    'evidence_collection_disabled',
-    'ready_to_submit_sim_order',
-    'unsupported_inputs',
+    "no_target",
+    "wrong_account",
+    "no_market_data",
+    "signal_below_threshold",
+    "risk_veto",
+    "route_disabled",
+    "evidence_collection_disabled",
+    "materialize_drift_checks",
+    "wait_for_fresh_signal_window",
+    "wait_for_market_session_open",
+    "ready_to_submit_sim_order",
+    "unsupported_inputs",
 )
 
 _MARKET_DATA_READY_KEYS = (
-    'ready',
-    'is_ready',
-    'available',
-    'is_available',
-    'fresh',
-    'has_latest',
+    "ready",
+    "is_ready",
+    "available",
+    "is_available",
+    "fresh",
+    "has_latest",
 )
 _ROUTE_FLAG_KEYS = (
-    'route_enabled',
-    'route_eligible',
-    'paper_route_enabled',
-    'paper_route_eligible',
-    'order_route_enabled',
-    'order_route_eligible',
-    'submit_route_enabled',
-    'submit_route_eligible',
-    'simulation_route_enabled',
-    'sim_route_enabled',
+    "route_enabled",
+    "route_eligible",
+    "paper_route_enabled",
+    "paper_route_eligible",
+    "order_route_enabled",
+    "order_route_eligible",
+    "submit_route_enabled",
+    "submit_route_eligible",
+    "simulation_route_enabled",
+    "sim_route_enabled",
 )
 _EVIDENCE_COLLECTION_KEYS = (
-    'evidence_collection_ok',
-    'evidence_collection_enabled',
-    'bounded_evidence_collection_authorized',
-    'source_collection_enabled',
-    'source_collection_ok',
-    'collection_enabled',
+    "evidence_collection_ok",
+    "evidence_collection_enabled",
+    "bounded_evidence_collection_authorized",
+    "source_collection_enabled",
+    "source_collection_ok",
+    "collection_enabled",
 )
 _SIMPLE_SUBMIT_KEYS = (
-    'simple_submit_enabled',
-    'submit_enabled',
-    'trading_simple_submit_enabled',
+    "simple_submit_enabled",
+    "submit_enabled",
+    "trading_simple_submit_enabled",
 )
 
 
@@ -81,6 +84,7 @@ class AuditExpectations:
     runtime_strategy: str
     max_quote_age_seconds: float
     max_feature_age_seconds: float
+    max_signal_lag_seconds: float
 
 
 def _mapping(value: object) -> Mapping[str, object]:
@@ -109,9 +113,9 @@ def _bool_or_none(value: object) -> bool | None:
         return value
     if isinstance(value, str):
         normalized = value.strip().lower()
-        if normalized in {'1', 'true', 't', 'yes', 'y', 'enabled', 'ready', 'ok'}:
+        if normalized in {"1", "true", "t", "yes", "y", "enabled", "ready", "ok"}:
             return True
-        if normalized in {'0', 'false', 'f', 'no', 'n', 'disabled', 'blocked'}:
+        if normalized in {"0", "false", "f", "no", "n", "disabled", "blocked"}:
             return False
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return bool(value)
@@ -137,7 +141,7 @@ def _float_or_none(value: object) -> float | None:
 def _unique_text_items(value: object) -> list[str]:
     raw_items: Iterable[object]
     if isinstance(value, str):
-        raw_items = (item for item in value.replace(';', ',').split(','))
+        raw_items = (item for item in value.replace(";", ",").split(","))
     elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
         raw_items = value
     elif isinstance(value, Mapping):
@@ -162,26 +166,28 @@ def _json_default(value: object) -> str:
 
 
 def stable_json(payload: Mapping[str, object]) -> str:
-    return json.dumps(payload, default=_json_default, indent=2, sort_keys=True) + '\n'
+    return json.dumps(payload, default=_json_default, indent=2, sort_keys=True) + "\n"
 
 
 def _read_json_path(path: str | Path) -> Mapping[str, object]:
     loaded = json.loads(Path(path).read_text())
     if not isinstance(loaded, Mapping):
-        raise ValueError(f'{path} must contain a JSON object')
+        raise ValueError(f"{path} must contain a JSON object")
     return cast(Mapping[str, object], loaded)
 
 
 def _read_status_url(url: str, timeout: float) -> Mapping[str, object]:
-    request = urllib.request.Request(url, method='GET')
+    request = urllib.request.Request(url, method="GET")
     with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 - bounded explicit URL is user supplied.
-        loaded = json.loads(response.read().decode('utf-8'))
+        loaded = json.loads(response.read().decode("utf-8"))
     if not isinstance(loaded, Mapping):
-        raise ValueError(f'{url} returned a non-object JSON payload')
+        raise ValueError(f"{url} returned a non-object JSON payload")
     return cast(Mapping[str, object], loaded)
 
 
-def _merge_inputs(base: Mapping[str, object], overrides: Mapping[str, Mapping[str, object]]) -> dict[str, object]:
+def _merge_inputs(
+    base: Mapping[str, object], overrides: Mapping[str, Mapping[str, object]]
+) -> dict[str, object]:
     merged: dict[str, object] = dict(base)
     for key, value in overrides.items():
         if value:
@@ -189,23 +195,32 @@ def _merge_inputs(base: Mapping[str, object], overrides: Mapping[str, Mapping[st
     return merged
 
 
-def _target_matches(candidate: Mapping[str, object], expectations: AuditExpectations) -> bool:
-    candidate_id = _text(candidate.get('candidate_id') or candidate.get('target_candidate_id'))
-    hypothesis_id = _text(candidate.get('hypothesis_id') or candidate.get('hypothesis'))
+def _target_matches(
+    candidate: Mapping[str, object], expectations: AuditExpectations
+) -> bool:
+    candidate_id = _text(
+        candidate.get("candidate_id") or candidate.get("target_candidate_id")
+    )
+    hypothesis_id = _text(candidate.get("hypothesis_id") or candidate.get("hypothesis"))
     runtime_strategy = _text(
-        candidate.get('runtime_strategy_name')
-        or candidate.get('runtime_strategy')
-        or candidate.get('strategy_name')
-        or candidate.get('strategy')
+        candidate.get("runtime_strategy_name")
+        or candidate.get("runtime_strategy")
+        or candidate.get("strategy_name")
+        or candidate.get("strategy")
     )
     if candidate_id == expectations.candidate_id:
         return True
-    if hypothesis_id == expectations.hypothesis_id and runtime_strategy in (None, expectations.runtime_strategy):
+    if hypothesis_id == expectations.hypothesis_id and runtime_strategy in (
+        None,
+        expectations.runtime_strategy,
+    ):
         return True
     return False
 
 
-def _first_mapping_from_keys(source: Mapping[str, object], keys: Sequence[str]) -> Mapping[str, object]:
+def _first_mapping_from_keys(
+    source: Mapping[str, object], keys: Sequence[str]
+) -> Mapping[str, object]:
     for key in keys:
         candidate = _mapping(source.get(key))
         if candidate:
@@ -213,11 +228,24 @@ def _first_mapping_from_keys(source: Mapping[str, object], keys: Sequence[str]) 
     return {}
 
 
-def _target_from_source(source: Mapping[str, object], expectations: AuditExpectations) -> Mapping[str, object]:
-    target = _first_mapping_from_keys(source, ('target', 'target_candidate', 'target_candidate_identity'))
+def _first_value_from_keys(
+    source: Mapping[str, object], keys: Sequence[str]
+) -> object | None:
+    for key in keys:
+        if key in source:
+            return source.get(key)
+    return None
+
+
+def _target_from_source(
+    source: Mapping[str, object], expectations: AuditExpectations
+) -> Mapping[str, object]:
+    target = _first_mapping_from_keys(
+        source, ("target", "target_candidate", "target_candidate_identity")
+    )
     if target:
         return target
-    for key in ('targets', 'planned_targets', 'target_candidates', 'source_targets'):
+    for key in ("targets", "planned_targets", "target_candidates", "source_targets"):
         sequence = _sequence(source.get(key))
         mappings = [_mapping(item) for item in sequence]
         for candidate in mappings:
@@ -229,25 +257,33 @@ def _target_from_source(source: Mapping[str, object], expectations: AuditExpecta
     return {}
 
 
-def _candidate_identity(target: Mapping[str, object], expectations: AuditExpectations) -> dict[str, object]:
+def _candidate_identity(
+    target: Mapping[str, object], expectations: AuditExpectations
+) -> dict[str, object]:
     observed = {
-        'hypothesis_id': _text(target.get('hypothesis_id') or target.get('hypothesis')),
-        'candidate_id': _text(target.get('candidate_id') or target.get('target_candidate_id')),
-        'account_label': _text(target.get('account_label') or target.get('account')),
-        'observed_stage': _text(target.get('observed_stage') or target.get('stage') or target.get('evidence_collection_stage')),
-        'runtime_strategy': _text(
-            target.get('runtime_strategy_name')
-            or target.get('runtime_strategy')
-            or target.get('strategy_name')
-            or target.get('strategy')
+        "hypothesis_id": _text(target.get("hypothesis_id") or target.get("hypothesis")),
+        "candidate_id": _text(
+            target.get("candidate_id") or target.get("target_candidate_id")
+        ),
+        "account_label": _text(target.get("account_label") or target.get("account")),
+        "observed_stage": _text(
+            target.get("observed_stage")
+            or target.get("stage")
+            or target.get("evidence_collection_stage")
+        ),
+        "runtime_strategy": _text(
+            target.get("runtime_strategy_name")
+            or target.get("runtime_strategy")
+            or target.get("strategy_name")
+            or target.get("strategy")
         ),
     }
     expected = {
-        'hypothesis_id': expectations.hypothesis_id,
-        'candidate_id': expectations.candidate_id,
-        'account_label': expectations.account_label,
-        'observed_stage': expectations.observed_stage,
-        'runtime_strategy': expectations.runtime_strategy,
+        "hypothesis_id": expectations.hypothesis_id,
+        "candidate_id": expectations.candidate_id,
+        "account_label": expectations.account_label,
+        "observed_stage": expectations.observed_stage,
+        "runtime_strategy": expectations.runtime_strategy,
     }
     matches = {
         key: observed_value == expected[key]
@@ -256,31 +292,43 @@ def _candidate_identity(target: Mapping[str, object], expectations: AuditExpecta
     }
     missing = sorted(key for key, value in observed.items() if value is None)
     return {
-        'materialized': bool(target),
-        'expected': expected,
-        'observed': observed,
-        'matches': matches,
-        'missing_fields': missing,
+        "materialized": bool(target),
+        "expected": expected,
+        "observed": observed,
+        "matches": matches,
+        "missing_fields": missing,
     }
 
 
 def _symbols_from_target(target: Mapping[str, object]) -> list[str]:
     symbols: list[str] = []
-    for key in ('symbols', 'symbol_universe', 'required_symbols', 'pair_symbols', 'legs'):
+    for key in (
+        "symbols",
+        "symbol_universe",
+        "required_symbols",
+        "pair_symbols",
+        "legs",
+    ):
         raw_value = target.get(key)
         if isinstance(raw_value, Mapping):
             symbols.extend(str(symbol) for symbol in raw_value.keys())
         else:
             for item in _sequence(raw_value):
                 if isinstance(item, Mapping):
-                    symbol = _text(item.get('symbol') or item.get('ticker'))
+                    symbol = _text(item.get("symbol") or item.get("ticker"))
                     if symbol is not None:
                         symbols.append(symbol)
                 else:
                     symbol = _text(item)
                     if symbol is not None:
                         symbols.append(symbol)
-    for key in ('symbol', 'primary_symbol', 'secondary_symbol', 'long_symbol', 'short_symbol'):
+    for key in (
+        "symbol",
+        "primary_symbol",
+        "secondary_symbol",
+        "long_symbol",
+        "short_symbol",
+    ):
         symbol = _text(target.get(key))
         if symbol is not None:
             symbols.append(symbol)
@@ -300,14 +348,14 @@ def _normalize_symbols(symbols: Iterable[str]) -> list[str]:
 
 
 def _symbol_payload(container: Mapping[str, object]) -> Mapping[str, object]:
-    explicit = _mapping(container.get('symbols'))
+    explicit = _mapping(container.get("symbols"))
     if explicit:
         return explicit
-    latest = _mapping(container.get('latest'))
-    latest_symbols = _mapping(latest.get('symbols'))
+    latest = _mapping(container.get("latest"))
+    latest_symbols = _mapping(latest.get("symbols"))
     if latest_symbols:
         return latest_symbols
-    by_symbol = _mapping(container.get('by_symbol'))
+    by_symbol = _mapping(container.get("by_symbol"))
     if by_symbol:
         return by_symbol
     return {}
@@ -320,29 +368,43 @@ def _availability_for_symbol(
     *,
     quote_mode: bool,
 ) -> tuple[bool, dict[str, object]]:
-    raw = payload.get(symbol) or payload.get(symbol.lower()) or payload.get(symbol.upper())
+    raw = (
+        payload.get(symbol)
+        or payload.get(symbol.lower())
+        or payload.get(symbol.upper())
+    )
     details = _mapping(raw)
-    ready = _bool_or_none(details.get('ready'))
+    ready = _bool_or_none(details.get("ready"))
     for key in _MARKET_DATA_READY_KEYS:
         value = _bool_or_none(details.get(key))
         if value is not None:
             ready = value
             break
-    age_seconds = _float_or_none(details.get('age_seconds') or details.get('staleness_seconds'))
+    age_seconds = _float_or_none(
+        details.get("age_seconds") or details.get("staleness_seconds")
+    )
     if ready is None:
         ready = bool(details)
     if quote_mode and details:
-        bid = _float_or_none(details.get('bid') or details.get('bid_price'))
-        ask = _float_or_none(details.get('ask') or details.get('ask_price'))
-        if bid is not None and ask is not None and (bid <= 0.0 or ask <= 0.0 or bid > ask):
+        bid = _float_or_none(details.get("bid") or details.get("bid_price"))
+        ask = _float_or_none(details.get("ask") or details.get("ask_price"))
+        if (
+            bid is not None
+            and ask is not None
+            and (bid <= 0.0 or ask <= 0.0 or bid > ask)
+        ):
             ready = False
     if age_seconds is not None and age_seconds > max_age_seconds:
         ready = False
     return ready, {
-        'available': bool(details),
-        'ready': ready,
-        'age_seconds': age_seconds,
-        'timestamp': _text(details.get('timestamp') or details.get('as_of') or details.get('updated_at')),
+        "available": bool(details),
+        "ready": ready,
+        "age_seconds": age_seconds,
+        "timestamp": _text(
+            details.get("timestamp")
+            or details.get("as_of")
+            or details.get("updated_at")
+        ),
     }
 
 
@@ -368,89 +430,210 @@ def _availability_report(
             quote_mode=quote_mode,
         )
         by_symbol[symbol] = details
-        if not bool(details['available']):
+        if not bool(details["available"]):
             missing_symbols.append(symbol)
         elif not ready:
             not_ready_symbols.append(symbol)
-            if details.get('age_seconds') is not None:
+            if details.get("age_seconds") is not None:
                 stale_symbols.append(symbol)
     return {
-        'ready': bool(evaluated_symbols) and not missing_symbols and not not_ready_symbols,
-        'symbols_evaluated': evaluated_symbols,
-        'available_symbols': available_symbols,
-        'missing_symbols': missing_symbols,
-        'stale_symbols': stale_symbols,
-        'not_ready_symbols': not_ready_symbols,
-        'by_symbol': by_symbol,
-        'latest_timestamp': _text(
-            container.get('latest_timestamp')
-            or container.get('timestamp')
-            or _mapping(container.get('latest')).get('timestamp')
+        "ready": bool(evaluated_symbols)
+        and not missing_symbols
+        and not not_ready_symbols,
+        "symbols_evaluated": evaluated_symbols,
+        "available_symbols": available_symbols,
+        "missing_symbols": missing_symbols,
+        "stale_symbols": stale_symbols,
+        "not_ready_symbols": not_ready_symbols,
+        "by_symbol": by_symbol,
+        "latest_timestamp": _text(
+            container.get("latest_timestamp")
+            or container.get("timestamp")
+            or _mapping(container.get("latest")).get("timestamp")
         ),
     }
 
 
 def _signal_threshold_report(signal: Mapping[str, object]) -> dict[str, object]:
     score = _float_or_none(
-        signal.get('entry_score')
-        or signal.get('score')
-        or signal.get('signal')
-        or signal.get('entry_signal')
-        or signal.get('zscore')
+        signal.get("entry_score")
+        or signal.get("score")
+        or signal.get("signal")
+        or signal.get("entry_signal")
+        or signal.get("zscore")
     )
     threshold = _float_or_none(
-        signal.get('entry_threshold')
-        or signal.get('threshold')
-        or signal.get('min_entry_score')
-        or signal.get('abs_entry_zscore_threshold')
+        signal.get("entry_threshold")
+        or signal.get("threshold")
+        or signal.get("min_entry_score")
+        or signal.get("abs_entry_zscore_threshold")
     )
     margin = None if score is None or threshold is None else abs(score) - threshold
     explicit_pass = _bool_or_none(
-        signal.get('passes_threshold')
-        or signal.get('threshold_passed')
-        or signal.get('entry_signal_ready')
+        signal.get("passes_threshold")
+        or signal.get("threshold_passed")
+        or signal.get("entry_signal_ready")
     )
-    passes = explicit_pass if explicit_pass is not None else (None if margin is None else margin >= 0.0)
+    passes = (
+        explicit_pass
+        if explicit_pass is not None
+        else (None if margin is None else margin >= 0.0)
+    )
     return {
-        'score': score,
-        'threshold': threshold,
-        'margin': margin,
-        'passes': passes,
-        'direction': _text(signal.get('direction') or signal.get('side') or signal.get('entry_side')),
-        'missing_inputs': [
+        "score": score,
+        "threshold": threshold,
+        "margin": margin,
+        "passes": passes,
+        "direction": _text(
+            signal.get("direction") or signal.get("side") or signal.get("entry_side")
+        ),
+        "missing_inputs": [
             key
-            for key, value in (('score', score), ('threshold', threshold))
+            for key, value in (("score", score), ("threshold", threshold))
             if value is None and explicit_pass is None
         ],
     }
 
 
-def _veto_report(target: Mapping[str, object], signal: Mapping[str, object], risk: Mapping[str, object]) -> dict[str, object]:
-    entry_vetoes = _unique_text_items(target.get('entry_vetoes'))
-    entry_vetoes.extend(_unique_text_items(signal.get('entry_vetoes')))
-    exit_vetoes = _unique_text_items(target.get('exit_vetoes'))
-    exit_vetoes.extend(_unique_text_items(signal.get('exit_vetoes')))
-    risk_vetoes = _unique_text_items(risk.get('vetoes') or risk.get('risk_vetoes') or risk.get('blockers'))
-    if _bool_or_none(risk.get('risk_veto') or risk.get('vetoed')) is True and not risk_vetoes:
-        risk_vetoes.append('risk_veto')
+def _signal_drift_readiness_report(
+    *,
+    status: Mapping[str, object],
+    target: Mapping[str, object],
+    signal: Mapping[str, object],
+    expectations: AuditExpectations,
+) -> dict[str, object]:
+    observed = _mapping(status.get("observed"))
+    if not observed:
+        observed = _mapping(target.get("observed"))
+    signal_lag_seconds = _float_or_none(
+        _first_value_from_keys(
+            observed,
+            ("signal_lag_seconds", "signalLagSeconds"),
+        )
+        or _first_value_from_keys(
+            status,
+            ("signal_lag_seconds", "signalLagSeconds"),
+        )
+        or _first_value_from_keys(
+            signal,
+            ("signal_lag_seconds", "signalLagSeconds", "lag_seconds", "age_seconds"),
+        )
+    )
+    max_signal_lag_seconds = (
+        _float_or_none(
+            _first_value_from_keys(
+                observed,
+                ("max_signal_lag_seconds", "maxSignalLagSeconds"),
+            )
+            or _first_value_from_keys(
+                status,
+                ("max_signal_lag_seconds", "maxSignalLagSeconds"),
+            )
+        )
+        or expectations.max_signal_lag_seconds
+    )
+    drift_detection_checks_total = _float_or_none(
+        _first_value_from_keys(
+            observed,
+            (
+                "drift_detection_checks_total",
+                "driftDetectionChecksTotal",
+                "drift_detection_checks",
+                "drift_checks",
+            ),
+        )
+        or _first_value_from_keys(
+            status,
+            (
+                "drift_detection_checks_total",
+                "driftDetectionChecksTotal",
+                "drift_detection_checks",
+                "drift_checks",
+            ),
+        )
+    )
+    market_session_open = _bool_or_none(
+        _first_value_from_keys(observed, ("market_session_open", "marketSessionOpen"))
+        or _first_value_from_keys(status, ("market_session_open", "marketSessionOpen"))
+    )
+    observed_any = any(
+        value is not None
+        for value in (
+            signal_lag_seconds,
+            drift_detection_checks_total,
+            market_session_open,
+        )
+    )
+    blockers: list[str] = []
+    fresh_signal_window: bool | None = None
+    if signal_lag_seconds is not None:
+        fresh_signal_window = signal_lag_seconds <= max_signal_lag_seconds
+        if not fresh_signal_window:
+            blockers.append("signal_lag_exceeded")
+    if drift_detection_checks_total is not None and drift_detection_checks_total <= 0:
+        blockers.append("drift_checks_missing")
+    if market_session_open is False:
+        blockers.append("market_session_closed")
     return {
-        'entry_vetoes': sorted(set(entry_vetoes)),
-        'exit_vetoes': sorted(set(exit_vetoes)),
-        'risk_vetoes': sorted(set(risk_vetoes)),
-        'has_risk_veto': bool(risk_vetoes),
+        "observed_any": observed_any,
+        "signal_lag_seconds": signal_lag_seconds,
+        "max_signal_lag_seconds": max_signal_lag_seconds,
+        "fresh_signal_window": fresh_signal_window,
+        "drift_detection_checks_total": drift_detection_checks_total,
+        "drift_checks_present": None
+        if drift_detection_checks_total is None
+        else drift_detection_checks_total > 0,
+        "market_session_open": market_session_open,
+        "blockers": sorted(set(blockers)),
+        "ready": observed_any and not blockers,
     }
 
 
-def _nested_flag_containers(container: Mapping[str, object]) -> list[Mapping[str, object]]:
+def _veto_report(
+    target: Mapping[str, object],
+    signal: Mapping[str, object],
+    risk: Mapping[str, object],
+) -> dict[str, object]:
+    entry_vetoes = _unique_text_items(target.get("entry_vetoes"))
+    entry_vetoes.extend(_unique_text_items(signal.get("entry_vetoes")))
+    exit_vetoes = _unique_text_items(target.get("exit_vetoes"))
+    exit_vetoes.extend(_unique_text_items(signal.get("exit_vetoes")))
+    risk_vetoes = _unique_text_items(
+        risk.get("vetoes") or risk.get("risk_vetoes") or risk.get("blockers")
+    )
+    if (
+        _bool_or_none(risk.get("risk_veto") or risk.get("vetoed")) is True
+        and not risk_vetoes
+    ):
+        risk_vetoes.append("risk_veto")
+    return {
+        "entry_vetoes": sorted(set(entry_vetoes)),
+        "exit_vetoes": sorted(set(exit_vetoes)),
+        "risk_vetoes": sorted(set(risk_vetoes)),
+        "has_risk_veto": bool(risk_vetoes),
+    }
+
+
+def _nested_flag_containers(
+    container: Mapping[str, object],
+) -> list[Mapping[str, object]]:
     containers = [container]
-    for key in ('simple_lane', 'live_submission_gate', 'submission_gate', 'submit_gate', 'gate'):
+    for key in (
+        "simple_lane",
+        "live_submission_gate",
+        "submission_gate",
+        "submit_gate",
+        "gate",
+    ):
         nested = _mapping(container.get(key))
         if nested:
             containers.extend(_nested_flag_containers(nested))
     return containers
 
 
-def _flag_report(containers: Sequence[Mapping[str, object]], keys: Sequence[str]) -> dict[str, object]:
+def _flag_report(
+    containers: Sequence[Mapping[str, object]], keys: Sequence[str]
+) -> dict[str, object]:
     observed: dict[str, object] = {}
     disabled: list[str] = []
     enabled: list[str] = []
@@ -469,48 +652,79 @@ def _flag_report(containers: Sequence[Mapping[str, object]], keys: Sequence[str]
                 else:
                     disabled.append(key)
     return {
-        'observed': observed,
-        'enabled_flags': sorted(enabled),
-        'disabled_flags': sorted(disabled),
-        'eligible': not disabled,
-        'observed_any': bool(observed),
+        "observed": observed,
+        "enabled_flags": sorted(enabled),
+        "disabled_flags": sorted(disabled),
+        "eligible": not disabled,
+        "observed_any": bool(observed),
     }
 
 
 def _choose_next_action(blocker_codes: Sequence[str], unsupported: bool) -> str:
     blockers = set(blocker_codes)
-    if 'target_missing' in blockers:
-        return 'no_target'
-    if blockers.intersection({'account_label_mismatch', 'observed_stage_mismatch', 'runtime_strategy_mismatch'}):
-        return 'wrong_account'
-    if blockers.intersection({'latest_features_missing', 'latest_quotes_missing', 'latest_features_not_ready', 'latest_quotes_not_ready'}):
-        return 'no_market_data'
-    if 'signal_below_threshold' in blockers:
-        return 'signal_below_threshold'
-    if blockers.intersection({'risk_veto', 'entry_veto_present', 'exit_veto_present'}):
-        return 'risk_veto'
-    if blockers.intersection({'route_disabled', 'simple_submit_disabled'}):
-        return 'route_disabled'
-    if 'evidence_collection_disabled' in blockers:
-        return 'evidence_collection_disabled'
+    if "target_missing" in blockers:
+        return "no_target"
+    if blockers.intersection(
+        {
+            "account_label_mismatch",
+            "observed_stage_mismatch",
+            "runtime_strategy_mismatch",
+        }
+    ):
+        return "wrong_account"
+    if blockers.intersection(
+        {
+            "latest_features_missing",
+            "latest_quotes_missing",
+            "latest_features_not_ready",
+            "latest_quotes_not_ready",
+        }
+    ):
+        return "no_market_data"
+    if "signal_below_threshold" in blockers:
+        return "signal_below_threshold"
+    if blockers.intersection({"risk_veto", "entry_veto_present", "exit_veto_present"}):
+        return "risk_veto"
+    if blockers.intersection({"route_disabled", "simple_submit_disabled"}):
+        return "route_disabled"
+    if "evidence_collection_disabled" in blockers:
+        return "evidence_collection_disabled"
+    if "drift_checks_missing" in blockers:
+        return "materialize_drift_checks"
+    if "signal_lag_exceeded" in blockers:
+        return "wait_for_fresh_signal_window"
+    if "market_session_closed" in blockers:
+        return "wait_for_market_session_open"
     if unsupported:
-        return 'unsupported_inputs'
-    return 'ready_to_submit_sim_order'
+        return "unsupported_inputs"
+    return "ready_to_submit_sim_order"
 
 
-def build_liveness_report(source: Mapping[str, object], expectations: AuditExpectations) -> dict[str, object]:
+def build_liveness_report(
+    source: Mapping[str, object], expectations: AuditExpectations
+) -> dict[str, object]:
     target = _target_from_source(source, expectations)
-    status = _first_mapping_from_keys(source, ('status', 'service_status', 'runtime_status'))
-    features = _first_mapping_from_keys(source, ('features', 'latest_features', 'feature_status'))
-    quotes = _first_mapping_from_keys(source, ('quotes', 'latest_quotes', 'quote_status', 'market_data'))
-    signal = _first_mapping_from_keys(source, ('signal', 'signals', 'signal_status'))
-    route = _first_mapping_from_keys(source, ('route', 'route_eligibility', 'route_status'))
-    risk = _first_mapping_from_keys(source, ('risk', 'risk_status', 'risk_veto'))
+    status = _first_mapping_from_keys(
+        source, ("status", "service_status", "runtime_status")
+    )
+    features = _first_mapping_from_keys(
+        source, ("features", "latest_features", "feature_status")
+    )
+    quotes = _first_mapping_from_keys(
+        source, ("quotes", "latest_quotes", "quote_status", "market_data")
+    )
+    signal = _first_mapping_from_keys(source, ("signal", "signals", "signal_status"))
+    route = _first_mapping_from_keys(
+        source, ("route", "route_eligibility", "route_status")
+    )
+    risk = _first_mapping_from_keys(source, ("risk", "risk_status", "risk_veto"))
 
     identity = _candidate_identity(target, expectations)
     symbols = _symbols_from_target(target)
     if not symbols:
-        symbols = _normalize_symbols(str(key) for key in _symbol_payload(features).keys())
+        symbols = _normalize_symbols(
+            str(key) for key in _symbol_payload(features).keys()
+        )
     if not symbols:
         symbols = _normalize_symbols(str(key) for key in _symbol_payload(quotes).keys())
 
@@ -527,6 +741,12 @@ def build_liveness_report(source: Mapping[str, object], expectations: AuditExpec
         quote_mode=True,
     )
     signal_report = _signal_threshold_report(signal)
+    signal_drift_readiness = _signal_drift_readiness_report(
+        status=status,
+        target=target,
+        signal=signal,
+        expectations=expectations,
+    )
     vetoes = _veto_report(target, signal, risk)
     route_flags = _flag_report((target, status, route), _ROUTE_FLAG_KEYS)
     evidence_flags = _flag_report((target, status, route), _EVIDENCE_COLLECTION_KEYS)
@@ -534,140 +754,158 @@ def build_liveness_report(source: Mapping[str, object], expectations: AuditExpec
 
     blocker_codes: list[str] = []
     if not target:
-        blocker_codes.append('target_missing')
-    observed = _mapping(identity['observed'])
-    if observed.get('account_label') not in (None, expectations.account_label):
-        blocker_codes.append('account_label_mismatch')
-    if observed.get('observed_stage') not in (None, expectations.observed_stage):
-        blocker_codes.append('observed_stage_mismatch')
-    if observed.get('runtime_strategy') not in (None, expectations.runtime_strategy):
-        blocker_codes.append('runtime_strategy_mismatch')
+        blocker_codes.append("target_missing")
+    observed = _mapping(identity["observed"])
+    if observed.get("account_label") not in (None, expectations.account_label):
+        blocker_codes.append("account_label_mismatch")
+    if observed.get("observed_stage") not in (None, expectations.observed_stage):
+        blocker_codes.append("observed_stage_mismatch")
+    if observed.get("runtime_strategy") not in (None, expectations.runtime_strategy):
+        blocker_codes.append("runtime_strategy_mismatch")
     if not features:
-        blocker_codes.append('latest_features_missing')
-    elif not bool(feature_report['ready']):
-        blocker_codes.append('latest_features_not_ready')
+        blocker_codes.append("latest_features_missing")
+    elif not bool(feature_report["ready"]):
+        blocker_codes.append("latest_features_not_ready")
     if not quotes:
-        blocker_codes.append('latest_quotes_missing')
-    elif not bool(quote_report['ready']):
-        blocker_codes.append('latest_quotes_not_ready')
-    if signal_report['passes'] is False:
-        blocker_codes.append('signal_below_threshold')
-    if vetoes['entry_vetoes']:
-        blocker_codes.append('entry_veto_present')
-    if vetoes['exit_vetoes']:
-        blocker_codes.append('exit_veto_present')
-    if vetoes['has_risk_veto']:
-        blocker_codes.append('risk_veto')
-    if route_flags['disabled_flags']:
-        blocker_codes.append('route_disabled')
-    if submit_flags['disabled_flags']:
-        blocker_codes.append('simple_submit_disabled')
-    if evidence_flags['disabled_flags']:
-        blocker_codes.append('evidence_collection_disabled')
+        blocker_codes.append("latest_quotes_missing")
+    elif not bool(quote_report["ready"]):
+        blocker_codes.append("latest_quotes_not_ready")
+    if signal_report["passes"] is False:
+        blocker_codes.append("signal_below_threshold")
+    if vetoes["entry_vetoes"]:
+        blocker_codes.append("entry_veto_present")
+    if vetoes["exit_vetoes"]:
+        blocker_codes.append("exit_veto_present")
+    if vetoes["has_risk_veto"]:
+        blocker_codes.append("risk_veto")
+    if route_flags["disabled_flags"]:
+        blocker_codes.append("route_disabled")
+    if submit_flags["disabled_flags"]:
+        blocker_codes.append("simple_submit_disabled")
+    if evidence_flags["disabled_flags"]:
+        blocker_codes.append("evidence_collection_disabled")
+    blocker_codes.extend(cast(Sequence[str], signal_drift_readiness["blockers"]))
 
-    explicit_blockers = _unique_text_items(source.get('blockers'))
-    explicit_blockers.extend(_unique_text_items(status.get('blockers') or status.get('blocked_reasons')))
+    explicit_blockers = _unique_text_items(source.get("blockers"))
+    explicit_blockers.extend(
+        _unique_text_items(status.get("blockers") or status.get("blocked_reasons"))
+    )
     for nested_status in _nested_flag_containers(status):
-        explicit_blockers.extend(_unique_text_items(nested_status.get('blockers') or nested_status.get('blocked_reasons')))
-    explicit_blockers.extend(_unique_text_items(target.get('blockers')))
-    explicit_blockers.extend(_unique_text_items(route.get('blockers')))
+        explicit_blockers.extend(
+            _unique_text_items(
+                nested_status.get("blockers") or nested_status.get("blocked_reasons")
+            )
+        )
+    explicit_blockers.extend(_unique_text_items(target.get("blockers")))
+    explicit_blockers.extend(_unique_text_items(route.get("blockers")))
     blocker_codes.extend(explicit_blockers)
 
     unsupported = False
     unsupported_reasons: list[str] = []
-    if signal_report['passes'] is None:
+    if signal_report["passes"] is None:
         unsupported = True
-        unsupported_reasons.extend(cast(list[str], signal_report['missing_inputs']))
-        blocker_codes.append('unsupported_signal_threshold_inputs')
+        unsupported_reasons.extend(cast(list[str], signal_report["missing_inputs"]))
+        blocker_codes.append("unsupported_signal_threshold_inputs")
     if not symbols and target:
         unsupported = True
-        unsupported_reasons.append('symbol_universe')
-        blocker_codes.append('unsupported_symbol_universe_inputs')
+        unsupported_reasons.append("symbol_universe")
+        blocker_codes.append("unsupported_symbol_universe_inputs")
 
     blocker_codes = sorted(set(blocker_codes))
     next_action = _choose_next_action(blocker_codes, unsupported)
-    ready = next_action == 'ready_to_submit_sim_order'
+    ready = next_action == "ready_to_submit_sim_order"
     human_verdict = (
-        'H-PAIRS liveness READY: target can submit a TORGHUT_SIM paper order.'
+        "H-PAIRS liveness READY: target can submit a TORGHUT_SIM paper order."
         if ready
-        else f'H-PAIRS liveness BLOCKED: next_action={next_action}; blockers={",".join(blocker_codes)}.'
+        else f"H-PAIRS liveness BLOCKED: next_action={next_action}; blockers={','.join(blocker_codes)}."
     )
 
     return {
-        'schema_version': HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION,
-        'read_only': True,
-        'target_candidate_identity': identity,
-        'account_stage_runtime_strategy': {
-            'account_label': observed.get('account_label'),
-            'observed_stage': observed.get('observed_stage'),
-            'runtime_strategy': observed.get('runtime_strategy'),
-            'expected_account_label': expectations.account_label,
-            'expected_observed_stage': expectations.observed_stage,
-            'expected_runtime_strategy': expectations.runtime_strategy,
+        "schema_version": HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION,
+        "read_only": True,
+        "target_candidate_identity": identity,
+        "account_stage_runtime_strategy": {
+            "account_label": observed.get("account_label"),
+            "observed_stage": observed.get("observed_stage"),
+            "runtime_strategy": observed.get("runtime_strategy"),
+            "expected_account_label": expectations.account_label,
+            "expected_observed_stage": expectations.observed_stage,
+            "expected_runtime_strategy": expectations.runtime_strategy,
         },
-        'symbol_universe': {
-            'symbols': symbols,
-            'count': len(symbols),
+        "symbol_universe": {
+            "symbols": symbols,
+            "count": len(symbols),
         },
-        'latest_feature_availability': feature_report,
-        'latest_quote_availability': quote_report,
-        'signal_threshold_status': signal_report,
-        'entry_exit_vetoes': vetoes,
-        'route_eligibility_flags': route_flags,
-        'simple_submit_flag_state': submit_flags,
-        'evidence_collection_flags': evidence_flags,
-        'blocker_codes': blocker_codes,
-        'unsupported_reasons': sorted(set(unsupported_reasons)),
-        'next_action': next_action,
-        'ready_to_submit_sim_order': ready,
-        'human_verdict': human_verdict,
+        "latest_feature_availability": feature_report,
+        "latest_quote_availability": quote_report,
+        "signal_threshold_status": signal_report,
+        "signal_drift_readiness": signal_drift_readiness,
+        "entry_exit_vetoes": vetoes,
+        "route_eligibility_flags": route_flags,
+        "simple_submit_flag_state": submit_flags,
+        "evidence_collection_flags": evidence_flags,
+        "blocker_codes": blocker_codes,
+        "unsupported_reasons": sorted(set(unsupported_reasons)),
+        "next_action": next_action,
+        "ready_to_submit_sim_order": ready,
+        "human_verdict": human_verdict,
     }
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--fixture-json', '--input-json', dest='fixture_json')
-    parser.add_argument('--target-json')
-    parser.add_argument('--status-json')
-    parser.add_argument('--features-json')
-    parser.add_argument('--quotes-json')
-    parser.add_argument('--signal-json')
-    parser.add_argument('--route-json')
-    parser.add_argument('--risk-json')
-    parser.add_argument('--status-url', help='optional bounded read-only HTTP GET that returns status JSON')
-    parser.add_argument('--http-timeout-seconds', type=float, default=2.0)
-    parser.add_argument('--hypothesis-id', default=DEFAULT_HPAIRS_HYPOTHESIS_ID)
-    parser.add_argument('--candidate-id', default=DEFAULT_HPAIRS_CANDIDATE_ID)
-    parser.add_argument('--account-label', default=DEFAULT_HPAIRS_ACCOUNT_LABEL)
-    parser.add_argument('--observed-stage', default=DEFAULT_OBSERVED_STAGE)
-    parser.add_argument('--runtime-strategy-name', default=DEFAULT_HPAIRS_RUNTIME_STRATEGY)
-    parser.add_argument('--max-quote-age-seconds', type=float, default=90.0)
-    parser.add_argument('--max-feature-age-seconds', type=float, default=180.0)
+    parser.add_argument("--fixture-json", "--input-json", dest="fixture_json")
+    parser.add_argument("--target-json")
+    parser.add_argument("--status-json")
+    parser.add_argument("--features-json")
+    parser.add_argument("--quotes-json")
+    parser.add_argument("--signal-json")
+    parser.add_argument("--route-json")
+    parser.add_argument("--risk-json")
     parser.add_argument(
-        '--fail-on-blockers',
-        action='store_true',
-        help='exit non-zero when the diagnostic next_action is not ready_to_submit_sim_order',
+        "--status-url",
+        help="optional bounded read-only HTTP GET that returns status JSON",
+    )
+    parser.add_argument("--http-timeout-seconds", type=float, default=2.0)
+    parser.add_argument("--hypothesis-id", default=DEFAULT_HPAIRS_HYPOTHESIS_ID)
+    parser.add_argument("--candidate-id", default=DEFAULT_HPAIRS_CANDIDATE_ID)
+    parser.add_argument("--account-label", default=DEFAULT_HPAIRS_ACCOUNT_LABEL)
+    parser.add_argument("--observed-stage", default=DEFAULT_OBSERVED_STAGE)
+    parser.add_argument(
+        "--runtime-strategy-name", default=DEFAULT_HPAIRS_RUNTIME_STRATEGY
+    )
+    parser.add_argument("--max-quote-age-seconds", type=float, default=90.0)
+    parser.add_argument("--max-feature-age-seconds", type=float, default=180.0)
+    parser.add_argument("--max-signal-lag-seconds", type=float, default=90.0)
+    parser.add_argument(
+        "--fail-on-blockers",
+        action="store_true",
+        help="exit non-zero when the diagnostic next_action is not ready_to_submit_sim_order",
     )
     return parser.parse_args(list(argv))
 
 
 def _load_cli_source(args: argparse.Namespace) -> Mapping[str, object]:
-    source: Mapping[str, object] = _read_json_path(args.fixture_json) if args.fixture_json else {}
+    source: Mapping[str, object] = (
+        _read_json_path(args.fixture_json) if args.fixture_json else {}
+    )
     overrides: dict[str, Mapping[str, object]] = {}
     for key, attr in (
-        ('target', 'target_json'),
-        ('status', 'status_json'),
-        ('features', 'features_json'),
-        ('quotes', 'quotes_json'),
-        ('signal', 'signal_json'),
-        ('route', 'route_json'),
-        ('risk', 'risk_json'),
+        ("target", "target_json"),
+        ("status", "status_json"),
+        ("features", "features_json"),
+        ("quotes", "quotes_json"),
+        ("signal", "signal_json"),
+        ("route", "route_json"),
+        ("risk", "risk_json"),
     ):
         value = getattr(args, attr)
         if value:
             overrides[key] = _read_json_path(value)
     if args.status_url:
-        overrides['status'] = _read_status_url(args.status_url, args.http_timeout_seconds)
+        overrides["status"] = _read_status_url(
+            args.status_url, args.http_timeout_seconds
+        )
     return _merge_inputs(source, overrides)
 
 
@@ -681,26 +919,30 @@ def main(argv: list[str] | None = None) -> int:
         runtime_strategy=args.runtime_strategy_name,
         max_quote_age_seconds=args.max_quote_age_seconds,
         max_feature_age_seconds=args.max_feature_age_seconds,
+        max_signal_lag_seconds=args.max_signal_lag_seconds,
     )
     try:
         source = _load_cli_source(args)
         report = build_liveness_report(source, expectations)
     except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError) as exc:
         report = {
-            'schema_version': HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION,
-            'read_only': True,
-            'next_action': 'unsupported_inputs',
-            'ready_to_submit_sim_order': False,
-            'blocker_codes': ['unsupported_input_read_error'],
-            'human_verdict': f'H-PAIRS liveness BLOCKED: next_action=unsupported_inputs; error={exc}.',
-            'error': str(exc),
+            "schema_version": HPAIRS_SIGNAL_LIVENESS_SCHEMA_VERSION,
+            "read_only": True,
+            "next_action": "unsupported_inputs",
+            "ready_to_submit_sim_order": False,
+            "blocker_codes": ["unsupported_input_read_error"],
+            "human_verdict": f"H-PAIRS liveness BLOCKED: next_action=unsupported_inputs; error={exc}.",
+            "error": str(exc),
         }
     sys.stdout.write(stable_json(report))
-    sys.stderr.write(str(report['human_verdict']) + '\n')
-    if args.fail_on_blockers and report.get('next_action') != 'ready_to_submit_sim_order':
+    sys.stderr.write(str(report["human_verdict"]) + "\n")
+    if (
+        args.fail_on_blockers
+        and report.get("next_action") != "ready_to_submit_sim_order"
+    ):
         return 1
     return 0
 
 
-if __name__ == '__main__':  # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())

--- a/services/torghut/tests/test_audit_hpairs_signal_liveness.py
+++ b/services/torghut/tests/test_audit_hpairs_signal_liveness.py
@@ -8,40 +8,48 @@ from scripts import audit_hpairs_signal_liveness as audit
 
 def _base_fixture() -> dict[str, object]:
     return {
-        'target': {
-            'hypothesis_id': audit.DEFAULT_HPAIRS_HYPOTHESIS_ID,
-            'candidate_id': audit.DEFAULT_HPAIRS_CANDIDATE_ID,
-            'account_label': audit.DEFAULT_HPAIRS_ACCOUNT_LABEL,
-            'observed_stage': audit.DEFAULT_OBSERVED_STAGE,
-            'runtime_strategy_name': audit.DEFAULT_HPAIRS_RUNTIME_STRATEGY,
-            'symbols': ['AAPL', 'AMZN'],
-            'route_enabled': True,
-            'bounded_evidence_collection_authorized': True,
+        "target": {
+            "hypothesis_id": audit.DEFAULT_HPAIRS_HYPOTHESIS_ID,
+            "candidate_id": audit.DEFAULT_HPAIRS_CANDIDATE_ID,
+            "account_label": audit.DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            "observed_stage": audit.DEFAULT_OBSERVED_STAGE,
+            "runtime_strategy_name": audit.DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+            "symbols": ["AAPL", "AMZN"],
+            "route_enabled": True,
+            "bounded_evidence_collection_authorized": True,
         },
-        'features': {
-            'symbols': {
-                'AAPL': {'ready': True, 'age_seconds': 12, 'timestamp': '2026-06-01T14:31:00Z'},
-                'AMZN': {'ready': True, 'age_seconds': 10, 'timestamp': '2026-06-01T14:31:00Z'},
+        "features": {
+            "symbols": {
+                "AAPL": {
+                    "ready": True,
+                    "age_seconds": 12,
+                    "timestamp": "2026-06-01T14:31:00Z",
+                },
+                "AMZN": {
+                    "ready": True,
+                    "age_seconds": 10,
+                    "timestamp": "2026-06-01T14:31:00Z",
+                },
             },
         },
-        'quotes': {
-            'symbols': {
-                'AAPL': {'bid': 201.01, 'ask': 201.03, 'age_seconds': 3},
-                'AMZN': {'bid': 190.01, 'ask': 190.05, 'age_seconds': 4},
+        "quotes": {
+            "symbols": {
+                "AAPL": {"bid": 201.01, "ask": 201.03, "age_seconds": 3},
+                "AMZN": {"bid": 190.01, "ask": 190.05, "age_seconds": 4},
             },
         },
-        'signal': {'score': 1.25, 'threshold': 1.0, 'direction': 'pair_convergence'},
-        'risk': {'vetoes': []},
-        'route': {'route_eligible': True},
-        'status': {'simple_submit_enabled': True},
+        "signal": {"score": 1.25, "threshold": 1.0, "direction": "pair_convergence"},
+        "risk": {"vetoes": []},
+        "route": {"route_eligible": True},
+        "status": {"simple_submit_enabled": True},
     }
 
 
 def _run_fixture(tmp_path: Path, fixture: dict[str, object]) -> dict[str, object]:
-    path = tmp_path / 'fixture.json'
+    path = tmp_path / "fixture.json"
     path.write_text(json.dumps(fixture, sort_keys=True))
 
-    exit_code = audit.main(['--fixture-json', str(path)])
+    exit_code = audit.main(["--fixture-json", str(path)])
 
     assert exit_code == 0
     return audit.build_liveness_report(
@@ -54,98 +62,179 @@ def _run_fixture(tmp_path: Path, fixture: dict[str, object]) -> dict[str, object
             runtime_strategy=audit.DEFAULT_HPAIRS_RUNTIME_STRATEGY,
             max_quote_age_seconds=90.0,
             max_feature_age_seconds=180.0,
+            max_signal_lag_seconds=90.0,
         ),
     )
 
 
 def test_wrong_account_fixture_classifies_wrong_account(tmp_path: Path) -> None:
     fixture = _base_fixture()
-    target = fixture['target']
+    target = fixture["target"]
     assert isinstance(target, dict)
-    target['account_label'] = 'ALPACA_PAPER'
+    target["account_label"] = "ALPACA_PAPER"
 
     report = _run_fixture(tmp_path, fixture)
 
-    assert report['next_action'] == 'wrong_account'
-    assert 'account_label_mismatch' in report['blocker_codes']
-    assert report['account_stage_runtime_strategy']['expected_account_label'] == 'TORGHUT_SIM'
+    assert report["next_action"] == "wrong_account"
+    assert "account_label_mismatch" in report["blocker_codes"]
+    assert (
+        report["account_stage_runtime_strategy"]["expected_account_label"]
+        == "TORGHUT_SIM"
+    )
 
 
-def test_missing_quotes_and_features_fixture_classifies_no_market_data(tmp_path: Path) -> None:
+def test_missing_quotes_and_features_fixture_classifies_no_market_data(
+    tmp_path: Path,
+) -> None:
     fixture = _base_fixture()
-    fixture['features'] = {'symbols': {'AAPL': {'ready': True, 'age_seconds': 12}}}
-    fixture['quotes'] = {'symbols': {'AAPL': {'bid': 201.01, 'ask': 201.03, 'age_seconds': 3}}}
+    fixture["features"] = {"symbols": {"AAPL": {"ready": True, "age_seconds": 12}}}
+    fixture["quotes"] = {
+        "symbols": {"AAPL": {"bid": 201.01, "ask": 201.03, "age_seconds": 3}}
+    }
 
     report = _run_fixture(tmp_path, fixture)
 
-    assert report['next_action'] == 'no_market_data'
-    assert 'latest_features_not_ready' in report['blocker_codes']
-    assert 'latest_quotes_not_ready' in report['blocker_codes']
-    assert report['latest_feature_availability']['missing_symbols'] == ['AMZN']
-    assert report['latest_quote_availability']['missing_symbols'] == ['AMZN']
+    assert report["next_action"] == "no_market_data"
+    assert "latest_features_not_ready" in report["blocker_codes"]
+    assert "latest_quotes_not_ready" in report["blocker_codes"]
+    assert report["latest_feature_availability"]["missing_symbols"] == ["AMZN"]
+    assert report["latest_quote_availability"]["missing_symbols"] == ["AMZN"]
 
 
-def test_threshold_miss_fixture_classifies_signal_below_threshold(tmp_path: Path) -> None:
+def test_threshold_miss_fixture_classifies_signal_below_threshold(
+    tmp_path: Path,
+) -> None:
     fixture = _base_fixture()
-    fixture['signal'] = {'score': 0.25, 'threshold': 1.0}
+    fixture["signal"] = {"score": 0.25, "threshold": 1.0}
 
     report = _run_fixture(tmp_path, fixture)
 
-    assert report['next_action'] == 'signal_below_threshold'
-    assert 'signal_below_threshold' in report['blocker_codes']
-    assert report['signal_threshold_status']['passes'] is False
+    assert report["next_action"] == "signal_below_threshold"
+    assert "signal_below_threshold" in report["blocker_codes"]
+    assert report["signal_threshold_status"]["passes"] is False
 
 
 def test_risk_veto_fixture_classifies_risk_veto(tmp_path: Path) -> None:
     fixture = _base_fixture()
-    fixture['risk'] = {'vetoes': ['max_position_notional_exceeded']}
+    fixture["risk"] = {"vetoes": ["max_position_notional_exceeded"]}
 
     report = _run_fixture(tmp_path, fixture)
 
-    assert report['next_action'] == 'risk_veto'
-    assert 'risk_veto' in report['blocker_codes']
-    assert report['entry_exit_vetoes']['risk_vetoes'] == ['max_position_notional_exceeded']
+    assert report["next_action"] == "risk_veto"
+    assert "risk_veto" in report["blocker_codes"]
+    assert report["entry_exit_vetoes"]["risk_vetoes"] == [
+        "max_position_notional_exceeded"
+    ]
 
 
 def test_route_disabled_fixture_classifies_route_disabled(tmp_path: Path) -> None:
     fixture = _base_fixture()
-    fixture['route'] = {'route_eligible': False, 'blockers': ['paper_route_closed']}
+    fixture["route"] = {"route_eligible": False, "blockers": ["paper_route_closed"]}
 
     report = _run_fixture(tmp_path, fixture)
 
-    assert report['next_action'] == 'route_disabled'
-    assert 'route_disabled' in report['blocker_codes']
-    assert 'paper_route_closed' in report['blocker_codes']
-    assert report['route_eligibility_flags']['disabled_flags'] == ['route_eligible']
+    assert report["next_action"] == "route_disabled"
+    assert "route_disabled" in report["blocker_codes"]
+    assert "paper_route_closed" in report["blocker_codes"]
+    assert report["route_eligibility_flags"]["disabled_flags"] == ["route_eligible"]
 
 
-def test_collection_disabled_fixture_classifies_evidence_collection_disabled(tmp_path: Path) -> None:
+def test_collection_disabled_fixture_classifies_evidence_collection_disabled(
+    tmp_path: Path,
+) -> None:
     fixture = _base_fixture()
-    target = fixture['target']
+    target = fixture["target"]
     assert isinstance(target, dict)
-    target['bounded_evidence_collection_authorized'] = False
+    target["bounded_evidence_collection_authorized"] = False
 
     report = _run_fixture(tmp_path, fixture)
 
-    assert report['next_action'] == 'evidence_collection_disabled'
-    assert 'evidence_collection_disabled' in report['blocker_codes']
-    assert report['evidence_collection_flags']['disabled_flags'] == ['bounded_evidence_collection_authorized']
+    assert report["next_action"] == "evidence_collection_disabled"
+    assert "evidence_collection_disabled" in report["blocker_codes"]
+    assert report["evidence_collection_flags"]["disabled_flags"] == [
+        "bounded_evidence_collection_authorized"
+    ]
 
 
-def test_ready_fixture_classifies_ready_to_submit_sim_order(tmp_path: Path, capsys: object) -> None:
+def test_missing_drift_checks_fixture_classifies_materialize_drift_checks(
+    tmp_path: Path,
+) -> None:
     fixture = _base_fixture()
-    path = tmp_path / 'ready.json'
+    fixture["status"] = {
+        "simple_submit_enabled": True,
+        "market_session_open": True,
+        "signal_lag_seconds": 14,
+        "drift_detection_checks_total": 0,
+    }
+
+    report = _run_fixture(tmp_path, fixture)
+
+    assert report["next_action"] == "materialize_drift_checks"
+    assert "drift_checks_missing" in report["blocker_codes"]
+    assert report["signal_drift_readiness"]["drift_checks_present"] is False
+    assert report["ready_to_submit_sim_order"] is False
+
+
+def test_stale_signal_lag_fixture_classifies_wait_for_fresh_signal_window(
+    tmp_path: Path,
+) -> None:
+    fixture = _base_fixture()
+    fixture["status"] = {
+        "simple_submit_enabled": True,
+        "market_session_open": True,
+        "signal_lag_seconds": 9_958,
+        "drift_detection_checks_total": 3,
+    }
+
+    report = _run_fixture(tmp_path, fixture)
+
+    assert report["next_action"] == "wait_for_fresh_signal_window"
+    assert "signal_lag_exceeded" in report["blocker_codes"]
+    assert report["signal_drift_readiness"]["fresh_signal_window"] is False
+    assert report["ready_to_submit_sim_order"] is False
+
+
+def test_closed_market_fixture_classifies_wait_for_market_session_open(
+    tmp_path: Path,
+) -> None:
+    fixture = _base_fixture()
+    fixture["status"] = {
+        "simple_submit_enabled": True,
+        "market_session_open": False,
+        "signal_lag_seconds": 14,
+        "drift_detection_checks_total": 3,
+    }
+
+    report = _run_fixture(tmp_path, fixture)
+
+    assert report["next_action"] == "wait_for_market_session_open"
+    assert "market_session_closed" in report["blocker_codes"]
+    assert report["signal_drift_readiness"]["ready"] is False
+    assert report["ready_to_submit_sim_order"] is False
+
+
+def test_ready_fixture_classifies_ready_to_submit_sim_order(
+    tmp_path: Path, capsys: object
+) -> None:
+    fixture = _base_fixture()
+    fixture["status"] = {
+        "simple_submit_enabled": True,
+        "market_session_open": True,
+        "signal_lag_seconds": 14,
+        "drift_detection_checks_total": 3,
+    }
+    path = tmp_path / "ready.json"
     path.write_text(json.dumps(fixture, sort_keys=True))
 
-    exit_code = audit.main(['--fixture-json', str(path), '--fail-on-blockers'])
+    exit_code = audit.main(["--fixture-json", str(path), "--fail-on-blockers"])
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
 
     assert exit_code == 0
-    assert payload['next_action'] == 'ready_to_submit_sim_order'
-    assert payload['blocker_codes'] == []
-    assert payload['ready_to_submit_sim_order'] is True
-    assert 'H-PAIRS liveness READY' in captured.err
+    assert payload["next_action"] == "ready_to_submit_sim_order"
+    assert payload["blocker_codes"] == []
+    assert payload["ready_to_submit_sim_order"] is True
+    assert "H-PAIRS liveness READY" in captured.err
 
 
 def _expectations() -> audit.AuditExpectations:
@@ -157,129 +246,145 @@ def _expectations() -> audit.AuditExpectations:
         runtime_strategy=audit.DEFAULT_HPAIRS_RUNTIME_STRATEGY,
         max_quote_age_seconds=90.0,
         max_feature_age_seconds=180.0,
+        max_signal_lag_seconds=90.0,
     )
 
 
 def test_no_target_empty_fixture_reports_no_target_and_missing_inputs() -> None:
     report = audit.build_liveness_report({}, _expectations())
 
-    assert report['next_action'] == 'no_target'
-    assert {'target_missing', 'latest_features_missing', 'latest_quotes_missing'}.issubset(
-        set(report['blocker_codes'])
-    )
-    assert report['unsupported_reasons'] == ['score', 'threshold']
+    assert report["next_action"] == "no_target"
+    assert {
+        "target_missing",
+        "latest_features_missing",
+        "latest_quotes_missing",
+    }.issubset(set(report["blocker_codes"]))
+    assert report["unsupported_reasons"] == ["score", "threshold"]
 
 
 def test_target_list_nested_status_and_vetoes_are_diagnosed() -> None:
     fixture = _base_fixture()
-    target = fixture.pop('target')
+    target = fixture.pop("target")
     assert isinstance(target, dict)
-    target['symbols'] = {'aapl': {}, 'amzn': {}}
-    target['observed_stage'] = 'live'
-    target['runtime_strategy_name'] = 'other-strategy'
-    target['entry_vetoes'] = ['entry_closed']
-    fixture['targets'] = [{'candidate_id': 'other'}, target]
-    fixture['status'] = {
-        'live_submission_gate': {
-            'simple_lane': {'submit_enabled': 'disabled', 'blocked_reasons': ['simple_submit_disabled']},
-        },
-    }
-
-    report = audit.build_liveness_report(fixture, _expectations())
-
-    assert report['next_action'] == 'wrong_account'
-    assert 'observed_stage_mismatch' in report['blocker_codes']
-    assert 'runtime_strategy_mismatch' in report['blocker_codes']
-    assert 'entry_veto_present' in report['blocker_codes']
-    assert 'simple_submit_disabled' in report['blocker_codes']
-    assert report['simple_submit_flag_state']['disabled_flags'] == ['submit_enabled']
-    assert report['symbol_universe']['symbols'] == ['AAPL', 'AMZN']
-
-
-def test_latest_and_by_symbol_market_data_shapes_cover_stale_and_invalid_quotes() -> None:
-    fixture = _base_fixture()
-    fixture['features'] = {
-        'latest': {
-            'timestamp': '2026-06-01T14:32:00Z',
-            'symbols': {
-                'AAPL': {'ready': 'yes', 'staleness_seconds': '181'},
-                'AMZN': {'ready': 'yes', 'staleness_seconds': '1'},
+    target["symbols"] = {"aapl": {}, "amzn": {}}
+    target["observed_stage"] = "live"
+    target["runtime_strategy_name"] = "other-strategy"
+    target["entry_vetoes"] = ["entry_closed"]
+    fixture["targets"] = [{"candidate_id": "other"}, target]
+    fixture["status"] = {
+        "live_submission_gate": {
+            "simple_lane": {
+                "submit_enabled": "disabled",
+                "blocked_reasons": ["simple_submit_disabled"],
             },
         },
     }
-    fixture['quotes'] = {
-        'by_symbol': {
-            'aapl': {'bid_price': '202', 'ask_price': '201', 'age_seconds': '1'},
-            'amzn': {'bid_price': '190', 'ask_price': '191', 'age_seconds': 'not-a-number'},
+
+    report = audit.build_liveness_report(fixture, _expectations())
+
+    assert report["next_action"] == "wrong_account"
+    assert "observed_stage_mismatch" in report["blocker_codes"]
+    assert "runtime_strategy_mismatch" in report["blocker_codes"]
+    assert "entry_veto_present" in report["blocker_codes"]
+    assert "simple_submit_disabled" in report["blocker_codes"]
+    assert report["simple_submit_flag_state"]["disabled_flags"] == ["submit_enabled"]
+    assert report["symbol_universe"]["symbols"] == ["AAPL", "AMZN"]
+
+
+def test_latest_and_by_symbol_market_data_shapes_cover_stale_and_invalid_quotes() -> (
+    None
+):
+    fixture = _base_fixture()
+    fixture["features"] = {
+        "latest": {
+            "timestamp": "2026-06-01T14:32:00Z",
+            "symbols": {
+                "AAPL": {"ready": "yes", "staleness_seconds": "181"},
+                "AMZN": {"ready": "yes", "staleness_seconds": "1"},
+            },
+        },
+    }
+    fixture["quotes"] = {
+        "by_symbol": {
+            "aapl": {"bid_price": "202", "ask_price": "201", "age_seconds": "1"},
+            "amzn": {
+                "bid_price": "190",
+                "ask_price": "191",
+                "age_seconds": "not-a-number",
+            },
         },
     }
 
     report = audit.build_liveness_report(fixture, _expectations())
 
-    assert report['next_action'] == 'no_market_data'
-    assert report['latest_feature_availability']['stale_symbols'] == ['AAPL']
-    assert report['latest_quote_availability']['not_ready_symbols'] == ['AAPL']
-    assert 'latest_features_not_ready' in report['blocker_codes']
-    assert 'latest_quotes_not_ready' in report['blocker_codes']
+    assert report["next_action"] == "no_market_data"
+    assert report["latest_feature_availability"]["stale_symbols"] == ["AAPL"]
+    assert report["latest_quote_availability"]["not_ready_symbols"] == ["AAPL"]
+    assert "latest_features_not_ready" in report["blocker_codes"]
+    assert "latest_quotes_not_ready" in report["blocker_codes"]
 
 
 def test_symbol_fallback_from_features_and_unsupported_symbol_universe() -> None:
     fixture = {
-        'target': {
-            'hypothesis_id': audit.DEFAULT_HPAIRS_HYPOTHESIS_ID,
-            'candidate_id': audit.DEFAULT_HPAIRS_CANDIDATE_ID,
-            'account_label': audit.DEFAULT_HPAIRS_ACCOUNT_LABEL,
-            'observed_stage': audit.DEFAULT_OBSERVED_STAGE,
-            'runtime_strategy_name': audit.DEFAULT_HPAIRS_RUNTIME_STRATEGY,
-            'route_enabled': True,
+        "target": {
+            "hypothesis_id": audit.DEFAULT_HPAIRS_HYPOTHESIS_ID,
+            "candidate_id": audit.DEFAULT_HPAIRS_CANDIDATE_ID,
+            "account_label": audit.DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            "observed_stage": audit.DEFAULT_OBSERVED_STAGE,
+            "runtime_strategy_name": audit.DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+            "route_enabled": True,
         },
-        'features': {'symbols': {'MSFT': {'ready': True}}},
-        'quotes': {'symbols': {'MSFT': {'bid': 1, 'ask': 2}}},
-        'signal': {'passes_threshold': True},
-        'status': {'simple_submit_enabled': True},
+        "features": {"symbols": {"MSFT": {"ready": True}}},
+        "quotes": {"symbols": {"MSFT": {"bid": 1, "ask": 2}}},
+        "signal": {"passes_threshold": True},
+        "status": {"simple_submit_enabled": True},
     }
 
     report = audit.build_liveness_report(fixture, _expectations())
 
-    assert report['symbol_universe']['symbols'] == ['MSFT']
-    assert report['next_action'] == 'ready_to_submit_sim_order'
+    assert report["symbol_universe"]["symbols"] == ["MSFT"]
+    assert report["next_action"] == "ready_to_submit_sim_order"
 
-    fixture['features'] = {}
-    fixture['quotes'] = {}
+    fixture["features"] = {}
+    fixture["quotes"] = {}
     report_without_symbols = audit.build_liveness_report(fixture, _expectations())
-    assert report_without_symbols['next_action'] == 'no_market_data'
-    assert 'unsupported_symbol_universe_inputs' in report_without_symbols['blocker_codes']
+    assert report_without_symbols["next_action"] == "no_market_data"
+    assert (
+        "unsupported_symbol_universe_inputs" in report_without_symbols["blocker_codes"]
+    )
 
 
 def test_helper_normalizers_cover_non_fixture_shapes(tmp_path: Path) -> None:
-    assert audit._text(123) == '123'
-    assert audit._bool_or_none('enabled') is True
-    assert audit._bool_or_none('disabled') is False
+    assert audit._text(123) == "123"
+    assert audit._bool_or_none("enabled") is True
+    assert audit._bool_or_none("disabled") is False
     assert audit._bool_or_none(1) is True
-    assert audit._float_or_none('') is None
-    assert audit._float_or_none('bad') is None
-    assert audit._unique_text_items({'a': 1, 'b': 2}) == ['a', 'b']
-    assert audit._unique_text_items(7) == ['7']
-    assert audit._unique_text_items(['x', 'x', None]) == ['x']
-    assert audit.stable_json({'value': object()}).endswith('\n')
+    assert audit._float_or_none("") is None
+    assert audit._float_or_none("bad") is None
+    assert audit._unique_text_items({"a": 1, "b": 2}) == ["a", "b"]
+    assert audit._unique_text_items(7) == ["7"]
+    assert audit._unique_text_items(["x", "x", None]) == ["x"]
+    assert audit.stable_json({"value": object()}).endswith("\n")
 
-    non_object = tmp_path / 'array.json'
-    non_object.write_text('[]')
+    non_object = tmp_path / "array.json"
+    non_object.write_text("[]")
     try:
         audit._read_json_path(non_object)
     except ValueError as exc:
-        assert 'must contain a JSON object' in str(exc)
+        assert "must contain a JSON object" in str(exc)
     else:  # pragma: no cover - defensive assertion branch
-        raise AssertionError('expected non-object JSON to fail')
+        raise AssertionError("expected non-object JSON to fail")
 
 
-def test_cli_inputs_support_overrides_status_url_errors_and_fail_on_blockers(tmp_path: Path, monkeypatch: object) -> None:
-    base_path = tmp_path / 'base.json'
-    target_path = tmp_path / 'target.json'
-    bad_path = tmp_path / 'bad.json'
+def test_cli_inputs_support_overrides_status_url_errors_and_fail_on_blockers(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    base_path = tmp_path / "base.json"
+    target_path = tmp_path / "target.json"
+    bad_path = tmp_path / "bad.json"
     base_path.write_text(json.dumps(_base_fixture()))
-    target_path.write_text(json.dumps({'account_label': 'ALPACA_PAPER'}))
-    bad_path.write_text('[]')
+    target_path.write_text(json.dumps({"account_label": "ALPACA_PAPER"}))
+    bad_path.write_text("[]")
 
     class _FakeResponse:
         def __enter__(self) -> _FakeResponse:
@@ -295,22 +400,22 @@ def test_cli_inputs_support_overrides_status_url_errors_and_fail_on_blockers(tmp
         assert timeout == 0.25
         return _FakeResponse()
 
-    monkeypatch.setattr(audit.urllib.request, 'urlopen', _fake_urlopen)
+    monkeypatch.setattr(audit.urllib.request, "urlopen", _fake_urlopen)
     args = audit.parse_args(
         [
-            '--fixture-json',
+            "--fixture-json",
             str(base_path),
-            '--target-json',
+            "--target-json",
             str(target_path),
-            '--status-url',
-            'http://127.0.0.1/status',
-            '--http-timeout-seconds',
-            '0.25',
+            "--status-url",
+            "http://127.0.0.1/status",
+            "--http-timeout-seconds",
+            "0.25",
         ]
     )
     merged = audit._load_cli_source(args)
-    assert merged['target'] == {'account_label': 'ALPACA_PAPER'}
-    assert merged['status'] == {'simple_lane': {'submit_enabled': False}}
+    assert merged["target"] == {"account_label": "ALPACA_PAPER"}
+    assert merged["status"] == {"simple_lane": {"submit_enabled": False}}
 
-    assert audit.main(['--fixture-json', str(bad_path), '--fail-on-blockers']) == 1
-    assert audit.main(['--fixture-json', str(base_path), '--fail-on-blockers']) == 0
+    assert audit.main(["--fixture-json", str(bad_path), "--fail-on-blockers"]) == 1
+    assert audit.main(["--fixture-json", str(base_path), "--fail-on-blockers"]) == 0

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -168,6 +168,43 @@ def _runtime_ledger_summary(
     }
 
 
+def _hpairs_route_repair_tca_summary() -> dict[str, object]:
+    return {
+        "account_label": "TORGHUT_SIM",
+        "order_count": 2,
+        "avg_abs_slippage_bps": "24.34",
+        "avg_realized_shortfall_bps": "24.34",
+        "last_computed_at": "2026-06-01T19:16:00+00:00",
+        "scope_symbols": ["AAPL", "AMZN"],
+        "symbol_breakdown": [
+            {
+                "symbol": "AAPL",
+                "order_count": 1,
+                "avg_abs_slippage_bps": "24.34",
+                "avg_realized_shortfall_bps": "24.34",
+                "last_computed_at": "2026-06-01T19:16:00+00:00",
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": _MANIFEST_CANDIDATE_IDS["H-PAIRS-01"],
+                "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-PAIRS-01"],
+                "account_label": "TORGHUT_SIM",
+                "source_kind": "live_paper_execution_tca",
+            },
+            {
+                "symbol": "AMZN",
+                "order_count": 1,
+                "avg_abs_slippage_bps": "24.34",
+                "avg_realized_shortfall_bps": "24.34",
+                "last_computed_at": "2026-06-01T19:16:00+00:00",
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": _MANIFEST_CANDIDATE_IDS["H-PAIRS-01"],
+                "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-PAIRS-01"],
+                "account_label": "TORGHUT_SIM",
+                "source_kind": "live_paper_execution_tca",
+            },
+        ],
+    }
+
+
 class _FakeHttpResponse:
     def __init__(self, payload: dict[str, object], status: int = 200) -> None:
         self.status = status
@@ -1656,6 +1693,173 @@ class TestHypothesisReadiness(TestCase):
         self.assertIn(
             "route_tca_non_authority_source_decision_mode",
             observed["route_tca_blocking_reason_codes"],
+        )
+        self.assertTrue(observed["bounded_route_evidence_collection_ready"])
+        self.assertEqual(
+            observed["bounded_route_evidence_collection_next_action"],
+            "collect_bounded_paper_route_source_rows",
+        )
+        self.assertEqual(observed["bounded_route_evidence_collection_blockers"], [])
+
+    def test_compile_hypothesis_runtime_statuses_blocks_bounded_hpairs_collection_when_drift_missing(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=_state(
+                feature_rows=2770,
+                drift_checks=0,
+                evidence_checks=2,
+                signal_lag_seconds=14,
+                evidence_report={
+                    "ok": True,
+                    "checked_at": "2026-06-01T19:15:00+00:00",
+                },
+            ),
+            tca_summary=_hpairs_route_repair_tca_summary(),
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-PAIRS-01",
+                bucket_started_at="2026-06-01T19:00:00+00:00",
+                bucket_ended_at="2026-06-01T19:15:00+00:00",
+                submitted_order_count=120,
+                post_cost_expectancy_bps="12",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 6, 1, 19, 17, tzinfo=timezone.utc),
+            market_session_open=True,
+            route_symbol_filter_enabled=True,
+        )
+
+        hpairs = next(
+            item for item in statuses if item["hypothesis_id"] == "H-PAIRS-01"
+        )
+        observed = hpairs["observed"]
+        self.assertIn("drift_checks_missing", hpairs["reasons"])
+        self.assertFalse(hpairs["promotion_eligible"])
+        self.assertTrue(observed["bounded_route_evidence_collection_eligible"])
+        self.assertFalse(observed["bounded_route_evidence_collection_ready"])
+        self.assertEqual(
+            observed["bounded_route_evidence_collection_next_action"],
+            "materialize_drift_checks",
+        )
+        self.assertEqual(
+            observed["bounded_route_evidence_collection_blockers"],
+            ["drift_checks_missing"],
+        )
+
+    def test_compile_hypothesis_runtime_statuses_blocks_bounded_hpairs_collection_on_stale_signal_lag(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=_state(
+                feature_rows=2770,
+                drift_checks=3,
+                evidence_checks=2,
+                signal_lag_seconds=9_958,
+                evidence_report={
+                    "ok": True,
+                    "checked_at": "2026-06-01T19:15:00+00:00",
+                },
+            ),
+            tca_summary=_hpairs_route_repair_tca_summary(),
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-PAIRS-01",
+                bucket_started_at="2026-06-01T19:00:00+00:00",
+                bucket_ended_at="2026-06-01T19:15:00+00:00",
+                submitted_order_count=120,
+                post_cost_expectancy_bps="12",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 6, 1, 19, 17, tzinfo=timezone.utc),
+            market_session_open=True,
+            route_symbol_filter_enabled=True,
+        )
+
+        hpairs = next(
+            item for item in statuses if item["hypothesis_id"] == "H-PAIRS-01"
+        )
+        observed = hpairs["observed"]
+        self.assertIn("signal_lag_exceeded", hpairs["reasons"])
+        self.assertFalse(hpairs["promotion_eligible"])
+        self.assertTrue(observed["bounded_route_evidence_collection_eligible"])
+        self.assertFalse(observed["bounded_route_evidence_collection_ready"])
+        self.assertEqual(
+            observed["bounded_route_evidence_collection_next_action"],
+            "wait_for_fresh_signal_window",
+        )
+        self.assertEqual(
+            observed["bounded_route_evidence_collection_blockers"],
+            ["signal_lag_exceeded"],
+        )
+        self.assertEqual(
+            observed["bounded_route_evidence_collection_liveness"][
+                "fresh_signal_window"
+            ],
+            False,
+        )
+
+    def test_compile_hypothesis_runtime_statuses_does_not_ready_bounded_hpairs_collection_while_market_closed(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=_state(
+                feature_rows=2770,
+                drift_checks=3,
+                evidence_checks=2,
+                signal_lag_seconds=14,
+                evidence_report={
+                    "ok": True,
+                    "checked_at": "2026-06-01T19:15:00+00:00",
+                },
+            ),
+            tca_summary=_hpairs_route_repair_tca_summary(),
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-PAIRS-01",
+                bucket_started_at="2026-06-01T19:00:00+00:00",
+                bucket_ended_at="2026-06-01T19:15:00+00:00",
+                submitted_order_count=120,
+                post_cost_expectancy_bps="12",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 6, 1, 23, 17, tzinfo=timezone.utc),
+            market_session_open=False,
+            route_symbol_filter_enabled=True,
+        )
+
+        hpairs = next(
+            item for item in statuses if item["hypothesis_id"] == "H-PAIRS-01"
+        )
+        observed = hpairs["observed"]
+        self.assertFalse(hpairs["promotion_eligible"])
+        self.assertTrue(observed["bounded_route_evidence_collection_eligible"])
+        self.assertFalse(observed["bounded_route_evidence_collection_ready"])
+        self.assertEqual(
+            observed["bounded_route_evidence_collection_next_action"],
+            "wait_for_market_session_open",
+        )
+        self.assertEqual(
+            observed["bounded_route_evidence_collection_blockers"],
+            ["market_session_closed"],
         )
 
     def test_compile_hypothesis_runtime_statuses_selects_clean_current_hpairs_route_tca(


### PR DESCRIPTION
## Summary

- Added fail-closed H-PAIRS bounded-route readiness readback that separates repair eligibility from collection readiness.
- Exposes deterministic blockers and next actions for missing drift checks, stale or unmeasured signal lag, and closed market sessions.
- Extended the read-only H-PAIRS liveness audit with signal/drift/session readiness diagnostics.
- Added regression coverage for closed-market holds, stale signal lag, missing drift checks, and fresh bounded readiness without promotion.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_hypotheses.py tests/test_profit_freshness_frontier.py tests/test_audit_hpairs_signal_liveness.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/hypotheses.py scripts/audit_hpairs_signal_liveness.py tests/test_hypotheses.py tests/test_audit_hpairs_signal_liveness.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/hypotheses.py scripts/audit_hpairs_signal_liveness.py tests/test_hypotheses.py tests/test_audit_hpairs_signal_liveness.py`
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
