### PR TITLE
fix(torghut): bound paper target plan audits

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4885,7 +4885,9 @@ def trading_paper_route_target_plan() -> JSONResponse:
             session,
             live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
             route_reacquisition_book=route_reacquisition_book,
-            include_runtime_window_import_audit=None,
+            # Keep this provider endpoint bounded; proof-grade runtime import
+            # audits run from /trading/paper-route-evidence.
+            include_runtime_window_import_audit=False,
             target_account_audit_available=settings.trading_mode == "paper",
         )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7600,7 +7600,7 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
-    def test_trading_paper_route_target_plan_uses_auto_import_audit_mode(self) -> None:
+    def test_trading_paper_route_target_plan_defers_runtime_import_audit(self) -> None:
         original_scheduler = getattr(app.state, "trading_scheduler", None)
         target = {
             "hypothesis_id": "H-PAIRS-01",
@@ -7638,7 +7638,7 @@ class TestTradingApi(TestCase):
             if hasattr(app.state, "trading_scheduler"):
                 del app.state.trading_scheduler
 
-            def _assert_auto_audit_mode(
+            def _assert_deferred_audit_mode(
                 *args: object, **kwargs: object
             ) -> dict[str, object]:
                 self.assertEqual(
@@ -7647,7 +7647,7 @@ class TestTradingApi(TestCase):
                     ],
                     live_gate["runtime_ledger_paper_probation_import_plan"],
                 )
-                self.assertIsNone(kwargs["include_runtime_window_import_audit"])
+                self.assertFalse(kwargs["include_runtime_window_import_audit"])
                 self.assertTrue(kwargs["route_reacquisition_book"])
                 return {
                     "schema_version": "torghut.paper-route-target-plan.v1",
@@ -7709,7 +7709,7 @@ class TestTradingApi(TestCase):
                 ),
                 patch(
                     "app.main.build_paper_route_target_plan_payload",
-                    side_effect=_assert_auto_audit_mode,
+                    side_effect=_assert_deferred_audit_mode,
                 ),
             ):
                 response = self.client.get("/trading/paper-route-target-plan")
@@ -8653,7 +8653,7 @@ class TestTradingApi(TestCase):
             *args: object, **kwargs: object
         ) -> dict[str, object]:
             self.assertEqual(kwargs["route_reacquisition_book"], {})
-            self.assertIsNone(kwargs["include_runtime_window_import_audit"])
+            self.assertFalse(kwargs["include_runtime_window_import_audit"])
             return {
                 "schema_version": "torghut.paper-route-target-plan.v1",
                 "target_count": 1,
@@ -8945,9 +8945,7 @@ class TestTradingApi(TestCase):
                     "app.main._build_live_submission_gate_payload",
                     return_value={
                         "allowed": False,
-                        "runtime_ledger_paper_probation_import_plan": {
-                            "targets": []
-                        },
+                        "runtime_ledger_paper_probation_import_plan": {"targets": []},
                     },
                 ),
                 patch(


### PR DESCRIPTION
## Summary

- Keeps `/trading/paper-route-target-plan` bounded by deferring runtime-window import audits on the lightweight provider path.
- Preserves `#9623`'s DB-session lifetime repair while changing only the target-plan audit mode contract.
- Updates target-plan API regression tests so the endpoint contract asserts deferred audit mode, including the empty route-book fallback.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k 'runtime_window_import_audit' -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
