### PR TITLE
feat(torghut): dedupe hpairs fast replay frontier

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import timezone
@@ -36,6 +38,12 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
     "conformal_tail_risk_prefilter",
+)
+FAST_REPLAY_FRONTIER_IDENTITY_SCHEMA_VERSION = (
+    "torghut.fast-replay-frontier-identity.v1"
+)
+FAST_REPLAY_EXACT_FRONTIER_KEY_SCHEMA_VERSION = (
+    "torghut.fast-replay-exact-frontier-key.v1"
 )
 
 
@@ -72,6 +80,11 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
+    candidate_frontier_hash: str = ""
+    exact_replay_frontier_key: str = ""
+    frontier_dedupe_status: str = "unique"
+    duplicate_of_candidate_spec_id: str | None = None
+    duplicate_candidate_spec_ids: tuple[str, ...] = ()
 
     def to_payload(self) -> dict[str, Any]:
         observed_post_cost_expectancy_bps = _observed_post_cost_expectancy_bps(self)
@@ -120,6 +133,29 @@ class FastReplayPreviewRow:
             ),
             "exploration_score": str(self.exploration_score),
             "frontier_bucket": self.frontier_bucket,
+            "candidate_frontier_hash": self.candidate_frontier_hash,
+            "exact_replay_frontier_key": self.exact_replay_frontier_key,
+            "frontier_dedupe_status": self.frontier_dedupe_status,
+            "duplicate_of_candidate_spec_id": self.duplicate_of_candidate_spec_id,
+            "duplicate_candidate_spec_ids": list(self.duplicate_candidate_spec_ids),
+            "frontier_dedupe_metadata": {
+                "schema_version": "torghut.fast-replay-frontier-dedupe.v1",
+                "status": self.frontier_dedupe_status,
+                "candidate_frontier_hash": self.candidate_frontier_hash,
+                "exact_replay_frontier_key": self.exact_replay_frontier_key,
+                "duplicate_of_candidate_spec_id": self.duplicate_of_candidate_spec_id,
+                "duplicate_candidate_spec_ids": list(
+                    self.duplicate_candidate_spec_ids
+                ),
+                "dedupe_scope": "same_replay_tape_cache_and_execution_identity",
+                "proof_source": "prefilter_only",
+                "prefilter_only": True,
+                "promotion_proof": False,
+                "proof_authority": False,
+                "promotion_authority": False,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+            },
             "microstructure_prefilter": dict(self.microstructure_prefilter),
             "hpairs_microstructure_prefilter": dict(self.microstructure_prefilter),
             "hpairs_macro_window_stress": prefilter_macro_window_stress,
@@ -243,6 +279,35 @@ class FastReplayPreviewResult:
             "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
             "selected_candidate_spec_count": len(self.selected_candidate_spec_ids),
             "selected_row_count": self.selected_row_count,
+            "frontier_dedupe_policy": {
+                "schema_version": "torghut.fast-replay-frontier-dedupe-policy.v1",
+                "status": "enabled",
+                "dedupe_scope": "same_replay_tape_cache_and_execution_identity",
+                "candidate_frontier_hash_components": [
+                    "candidate_kind",
+                    "family_template_id",
+                    "runtime_family",
+                    "runtime_strategy_name",
+                    "strategy_overrides",
+                    "objective",
+                    "hard_vetoes",
+                ],
+                "exact_replay_frontier_key_components": [
+                    "replay_cache_key",
+                    "dataset_snapshot_ref",
+                    "source_query_digest",
+                    "feature_schema_hash",
+                    "cost_model_hash",
+                    "strategy_family",
+                    "candidate_frontier_hash",
+                ],
+                "prefilter_only": True,
+                "promotion_proof": False,
+                "proof_authority": False,
+                "promotion_authority": False,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+            },
             "replay_tape": {
                 "dataset_snapshot_ref": self.replay_tape_manifest.dataset_snapshot_ref,
                 "content_sha256": self.replay_tape_manifest.content_sha256,
@@ -367,10 +432,12 @@ def build_fast_replay_preview(
                 microstructure_prefilter=hpairs_prefilter_payload_by_spec.get(
                     spec.candidate_spec_id, {}
                 ),
+                replay_tape_manifest=replay_tape_manifest,
             )
         )
 
     ranked_rows = sorted(scored_rows, key=_preview_rank_key)
+    ranked_rows = _mark_frontier_duplicates(ranked_rows)
     selected_bucket_by_id = _select_frontier_buckets(
         ranked_rows=ranked_rows,
         exploitation_count=bounded_exploitation_count,
@@ -489,7 +556,13 @@ def _score_candidate_spec(
     symbol_stats: Mapping[str, _SymbolTapeStats],
     min_rows_per_candidate: int,
     microstructure_prefilter: Mapping[str, Any],
+    replay_tape_manifest: ReplayTapeManifest,
 ) -> FastReplayPreviewRow:
+    candidate_frontier_hash = _candidate_frontier_hash(spec)
+    exact_replay_frontier_key = _exact_replay_frontier_key(
+        replay_tape_manifest=replay_tape_manifest,
+        candidate_frontier_hash=candidate_frontier_hash,
+    )
     requested_symbols = _candidate_symbols(spec)
     matched = [
         stat for symbol in requested_symbols if (stat := symbol_stats.get(symbol))
@@ -529,6 +602,8 @@ def _score_candidate_spec(
             exploration_score=Decimal("0"),
             frontier_bucket="not_selected",
             microstructure_prefilter=dict(microstructure_prefilter),
+            candidate_frontier_hash=candidate_frontier_hash,
+            exact_replay_frontier_key=exact_replay_frontier_key,
         )
 
     return_vectors = [stat.returns_bps for stat in matched if stat.returns_bps.size]
@@ -654,6 +729,8 @@ def _score_candidate_spec(
         exploration_score=_decimal_from_float(exploration_score),
         frontier_bucket="not_selected",
         microstructure_prefilter=dict(microstructure_prefilter),
+        candidate_frontier_hash=candidate_frontier_hash,
+        exact_replay_frontier_key=exact_replay_frontier_key,
     )
 
 
@@ -675,6 +752,67 @@ def _row_explicitly_non_hpairs(row: FastReplayPreviewRow) -> bool:
     return isinstance(value, bool) and not value
 
 
+def _mark_frontier_duplicates(
+    ranked_rows: Sequence[FastReplayPreviewRow],
+) -> list[FastReplayPreviewRow]:
+    grouped_ids: dict[str, list[str]] = {}
+    representative_by_key: dict[str, str] = {}
+    for row in ranked_rows:
+        key = _frontier_dedupe_key(row)
+        grouped_ids.setdefault(key, []).append(row.candidate_spec_id)
+        representative_by_key.setdefault(key, row.candidate_spec_id)
+
+    deduped_rows: list[FastReplayPreviewRow] = []
+    for row in ranked_rows:
+        key = _frontier_dedupe_key(row)
+        group = tuple(grouped_ids[key])
+        representative = representative_by_key[key]
+        if len(group) <= 1:
+            deduped_rows.append(
+                _row_with_frontier_dedupe(
+                    row=row,
+                    frontier_dedupe_status="unique",
+                    duplicate_of_candidate_spec_id=None,
+                    duplicate_candidate_spec_ids=(),
+                )
+            )
+        elif row.candidate_spec_id == representative:
+            deduped_rows.append(
+                _row_with_frontier_dedupe(
+                    row=row,
+                    frontier_dedupe_status="representative",
+                    duplicate_of_candidate_spec_id=None,
+                    duplicate_candidate_spec_ids=tuple(
+                        candidate_spec_id
+                        for candidate_spec_id in group
+                        if candidate_spec_id != row.candidate_spec_id
+                    ),
+                )
+            )
+        else:
+            deduped_rows.append(
+                _row_with_frontier_dedupe(
+                    row=row,
+                    frontier_dedupe_status="duplicate_filtered",
+                    duplicate_of_candidate_spec_id=representative,
+                    duplicate_candidate_spec_ids=tuple(
+                        candidate_spec_id
+                        for candidate_spec_id in group
+                        if candidate_spec_id != row.candidate_spec_id
+                    ),
+                )
+            )
+    return deduped_rows
+
+
+def _frontier_dedupe_key(row: FastReplayPreviewRow) -> str:
+    return row.exact_replay_frontier_key or row.candidate_frontier_hash or row.candidate_spec_id
+
+
+def _row_frontier_duplicate_filtered(row: FastReplayPreviewRow) -> bool:
+    return row.frontier_dedupe_status == "duplicate_filtered"
+
+
 def _select_frontier_buckets(
     *,
     ranked_rows: Sequence[FastReplayPreviewRow],
@@ -687,6 +825,7 @@ def _select_frontier_buckets(
         for row in ranked_rows
         if row.selection_reason != "insufficient_replay_tape_rows"
         and not _row_explicitly_non_hpairs(row)
+        and not _row_frontier_duplicate_filtered(row)
     ]
     selected: dict[str, str] = {}
     for row in eligible[:exploitation_count]:
@@ -743,6 +882,59 @@ def _row_with_rank_and_selection(
         frontier_bucket=frontier_bucket,
         microstructure_prefilter=dict(row.microstructure_prefilter),
         proof_semantics_label=row.proof_semantics_label,
+        candidate_frontier_hash=row.candidate_frontier_hash,
+        exact_replay_frontier_key=row.exact_replay_frontier_key,
+        frontier_dedupe_status=row.frontier_dedupe_status,
+        duplicate_of_candidate_spec_id=row.duplicate_of_candidate_spec_id,
+        duplicate_candidate_spec_ids=row.duplicate_candidate_spec_ids,
+    )
+
+
+def _row_with_frontier_dedupe(
+    *,
+    row: FastReplayPreviewRow,
+    frontier_dedupe_status: str,
+    duplicate_of_candidate_spec_id: str | None,
+    duplicate_candidate_spec_ids: tuple[str, ...],
+) -> FastReplayPreviewRow:
+    selection_reason = row.selection_reason
+    if frontier_dedupe_status == "duplicate_filtered":
+        selection_reason = "fast_replay_frontier_duplicate_filtered"
+    return FastReplayPreviewRow(
+        candidate_spec_id=row.candidate_spec_id,
+        rank=row.rank,
+        preview_score=row.preview_score,
+        selected=False,
+        selection_reason=selection_reason,
+        matched_row_count=row.matched_row_count,
+        matched_symbol_count=row.matched_symbol_count,
+        requested_symbol_count=row.requested_symbol_count,
+        trading_day_count=row.trading_day_count,
+        signed_return_bps=row.signed_return_bps,
+        avg_abs_return_bps=row.avg_abs_return_bps,
+        median_spread_bps=row.median_spread_bps,
+        activity_score=row.activity_score,
+        coverage_score=row.coverage_score,
+        ofi_pressure_score=row.ofi_pressure_score,
+        microprice_bias_bps=row.microprice_bias_bps,
+        spread_tail_bps=row.spread_tail_bps,
+        return_tail_abs_bps=row.return_tail_abs_bps,
+        impact_liquidity_penalty_bps=row.impact_liquidity_penalty_bps,
+        cluster_lob_activity_score=row.cluster_lob_activity_score,
+        ofi_decay_alignment_score=row.ofi_decay_alignment_score,
+        liquidity_regime_score=row.liquidity_regime_score,
+        macro_stress_veto_score=row.macro_stress_veto_score,
+        conformal_tail_risk_penalty_bps=row.conformal_tail_risk_penalty_bps,
+        square_root_impact_capacity_penalty_bps=row.square_root_impact_capacity_penalty_bps,
+        exploration_score=row.exploration_score,
+        frontier_bucket=row.frontier_bucket,
+        microstructure_prefilter=dict(row.microstructure_prefilter),
+        proof_semantics_label=row.proof_semantics_label,
+        candidate_frontier_hash=row.candidate_frontier_hash,
+        exact_replay_frontier_key=row.exact_replay_frontier_key,
+        frontier_dedupe_status=frontier_dedupe_status,
+        duplicate_of_candidate_spec_id=duplicate_of_candidate_spec_id,
+        duplicate_candidate_spec_ids=duplicate_candidate_spec_ids,
     )
 
 
@@ -916,6 +1108,49 @@ def _square_root_impact_capacity_penalty_bps(
 
 def _candidate_notional(spec: CandidateSpec) -> float:
     return _float_or_none(spec.strategy_overrides.get("max_notional_per_trade")) or 0.0
+
+
+def _candidate_frontier_hash(spec: CandidateSpec) -> str:
+    """Hash the exact-replay execution identity, excluding hypothesis lineage.
+
+    Two candidate specs with different paper or hypothesis lineage but identical
+    runtime parameters produce the same offline replay target. The preview can
+    keep both rows for auditability while allowing only one representative into
+    the bounded exact-replay handoff.
+    """
+
+    return _stable_hash(
+        {
+            "schema_version": FAST_REPLAY_FRONTIER_IDENTITY_SCHEMA_VERSION,
+            "candidate_kind": spec.candidate_kind,
+            "family_template_id": spec.family_template_id,
+            "runtime_family": spec.runtime_family,
+            "runtime_strategy_name": spec.runtime_strategy_name,
+            "strategy_overrides": spec.strategy_overrides,
+            "objective": spec.objective,
+            "hard_vetoes": spec.hard_vetoes,
+        }
+    )
+
+
+def _exact_replay_frontier_key(
+    *,
+    replay_tape_manifest: ReplayTapeManifest,
+    candidate_frontier_hash: str,
+) -> str:
+    return _stable_hash(
+        {
+            "schema_version": FAST_REPLAY_EXACT_FRONTIER_KEY_SCHEMA_VERSION,
+            "replay_cache_key": replay_tape_manifest.replay_cache_key,
+            "dataset_snapshot_ref": replay_tape_manifest.dataset_snapshot_ref,
+            "source_query_digest": replay_tape_manifest.source_query_digest,
+            "source_table_versions": dict(replay_tape_manifest.source_table_versions),
+            "feature_schema_hash": replay_tape_manifest.feature_schema_hash,
+            "cost_model_hash": replay_tape_manifest.cost_model_hash,
+            "strategy_family": replay_tape_manifest.strategy_family,
+            "candidate_frontier_hash": candidate_frontier_hash,
+        }
+    )
 
 
 def _candidate_symbols(spec: CandidateSpec) -> tuple[str, ...]:
@@ -1202,6 +1437,30 @@ def _mapping(value: Any) -> dict[str, Any]:
         return {}
     mapping = cast(Mapping[Any, Any], value)
     return {str(key): item for key, item in mapping.items()}
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        _json_ready(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[Any, Any], value)
+        ready: dict[str, Any] = {}
+        for key in sorted(mapping.keys(), key=str):
+            ready[str(key)] = _json_ready(mapping[key])
+        return ready
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        sequence = cast(Sequence[Any], value)
+        return [_json_ready(item) for item in sequence]
+    return value
 
 
 def _string(value: Any) -> str:

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6622,6 +6622,18 @@ def _apply_fast_replay_preview_narrowing(
                 cast(Sequence[Any], preview_row.get("risk_flags") or ())
             )
             updated["fast_replay_frontier_bucket"] = preview_row["frontier_bucket"]
+            updated["fast_replay_candidate_frontier_hash"] = preview_row.get(
+                "candidate_frontier_hash"
+            )
+            updated["fast_replay_exact_replay_frontier_key"] = preview_row.get(
+                "exact_replay_frontier_key"
+            )
+            updated["fast_replay_frontier_dedupe_status"] = preview_row.get(
+                "frontier_dedupe_status"
+            )
+            updated["fast_replay_frontier_dedupe_metadata"] = preview_row.get(
+                "frontier_dedupe_metadata"
+            )
             updated["fast_replay_proof_semantics_label"] = preview_row[
                 "proof_semantics_label"
             ]
@@ -6782,9 +6794,27 @@ def _bounded_sim_target_queue_metadata(
     exploitation_slots: int,
     exploration_slots: int,
 ) -> dict[str, Any]:
-    selected_rows = [dict(row) for row in preview_rows if bool(row.get("selected"))][
-        :exact_replay_candidate_cap
+    selected_preview_rows = [
+        dict(row) for row in preview_rows if bool(row.get("selected"))
     ]
+    selected_rows: list[dict[str, Any]] = []
+    duplicate_filtered_candidate_spec_ids: list[str] = []
+    seen_frontier_keys: set[str] = set()
+    for row in selected_preview_rows:
+        frontier_key = (
+            _string(row.get("exact_replay_frontier_key"))
+            or _string(row.get("candidate_frontier_hash"))
+            or _string(row.get("candidate_spec_id"))
+        )
+        if frontier_key in seen_frontier_keys:
+            duplicate_filtered_candidate_spec_ids.append(
+                _string(row.get("candidate_spec_id"))
+            )
+            continue
+        seen_frontier_keys.add(frontier_key)
+        selected_rows.append(row)
+        if len(selected_rows) >= exact_replay_candidate_cap:
+            break
     entries: list[dict[str, Any]] = []
     for index, row in enumerate(selected_rows, start=1):
         candidate_spec_id = _string(row.get("candidate_spec_id"))
@@ -6802,6 +6832,10 @@ def _bounded_sim_target_queue_metadata(
                 "queue_priority": index,
                 "candidate_spec_id": candidate_spec_id,
                 "frontier_bucket": frontier_bucket,
+                "candidate_frontier_hash": row.get("candidate_frontier_hash"),
+                "exact_replay_frontier_key": row.get("exact_replay_frontier_key"),
+                "frontier_dedupe_status": row.get("frontier_dedupe_status"),
+                "frontier_dedupe_metadata": row.get("frontier_dedupe_metadata"),
                 "preview_rank": row.get("rank"),
                 "preview_score": row.get("preview_score"),
                 "observed_post_cost_expectancy_bps": row.get(
@@ -6867,6 +6901,17 @@ def _bounded_sim_target_queue_metadata(
         "proof_semantics": _fast_replay_preview_proof_semantics(),
         "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
         "queue_policy": "top_exploitation_plus_exploration_exact_replay_cap",
+        "dedupe_policy": {
+            "schema_version": "torghut.fast-replay-sim-target-queue-dedupe.v1",
+            "status": "enabled",
+            "dedupe_scope": "same_replay_tape_cache_and_execution_identity",
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+        },
         "runner_policy": {
             "default_shard_timeout_seconds": _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
             "default_worker_cap": _DEFAULT_REAL_REPLAY_SHARD_WORKERS,
@@ -6901,7 +6946,13 @@ def _bounded_sim_target_queue_metadata(
         "exploitation_slots": exploitation_slots,
         "exploration_slots": exploration_slots,
         "exact_replay_candidate_count": len(entries),
+        "pre_dedupe_selected_candidate_count": len(selected_preview_rows),
+        "deduped_candidate_count": len(entries),
+        "duplicate_filtered_candidate_spec_ids": duplicate_filtered_candidate_spec_ids,
         "candidate_spec_ids": [entry["candidate_spec_id"] for entry in entries],
+        "exact_replay_frontier_keys": [
+            entry["exact_replay_frontier_key"] for entry in entries
+        ],
         "handoff_lineage_hashes": [entry["handoff_lineage_hash"] for entry in entries],
         "entries": entries,
     }
@@ -6928,6 +6979,10 @@ def _fast_replay_exact_handoff_lineage(
         "candidate_spec_id": candidate_spec_id,
         "queue_priority": queue_priority,
         "frontier_bucket": frontier_bucket,
+        "candidate_frontier_hash": row.get("candidate_frontier_hash"),
+        "exact_replay_frontier_key": row.get("exact_replay_frontier_key"),
+        "frontier_dedupe_status": row.get("frontier_dedupe_status"),
+        "frontier_dedupe_metadata": row.get("frontier_dedupe_metadata"),
         "preview_rank": row.get("rank"),
         "preview_score": row.get("preview_score"),
         "proof_semantics_label": row.get("proof_semantics_label"),

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -459,7 +459,12 @@ class TestFastReplayPreview(TestCase):
                 source_query_digest=build_source_query_digest({"window": "cap"}),
             )
         specs = tuple(
-            self._spec(f"spec-{index}", symbols=["AAA"]) for index in range(8)
+            self._spec(
+                f"spec-{index}",
+                symbols=["AAA"],
+                max_notional_per_trade=str(2500 + index),
+            )
+            for index in range(8)
         )
 
         preview = build_fast_replay_preview(
@@ -487,4 +492,89 @@ class TestFastReplayPreview(TestCase):
                 "exploration",
                 "exploration",
             ],
+        )
+
+    def test_frontier_selection_dedupes_equivalent_exact_replay_targets(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            rows = [
+                self._signal(
+                    symbol="AAA", offset=index, price=str(100 + index), ofi="0.50"
+                )
+                for index in range(1, 6)
+            ]
+            manifest = materialize_signal_tape(
+                rows=rows,
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-dedupe",
+                symbols=("AAA",),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest({"window": "dedupe"}),
+                feature_schema_hash="feature-dedupe",
+                cost_model_hash="cost-dedupe",
+                strategy_family="hpairs-dedupe",
+            )
+        representative = self._spec("spec-a-representative", symbols=["AAA"])
+        duplicate = self._spec("spec-b-duplicate", symbols=["AAA"])
+        unique = self._spec(
+            "spec-c-unique",
+            symbols=["AAA"],
+            max_notional_per_trade="5000",
+        )
+
+        preview = build_fast_replay_preview(
+            specs=(representative, duplicate, unique),
+            rows=rows,
+            replay_tape_manifest=manifest,
+            top_k=3,
+            min_rows_per_candidate=2,
+            exploitation_count=3,
+            exploration_count=0,
+            exact_replay_candidate_cap=3,
+        )
+
+        self.assertEqual(
+            preview.selected_candidate_spec_ids,
+            ("spec-a-representative", "spec-c-unique"),
+        )
+        payloads = {row.candidate_spec_id: row.to_payload() for row in preview.rows}
+        representative_payload = payloads["spec-a-representative"]
+        duplicate_payload = payloads["spec-b-duplicate"]
+        self.assertEqual(
+            representative_payload["frontier_dedupe_status"], "representative"
+        )
+        self.assertEqual(
+            duplicate_payload["frontier_dedupe_status"], "duplicate_filtered"
+        )
+        self.assertEqual(
+            duplicate_payload["selection_reason"],
+            "fast_replay_frontier_duplicate_filtered",
+        )
+        self.assertFalse(duplicate_payload["selected"])
+        self.assertEqual(
+            duplicate_payload["duplicate_of_candidate_spec_id"],
+            "spec-a-representative",
+        )
+        self.assertEqual(
+            representative_payload["candidate_frontier_hash"],
+            duplicate_payload["candidate_frontier_hash"],
+        )
+        self.assertEqual(
+            representative_payload["exact_replay_frontier_key"],
+            duplicate_payload["exact_replay_frontier_key"],
+        )
+        self.assertFalse(
+            duplicate_payload["frontier_dedupe_metadata"]["proof_authority"]
+        )
+        self.assertFalse(
+            duplicate_payload["frontier_dedupe_metadata"]["promotion_allowed"]
+        )
+        manifest_payload = preview.to_manifest_payload()
+        self.assertEqual(
+            manifest_payload["frontier_dedupe_policy"]["status"], "enabled"
+        )
+        self.assertFalse(
+            manifest_payload["frontier_dedupe_policy"]["promotion_allowed"]
         )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4695,7 +4695,11 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 source_table_versions={"signals": "v1"},
             )
             specs = [
-                self._candidate_spec(f"spec-frontier-{index}") for index in range(8)
+                self._candidate_spec(
+                    f"spec-frontier-{index}",
+                    entry_minute_after_open=str(45 + index),
+                )
+                for index in range(8)
             ]
             args = self._args(output_dir)
             args.replay_mode = "real"
@@ -4890,6 +4894,105 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn(
             "impact_capacity_lineage",
             first_entry["hpairs_microstructure_prefilter"],
+        )
+
+    def test_bounded_sim_target_queue_dedupes_duplicate_frontier_keys(self) -> None:
+        manifest = ReplayTapeManifest(
+            schema_version=REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
+            dataset_snapshot_ref="queue-dedupe-snapshot",
+            symbols=("NVDA",),
+            row_symbols=("NVDA",),
+            start_date=date(2026, 2, 23),
+            end_date=date(2026, 2, 23),
+            start_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc),
+            end_ts=datetime(2026, 2, 23, 21, 0, tzinfo=timezone.utc),
+            min_event_ts=None,
+            max_event_ts=None,
+            trading_day_count=1,
+            row_count=0,
+            source_query_digest="queue-dedupe-query",
+            content_sha256="queue-dedupe-sha",
+            artifact_refs={},
+            source_table_versions={"signals": "v1"},
+            created_at=datetime(2026, 2, 24, tzinfo=timezone.utc),
+            feature_schema_hash="queue-feature",
+            cost_model_hash="queue-cost",
+            strategy_family="queue-family",
+            replay_cache_key="queue-cache-key",
+        )
+        duplicate_rows = [
+            {
+                "candidate_spec_id": "spec-a",
+                "selected": True,
+                "rank": 1,
+                "frontier_bucket": "exploitation",
+                "preview_score": "10",
+                "proof_semantics_label": fast_replay.FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+                "candidate_frontier_hash": "candidate-frontier-a",
+                "exact_replay_frontier_key": "exact-frontier-a",
+                "frontier_dedupe_status": "representative",
+                "frontier_dedupe_metadata": {
+                    "proof_authority": False,
+                    "promotion_allowed": False,
+                },
+            },
+            {
+                "candidate_spec_id": "spec-b",
+                "selected": True,
+                "rank": 2,
+                "frontier_bucket": "exploitation",
+                "preview_score": "9",
+                "proof_semantics_label": fast_replay.FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+                "candidate_frontier_hash": "candidate-frontier-a",
+                "exact_replay_frontier_key": "exact-frontier-a",
+                "frontier_dedupe_status": "duplicate_filtered",
+                "frontier_dedupe_metadata": {
+                    "proof_authority": False,
+                    "promotion_allowed": False,
+                },
+            },
+            {
+                "candidate_spec_id": "spec-c",
+                "selected": True,
+                "rank": 3,
+                "frontier_bucket": "exploration",
+                "preview_score": "8",
+                "proof_semantics_label": fast_replay.FAST_REPLAY_PROOF_SEMANTICS_LABEL,
+                "candidate_frontier_hash": "candidate-frontier-c",
+                "exact_replay_frontier_key": "exact-frontier-c",
+                "frontier_dedupe_status": "unique",
+                "frontier_dedupe_metadata": {
+                    "proof_authority": False,
+                    "promotion_allowed": False,
+                },
+            },
+        ]
+
+        queue_payload = runner._bounded_sim_target_queue_metadata(
+            preview_rows=duplicate_rows,
+            replay_tape_manifest=manifest,
+            exact_replay_candidate_cap=6,
+            exploitation_slots=4,
+            exploration_slots=2,
+        )
+
+        self.assertEqual(queue_payload["pre_dedupe_selected_candidate_count"], 3)
+        self.assertEqual(queue_payload["exact_replay_candidate_count"], 2)
+        self.assertEqual(queue_payload["duplicate_filtered_candidate_spec_ids"], ["spec-b"])
+        self.assertEqual(queue_payload["candidate_spec_ids"], ["spec-a", "spec-c"])
+        self.assertEqual(
+            queue_payload["exact_replay_frontier_keys"],
+            ["exact-frontier-a", "exact-frontier-c"],
+        )
+        self.assertEqual(queue_payload["dedupe_policy"]["status"], "enabled")
+        self.assertFalse(queue_payload["dedupe_policy"]["proof_authority"])
+        self.assertFalse(queue_payload["dedupe_policy"]["promotion_allowed"])
+        self.assertFalse(queue_payload["promotion_allowed"])
+        self.assertEqual(
+            queue_payload["entries"][0]["exact_replay_handoff_lineage"][
+                "exact_replay_frontier_key"
+            ],
+            "exact-frontier-a",
         )
 
     def test_staged_replay_frontier_default_resolvers_fail_closed(self) -> None:


### PR DESCRIPTION
## Summary

- Added deterministic H-PAIRS fast-replay frontier identity hashes that combine replay-tape cache identity with candidate execution identity.
- Dedupe equivalent exact-replay targets before bounded frontier selection while preserving duplicate rows as preview-only audit metadata.
- Propagated dedupe keys/status into autoresearch candidate-selection rows, bounded SIM target queue entries, and exact replay handoff lineage.
- Added focused coverage for duplicate filtering, six-candidate caps, queue dedupe, and non-authority semantics.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_run_whitepaper_autoresearch_profit_target.py` — pass
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` — pass (216 passed, 1 warning)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` — pass
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` — pass
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` — fails on pre-existing out-of-scope `app/options_lane/*` deprecated contextmanager annotations; no errors in touched files
- `git diff --check` — pass

## Screenshots (if applicable)

N/A — backend discovery metadata and tests only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
