### PR TITLE
fix(torghut): release target-plan fetch DB sessions

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4717,7 +4717,6 @@ def trading_paper_route_evidence(
         le=MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
         description="Maximum number of paper-route targets to audit.",
     ),
-    session: Session = Depends(get_session),
 ) -> JSONResponse:
     """Return target-by-target paper-route evidence collection status."""
 
@@ -4730,7 +4729,8 @@ def trading_paper_route_evidence(
     quant_evidence = load_quant_evidence_status(
         account_label=settings.trading_account_label,
     )
-    tca_summary = _load_tca_summary(session, scheduler=scheduler)
+    with SessionLocal() as session:
+        tca_summary = _load_tca_summary(session, scheduler=scheduler)
     market_context_status = scheduler.market_context_status()
     hypothesis_payload, _hypothesis_summary, _dependency_quorum = (
         _build_hypothesis_runtime_payload(
@@ -4739,27 +4739,29 @@ def trading_paper_route_evidence(
             market_context_status=market_context_status,
         )
     )
-    live_submission_gate = _build_live_submission_gate_payload(
-        scheduler.state,
-        session=session,
-        hypothesis_summary=hypothesis_payload,
-        empirical_jobs_status=empirical_jobs,
-        dspy_runtime_status=cast(
-            dict[str, object],
-            scheduler.llm_status().get("dspy_runtime", {}),
-        ),
-        quant_health_status=quant_evidence,
-    )
+    with SessionLocal() as session:
+        live_submission_gate = _build_live_submission_gate_payload(
+            scheduler.state,
+            session=session,
+            hypothesis_summary=hypothesis_payload,
+            empirical_jobs_status=empirical_jobs,
+            dspy_runtime_status=cast(
+                dict[str, object],
+                scheduler.llm_status().get("dspy_runtime", {}),
+            ),
+            quant_health_status=quant_evidence,
+        )
     live_submission_gate = _merge_external_paper_route_target_plan(
         cast(Mapping[str, Any], live_submission_gate)
     )
     simple_lane_status = _build_simple_lane_status_payload()
-    route_reacquisition_book = _paper_route_probe_book_from_target_plan(
-        live_submission_gate,
-        simple_lane_status=simple_lane_status,
-        state=scheduler.state,
-        session=session,
-    )
+    with SessionLocal() as session:
+        route_reacquisition_book = _paper_route_probe_book_from_target_plan(
+            live_submission_gate,
+            simple_lane_status=simple_lane_status,
+            state=scheduler.state,
+            session=session,
+        )
     if route_reacquisition_book is None:
         proof_floor = _build_profitability_proof_floor_payload(
             state=scheduler.state,
@@ -4776,21 +4778,20 @@ def trading_paper_route_evidence(
             Mapping[str, Any],
             proof_floor.get("route_reacquisition_book") or {},
         )
-    payload = build_paper_route_evidence_audit(
-        session,
-        live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
-        route_reacquisition_book=route_reacquisition_book,
-        lookback_hours=lookback_hours,
-        target_limit=target_limit,
-        target_account_audit_available=settings.trading_mode == "paper",
-    )
+    with SessionLocal() as session:
+        payload = build_paper_route_evidence_audit(
+            session,
+            live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
+            route_reacquisition_book=route_reacquisition_book,
+            lookback_hours=lookback_hours,
+            target_limit=target_limit,
+            target_account_audit_available=settings.trading_mode == "paper",
+        )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
 
 @app.get("/trading/paper-route-target-plan")
-def trading_paper_route_target_plan(
-    session: Session = Depends(get_session),
-) -> JSONResponse:
+def trading_paper_route_target_plan() -> JSONResponse:
     """Return the lightweight next-window paper-route target plan."""
 
     scheduler: TradingScheduler | None = getattr(app.state, "trading_scheduler", None)
@@ -4814,7 +4815,8 @@ def trading_paper_route_target_plan(
         quant_evidence = load_quant_evidence_status(
             account_label=settings.trading_account_label,
         )
-        tca_summary = _load_tca_summary(session, scheduler=scheduler)
+        with SessionLocal() as session:
+            tca_summary = _load_tca_summary(session, scheduler=scheduler)
         market_context_status = scheduler.market_context_status()
         hypothesis_payload, _hypothesis_summary, _dependency_quorum = (
             _build_hypothesis_runtime_payload(
@@ -4823,28 +4825,30 @@ def trading_paper_route_target_plan(
                 market_context_status=market_context_status,
             )
         )
-        live_submission_gate = _build_live_submission_gate_payload(
-            scheduler.state,
-            session=session,
-            hypothesis_summary=hypothesis_payload,
-            empirical_jobs_status=empirical_jobs,
-            dspy_runtime_status=cast(
-                dict[str, object],
-                scheduler.llm_status().get("dspy_runtime", {}),
-            ),
-            quant_health_status=quant_evidence,
-        )
+        with SessionLocal() as session:
+            live_submission_gate = _build_live_submission_gate_payload(
+                scheduler.state,
+                session=session,
+                hypothesis_summary=hypothesis_payload,
+                empirical_jobs_status=empirical_jobs,
+                dspy_runtime_status=cast(
+                    dict[str, object],
+                    scheduler.llm_status().get("dspy_runtime", {}),
+                ),
+                quant_health_status=quant_evidence,
+            )
         loaded_full_live_gate = True
     live_submission_gate = _merge_external_paper_route_target_plan(
         cast(Mapping[str, Any], live_submission_gate)
     )
     simple_lane_status = _build_simple_lane_status_payload()
-    route_reacquisition_book = _paper_route_probe_book_from_target_plan(
-        live_submission_gate,
-        simple_lane_status=simple_lane_status,
-        state=scheduler.state,
-        session=session,
-    )
+    with SessionLocal() as session:
+        route_reacquisition_book = _paper_route_probe_book_from_target_plan(
+            live_submission_gate,
+            simple_lane_status=simple_lane_status,
+            state=scheduler.state,
+            session=session,
+        )
     if settings.trading_mode == "live" and loaded_full_live_gate:
         assert empirical_jobs is not None
         assert quant_evidence is not None
@@ -4876,13 +4880,14 @@ def trading_paper_route_target_plan(
                 )
     if route_reacquisition_book is None:
         route_reacquisition_book = cast(Mapping[str, Any], {})
-    payload = build_paper_route_target_plan_payload(
-        session,
-        live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
-        route_reacquisition_book=route_reacquisition_book,
-        include_runtime_window_import_audit=None,
-        target_account_audit_available=settings.trading_mode == "paper",
-    )
+    with SessionLocal() as session:
+        payload = build_paper_route_target_plan_payload(
+            session,
+            live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
+            route_reacquisition_book=route_reacquisition_book,
+            include_runtime_window_import_audit=None,
+            target_account_audit_available=settings.trading_mode == "paper",
+        )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
 
@@ -5214,7 +5219,16 @@ def _fetch_paper_route_target_plan_url(
             timeout=max(float(timeout_seconds), 0.1),
         )
         try:
-            connection.request("GET", path, headers={"Accept": "application/json"})
+            host_header = parsed.netloc or parsed.hostname
+            connection.request(
+                "GET",
+                path,
+                headers={
+                    "Accept": "application/json",
+                    "Connection": "close",
+                    "Host": host_header,
+                },
+            )
             response = connection.getresponse()
             if response.status < 200 or response.status >= 300:
                 result = {

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -135,7 +135,16 @@ def _fetch_paper_route_target_plan_url_once(
         timeout=max(float(timeout_seconds), 0.1),
     )
     try:
-        connection.request("GET", path, headers={"Accept": "application/json"})
+        host_header = parsed.netloc or parsed.hostname
+        connection.request(
+            "GET",
+            path,
+            headers={
+                "Accept": "application/json",
+                "Connection": "close",
+                "Host": host_header,
+            },
+        )
         response = connection.getresponse()
         if response.status < 200 or response.status >= 300:
             return {

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -8893,6 +8893,184 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
+    def test_paper_route_evidence_releases_db_session_before_external_plan_fetch(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        settings.trading_paper_route_target_plan_url = (
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan"
+        )
+        active_sessions = 0
+
+        class TrackingSession:
+            def __enter__(self) -> "TrackingSession":
+                nonlocal active_sessions
+                active_sessions += 1
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                nonlocal active_sessions
+                active_sessions -= 1
+
+        def _load_external_without_held_session() -> dict[str, object]:
+            self.assertEqual(active_sessions, 0)
+            return {
+                "targets": [
+                    {
+                        "candidate_id": "fresh-authoritative",
+                        "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ]
+            }
+
+        try:
+            app.state.trading_scheduler = SimpleNamespace(
+                state=SimpleNamespace(market_session_open=False),
+                llm_status=lambda: {"dspy_runtime": {}},
+                market_context_status=lambda: {},
+            )
+            with (
+                patch("app.main.SessionLocal", return_value=TrackingSession()),
+                patch("app.main._empirical_jobs_status", return_value={}),
+                patch("app.main.load_quant_evidence_status", return_value={}),
+                patch("app.main._load_tca_summary", return_value={}),
+                patch(
+                    "app.main._build_hypothesis_runtime_payload",
+                    return_value=({}, {}, {}),
+                ),
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value={
+                        "allowed": False,
+                        "runtime_ledger_paper_probation_import_plan": {
+                            "targets": []
+                        },
+                    },
+                ),
+                patch(
+                    "app.main._load_external_paper_route_target_plan",
+                    side_effect=_load_external_without_held_session,
+                ),
+                patch("app.main._build_simple_lane_status_payload", return_value={}),
+                patch(
+                    "app.main._paper_route_probe_book_from_target_plan",
+                    return_value={},
+                ),
+                patch(
+                    "app.main.build_paper_route_evidence_audit",
+                    return_value={
+                        "schema_version": "torghut.paper-route-evidence.v1",
+                        "summary": {"target_count": 1},
+                    },
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-evidence")
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(active_sessions, 0)
+            self.assertEqual(response.json()["summary"]["target_count"], 1)
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
+    def test_paper_route_target_plan_releases_db_session_before_external_plan_fetch(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        settings.trading_paper_route_target_plan_url = (
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan"
+        )
+        active_sessions = 0
+        cached_gate = {
+            "allowed": False,
+            "runtime_ledger_paper_probation_import_plan": {
+                "target_count": 1,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [
+                    {
+                        "candidate_id": "cached-authoritative",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ],
+            },
+        }
+
+        class TrackingSession:
+            def __enter__(self) -> "TrackingSession":
+                nonlocal active_sessions
+                active_sessions += 1
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                nonlocal active_sessions
+                active_sessions -= 1
+
+        def _load_external_without_held_session() -> dict[str, object]:
+            self.assertEqual(active_sessions, 0)
+            return {
+                "targets": [
+                    {
+                        "candidate_id": "fresh-authoritative",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ]
+            }
+
+        try:
+            app.state.trading_scheduler = SimpleNamespace(
+                state=SimpleNamespace(market_session_open=False),
+                _last_live_submission_gate=cached_gate,
+            )
+            with (
+                patch("app.main.SessionLocal", return_value=TrackingSession()),
+                patch(
+                    "app.main._load_external_paper_route_target_plan",
+                    side_effect=_load_external_without_held_session,
+                ),
+                patch("app.main._build_simple_lane_status_payload", return_value={}),
+                patch(
+                    "app.main._paper_route_probe_book_from_target_plan",
+                    return_value={},
+                ),
+                patch(
+                    "app.main.build_paper_route_target_plan_payload",
+                    return_value={
+                        "schema_version": "torghut.paper-route-target-plan.v1",
+                        "target_count": 1,
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                        "targets": [{"candidate_id": "fresh-authoritative"}],
+                    },
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-target-plan")
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(active_sessions, 0)
+            self.assertEqual(response.json()["target_count"], 1)
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
     def test_trading_paper_route_evidence_resolves_target_plan_strategy_universe(
         self,
     ) -> None:
@@ -9246,6 +9424,13 @@ class TestTradingApi(TestCase):
         self.assertEqual(
             http_error_connection.instances[0].request_path, "/plan?mode=paper"
         )
+        self.assertEqual(
+            http_error_connection.instances[0].request_headers["Host"],
+            "torghut.example",
+        )
+        self.assertEqual(
+            http_error_connection.instances[0].request_headers["Connection"], "close"
+        )
         self.assertEqual(http_error_connection.instances[0].timeout, 0.1)
         self.assertTrue(http_error_connection.instances[0].closed)
 
@@ -9472,6 +9657,13 @@ class TestTradingApi(TestCase):
         self.assertEqual(http_error_connection.instances[0].hostname, "torghut.example")
         self.assertEqual(
             http_error_connection.instances[0].request_path, "/plan?mode=paper"
+        )
+        self.assertEqual(
+            http_error_connection.instances[0].request_headers["Host"],
+            "torghut.example",
+        )
+        self.assertEqual(
+            http_error_connection.instances[0].request_headers["Connection"], "close"
         )
         self.assertEqual(http_error_connection.instances[0].timeout, 0.1)
         self.assertTrue(http_error_connection.instances[0].closed)


### PR DESCRIPTION
## Summary

- Releases database sessions before the paper-route endpoints perform external target-plan fetches so slow live/sim HTTP calls cannot pin DB pool connections.
- Keeps the target-plan fetch path Knative-friendly by sending explicit `Host` and `Connection: close` headers from both fetch helpers.
- Adds focused regressions for the DB-session lifetime failure mode and fetch header behavior while preserving fail-closed/no-promotion target-plan semantics.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/paper_route_target_plan.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q -k "fetch_paper_route_target_plan_url_validates_response or shared_paper_route_target_plan_helpers_validate_response or paper_route_evidence_releases_db_session_before_external_plan_fetch or paper_route_target_plan_releases_db_session_before_external_plan_fetch"`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
