### PR TITLE
fix(torghut): refresh paper route quote snapshots

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -2447,7 +2447,20 @@ class SimpleTradingPipeline(TradingPipeline):
     def _ensure_decision_price(
         self, decision: StrategyDecision, signal_price: Any
     ) -> tuple[StrategyDecision, Optional[MarketSnapshot]]:
+        requires_executable_quote = (
+            self._paper_route_decision_requires_executable_quote(decision)
+        )
         if signal_price is not None and "price_snapshot" in decision.params:
+            if (
+                not requires_executable_quote
+                or self._decision_has_executable_quote_payload(decision)
+            ):
+                return decision, None
+        if (
+            signal_price is not None
+            and requires_executable_quote
+            and self._decision_has_executable_quote_payload(decision)
+        ):
             return decision, None
         snapshot = self.price_fetcher.fetch_market_snapshot(
             SignalEnvelope(
@@ -2474,6 +2487,16 @@ class SimpleTradingPipeline(TradingPipeline):
         if snapshot.spread is not None:
             updated_params.setdefault("imbalance_spread", snapshot.spread)
         return decision.model_copy(update={"params": updated_params}), snapshot
+
+    @staticmethod
+    def _decision_has_executable_quote_payload(decision: StrategyDecision) -> bool:
+        params = decision.params
+        if _executable_bid_ask_present(params):
+            return True
+        price_snapshot = params.get("price_snapshot")
+        if isinstance(price_snapshot, Mapping):
+            return _executable_bid_ask_present(cast(Mapping[str, Any], price_snapshot))
+        return False
 
     @staticmethod
     def _paper_route_price_snapshot_payload(
@@ -5097,6 +5120,20 @@ def _first_decimal(*values: Decimal | None) -> Decimal | None:
         if value is not None:
             return value
     return None
+
+
+def _executable_bid_ask_present(payload: Mapping[str, Any]) -> bool:
+    bid = _first_decimal(
+        _optional_decimal(payload.get("imbalance_bid_px")),
+        _optional_decimal(payload.get("bid")),
+    )
+    ask = _first_decimal(
+        _optional_decimal(payload.get("imbalance_ask_px")),
+        _optional_decimal(payload.get("ask")),
+    )
+    if bid is None or ask is None:
+        return False
+    return bid > 0 and ask >= bid
 
 
 def _min_optional_decimal(*values: Decimal | None) -> Decimal | None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -761,11 +761,13 @@ class FakePriceFetcher(PriceFetcher):
         self.spread = spread
         self.bid = bid
         self.ask = ask
+        self.snapshot_requests = 0
 
     def fetch_price(self, signal: SignalEnvelope) -> Decimal:
         return self.price
 
     def fetch_market_snapshot(self, signal: SignalEnvelope) -> MarketSnapshot:
+        self.snapshot_requests += 1
         return MarketSnapshot(
             symbol=signal.symbol,
             as_of=signal.event_ts,
@@ -3806,6 +3808,103 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(routeability.get("status"), "accepted")
         self.assertEqual(routeability.get("reason"), "executable_quote_ready")
         self.assertEqual(params.get("price_snapshot", {}).get("bid"), "190.10")
+        self.assertEqual(row.status, "planned")
+
+    def test_paper_route_target_price_only_snapshot_refreshes_executable_quote(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded target strategy",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="paper-route-target-source",
+            params={
+                "paper_route_target_plan": {"candidate_id": "c88421d619759b2cfaa6f4d0"},
+                "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+                "price": Decimal("190.12"),
+                "price_snapshot": {
+                    "as_of": now.isoformat(),
+                    "price": "190.12",
+                    "spread": "0.04",
+                    "source": "decision_engine_price_only",
+                },
+            },
+        )
+        price_fetcher = FakePriceFetcher(
+            Decimal("190.12"),
+            spread=Decimal("0.04"),
+            bid=Decimal("190.10"),
+            ask=Decimal("190.14"),
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+            price_fetcher=price_fetcher,
+        )
+        with self.session_local() as session:
+            session.add(strategy)
+            session.commit()
+            row = pipeline.executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "TORGHUT_SIM",
+            )
+
+            prepared = pipeline._prepare_decision_for_submission(
+                session=session,
+                decision=decision,
+                decision_row=row,
+                strategy=strategy,
+                account={
+                    "equity": "100000",
+                    "cash": "100000",
+                    "buying_power": "100000",
+                },
+                positions=[],
+            )
+            session.refresh(row)
+            row_json = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], row_json.get("params"))
+            routeability = cast(dict[str, Any], params.get("quote_routeability"))
+            refreshed_snapshot = cast(dict[str, Any], params.get("price_snapshot"))
+
+        self.assertIsNotNone(prepared)
+        self.assertEqual(price_fetcher.snapshot_requests, 1)
+        self.assertEqual(routeability.get("status"), "accepted")
+        self.assertEqual(routeability.get("reason"), "executable_quote_ready")
+        self.assertEqual(refreshed_snapshot.get("bid"), "190.10")
+        self.assertEqual(refreshed_snapshot.get("ask"), "190.14")
         self.assertEqual(row.status, "planned")
 
     def test_bounded_collection_contamination_blocker_is_not_hidden_by_quote_readiness(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -71,6 +71,7 @@ from app.trading.scheduler.simple_pipeline import (
     _bounded_sim_collection_blockers,
     _bounded_sim_collection_target_with_runtime_account_audit,
     _bounded_sim_collection_metadata_from_decision,
+    _executable_bid_ask_present,
     _paper_route_probe_entry_metadata,
     _paper_route_probe_lineage_from_params,
     _strategy_signal_paper_entry_metadata,
@@ -3906,6 +3907,93 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(refreshed_snapshot.get("bid"), "190.10")
         self.assertEqual(refreshed_snapshot.get("ask"), "190.14")
         self.assertEqual(row.status, "planned")
+
+    def test_decision_price_uses_existing_executable_quote_without_refetch(
+        self,
+    ) -> None:
+        now = datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc)
+        price_fetcher = FakePriceFetcher(Decimal("190.12"))
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+            price_fetcher=price_fetcher,
+        )
+        non_paper_route_decision = StrategyDecision(
+            strategy_id=str(uuid4()),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="strategy-signal",
+            params={
+                "price": Decimal("190.12"),
+                "price_snapshot": {"price": "190.12", "spread": "0.04"},
+            },
+        )
+        nested_quote_decision = StrategyDecision(
+            strategy_id=str(uuid4()),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="paper-route-target-source",
+            params={
+                "paper_route_target_plan": {"candidate_id": "c88421d619759b2cfaa6f4d0"},
+                "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+                "price": Decimal("190.12"),
+                "price_snapshot": {
+                    "price": "190.12",
+                    "bid": "190.10",
+                    "ask": "190.14",
+                },
+            },
+        )
+        top_level_quote_decision = nested_quote_decision.model_copy(
+            update={
+                "params": {
+                    "paper_route_target_plan": {
+                        "candidate_id": "c88421d619759b2cfaa6f4d0"
+                    },
+                    "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+                    "price": Decimal("190.12"),
+                    "imbalance_bid_px": "190.10",
+                    "imbalance_ask_px": "190.14",
+                }
+            }
+        )
+
+        for decision in (
+            non_paper_route_decision,
+            nested_quote_decision,
+            top_level_quote_decision,
+        ):
+            prepared, snapshot = pipeline._ensure_decision_price(
+                decision,
+                Decimal("190.12"),
+            )
+            self.assertIs(prepared, decision)
+            self.assertIsNone(snapshot)
+
+        self.assertEqual(price_fetcher.snapshot_requests, 0)
+
+    def test_executable_bid_ask_rejects_crossed_or_missing_quotes(self) -> None:
+        self.assertFalse(
+            _executable_bid_ask_present({"bid": "190.14", "ask": "190.10"})
+        )
+        self.assertFalse(_executable_bid_ask_present({"bid": "190.10"}))
+        self.assertTrue(_executable_bid_ask_present({"bid": "190.10", "ask": "190.14"}))
 
     def test_bounded_collection_contamination_blocker_is_not_hidden_by_quote_readiness(
         self,


### PR DESCRIPTION
## Summary

- Refresh paper-route quote-gated decisions when an existing `price_snapshot` has only price/spread and lacks executable bid/ask.
- Preserve fail-closed quote gates: paper-route decisions still reject when no valid bid/ask can be fetched.
- Add a regression proving price-only snapshots refresh to executable quote evidence before submit eligibility.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_target_quote_routeability or price_only_snapshot or executable_quote_reaches_submit_eligibility' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py tests/test_quote_quality.py tests/test_prices.py -q`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are not required for this code/test-only fix.
