### PR TITLE
fix(torghut): add tigerbeetle stable audit refs

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_ids.py
+++ b/services/torghut/app/trading/tigerbeetle_ids.py
@@ -35,6 +35,51 @@ def stable_u128(namespace: str, key: str) -> int:
     return value
 
 
+def stable_ref_u128(
+    *,
+    cluster_id: int,
+    account_label: str | None,
+    source_type: str,
+    source_id: str,
+    transfer_kind: str,
+    source_signature: str | None = None,
+) -> int:
+    """Derive a deterministic journal-ref ID from the audit source identity.
+
+    This is deliberately separate from the TigerBeetle transfer ID so existing
+    ledger transfers remain idempotent. The journal-ref ID gives proof/readiness
+    consumers a stable audit handle whose derivation includes the cluster,
+    account, source row, transfer kind, and optional source/economic signature.
+    """
+
+    normalized_cluster_id = int(cluster_id)
+    normalized_account_label = (account_label or "unknown").strip() or "unknown"
+    normalized_source_type = source_type.strip()
+    normalized_source_id = source_id.strip()
+    normalized_transfer_kind = transfer_kind.strip()
+    normalized_source_signature = (source_signature or "none").strip() or "none"
+    if normalized_cluster_id <= 0:
+        raise ValueError("tigerbeetle_cluster_id_invalid")
+    if not normalized_source_type:
+        raise ValueError("tigerbeetle_source_type_empty")
+    if not normalized_source_id:
+        raise ValueError("tigerbeetle_source_id_empty")
+    if not normalized_transfer_kind:
+        raise ValueError("tigerbeetle_transfer_kind_empty")
+
+    key = "\0".join(
+        (
+            f"cluster:{normalized_cluster_id}",
+            f"account:{normalized_account_label}",
+            f"source_type:{normalized_source_type}",
+            f"source_id:{normalized_source_id}",
+            f"transfer_kind:{normalized_transfer_kind}",
+            f"source_signature:{normalized_source_signature}",
+        )
+    )
+    return stable_u128("torghut.tigerbeetle.journal_ref", key)
+
+
 def u128_decimal(value: int) -> str:
     """Serialize a TigerBeetle u128 for Postgres storage."""
 

--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from decimal import Decimal
 import hashlib
+import json
 from types import TracebackType
 from typing import Any, Self, cast
 
@@ -27,7 +28,7 @@ from app.trading.tigerbeetle_client import (
     TigerBeetleClientProtocol,
     create_tigerbeetle_client,
 )
-from app.trading.tigerbeetle_ids import stable_u128, u128_decimal
+from app.trading.tigerbeetle_ids import stable_ref_u128, stable_u128, u128_decimal
 from app.trading.tigerbeetle_ledger_model import (
     ACCOUNT_CODE_CASH_CONTROL,
     ACCOUNT_CODE_EVIDENCE_CONTROL,
@@ -61,6 +62,8 @@ SOURCE_TYPE_RUNTIME_LEDGER_BUCKET = "strategy_runtime_ledger_bucket"
 TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_PARITY_SCHEMA_VERSION = (
     "torghut.tigerbeetle-runtime-ledger-journal-parity.v1"
 )
+TIGERBEETLE_STABLE_REF_SCHEMA_VERSION = "torghut.tigerbeetle-stable-ref.v1"
+TIGERBEETLE_STABLE_REF_NAMESPACE = "torghut.tigerbeetle.journal_ref"
 TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS = "pass"
 TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_NON_AUTHORITY_BLOCKED = (
     "non_authority_blocked"
@@ -146,6 +149,122 @@ def _lookup_payload_decimal(
 
 def _nested_mapping(value: object) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _stable_ref_source_signature(
+    payload_json: Mapping[str, object],
+    *,
+    event_fingerprint: str | None = None,
+) -> str | None:
+    for key in (
+        "source_economic_fingerprint",
+        "runtime_key",
+        "economic_event_key",
+        "event_fingerprint",
+    ):
+        value = payload_json.get(key)
+        text = str(value).strip() if value is not None else ""
+        if text:
+            if key == "economic_event_key":
+                return hashlib.sha256(text.encode("utf-8")).hexdigest()
+            return text
+    return event_fingerprint
+
+
+def _stable_ref_account_label(
+    account_specs: Sequence[TigerBeetleAccountSpec],
+    payload_json: Mapping[str, object],
+) -> str | None:
+    payload_account_label = str(payload_json.get("account_label") or "").strip()
+    if payload_account_label:
+        return payload_account_label
+    for spec in account_specs:
+        account_label = (spec.account_label or "").strip()
+        if account_label:
+            return account_label
+    return None
+
+
+def _payload_account_ids(
+    payload_json: Mapping[str, object],
+    account_specs: Sequence[TigerBeetleAccountSpec],
+) -> list[str]:
+    account_ids = [u128_decimal(spec.account_id) for spec in account_specs]
+    raw_account_ids = payload_json.get("account_ids")
+    if isinstance(raw_account_ids, Sequence) and not isinstance(
+        raw_account_ids, (str, bytes, bytearray)
+    ):
+        for value in cast(Sequence[object], raw_account_ids):
+            account_id = str(value).strip() if value is not None else ""
+            if account_id and account_id not in account_ids:
+                account_ids.append(account_id)
+    for key in ("debit_account_id", "credit_account_id"):
+        value = payload_json.get(key)
+        account_id = str(value).strip() if value is not None else ""
+        if account_id and account_id not in account_ids:
+            account_ids.append(account_id)
+    return sorted(account_ids)
+
+
+def tigerbeetle_stable_ref_payload(
+    *,
+    cluster_id: int,
+    account_specs: Sequence[TigerBeetleAccountSpec],
+    transfer_spec: TigerBeetleTransferSpec,
+    source_type: str,
+    source_id: str,
+    payload_json: Mapping[str, object],
+    event_fingerprint: str | None = None,
+) -> dict[str, object]:
+    """Return a signed, deterministic audit-ref payload for a transfer ref.
+
+    TigerBeetle transfer IDs are immutable once written. This stable ref is a
+    source-backed audit handle that includes cluster/account/source/kind inputs
+    without rewriting old transfer IDs or letting TigerBeetle become promotion
+    authority.
+    """
+
+    account_label = _stable_ref_account_label(account_specs, payload_json)
+    source_signature = _stable_ref_source_signature(
+        payload_json,
+        event_fingerprint=event_fingerprint,
+    )
+    components = {
+        "cluster_id": int(cluster_id),
+        "account_label": account_label or "unknown",
+        "source_type": source_type,
+        "source_id": source_id,
+        "transfer_kind": transfer_spec.transfer_kind,
+        "source_signature": source_signature or "none",
+    }
+    stable_ref_id = u128_decimal(
+        stable_ref_u128(
+            cluster_id=int(cluster_id),
+            account_label=account_label,
+            source_type=source_type,
+            source_id=source_id,
+            transfer_kind=transfer_spec.transfer_kind,
+            source_signature=source_signature,
+        )
+    )
+    stable_ref: dict[str, object] = {
+        "schema_version": TIGERBEETLE_STABLE_REF_SCHEMA_VERSION,
+        "derivation_namespace": TIGERBEETLE_STABLE_REF_NAMESPACE,
+        "stable_ref_id": stable_ref_id,
+        "components": components,
+        "account_ids": _payload_account_ids(payload_json, account_specs),
+        "account_keys": sorted({spec.account_key for spec in account_specs}),
+        "transfer_id": u128_decimal(transfer_spec.transfer_id),
+        "ledger": transfer_spec.ledger,
+        "code": transfer_spec.code,
+        "amount": str(transfer_spec.amount),
+        "authority": "accounting_parity_only",
+        "promotion_authority": False,
+        "overrides_runtime_ledger_authority": False,
+    }
+    canonical = json.dumps(stable_ref, sort_keys=True, separators=(",", ":"))
+    stable_ref["payload_hash"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return {"stable_ref": stable_ref, "stable_ref_id": stable_ref_id}
 
 
 def _payload_text_list(value: object) -> list[str]:
@@ -247,6 +366,9 @@ def tigerbeetle_runtime_ledger_journal_payload(
                 account_id = str(raw_account_id)
                 if account_id not in account_ids:
                     account_ids.append(account_id)
+    stable_ref_payload = _nested_mapping(transfer_payload.get("stable_ref"))
+    stable_ref_id = str(stable_ref_payload.get("stable_ref_id") or "").strip()
+    stable_refs = [stable_ref_payload] if stable_ref_id else []
     for account_ref in account_refs:
         if account_ref.account_id not in account_ids:
             account_ids.append(account_ref.account_id)
@@ -275,10 +397,14 @@ def tigerbeetle_runtime_ledger_journal_payload(
             "account_keys": sorted({row.account_key for row in account_refs}),
             "transfer_count": len(transfer_ids),
             "transfer_ids": sorted(transfer_ids),
+            "stable_ref_count": len(stable_refs),
+            "stable_ref_ids": [stable_ref_id] if stable_ref_id else [],
+            "stable_refs": stable_refs,
             "source_refs": source_refs,
             "transfer": {
                 "cluster_id": ref.cluster_id,
                 "transfer_id": ref.transfer_id,
+                "stable_ref_id": stable_ref_id or None,
                 "transfer_kind": ref.transfer_kind,
                 "ledger": ref.ledger,
                 "code": ref.code,
@@ -1212,6 +1338,18 @@ class TigerBeetleLedgerJournal:
         payload_json: Mapping[str, object],
     ) -> TigerBeetleTransferRef:
         transfer_id_text = u128_decimal(transfer_spec.transfer_id)
+        payload_json = {
+            **payload_json,
+            **tigerbeetle_stable_ref_payload(
+                cluster_id=self._settings.tigerbeetle_cluster_id,
+                account_specs=account_specs,
+                transfer_spec=transfer_spec,
+                source_type=source_type,
+                source_id=source_id,
+                payload_json=payload_json,
+                event_fingerprint=event_fingerprint,
+            ),
+        }
         source_existing = session.execute(
             select(TigerBeetleTransferRef).where(
                 TigerBeetleTransferRef.cluster_id
@@ -1317,6 +1455,76 @@ class TigerBeetleLedgerJournal:
         session.add(ref)
         session.flush()
         return ref
+
+    def backfill_stable_ref_payloads(
+        self,
+        session: Session,
+        *,
+        limit: int = 1000,
+    ) -> dict[str, object]:
+        """Backfill stable audit-ref payloads on existing PostgreSQL refs only."""
+
+        if (
+            not self._settings.tigerbeetle_enabled
+            or not self._settings.tigerbeetle_journal_enabled
+        ):
+            return {"selected": 0, "updated": 0, "skipped": 0}
+
+        refs = (
+            session.execute(
+                select(TigerBeetleTransferRef)
+                .where(
+                    TigerBeetleTransferRef.cluster_id
+                    == self._settings.tigerbeetle_cluster_id,
+                    TigerBeetleTransferRef.source_type.is_not(None),
+                    TigerBeetleTransferRef.source_id.is_not(None),
+                )
+                .order_by(TigerBeetleTransferRef.created_at.desc())
+                .limit(max(1, int(limit)))
+            )
+            .scalars()
+            .all()
+        )
+        updated = 0
+        skipped = 0
+        for ref in refs:
+            existing_payload = _nested_mapping(ref.payload_json)
+            if isinstance(existing_payload.get("stable_ref"), Mapping):
+                skipped += 1
+                continue
+            source_type = str(ref.source_type or "").strip()
+            source_id = str(ref.source_id or "").strip()
+            if not source_type or not source_id:
+                skipped += 1
+                continue
+            transfer_spec = TigerBeetleTransferSpec(
+                transfer_id=int(ref.transfer_id),
+                transfer_kind=ref.transfer_kind,
+                debit_account_id=0,
+                credit_account_id=0,
+                amount=int(ref.amount),
+                ledger=ref.ledger,
+                code=ref.code,
+            )
+            ref.payload_json = coerce_json_payload(
+                {
+                    **existing_payload,
+                    **tigerbeetle_stable_ref_payload(
+                        cluster_id=ref.cluster_id,
+                        account_specs=(),
+                        transfer_spec=transfer_spec,
+                        source_type=source_type,
+                        source_id=source_id,
+                        payload_json=existing_payload,
+                        event_fingerprint=ref.event_fingerprint,
+                    ),
+                }
+            )
+            session.add(ref)
+            updated += 1
+        if updated:
+            session.flush()
+        return {"selected": len(refs), "updated": updated, "skipped": skipped}
 
     def journal_order_event(
         self, session: Session, event: ExecutionOrderEvent

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -26,7 +26,7 @@ from app.trading.tigerbeetle_client import (
     TigerBeetleClientProtocol,
     create_tigerbeetle_client,
 )
-from app.trading.tigerbeetle_ids import u128_decimal
+from app.trading.tigerbeetle_ids import stable_ref_u128, u128_decimal
 from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION,
     SOURCE_TYPE_EXECUTION_ORDER_EVENT,
@@ -71,6 +71,7 @@ BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING = (
 BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING = (
     "tigerbeetle_runtime_ledger_account_refs_missing"
 )
+BLOCKER_STABLE_REF_PAYLOAD_MISMATCH = "tigerbeetle_stable_ref_payload_mismatch"
 BLOCKER_CLIENT_UNAVAILABLE = "tigerbeetle_client_unavailable"
 BLOCKER_RECONCILIATION_STALE = "tigerbeetle_reconciliation_stale"
 SAMPLE_LIMIT = 50
@@ -126,6 +127,55 @@ def _payload_mapping(row: TigerBeetleTransferRef) -> Mapping[str, object]:
     if isinstance(raw_payload, Mapping):
         return cast(Mapping[str, object], raw_payload)
     return {}
+
+
+def _stable_ref_payload(row: TigerBeetleTransferRef) -> Mapping[str, object]:
+    stable_ref = _payload_mapping(row).get("stable_ref")
+    if isinstance(stable_ref, Mapping):
+        return cast(Mapping[str, object], stable_ref)
+    return {}
+
+
+def _stable_ref_matches(row: TigerBeetleTransferRef) -> bool:
+    stable_ref = _stable_ref_payload(row)
+    if not stable_ref:
+        return True
+    components = stable_ref.get("components")
+    if not isinstance(components, Mapping):
+        return False
+    component_mapping = cast(Mapping[str, object], components)
+    source_type = str(row.source_type or "").strip()
+    source_id = str(row.source_id or "").strip()
+    transfer_kind = str(row.transfer_kind or "").strip()
+    account_label = str(component_mapping.get("account_label") or "unknown")
+    source_signature = str(component_mapping.get("source_signature") or "none")
+    try:
+        expected_stable_ref_id = u128_decimal(
+            stable_ref_u128(
+                cluster_id=row.cluster_id,
+                account_label=account_label,
+                source_type=source_type,
+                source_id=source_id,
+                transfer_kind=transfer_kind,
+                source_signature=source_signature,
+            )
+        )
+    except ValueError:
+        return False
+    return (
+        stable_ref.get("schema_version") == "torghut.tigerbeetle-stable-ref.v1"
+        and str(stable_ref.get("stable_ref_id") or "") == expected_stable_ref_id
+        and str(component_mapping.get("cluster_id") or "") == str(row.cluster_id)
+        and str(component_mapping.get("source_type") or "") == source_type
+        and str(component_mapping.get("source_id") or "") == source_id
+        and str(component_mapping.get("transfer_kind") or "") == transfer_kind
+        and str(stable_ref.get("transfer_id") or "") == str(row.transfer_id)
+        and str(stable_ref.get("ledger") or "") == str(row.ledger)
+        and str(stable_ref.get("code") or "") == str(row.code)
+        and str(stable_ref.get("amount") or "") == str(int(row.amount))
+        and stable_ref.get("promotion_authority") is False
+        and stable_ref.get("overrides_runtime_ledger_authority") is False
+    )
 
 
 def _ref_matches_expected_event(
@@ -589,6 +639,24 @@ def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, ob
             TigerBeetleTransferRef.cluster_id == cluster_id
         )
     )
+    refs = (
+        session.execute(
+            select(TigerBeetleTransferRef).where(
+                TigerBeetleTransferRef.cluster_id == cluster_id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    stable_ref_count = sum(1 for ref in refs if _stable_ref_payload(ref))
+    stable_ref_missing_count = sum(
+        1
+        for ref in refs
+        if ref.source_type and ref.source_id and not _stable_ref_payload(ref)
+    )
+    stable_ref_mismatch_count = sum(
+        1 for ref in refs if _stable_ref_payload(ref) and not _stable_ref_matches(ref)
+    )
     runtime_coverage = _runtime_ledger_ref_coverage(
         session,
         cluster_id=cluster_id,
@@ -606,6 +674,9 @@ def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, ob
             SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             0,
         ),
+        "stable_ref_count": stable_ref_count,
+        "stable_ref_missing_count": stable_ref_missing_count,
+        "stable_ref_mismatch_count": stable_ref_mismatch_count,
         "source_materialization": {
             "account_ref_table": "tigerbeetle_account_refs",
             "transfer_ref_table": "tigerbeetle_transfer_refs",
@@ -658,6 +729,15 @@ def _latest_run_payload(
         payload,
         "runtime_ledger_signed_ref_count",
     ) or _payload_int(ref_counts, "runtime_ledger_signed_ref_count")
+    stable_ref_count = _payload_int(payload, "stable_ref_count") or _payload_int(
+        ref_counts, "stable_ref_count"
+    )
+    stable_ref_missing_count = _payload_int(
+        payload, "stable_ref_missing_count"
+    ) or _payload_int(ref_counts, "stable_ref_missing_count")
+    stable_ref_mismatch_count = _payload_int(
+        payload, "stable_ref_mismatch_count"
+    ) or _payload_int(ref_counts, "stable_ref_mismatch_count")
     source_row_missing_count = _payload_int(payload, "source_row_missing_count")
     missing_source_row_count = (
         _payload_int(
@@ -721,6 +801,9 @@ def _latest_run_payload(
             payload,
             "runtime_ledger_missing_account_ref_count",
         ),
+        "stable_ref_count": stable_ref_count,
+        "stable_ref_missing_count": stable_ref_missing_count,
+        "stable_ref_mismatch_count": stable_ref_mismatch_count,
         "archived_runtime_ledger_source_missing_count": _payload_int(
             payload, "archived_runtime_ledger_source_missing_count"
         ),
@@ -812,6 +895,7 @@ def reconcile_tigerbeetle_transfers(
     archived_runtime_ledger_source_missing_count = 0
     runtime_ledger_direction_mismatch_count = 0
     runtime_ledger_metadata_mismatch_count = 0
+    stable_ref_mismatch_count = 0
     blockers: list[str] = []
     mismatched_refs: list[dict[str, object]] = []
     missing_transfer_refs: list[dict[str, object]] = []
@@ -842,6 +926,18 @@ def reconcile_tigerbeetle_transfers(
 
     for ref in refs:
         ref_transfer_id = _u128_text(ref.transfer_id) or str(ref.transfer_id)
+        if not _stable_ref_matches(ref):
+            stable_ref_mismatch_count += 1
+            mismatched_transfer_count += 1
+            blockers.append(BLOCKER_STABLE_REF_PAYLOAD_MISMATCH)
+            _append_sample(
+                mismatched_refs,
+                _ref_sample(
+                    ref,
+                    blocker=BLOCKER_STABLE_REF_PAYLOAD_MISMATCH,
+                    reason="stable_ref_payload_does_not_match_transfer_ref_identity",
+                ),
+            )
         actual = transfer_lookup.get(ref_transfer_id)
         if actual is None:
             missing_transfer_count += 1
@@ -1177,10 +1273,16 @@ def reconcile_tigerbeetle_transfers(
         ref_counts,
         "runtime_ledger_missing_account_ref_count",
     )
+    ref_count_stable_ref_mismatch_count = _payload_int(
+        ref_counts,
+        "stable_ref_mismatch_count",
+    )
     if runtime_ledger_missing_signed_ref_count:
         blockers.append(BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING)
     if runtime_ledger_missing_account_ref_count:
         blockers.append(BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING)
+    if ref_count_stable_ref_mismatch_count:
+        blockers.append(BLOCKER_STABLE_REF_PAYLOAD_MISMATCH)
     unique_blockers = sorted(set(blockers))
     ok = not unique_blockers
     max_age_seconds = max(1, int(settings_obj.tigerbeetle_reconcile_max_age_seconds))
@@ -1227,6 +1329,15 @@ def reconcile_tigerbeetle_transfers(
         ),
         "runtime_ledger_missing_account_ref_count": (
             runtime_ledger_missing_account_ref_count
+        ),
+        "stable_ref_count": _payload_int(ref_counts, "stable_ref_count"),
+        "stable_ref_missing_count": _payload_int(
+            ref_counts,
+            "stable_ref_missing_count",
+        ),
+        "stable_ref_mismatch_count": max(
+            stable_ref_mismatch_count,
+            ref_count_stable_ref_mismatch_count,
         ),
         "archived_runtime_ledger_source_missing_count": archived_runtime_ledger_source_missing_count,
         "runtime_ledger_direction_mismatch_count": (

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -506,6 +506,21 @@ def main() -> int:
                 session.rollback()
                 _reset_session_identity_map(session)
                 break
+            stable_ref_backfill = journal.backfill_stable_ref_payloads(
+                session,
+                limit=batch_size,
+            )
+            batches.append(
+                {
+                    "source": "tigerbeetle_stable_ref_payload",
+                    "selected": int(stable_ref_backfill["selected"]),
+                    "journaled": int(stable_ref_backfill["updated"]),
+                    "skipped": int(stable_ref_backfill["skipped"]),
+                    "failed": 0,
+                    "error_counts": {},
+                    "sample_errors": [],
+                }
+            )
             session.commit()
             _reset_session_identity_map(session)
             if all(

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -189,6 +189,15 @@ class FakeJournal:
     def client_for_reconciliation(self) -> object:
         return self.reconciliation_client
 
+    def backfill_stable_ref_payloads(
+        self,
+        session: Session,
+        *,
+        limit: int = 1000,
+    ) -> dict[str, object]:
+        del session, limit
+        return {"selected": 0, "updated": 0, "skipped": 0}
+
 
 class TestJournalTigerBeetleOrderEventsScript(TestCase):
     def setUp(self) -> None:

--- a/services/torghut/tests/test_tigerbeetle_ids.py
+++ b/services/torghut/tests/test_tigerbeetle_ids.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import uuid
 from unittest import TestCase
 
-from app.trading.tigerbeetle_ids import stable_u128, u128_decimal, uuid_to_u128
+from app.trading.tigerbeetle_ids import (
+    stable_ref_u128,
+    stable_u128,
+    u128_decimal,
+    uuid_to_u128,
+)
 
 
 class TestTigerBeetleIds(TestCase):
@@ -32,3 +37,48 @@ class TestTigerBeetleIds(TestCase):
     def test_decimal_serialization_rejects_out_of_range_values(self) -> None:
         with self.assertRaisesRegex(ValueError, "tigerbeetle_id_out_of_range"):
             u128_decimal(0)
+
+    def test_stable_ref_ids_include_cluster_account_source_and_kind(self) -> None:
+        base = stable_ref_u128(
+            cluster_id=2001,
+            account_label="paper",
+            source_type="strategy_runtime_ledger_bucket",
+            source_id="bucket-1",
+            transfer_kind="runtime_net_pnl",
+            source_signature="runtime-key",
+        )
+
+        self.assertEqual(
+            base,
+            stable_ref_u128(
+                cluster_id=2001,
+                account_label="paper",
+                source_type="strategy_runtime_ledger_bucket",
+                source_id="bucket-1",
+                transfer_kind="runtime_net_pnl",
+                source_signature="runtime-key",
+            ),
+        )
+        self.assertNotEqual(
+            base,
+            stable_ref_u128(
+                cluster_id=2002,
+                account_label="paper",
+                source_type="strategy_runtime_ledger_bucket",
+                source_id="bucket-1",
+                transfer_kind="runtime_net_pnl",
+                source_signature="runtime-key",
+            ),
+        )
+        self.assertNotEqual(
+            base,
+            stable_ref_u128(
+                cluster_id=2001,
+                account_label="live",
+                source_type="strategy_runtime_ledger_bucket",
+                source_id="bucket-1",
+                transfer_kind="runtime_net_pnl",
+                source_signature="runtime-key",
+            ),
+        )
+        self.assertGreater(base, 0)

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -770,6 +770,30 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(ref.payload_json["transfer_id"], ref.transfer_id)
             self.assertEqual(ref.payload_json["ledger"], ref.ledger)
             self.assertEqual(ref.payload_json["code"], ref.code)
+            stable_ref = ref.payload_json["stable_ref"]
+            self.assertEqual(
+                stable_ref["schema_version"], "torghut.tigerbeetle-stable-ref.v1"
+            )
+            self.assertEqual(
+                stable_ref["stable_ref_id"], ref.payload_json["stable_ref_id"]
+            )
+            self.assertEqual(stable_ref["transfer_id"], ref.transfer_id)
+            self.assertFalse(stable_ref["promotion_authority"])
+            self.assertFalse(stable_ref["overrides_runtime_ledger_authority"])
+            stable_components = stable_ref["components"]
+            self.assertEqual(stable_components["cluster_id"], 2001)
+            self.assertEqual(stable_components["account_label"], "paper")
+            self.assertEqual(
+                stable_components["source_type"],
+                "strategy_runtime_ledger_bucket",
+            )
+            self.assertEqual(stable_components["source_id"], str(bucket.id))
+            self.assertEqual(
+                stable_components["transfer_kind"], TRANSFER_KIND_RUNTIME_NET_PNL
+            )
+            self.assertEqual(
+                stable_components["source_signature"], ref.payload_json["runtime_key"]
+            )
             self.assertFalse(ref.payload_json["promotion_authority"])
             self.assertFalse(ref.payload_json["overrides_runtime_ledger_authority"])
             parity = tigerbeetle_runtime_ledger_journal_payload(
@@ -778,6 +802,11 @@ class TestTigerBeetleLedgerJournal(TestCase):
                 status=TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
             )
             self.assertEqual(parity["status"], "pass")
+            self.assertEqual(parity["stable_ref_count"], 1)
+            self.assertEqual(parity["stable_ref_ids"], [stable_ref["stable_ref_id"]])
+            self.assertEqual(
+                parity["transfer"]["stable_ref_id"], stable_ref["stable_ref_id"]
+            )
             self.assertFalse(parity["promotion_authority"])
             self.assertIn(
                 TIGERBEETLE_AUTHORITY_BLOCKER_ACCOUNTING_ONLY,
@@ -800,6 +829,48 @@ class TestTigerBeetleLedgerJournal(TestCase):
                 ref.payload_json["credit_account_id"],
                 str(getattr(transfer, "credit_account_id")),
             )
+
+    def test_stable_ref_payload_backfill_is_idempotent_without_tigerbeetle_write(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket()
+            session.add(bucket)
+            session.flush()
+            ref = TigerBeetleTransferRef(
+                cluster_id=2001,
+                transfer_id=str(runtime_ledger_transfer_id(bucket)),
+                transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+                ledger=LEDGER_USD_MICRO,
+                code=2012,
+                amount=Decimal("2500000"),
+                status="created",
+                runtime_ledger_bucket_id=bucket.id,
+                source_type="strategy_runtime_ledger_bucket",
+                source_id=str(bucket.id),
+                payload_json={
+                    "debit_account_id": "100100100100100100100100100100100101",
+                    "credit_account_id": "100100100100100100100100100100100102",
+                    "runtime_key": "hypothesis-1:runtime-run-1:source-window",
+                },
+            )
+            session.add(ref)
+            session.flush()
+            client = FakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            first = journal.backfill_stable_ref_payloads(session)
+            first_payload = dict(ref.payload_json)
+            second = journal.backfill_stable_ref_payloads(session)
+
+            self.assertEqual(first, {"selected": 1, "updated": 1, "skipped": 0})
+            self.assertEqual(second, {"selected": 1, "updated": 0, "skipped": 1})
+            self.assertEqual(client.transfers, {})
+            self.assertEqual(ref.payload_json, first_payload)
+            self.assertIn("stable_ref", ref.payload_json)
 
     def test_runtime_bucket_journal_payload_marks_aggregate_only_non_authority(
         self,

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -26,6 +26,7 @@ from app.trading.tigerbeetle_journal import (
     build_order_event_transfer_plan,
     build_runtime_ledger_bucket_transfer_plan,
     submitted_pending_transfer_id,
+    tigerbeetle_stable_ref_payload,
 )
 from app.trading.tigerbeetle_ledger_model import (
     LEDGER_USD_MICRO,
@@ -50,6 +51,7 @@ from app.trading.tigerbeetle_reconcile import (
     BLOCKER_RUNTIME_LEDGER_METADATA_MISMATCH,
     BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING,
     BLOCKER_SOURCE_ROW_MISSING,
+    BLOCKER_STABLE_REF_PAYLOAD_MISMATCH,
     BLOCKER_UNLINKED_COST,
     BLOCKER_UNLINKED_EXECUTION,
     BLOCKER_SOURCE_AMOUNT_MISMATCH,
@@ -64,6 +66,7 @@ from app.trading.tigerbeetle_reconcile import (
     _payload_int,
     _payload_string_list,
     _runtime_ledger_payload_account_ids,
+    _stable_ref_matches,
     _runtime_ledger_amount_micros,
     _usd_to_micros,
     _uuid_or_none,
@@ -710,6 +713,79 @@ class TestTigerBeetleReconcile(TestCase):
             )
             self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 1)
             self.assertEqual(payload["runtime_ledger_missing_account_ref_count"], 2)
+
+    def test_reconciliation_blocks_stable_ref_payload_mismatch(self) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket(net_pnl=Decimal("2.50"))
+            session.add(bucket)
+            session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            _add_account_refs_for_plan(session, plan)
+            transfer = plan.transfer_spec
+            stable_payload = tigerbeetle_stable_ref_payload(
+                cluster_id=2001,
+                account_specs=plan.account_specs,
+                transfer_spec=transfer,
+                source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                source_id=str(bucket.id),
+                payload_json={
+                    "runtime_key": plan.runtime_key,
+                    "debit_account_id": str(transfer.debit_account_id),
+                    "credit_account_id": str(transfer.credit_account_id),
+                },
+            )
+            stable_ref = stable_payload["stable_ref"]
+            assert isinstance(stable_ref, dict)
+            components = stable_ref["components"]
+            assert isinstance(components, dict)
+            components["source_id"] = "different-runtime-bucket"
+            payload_json = {
+                "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                "run_id": bucket.run_id,
+                "candidate_id": bucket.candidate_id,
+                "hypothesis_id": bucket.hypothesis_id,
+                "observed_stage": bucket.observed_stage,
+                "pnl_basis": bucket.pnl_basis,
+                "ledger_schema_version": bucket.ledger_schema_version,
+                "amount_source": str(plan.amount_source),
+                "signed_amount_micros": plan.signed_amount_micros,
+                "pnl_direction": plan.pnl_direction,
+                "runtime_key": plan.runtime_key,
+                "debit_account_id": str(transfer.debit_account_id),
+                "credit_account_id": str(transfer.credit_account_id),
+                **stable_payload,
+            }
+            ref = TigerBeetleTransferRef(
+                cluster_id=2001,
+                transfer_id=str(transfer.transfer_id),
+                transfer_kind=transfer.transfer_kind,
+                ledger=transfer.ledger,
+                code=transfer.code,
+                amount=Decimal(transfer.amount),
+                status="created",
+                runtime_ledger_bucket_id=bucket.id,
+                source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                source_id=str(bucket.id),
+                payload_json=payload_json,
+            )
+            session.add(ref)
+            session.flush()
+            client = FakeTigerBeetleClient()
+            client.transfers[transfer.transfer_id] = transfer
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+        self.assertFalse(_stable_ref_matches(ref))
+        self.assertFalse(payload["ok"], payload)
+        self.assertIn(BLOCKER_STABLE_REF_PAYLOAD_MISMATCH, payload["blockers"])
+        self.assertEqual(payload["stable_ref_count"], 1)
+        self.assertEqual(payload["stable_ref_mismatch_count"], 1)
 
     def test_ref_counts_expose_source_materialization_identifiers(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Added deterministic TigerBeetle `stable_ref` audit payloads derived from cluster, account, source, kind, and source-signature inputs without changing existing transfer IDs.
- Persisted stable refs during TigerBeetle journaling and exposed them through runtime-ledger journal parity payloads for proof-packet/readiness consumers.
- Added a journal-script backfill pass for existing refs and reconciliation coverage/mismatch blockers for tampered stable-ref payloads.
- Preserved TigerBeetle as `accounting_parity_only`; payloads continue to mark `promotion_authority` and runtime-ledger overrides as false.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle*.py tests/test_journal_tigerbeetle_order_events.py -q` (125 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_ids.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tigerbeetle_ids.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A; backend ledger audit integration only.

## Breaking Changes

None. Existing TigerBeetle transfer IDs are not rewritten; the stable-ref backfill only augments PostgreSQL ref payloads through the existing GitOps-run journal path.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no separate docs were required for this focused Torghut ledger audit tranche.
