### PR TITLE
fix(torghut): harden bounded target-plan fetch

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -83,6 +83,7 @@ _PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS = 86_400
 _SIMPLE_MARKET_CONTEXT_RETRY_INTERVAL = timedelta(seconds=30)
 _PAPER_ROUTE_PROBE_QTY_STEP = Decimal("0.0001")
 _REGULAR_SESSION_MINUTES = 390
+_PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS = 3
 _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS = 60
 _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS = 600
 _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK = timedelta(days=7)
@@ -1226,6 +1227,36 @@ class SimpleTradingPipeline(TradingPipeline):
             len(batch.fallback_signals),
         )
 
+    def _record_bounded_target_plan_blocker(
+        self,
+        *,
+        reason: str,
+        symbols: set[str] | None = None,
+        targets: Sequence[Mapping[str, Any]] | None = None,
+    ) -> None:
+        normalized_reason = reason.strip() or "paper_route_target_plan_unavailable"
+        blocker = {
+            "blockers": [normalized_reason],
+            "reason": normalized_reason,
+            "account_label": self.account_label,
+            "source": "external_target_plan_url",
+            "target_plan_url_configured": bool(
+                str(settings.trading_paper_route_target_plan_url or "").strip()
+            ),
+            "target_symbols": sorted(symbols or set()),
+            "target_count": len(targets or []),
+            "fetch_attempts": _PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS,
+        }
+        setattr(self.state, "last_bounded_evidence_collection_blocker", blocker)
+        logger.warning(
+            "Blocking bounded paper-route evidence decisions because target plan is unavailable account_label=%s reason=%s symbols=%s target_count=%s attempts=%s",
+            self.account_label,
+            normalized_reason,
+            ",".join(sorted(symbols or set())) or "*",
+            len(targets or []),
+            _PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS,
+        )
+
     def _bounded_paper_route_signal_scope(
         self,
         strategies: Sequence[Strategy],
@@ -1240,7 +1271,20 @@ class SimpleTradingPipeline(TradingPipeline):
         target_symbols, target_plan_error, targets = (
             self._external_paper_route_target_probe_symbols_cached()
         )
-        if target_plan_error or not target_symbols:
+        if target_plan_error:
+            self._record_bounded_target_plan_blocker(
+                reason=target_plan_error,
+                symbols=target_symbols,
+                targets=targets,
+            )
+            return None
+        if not target_symbols:
+            if str(settings.trading_paper_route_target_plan_url or "").strip():
+                self._record_bounded_target_plan_blocker(
+                    reason="paper_route_target_plan_probe_symbols_missing",
+                    symbols=target_symbols,
+                    targets=targets,
+                )
             return None
 
         symbols: set[str] = set()
@@ -3214,7 +3258,7 @@ class SimpleTradingPipeline(TradingPipeline):
         plan = fetch_paper_route_target_plan_url(
             url,
             timeout_seconds=settings.trading_paper_route_target_plan_timeout_seconds,
-            attempts=2,
+            attempts=_PAPER_ROUTE_TARGET_PLAN_FETCH_ATTEMPTS,
             retry_backoff_seconds=0.25,
         )
         load_error = str(plan.get("load_error") or "").strip()
@@ -3591,7 +3635,20 @@ class SimpleTradingPipeline(TradingPipeline):
         target_symbols, target_plan_error, target_plan_targets = (
             self._external_paper_route_target_probe_symbols_cached()
         )
-        if target_plan_error or not target_symbols:
+        if target_plan_error:
+            self._record_bounded_target_plan_blocker(
+                reason=target_plan_error,
+                symbols=target_symbols,
+                targets=target_plan_targets,
+            )
+            return []
+        if not target_symbols:
+            if str(settings.trading_paper_route_target_plan_url or "").strip():
+                self._record_bounded_target_plan_blocker(
+                    reason="paper_route_target_plan_probe_symbols_missing",
+                    symbols=target_symbols,
+                    targets=target_plan_targets,
+                )
             return []
 
         normalized_allowed = {

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8796,6 +8796,166 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(blocker.get("account_label"), "TORGHUT_SIM")
         self.assertEqual(blocker.get("fetch_attempts"), 3)
 
+    def test_bounded_signal_scope_records_configured_target_plan_missing_symbols(
+        self,
+    ) -> None:
+        from app import config
+
+        original_target_plan_url = config.settings.trading_paper_route_target_plan_url
+        original_mode = config.settings.trading_mode
+        original_probe_enabled = (
+            config.settings.trading_simple_paper_route_probe_enabled
+        )
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-target-plan"
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+        now = datetime(2026, 6, 1, 14, 30, tzinfo=timezone.utc)
+        try:
+            with (
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=now,
+                ),
+                patch.object(
+                    SimpleTradingPipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=(set(), None, []),
+                ),
+            ):
+                self.assertIsNone(pipeline._bounded_paper_route_signal_scope([]))
+        finally:
+            config.settings.trading_mode = original_mode
+            config.settings.trading_simple_paper_route_probe_enabled = (
+                original_probe_enabled
+            )
+            config.settings.trading_paper_route_target_plan_url = (
+                original_target_plan_url
+            )
+
+        blocker = cast(
+            dict[str, Any],
+            getattr(pipeline.state, "last_bounded_evidence_collection_blocker"),
+        )
+        self.assertEqual(
+            blocker.get("reason"),
+            "paper_route_target_plan_probe_symbols_missing",
+        )
+        self.assertEqual(blocker.get("target_symbols"), [])
+        self.assertEqual(blocker.get("target_count"), 0)
+
+    def test_paper_route_target_source_decisions_record_target_plan_unavailable(
+        self,
+    ) -> None:
+        from app import config
+
+        original_target_plan_url = config.settings.trading_paper_route_target_plan_url
+        original_mode = config.settings.trading_mode
+        original_probe_enabled = (
+            config.settings.trading_simple_paper_route_probe_enabled
+        )
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-target-plan"
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+        now = datetime(2026, 6, 1, 14, 30, tzinfo=timezone.utc)
+        try:
+            with patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=now,
+            ):
+                with patch.object(
+                    SimpleTradingPipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=(
+                        set(),
+                        "paper_route_target_plan_fetch_failed:timed out",
+                        [],
+                    ),
+                ):
+                    self.assertEqual(
+                        pipeline._paper_route_target_source_decisions(
+                            strategies=[],
+                            allowed_symbols=set(),
+                        ),
+                        [],
+                    )
+                fetch_blocker = cast(
+                    dict[str, Any],
+                    getattr(pipeline.state, "last_bounded_evidence_collection_blocker"),
+                )
+
+                with patch.object(
+                    SimpleTradingPipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=(set(), None, []),
+                ):
+                    self.assertEqual(
+                        pipeline._paper_route_target_source_decisions(
+                            strategies=[],
+                            allowed_symbols=set(),
+                        ),
+                        [],
+                    )
+                missing_symbol_blocker = cast(
+                    dict[str, Any],
+                    getattr(pipeline.state, "last_bounded_evidence_collection_blocker"),
+                )
+        finally:
+            config.settings.trading_mode = original_mode
+            config.settings.trading_simple_paper_route_probe_enabled = (
+                original_probe_enabled
+            )
+            config.settings.trading_paper_route_target_plan_url = (
+                original_target_plan_url
+            )
+
+        self.assertEqual(
+            fetch_blocker.get("reason"),
+            "paper_route_target_plan_fetch_failed:timed out",
+        )
+        self.assertEqual(
+            missing_symbol_blocker.get("reason"),
+            "paper_route_target_plan_probe_symbols_missing",
+        )
+        self.assertEqual(fetch_blocker.get("source"), "external_target_plan_url")
+        self.assertEqual(
+            missing_symbol_blocker.get("source"),
+            "external_target_plan_url",
+        )
+
     def test_matching_paper_target_signal_gets_strategy_signal_paper_authority(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8710,6 +8710,92 @@ class TestTradingPipeline(TestCase):
         )
         self.assertEqual(fetch_plan.call_count, 2)
 
+    def test_bounded_signal_scope_records_target_plan_fetch_failure(
+        self,
+    ) -> None:
+        from app import config
+
+        original_target_plan_url = config.settings.trading_paper_route_target_plan_url
+        original_target_plan_timeout = (
+            config.settings.trading_paper_route_target_plan_timeout_seconds
+        )
+        original_mode = config.settings.trading_mode
+        original_probe_enabled = (
+            config.settings.trading_simple_paper_route_probe_enabled
+        )
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-target-plan"
+        )
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+        now = datetime(2026, 6, 1, 14, 30, tzinfo=timezone.utc)
+        try:
+            with (
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=now,
+                ),
+                patch(
+                    "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+                    return_value={
+                        "load_error": (
+                            "paper_route_target_plan_fetch_failed:timed out"
+                        ),
+                        "fetch_attempts": 3,
+                    },
+                ) as fetch_plan,
+            ):
+                self.assertIsNone(pipeline._bounded_paper_route_signal_scope([]))
+        finally:
+            config.settings.trading_mode = original_mode
+            config.settings.trading_simple_paper_route_probe_enabled = (
+                original_probe_enabled
+            )
+            config.settings.trading_paper_route_target_plan_url = (
+                original_target_plan_url
+            )
+            config.settings.trading_paper_route_target_plan_timeout_seconds = (
+                original_target_plan_timeout
+            )
+
+        fetch_plan.assert_called_once_with(
+            "http://torghut.local/trading/paper-route-target-plan",
+            timeout_seconds=1.0,
+            attempts=3,
+            retry_backoff_seconds=0.25,
+        )
+        blocker = cast(
+            dict[str, Any],
+            getattr(pipeline.state, "last_bounded_evidence_collection_blocker"),
+        )
+        self.assertEqual(
+            blocker.get("reason"),
+            "paper_route_target_plan_fetch_failed:timed out",
+        )
+        self.assertEqual(
+            blocker.get("blockers"),
+            ["paper_route_target_plan_fetch_failed:timed out"],
+        )
+        self.assertEqual(blocker.get("source"), "external_target_plan_url")
+        self.assertEqual(blocker.get("account_label"), "TORGHUT_SIM")
+        self.assertEqual(blocker.get("fetch_attempts"), 3)
+
     def test_matching_paper_target_signal_gets_strategy_signal_paper_authority(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Increases bounded paper-route target-plan fetch attempts to three, matching the endpoint-side loader used by the Torghut service.
- Records target-plan fetch and missing-symbol failures in `last_bounded_evidence_collection_blocker` so the scheduler surfaces why bounded source decisions were not emitted.
- Keeps fail-closed profitability semantics: no capital promotion or order submission bypass is introduced.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k "target_plan_fetch_failure or external_paper_route_target_plan_cache_uses_recent_success_after_timeout" -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py::TestTradingPipeline::test_bounded_signal_scope_records_configured_target_plan_missing_symbols tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_target_source_decisions_record_target_plan_unavailable -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
