### PR TITLE
fix(torghut): accelerate execution tca lineage refresh

### DIFF
--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -14,7 +14,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 240
+      activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: OnFailure
@@ -49,7 +49,7 @@ spec:
                   cd /app
                   /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
                     --older-than-seconds 900 \
-                    --batch-size 100 \
-                    --max-batches 3 \
+                    --batch-size 1000 \
+                    --max-batches 5 \
                     --apply \
                     --json

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1143,7 +1143,7 @@ class TestLiveConfigManifestContract(TestCase):
 
         self.assertEqual(spec.get("schedule"), "*/5 * * * *")
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
-        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 240)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 900)
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
         self.assertEqual(
             pod_spec.get("nodeSelector"),
@@ -1186,8 +1186,8 @@ class TestLiveConfigManifestContract(TestCase):
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/refresh_execution_tca_metrics.py", args)
         self.assertIn("--older-than-seconds 900", args)
-        self.assertIn("--batch-size 100", args)
-        self.assertIn("--max-batches 3", args)
+        self.assertIn("--batch-size 1000", args)
+        self.assertIn("--max-batches 5", args)
         self.assertIn("--apply", args)
 
     def test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account(


### PR DESCRIPTION
## Summary

- Increases the Torghut execution TCA refresh CronJob deadline from 240s to 900s.
- Raises each scheduled refresh from 300 rows per run to up to 5,000 rows per run.
- Updates the live manifest contract test so the repair throughput remains intentional and bounded.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_execution_tca_refresh_cronjob_keeps_readiness_evidence_fresh -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
