### PR TITLE
chore(torghut): format proof packet authority checks

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1141,7 +1141,9 @@ def _runtime_import_materialization_metadata_blockers(
         observation.get("runtime_ledger_source_execution_materialized_bucket_count")
     )
     if source_materialized_count < proof_count:
-        blockers.append("runtime_window_import_source_execution_materialization_missing")
+        blockers.append(
+            "runtime_window_import_source_execution_materialization_missing"
+        )
 
     source_materializations = _text_list(
         observation.get("runtime_ledger_source_materializations")
@@ -1168,7 +1170,9 @@ def _runtime_import_materialization_metadata_blockers(
         _runtime_ledger_non_authority_marker_present(value)
         for value in [*derivations, *authority_reasons]
     ):
-        blockers.append("runtime_window_import_replay_or_artifact_derivation_not_authority")
+        blockers.append(
+            "runtime_window_import_replay_or_artifact_derivation_not_authority"
+        )
     return list(dict.fromkeys(blockers))
 
 

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -351,14 +351,10 @@ def _paper_route_quote_fillability_summary(
                     "hypothesis_id": _text(target.get("hypothesis_id")),
                     "candidate_id": _text(target.get("candidate_id")),
                     "strategy_name": _text(target.get("strategy_name")),
-                    "symbol": _text(
-                        routeability.get("symbol") or target.get("symbol")
-                    ),
+                    "symbol": _text(routeability.get("symbol") or target.get("symbol")),
                     "status": _text(routeability.get("status"), "unknown"),
                     "reasons": target_reasons,
-                    "repair_action": _text(
-                        routeability.get("repair_action")
-                    )
+                    "repair_action": _text(routeability.get("repair_action"))
                     or (
                         _quote_fillability_repair_action(target_reasons)
                         if target_reasons
@@ -1011,7 +1007,9 @@ def _readiness_next_action(
                     blockers.append(text)
     for blocker in blockers:
         if _quote_fillability_reason(blocker):
-            return "repair_quote_quality_or_fillability_before_runtime_ledger_collection"
+            return (
+                "repair_quote_quality_or_fillability_before_runtime_ledger_collection"
+            )
         if blocker in {
             "runtime_window_import_missing",
             "runtime_window_import_runtime_ledger_materialization_missing",
@@ -1043,7 +1041,9 @@ def _readiness_next_action(
             return "repair_runtime_ledger_lifecycle_cost_or_lineage_evidence"
     for failed_check in failed_checks:
         if "quote_fillability" in failed_check:
-            return "repair_quote_quality_or_fillability_before_runtime_ledger_collection"
+            return (
+                "repair_quote_quality_or_fillability_before_runtime_ledger_collection"
+            )
         if failed_check.startswith("paper_route_target_plan"):
             return "repair_candidate_frontier_or_paper_route_target_plan"
         if failed_check.startswith("runtime_ledger"):

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -918,9 +918,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 "runtime_ledger_materialization_pnl_derivations": [
                     "aggregate_only_runtime_ledger"
                 ],
-                "runtime_ledger_materialization_authority_reasons": [
-                    "aggregate_only"
-                ],
+                "runtime_ledger_materialization_authority_reasons": ["aggregate_only"],
             }
         )
 


### PR DESCRIPTION
## Summary

- Applies ruff formatting to the Torghut runtime-ledger proof-packet authority checks and readiness reporting code.
- Keeps the existing explicit smoke, probation, and authority proof-packet contracts intact while making the required formatter gate pass on the audited files.
- Confirms current main already includes fail-closed final-authority blockers for one-day/smoke/probation proof packets and source-backed authority gates.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (passed after installing local `build-essential` so `crosshair-tool` could compile in this workspace)
- `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q` (passed: 105 tests, 1 existing warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py` (passed)
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py` (passed)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` (passed: 0 errors)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` (passed: 0 errors)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` (passed: 0 errors)
- `git diff --check` (passed)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
