### PR TITLE
fix(torghut): guard routeability source identity

### DIFF
--- a/services/torghut/app/trading/route_evidence_clearinghouse.py
+++ b/services/torghut/app/trading/route_evidence_clearinghouse.py
@@ -429,13 +429,112 @@ def _capital_book(
     )
 
 
-def _routeability_reasons(ledger: Mapping[str, Any]) -> list[str]:
+def _lineage_values(
+    source: Mapping[str, Any], *keys: str, uppercase: bool = False
+) -> list[str]:
+    values: list[str] = []
+    for key in keys:
+        raw = source.get(key)
+        if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+            values.extend(_text(item) for item in cast(Sequence[object], raw))
+        elif raw is not None:
+            values.append(_text(raw))
+    if uppercase:
+        return _unique([value.upper() for value in values])
+    return _unique(values)
+
+
+def _source_identity(ledger: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _mapping(ledger.get("source_identity"))
+
+
+def _lineage_mismatch_reason(
+    *,
+    expected: Sequence[str],
+    observed: Sequence[str],
+    missing_reason: str,
+    mismatch_reason: str,
+) -> str | None:
+    expected_values = sorted({_text(item) for item in expected if _text(item)})
+    observed_values = sorted({_text(item) for item in observed if _text(item)})
+    if not expected_values:
+        return None
+    if not observed_values:
+        return missing_reason
+    return None if expected_values == observed_values else mismatch_reason
+
+
+def _routeability_reasons(
+    ledger: Mapping[str, Any],
+    *,
+    account_label: str,
+    session_id: str,
+    trading_mode: str,
+) -> list[str]:
     if not ledger:
         return ["routeability_acceptance_ledger_missing"]
     state = _text(ledger.get("aggregate_state"), "unknown").lower()
-    reasons = _strings(ledger.get("aggregate_blocking_reason_codes"))
+    identity = _source_identity(ledger)
+    reasons = [
+        *_strings(ledger.get("aggregate_blocking_reason_codes")),
+        *_strings(identity.get("blocking_reason_codes")),
+    ]
     if state != "accepted":
         reasons.append(f"routeability_acceptance_{state}")
+
+    ledger_account = _text(ledger.get("account") or identity.get("account"))
+    ledger_window = _text(ledger.get("window") or identity.get("window"))
+    ledger_mode = _text(ledger.get("trading_mode") or identity.get("trading_mode"))
+    if not ledger_account:
+        reasons.append("routeability_acceptance_account_missing")
+    elif ledger_account != account_label:
+        reasons.append("routeability_acceptance_account_mismatch")
+    if not ledger_window:
+        reasons.append("routeability_acceptance_window_missing")
+    elif ledger_window != session_id:
+        reasons.append("routeability_acceptance_window_mismatch")
+    if not ledger_mode:
+        reasons.append("routeability_acceptance_trading_mode_missing")
+    elif ledger_mode != trading_mode:
+        reasons.append("routeability_acceptance_trading_mode_mismatch")
+    if ledger.get("promotion_authority") is True:
+        reasons.append("routeability_acceptance_promotion_authority_must_be_false")
+
+    return _unique(reasons)
+
+
+def _routeability_claim_lineage_reasons(
+    ledger: Mapping[str, Any], claim: Mapping[str, Any]
+) -> list[str]:
+    if not ledger:
+        return []
+    identity = _source_identity(ledger)
+    reasons: list[str] = []
+    claim_candidate_ids = _unique(
+        [_text(claim.get("candidate_id"))] if _text(claim.get("candidate_id")) else []
+    )
+    ledger_candidate_ids = _lineage_values(
+        identity, "route_candidate_ids", "candidate_ids", "candidateIds"
+    )
+    if reason := _lineage_mismatch_reason(
+        expected=claim_candidate_ids,
+        observed=ledger_candidate_ids,
+        missing_reason="routeability_acceptance_candidate_lineage_missing",
+        mismatch_reason="routeability_acceptance_candidate_lineage_mismatch",
+    ):
+        reasons.append(reason)
+
+    claim_symbols = _claim_symbols(claim)
+    ledger_symbols = _lineage_values(
+        identity, "route_symbols", "symbols", uppercase=True
+    )
+    if reason := _lineage_mismatch_reason(
+        expected=claim_symbols,
+        observed=ledger_symbols,
+        missing_reason="routeability_acceptance_symbol_scope_missing",
+        mismatch_reason="routeability_acceptance_symbol_scope_mismatch",
+    ):
+        reasons.append(reason)
     return _unique(reasons)
 
 
@@ -545,6 +644,7 @@ def _route_claims(
     *,
     common_reasons: Sequence[str],
     source_reasons_by_claim: Sequence[Sequence[str]],
+    routeability_acceptance_ledger: Mapping[str, Any],
 ) -> list[dict[str, object]]:
     route_claims: list[dict[str, object]] = []
     for index, claim in enumerate(claims):
@@ -558,7 +658,11 @@ def _route_claims(
             if index < len(source_reasons_by_claim)
             else []
         )
-        reasons = [*_strings(claim.get("reason_codes")), *common_reasons]
+        reasons = [
+            *_strings(claim.get("reason_codes")),
+            *common_reasons,
+            *_routeability_claim_lineage_reasons(routeability_acceptance_ledger, claim),
+        ]
         if asset_class == "options":
             reasons.extend(claim_source_reasons)
         reason_codes = _unique(reasons)
@@ -665,7 +769,12 @@ def build_route_evidence_clearinghouse_packet(
             *cast(Sequence[str], rollout_book["reason_codes"]),
             *cast(Sequence[str], profit_window_book["reason_codes"]),
             *cast(Sequence[str], capital_book["reason_codes"]),
-            *_routeability_reasons(_mapping(routeability_acceptance_ledger)),
+            *_routeability_reasons(
+                _mapping(routeability_acceptance_ledger),
+                account_label=account_label,
+                session_id=session_id,
+                trading_mode=trading_mode,
+            ),
             *_profit_signal_reasons(profit_signal_quorum),
         ]
     )
@@ -673,6 +782,7 @@ def build_route_evidence_clearinghouse_packet(
         claim_inputs,
         common_reasons=common_reasons,
         source_reasons_by_claim=source_reasons_by_claim,
+        routeability_acceptance_ledger=_mapping(routeability_acceptance_ledger),
     )
     all_reasons = _unique(
         [

--- a/services/torghut/app/trading/route_warrant_exchange.py
+++ b/services/torghut/app/trading/route_warrant_exchange.py
@@ -404,7 +404,9 @@ def _repair_packet(witness: Mapping[str, Any]) -> dict[str, object]:
     dependency_name = _text(witness.get("published_clock"))
     dependency = _WARRANT_DEPENDENCIES[dependency_name]
     reason_codes = _strings(witness.get("reason_codes"))
-    primary_reason = reason_codes[0] if reason_codes else _text(witness.get("state"), "missing")
+    primary_reason = (
+        reason_codes[0] if reason_codes else _text(witness.get("state"), "missing")
+    )
     payload = {
         "dependency": dependency["target_dependency"],
         "state": _text(witness.get("state")),
@@ -439,6 +441,91 @@ def _repair_packet(witness: Mapping[str, Any]) -> dict[str, object]:
             "promotion_authority": False,
         },
     }
+
+
+def _routeability_acceptance_identity_blockers(
+    *,
+    account_label: str,
+    window: str,
+    trading_mode: str,
+    routeability_repair_acceptance_ledger: Mapping[str, Any],
+) -> list[str]:
+    if not routeability_repair_acceptance_ledger:
+        return ["routeability_acceptance_ledger_missing"]
+    blockers: list[str] = []
+    ledger_account = _text(routeability_repair_acceptance_ledger.get("account"))
+    ledger_window = _text(routeability_repair_acceptance_ledger.get("window"))
+    ledger_mode = _text(routeability_repair_acceptance_ledger.get("trading_mode"))
+    if not ledger_account:
+        blockers.append("routeability_acceptance_account_missing")
+    elif ledger_account != account_label:
+        blockers.append("routeability_acceptance_account_mismatch")
+    if not ledger_window:
+        blockers.append("routeability_acceptance_window_missing")
+    elif ledger_window != window:
+        blockers.append("routeability_acceptance_window_mismatch")
+    if not ledger_mode:
+        blockers.append("routeability_acceptance_trading_mode_missing")
+    elif ledger_mode != trading_mode:
+        blockers.append("routeability_acceptance_trading_mode_mismatch")
+    if routeability_repair_acceptance_ledger.get("promotion_authority") is True:
+        blockers.append("routeability_acceptance_promotion_authority_must_be_false")
+    if (
+        _text(routeability_repair_acceptance_ledger.get("aggregate_state"))
+        != "accepted"
+    ):
+        blockers.append("routeability_acceptance_not_accepted")
+    return _unique(blockers)
+
+
+def _guard_routeability_acceptance_witness(
+    witnesses: Sequence[Mapping[str, Any]],
+    *,
+    account_label: str,
+    window: str,
+    trading_mode: str,
+    routeability_repair_acceptance_ledger: Mapping[str, Any],
+) -> list[dict[str, object]]:
+    blockers = _routeability_acceptance_identity_blockers(
+        account_label=account_label,
+        window=window,
+        trading_mode=trading_mode,
+        routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
+    )
+    guarded: list[dict[str, object]] = []
+    for witness in witnesses:
+        updated = cast(dict[str, object], dict(witness))
+        if (
+            _text(witness.get("published_clock")) == "routeability_acceptance"
+            and blockers
+        ):
+            updated["state"] = "blocked"
+            updated["reason_codes"] = _unique(
+                [*_strings(witness.get("reason_codes")), *blockers]
+            )
+            updated["matching_published_clock"] = False
+            updated["contradiction_reason_codes"] = _unique(
+                [
+                    *_strings(witness.get("contradiction_reason_codes")),
+                    "routeability_acceptance_identity_guard_blocked",
+                ]
+            )
+            details = dict(_mapping(witness.get("details")))
+            details["expected_account"] = account_label
+            details["expected_window"] = window
+            details["expected_trading_mode"] = trading_mode
+            details["ledger_account"] = routeability_repair_acceptance_ledger.get(
+                "account"
+            )
+            details["ledger_window"] = routeability_repair_acceptance_ledger.get(
+                "window"
+            )
+            details["ledger_trading_mode"] = routeability_repair_acceptance_ledger.get(
+                "trading_mode"
+            )
+            updated["details"] = details
+        guarded.append(updated)
+    return guarded
 
 
 def _group_witnesses(
@@ -552,25 +639,31 @@ def build_route_warrant_exchange(
         "profit_signal_quorum",
         "capital_gate",
     ]
-    witnesses = [
-        _witness(
-            clock_name=clock_name,
-            source=_source_for_clock(
-                clock_name,
-                quant_evidence=quant_evidence,
-                tca_summary=tca_summary,
-                empirical_jobs_status=empirical_jobs_status,
-                market_context_status=market_context_status,
-                routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
-                live_submission_gate=live_submission_gate,
-                build=build,
-                profit_freshness_frontier=profit_freshness_frontier,
-            ),
-            clock=clocks.get(clock_name, {}),
-            fallback_reason=f"{clock_name}_clock_missing",
-        )
-        for clock_name in required_clock_names
-    ]
+    witnesses = _guard_routeability_acceptance_witness(
+        [
+            _witness(
+                clock_name=clock_name,
+                source=_source_for_clock(
+                    clock_name,
+                    quant_evidence=quant_evidence,
+                    tca_summary=tca_summary,
+                    empirical_jobs_status=empirical_jobs_status,
+                    market_context_status=market_context_status,
+                    routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
+                    live_submission_gate=live_submission_gate,
+                    build=build,
+                    profit_freshness_frontier=profit_freshness_frontier,
+                ),
+                clock=clocks.get(clock_name, {}),
+                fallback_reason=f"{clock_name}_clock_missing",
+            )
+            for clock_name in required_clock_names
+        ],
+        account_label=account_label,
+        window=window,
+        trading_mode=trading_mode,
+        routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
+    )
     noncurrent_witnesses = [
         witness for witness in witnesses if _text(witness.get("state")) != "current"
     ]

--- a/services/torghut/app/trading/routeability_repair_acceptance.py
+++ b/services/torghut/app/trading/routeability_repair_acceptance.py
@@ -143,7 +143,248 @@ def _hypothesis_ids(rows: Sequence[Mapping[str, Any]]) -> list[str]:
     ids: list[str] = []
     for row in rows:
         ids.extend(_strings(row.get("hypothesis_ids")))
+        source_metadata = _source_metadata(row)
+        ids.extend(
+            _identity_strings(source_metadata, "hypothesis_ids", "hypothesisIds")
+        )
+        if hypothesis_id := _text(
+            source_metadata.get("hypothesis_id") or source_metadata.get("hypothesisId")
+        ):
+            ids.append(hypothesis_id)
     return sorted(set(ids))
+
+
+def _source_metadata(row: Mapping[str, Any]) -> Mapping[str, Any]:
+    metadata = _mapping(row.get("source_metadata"))
+    if metadata:
+        return metadata
+    return _mapping(_mapping(row.get("audit_receipt")).get("source_metadata"))
+
+
+def _identity_strings(
+    source: Mapping[str, Any], *keys: str, uppercase: bool = False
+) -> list[str]:
+    values: list[str] = []
+    for key in keys:
+        raw = source.get(key)
+        if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+            values.extend(_text(item) for item in cast(Sequence[object], raw))
+        elif raw is not None:
+            values.append(_text(raw))
+    if uppercase:
+        return _unique([value.upper() for value in values])
+    return _unique(values)
+
+
+def _nested_identity(ref: Mapping[str, Any]) -> Mapping[str, Any]:
+    for key in ("source_identity", "route_identity", "identity", "source_ref"):
+        nested = _mapping(ref.get(key))
+        if nested:
+            return nested
+    return {}
+
+
+def _identity_field_values(
+    source: Mapping[str, Any], *keys: str, uppercase: bool = False
+) -> list[str]:
+    nested = _nested_identity(source)
+    return _unique(
+        [
+            *_identity_strings(source, *keys, uppercase=uppercase),
+            *_identity_strings(nested, *keys, uppercase=uppercase),
+        ]
+    )
+
+
+def _candidate_ids(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    ids: list[str] = []
+    for row in rows:
+        ids.extend(_identity_strings(row, "candidate_ids", "candidateIds"))
+        source_metadata = _source_metadata(row)
+        ids.extend(_identity_strings(source_metadata, "candidate_ids", "candidateIds"))
+        if candidate_id := _text(
+            source_metadata.get("candidate_id") or source_metadata.get("candidateId")
+        ):
+            ids.append(candidate_id)
+    return sorted(set(ids))
+
+
+def _source_manifest_refs(rows: Sequence[Mapping[str, Any]]) -> list[str]:
+    refs: list[str] = []
+    for row in rows:
+        source_metadata = _source_metadata(row)
+        if manifest_ref := _text(
+            row.get("source_manifest_ref")
+            or row.get("sourceManifestRef")
+            or source_metadata.get("source_manifest_ref")
+            or source_metadata.get("sourceManifestRef")
+        ):
+            refs.append(manifest_ref)
+    return sorted(set(refs))
+
+
+def _identity_mismatch_blockers(
+    *,
+    expected: Sequence[str],
+    observed: Sequence[str],
+    missing_reason: str,
+    mismatch_reason: str,
+) -> list[str]:
+    expected_values = sorted({_text(item) for item in expected if _text(item)})
+    observed_values = sorted({_text(item) for item in observed if _text(item)})
+    if not expected_values:
+        return []
+    if not observed_values:
+        return [missing_reason]
+    if expected_values != observed_values:
+        return [mismatch_reason]
+    return []
+
+
+def _source_identity_contract(
+    *,
+    account: str | None,
+    window: str | None,
+    trading_mode: str,
+    proof_floor_receipt: Mapping[str, Any],
+    route_reacquisition_board: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+    torghut_routeability_admission_ref: Mapping[str, Any],
+) -> dict[str, object]:
+    nested_admission = _nested_identity(torghut_routeability_admission_ref)
+    route_account = _text(route_reacquisition_board.get("account_label")) or account
+    proof_account = _text(proof_floor_receipt.get("account_label")) or account
+    admission_account = _text(
+        torghut_routeability_admission_ref.get("account_label")
+        or torghut_routeability_admission_ref.get("account")
+        or torghut_routeability_admission_ref.get("account_id")
+        or nested_admission.get("account_label")
+        or nested_admission.get("account")
+        or nested_admission.get("account_id")
+    )
+    route_symbols = _symbols(rows)
+    route_hypothesis_ids = _hypothesis_ids(rows)
+    route_candidate_ids = _candidate_ids(rows)
+    route_manifest_refs = _source_manifest_refs(rows)
+    admission_symbols = sorted(
+        set(
+            _identity_field_values(
+                torghut_routeability_admission_ref,
+                "symbols",
+                "route_symbols",
+                "routeSymbols",
+                "accepted_symbols",
+                "acceptedSymbols",
+                "candidate_symbols",
+                "candidateSymbols",
+                "symbol",
+                uppercase=True,
+            )
+        )
+    )
+    admission_hypothesis_ids = _identity_field_values(
+        torghut_routeability_admission_ref,
+        "hypothesis_ids",
+        "hypothesisIds",
+        "hypothesis_id",
+        "hypothesisId",
+    )
+    admission_candidate_ids = _identity_field_values(
+        torghut_routeability_admission_ref,
+        "candidate_ids",
+        "candidateIds",
+        "candidate_id",
+        "candidateId",
+    )
+    admission_manifest_refs = _identity_field_values(
+        torghut_routeability_admission_ref,
+        "source_manifest_refs",
+        "sourceManifestRefs",
+        "source_manifest_ref",
+        "sourceManifestRef",
+    )
+    admission_window = _text(
+        torghut_routeability_admission_ref.get("window")
+        or torghut_routeability_admission_ref.get("session_id")
+        or torghut_routeability_admission_ref.get("sessionId")
+        or nested_admission.get("window")
+        or nested_admission.get("session_id")
+    )
+    admission_mode = _text(
+        torghut_routeability_admission_ref.get("trading_mode")
+        or torghut_routeability_admission_ref.get("tradingMode")
+        or nested_admission.get("trading_mode")
+    )
+
+    blockers: list[str] = []
+    if route_account and account and route_account != account:
+        blockers.append("route_identity_route_board_account_mismatch")
+    if proof_account and account and proof_account != account:
+        blockers.append("route_identity_proof_floor_account_mismatch")
+    if torghut_routeability_admission_ref:
+        if account and not admission_account:
+            blockers.append("route_identity_admission_account_missing")
+        elif account and admission_account != account:
+            blockers.append("route_identity_admission_account_mismatch")
+        if window and not admission_window:
+            blockers.append("route_identity_admission_window_missing")
+        elif window and admission_window != window:
+            blockers.append("route_identity_admission_window_mismatch")
+        if trading_mode and not admission_mode:
+            blockers.append("route_identity_admission_trading_mode_missing")
+        elif trading_mode and admission_mode != trading_mode:
+            blockers.append("route_identity_admission_trading_mode_mismatch")
+        blockers.extend(
+            _identity_mismatch_blockers(
+                expected=route_symbols,
+                observed=admission_symbols,
+                missing_reason="route_identity_admission_symbol_scope_missing",
+                mismatch_reason="route_identity_admission_symbol_scope_mismatch",
+            )
+        )
+        blockers.extend(
+            _identity_mismatch_blockers(
+                expected=route_hypothesis_ids,
+                observed=admission_hypothesis_ids,
+                missing_reason="route_identity_hypothesis_lineage_missing",
+                mismatch_reason="route_identity_hypothesis_lineage_mismatch",
+            )
+        )
+        blockers.extend(
+            _identity_mismatch_blockers(
+                expected=route_candidate_ids,
+                observed=admission_candidate_ids,
+                missing_reason="route_identity_candidate_lineage_missing",
+                mismatch_reason="route_identity_candidate_lineage_mismatch",
+            )
+        )
+        blockers.extend(
+            _identity_mismatch_blockers(
+                expected=route_manifest_refs,
+                observed=admission_manifest_refs,
+                missing_reason="route_identity_source_manifest_missing",
+                mismatch_reason="route_identity_source_manifest_mismatch",
+            )
+        )
+    return {
+        "account": account,
+        "route_board_account": route_account,
+        "proof_floor_account": proof_account,
+        "admission_account": admission_account or None,
+        "window": window,
+        "admission_window": admission_window or None,
+        "trading_mode": trading_mode,
+        "admission_trading_mode": admission_mode or None,
+        "route_symbols": route_symbols,
+        "admission_symbols": admission_symbols,
+        "route_hypothesis_ids": route_hypothesis_ids,
+        "admission_hypothesis_ids": admission_hypothesis_ids,
+        "route_candidate_ids": route_candidate_ids,
+        "admission_candidate_ids": admission_candidate_ids,
+        "route_source_manifest_refs": route_manifest_refs,
+        "admission_source_manifest_refs": admission_manifest_refs,
+        "blocking_reason_codes": _unique(blockers),
+    }
 
 
 def _dimension(
@@ -463,6 +704,7 @@ def _lot(
     rollback_trigger: str,
     symbols: Sequence[str] = (),
     hypothesis_ids: Sequence[str] = (),
+    source_identity: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     normalized_symbols = sorted(
         {_text(symbol).upper() for symbol in symbols if _text(symbol)}
@@ -483,7 +725,7 @@ def _lot(
             "blockers": blocking_reason_codes,
         },
     )
-    return {
+    lot: dict[str, object] = {
         "lot_id": lot_id,
         "lot_type": lot_type,
         "symbols": normalized_symbols,
@@ -501,6 +743,9 @@ def _lot(
         "authority_semantics": "audit_only_until_source_backed_runtime_ledger_fill_proof",
         "rollback_trigger": rollback_trigger,
     }
+    if source_identity is not None:
+        lot["source_identity"] = dict(source_identity)
+    return lot
 
 
 def _aggregate_state(lots: Sequence[Mapping[str, Any]]) -> str:
@@ -572,6 +817,16 @@ def build_routeability_repair_acceptance_ledger(
         proof_floor_receipt=proof_floor_receipt,
     )
     torghut_blockers = _torghut_admission_blockers(torghut_routeability_admission_ref)
+    source_identity = _source_identity_contract(
+        account=account,
+        window=window,
+        trading_mode=trading_mode,
+        proof_floor_receipt=proof_floor_receipt,
+        route_reacquisition_board=route_reacquisition_board,
+        rows=route_rows,
+        torghut_routeability_admission_ref=torghut_routeability_admission_ref,
+    )
+    source_identity_blockers = _strings(source_identity.get("blocking_reason_codes"))
 
     lots = [
         _lot(
@@ -682,6 +937,30 @@ def build_routeability_repair_acceptance_ledger(
             next_repair_action="refresh_torghut_routeability_admission_witness",
             rollback_trigger="routeability ledger accepts a candidate without current Torghut admission",
         ),
+        _lot(
+            account=account,
+            window=window,
+            trading_mode=trading_mode,
+            lot_type="source_identity_match",
+            value_gate="routeable_candidate_count",
+            expected_gate_delta="bind_routeability_acceptance_to_account_symbol_candidate_source_identity",
+            required_receipts=[
+                "route_source_identity_receipt",
+                "torghut_routeability_admission",
+            ],
+            blockers=source_identity_blockers,
+            acceptance_condition=(
+                "route board, proof floor, and Torghut admission agree on "
+                "account/window/mode/symbol/hypothesis/candidate lineage"
+            ),
+            next_repair_action="repair_route_source_identity_before_routeable_candidate_claim",
+            rollback_trigger="routeability acceptance consumed with mismatched source identity",
+            symbols=cast(Sequence[str], source_identity.get("route_symbols") or []),
+            hypothesis_ids=cast(
+                Sequence[str], source_identity.get("route_hypothesis_ids") or []
+            ),
+            source_identity=source_identity,
+        ),
     ]
 
     aggregate_state = _aggregate_state(lots)
@@ -743,6 +1022,7 @@ def build_routeability_repair_acceptance_ledger(
             "ledger_id"
         ),
         "torghut_routeability_admission_ref": dict(torghut_routeability_admission_ref),
+        "source_identity": source_identity,
         "lots": lots,
         "aggregate_state": aggregate_state,
         "aggregate_blocking_reason_codes": aggregate_blockers,

--- a/services/torghut/tests/test_route_evidence_clearinghouse.py
+++ b/services/torghut/tests/test_route_evidence_clearinghouse.py
@@ -32,7 +32,7 @@ BASE_INPUTS: dict[str, Any] = {
     "tca_summary": BASE_TCA,
     "options_catalog_freshness": {"active_contracts": 100, "missing_provider_updated_ts_count": 0, "provider_updated_ts_present": True, "newest_provider_updated_ts": NOW.isoformat(), "newest_last_seen_ts": NOW.isoformat()},
     "image_proof_summary": {"image_digest": "sha256:ready", "active_revision": "torghut-00324", "route_workloads_ok": True, "state": "current"},
-    "routeability_acceptance_ledger": {"ledger_id": "routeability:accepted", "aggregate_state": "accepted"},
+    "routeability_acceptance_ledger": {"ledger_id": "routeability:accepted", "account": "PA3SX7FYNUTF", "window": "15m", "trading_mode": "live", "aggregate_state": "accepted", "promotion_authority": False, "source_identity": {"account": "PA3SX7FYNUTF", "window": "15m", "trading_mode": "live", "route_symbols": ["AAPL"], "route_candidate_ids": ["candidate-micro"], "blocking_reason_codes": []}},
     "live_submission_gate": {"allowed": True, "reason": "ready"},
     "now": NOW,
 }
@@ -346,4 +346,32 @@ def test_route_repair_bids_emit_audit_receipts_and_blocker_recommendations() -> 
         assert receipt["requires_runtime_ledger_source_proof"] is True
     route_claim = cast(Mapping[str, Any], packet["route_claims"][0])
     assert route_claim["promotion_authority"] is False
+    assert packet["promotion_authority"] is False
+
+
+def test_routeability_acceptance_lineage_mismatch_holds_route_claim() -> None:
+    packet = _build(
+        routeability_acceptance_ledger={
+            **BASE_INPUTS["routeability_acceptance_ledger"],
+            "source_identity": {
+                "account": "PA3SX7FYNUTF",
+                "window": "15m",
+                "trading_mode": "live",
+                "route_symbols": ["MSFT"],
+                "route_candidate_ids": ["candidate-other"],
+                "blocking_reason_codes": [],
+            },
+        }
+    )
+    route_claim = packet["route_claims"][0]
+
+    assert packet["accepted_routeable_candidate_count"] == 0
+    assert route_claim["routeability_decision"] == "repair_only"
+    assert (
+        "routeability_acceptance_symbol_scope_mismatch" in route_claim["reason_codes"]
+    )
+    assert (
+        "routeability_acceptance_candidate_lineage_mismatch"
+        in route_claim["reason_codes"]
+    )
     assert packet["promotion_authority"] is False

--- a/services/torghut/tests/test_route_warrant_exchange.py
+++ b/services/torghut/tests/test_route_warrant_exchange.py
@@ -28,7 +28,7 @@ def _base_inputs() -> dict[str, Any]:
         "tca_summary": {"order_count": 72, "filled_execution_count": 72, "last_computed_at": NOW.isoformat(), "latest_execution_created_at": NOW.isoformat(), "avg_abs_slippage_bps": "4.5", "expected_shortfall_sample_count": 80},
         "empirical_jobs_status": {"ready": True, "status": "ready", "updated_at": NOW.isoformat(), "authority": "empirical-jobs:ready"},
         "proof_floor_receipt": {"schema_version": "torghut.profitability-proof-floor.v1", "route_state": "paper_candidate", "capital_state": "paper_allowed", "max_notional": "25", "generated_at": NOW.isoformat()},
-        "routeability_repair_acceptance_ledger": {"ledger_id": "routeability:accepted", "aggregate_state": "accepted", "accepted_routeable_candidate_count": 1, "aggregate_blocking_reason_codes": [], "generated_at": NOW.isoformat()},
+        "routeability_repair_acceptance_ledger": {"ledger_id": "routeability:accepted", "account": "PA3SX7FYNUTF", "window": "15m", "trading_mode": "live", "aggregate_state": "accepted", "accepted_routeable_candidate_count": 1, "aggregate_blocking_reason_codes": [], "promotion_authority": False, "generated_at": NOW.isoformat()},
         "profit_signal_quorum": {"quorum_set_id": "profit-quorum:ready", "aggregate_decision": "paper_candidate", "aggregate_reason_codes": [], "generated_at": NOW.isoformat(), "quorums": [{"quorum_id": "quorum:H-MICRO-01", "hypothesis_id": "H-MICRO-01", "candidate_id": "candidate-micro", "strategy_id": "strategy-micro", "decision": "paper_candidate"}]},
         "profit_freshness_frontier": {"frontier_id": "profit-freshness-frontier:ready", "frontier_state": "ready", "summary": {"ranked_daily_net_pnl_repair_count": 0, "selected_expected_daily_net_pnl_unlock": None}},
         "live_submission_gate": {"allowed": True, "reason": "ready", "blocked_reasons": []},
@@ -238,3 +238,37 @@ def test_repair_packets_are_zero_notional_and_single_receipt() -> None:
             "fill_tca_or_slippage_quality",
             "capital_gate_safety",
         }
+
+
+def test_routeability_acceptance_account_mismatch_blocks_warrant_candidate() -> None:
+    warrant = _build(
+        routeability_repair_acceptance_ledger={
+            **_base_inputs()["routeability_repair_acceptance_ledger"],
+            "account": "TORGHUT_SIM",
+        }
+    )
+
+    assert warrant["warrant_state"] == "repair_only"
+    assert warrant["accepted_routeable_candidate_count"] == 0
+    packet = _packet_for(warrant, "routeability")
+    assert "routeability_acceptance_account_mismatch" in packet["reason_codes"]
+    assert packet["promotion_authority"] is False
+    assert warrant["promotion_authority"] is False
+
+
+def test_routeability_acceptance_promotion_authority_blocks_warrant_candidate() -> None:
+    warrant = _build(
+        routeability_repair_acceptance_ledger={
+            **_base_inputs()["routeability_repair_acceptance_ledger"],
+            "promotion_authority": True,
+        }
+    )
+
+    assert warrant["warrant_state"] == "repair_only"
+    assert warrant["accepted_routeable_candidate_count"] == 0
+    packet = _packet_for(warrant, "routeability")
+    assert (
+        "routeability_acceptance_promotion_authority_must_be_false"
+        in packet["reason_codes"]
+    )
+    assert warrant["max_notional"] == "0"

--- a/services/torghut/tests/test_routeability_repair_acceptance.py
+++ b/services/torghut/tests/test_routeability_repair_acceptance.py
@@ -156,8 +156,8 @@ def test_routeability_acceptance_ledger_projects_all_doc185_lots_at_zero_notiona
     assert (
         ledger["profit_repair_settlement_ref"] == "profit-repair-settlement-ledger:test"
     )
-    assert ledger["summary"]["lot_count"] == 7
-    assert ledger["summary"]["zero_notional_lot_count"] == 7
+    assert ledger["summary"]["lot_count"] == 8
+    assert ledger["summary"]["zero_notional_lot_count"] == 8
 
     lots = cast(list[Mapping[str, Any]], ledger["lots"])
     assert {lot["paper_notional_limit"] for lot in lots} == {"0"}
@@ -172,6 +172,7 @@ def test_routeability_acceptance_ledger_projects_all_doc185_lots_at_zero_notiona
         "forecast_and_promotion_repair",
         "submit_gate_hold",
         "torghut_admission_witness",
+        "source_identity_match",
     }
 
 
@@ -305,6 +306,11 @@ def test_probing_route_rows_keep_routeability_unsettled_until_tca_acceptance() -
             "admission_ref": "jangar-routeability:ready",
             "decision": "allow",
             "state": "current",
+            "account_label": "PA3SX7FYNUTF",
+            "window": "15m",
+            "trading_mode": "live",
+            "symbols": ["AAPL"],
+            "hypothesis_ids": ["H-AAPL"],
             "reason_codes": [],
         },
     )
@@ -376,13 +382,18 @@ def test_all_receipts_must_settle_before_accepting_routeable_candidates() -> Non
             "admission_ref": "jangar-routeability:ready",
             "decision": "allow",
             "state": "current",
+            "account_label": "PA3SX7FYNUTF",
+            "window": "15m",
+            "trading_mode": "live",
+            "symbols": ["AAPL"],
+            "hypothesis_ids": ["H-AAPL"],
             "reason_codes": [],
         },
     )
 
     assert ledger["aggregate_state"] == "accepted"
     assert ledger["accepted_routeable_candidate_count"] == 1
-    assert ledger["summary"]["accepted_lot_count"] == 7
+    assert ledger["summary"]["accepted_lot_count"] == 8
 
 
 def test_blocked_autoresearch_portfolios_keep_promotion_repair_unsettled() -> None:
@@ -425,3 +436,158 @@ def test_blocked_autoresearch_portfolios_keep_promotion_repair_unsettled() -> No
         "autoresearch_portfolio_candidates_blocked"
         in promotion_lot["blocking_reason_codes"]
     )
+
+
+def _hpairs_ready_ledger(**overrides: object) -> dict[str, object]:
+    ready = {
+        "account_label": "TORGHUT_SIM",
+        "window": "15m",
+        "trading_mode": "paper",
+        "torghut_revision": "torghut-hpairs",
+        "revenue_repair_digest_ref": "/trading/revenue-repair/hpairs",
+        "consumer_evidence_receipt": {
+            "receipt_id": "torghut-consumer-evidence:hpairs-ready",
+            "fresh_until": "2026-05-08T12:33:00+00:00",
+            "forecast_registry_state": "ready",
+            "reason_codes": [],
+        },
+        "proof_floor_receipt": {
+            "schema_version": "torghut.profitability-proof-floor.v1",
+            "account_label": "TORGHUT_SIM",
+            "route_state": "paper_candidate",
+            "capital_state": "paper_allowed",
+            "max_notional": "25",
+            "blocking_reasons": [],
+            "proof_dimensions": [
+                {
+                    "dimension": "alpha_readiness",
+                    "state": "pass",
+                    "source_ref": {"promotion_eligible_total": 1},
+                }
+            ],
+        },
+        "capital_reentry_cohort_ledger": {"ledger_id": "capital-reentry:hpairs"},
+        "quality_adjusted_profit_frontier": {
+            "frontier_id": "quality-frontier:hpairs-ready",
+            "blocked_capital_surfaces": [],
+        },
+        "profit_repair_settlement_ledger": {"ledger_id": "profit-repair:hpairs"},
+        "route_reacquisition_board": {
+            "account_label": "TORGHUT_SIM",
+            "trading_mode": "paper",
+            "summary": {"capital_eligible_symbol_count": 1},
+            "rows": [
+                {
+                    "symbol": "AAPL",
+                    "state": "routeable",
+                    "hypothesis_ids": ["H-PAIRS-01"],
+                    "avg_abs_slippage_bps": "4",
+                    "slippage_guardrail_bps": "8",
+                    "source_metadata": {
+                        "account_label": "TORGHUT_SIM",
+                        "symbol": "AAPL",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "candidate-hpairs",
+                        "source_manifest_ref": "runtime-manifest:H-PAIRS-01",
+                    },
+                }
+            ],
+        },
+        "live_submission_gate": {"allowed": True, "reason": "ready"},
+        "quant_evidence": {
+            "ok": True,
+            "status": "healthy",
+            "latest_metrics_count": 144,
+            "stage_count": 3,
+        },
+        "market_context_status": {"status": "healthy", "last_domain_states": {}},
+        "torghut_routeability_admission_ref": {
+            "admission_ref": "jangar-routeability:hpairs-ready",
+            "decision": "allow",
+            "state": "current",
+            "account_label": "TORGHUT_SIM",
+            "window": "15m",
+            "trading_mode": "paper",
+            "symbols": ["AAPL"],
+            "hypothesis_ids": ["H-PAIRS-01"],
+            "candidate_ids": ["candidate-hpairs"],
+            "source_manifest_refs": ["runtime-manifest:H-PAIRS-01"],
+            "reason_codes": [],
+        },
+        "now": NOW,
+    }
+    ready.update(overrides)
+    return build_routeability_repair_acceptance_ledger(**ready)
+
+
+def test_clean_hpairs_torghut_sim_routeability_accepts_collection_only() -> None:
+    ledger = _hpairs_ready_ledger()
+    source_lot = _lot(ledger, "source_identity_match")
+
+    assert ledger["aggregate_state"] == "accepted"
+    assert ledger["accepted_routeable_candidate_count"] == 1
+    assert ledger["promotion_authority"] is False
+    assert (
+        ledger["rollback_target"]["routeability_acceptance_consumption_enabled"]
+        is False
+    )
+    assert source_lot["current_state"] == "accepted"
+    assert source_lot["blocking_reason_codes"] == []
+    assert source_lot["paper_notional_limit"] == "0"
+    assert source_lot["live_notional_limit"] == "0"
+
+
+def test_routeability_source_identity_account_mismatch_blocks_acceptance() -> None:
+    ledger = _hpairs_ready_ledger(
+        torghut_routeability_admission_ref={
+            "admission_ref": "jangar-routeability:wrong-account",
+            "decision": "allow",
+            "state": "current",
+            "account_label": "PA3SX7FYNUTF",
+            "window": "15m",
+            "trading_mode": "paper",
+            "symbols": ["AAPL"],
+            "hypothesis_ids": ["H-PAIRS-01"],
+            "candidate_ids": ["candidate-hpairs"],
+            "source_manifest_refs": ["runtime-manifest:H-PAIRS-01"],
+            "reason_codes": [],
+        }
+    )
+    source_lot = _lot(ledger, "source_identity_match")
+
+    assert ledger["aggregate_state"] == "repairing"
+    assert ledger["accepted_routeable_candidate_count"] == 0
+    assert (
+        "route_identity_admission_account_mismatch"
+        in source_lot["blocking_reason_codes"]
+    )
+
+
+def test_routeability_source_identity_symbol_and_candidate_mismatch_blocks() -> None:
+    ledger = _hpairs_ready_ledger(
+        torghut_routeability_admission_ref={
+            "admission_ref": "jangar-routeability:wrong-lineage",
+            "decision": "allow",
+            "state": "current",
+            "account_label": "TORGHUT_SIM",
+            "window": "15m",
+            "trading_mode": "paper",
+            "symbols": ["MSFT"],
+            "hypothesis_ids": ["H-PAIRS-01"],
+            "candidate_ids": ["candidate-other"],
+            "source_manifest_refs": ["runtime-manifest:H-PAIRS-01"],
+            "reason_codes": [],
+        }
+    )
+    source_lot = _lot(ledger, "source_identity_match")
+
+    assert ledger["accepted_routeable_candidate_count"] == 0
+    assert (
+        "route_identity_admission_symbol_scope_mismatch"
+        in source_lot["blocking_reason_codes"]
+    )
+    assert (
+        "route_identity_candidate_lineage_mismatch"
+        in source_lot["blocking_reason_codes"]
+    )
+    assert ledger["promotion_authority"] is False

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1841,7 +1841,7 @@ class TestTradingApi(TestCase):
             routeability["schema_version"],
             "torghut.routeability-repair-acceptance-ledger.v1",
         )
-        self.assertEqual(routeability["summary"]["zero_notional_lot_count"], 7)
+        self.assertEqual(routeability["summary"]["zero_notional_lot_count"], 8)
         self.assertEqual(routeability["accepted_routeable_candidate_count"], 0)
         clearinghouse = payload["route_evidence_clearinghouse_packet"]
         self.assertEqual(
@@ -2807,7 +2807,7 @@ class TestTradingApi(TestCase):
             "torghut.routeability-repair-acceptance-ledger.v1",
         )
         self.assertEqual(status_routeability["accepted_routeable_candidate_count"], 0)
-        self.assertEqual(status_routeability["summary"]["zero_notional_lot_count"], 7)
+        self.assertEqual(status_routeability["summary"]["zero_notional_lot_count"], 8)
         self.assertEqual(
             health_routeability["schema_version"],
             status_routeability["schema_version"],


### PR DESCRIPTION
## Summary

- Adds a routeability source-identity acceptance lot that binds account, window, trading mode, symbols, hypothesis IDs, candidate IDs, and source manifests before accepting routeable candidates.
- Propagates routeability identity guards into the route warrant exchange and route evidence clearinghouse so mismatched ledgers fail closed with explicit blockers.
- Adds H-PAIRS/TORGHUT_SIM regression coverage proving clean bounded collection can be accepted while account, symbol, candidate, and promotion-authority mismatches block.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass; required installing `build-essential` in the workspace so `crosshair-tool` could compile)
- `cd services/torghut && uv run --frozen pytest tests/test_routeability_repair_acceptance.py tests/test_route_reacquisition.py tests/test_route_warrant_exchange.py tests/test_route_evidence_clearinghouse.py tests/test_route_metadata.py -q` (pass: 51 passed, 1 deprecation warning from tests/conftest.py event loop setup)
- `cd services/torghut && uv run --frozen ruff check app/trading/routeability_repair_acceptance.py app/trading/route_warrant_exchange.py app/trading/route_evidence_clearinghouse.py tests/test_routeability_repair_acceptance.py tests/test_route_warrant_exchange.py tests/test_route_evidence_clearinghouse.py` (pass)
- `cd services/torghut && uv run --frozen ruff format --check app/trading/routeability_repair_acceptance.py app/trading/route_warrant_exchange.py app/trading/route_evidence_clearinghouse.py tests/test_routeability_repair_acceptance.py tests/test_route_warrant_exchange.py tests/test_route_evidence_clearinghouse.py` (pass)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` (pass)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` (pass)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` (pass)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
