### PR TITLE
fix(torghut): require source refs for runtime ledger authority

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -442,8 +442,7 @@ def _build_bucket(
                     for row in lifecycle_rows
                     if row.event_type in _FILL_EVENTS
                     and (
-                        row.order_feed_lifecycle_source
-                        or not source_lifecycle_present
+                        row.order_feed_lifecycle_source or not source_lifecycle_present
                     )
                 ],
                 usable_fills=all_usable_fills,
@@ -456,7 +455,7 @@ def _build_bucket(
                 lineage_hash_counter=lineage_hash_counter,
             )
         )
-        blockers.extend(_source_materialization_blockers(lifecycle_rows))
+    blockers.extend(_source_materialization_blockers(lifecycle_rows))
 
     unique_blockers = _dedupe(blockers)
     post_cost_expectancy_bps: Decimal | None = None
@@ -817,7 +816,7 @@ def _normalize_fill_row(
     )
     source_offset_present = _source_offset_present(row)
     source_materialization = _coerce_text(
-        _row_value(row, "source_materialization", "source")
+        _row_value(row, "source_materialization", "authority_class", "source")
     )
     order_id = _coerce_text(
         _row_value(
@@ -872,7 +871,10 @@ def _normalize_fill_row(
             blockers.append("side_missing_or_invalid")
         if filled_qty is None:
             blockers.append("filled_qty_missing_or_non_positive")
-        if order_feed_source_fill and fill_quantity_basis not in _DELTA_FILL_QUANTITY_BASES:
+        if (
+            order_feed_source_fill
+            and fill_quantity_basis not in _DELTA_FILL_QUANTITY_BASES
+        ):
             blockers.append("fill_quantity_delta_basis_missing")
         elif (
             order_feed_source_fill
@@ -1095,7 +1097,9 @@ def _source_offset_present(row: RuntimeLedgerFill | Mapping[str, object]) -> boo
 def _is_non_promotion_runtime_source_row(
     row: RuntimeLedgerFill | Mapping[str, object],
 ) -> bool:
-    promotion_authority = _row_value(row, "promotion_authority", "promotion_authority_eligible")
+    promotion_authority = _row_value(
+        row, "promotion_authority", "promotion_authority_eligible"
+    )
     if promotion_authority is False:
         return True
     for key in (
@@ -1207,7 +1211,8 @@ def _tigerbeetle_journal_blockers(
     )
     if (
         status is not None
-        and status.lower().replace("-", "_") not in _TIGERBEETLE_JOURNAL_SUCCESS_STATUSES
+        and status.lower().replace("-", "_")
+        not in _TIGERBEETLE_JOURNAL_SUCCESS_STATUSES
     ):
         blockers.append(_TIGERBEETLE_EXECUTION_COST_JOURNAL_FAILURE_BLOCKER)
     return _dedupe(blockers)

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -780,7 +780,9 @@ def test_order_feed_source_fill_requires_delta_basis() -> None:
     assert "runtime_fills_missing" in bucket.blockers
 
 
-def test_order_feed_lifecycle_fill_without_execution_economics_is_not_pnl_proof() -> None:
+def test_order_feed_lifecycle_fill_without_execution_economics_is_not_pnl_proof() -> (
+    None
+):
     bucket = build_runtime_ledger_buckets(
         [
             {
@@ -825,7 +827,9 @@ def test_order_feed_lifecycle_fill_without_execution_economics_is_not_pnl_proof(
     assert "explicit_cost_missing" not in bucket.blockers
 
 
-def test_execution_economics_with_linked_order_feed_lifecycle_satisfies_runtime_inputs() -> None:
+def test_execution_economics_with_linked_order_feed_lifecycle_satisfies_runtime_inputs() -> (
+    None
+):
     bucket = build_runtime_ledger_buckets(
         [
             {
@@ -1418,6 +1422,13 @@ def test_order_feed_source_fill_accepts_authority_class_marker() -> None:
                 "event_type": "fill",
                 "executed_at": _ts(1),
                 "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+                "execution_order_event_id": "event-buy",
+                "execution_id": "execution-buy",
+                "trade_decision_id": "decision-buy",
+                "source_window_id": "window-buy",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 7,
                 "account_label": "paper",
                 "strategy_id": "strategy-1",
                 "symbol": "NVDA",
@@ -1433,6 +1444,13 @@ def test_order_feed_source_fill_accepts_authority_class_marker() -> None:
                 "event_type": "fill",
                 "executed_at": _ts(2),
                 "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+                "execution_order_event_id": "event-sell",
+                "execution_id": "execution-sell",
+                "trade_decision_id": "decision-sell",
+                "source_window_id": "window-sell",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 8,
                 "account_label": "paper",
                 "strategy_id": "strategy-1",
                 "symbol": "NVDA",
@@ -1450,6 +1468,54 @@ def test_order_feed_source_fill_accepts_authority_class_marker() -> None:
     assert bucket.fill_count == 2
     assert bucket.closed_trade_count == 1
     assert bucket.filled_notional == Decimal("201")
+
+
+def test_promotion_authority_class_requires_source_refs_without_lifecycle_gate() -> (
+    None
+):
+    bucket = _bucket(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(1),
+                "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "1",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(2),
+                "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "1",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "101",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+        ]
+    )
+
+    assert bucket.fill_count == 2
+    assert bucket.closed_trade_count == 1
+    assert bucket.post_cost_expectancy_bps is None
+    assert "runtime_ledger_execution_order_event_refs_missing" in bucket.blockers
+    assert "runtime_ledger_trade_decision_refs_missing" in bucket.blockers
+    assert "runtime_ledger_execution_refs_missing" in bucket.blockers
+    assert "runtime_ledger_source_window_ids_missing" in bucket.blockers
+    assert "runtime_ledger_source_offsets_missing" in bucket.blockers
 
 
 def test_fill_quantity_basis_aliases_are_normalized() -> None:


### PR DESCRIPTION
## Summary

- Enforces runtime-ledger source materialization blockers outside the optional lifecycle gate so promotion-grade source rows cannot produce authority without durable refs.
- Treats `authority_class` as a source materialization marker when normalizing runtime-ledger rows.
- Adds regression coverage that authority-class order-feed fills require execution-order-event, execution, trade-decision, source-window, and source-offset refs before post-cost authority is allowed.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_simple_pipeline.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger.py tests/test_runtime_ledger.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger.py tests/test_runtime_ledger.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
