### PR TITLE
fix(torghut): cap hpairs replay shard harness

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -3692,16 +3692,28 @@ def _profitability_next_epoch_plan(
     real_replay_shard_size = _int_arg(args, "real_replay_shard_size", 0)
     if real_replay_shard_size > 0:
         flags["--real-replay-shard-size"] = str(real_replay_shard_size)
-    real_replay_shard_timeout_seconds = _int_arg(
+    requested_real_replay_shard_timeout_seconds = _int_arg(
         args,
         "real_replay_shard_timeout_seconds",
         _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+    )
+    real_replay_shard_timeout_seconds = _bounded_real_replay_shard_timeout_seconds(
+        requested_real_replay_shard_timeout_seconds
     )
     if real_replay_shard_timeout_seconds > 0:
         flags["--real-replay-shard-timeout-seconds"] = str(
             real_replay_shard_timeout_seconds
         )
     capped_runtime_flags: list[dict[str, str]] = []
+    if requested_real_replay_shard_timeout_seconds != real_replay_shard_timeout_seconds:
+        capped_runtime_flags.append(
+            {
+                "flag": "--real-replay-shard-timeout-seconds",
+                "requested_value": str(requested_real_replay_shard_timeout_seconds),
+                "capped_value": str(real_replay_shard_timeout_seconds),
+                "reason": "capped_to_local_shard_timeout_no_cluster_fanout",
+            }
+        )
     requested_real_replay_shard_workers = _int_arg(
         args, "real_replay_shard_workers", _DEFAULT_REAL_REPLAY_SHARD_WORKERS
     )
@@ -3790,6 +3802,40 @@ def _profitability_next_epoch_plan(
                                 "current_value": str(current_value or ""),
                                 "recommended_value": _string(value),
                                 "reason": "rejected_broad_replay_worker_fanout",
+                            }
+                        )
+                        continue
+                    if key == "--real-replay-shard-timeout-seconds":
+                        if recommended_int is None:
+                            rejected_recommended_flags.append(
+                                {
+                                    "action": action_name,
+                                    "flag": key,
+                                    "current_value": str(current_value or ""),
+                                    "recommended_value": _string(value),
+                                    "reason": "rejected_invalid_numeric_remediation_flag",
+                                }
+                            )
+                            continue
+                        capped_timeout = _bounded_real_replay_shard_timeout_seconds(
+                            recommended_int
+                        )
+                        if capped_timeout != recommended_int:
+                            capped_runtime_flags.append(
+                                {
+                                    "action": action_name,
+                                    "flag": key,
+                                    "requested_value": str(recommended_int),
+                                    "capped_value": str(capped_timeout),
+                                    "reason": "capped_to_local_shard_timeout_no_cluster_fanout",
+                                }
+                            )
+                        flags[key] = str(capped_timeout)
+                        applied_recommended_flags.append(
+                            {
+                                "action": action_name,
+                                "flag": key,
+                                "value": str(capped_timeout),
                             }
                         )
                         continue
@@ -7660,16 +7706,12 @@ def _run_replay_with_optional_timeout(
 
     shard_size = max(0, int(getattr(args, "real_replay_shard_size", 0) or 0))
     if shard_size > 0 and len(specs) > shard_size:
-        shard_timeout_seconds = max(
-            0,
-            int(
-                getattr(
-                    args,
-                    "real_replay_shard_timeout_seconds",
-                    _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
-                )
-                or 0
-            ),
+        shard_timeout_seconds = _bounded_real_replay_shard_timeout_seconds(
+            getattr(
+                args,
+                "real_replay_shard_timeout_seconds",
+                _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            )
         )
         return _run_real_replay_shards(
             args=args,
@@ -7806,6 +7848,9 @@ def _build_real_replay_shards(
 ) -> tuple[_ReplayShardPlan, ...]:
     ordered_specs = list(specs)
     bounded_shard_size = max(1, int(shard_size))
+    bounded_shard_timeout_seconds = _bounded_real_replay_shard_timeout_seconds(
+        shard_timeout_seconds
+    )
     max_frontier_candidates_per_spec = max(
         1,
         int(
@@ -7857,7 +7902,7 @@ def _build_real_replay_shards(
                 / "strategy-factory-shards"
                 / f"shard-{shard_index:03d}",
                 specs=shard_specs,
-                timeout_seconds=shard_timeout_seconds,
+                timeout_seconds=bounded_shard_timeout_seconds,
             )
         )
     return tuple(plans)
@@ -8086,6 +8131,7 @@ def _bounded_real_replay_shard_workers(
         1,
         min(
             len(plans) or 1,
+            _DEFAULT_REAL_REPLAY_SHARD_WORKERS,
             int(
                 getattr(
                     args,
@@ -8118,6 +8164,16 @@ def _bounded_real_replay_shard_workers(
     return max(1, min(requested_workers, budget_capped_workers))
 
 
+def _bounded_real_replay_shard_timeout_seconds(raw_timeout_seconds: object) -> int:
+    requested_timeout_seconds = max(
+        0,
+        int(raw_timeout_seconds or _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS),
+    )
+    if requested_timeout_seconds <= 0:
+        return _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS
+    return min(requested_timeout_seconds, _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS)
+
+
 def _run_real_replay_shards(
     *,
     args: argparse.Namespace,
@@ -8129,12 +8185,15 @@ def _run_real_replay_shards(
     evidence_bundles: list[CandidateEvidenceBundle] = []
     replay_results: list[Mapping[str, Any]] = []
     shard_failures: list[dict[str, Any]] = []
+    bounded_shard_timeout_seconds = _bounded_real_replay_shard_timeout_seconds(
+        shard_timeout_seconds
+    )
     plans = _build_real_replay_shards(
         args=args,
         output_dir=output_dir,
         specs=specs,
         shard_size=shard_size,
-        shard_timeout_seconds=shard_timeout_seconds,
+        shard_timeout_seconds=bounded_shard_timeout_seconds,
     )
     bounded_shard_size = max(1, int(shard_size))
     shard_workers = _bounded_real_replay_shard_workers(
@@ -8171,7 +8230,7 @@ def _run_real_replay_shards(
             output_dir=output_dir,
             specs=specs,
             shard_failures=shard_failures,
-            shard_timeout_seconds=shard_timeout_seconds,
+            shard_timeout_seconds=bounded_shard_timeout_seconds,
             starting_shard_index=len(plans),
         )
         if retry_evidence:
@@ -8190,7 +8249,7 @@ def _run_real_replay_shards(
                 "schema_version": "torghut.whitepaper-autoresearch-shards.v1",
                 "shard_size": bounded_shard_size,
                 "shard_workers": shard_workers,
-                "shard_timeout_seconds": shard_timeout_seconds,
+                "shard_timeout_seconds": bounded_shard_timeout_seconds,
                 "selected_candidate_spec_count": len(specs),
                 "evidence_bundle_count": len(deduped_evidence),
                 "failures": shard_failures,
@@ -12454,12 +12513,13 @@ def run_whitepaper_autoresearch_profit_target(
                 getattr(args, "real_replay_shard_size", 0) or 0
             ),
             "real_replay_shard_timeout_seconds": int(
-                getattr(
-                    args,
-                    "real_replay_shard_timeout_seconds",
-                    _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+                _bounded_real_replay_shard_timeout_seconds(
+                    getattr(
+                        args,
+                        "real_replay_shard_timeout_seconds",
+                        _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+                    )
                 )
-                or _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS
             ),
             "real_replay_shard_workers": int(
                 getattr(

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -10739,6 +10739,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             runner._bounded_real_replay_shard_timeout_seconds(0),
             runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
         )
+        self.assertEqual(
+            runner._bounded_real_replay_shard_timeout_seconds(-1),
+            runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+        )
         self.assertEqual(plan["flags"]["--real-replay-shard-timeout-seconds"], "900")
         self.assertIn(
             {
@@ -10749,6 +10753,39 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "reason": "rejected_invalid_numeric_remediation_flag",
             },
             plan["rejected_recommended_flags"],
+        )
+
+    def test_next_epoch_plan_applies_within_limit_shard_timeout_remediation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir) / "epoch")
+            args.real_replay_shard_timeout_seconds = 900
+            remediation = {
+                "next_actions": [
+                    {
+                        "action": "shrink_per_spec_frontier_or_extend_timeout",
+                        "recommended_flags": {
+                            "--real-replay-shard-timeout-seconds": "600",
+                        },
+                    }
+                ]
+            }
+
+            plan = runner._profitability_next_epoch_plan(
+                args=args, target=Decimal("500"), remediation=remediation
+            )
+
+        self.assertEqual(plan["flags"]["--real-replay-shard-timeout-seconds"], "600")
+        self.assertFalse(plan["rejected_recommended_flags"])
+        self.assertFalse(plan["capped_runtime_flags"])
+        self.assertIn(
+            {
+                "action": "shrink_per_spec_frontier_or_extend_timeout",
+                "flag": "--real-replay-shard-timeout-seconds",
+                "value": "600",
+            },
+            plan["applied_recommended_flags"],
         )
 
     def test_train_ranker_script_main_writes_model_and_scores(self) -> None:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4978,7 +4978,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
 
         self.assertEqual(queue_payload["pre_dedupe_selected_candidate_count"], 3)
         self.assertEqual(queue_payload["exact_replay_candidate_count"], 2)
-        self.assertEqual(queue_payload["duplicate_filtered_candidate_spec_ids"], ["spec-b"])
+        self.assertEqual(
+            queue_payload["duplicate_filtered_candidate_spec_ids"], ["spec-b"]
+        )
         self.assertEqual(queue_payload["candidate_spec_ids"], ["spec-a", "spec-c"])
         self.assertEqual(
             queue_payload["exact_replay_frontier_keys"],
@@ -10595,7 +10597,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.max_total_frontier_candidates = 24
             args.real_replay_timeout_seconds = 7200
             args.real_replay_shard_size = 2
-            args.real_replay_shard_timeout_seconds = 900
+            args.real_replay_shard_timeout_seconds = 1200
             args.real_replay_shard_workers = 3
             args.real_replay_failed_spec_retries = 2
             args.real_replay_retry_timeout_seconds = 1800
@@ -10610,6 +10612,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                             "--max-total-frontier-candidates": "48",
                             "--kubernetes-fanout": "32",
                             "--real-replay-shard-workers": "16",
+                            "--real-replay-shard-timeout-seconds": "3600",
                         },
                     }
                 ]
@@ -10672,6 +10675,33 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertIn(
             {
+                "flag": "--real-replay-shard-timeout-seconds",
+                "requested_value": "1200",
+                "capped_value": "900",
+                "reason": "capped_to_local_shard_timeout_no_cluster_fanout",
+            },
+            plan["capped_runtime_flags"],
+        )
+        self.assertIn(
+            {
+                "action": "increase_breadth_and_portfolio_diversity",
+                "flag": "--real-replay-shard-timeout-seconds",
+                "requested_value": "3600",
+                "capped_value": "900",
+                "reason": "capped_to_local_shard_timeout_no_cluster_fanout",
+            },
+            plan["capped_runtime_flags"],
+        )
+        self.assertIn(
+            {
+                "action": "increase_breadth_and_portfolio_diversity",
+                "flag": "--real-replay-shard-timeout-seconds",
+                "value": "900",
+            },
+            plan["applied_recommended_flags"],
+        )
+        self.assertIn(
+            {
                 "flag": "--real-replay-shard-workers",
                 "requested_value": "3",
                 "capped_value": "2",
@@ -10684,6 +10714,42 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             plan["no_fast_path_policy"]["max_generated_real_replay_shard_workers"], 2
         )
         self.assertNotIn("--kubernetes-fanout", plan["flags"])
+
+    def test_next_epoch_plan_rejects_invalid_shard_timeout_remediation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            args = self._args(Path(tmpdir) / "epoch")
+            remediation = {
+                "next_actions": [
+                    {
+                        "action": "increase_breadth_and_portfolio_diversity",
+                        "recommended_flags": {
+                            "--real-replay-shard-timeout-seconds": "not-a-number",
+                        },
+                    }
+                ]
+            }
+
+            plan = runner._profitability_next_epoch_plan(
+                args=args, target=Decimal("500"), remediation=remediation
+            )
+
+        self.assertEqual(
+            runner._bounded_real_replay_shard_timeout_seconds(0),
+            runner._DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(plan["flags"]["--real-replay-shard-timeout-seconds"], "900")
+        self.assertIn(
+            {
+                "action": "increase_breadth_and_portfolio_diversity",
+                "flag": "--real-replay-shard-timeout-seconds",
+                "current_value": "900",
+                "recommended_value": "not-a-number",
+                "reason": "rejected_invalid_numeric_remediation_flag",
+            },
+            plan["rejected_recommended_flags"],
+        )
 
     def test_train_ranker_script_main_writes_model_and_scores(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -12600,16 +12666,50 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 output_dir=output_dir,
                 specs=specs,
                 shard_size=2,
-                shard_timeout_seconds=7,
+                shard_timeout_seconds=1200,
             )
 
         self.assertEqual(
             [runner._replay_shard_frontier_candidate_budget(plan) for plan in plans],
             [8, 8, 8],
         )
+        self.assertEqual([plan.timeout_seconds for plan in plans], [900, 900, 900])
         self.assertEqual(
             runner._bounded_real_replay_shard_workers(args=args, plans=plans),
             1,
+        )
+
+    def test_real_replay_shards_cap_workers_to_local_limit_even_under_budget(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
+                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+            )
+            compilation = runner.compile_whitepaper_candidate_specs(
+                hypothesis_cards=cards,
+                family_template_dir=Path("config/trading/families"),
+                seed_sweep_dir=Path("config/trading"),
+            )
+            specs = compilation.executable_specs[:4]
+            args = self._args(output_dir)
+            args.max_frontier_candidates_per_spec = 1
+            args.max_total_frontier_candidates = 4
+            args.real_replay_shard_workers = 8
+            args.real_replay_max_parallel_frontier_candidates = 99
+
+            plans = runner._build_real_replay_shards(
+                args=args,
+                output_dir=output_dir,
+                specs=specs,
+                shard_size=1,
+                shard_timeout_seconds=7,
+            )
+
+        self.assertEqual(
+            runner._bounded_real_replay_shard_workers(args=args, plans=plans),
+            2,
         )
 
     def test_incomplete_sharded_replay_cannot_report_oracle_candidate_found(


### PR DESCRIPTION
## Summary

- Hardened the Torghut H-PAIRS exact replay harness so per-shard replay timeouts are capped at the local/offline 900-second limit in next-epoch plans, shard construction, replay execution, and persisted runner config.
- Enforced the two-worker local replay ceiling directly in the bounded shard worker helper, independent of the parallel frontier budget.
- Added regression coverage proving oversized timeout and worker requests are capped without Kubernetes fanout.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed after installing the missing system compiler toolchain required to build `crosshair-tool` in this container.
- `cd services/torghut && uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q -k "runtime_flags or shard_timeout_remediation or cap_workers"` — passed: 3 passed, 176 deselected.
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` — passed: 218 passed.
- `cd services/torghut && uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py` — passed.
- `cd services/torghut && uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed: 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed: 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed: 0 errors.
- `git diff --check` — passed.

## Screenshots (if applicable)

N/A — backend discovery harness safety change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.