### PR TITLE
fix(torghut): restore tigerbeetle journal safety cadence

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: tigerbeetle-journal-order-events
 spec:
-  schedule: "1,6,11,16,21,26,31,36,41,46,51,56 * * * *"
+  schedule: "6,36 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
@@ -15,7 +15,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 1200
+      activeDeadlineSeconds: 900
       template:
         spec:
           restartPolicy: Never

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1382,7 +1382,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             spec.get("schedule"),
-            "1,6,11,16,21,26,31,36,41,46,51,56 * * * *",
+            "6,36 * * * *",
         )
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
         self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
@@ -1398,7 +1398,7 @@ class TestLiveConfigManifestContract(TestCase):
             cast(Mapping[str, object], job_spec.get("template", {})),
         )
         pod_spec = cast(Mapping[str, object], template.get("spec", {}))
-        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 1200)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 900)
         self.assertEqual(job_spec.get("backoffLimit"), 0)
         self.assertEqual(pod_spec.get("restartPolicy"), "Never")
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")


### PR DESCRIPTION
## Summary

- Restores the Torghut TigerBeetle order-event journal CronJob to the twice-hourly safety cadence.
- Restores the 900-second job deadline so the journal job cannot occupy runtime capacity for longer windows.
- Updates the live manifest contract test to enforce the lower cadence and deadline.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim -q`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
