### PR TITLE
fix(torghut): keep tigerbeetle journal cron safe

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: tigerbeetle-journal-order-events
 spec:
-  schedule: "1,6,11,16,21,26,31,36,41,46,51,56 * * * *"
+  schedule: "6,36 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
@@ -15,7 +15,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 1200
+      activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: Never
@@ -57,37 +57,18 @@ spec:
                   cd /app
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env DB_DSN \
-                    --sources execution,execution_tca_metric \
-                    --batch-size 500 \
-                    --max-batches 2 \
-                    --reconcile-limit 1000 \
-                    --skip-reconcile \
-                    --json
-                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
-                    --dsn-env SIM_DB_DSN \
-                    --account-label TORGHUT_SIM \
-                    --sources execution,execution_tca_metric \
-                    --batch-size 250 \
-                    --max-batches 2 \
-                    --reconcile-limit 500 \
-                    --skip-reconcile \
-                    --json
-                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
-                    --dsn-env DB_DSN \
-                    --sources execution_order_event,strategy_runtime_ledger_bucket \
                     --batch-size 125 \
                     --max-batches 2 \
                     --event-scan-limit 1000 \
-                    --reconcile-limit 1000 \
+                    --reconcile-limit 500 \
                     --json
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
-                    --sources execution_order_event,strategy_runtime_ledger_bucket \
                     --batch-size 75 \
                     --max-batches 4 \
                     --event-scan-limit 300 \
-                    --reconcile-limit 500 \
+                    --reconcile-limit 250 \
                     --json
               env:
                 - name: DB_DSN

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1380,10 +1380,7 @@ class TestLiveConfigManifestContract(TestCase):
             metadata.get("name"),
             "torghut-tigerbeetle-journal-order-events",
         )
-        self.assertEqual(
-            spec.get("schedule"),
-            "1,6,11,16,21,26,31,36,41,46,51,56 * * * *",
-        )
+        self.assertEqual(spec.get("schedule"), "6,36 * * * *")
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
         self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
         self.assertEqual(spec.get("successfulJobsHistoryLimit"), 2)
@@ -1398,7 +1395,7 @@ class TestLiveConfigManifestContract(TestCase):
             cast(Mapping[str, object], job_spec.get("template", {})),
         )
         pod_spec = cast(Mapping[str, object], template.get("spec", {}))
-        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 1200)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 900)
         self.assertEqual(job_spec.get("backoffLimit"), 0)
         self.assertEqual(pod_spec.get("restartPolicy"), "Never")
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
@@ -1477,25 +1474,17 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/journal_tigerbeetle_order_events.py", args)
         self.assertNotIn("scripts/repair_order_feed_source_windows.py", args)
         self.assertIn("--dsn-env DB_DSN", args)
-        self.assertIn("--sources execution,execution_tca_metric", args)
-        self.assertIn("--batch-size 500", args)
-        self.assertIn("--reconcile-limit 1000", args)
-        self.assertIn("--skip-reconcile", args)
-        self.assertIn("--dsn-env SIM_DB_DSN", args)
-        self.assertIn("--account-label TORGHUT_SIM", args)
-        self.assertIn("--batch-size 250", args)
-        self.assertIn("--reconcile-limit 500", args)
-        self.assertIn(
-            "--sources execution_order_event,strategy_runtime_ledger_bucket",
-            args,
-        )
         self.assertIn("--batch-size 125", args)
         self.assertIn("--max-batches 2", args)
         self.assertIn("--event-scan-limit 1000", args)
+        self.assertIn("--reconcile-limit 500", args)
+        self.assertIn("--dsn-env SIM_DB_DSN", args)
+        self.assertIn("--account-label TORGHUT_SIM", args)
         self.assertIn("--batch-size 75", args)
         self.assertIn("--max-batches 4", args)
         self.assertIn("--event-scan-limit 300", args)
-        self.assertEqual(args.count("scripts/journal_tigerbeetle_order_events.py"), 4)
+        self.assertIn("--reconcile-limit 250", args)
+        self.assertEqual(args.count("scripts/journal_tigerbeetle_order_events.py"), 2)
         self.assertNotIn("--fail-on-degraded", args)
         self.assertIn("--json", args)
         security_context = cast(


### PR DESCRIPTION
## Summary

- Restores the TigerBeetle journal CronJob to the known-safe twice-hourly cadence.
- Removes the new source-filter and skip-reconcile CLI flags from the live manifest until a matching Torghut image is promoted.
- Updates the live manifest contract test so GitOps stays aligned with the safer runtime schedule.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -q -k tigerbeetle_journal_order_events_cronjob`
- `cd services/torghut && uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `cd services/torghut && git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
