### PR TITLE
fix(torghut): accelerate tigerbeetle cost journaling

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: tigerbeetle-journal-order-events
 spec:
-  schedule: "6,36 * * * *"
+  schedule: "1,6,11,16,21,26,31,36,41,46,51,56 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
@@ -15,7 +15,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 900
+      activeDeadlineSeconds: 1200
       template:
         spec:
           restartPolicy: Never
@@ -57,18 +57,37 @@ spec:
                   cd /app
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env DB_DSN \
-                    --batch-size 125 \
+                    --sources execution,execution_tca_metric \
+                    --batch-size 500 \
                     --max-batches 2 \
-                    --event-scan-limit 1000 \
-                    --reconcile-limit 500 \
+                    --reconcile-limit 1000 \
+                    --skip-reconcile \
                     --json
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
+                    --sources execution,execution_tca_metric \
+                    --batch-size 250 \
+                    --max-batches 2 \
+                    --reconcile-limit 500 \
+                    --skip-reconcile \
+                    --json
+                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
+                    --dsn-env DB_DSN \
+                    --sources execution_order_event,strategy_runtime_ledger_bucket \
+                    --batch-size 125 \
+                    --max-batches 2 \
+                    --event-scan-limit 1000 \
+                    --reconcile-limit 1000 \
+                    --json
+                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --sources execution_order_event,strategy_runtime_ledger_bucket \
                     --batch-size 75 \
                     --max-batches 4 \
                     --event-scan-limit 300 \
-                    --reconcile-limit 250 \
+                    --reconcile-limit 500 \
                     --json
               env:
                 - name: DB_DSN

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -39,6 +39,30 @@ from app.trading.tigerbeetle_ledger_model import (
 )
 from app.trading.tigerbeetle_reconcile import reconcile_tigerbeetle_transfers
 
+DEFAULT_SOURCES = (
+    SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    SOURCE_TYPE_EXECUTION,
+    SOURCE_TYPE_EXECUTION_TCA_METRIC,
+    SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+)
+SOURCE_ALIASES = {
+    "event": SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    "events": SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    "execution_order_event": SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    "execution_order_events": SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    "execution": SOURCE_TYPE_EXECUTION,
+    "executions": SOURCE_TYPE_EXECUTION,
+    "execution_tca_metric": SOURCE_TYPE_EXECUTION_TCA_METRIC,
+    "execution_tca_metrics": SOURCE_TYPE_EXECUTION_TCA_METRIC,
+    "tca": SOURCE_TYPE_EXECUTION_TCA_METRIC,
+    "cost": SOURCE_TYPE_EXECUTION_TCA_METRIC,
+    "costs": SOURCE_TYPE_EXECUTION_TCA_METRIC,
+    "runtime": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+    "runtime_ledger": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+    "strategy_runtime_ledger_bucket": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+    "strategy_runtime_ledger_buckets": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+}
+
 
 @dataclass(frozen=True)
 class OrderEventSelection:
@@ -62,6 +86,20 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--reconcile-limit", type=int, default=1000)
     parser.add_argument(
+        "--sources",
+        default="all",
+        help=(
+            "Comma-separated source groups to journal. Supported values: all, "
+            "execution_order_event, execution, execution_tca_metric, "
+            "strategy_runtime_ledger_bucket."
+        ),
+    )
+    parser.add_argument(
+        "--skip-reconcile",
+        action="store_true",
+        help="Persist journal refs without running reconciliation in this invocation.",
+    )
+    parser.add_argument(
         "--fail-on-degraded",
         action="store_true",
         help="Exit non-zero when journaling/reconciliation is degraded.",
@@ -80,6 +118,29 @@ def _sqlalchemy_dsn(dsn: str) -> str:
     if text.startswith("postgresql://"):
         return text.replace("postgresql://", "postgresql+psycopg://", 1)
     return text
+
+
+def _parse_sources(raw_sources: object) -> tuple[str, ...]:
+    raw = str(raw_sources or "all").strip()
+    if not raw or raw.lower() == "all":
+        return DEFAULT_SOURCES
+
+    selected: list[str] = []
+    for item in raw.split(","):
+        key = item.strip().lower().replace("-", "_")
+        if not key:
+            continue
+        source = SOURCE_ALIASES.get(key)
+        if source is None:
+            supported = ", ".join(("all", *DEFAULT_SOURCES))
+            raise ValueError(
+                f"unsupported source {item!r}; expected one of: {supported}"
+            )
+        if source not in selected:
+            selected.append(source)
+    if not selected:
+        raise ValueError("at least one journal source must be selected")
+    return tuple(selected)
 
 
 def _select_unlinked_events(
@@ -384,6 +445,8 @@ def _payload(
         "batch_size": max(1, min(int(args.batch_size), 5000)),
         "max_batches": max(1, int(args.max_batches)),
         "event_scan_limit": getattr(args, "event_scan_limit", None),
+        "sources": list(_parse_sources(getattr(args, "sources", "all"))),
+        "skip_reconcile": bool(getattr(args, "skip_reconcile", False)),
         "started_at": started_at.isoformat(),
         "completed_at": datetime.now(timezone.utc).isoformat(),
         "selected": selected,
@@ -404,6 +467,10 @@ def main() -> int:
     started_at = datetime.now(timezone.utc)
     batch_size = max(1, min(int(args.batch_size), 5000))
     max_batches = max(1, int(args.max_batches))
+    try:
+        enabled_sources = _parse_sources(args.sources)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     settings_obj = Settings(
         DB_DSN=dsn,
         TORGHUT_TIGERBEETLE_ENABLED=True,
@@ -427,47 +494,40 @@ def main() -> int:
         ) as journal,
     ):
         for _ in range(max_batches):
-            events = _select_unlinked_events(
-                session,
-                settings_obj=settings_obj,
-                account_label=args.account_label,
-                limit=batch_size,
-                event_scan_limit=args.event_scan_limit,
-            )
-            executions = _select_unlinked_executions(
-                session,
-                settings_obj=settings_obj,
-                account_label=args.account_label,
-                limit=batch_size,
-            )
-            tca_metrics = _select_unlinked_tca_metrics(
-                session,
-                settings_obj=settings_obj,
-                account_label=args.account_label,
-                limit=batch_size,
-            )
-            runtime_buckets = _select_unlinked_runtime_buckets(
-                session,
-                settings_obj=settings_obj,
-                account_label=args.account_label,
-                limit=batch_size,
-            )
-            event_batch = _journal_source_batch(
-                session,
-                args=args,
-                source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
-                rows=events.rows,
-                journal_one=lambda event: journal.journal_order_event(
+            batch_lengths: list[int] = []
+            if SOURCE_TYPE_EXECUTION_ORDER_EVENT in enabled_sources:
+                events = _select_unlinked_events(
                     session,
-                    event,
-                ),
-            )
-            if events.scan_failed:
-                event_batch["failed"] = int(event_batch["failed"]) + events.scan_failed
-                event_batch["scan_failed"] = events.scan_failed
-            batches.extend(
-                [
-                    event_batch,
+                    settings_obj=settings_obj,
+                    account_label=args.account_label,
+                    limit=batch_size,
+                    event_scan_limit=args.event_scan_limit,
+                )
+                event_batch = _journal_source_batch(
+                    session,
+                    args=args,
+                    source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                    rows=events.rows,
+                    journal_one=lambda event: journal.journal_order_event(
+                        session,
+                        event,
+                    ),
+                )
+                if events.scan_failed:
+                    event_batch["failed"] = (
+                        int(event_batch["failed"]) + events.scan_failed
+                    )
+                    event_batch["scan_failed"] = events.scan_failed
+                batches.append(event_batch)
+                batch_lengths.append(len(events.rows))
+            if SOURCE_TYPE_EXECUTION in enabled_sources:
+                executions = _select_unlinked_executions(
+                    session,
+                    settings_obj=settings_obj,
+                    account_label=args.account_label,
+                    limit=batch_size,
+                )
+                batches.append(
                     _journal_source_batch(
                         session,
                         args=args,
@@ -477,7 +537,17 @@ def main() -> int:
                             session,
                             execution,
                         ),
-                    ),
+                    )
+                )
+                batch_lengths.append(len(executions))
+            if SOURCE_TYPE_EXECUTION_TCA_METRIC in enabled_sources:
+                tca_metrics = _select_unlinked_tca_metrics(
+                    session,
+                    settings_obj=settings_obj,
+                    account_label=args.account_label,
+                    limit=batch_size,
+                )
+                batches.append(
                     _journal_source_batch(
                         session,
                         args=args,
@@ -487,7 +557,17 @@ def main() -> int:
                             session,
                             metric,
                         ),
-                    ),
+                    )
+                )
+                batch_lengths.append(len(tca_metrics))
+            if SOURCE_TYPE_RUNTIME_LEDGER_BUCKET in enabled_sources:
+                runtime_buckets = _select_unlinked_runtime_buckets(
+                    session,
+                    settings_obj=settings_obj,
+                    account_label=args.account_label,
+                    limit=batch_size,
+                )
+                batches.append(
                     _journal_source_batch(
                         session,
                         args=args,
@@ -499,22 +579,19 @@ def main() -> int:
                                 bucket,
                             )
                         ),
-                    ),
-                ]
-            )
+                    )
+                )
+                batch_lengths.append(len(runtime_buckets))
             if args.dry_run:
                 session.rollback()
                 _reset_session_identity_map(session)
                 break
             session.commit()
             _reset_session_identity_map(session)
-            if all(
-                len(rows) < batch_size
-                for rows in (events.rows, executions, tca_metrics, runtime_buckets)
-            ):
+            if batch_lengths and all(length < batch_size for length in batch_lengths):
                 break
 
-        if not args.dry_run:
+        if not args.dry_run and not args.skip_reconcile:
             reconciliation = reconcile_tigerbeetle_transfers(
                 session,
                 settings_obj=settings_obj,

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -214,6 +214,19 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             "sqlite+pysqlite:///:memory:",
         )
 
+    def test_parse_sources_accepts_aliases_and_deduplicates(self) -> None:
+        self.assertEqual(
+            script._parse_sources("execution,tca,cost,runtime_ledger"),
+            (
+                script.SOURCE_TYPE_EXECUTION,
+                script.SOURCE_TYPE_EXECUTION_TCA_METRIC,
+                script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            ),
+        )
+        self.assertEqual(script._parse_sources("all"), script.DEFAULT_SOURCES)
+        with self.assertRaises(ValueError):
+            script._parse_sources("unknown-source")
+
     def test_payload_summarizes_batches(self) -> None:
         args = argparse.Namespace(
             dry_run=True,
@@ -663,6 +676,55 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             reconcile.call_args.kwargs["client"],
             FakeJournal.instances[0].reconciliation_client,
         )
+
+    def test_main_can_target_tca_metrics_without_reconcile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                _add_order_event(session, fingerprint="selected", source_offset=1)
+                _add_real_source_rows(session)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--sources",
+                        "execution_tca_metric",
+                        "--batch-size",
+                        "10",
+                        "--max-batches",
+                        "2",
+                        "--skip-reconcile",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script, "reconcile_tigerbeetle_transfers") as reconcile,
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["sources"], [script.SOURCE_TYPE_EXECUTION_TCA_METRIC])
+        self.assertTrue(payload["skip_reconcile"])
+        self.assertEqual(payload["journaled"], 1)
+        self.assertEqual(FakeJournal.instances[0].events, [])
+        self.assertEqual(FakeJournal.instances[0].executions, [])
+        self.assertEqual(FakeJournal.instances[0].tca_metrics, ["AAPL"])
+        self.assertEqual(FakeJournal.instances[0].runtime_buckets, [])
+        reconcile.assert_not_called()
 
     def test_main_dry_run_rolls_back_without_reconcile(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1380,7 +1380,10 @@ class TestLiveConfigManifestContract(TestCase):
             metadata.get("name"),
             "torghut-tigerbeetle-journal-order-events",
         )
-        self.assertEqual(spec.get("schedule"), "6,36 * * * *")
+        self.assertEqual(
+            spec.get("schedule"),
+            "1,6,11,16,21,26,31,36,41,46,51,56 * * * *",
+        )
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
         self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
         self.assertEqual(spec.get("successfulJobsHistoryLimit"), 2)
@@ -1395,7 +1398,7 @@ class TestLiveConfigManifestContract(TestCase):
             cast(Mapping[str, object], job_spec.get("template", {})),
         )
         pod_spec = cast(Mapping[str, object], template.get("spec", {}))
-        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 900)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 1200)
         self.assertEqual(job_spec.get("backoffLimit"), 0)
         self.assertEqual(pod_spec.get("restartPolicy"), "Never")
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
@@ -1474,17 +1477,25 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/journal_tigerbeetle_order_events.py", args)
         self.assertNotIn("scripts/repair_order_feed_source_windows.py", args)
         self.assertIn("--dsn-env DB_DSN", args)
+        self.assertIn("--sources execution,execution_tca_metric", args)
+        self.assertIn("--batch-size 500", args)
+        self.assertIn("--reconcile-limit 1000", args)
+        self.assertIn("--skip-reconcile", args)
+        self.assertIn("--dsn-env SIM_DB_DSN", args)
+        self.assertIn("--account-label TORGHUT_SIM", args)
+        self.assertIn("--batch-size 250", args)
+        self.assertIn("--reconcile-limit 500", args)
+        self.assertIn(
+            "--sources execution_order_event,strategy_runtime_ledger_bucket",
+            args,
+        )
         self.assertIn("--batch-size 125", args)
         self.assertIn("--max-batches 2", args)
         self.assertIn("--event-scan-limit 1000", args)
-        self.assertIn("--reconcile-limit 500", args)
-        self.assertIn("--dsn-env SIM_DB_DSN", args)
-        self.assertIn("--account-label TORGHUT_SIM", args)
         self.assertIn("--batch-size 75", args)
         self.assertIn("--max-batches 4", args)
         self.assertIn("--event-scan-limit 300", args)
-        self.assertIn("--reconcile-limit 250", args)
-        self.assertEqual(args.count("scripts/journal_tigerbeetle_order_events.py"), 2)
+        self.assertEqual(args.count("scripts/journal_tigerbeetle_order_events.py"), 4)
         self.assertNotIn("--fail-on-degraded", args)
         self.assertIn("--json", args)
         security_context = cast(


### PR DESCRIPTION
## Summary

- Add `--sources` and `--skip-reconcile` to `journal_tigerbeetle_order_events.py` so backlog catch-up can prioritize execution-fill and execution-TCA cost refs.
- Move `torghut-tigerbeetle-journal-order-events` from half-hour cadence to five-minute offset cadence, with high-priority live/sim execution and TCA passes before lifecycle/runtime reconciliation sweeps.
- Update Torghut manifest contract coverage and journal script tests for source filtering, deduped aliases, and skip-reconcile behavior.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
