### PR TITLE
fix(torghut): seal runtime import materialization authority

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1090,16 +1090,86 @@ def _runtime_import_target_blocker_codes(value: object) -> list[str]:
     return blockers
 
 
+_RUNTIME_LEDGER_PROMOTION_GRADE_SOURCE_MATERIALIZATIONS = frozenset(
+    {
+        "execution_order_events",
+        "source_execution_lifecycle",
+    }
+)
+_RUNTIME_LEDGER_NON_AUTHORITY_MATERIALIZATION_MARKERS = frozenset(
+    {
+        "aggregate_only",
+        "artifact_only",
+        "exact_replay",
+        "replay_artifact",
+        "simulation_source_replay_only",
+    }
+)
+
+
+def _runtime_ledger_non_authority_marker_present(value: object) -> bool:
+    text = _text(value)
+    if text is None:
+        return False
+    normalized = text.lower().replace("-", "_")
+    return any(
+        marker in normalized
+        for marker in _RUNTIME_LEDGER_NON_AUTHORITY_MATERIALIZATION_MARKERS
+    )
+
+
 def _runtime_import_materialization_metadata_blockers(
     observation: Mapping[str, Any],
 ) -> list[str]:
-    return [
+    blockers = [
         blocker
         for blocker in _text_list(
             observation.get("runtime_ledger_target_metadata_blockers")
         )
         if blocker not in RUNTIME_IMPORT_MATERIALIZATION_PROMOTION_ONLY_BLOCKERS
     ]
+    proof_count = max(
+        _int(observation.get("runtime_ledger_tca_profit_proof_count")),
+        _int(observation.get("runtime_ledger_source_bucket_profit_proof_count")),
+        _int(observation.get("runtime_ledger_durable_bucket_profit_proof_count")),
+        1 if _bool(observation.get("runtime_ledger_profit_proof_present")) else 0,
+    )
+    if proof_count <= 0:
+        return blockers
+
+    source_materialized_count = _int(
+        observation.get("runtime_ledger_source_execution_materialized_bucket_count")
+    )
+    if source_materialized_count < proof_count:
+        blockers.append("runtime_window_import_source_execution_materialization_missing")
+
+    source_materializations = _text_list(
+        observation.get("runtime_ledger_source_materializations")
+    )
+    if not any(
+        materialization in _RUNTIME_LEDGER_PROMOTION_GRADE_SOURCE_MATERIALIZATIONS
+        for materialization in source_materializations
+    ) or any(
+        _runtime_ledger_non_authority_marker_present(materialization)
+        for materialization in source_materializations
+    ):
+        blockers.append("runtime_window_import_source_materialization_missing")
+
+    derivations = _text_list(
+        observation.get("runtime_ledger_materialization_pnl_derivations")
+    )
+    authority_reasons = _text_list(
+        observation.get("runtime_ledger_materialization_authority_reasons")
+    )
+    authority_reason = _text(observation.get("authority_reason"))
+    if authority_reason is not None:
+        authority_reasons.append(authority_reason)
+    if any(
+        _runtime_ledger_non_authority_marker_present(value)
+        for value in [*derivations, *authority_reasons]
+    ):
+        blockers.append("runtime_window_import_replay_or_artifact_derivation_not_authority")
+    return list(dict.fromkeys(blockers))
 
 
 def _runtime_import_readback_payload(

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -902,6 +902,51 @@ class TestRuntimeLedgerProofPacket(TestCase):
         )
         self.assertEqual(result["next_action"], "rerun_proof_packet_in_authority_mode")
 
+    def test_authority_packet_rejects_aggregate_only_runtime_import_materialization(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        runtime_observation = cast(
+            dict[str, object],
+            cast(dict[str, object], runtime_import["imports"][0])["summary"],
+        )["runtime_observation"]
+        assert isinstance(runtime_observation, dict)
+        runtime_observation.update(
+            {
+                "runtime_ledger_source_execution_materialized_bucket_count": 0,
+                "runtime_ledger_source_materializations": [],
+                "runtime_ledger_materialization_pnl_derivations": [
+                    "aggregate_only_runtime_ledger"
+                ],
+                "runtime_ledger_materialization_authority_reasons": [
+                    "aggregate_only"
+                ],
+            }
+        )
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["final_authority_ok"], result)
+        self.assertIn(
+            "runtime_window_import_source_execution_materialization_missing",
+            result["authority_blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_source_materialization_missing",
+            result["authority_blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_replay_or_artifact_derivation_not_authority",
+            result["authority_blockers"],
+        )
+
     def test_authority_packet_fails_each_mechanical_authority_floor(self) -> None:
         cases = [
             (
@@ -2752,6 +2797,14 @@ class TestRuntimeLedgerProofPacket(TestCase):
                     "runtime_observation": {
                         "authoritative": True,
                         "runtime_ledger_profit_proof_present": True,
+                        "runtime_ledger_tca_profit_proof_count": 1,
+                        "runtime_ledger_source_execution_materialized_bucket_count": 1,
+                        "runtime_ledger_source_materializations": [
+                            "execution_order_events"
+                        ],
+                        "runtime_ledger_materialization_pnl_derivations": [
+                            "execution_order_events_runtime_ledger"
+                        ],
                     },
                     "runtime_materialization_target": {
                         "candidate_id": "c88421d619759b2cfaa6f4d0",


### PR DESCRIPTION
## Summary

- Seals proof-packet runtime-window import materialization so aggregate-only runtime-ledger observations cannot be treated as authority proof by metadata shape alone.
- Requires source-execution materialized bucket counts to cover runtime-ledger profit-proof counts and requires promotion-grade source materialization names.
- Blocks aggregate/exact-replay/artifact/simulation derivation markers from contributing to authority materialization proof.
- Adds regression coverage for aggregate-only runtime import materialization rejection and updates alternate-shape authority fixture with source-backed materialization metadata.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass)
- `cd services/torghut && uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py` (pass)
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q` (pass: 279 passed, 1 warning)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json` (pass)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
