### PR TITLE
fix(torghut): fail closed tigerbeetle parity readback

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -1466,6 +1466,10 @@ class TigerBeetleLedgerJournal:
             source_id=str(bucket.id),
             payload_json={
                 "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                "source_refs": [
+                    f"postgres:strategy_runtime_ledger_buckets:{bucket.id}",
+                ],
+                "source_row_id": str(bucket.id),
                 "run_id": bucket.run_id,
                 "candidate_id": bucket.candidate_id,
                 "hypothesis_id": bucket.hypothesis_id,
@@ -1483,7 +1487,17 @@ class TigerBeetleLedgerJournal:
                 "signed_amount_micros": plan.signed_amount_micros,
                 "pnl_direction": plan.pnl_direction,
                 "runtime_key": plan.runtime_key,
+                "transfer_id": u128_decimal(transfer_spec.transfer_id),
+                "ledger": transfer_spec.ledger,
+                "code": transfer_spec.code,
                 "debit_account_id": u128_decimal(transfer_spec.debit_account_id),
                 "credit_account_id": u128_decimal(transfer_spec.credit_account_id),
+                "account_ids": [
+                    u128_decimal(spec.account_id) for spec in plan.account_specs
+                ],
+                "account_keys": [spec.account_key for spec in plan.account_specs],
+                "authority": "accounting_parity_only",
+                "promotion_authority": False,
+                "overrides_runtime_ledger_authority": False,
             },
         )

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -674,12 +674,25 @@ def _latest_run_payload(
         0,
         int((datetime.now(timezone.utc) - observed_at).total_seconds()),
     )
+    max_age_seconds = _payload_int(payload, "reconciliation_max_age_seconds")
+    stale = bool(max_age_seconds > 0 and age_seconds > max_age_seconds)
     return {
         "schema_version": SCHEMA_VERSION,
         "ok": row.status == "ok",
         "cluster_id": row.cluster_id,
         "status": row.status,
         "age_seconds": age_seconds,
+        "reconciliation_max_age_seconds": max_age_seconds,
+        "reconciliation_stale": stale,
+        "reconciliation_freshness": {
+            "observed_at": observed_at.isoformat(),
+            "age_seconds": age_seconds,
+            "max_age_seconds": max_age_seconds,
+            "stale": stale,
+        },
+        "authority": "accounting_parity_only",
+        "promotion_authority": False,
+        "overrides_runtime_ledger_authority": False,
         "account_ref_count": account_ref_count,
         "transfer_ref_count": transfer_ref_count,
         "checked_transfer_count": row.checked_transfer_count,
@@ -1170,10 +1183,25 @@ def reconcile_tigerbeetle_transfers(
         blockers.append(BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING)
     unique_blockers = sorted(set(blockers))
     ok = not unique_blockers
+    max_age_seconds = max(1, int(settings_obj.tigerbeetle_reconcile_max_age_seconds))
     payload: dict[str, object] = {
         "schema_version": SCHEMA_VERSION,
         "ok": ok,
         "cluster_id": settings_obj.tigerbeetle_cluster_id,
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat(),
+        "age_seconds": 0,
+        "reconciliation_stale": False,
+        "reconciliation_max_age_seconds": max_age_seconds,
+        "reconciliation_freshness": {
+            "observed_at": finished_at.isoformat(),
+            "age_seconds": 0,
+            "max_age_seconds": max_age_seconds,
+            "stale": False,
+        },
+        "authority": "accounting_parity_only",
+        "promotion_authority": False,
+        "overrides_runtime_ledger_authority": False,
         "account_ref_count": _payload_int(ref_counts, "account_ref_count"),
         "transfer_ref_count": _payload_int(ref_counts, "transfer_ref_count"),
         "checked_transfer_count": checked_transfer_count,

--- a/services/torghut/app/trading/tigerbeetle_runtime_ledger_parity.py
+++ b/services/torghut/app/trading/tigerbeetle_runtime_ledger_parity.py
@@ -44,6 +44,9 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_RUNTIME_NET_PNL,
     TigerBeetleTransferSpec,
 )
+from app.trading.tigerbeetle_reconcile import (
+    latest_tigerbeetle_reconciliation_payload,
+)
 
 
 SCHEMA_VERSION = "torghut.tigerbeetle-runtime-ledger-parity.v1"
@@ -60,7 +63,9 @@ BLOCKER_CANDIDATE_MISMATCH = "tigerbeetle_parity_candidate_mismatch"
 BLOCKER_TRANSFER_SHAPE_MISMATCH = "tigerbeetle_parity_transfer_shape_mismatch"
 BLOCKER_TRANSFER_MISSING = "tigerbeetle_parity_transfer_missing"
 BLOCKER_CLIENT_UNAVAILABLE = "tigerbeetle_parity_client_unavailable"
+BLOCKER_RECONCILIATION_MISSING = "tigerbeetle_reconciliation_missing"
 BLOCKER_RECONCILIATION_NOT_OK = "tigerbeetle_reconciliation_not_ok"
+BLOCKER_RECONCILIATION_STALE = "tigerbeetle_reconciliation_stale"
 
 
 @dataclass(frozen=True)
@@ -106,6 +111,107 @@ def _increment(mapping: dict[str, int], key: str, value: int = 1) -> None:
 def _add_blocker(blockers: list[str], blocker: str) -> None:
     if blocker not in blockers:
         blockers.append(blocker)
+
+
+def _payload_text_list(payload: Mapping[str, object], key: str) -> list[str]:
+    value = payload.get(key)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [str(item) for item in cast(Sequence[object], value) if item is not None]
+    if value is None:
+        return []
+    return [str(value)]
+
+
+def _source_table(source_type: str) -> str:
+    if source_type == SOURCE_TYPE_EXECUTION:
+        return "executions"
+    if source_type == SOURCE_TYPE_EXECUTION_TCA_METRIC:
+        return "execution_tca_metrics"
+    if source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET:
+        return "strategy_runtime_ledger_buckets"
+    return source_type
+
+
+def _source_row_id(source_id: str) -> str:
+    return source_id.split(":", 1)[0]
+
+
+def _stable_source_refs(
+    source: _ParitySource,
+    ref: TigerBeetleTransferRef | None,
+) -> list[str]:
+    refs: list[str] = []
+    if ref is not None:
+        payload = _payload_mapping(ref)
+        refs.extend(_payload_text_list(payload, "source_refs"))
+        row_id = str(payload.get("source_row_id") or "")
+        if row_id:
+            refs.append(f"postgres:{_source_table(source.source_type)}:{row_id}")
+    refs.append(
+        f"postgres:{_source_table(source.source_type)}:{_source_row_id(source.source_id)}"
+    )
+    deduped: list[str] = []
+    for item in refs:
+        if item and item not in deduped:
+            deduped.append(item)
+    return deduped
+
+
+def _tigerbeetle_transfer_ref(
+    *,
+    cluster_id: int,
+    transfer_id: str,
+) -> str:
+    return f"tigerbeetle:{cluster_id}:transfers:{transfer_id}"
+
+
+def _reconciliation_freshness(
+    session: Session,
+    *,
+    settings_obj: Settings,
+    required: bool,
+    source_count: int,
+) -> tuple[dict[str, object], list[str]]:
+    latest_reconciliation = latest_tigerbeetle_reconciliation_payload(
+        session,
+        cluster_id=settings_obj.tigerbeetle_cluster_id,
+    )
+    max_age_seconds = max(1, int(settings_obj.tigerbeetle_reconcile_max_age_seconds))
+    age_seconds = None
+    if latest_reconciliation is not None:
+        try:
+            age_seconds = int(str(latest_reconciliation.get("age_seconds", 0)))
+        except (TypeError, ValueError):
+            age_seconds = 0
+    stale = age_seconds is not None and age_seconds > max_age_seconds
+    reconciliation_required = required and source_count > 0
+    blockers: list[str] = []
+    if reconciliation_required and latest_reconciliation is None:
+        blockers.append(BLOCKER_RECONCILIATION_MISSING)
+    elif reconciliation_required and latest_reconciliation is not None:
+        if not bool(latest_reconciliation.get("ok")):
+            blockers.append(BLOCKER_RECONCILIATION_NOT_OK)
+        if stale:
+            blockers.append(BLOCKER_RECONCILIATION_STALE)
+        raw_blockers = latest_reconciliation.get("blockers")
+        if isinstance(raw_blockers, Sequence) and not isinstance(
+            raw_blockers,
+            (str, bytes, bytearray),
+        ):
+            blockers.extend(str(item) for item in cast(Sequence[object], raw_blockers))
+    reconciliation_ok = not blockers if reconciliation_required else True
+    return (
+        {
+            "required": reconciliation_required,
+            "ok": reconciliation_ok,
+            "stale": stale,
+            "age_seconds": age_seconds,
+            "max_age_seconds": max_age_seconds,
+            "latest_reconciliation": latest_reconciliation,
+            "blockers": sorted(set(blockers)),
+        },
+        sorted(set(blockers)),
+    )
 
 
 def _query_transfer_ref(
@@ -362,13 +468,24 @@ def audit_tigerbeetle_runtime_ledger_parity(
             "family": source.family,
             "source_type": source.source_type,
             "source_id": source.source_id,
+            "source_refs": _stable_source_refs(source, None),
             "account_label": source.account_label,
             "candidate_id": source.candidate_id,
             "expected_transfer_id": u128_decimal(spec.transfer_id),
+            "expected_transfer_kind": spec.transfer_kind,
             "expected_amount_micros": _stable_decimal(expected_amount),
+            "authority": "accounting_parity_only",
+            "promotion_authority": False,
+            "overrides_runtime_ledger_authority": False,
             "status": "pass",
             "blockers": [],
         }
+        if isinstance(source.plan, TigerBeetleRuntimeLedgerTransferPlan):
+            sample["expected_signed_amount_micros"] = str(
+                source.plan.signed_amount_micros
+            )
+            sample["expected_pnl_direction"] = source.plan.pnl_direction
+            sample["runtime_key"] = source.plan.runtime_key
         sample_blockers = cast(list[str], sample["blockers"])
         if ref is None:
             missing_ref_count += 1
@@ -383,8 +500,24 @@ def audit_tigerbeetle_runtime_ledger_parity(
         ref_totals[source.family] = ref_totals.get(
             source.family, Decimal("0")
         ) + Decimal(ref.amount)
+        ref_payload = _payload_mapping(ref)
+        sample["source_refs"] = _stable_source_refs(source, ref)
         sample["ref_transfer_id"] = ref.transfer_id
+        sample["tigerbeetle_transfer_ref"] = _tigerbeetle_transfer_ref(
+            cluster_id=ref.cluster_id,
+            transfer_id=ref.transfer_id,
+        )
         sample["ref_amount_micros"] = _stable_decimal(ref.amount)
+        sample["ref_transfer_kind"] = ref.transfer_kind
+        if source.family == TRANSFER_KIND_RUNTIME_NET_PNL:
+            sample["runtime_ledger_net_pnl_transfer_ref"] = sample[
+                "tigerbeetle_transfer_ref"
+            ]
+            sample["signed_amount_micros"] = str(
+                ref_payload.get("signed_amount_micros") or ""
+            )
+            sample["pnl_direction"] = str(ref_payload.get("pnl_direction") or "")
+            sample["runtime_key"] = str(ref_payload.get("runtime_key") or "")
         if ref.amount != expected_amount:
             amount_mismatch_count += 1
             _add_blocker(blockers, BLOCKER_AMOUNT_MISMATCH)
@@ -485,6 +618,15 @@ def audit_tigerbeetle_runtime_ledger_parity(
     for family, value in sorted(actual_totals.items()):
         actual_micros_by_family[family] = _stable_decimal(value)
 
+    reconciliation_freshness, reconciliation_blockers = _reconciliation_freshness(
+        session,
+        settings_obj=settings_obj,
+        required=required,
+        source_count=len(sources),
+    )
+    for blocker in reconciliation_blockers:
+        _add_blocker(blockers, blocker)
+
     unique_blockers = sorted(blockers)
     parity_status = _status(
         blockers=unique_blockers,
@@ -508,8 +650,19 @@ def audit_tigerbeetle_runtime_ledger_parity(
             "ok": ok,
             "parity_status": parity_status,
             "blockers": unique_blockers,
+            "authority": "accounting_parity_only",
+            "promotion_authority": False,
+            "overrides_runtime_ledger_authority": False,
             "client_lookup": client is not None,
             "client_error": client_error,
+            "reconciliation_ok": reconciliation_freshness["ok"],
+            "reconciliation_stale": reconciliation_freshness["stale"],
+            "reconciliation_age_seconds": reconciliation_freshness["age_seconds"],
+            "reconciliation_max_age_seconds": reconciliation_freshness[
+                "max_age_seconds"
+            ],
+            "reconciliation_freshness": reconciliation_freshness,
+            "latest_reconciliation": reconciliation_freshness["latest_reconciliation"],
             "totals": {
                 "checked_source_count": len(sources),
                 "checked_ref_count": checked_ref_count,
@@ -545,6 +698,11 @@ def tigerbeetle_runtime_ledger_parity_blockers(
     if not required:
         return []
     blockers: list[str] = []
+    if (
+        payload.get("latest_reconciliation") is None
+        and payload.get("reconciliation_ok") is False
+    ):
+        blockers.append(BLOCKER_RECONCILIATION_MISSING)
     if payload.get("reconciliation_ok") is False:
         blockers.append(BLOCKER_RECONCILIATION_NOT_OK)
         latest_reconciliation = payload.get("latest_reconciliation")
@@ -562,6 +720,8 @@ def tigerbeetle_runtime_ledger_parity_blockers(
                     str(item)
                     for item in cast(Sequence[object], raw_reconciliation_blockers)
                 )
+    if payload.get("reconciliation_stale") is True:
+        blockers.append(BLOCKER_RECONCILIATION_STALE)
     raw_blockers = payload.get("blockers")
     if not isinstance(raw_blockers, Sequence) or isinstance(
         raw_blockers, (str, bytes, bytearray)

--- a/services/torghut/tests/test_audit_tigerbeetle_runtime_ledger_parity.py
+++ b/services/torghut/tests/test_audit_tigerbeetle_runtime_ledger_parity.py
@@ -5,7 +5,7 @@ import io
 import os
 import sys
 from contextlib import redirect_stdout
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import TracebackType
 from unittest import TestCase
@@ -20,6 +20,7 @@ from app.models import (
     Execution,
     ExecutionTCAMetric,
     StrategyRuntimeLedgerBucket,
+    TigerBeetleReconciliationRun,
     TigerBeetleTransferRef,
     coerce_json_payload,
 )
@@ -38,6 +39,7 @@ from app.trading.tigerbeetle_runtime_ledger_parity import (
     BLOCKER_AMOUNT_MISMATCH,
     BLOCKER_CANDIDATE_MISMATCH,
     BLOCKER_ENTRY_MISSING,
+    BLOCKER_RECONCILIATION_MISSING,
     BLOCKER_TRANSFER_MISSING,
     BLOCKER_TRANSFER_SHAPE_MISMATCH,
     PARITY_STATUS_BLOCKED,
@@ -45,9 +47,11 @@ from app.trading.tigerbeetle_runtime_ledger_parity import (
     PARITY_STATUS_OPTIONAL_DEGRADED,
     PARITY_STATUS_PASS,
     BLOCKER_RECONCILIATION_NOT_OK,
+    BLOCKER_RECONCILIATION_STALE,
     audit_tigerbeetle_runtime_ledger_parity,
     tigerbeetle_runtime_ledger_parity_blockers,
 )
+from app.trading.tigerbeetle_reconcile import reconcile_tigerbeetle_transfers
 from scripts import audit_tigerbeetle_runtime_ledger_parity as audit_script
 from scripts.audit_tigerbeetle_runtime_ledger_parity import main as audit_main
 
@@ -221,6 +225,11 @@ class TestAuditTigerBeetleRuntimeLedgerParity(TestCase):
             _seed_sources(session)
             client = FakeTigerBeetleClient()
             _journal_all(session, client)
+            reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(required=True),
+                client=client,
+            )
 
             payload = audit_tigerbeetle_runtime_ledger_parity(
                 session,
@@ -248,6 +257,22 @@ class TestAuditTigerBeetleRuntimeLedgerParity(TestCase):
         self.assertFalse(read_only["generates_proof"])
         self.assertFalse(read_only["synthesizes_fills"])
         self.assertFalse(read_only["overrides_runtime_ledger_authority"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertTrue(payload["reconciliation_ok"])
+        self.assertFalse(payload["reconciliation_stale"])
+        samples = payload["samples"]
+        assert isinstance(samples, list)
+        runtime_sample = next(
+            sample for sample in samples if sample["family"] == "runtime_net_pnl"
+        )
+        self.assertFalse(runtime_sample["promotion_authority"])
+        self.assertIn(
+            "postgres:strategy_runtime_ledger_buckets:",
+            str(runtime_sample["source_refs"]),
+        )
+        self.assertTrue(str(runtime_sample["runtime_ledger_net_pnl_transfer_ref"]))
+        self.assertEqual(runtime_sample["signed_amount_micros"], "4250000")
+        self.assertEqual(runtime_sample["pnl_direction"], "profit")
 
     def test_missing_tigerbeetle_entries_are_optional_degraded_when_not_required(
         self,
@@ -280,6 +305,82 @@ class TestAuditTigerBeetleRuntimeLedgerParity(TestCase):
         self.assertTrue(payload["required"])
         self.assertEqual(payload["parity_status"], PARITY_STATUS_BLOCKED)
         self.assertIn(BLOCKER_ENTRY_MISSING, payload["blockers"])
+        self.assertIn(BLOCKER_RECONCILIATION_MISSING, payload["blockers"])
+
+    def test_stale_reconciliation_blocks_required_parity(self) -> None:
+        with Session(self.engine) as session:
+            _seed_sources(session)
+            client = FakeTigerBeetleClient()
+            _journal_all(session, client)
+            stale_at = datetime.now(timezone.utc) - timedelta(hours=2)
+            session.add(
+                TigerBeetleReconciliationRun(
+                    cluster_id=_settings(required=True).tigerbeetle_cluster_id,
+                    started_at=stale_at,
+                    finished_at=stale_at,
+                    status="ok",
+                    checked_transfer_count=3,
+                    missing_transfer_count=0,
+                    mismatched_transfer_count=0,
+                    source_missing_count=0,
+                    payload_json={
+                        "blockers": [],
+                        "reconciliation_max_age_seconds": 60,
+                    },
+                )
+            )
+            session.flush()
+
+            payload = audit_tigerbeetle_runtime_ledger_parity(
+                session,
+                settings_obj=Settings(
+                    TORGHUT_TIGERBEETLE_ENABLED=True,
+                    TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
+                    TORGHUT_TIGERBEETLE_REQUIRED=True,
+                    TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED=True,
+                    TORGHUT_TIGERBEETLE_RECONCILE_MAX_AGE_SECONDS=60,
+                ),
+                client=client,
+            )
+
+        self.assertFalse(payload["ok"])
+        self.assertFalse(payload["reconciliation_ok"])
+        self.assertTrue(payload["reconciliation_stale"])
+        self.assertIn(BLOCKER_RECONCILIATION_STALE, payload["blockers"])
+
+    def test_missing_runtime_ledger_ref_blocks_required_parity(self) -> None:
+        with Session(self.engine) as session:
+            _seed_sources(session)
+            client = FakeTigerBeetleClient()
+            execution = session.execute(select(Execution)).scalar_one()
+            metric = session.execute(select(ExecutionTCAMetric)).scalar_one()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(required=True),
+                client=client,
+            )
+            journal.journal_execution(session, execution)
+            journal.journal_execution_tca_metric(session, metric)
+            reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(required=True),
+                client=client,
+            )
+
+            payload = audit_tigerbeetle_runtime_ledger_parity(
+                session,
+                settings_obj=_settings(required=True),
+                client=client,
+            )
+
+        self.assertFalse(payload["ok"])
+        self.assertIn(BLOCKER_ENTRY_MISSING, payload["blockers"])
+        samples = payload["samples"]
+        assert isinstance(samples, list)
+        runtime_sample = next(
+            sample for sample in samples if sample["family"] == "runtime_net_pnl"
+        )
+        self.assertEqual(runtime_sample["status"], "missing_ref")
+        self.assertFalse(runtime_sample["promotion_authority"])
 
     def test_amount_mismatch_blocks_required_parity(self) -> None:
         with Session(self.engine) as session:
@@ -488,6 +589,22 @@ class TestAuditTigerBeetleRuntimeLedgerParity(TestCase):
                 BLOCKER_ENTRY_MISSING,
                 "tigerbeetle_postgres_ref_mismatch",
                 BLOCKER_RECONCILIATION_NOT_OK,
+            ],
+        )
+        self.assertEqual(
+            tigerbeetle_runtime_ledger_parity_blockers(
+                {
+                    "required": True,
+                    "reconciliation_ok": False,
+                    "reconciliation_stale": True,
+                    "latest_reconciliation": None,
+                    "blockers": [],
+                }
+            ),
+            [
+                BLOCKER_RECONCILIATION_MISSING,
+                BLOCKER_RECONCILIATION_NOT_OK,
+                BLOCKER_RECONCILIATION_STALE,
             ],
         )
 

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -554,9 +554,7 @@ class TestTigerBeetleLedgerJournal(TestCase):
         self,
     ) -> None:
         with Session(self.engine) as session:
-            event = _create_fill_event(
-                session, fingerprint="fingerprint-cost-revision"
-            )
+            event = _create_fill_event(session, fingerprint="fingerprint-cost-revision")
             metric = ExecutionTCAMetric(
                 execution_id=event.execution_id,
                 trade_decision_id=event.trade_decision_id,
@@ -599,8 +597,7 @@ class TestTigerBeetleLedgerJournal(TestCase):
             refs = (
                 session.execute(
                     select(TigerBeetleTransferRef).where(
-                        TigerBeetleTransferRef.source_type
-                        == "execution_tca_metric"
+                        TigerBeetleTransferRef.source_type == "execution_tca_metric"
                     )
                 )
                 .scalars()
@@ -765,6 +762,16 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(ref.amount, Decimal("2500000"))
             self.assertEqual(ref.payload_json["pnl_direction"], "profit")
             self.assertEqual(ref.payload_json["signed_amount_micros"], 2500000)
+            self.assertEqual(
+                ref.payload_json["source_refs"],
+                [f"postgres:strategy_runtime_ledger_buckets:{bucket.id}"],
+            )
+            self.assertEqual(ref.payload_json["source_row_id"], str(bucket.id))
+            self.assertEqual(ref.payload_json["transfer_id"], ref.transfer_id)
+            self.assertEqual(ref.payload_json["ledger"], ref.ledger)
+            self.assertEqual(ref.payload_json["code"], ref.code)
+            self.assertFalse(ref.payload_json["promotion_authority"])
+            self.assertFalse(ref.payload_json["overrides_runtime_ledger_authority"])
             parity = tigerbeetle_runtime_ledger_journal_payload(
                 bucket=bucket,
                 ref=ref,

--- a/services/torghut/tests/test_tigerbeetle_proof_packet_authority.py
+++ b/services/torghut/tests/test_tigerbeetle_proof_packet_authority.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest import TestCase
+
+from scripts import assemble_runtime_ledger_proof_packet as packet
+from tests.test_assemble_runtime_ledger_proof_packet import (
+    _completion,
+    _paper_route_evidence,
+    _runtime_import,
+    _status,
+    _tigerbeetle_ledger_status,
+)
+
+
+class TestTigerBeetleProofPacketAuthority(TestCase):
+    def test_tigerbeetle_only_refs_do_not_create_promotion_authority(self) -> None:
+        runtime_import = _runtime_import(authoritative=False)
+        import_summary = runtime_import["imports"][0]["summary"]
+        materialized_target = import_summary["runtime_materialization_target"]
+        materialized_target["tigerbeetle"] = {
+            "schema_version": "torghut.tigerbeetle-runtime-ledger-proof-refs.v1",
+            "cluster_ids": [2001],
+            "account_count": 2,
+            "transfer_count": 1,
+            "account_ids": ["1001", "1002"],
+            "account_keys": ["evidence_control:paper:usd", "runtime_ledger:paper:run"],
+            "transfer_ids": ["340282366920938463463374607431768211"],
+            "source_refs": [
+                "postgres:tigerbeetle_account_refs:account-ref-1",
+                "postgres:tigerbeetle_transfer_refs:transfer-ref-1",
+            ],
+            "runtime_ledger_buckets": [
+                {
+                    "runtime_ledger_bucket_id": "runtime-ledger-bucket-1",
+                    "transfer_ids": ["340282366920938463463374607431768211"],
+                }
+            ],
+        }
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(tigerbeetle_ledger=_tigerbeetle_ledger_status()),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"], result)
+        self.assertFalse(result["promotion_authority"]["allowed"], result)
+        self.assertFalse(result["capital_promotion_allowed"], result)
+        self.assertIn(
+            "runtime_window_import_runtime_ledger_bucket_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        tigerbeetle_check = result["checks"]["tigerbeetle_runtime_pnl_authority_refs"]
+        self.assertTrue(tigerbeetle_check["passed"], tigerbeetle_check)
+        self.assertTrue(tigerbeetle_check["observed"]["claimed"])

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -388,7 +388,9 @@ class TestTigerBeetleReconcile(TestCase):
             )
             session.add(event)
             session.flush()
-            plan = build_order_event_transfer_plan(session, event, settings_obj=_settings())
+            plan = build_order_event_transfer_plan(
+                session, event, settings_obj=_settings()
+            )
             self.assertIsNotNone(plan)
             assert plan is not None
             transfer = plan.transfer_spec
@@ -462,7 +464,9 @@ class TestTigerBeetleReconcile(TestCase):
             _payload_string_list({"account_ids": ["11", None, 12]}, "account_ids"),
             ["11", "12"],
         )
-        self.assertEqual(_payload_string_list({"account_ids": "11"}, "account_ids"), ["11"])
+        self.assertEqual(
+            _payload_string_list({"account_ids": "11"}, "account_ids"), ["11"]
+        )
 
         ref = TigerBeetleTransferRef(
             cluster_id=2001,
@@ -541,6 +545,13 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertEqual(payload["runtime_ledger_signed_transfer_count"], 2)
             self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 0)
             self.assertEqual(payload["runtime_ledger_missing_account_ref_count"], 0)
+            self.assertFalse(payload["promotion_authority"])
+            self.assertFalse(payload["overrides_runtime_ledger_authority"])
+            self.assertFalse(payload["reconciliation_stale"])
+            freshness = payload["reconciliation_freshness"]
+            assert isinstance(freshness, dict)
+            self.assertEqual(freshness["age_seconds"], 0)
+            self.assertFalse(freshness["stale"])
             ref_counts = payload["ref_counts"]
             assert isinstance(ref_counts, dict)
             self.assertEqual(ref_counts["runtime_ledger_signed_ref_count"], 2)
@@ -1212,10 +1223,16 @@ class TestTigerBeetleReconcile(TestCase):
         self.assertEqual(payload["transfer_ref_count"], 2)
         self.assertEqual(payload["runtime_ledger_ref_count"], 5)
         self.assertEqual(payload["runtime_ledger_signed_ref_count"], 4)
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["overrides_runtime_ledger_authority"])
+        self.assertIn("reconciliation_freshness", payload)
         self.assertEqual(payload["mismatched_ref_count"], 1)
         self.assertEqual(payload["missing_source_row_count"], 3)
         self.assertEqual(payload["unlinked_order_event_ref_count"], 4)
-        self.assertEqual(payload["mismatched_refs"], [{"blocker": BLOCKER_CODE_MISMATCH, "row_id": "ref-1"}])
+        self.assertEqual(
+            payload["mismatched_refs"],
+            [{"blocker": BLOCKER_CODE_MISMATCH, "row_id": "ref-1"}],
+        )
         self.assertEqual(
             payload["ref_counts"],
             {
@@ -1239,11 +1256,7 @@ class TestTigerBeetleReconcile(TestCase):
         self.assertIsNone(_uuid_or_none(None))
         self.assertIsNone(_uuid_or_none("not-a-uuid"))
         self.assertEqual(
-            str(
-                _uuid_or_none(
-                    "6f767a53-6b44-428a-bd85-2f662642f637:revision"
-                )
-            ),
+            str(_uuid_or_none("6f767a53-6b44-428a-bd85-2f662642f637:revision")),
             "6f767a53-6b44-428a-bd85-2f662642f637",
         )
         self.assertIsNone(_usd_to_micros(None))

--- a/services/torghut/tests/test_tigerbeetle_runtime_ledger_parity.py
+++ b/services/torghut/tests/test_tigerbeetle_runtime_ledger_parity.py
@@ -18,6 +18,7 @@ from app.trading.tigerbeetle_runtime_ledger_parity import (
     PARITY_STATUS_PASS,
     audit_tigerbeetle_runtime_ledger_parity,
 )
+from app.trading.tigerbeetle_reconcile import reconcile_tigerbeetle_transfers
 
 
 def _settings() -> Settings:
@@ -31,36 +32,36 @@ def _settings() -> Settings:
 
 class TestTigerBeetleRuntimeLedgerParity(TestCase):
     def setUp(self) -> None:
-        self.engine = create_engine('sqlite+pysqlite:///:memory:', future=True)
+        self.engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         Base.metadata.create_all(self.engine)
 
     def test_parity_reads_revisioned_tca_ref_after_same_metric_retry(self) -> None:
         with Session(self.engine) as session:
             execution = Execution(
-                alpaca_account_label='paper',
-                alpaca_order_id='order-parity-revision',
-                client_order_id='client-parity-revision',
-                symbol='AAPL',
-                side='buy',
-                order_type='market',
-                time_in_force='day',
-                submitted_qty=Decimal('1'),
-                filled_qty=Decimal('1'),
-                avg_fill_price=Decimal('190.25'),
-                status='filled',
-                raw_order={'id': 'order-parity-revision'},
+                alpaca_account_label="paper",
+                alpaca_order_id="order-parity-revision",
+                client_order_id="client-parity-revision",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                status="filled",
+                raw_order={"id": "order-parity-revision"},
             )
             session.add(execution)
             session.flush()
             metric = ExecutionTCAMetric(
                 execution_id=execution.id,
-                alpaca_account_label='paper',
-                symbol='AAPL',
-                side='buy',
-                filled_qty=Decimal('1'),
-                signed_qty=Decimal('1'),
-                shortfall_notional=Decimal('0.25'),
-                realized_shortfall_bps=Decimal('1.3'),
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.25"),
+                realized_shortfall_bps=Decimal("1.3"),
                 computed_at=datetime.now(timezone.utc),
             )
             session.add(metric)
@@ -71,8 +72,8 @@ class TestTigerBeetleRuntimeLedgerParity(TestCase):
             self.assertIsNotNone(journal.journal_execution(session, execution))
             first = journal.journal_execution_tca_metric(session, metric)
             self.assertIsNotNone(first)
-            metric.shortfall_notional = Decimal('0.40')
-            metric.realized_shortfall_bps = Decimal('2.1')
+            metric.shortfall_notional = Decimal("0.40")
+            metric.realized_shortfall_bps = Decimal("2.1")
             session.add(metric)
             session.flush()
             second = journal.journal_execution_tca_metric(session, metric)
@@ -80,6 +81,11 @@ class TestTigerBeetleRuntimeLedgerParity(TestCase):
             self.assertIsNotNone(second)
             assert second is not None
             self.assertEqual(second.source_id, execution_tca_metric_source_id(metric))
+            reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
             payload = audit_tigerbeetle_runtime_ledger_parity(
                 session,
                 settings_obj=_settings(),
@@ -87,9 +93,9 @@ class TestTigerBeetleRuntimeLedgerParity(TestCase):
                 limit=1,
             )
 
-        self.assertTrue(payload['ok'])
-        self.assertEqual(payload['parity_status'], PARITY_STATUS_PASS)
-        samples = payload['samples']
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["parity_status"], PARITY_STATUS_PASS)
+        samples = payload["samples"]
         assert isinstance(samples, list)
-        self.assertEqual(samples[0]['source_id'], second.source_id)
-        self.assertEqual(samples[0]['expected_amount_micros'], '400000')
+        self.assertEqual(samples[0]["source_id"], second.source_id)
+        self.assertEqual(samples[0]["expected_amount_micros"], "400000")


### PR DESCRIPTION
## Summary

- Adds fail-closed TigerBeetle/runtime-ledger parity readback for missing, stale, or degraded reconciliation when parity is required.
- Exposes stable source refs, signed runtime-ledger net-PnL TigerBeetle transfer refs, reconciliation freshness, and accounting-only authority metadata in journal/reconcile/parity payloads.
- Adds regression coverage for stale reconciliation, missing runtime-ledger refs, runtime signed ref readback, and proof packets not treating TigerBeetle-only refs as promotion authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_runtime_ledger_parity.py tests/test_audit_tigerbeetle_runtime_ledger_parity.py tests/test_journal_tigerbeetle_order_events.py tests/test_verify_tigerbeetle_ledger.py tests/test_tigerbeetle_proof_packet_authority.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_runtime_ledger_parity.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py tests/test_audit_tigerbeetle_runtime_ledger_parity.py tests/test_tigerbeetle_runtime_ledger_parity.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_proof_packet_authority.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tigerbeetle_runtime_ledger_parity.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py tests/test_audit_tigerbeetle_runtime_ledger_parity.py tests/test_tigerbeetle_runtime_ledger_parity.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_proof_packet_authority.py`
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS='--max-old-space-size=4096' uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
