### PR TITLE
fix(torghut): keep target-plan deferred path lightweight

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -7012,32 +7012,10 @@ def build_paper_route_target_plan_payload(
         generated_at=resolved_generated_at,
         target_account_audit_available=target_account_audit_available,
     )
-    closed_window_start, closed_window_end = (
-        _latest_closed_regular_equities_session_window(resolved_generated_at)
-    )
-    latest_closed_targets = _next_paper_route_runtime_window_targets(
-        session=session,
-        targets=targets,
-        probe=probe,
-        live_submission_gate=live_submission_gate,
-        generated_at=resolved_generated_at,
-        require_clean_pre_session=False,
-        window_start=closed_window_start,
-        window_end=closed_window_end,
-        purpose="latest_closed_session_paper_route_runtime_window_import",
-        target_account_audit_available=target_account_audit_available,
-    )
-    source_targets = _next_paper_route_runtime_window_targets(
-        session=session,
-        targets=targets,
-        probe=probe,
-        live_submission_gate=live_submission_gate,
-        generated_at=resolved_generated_at,
-        require_clean_pre_session=False,
-        target_account_audit_available=target_account_audit_available,
-    )
     runtime_window_import_plan = next_targets
     next_clean_after_discard_targets: Mapping[str, Any] = {}
+    latest_closed_targets: Mapping[str, Any] = {}
+    source_targets: Mapping[str, Any] = {}
     latest_closed_runtime_window_import_target_audits: (
         list[dict[str, object]] | None
     ) = None
@@ -7048,61 +7026,83 @@ def build_paper_route_target_plan_payload(
             selected=False,
         )
     )
-    latest_closed_runtime_window_import_plan = _runtime_window_import_plan_for_audit(
-        latest_closed_targets=latest_closed_targets,
-        next_targets=next_targets,
-    )
-    if (
-        latest_closed_runtime_window_import_plan is latest_closed_targets
-        and include_runtime_window_import_audit is not False
-    ):
-        latest_closed_runtime_window_import_target_audits = [
-            _target_audit_fail_closed(
-                session,
-                raw_target=target,
-                probe=probe,
-                generated_at=resolved_generated_at,
-                lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
-                error_source="target_plan_runtime_window_target_audit",
+    if include_runtime_window_import_audit is not False:
+        closed_window_start, closed_window_end = (
+            _latest_closed_regular_equities_session_window(resolved_generated_at)
+        )
+        latest_closed_targets = _next_paper_route_runtime_window_targets(
+            session=session,
+            targets=targets,
+            probe=probe,
+            live_submission_gate=live_submission_gate,
+            generated_at=resolved_generated_at,
+            require_clean_pre_session=False,
+            window_start=closed_window_start,
+            window_end=closed_window_end,
+            purpose="latest_closed_session_paper_route_runtime_window_import",
+            target_account_audit_available=target_account_audit_available,
+        )
+        source_targets = _next_paper_route_runtime_window_targets(
+            session=session,
+            targets=targets,
+            probe=probe,
+            live_submission_gate=live_submission_gate,
+            generated_at=resolved_generated_at,
+            require_clean_pre_session=False,
+            target_account_audit_available=target_account_audit_available,
+        )
+        latest_closed_runtime_window_import_plan = (
+            _runtime_window_import_plan_for_audit(
+                latest_closed_targets=latest_closed_targets,
+                next_targets=next_targets,
             )
-            for target in _as_mapping_items(latest_closed_targets.get("targets"))
-        ]
-        latest_closed_importable = (
-            _target_audits_have_importable_source_backed_runtime_window_import_evidence(
+        )
+        if latest_closed_runtime_window_import_plan is latest_closed_targets:
+            latest_closed_runtime_window_import_target_audits = [
+                _target_audit_fail_closed(
+                    session,
+                    raw_target=target,
+                    probe=probe,
+                    generated_at=resolved_generated_at,
+                    lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+                    error_source="target_plan_runtime_window_target_audit",
+                )
+                for target in _as_mapping_items(latest_closed_targets.get("targets"))
+            ]
+            latest_closed_importable = _target_audits_have_importable_source_backed_runtime_window_import_evidence(
                 latest_closed_runtime_window_import_target_audits
             )
-        )
-        latest_closed_runtime_window_import_selection = (
-            _runtime_window_import_candidate_selection(
-                latest_closed_targets=latest_closed_targets,
-                latest_closed_target_audits=(
-                    latest_closed_runtime_window_import_target_audits
-                ),
-                selected=latest_closed_importable,
+            latest_closed_runtime_window_import_selection = (
+                _runtime_window_import_candidate_selection(
+                    latest_closed_targets=latest_closed_targets,
+                    latest_closed_target_audits=(
+                        latest_closed_runtime_window_import_target_audits
+                    ),
+                    selected=latest_closed_importable,
+                )
             )
-        )
-        if latest_closed_importable:
-            runtime_window_import_plan = latest_closed_targets
-        elif _runtime_window_import_candidate_discard_blockers(
-            latest_closed_runtime_window_import_target_audits
-        ):
-            followup_window_start, followup_window_end = (
-                _following_regular_equities_session_window(closed_window_end)
-            )
-            next_clean_after_discard_targets = _next_paper_route_runtime_window_targets(
-                session=session,
-                targets=targets,
-                probe=probe,
-                live_submission_gate=live_submission_gate,
-                generated_at=resolved_generated_at,
-                window_start=followup_window_start,
-                window_end=followup_window_end,
-                purpose=(
-                    "next_clean_session_paper_route_runtime_window_collection_after_discard"
-                ),
-                target_account_audit_available=target_account_audit_available,
-            )
-            runtime_window_import_plan = next_clean_after_discard_targets
+            if latest_closed_importable:
+                runtime_window_import_plan = latest_closed_targets
+            elif _runtime_window_import_candidate_discard_blockers(
+                latest_closed_runtime_window_import_target_audits
+            ):
+                followup_window_start, followup_window_end = (
+                    _following_regular_equities_session_window(closed_window_end)
+                )
+                next_clean_after_discard_targets = _next_paper_route_runtime_window_targets(
+                    session=session,
+                    targets=targets,
+                    probe=probe,
+                    live_submission_gate=live_submission_gate,
+                    generated_at=resolved_generated_at,
+                    window_start=followup_window_start,
+                    window_end=followup_window_end,
+                    purpose=(
+                        "next_clean_session_paper_route_runtime_window_collection_after_discard"
+                    ),
+                    target_account_audit_available=target_account_audit_available,
+                )
+                runtime_window_import_plan = next_clean_after_discard_targets
     runtime_import_readiness = _as_mapping(
         runtime_window_import_plan.get("session_readiness")
     )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
+import app.trading.paper_route_evidence as paper_route_evidence
 from app.models import (
     Base,
     Execution,
@@ -897,6 +898,45 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(
             import_audit["counts"]["selected_target_count"],
             1,
+        )
+
+    def test_target_plan_deferred_mode_builds_only_next_window(self) -> None:
+        generated_at = datetime(2026, 5, 26, 12, tzinfo=timezone.utc)
+        window_purposes: list[str] = []
+        original_builder = paper_route_evidence._next_paper_route_runtime_window_targets
+
+        def _record_window_build(*args: object, **kwargs: object) -> dict[str, object]:
+            window_purposes.append(str(kwargs.get("purpose") or "next_session"))
+            return original_builder(*args, **kwargs)
+
+        with Session(self.engine) as session:
+            with patch(
+                "app.trading.paper_route_evidence._next_paper_route_runtime_window_targets",
+                side_effect=_record_window_build,
+            ):
+                payload = self._build_basic_paper_route_target_plan(
+                    session,
+                    generated_at=generated_at,
+                    include_runtime_window_import_audit=False,
+                )
+
+        self.assertEqual(window_purposes, ["next_session"])
+        self.assertEqual(payload["source_runtime_window_import_plan"], {})
+        self.assertEqual(
+            payload["latest_closed_paper_route_runtime_window_targets"], {}
+        )
+        self.assertEqual(
+            payload["runtime_window_import_audit_mode"],
+            "deferred_until_import_ready",
+        )
+        self.assertEqual(payload["runtime_window_import_plan"]["target_count"], 1)
+        self.assertEqual(
+            payload["summary"]["source_runtime_window_target_count"],
+            0,
+        )
+        self.assertEqual(
+            payload["summary"]["latest_closed_runtime_window_target_count"],
+            0,
         )
 
     def test_target_plan_auto_runs_full_runtime_window_audit_when_import_ready(


### PR DESCRIPTION
## Summary

- Keep the deferred `/trading/paper-route-target-plan` builder path to the next-session target plan instead of constructing source and latest-closed alternate windows.
- Preserve the full/import-ready runtime-window audit path, including latest-closed clean-window selection and fail-closed proof behavior.
- Add a regression test proving deferred target-plan construction calls the next-window builder only once and leaves alternate-window payloads empty.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'target_plan_deferred_mode_builds_only_next_window or target_plan_can_defer_full_runtime_window_audit or target_plan_auto_runs_full_runtime_window_audit_when_import_ready' -q`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
