### PR TITLE
feat(torghut): add hpairs replay tape features

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -795,6 +795,12 @@ def _event_label(signal: SignalEnvelope) -> str:
         value = str(payload.get(key) or "").strip().lower()
         if value:
             return value
+    hpairs_features = _hpairs_replay_tape_features(signal)
+    cluster_lob = _mapping(hpairs_features.get("cluster_lob"))
+    for key in ("bucket", "label"):
+        value = str(cluster_lob.get(key) or "").strip().lower()
+        if value:
+            return value
     return "unknown"
 
 
@@ -866,6 +872,13 @@ def _extract_macro_stress(signal: SignalEnvelope) -> float | None:
             return 1.0
         if text in {"no", "false", "none", "normal"}:
             return 0.0
+    hpairs_features = _hpairs_replay_tape_features(signal)
+    stress_tags = hpairs_features.get("stress_tags")
+    if isinstance(stress_tags, Sequence) and not isinstance(
+        stress_tags, (str, bytes, bytearray)
+    ):
+        parsed_stress_tags = cast(Sequence[object], stress_tags)
+        return 1.0 if any(str(item).strip() for item in parsed_stress_tags) else 0.0
     return None
 
 
@@ -985,6 +998,24 @@ def _extract_ofi_pressure(signal: SignalEnvelope) -> float | None:
         if -1.0 <= value <= 1.0:
             return value
         return float(np.tanh(value / 100.0))
+    hpairs_ofi = _mapping(
+        _hpairs_replay_tape_features(signal).get("order_flow_imbalance_horizons")
+    )
+    values: list[float] = []
+    for horizon in ("instant", "1", "3", "12", "36"):
+        value = _float_or_none(hpairs_ofi.get(horizon))
+        if value is not None:
+            values.append(value)
+    if not values:
+        for value in hpairs_ofi.values():
+            parsed = _float_or_none(value)
+            if parsed is not None:
+                values.append(parsed)
+    if values:
+        mean_value = float(np.mean(np.asarray(values, dtype=np.float64)))
+        if -1.0 <= mean_value <= 1.0:
+            return mean_value
+        return float(np.tanh(mean_value / 100.0))
     return _extract_quote_depth_imbalance(signal)
 
 
@@ -1100,6 +1131,15 @@ def _float_or_none(value: Any) -> float | None:
     if not np.isfinite(parsed):
         return None
     return parsed
+
+
+def _hpairs_replay_tape_features(signal: SignalEnvelope) -> dict[str, Any]:
+    raw = signal.payload.get("hpairs_replay_tape_features") or signal.payload.get(
+        "hpairs_features"
+    )
+    if not isinstance(raw, Mapping):
+        return {}
+    return dict(cast(Mapping[str, Any], raw))
 
 
 def _decimal_from_float(value: float) -> Decimal:

--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -8,7 +8,7 @@ import json
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, TextIO, cast
 
@@ -22,6 +22,7 @@ from app.trading.session_context import (
 REPLAY_TAPE_SCHEMA_VERSION = "torghut.replay-tape.v1"
 REPLAY_TAPE_MANIFEST_SCHEMA_VERSION = "torghut.replay-tape-manifest.v1"
 REPLAY_TAPE_CACHE_IDENTITY_SCHEMA_VERSION = "torghut.replay-tape-cache-identity.v1"
+HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION = "torghut.hpairs-replay-tape-features.v1"
 _DECIMAL_TAG = "__torghut_decimal__"
 _DATETIME_TAG = "__torghut_datetime__"
 
@@ -590,6 +591,7 @@ def signal_to_tape_payload(signal: SignalEnvelope) -> dict[str, Any]:
         "event_ts": signal.event_ts.astimezone(timezone.utc).isoformat(),
         "symbol": signal.symbol,
         "payload": _encode_value(signal.payload),
+        "hpairs_features": _encode_value(hpairs_replay_tape_features(signal)),
         "timeframe": signal.timeframe,
         "ingest_ts": signal.ingest_ts.astimezone(timezone.utc).isoformat()
         if signal.ingest_ts is not None
@@ -604,15 +606,98 @@ def signal_from_tape_payload(payload: Mapping[str, Any]) -> SignalEnvelope:
     if schema_version != REPLAY_TAPE_SCHEMA_VERSION:
         raise ValueError(f"replay_tape_row_schema_invalid:{schema_version}")
     ingest_ts = payload.get("ingest_ts")
+    decoded_signal_payload = _decode_value(payload.get("payload") or {})
+    signal_payload: dict[str, Any] = (
+        dict(cast(Mapping[str, Any], decoded_signal_payload))
+        if isinstance(decoded_signal_payload, Mapping)
+        else {}
+    )
+    hpairs_features = _decode_value(payload.get("hpairs_features") or {})
+    if (
+        isinstance(hpairs_features, Mapping)
+        and hpairs_features
+        and "hpairs_replay_tape_features" not in signal_payload
+    ):
+        signal_payload["hpairs_replay_tape_features"] = dict(
+            cast(Mapping[str, Any], hpairs_features)
+        )
     return SignalEnvelope(
         event_ts=_parse_datetime(str(payload["event_ts"])),
         symbol=str(payload["symbol"]),
-        payload=_decode_value(payload.get("payload") or {}),
+        payload=signal_payload,
         timeframe=str(payload["timeframe"]) if payload.get("timeframe") else None,
         ingest_ts=_parse_datetime(str(ingest_ts)) if ingest_ts else None,
         seq=int(payload["seq"]) if payload.get("seq") is not None else None,
         source=str(payload["source"]) if payload.get("source") else None,
     )
+
+
+def hpairs_replay_tape_features(signal: SignalEnvelope) -> dict[str, Any]:
+    """Normalize H-PAIRS discovery features carried by a replay-tape row.
+
+    The representation is deliberately metadata-only: it preserves ClusterLOB/
+    OFI-style inputs for deterministic offline candidate narrowing, but marks
+    every row as prefilter-only so a downstream consumer cannot treat it as
+    runtime-ledger proof or promotion authority.
+    """
+
+    payload = signal.payload
+    source_fields: set[str] = set()
+    horizon_ofi = _hpairs_ofi_horizons(payload, source_fields=source_fields)
+    decay_memory = _hpairs_ofi_decay_memory(payload, source_fields=source_fields)
+    cluster_label = _first_text(
+        payload,
+        (
+            "cluster_lob_label",
+            "cluster_label",
+            "order_cluster",
+            "lob_event_type",
+            "event_type",
+        ),
+        source_fields=source_fields,
+    )
+    cluster_bucket = _first_text(
+        payload,
+        (
+            "cluster_lob_bucket",
+            "cluster_bucket",
+            "participant_bucket",
+            "behavior_bucket",
+        ),
+        source_fields=source_fields,
+    )
+    regime_tags = _tag_tuple(
+        payload,
+        ("regime_tags", "regime_tag", "market_regime", "liquidity_regime"),
+        source_fields=source_fields,
+    )
+    stress_tags = _stress_tag_tuple(payload, source_fields=source_fields)
+    capacity_notional_lineage = _hpairs_capacity_notional_lineage(
+        payload,
+        source_fields=source_fields,
+    )
+    return {
+        "schema_version": HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
+        "order_flow_imbalance_horizons": horizon_ofi,
+        "ofi_decay_memory": decay_memory,
+        "cluster_lob": {
+            "label": cluster_label,
+            "bucket": cluster_bucket,
+        },
+        "regime_tags": list(regime_tags),
+        "stress_tags": list(stress_tags),
+        "capacity_notional_lineage": capacity_notional_lineage,
+        "source_fields": sorted(source_fields),
+        "prefilter_only": True,
+        "promotion_proof": False,
+        "proof_authority": False,
+        "promotion_authority": False,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "proof_semantics_label": (
+            "hpairs_replay_tape_features_prefilter_only_exact_replay_and_runtime_ledger_required"
+        ),
+    }
 
 
 def _canonical_row_json(signal: SignalEnvelope) -> str:
@@ -626,6 +711,208 @@ def _canonical_row_json(signal: SignalEnvelope) -> str:
 def _signal_sort_key(signal: SignalEnvelope) -> tuple[datetime, str, int]:
     seq = signal.seq if signal.seq is not None else 0
     return (signal.event_ts.astimezone(timezone.utc), signal.symbol.upper(), seq)
+
+
+def _hpairs_ofi_horizons(
+    payload: Mapping[str, Any],
+    *,
+    source_fields: set[str],
+) -> dict[str, str]:
+    horizons: dict[str, str] = {}
+    for key in (
+        "order_flow_imbalance_horizons",
+        "ofi_horizons",
+        "horizon_ofi",
+        "ofi_by_horizon",
+    ):
+        raw = payload.get(key)
+        if not isinstance(raw, Mapping):
+            continue
+        source_fields.add(key)
+        for horizon, value in cast(Mapping[object, object], raw).items():
+            parsed = _decimal_or_none(value)
+            if parsed is not None:
+                horizons[str(horizon)] = str(parsed)
+    for key in (
+        "ofi_pressure_score",
+        "order_flow_imbalance",
+        "ofi",
+        "signed_order_flow_imbalance",
+        "queue_imbalance",
+        "book_imbalance",
+        "depth_imbalance",
+    ):
+        parsed = _decimal_or_none(payload.get(key))
+        if parsed is not None:
+            source_fields.add(key)
+            horizons.setdefault("instant", str(parsed))
+            break
+    for key, value in payload.items():
+        text_key = str(key)
+        if not (
+            text_key.startswith("ofi_horizon_")
+            or text_key.startswith("order_flow_imbalance_horizon_")
+        ):
+            continue
+        parsed = _decimal_or_none(value)
+        if parsed is None:
+            continue
+        source_fields.add(text_key)
+        horizons[text_key.rsplit("_", 1)[-1]] = str(parsed)
+    return dict(sorted(horizons.items()))
+
+
+def _hpairs_ofi_decay_memory(
+    payload: Mapping[str, Any],
+    *,
+    source_fields: set[str],
+) -> dict[str, str]:
+    memory: dict[str, str] = {}
+    for key in (
+        "ofi_decay_memory",
+        "ofi_memory",
+        "order_flow_memory",
+        "ofi_decay",
+    ):
+        raw = payload.get(key)
+        if not isinstance(raw, Mapping):
+            continue
+        source_fields.add(key)
+        for name, value in cast(Mapping[object, object], raw).items():
+            parsed = _decimal_or_none(value)
+            if parsed is not None:
+                memory[str(name)] = str(parsed)
+    for key in (
+        "ofi_decay_score",
+        "ofi_memory_score",
+        "ofi_ewma_short",
+        "ofi_ewma_long",
+    ):
+        parsed = _decimal_or_none(payload.get(key))
+        if parsed is None:
+            continue
+        source_fields.add(key)
+        memory[key] = str(parsed)
+    return dict(sorted(memory.items()))
+
+
+def _hpairs_capacity_notional_lineage(
+    payload: Mapping[str, Any],
+    *,
+    source_fields: set[str],
+) -> dict[str, Any]:
+    lineage: dict[str, Any] = {
+        "status": "source_row_metadata" if payload else "missing_inputs",
+        "prefilter_only": True,
+        "proof_authority": False,
+        "promotion_authority": False,
+    }
+    for key in (
+        "capacity_notional_lineage",
+        "impact_capacity_lineage",
+        "target_implied_notional_context",
+        "cost_impact_lineage",
+    ):
+        raw = payload.get(key)
+        if isinstance(raw, Mapping):
+            source_fields.add(key)
+            lineage[key] = _json_ready(raw)
+    for key in (
+        "target_implied_notional",
+        "required_daily_notional",
+        "max_notional_per_trade",
+        "configured_daily_notional_capacity",
+        "adv_notional_capacity",
+        "dollar_volume",
+    ):
+        parsed = _decimal_or_none(payload.get(key))
+        if parsed is None:
+            continue
+        source_fields.add(key)
+        lineage[key] = str(parsed)
+    return lineage
+
+
+def _stress_tag_tuple(
+    payload: Mapping[str, Any],
+    *,
+    source_fields: set[str],
+) -> tuple[str, ...]:
+    tags = set(
+        _tag_tuple(
+            payload,
+            ("stress_tags", "stress_tag", "news_stress_tag", "macro_stress_tag"),
+            source_fields=source_fields,
+        )
+    )
+    for key in (
+        "macro_event_window",
+        "macro_announcement_window",
+        "news_event_window",
+        "stress_veto_window",
+    ):
+        value = payload.get(key)
+        if value is None:
+            continue
+        source_fields.add(key)
+        if isinstance(value, bool):
+            if value:
+                tags.add(key)
+            continue
+        text = str(value).strip().lower()
+        if text in {"yes", "true", "macro", "news", "event", "stress", "1"}:
+            tags.add(key)
+    return tuple(sorted(tags))
+
+
+def _tag_tuple(
+    payload: Mapping[str, Any],
+    keys: Sequence[str],
+    *,
+    source_fields: set[str],
+) -> tuple[str, ...]:
+    tags: set[str] = set()
+    for key in keys:
+        if key not in payload:
+            continue
+        value = payload.get(key)
+        source_fields.add(key)
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            for item in cast(Sequence[object], value):
+                tag = str(item).strip().lower()
+                if tag:
+                    tags.add(tag)
+            continue
+        tag = str(value).strip().lower()
+        if tag:
+            tags.add(tag)
+    return tuple(sorted(tags))
+
+
+def _first_text(
+    payload: Mapping[str, Any],
+    keys: Sequence[str],
+    *,
+    source_fields: set[str],
+) -> str | None:
+    for key in keys:
+        text = str(payload.get(key) or "").strip().lower()
+        if not text:
+            continue
+        source_fields.add(key)
+        return text
+    return None
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
 
 
 def _open_text_writer(path: Path) -> TextIO:
@@ -870,6 +1157,7 @@ def _json_ready(value: Any) -> Any:
 
 __all__ = [
     "REPLAY_TAPE_CACHE_IDENTITY_SCHEMA_VERSION",
+    "HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION",
     "REPLAY_TAPE_MANIFEST_SCHEMA_VERSION",
     "REPLAY_TAPE_SCHEMA_VERSION",
     "ReplayTape",
@@ -881,6 +1169,7 @@ __all__ = [
     "default_manifest_path",
     "load_replay_tape",
     "materialize_signal_tape",
+    "hpairs_replay_tape_features",
     "signal_from_tape_payload",
     "signal_to_tape_payload",
     "slice_tape_by_symbols",

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -17,6 +17,7 @@ from app.trading.discovery.fast_replay import (
 )
 from app.trading.discovery.replay_tape import (
     build_source_query_digest,
+    load_replay_tape,
     materialize_signal_tape,
 )
 from app.trading.models import SignalEnvelope
@@ -201,6 +202,75 @@ class TestFastReplayPreview(TestCase):
             "replay_tape_cache_identity_missing_feature_schema_hash",
             payload["replay_tape"]["cache_identity"]["blockers"],
         )
+        self.assertFalse(payload["proof_authority"])
+
+    def test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only(
+        self,
+    ) -> None:
+        def hpairs_signal(offset: int, price: str, ofi: str) -> SignalEnvelope:
+            return SignalEnvelope(
+                event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc)
+                + timedelta(minutes=offset),
+                symbol="AAA",
+                timeframe="1Min",
+                seq=offset,
+                source="test",
+                payload={
+                    "price": Decimal(price),
+                    "spread_bps": Decimal("2"),
+                    "microbar_volume": Decimal("100000"),
+                    "ofi_horizons": {
+                        "3": Decimal(ofi),
+                        "12": Decimal("0.25"),
+                    },
+                    "ofi_decay_memory": {
+                        "half_life_3": Decimal("0.60"),
+                        "half_life_12": Decimal("0.30"),
+                    },
+                    "cluster_lob_bucket": "directional",
+                    "regime_tags": ["opening_drive"],
+                    "target_implied_notional": Decimal("50000"),
+                },
+                ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
+            )
+
+        with TemporaryDirectory() as tmpdir:
+            tape_path = Path(tmpdir) / "tape.jsonl"
+            materialize_signal_tape(
+                rows=[
+                    hpairs_signal(1, "100", "0.70"),
+                    hpairs_signal(2, "101", "0.80"),
+                    hpairs_signal(3, "102", "0.90"),
+                ],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-hpairs-features",
+                symbols=("AAA",),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest(
+                    {"window": "hpairs-features"}
+                ),
+            )
+            tape = load_replay_tape(tape_path)
+
+        preview = build_fast_replay_preview(
+            specs=(self._spec("spec-hpairs", symbols=["AAA"]),),
+            rows=tape.rows,
+            replay_tape_manifest=tape.manifest,
+            top_k=1,
+            min_rows_per_candidate=2,
+        )
+
+        row = preview.rows[0]
+        payload = row.to_payload()
+        self.assertGreater(row.ofi_pressure_score, Decimal("0"))
+        self.assertGreater(row.ofi_decay_alignment_score, Decimal("0"))
+        self.assertEqual(row.frontier_bucket, "exploitation")
+        self.assertIn("hpairs_replay_tape_features", tape.rows[0].payload)
+        self.assertFalse(
+            tape.rows[0].payload["hpairs_replay_tape_features"]["proof_authority"]
+        )
+        self.assertFalse(payload["promotion_allowed"])
         self.assertFalse(payload["proof_authority"])
 
     def test_target_implied_notional_blocks_non_positive_expectancy(self) -> None:

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -273,6 +273,32 @@ class TestFastReplayPreview(TestCase):
         self.assertFalse(payload["promotion_allowed"])
         self.assertFalse(payload["proof_authority"])
 
+    def test_ofi_pressure_uses_nonstandard_hpair_horizon_values(self) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc),
+            symbol="AAA",
+            timeframe="1Min",
+            seq=1,
+            source="test",
+            payload={
+                "hpairs_replay_tape_features": {
+                    "order_flow_imbalance_horizons": {
+                        "custom_short": "125",
+                        "custom_long": "175",
+                        "bad": "not-a-decimal",
+                    },
+                },
+            },
+            ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
+        )
+
+        ofi_pressure = fast_replay._extract_ofi_pressure(signal)
+
+        self.assertIsNotNone(ofi_pressure)
+        assert ofi_pressure is not None
+        self.assertGreater(ofi_pressure, 0.9)
+        self.assertLessEqual(ofi_pressure, 1.0)
+
     def test_target_implied_notional_blocks_non_positive_expectancy(self) -> None:
         with TemporaryDirectory() as tmpdir:
             rows = [

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -13,6 +13,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from app.trading.discovery.replay_tape import (
+    HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
     REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
     ReplayTapeCoverageError,
     ReplayTapeManifest,
@@ -159,6 +160,81 @@ class TestReplayTape(TestCase):
             ],
             [2],
         )
+
+    def test_materialize_signal_tape_carries_hpairs_clusterlob_ofi_features(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 14, 31, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=1,
+            source="ta",
+            payload={
+                "price": Decimal("900.10"),
+                "ofi_horizons": {
+                    "3_events": Decimal("0.42"),
+                    "12_events": Decimal("0.31"),
+                },
+                "ofi_decay_memory": {
+                    "half_life_3": Decimal("0.55"),
+                    "half_life_12": Decimal("0.21"),
+                },
+                "cluster_lob_label": "directional",
+                "cluster_lob_bucket": "aggressive_buy_pressure",
+                "regime_tags": ["opening_drive", "tight_spread"],
+                "macro_event_window": True,
+                "target_implied_notional": Decimal("125000"),
+                "capacity_notional_lineage": {
+                    "target_net_pnl_per_day": "500",
+                    "formula": "target/expectancy",
+                },
+            },
+            ingest_ts=datetime(2026, 3, 26, 14, 32, tzinfo=timezone.utc),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tape_path = Path(tmpdir) / "tape.jsonl"
+            materialize_signal_tape(
+                rows=[signal],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-hpairs",
+                symbols=("NVDA",),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 26),
+                source_query_digest=build_source_query_digest({"window": "hpairs"}),
+            )
+            raw_row = json.loads(tape_path.read_text(encoding="utf-8").splitlines()[0])
+            restored = signal_from_tape_payload(raw_row)
+
+        self.assertIn("hpairs_features", raw_row)
+        hpairs_features = restored.payload["hpairs_replay_tape_features"]
+        self.assertEqual(
+            hpairs_features["schema_version"],
+            HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            hpairs_features["order_flow_imbalance_horizons"],
+            {"12_events": "0.31", "3_events": "0.42"},
+        )
+        self.assertEqual(
+            hpairs_features["ofi_decay_memory"],
+            {"half_life_12": "0.21", "half_life_3": "0.55"},
+        )
+        self.assertEqual(hpairs_features["cluster_lob"]["label"], "directional")
+        self.assertEqual(
+            hpairs_features["cluster_lob"]["bucket"], "aggressive_buy_pressure"
+        )
+        self.assertEqual(
+            hpairs_features["regime_tags"], ["opening_drive", "tight_spread"]
+        )
+        self.assertEqual(hpairs_features["stress_tags"], ["macro_event_window"])
+        self.assertEqual(
+            hpairs_features["capacity_notional_lineage"]["target_implied_notional"],
+            "125000",
+        )
+        self.assertFalse(hpairs_features["promotion_allowed"])
+        self.assertFalse(hpairs_features["proof_authority"])
 
     def test_materialize_signal_tape_skips_nyse_full_day_holidays(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -236,6 +236,60 @@ class TestReplayTape(TestCase):
         self.assertFalse(hpairs_features["promotion_allowed"])
         self.assertFalse(hpairs_features["proof_authority"])
 
+    def test_materialize_signal_tape_coerces_loose_hpairs_feature_shapes(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 14, 31, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Sec",
+            seq=1,
+            source="ta",
+            payload={
+                "price": Decimal("900.10"),
+                "ofi_horizon_custom": "0.44",
+                "order_flow_imbalance_horizon_bad": "not-a-decimal",
+                "ofi_decay_score": "0.12",
+                "macro_announcement_window": "yes",
+                "regime_tags": "opening_drive",
+                "stress_tag": "fed",
+            },
+            ingest_ts=datetime(2026, 3, 26, 14, 32, tzinfo=timezone.utc),
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            tape_path = Path(tmpdir) / "tape.jsonl"
+            materialize_signal_tape(
+                rows=[signal],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-hpairs-loose",
+                symbols=("NVDA",),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 26),
+                source_query_digest=build_source_query_digest(
+                    {"window": "hpairs-loose"}
+                ),
+            )
+            restored = signal_from_tape_payload(
+                json.loads(tape_path.read_text(encoding="utf-8").splitlines()[0])
+            )
+
+        hpairs_features = restored.payload["hpairs_replay_tape_features"]
+        self.assertEqual(
+            hpairs_features["order_flow_imbalance_horizons"],
+            {"custom": "0.44"},
+        )
+        self.assertEqual(
+            hpairs_features["ofi_decay_memory"],
+            {"ofi_decay_score": "0.12"},
+        )
+        self.assertEqual(hpairs_features["regime_tags"], ["opening_drive"])
+        self.assertEqual(
+            hpairs_features["stress_tags"],
+            ["fed", "macro_announcement_window"],
+        )
+        self.assertFalse(hpairs_features["proof_authority"])
+
     def test_materialize_signal_tape_skips_nyse_full_day_holidays(self) -> None:
         with TemporaryDirectory() as tmpdir:
             tape_path = Path(tmpdir) / "tape.jsonl"


### PR DESCRIPTION
## Summary

- Added a replay-tape H-PAIRS feature payload that normalizes ClusterLOB labels/buckets, OFI horizons, OFI decay/memory, regime/stress tags, and capacity/notional lineage.
- Wired fast replay ranking to consume loaded H-PAIRS tape features as deterministic offline prefilter inputs while keeping exact replay and runtime ledger proof authoritative.
- Added regression coverage for feature parsing, loaded-tape ranking consumption, non-authority metadata, and target-implied notional lineage preservation.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_candidate_specs.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_replay_ledger_guided_search.py tests/test_replay_ledger_ranker.py tests/test_whitepaper_candidate_compiler.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/replay_tape.py app/trading/discovery/fast_replay.py tests/test_replay_tape.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/replay_tape.py app/trading/discovery/fast_replay.py tests/test_replay_tape.py tests/test_fast_replay.py`
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
