### PR TITLE
fix(torghut): activate hpairs runtime target lineage

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -41,6 +41,7 @@ from ..runtime_decision_authority import (
     normalize_source_decision_mode,
     source_decision_mode_is_profit_proof_eligible,
 )
+from ..runtime_strategy_resolution import strategy_names_from_strategy_id
 from ..session_context import regular_session_open_utc_for
 from ..simple_risk import (
     position_qty_for_symbol,
@@ -198,7 +199,8 @@ def _target_plan_lineage(
             continue
         candidate_id = _safe_text(target.get("candidate_id"))
         hypothesis_id = _safe_text(target.get("hypothesis_id"))
-        strategy_name = _safe_text(target.get("strategy_name"))
+        target_strategy_names = _target_lineage_strategy_names(target)
+        strategy_name = target_strategy_names[0] if target_strategy_names else None
         item = {
             key: value
             for key, value in {
@@ -214,14 +216,29 @@ def _target_plan_lineage(
             candidate_ids.append(candidate_id)
         if hypothesis_id and hypothesis_id not in hypothesis_ids:
             hypothesis_ids.append(hypothesis_id)
-        if strategy_name and strategy_name not in strategy_names:
-            strategy_names.append(strategy_name)
+        for target_strategy_name in target_strategy_names:
+            if target_strategy_name not in strategy_names:
+                strategy_names.append(target_strategy_name)
     return {
         "paper_route_probe_lineage_targets": lineage_targets,
         "source_candidate_ids": candidate_ids,
         "source_hypothesis_ids": hypothesis_ids,
         "source_strategy_names": strategy_names,
     }
+
+
+def _target_lineage_strategy_names(target: Mapping[str, Any]) -> list[str]:
+    names: list[str] = []
+    for value in (
+        target.get("strategy_name"),
+        target.get("runtime_strategy_name"),
+    ):
+        _merge_unique_texts(names, _lineage_text_values(value))
+    for resolved_name in strategy_names_from_strategy_id(target.get("strategy_id")):
+        _merge_unique_texts(names, [resolved_name])
+    if not names:
+        _merge_unique_texts(names, _lineage_text_values(target.get("strategy_id")))
+    return names
 
 
 def _bounded_sim_collection_blockers(
@@ -255,6 +272,7 @@ def _bounded_sim_collection_blockers(
         _safe_text(target.get("runtime_strategy_name"))
         or _safe_text(target.get("strategy_name"))
         or _lineage_text_values(target.get("source_strategy_names"))
+        or strategy_names_from_strategy_id(target.get("strategy_id"))
     ):
         blockers.append("bounded_sim_collection_runtime_strategy_missing")
     if _safe_text(target.get("source_manifest_ref")) is None:
@@ -490,13 +508,30 @@ def _bounded_sim_collection_metadata_from_decision(
 
 def _target_lookup_names(target: Mapping[str, Any]) -> list[str]:
     names: list[str] = []
+    strategy_id = target.get("strategy_id")
     for value in (
-        target.get("strategy_id"),
+        strategy_id,
         target.get("runtime_strategy_name"),
         target.get("strategy_name"),
         target.get("strategy_lookup_names"),
     ):
         _merge_unique_texts(names, _lineage_text_values(value))
+    for resolved_name in strategy_names_from_strategy_id(strategy_id):
+        _merge_unique_texts(names, [resolved_name])
+    return names
+
+
+def _strategy_lookup_names(strategy: Strategy) -> list[str]:
+    names: list[str] = []
+    _merge_unique_texts(names, _lineage_text_values(str(strategy.id)))
+    _merge_unique_texts(names, _lineage_text_values(strategy.name))
+
+    metadata = extract_catalog_metadata(strategy.description)
+    for key in ("strategy_id", "runtime_strategy_name", "strategy_name"):
+        _merge_unique_texts(names, _lineage_text_values(metadata.get(key)))
+    declared_strategy_id = metadata.get("strategy_id")
+    for resolved_name in strategy_names_from_strategy_id(declared_strategy_id):
+        _merge_unique_texts(names, [resolved_name])
     return names
 
 
@@ -3316,11 +3351,19 @@ class SimpleTradingPipeline(TradingPipeline):
         target: Mapping[str, Any],
         strategies: Sequence[Strategy],
     ) -> Strategy | None:
-        lookup_names = set(_target_lookup_names(target))
+        lookup_names = {
+            value.strip().lower()
+            for value in _target_lookup_names(target)
+            if value.strip()
+        }
         if not lookup_names:
             return None
         for strategy in strategies:
-            if str(strategy.id) in lookup_names or strategy.name in lookup_names:
+            if any(
+                candidate.strip().lower() in lookup_names
+                for candidate in _strategy_lookup_names(strategy)
+                if candidate.strip()
+            ):
                 return strategy
         return None
 
@@ -4117,8 +4160,7 @@ class SimpleTradingPipeline(TradingPipeline):
             str(decision.strategy_id).strip(),
         }
         if strategy is not None:
-            candidate_names.add(str(strategy.id))
-            candidate_names.add(str(strategy.name))
+            candidate_names.update(_strategy_lookup_names(strategy))
         return any(
             candidate.strip().lower() in lookup_names
             for candidate in candidate_names

--- a/services/torghut/scripts/audit_hpairs_signal_liveness.py
+++ b/services/torghut/scripts/audit_hpairs_signal_liveness.py
@@ -34,6 +34,7 @@ NEXT_ACTIONS = (
     "route_disabled",
     "evidence_collection_disabled",
     "materialize_drift_checks",
+    "materialize_runtime_buckets",
     "wait_for_fresh_signal_window",
     "wait_for_market_session_open",
     "ready_to_submit_sim_order",
@@ -307,6 +308,7 @@ def _symbols_from_target(target: Mapping[str, object]) -> list[str]:
         "symbol_universe",
         "required_symbols",
         "pair_symbols",
+        "paper_route_probe_symbols",
         "legs",
     ):
         raw_value = target.get(key)
@@ -589,6 +591,84 @@ def _signal_drift_readiness_report(
     }
 
 
+def _runtime_materialization_count(
+    containers: Sequence[Mapping[str, object]],
+    keys: Sequence[str],
+) -> float | None:
+    for container in containers:
+        value = _first_value_from_keys(container, keys)
+        count = _float_or_none(value)
+        if count is not None:
+            return count
+    return None
+
+
+def _runtime_materialization_report(
+    *,
+    source: Mapping[str, object],
+    status: Mapping[str, object],
+    target: Mapping[str, object],
+) -> dict[str, object]:
+    observed = _mapping(status.get("observed")) or _mapping(source.get("observed"))
+    containers = [observed, status, target, source]
+    decision_count = _runtime_materialization_count(
+        containers,
+        (
+            "hpairs_decisions",
+            "h_pairs_decisions",
+            "recent_hpairs_decisions",
+            "decision_count",
+            "decisions_count",
+            "recent_decision_count",
+        ),
+    )
+    order_event_count = _runtime_materialization_count(
+        containers,
+        (
+            "hpairs_order_events",
+            "h_pairs_order_events",
+            "recent_hpairs_order_events",
+            "order_event_count",
+            "order_events_count",
+            "recent_order_event_count",
+        ),
+    )
+    runtime_bucket_count = _runtime_materialization_count(
+        containers,
+        (
+            "hpairs_runtime_buckets",
+            "h_pairs_runtime_buckets",
+            "recent_hpairs_runtime_buckets",
+            "runtime_bucket_count",
+            "runtime_buckets_count",
+            "recent_runtime_bucket_count",
+        ),
+    )
+    counts = {
+        "decision_count": decision_count,
+        "order_event_count": order_event_count,
+        "runtime_bucket_count": runtime_bucket_count,
+    }
+    observed_counts: dict[str, float] = {
+        key: value for key, value in counts.items() if value is not None
+    }
+    zero_fields = sorted(key for key, value in observed_counts.items() if value <= 0)
+    return {
+        "observed_any": bool(observed_counts),
+        "counts": counts,
+        "zero_fields": zero_fields,
+        "ready": bool(observed_counts) and not zero_fields,
+        "window": _text(
+            observed.get("window")
+            or status.get("window")
+            or source.get("window")
+            or observed.get("recent_window")
+            or status.get("recent_window")
+            or source.get("recent_window")
+        ),
+    }
+
+
 def _veto_report(
     target: Mapping[str, object],
     signal: Mapping[str, object],
@@ -691,6 +771,8 @@ def _choose_next_action(blocker_codes: Sequence[str], unsupported: bool) -> str:
         return "evidence_collection_disabled"
     if "drift_checks_missing" in blockers:
         return "materialize_drift_checks"
+    if "runtime_materialization_missing" in blockers:
+        return "materialize_runtime_buckets"
     if "signal_lag_exceeded" in blockers:
         return "wait_for_fresh_signal_window"
     if "market_session_closed" in blockers:
@@ -747,6 +829,11 @@ def build_liveness_report(
         signal=signal,
         expectations=expectations,
     )
+    runtime_materialization = _runtime_materialization_report(
+        source=source,
+        status=status,
+        target=target,
+    )
     vetoes = _veto_report(target, signal, risk)
     route_flags = _flag_report((target, status, route), _ROUTE_FLAG_KEYS)
     evidence_flags = _flag_report((target, status, route), _EVIDENCE_COLLECTION_KEYS)
@@ -785,6 +872,8 @@ def build_liveness_report(
     if evidence_flags["disabled_flags"]:
         blocker_codes.append("evidence_collection_disabled")
     blocker_codes.extend(cast(Sequence[str], signal_drift_readiness["blockers"]))
+    if runtime_materialization["zero_fields"]:
+        blocker_codes.append("runtime_materialization_missing")
 
     explicit_blockers = _unique_text_items(source.get("blockers"))
     explicit_blockers.extend(
@@ -840,6 +929,7 @@ def build_liveness_report(
         "latest_quote_availability": quote_report,
         "signal_threshold_status": signal_report,
         "signal_drift_readiness": signal_drift_readiness,
+        "runtime_materialization_status": runtime_materialization,
         "entry_exit_vetoes": vetoes,
         "route_eligibility_flags": route_flags,
         "simple_submit_flag_state": submit_flags,

--- a/services/torghut/tests/test_audit_hpairs_signal_liveness.py
+++ b/services/torghut/tests/test_audit_hpairs_signal_liveness.py
@@ -156,6 +156,29 @@ def test_collection_disabled_fixture_classifies_evidence_collection_disabled(
     ]
 
 
+def test_zero_runtime_materialization_classifies_materialize_runtime_buckets(
+    tmp_path: Path,
+) -> None:
+    fixture = _base_fixture()
+    fixture["observed"] = {
+        "hpairs_decisions": 0,
+        "hpairs_order_events": 0,
+        "hpairs_runtime_buckets": 0,
+        "recent_window": "2026-06-01T14:00:00Z/PT30M",
+    }
+
+    report = _run_fixture(tmp_path, fixture)
+
+    assert report["next_action"] == "materialize_runtime_buckets"
+    assert "runtime_materialization_missing" in report["blocker_codes"]
+    assert report["runtime_materialization_status"]["zero_fields"] == [
+        "decision_count",
+        "order_event_count",
+        "runtime_bucket_count",
+    ]
+    assert report["ready_to_submit_sim_order"] is False
+
+
 def test_missing_drift_checks_fixture_classifies_materialize_drift_checks(
     tmp_path: Path,
 ) -> None:
@@ -352,6 +375,19 @@ def test_symbol_fallback_from_features_and_unsupported_symbol_universe() -> None
     assert (
         "unsupported_symbol_universe_inputs" in report_without_symbols["blocker_codes"]
     )
+
+
+def test_paper_route_probe_symbols_drive_market_data_liveness() -> None:
+    fixture = _base_fixture()
+    target = fixture["target"]
+    assert isinstance(target, dict)
+    target.pop("symbols")
+    target["paper_route_probe_symbols"] = ["amzn", "aapl"]
+
+    report = audit.build_liveness_report(fixture, _expectations())
+
+    assert report["symbol_universe"]["symbols"] == ["AAPL", "AMZN"]
+    assert report["next_action"] == "ready_to_submit_sim_order"
 
 
 def test_helper_normalizers_cover_non_fixture_shapes(tmp_path: Path) -> None:

--- a/services/torghut/tests/test_trading_scheduler_safety.py
+++ b/services/torghut/tests/test_trading_scheduler_safety.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from app import config
 from app.models import Strategy
+from app.strategies.catalog import StrategyConfig, _compose_strategy_description
 from app.trading.scheduler.simple_pipeline import (
     SimpleTradingPipeline,
     _target_pair_balance_state,
@@ -329,7 +330,11 @@ class TestTradingSchedulerSafety(TestCase):
             "_external_paper_route_target_probe_symbols_cached",
             lambda: ({"AAPL", "AMZN", "MSFT"}, None, [target]),
         )
-        setattr(pipeline, "_paper_route_target_strategy", lambda _target, _strategies: strategy)
+        setattr(
+            pipeline,
+            "_paper_route_target_strategy",
+            lambda _target, _strategies: strategy,
+        )
         setattr(
             pipeline,
             "_paper_route_target_strategy_symbols",
@@ -339,7 +344,10 @@ class TestTradingSchedulerSafety(TestCase):
         config.settings.trading_simple_paper_route_probe_enabled = True
         config.settings.trading_allow_shorts = True
 
-        with patch("app.trading.scheduler.simple_pipeline.trading_now", return_value=window_start):
+        with patch(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            return_value=window_start,
+        ):
             decisions = pipeline._paper_route_target_source_decisions(
                 strategies=[strategy],
                 allowed_symbols=set(),
@@ -376,7 +384,11 @@ class TestTradingSchedulerSafety(TestCase):
             "_external_paper_route_target_probe_symbols_cached",
             lambda: ({"AAPL", "AMZN"}, None, [target]),
         )
-        setattr(pipeline, "_paper_route_target_strategy", lambda _target, _strategies: strategy)
+        setattr(
+            pipeline,
+            "_paper_route_target_strategy",
+            lambda _target, _strategies: strategy,
+        )
         setattr(
             pipeline,
             "_paper_route_target_strategy_symbols",
@@ -386,13 +398,93 @@ class TestTradingSchedulerSafety(TestCase):
         config.settings.trading_simple_paper_route_probe_enabled = True
         config.settings.trading_allow_shorts = False
 
-        with patch("app.trading.scheduler.simple_pipeline.trading_now", return_value=window_start):
+        with patch(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            return_value=window_start,
+        ):
             decisions = pipeline._paper_route_target_source_decisions(
                 strategies=[strategy],
                 allowed_symbols=set(),
             )
 
         self.assertEqual(decisions, [])
+
+    def test_hpairs_target_strategy_matches_declared_catalog_strategy_id(self) -> None:
+        window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "account_label": "TORGHUT_SIM",
+            "observed_stage": "paper",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+            "source_manifest_ref": "runtime-window:H-PAIRS-01",
+            "source_decision_readiness": {"ready": True, "blockers": []},
+            "bounded_evidence_collection_authorized": True,
+            "evidence_collection_ok": True,
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_symbol_actions": {"AAPL": "buy", "AMZN": "sell"},
+            "paper_route_probe_next_session_max_notional": "1000",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+        }
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-cross-sectional-pairs-v1",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_type="microbar_cross_sectional_pairs_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_notional_per_trade=Decimal("1000"),
+                    params={"max_pair_legs": "2"},
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "_is_market_session_open", lambda _now: True)
+        setattr(
+            pipeline,
+            "_external_paper_route_target_probe_symbols_cached",
+            lambda: ({"AAPL", "AMZN"}, None, [target]),
+        )
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = True
+
+        with patch(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            return_value=window_start,
+        ):
+            scope = pipeline._bounded_paper_route_signal_scope([strategy])
+            decisions = pipeline._paper_route_target_source_decisions(
+                strategies=[strategy],
+                allowed_symbols=set(),
+                positions=[],
+            )
+
+        self.assertEqual(scope, ({"AAPL", "AMZN"}, {"1Sec"}))
+        self.assertEqual([decision.symbol for decision in decisions], ["AAPL", "AMZN"])
+        self.assertEqual(
+            [decision.params["source_decision_mode"] for decision in decisions],
+            ["bounded_paper_route_collection", "bounded_paper_route_collection"],
+        )
+        self.assertTrue(
+            all(decision.params["profit_proof_eligible"] for decision in decisions)
+        )
+        self.assertEqual(
+            decisions[0].params["source_strategy_names"],
+            ["microbar-cross-sectional-pairs-v1"],
+        )
 
     def test_emergency_stop_triggers_on_signal_lag(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Preserves H-PAIRS target lineage when the target plan carries the declared family strategy id instead of only the runtime strategy name.
- Lets bounded TORGHUT_SIM paper-route source decisions and scoped signal polling match catalog-managed H-PAIRS strategies via declared ids, runtime harness names, and DB row names.
- Extends the H-PAIRS liveness audit to treat `paper_route_probe_symbols` as the market-data universe and to surface zero decisions, order events, or runtime buckets as an actionable runtime materialization blocker.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (passed after installing build-essential so crosshair-tool could compile in this container)
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py scripts/audit_hpairs_signal_liveness.py tests/test_trading_scheduler_safety.py tests/test_audit_hpairs_signal_liveness.py` (passed)
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py scripts/audit_hpairs_signal_liveness.py tests/test_trading_scheduler_safety.py tests/test_audit_hpairs_signal_liveness.py` (passed)
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_runtime.py tests/test_trading_scheduler_autonomy.py tests/test_trading_scheduler_safety.py tests/test_audit_hpairs_signal_liveness.py -q` (passed, 177 tests)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json` (passed, 0 errors each)
- `git diff --check` (passed)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
