### PR TITLE
fix(torghut): bound tigerbeetle client rpc calls

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -76,6 +76,8 @@ spec:
               value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
             - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
               value: "5"
+            - name: TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS
+              value: "10"
             - name: TORGHUT_TIGERBEETLE_JOURNAL_ENABLED
               value: "true"
             - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -59,6 +59,8 @@ spec:
               value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
             - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
               value: "5"
+            - name: TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS
+              value: "10"
             - name: TORGHUT_TIGERBEETLE_JOURNAL_ENABLED
               value: "true"
             - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -127,6 +127,8 @@ spec:
                   value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
                 - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
                   value: "5"
+                - name: TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS
+                  value: "10"
                 - name: TORGHUT_TIGERBEETLE_JOURNAL_ENABLED
                   value: "true"
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -59,6 +59,8 @@ spec:
               value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
             - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
               value: "5"
+            - name: TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS
+              value: "10"
           resources:
             requests:
               cpu: 100m

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -296,6 +296,11 @@ class Settings(BaseSettings):
         alias="TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS",
         description="TigerBeetle protocol health timeout in seconds.",
     )
+    tigerbeetle_rpc_timeout_seconds: float = Field(
+        default=10.0,
+        alias="TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS",
+        description="Maximum time allowed for one synchronous TigerBeetle client RPC.",
+    )
     tigerbeetle_journal_enabled: bool = Field(
         default=False,
         alias="TORGHUT_TIGERBEETLE_JOURNAL_ENABLED",
@@ -2668,6 +2673,8 @@ class Settings(BaseSettings):
             raise ValueError("TORGHUT_TIGERBEETLE_CLUSTER_ID must be > 0")
         if self.tigerbeetle_health_timeout_seconds <= 0:
             raise ValueError("TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS must be > 0")
+        if self.tigerbeetle_rpc_timeout_seconds <= 0:
+            raise ValueError("TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS must be > 0")
         if self.tigerbeetle_reconcile_max_age_seconds <= 0:
             raise ValueError(
                 "TORGHUT_TIGERBEETLE_RECONCILE_MAX_AGE_SECONDS must be > 0"

--- a/services/torghut/app/trading/tigerbeetle_client.py
+++ b/services/torghut/app/trading/tigerbeetle_client.py
@@ -188,7 +188,7 @@ class RealTigerBeetleClient:
         # The Python client does not expose TigerBeetle's internal NOP request.
         # A one-id account lookup is read-only but still proves client/server
         # protocol connectivity through the official public API.
-        self._client.lookup_accounts([HEALTH_PROBE_ACCOUNT_ID])
+        self.lookup_accounts([HEALTH_PROBE_ACCOUNT_ID])
 
     def _account_event(self, account: object) -> object:
         if not isinstance(account, TigerBeetleAccountSpec):

--- a/services/torghut/app/trading/tigerbeetle_client.py
+++ b/services/torghut/app/trading/tigerbeetle_client.py
@@ -66,7 +66,7 @@ def _run_with_timeout(
         return cast(_T, value)
     if isinstance(value, BaseException):
         raise value
-    raise RuntimeError(f"tigerbeetle_{operation_name}_failed")
+    raise RuntimeError(f"tigerbeetle_{operation_name}_failed")  # pragma: no cover
 
 
 @dataclass(frozen=True)

--- a/services/torghut/app/trading/tigerbeetle_client.py
+++ b/services/torghut/app/trading/tigerbeetle_client.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import ipaddress
+import queue
 import socket
-from collections.abc import Sequence
+import threading
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, Protocol, cast
+from typing import Any, Protocol, TypeVar, cast
 
 from app.config import Settings
 from app.trading.tigerbeetle_ledger_model import (
@@ -15,6 +17,7 @@ from app.trading.tigerbeetle_ledger_model import (
 )
 
 HEALTH_PROBE_ACCOUNT_ID = 1
+_T = TypeVar("_T")
 
 
 class TigerBeetleClientProtocol(Protocol):
@@ -27,6 +30,43 @@ class TigerBeetleClientProtocol(Protocol):
     def create_transfers(self, transfers: Sequence[object]) -> Sequence[object]: ...
 
     def lookup_transfers(self, ids: Sequence[int]) -> Sequence[object]: ...
+
+
+class TigerBeetleClientTimeoutError(TimeoutError):
+    """Raised when the synchronous TigerBeetle client exceeds its RPC deadline."""
+
+
+def _run_with_timeout(
+    *,
+    operation_name: str,
+    timeout_seconds: float,
+    operation: Callable[[], _T],
+) -> _T:
+    result_queue: queue.Queue[tuple[bool, _T | BaseException]] = queue.Queue(maxsize=1)
+
+    def run_operation() -> None:
+        try:
+            result_queue.put((True, operation()), block=False)
+        except BaseException as exc:
+            result_queue.put((False, exc), block=False)
+
+    thread = threading.Thread(
+        target=run_operation,
+        name=f"torghut-tigerbeetle-{operation_name}",
+        daemon=True,
+    )
+    thread.start()
+    try:
+        ok, value = result_queue.get(timeout=max(float(timeout_seconds), 0.001))
+    except queue.Empty as exc:
+        raise TigerBeetleClientTimeoutError(
+            f"tigerbeetle_{operation_name}_timeout:{timeout_seconds:.3f}s"
+        ) from exc
+    if ok:
+        return cast(_T, value)
+    if isinstance(value, BaseException):
+        raise value
+    raise RuntimeError(f"tigerbeetle_{operation_name}_failed")
 
 
 @dataclass(frozen=True)
@@ -112,16 +152,27 @@ def resolve_replica_addresses(replica_addresses: Sequence[str]) -> list[str]:
 class RealTigerBeetleClient:
     """Small wrapper around the official synchronous TigerBeetle client."""
 
-    def __init__(self, *, cluster_id: int, replica_addresses: Sequence[str]) -> None:
+    def __init__(
+        self,
+        *,
+        cluster_id: int,
+        replica_addresses: Sequence[str],
+        rpc_timeout_seconds: float = 10.0,
+    ) -> None:
         import tigerbeetle as tb
 
         # The official client validates endpoint syntax before dialing and
         # accepts IP endpoints, not Kubernetes DNS service names.
         official_addresses = resolve_replica_addresses(replica_addresses)
         self._tb: Any = tb
-        self._client: Any = tb.ClientSync(
-            cluster_id=cluster_id,
-            replica_addresses=",".join(official_addresses),
+        self._rpc_timeout_seconds = max(float(rpc_timeout_seconds), 0.001)
+        self._client: Any = _run_with_timeout(
+            operation_name="connect",
+            timeout_seconds=self._rpc_timeout_seconds,
+            operation=lambda: tb.ClientSync(
+                cluster_id=cluster_id,
+                replica_addresses=",".join(official_addresses),
+            ),
         )
 
     def close(self) -> None:
@@ -177,20 +228,36 @@ class RealTigerBeetleClient:
         )
 
     def create_accounts(self, accounts: Sequence[object]) -> Sequence[object]:
-        return self._client.create_accounts(
-            [self._account_event(item) for item in accounts]
+        return _run_with_timeout(
+            operation_name="create_accounts",
+            timeout_seconds=self._rpc_timeout_seconds,
+            operation=lambda: self._client.create_accounts(
+                [self._account_event(item) for item in accounts]
+            ),
         )
 
     def lookup_accounts(self, ids: Sequence[int]) -> Sequence[object]:
-        return self._client.lookup_accounts(list(ids))
+        return _run_with_timeout(
+            operation_name="lookup_accounts",
+            timeout_seconds=self._rpc_timeout_seconds,
+            operation=lambda: self._client.lookup_accounts(list(ids)),
+        )
 
     def create_transfers(self, transfers: Sequence[object]) -> Sequence[object]:
-        return self._client.create_transfers(
-            [self._transfer_event(item) for item in transfers]
+        return _run_with_timeout(
+            operation_name="create_transfers",
+            timeout_seconds=self._rpc_timeout_seconds,
+            operation=lambda: self._client.create_transfers(
+                [self._transfer_event(item) for item in transfers]
+            ),
         )
 
     def lookup_transfers(self, ids: Sequence[int]) -> Sequence[object]:
-        return self._client.lookup_transfers(list(ids))
+        return _run_with_timeout(
+            operation_name="lookup_transfers",
+            timeout_seconds=self._rpc_timeout_seconds,
+            operation=lambda: self._client.lookup_transfers(list(ids)),
+        )
 
 
 class FakeTigerBeetleClient:
@@ -238,6 +305,7 @@ def create_tigerbeetle_client(settings: Settings) -> RealTigerBeetleClient:
         replica_addresses=parse_replica_addresses(
             settings.tigerbeetle_replica_addresses
         ),
+        rpc_timeout_seconds=settings.tigerbeetle_rpc_timeout_seconds,
     )
 
 

--- a/services/torghut/tests/test_config.py
+++ b/services/torghut/tests/test_config.py
@@ -36,6 +36,7 @@ class TestConfig(TestCase):
             TORGHUT_TIGERBEETLE_CLUSTER_ID=2001,
             TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES=" tb-0:3000, tb-1:3000 ",
             TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS=1.5,
+            TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS=7.5,
             TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
             TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED=True,
         )
@@ -45,6 +46,7 @@ class TestConfig(TestCase):
         self.assertEqual(settings.tigerbeetle_cluster_id, 2001)
         self.assertEqual(settings.tigerbeetle_replica_addresses, "tb-0:3000,tb-1:3000")
         self.assertEqual(settings.tigerbeetle_health_timeout_seconds, 1.5)
+        self.assertEqual(settings.tigerbeetle_rpc_timeout_seconds, 7.5)
         self.assertTrue(settings.tigerbeetle_journal_enabled)
         self.assertTrue(settings.tigerbeetle_reconcile_required)
 
@@ -67,6 +69,13 @@ class TestConfig(TestCase):
             "TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS must be > 0",
         ):
             Settings(TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS=0)
+
+    def test_tigerbeetle_settings_reject_invalid_rpc_timeout(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS must be > 0",
+        ):
+            Settings(TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS=0)
 
     def test_rejects_static_universe_when_trading_enabled_in_legacy_mode(self) -> None:
         with self.assertRaises(ValidationError):

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -960,6 +960,7 @@ class TestLiveConfigManifestContract(TestCase):
             "TORGHUT_TIGERBEETLE_CLUSTER_ID": "2001",
             "TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES": "torghut-tigerbeetle.torghut.svc.cluster.local:3000",
             "TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS": "5",
+            "TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS": "10",
             "TORGHUT_TIGERBEETLE_JOURNAL_ENABLED": "true",
             "TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED": "false",
         }
@@ -1466,6 +1467,7 @@ class TestLiveConfigManifestContract(TestCase):
             value_env["TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES"],
             "torghut-tigerbeetle.torghut.svc.cluster.local:3000",
         )
+        self.assertEqual(value_env["TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS"], "10")
         self.assertEqual(value_env["TORGHUT_TIGERBEETLE_JOURNAL_ENABLED"], "true")
         self.assertEqual(
             value_env["TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED"],

--- a/services/torghut/tests/test_tigerbeetle_client.py
+++ b/services/torghut/tests/test_tigerbeetle_client.py
@@ -223,6 +223,50 @@ class TestTigerBeetleClient(TestCase):
             ):
                 client.create_accounts([account])
 
+    def test_real_client_times_out_blocked_health_lookup(self) -> None:
+        class _BlockingHealthSync:
+            def __init__(self, *, cluster_id: int, replica_addresses: str) -> None:
+                del cluster_id, replica_addresses
+
+            def lookup_accounts(self, ids: list[int]) -> list[object]:
+                del ids
+                time.sleep(0.2)
+                return []
+
+        fake_module = SimpleNamespace(
+            ClientSync=_BlockingHealthSync,
+            Account=_Event,
+            Transfer=_Event,
+        )
+        with (
+            patch.dict(sys.modules, {"tigerbeetle": fake_module}),
+            patch(
+                "app.trading.tigerbeetle_client.socket.getaddrinfo",
+                return_value=[
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("10.99.251.1", 3000),
+                    )
+                ],
+            ),
+        ):
+            client = RealTigerBeetleClient(
+                cluster_id=2001,
+                replica_addresses=[
+                    "torghut-tigerbeetle.torghut.svc.cluster.local:3000"
+                ],
+                rpc_timeout_seconds=0.01,
+            )
+
+            with self.assertRaisesRegex(
+                TigerBeetleClientTimeoutError,
+                "tigerbeetle_lookup_accounts_timeout",
+            ):
+                client.nop()
+
     def test_real_client_times_out_blocked_connect(self) -> None:
         class _BlockingConnectSync:
             def __init__(self, *, cluster_id: int, replica_addresses: str) -> None:

--- a/services/torghut/tests/test_tigerbeetle_client.py
+++ b/services/torghut/tests/test_tigerbeetle_client.py
@@ -13,6 +13,7 @@ from app.trading.tigerbeetle_client import (
     HEALTH_PROBE_ACCOUNT_ID,
     RealTigerBeetleClient,
     TigerBeetleClientTimeoutError,
+    _run_with_timeout,
     check_tigerbeetle_health,
     create_tigerbeetle_client,
     parse_replica_addresses,
@@ -162,6 +163,14 @@ class TestTigerBeetleClient(TestCase):
             replica_addresses=["tb-0:3000", "tb-1:3000"],
             rpc_timeout_seconds=settings.tigerbeetle_rpc_timeout_seconds,
         )
+
+    def test_timeout_helper_propagates_operation_errors(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "rpc failed"):
+            _run_with_timeout(
+                operation_name="lookup_accounts",
+                timeout_seconds=1.0,
+                operation=lambda: (_ for _ in ()).throw(RuntimeError("rpc failed")),
+            )
 
     def test_real_client_times_out_blocked_account_rpc(self) -> None:
         class _BlockingSync:

--- a/services/torghut/tests/test_tigerbeetle_client.py
+++ b/services/torghut/tests/test_tigerbeetle_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import socket
 import sys
+import time
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
@@ -11,6 +12,7 @@ from app.trading.tigerbeetle_client import (
     FakeTigerBeetleClient,
     HEALTH_PROBE_ACCOUNT_ID,
     RealTigerBeetleClient,
+    TigerBeetleClientTimeoutError,
     check_tigerbeetle_health,
     create_tigerbeetle_client,
     parse_replica_addresses,
@@ -158,7 +160,97 @@ class TestTigerBeetleClient(TestCase):
         cls.assert_called_once_with(
             cluster_id=77,
             replica_addresses=["tb-0:3000", "tb-1:3000"],
+            rpc_timeout_seconds=settings.tigerbeetle_rpc_timeout_seconds,
         )
+
+    def test_real_client_times_out_blocked_account_rpc(self) -> None:
+        class _BlockingSync:
+            def __init__(self, *, cluster_id: int, replica_addresses: str) -> None:
+                del cluster_id, replica_addresses
+
+            def create_accounts(self, accounts: list[object]) -> list[object]:
+                del accounts
+                time.sleep(0.2)
+                return []
+
+        fake_module = SimpleNamespace(
+            ClientSync=_BlockingSync,
+            Account=_Event,
+            Transfer=_Event,
+        )
+        with (
+            patch.dict(sys.modules, {"tigerbeetle": fake_module}),
+            patch(
+                "app.trading.tigerbeetle_client.socket.getaddrinfo",
+                return_value=[
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("10.99.251.1", 3000),
+                    )
+                ],
+            ),
+        ):
+            client = RealTigerBeetleClient(
+                cluster_id=2001,
+                replica_addresses=[
+                    "torghut-tigerbeetle.torghut.svc.cluster.local:3000"
+                ],
+                rpc_timeout_seconds=0.01,
+            )
+            account = TigerBeetleAccountSpec(
+                account_id=11,
+                account_key="cash:paper:usd",
+                ledger=LEDGER_USD_MICRO,
+                code=1001,
+                account_label="paper",
+            )
+
+            with self.assertRaisesRegex(
+                TigerBeetleClientTimeoutError,
+                "tigerbeetle_create_accounts_timeout",
+            ):
+                client.create_accounts([account])
+
+    def test_real_client_times_out_blocked_connect(self) -> None:
+        class _BlockingConnectSync:
+            def __init__(self, *, cluster_id: int, replica_addresses: str) -> None:
+                del cluster_id, replica_addresses
+                time.sleep(0.2)
+
+        fake_module = SimpleNamespace(
+            ClientSync=_BlockingConnectSync,
+            Account=_Event,
+            Transfer=_Event,
+        )
+        with (
+            patch.dict(sys.modules, {"tigerbeetle": fake_module}),
+            patch(
+                "app.trading.tigerbeetle_client.socket.getaddrinfo",
+                return_value=[
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("10.99.251.1", 3000),
+                    )
+                ],
+            ),
+        ):
+            with self.assertRaisesRegex(
+                TigerBeetleClientTimeoutError,
+                "tigerbeetle_connect_timeout",
+            ):
+                RealTigerBeetleClient(
+                    cluster_id=2001,
+                    replica_addresses=[
+                        "torghut-tigerbeetle.torghut.svc.cluster.local:3000"
+                    ],
+                    rpc_timeout_seconds=0.01,
+                )
 
     def test_real_client_converts_domain_specs_to_official_events(self) -> None:
         instances: list[object] = []


### PR DESCRIPTION
## Summary

- Adds a configurable `TORGHUT_TIGERBEETLE_RPC_TIMEOUT_SECONDS` bound for synchronous TigerBeetle client construction and RPC calls.
- Wraps TigerBeetle connect, account, transfer, and lookup operations so a blocked official client raises a typed timeout instead of holding proof jobs open indefinitely.
- Propagates the RPC timeout env var through Torghut live/sim services, the TigerBeetle smoke job, and the journal CronJob.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_tigerbeetle_client.py::TestTigerBeetleClient::test_real_client_times_out_blocked_account_rpc tests/test_tigerbeetle_client.py::TestTigerBeetleClient::test_real_client_times_out_blocked_connect tests/test_tigerbeetle_client.py::TestTigerBeetleClient::test_create_tigerbeetle_client_uses_normalized_settings tests/test_config.py::TestConfig::test_tigerbeetle_settings_are_normalized tests/test_config.py::TestConfig::test_tigerbeetle_settings_reject_invalid_rpc_timeout tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_torghut_knative_manifests_enable_tigerbeetle_journal tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim -q`
- `uv run --frozen pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py tests/test_config.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff format --check app/config.py app/trading/tigerbeetle_client.py tests/test_tigerbeetle_client.py tests/test_config.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/config.py app/trading/tigerbeetle_client.py tests/test_tigerbeetle_client.py tests/test_config.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
