### PR TITLE
fix(torghut): materialize hpairs pair runtime signals

### DIFF
--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -215,12 +215,68 @@ def _microbar_rank_universe_size(
     features: FeatureVectorV3,
     rank_feature: str,
 ) -> int:
+    executable_universe_size = _microbar_observed_rank_universe_size(
+        features=features,
+        rank_feature=rank_feature,
+    )
+    if executable_universe_size is not None and executable_universe_size > 0:
+        return executable_universe_size
+    return _microbar_universe_size(context=context, params=params)
+
+
+def _microbar_observed_rank_universe_size(
+    *,
+    features: FeatureVectorV3,
+    rank_feature: str,
+) -> int | None:
     executable_universe_size = _decimal(
         features.values.get(f"{rank_feature}_universe_size")
     )
     if executable_universe_size is not None and executable_universe_size > 0:
         return max(1, int(executable_universe_size))
-    return _microbar_universe_size(context=context, params=params)
+    return None
+
+
+def _microbar_pair_rank_thresholds(
+    *,
+    context: "StrategyContext",
+    params: dict[str, Any],
+    features: FeatureVectorV3,
+    rank_feature: str,
+    pair_side_count: int,
+) -> tuple[Decimal, Decimal, str, int, int | None]:
+    configured_universe_size = _microbar_universe_size(context=context, params=params)
+    observed_universe_size = _microbar_observed_rank_universe_size(
+        features=features,
+        rank_feature=rank_feature,
+    )
+    if (
+        configured_universe_size == 2
+        and observed_universe_size is not None
+        and observed_universe_size > configured_universe_size
+        and pair_side_count == 1
+    ):
+        midpoint = Decimal("0.5")
+        return (
+            midpoint,
+            midpoint,
+            "configured_pair_midpoint",
+            configured_universe_size,
+            observed_universe_size,
+        )
+    low_threshold, high_threshold = _microbar_rank_thresholds(
+        universe_size=observed_universe_size or configured_universe_size,
+        top_n=pair_side_count,
+    )
+    return (
+        low_threshold,
+        high_threshold,
+        "observed_rank_universe"
+        if observed_universe_size is not None
+        else "configured_universe",
+        configured_universe_size,
+        observed_universe_size,
+    )
 
 
 def _microbar_runtime_position_qty(features: FeatureVectorV3) -> Decimal | None:
@@ -499,10 +555,31 @@ def _evaluate_microbar_cross_sectional(
                 },
             ),
         )
-    low_threshold, high_threshold = _microbar_rank_thresholds(
-        universe_size=universe_size,
-        top_n=pair_side_count if pair_mode else top_n,
+    rank_threshold_basis = "observed_rank_universe"
+    configured_universe_size = _microbar_universe_size(context=context, params=params)
+    observed_rank_universe_size = _microbar_observed_rank_universe_size(
+        features=features,
+        rank_feature=rank_feature,
     )
+    if pair_mode:
+        (
+            low_threshold,
+            high_threshold,
+            rank_threshold_basis,
+            configured_universe_size,
+            observed_rank_universe_size,
+        ) = _microbar_pair_rank_thresholds(
+            context=context,
+            params=params,
+            features=features,
+            rank_feature=rank_feature,
+            pair_side_count=pair_side_count,
+        )
+    else:
+        low_threshold, high_threshold = _microbar_rank_thresholds(
+            universe_size=universe_size,
+            top_n=top_n,
+        )
     if pair_mode:
         high_entry_action: Literal["buy", "sell"] = (
             "sell" if selection_mode == "reversal" else "buy"
@@ -514,7 +591,13 @@ def _evaluate_microbar_cross_sectional(
         pair_side: str | None = None
         comparator = "gte"
         threshold_value = high_threshold
-        if rank_value >= high_threshold:
+        if (
+            rank_threshold_basis == "configured_pair_midpoint"
+            and rank_value == high_threshold
+        ):
+            selected_entry_action = None
+            pair_side = None
+        elif rank_value >= high_threshold:
             selected_entry_action = high_entry_action
             pair_side = "high_rank"
             comparator = "gte"
@@ -524,6 +607,16 @@ def _evaluate_microbar_cross_sectional(
             pair_side = "low_rank"
             comparator = "lte"
             threshold_value = low_threshold
+        rejection_reason: str | None = None
+        if selected_entry_action is None:
+            rejection_reason = (
+                "ambiguous_pair_rank_midpoint"
+                if (
+                    rank_threshold_basis == "configured_pair_midpoint"
+                    and rank_value == high_threshold
+                )
+                else "rank_inside_pair_band"
+            )
         should_trade = selected_entry_action is not None
         resolved_action: Literal["buy", "sell"] | None = selected_entry_action
         rationale = (
@@ -585,9 +678,13 @@ def _evaluate_microbar_cross_sectional(
                 "selection_mode": selection_mode,
                 "top_n": top_n,
                 "universe_size": universe_size,
+                "configured_universe_size": configured_universe_size,
+                "observed_rank_universe_size": observed_rank_universe_size,
+                "rank_threshold_basis": rank_threshold_basis,
                 "pair_side_count": pair_side_count,
                 "max_pair_legs": max_pair_legs,
                 "pair_side": pair_side,
+                "reason": rejection_reason,
             },
         )
         if not should_trade:
@@ -894,6 +991,24 @@ def _coerce_plugin_result(
     if result is None:
         return PluginEvaluationResult(intent=None, trace=None)
     return PluginEvaluationResult(intent=result, trace=None)
+
+
+def _trace_suppression_reason(trace: StrategyTrace | None) -> str:
+    if trace is None:
+        return "no_runtime_intent"
+    failed_gate = trace.first_failed_gate
+    selected_gate = trace.gates[0] if trace.gates else None
+    gate = failed_gate or (selected_gate.gate if selected_gate is not None else "")
+    reason = ""
+    if selected_gate is not None:
+        raw_reason = selected_gate.context.get("reason")
+        if raw_reason is not None:
+            reason = str(raw_reason).strip()
+    if gate and reason:
+        return f"{gate}:{reason}"
+    if gate:
+        return gate
+    return "no_runtime_intent"
 
 
 @dataclass
@@ -2454,6 +2569,10 @@ class StrategyRuntime:
                 if plugin_result.trace is not None:
                     traces.append(plugin_result.trace)
                 if plugin_result.intent is None:
+                    observation.record_intent_suppression(
+                        definition.strategy_id,
+                        _trace_suppression_reason(plugin_result.trace),
+                    )
                     continue
                 decision = RuntimeDecision(
                     intent=plugin_result.intent,

--- a/services/torghut/app/trading/strategy_specs.py
+++ b/services/torghut/app/trading/strategy_specs.py
@@ -8,8 +8,9 @@ from typing import Any, Mapping, cast
 
 _SUPPORTED_STRATEGY_TYPES: frozenset[str] = frozenset(
     {
-        'legacy_macd_rsi',
-        'intraday_tsmom_v1',
+        "legacy_macd_rsi",
+        "intraday_tsmom_v1",
+        "microbar_cross_sectional_pairs_v1",
     }
 )
 
@@ -31,26 +32,26 @@ class StrategySpecV2:
     promotion_policy_ref: str
     replay_dependencies: list[str]
     runtime_parameters: dict[str, Any]
-    source: str = 'spec_v2'
+    source: str = "spec_v2"
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'strategy_id': self.strategy_id,
-            'semantic_version': self.semantic_version,
-            'universe': dict(self.universe),
-            'feature_view_spec_ref': self.feature_view_spec_ref,
-            'dataset_eligibility': dict(self.dataset_eligibility),
-            'model_ref': self.model_ref,
-            'deterministic_rule_ref': self.deterministic_rule_ref,
-            'signal_to_probability_transform': self.signal_to_probability_transform,
-            'sizing_policy_ref': self.sizing_policy_ref,
-            'risk_profile_ref': self.risk_profile_ref,
-            'execution_policy_ref': self.execution_policy_ref,
-            'rebalance_cadence': self.rebalance_cadence,
-            'promotion_policy_ref': self.promotion_policy_ref,
-            'replay_dependencies': list(self.replay_dependencies),
-            'runtime_parameters': dict(self.runtime_parameters),
-            'source': self.source,
+            "strategy_id": self.strategy_id,
+            "semantic_version": self.semantic_version,
+            "universe": dict(self.universe),
+            "feature_view_spec_ref": self.feature_view_spec_ref,
+            "dataset_eligibility": dict(self.dataset_eligibility),
+            "model_ref": self.model_ref,
+            "deterministic_rule_ref": self.deterministic_rule_ref,
+            "signal_to_probability_transform": self.signal_to_probability_transform,
+            "sizing_policy_ref": self.sizing_policy_ref,
+            "risk_profile_ref": self.risk_profile_ref,
+            "execution_policy_ref": self.execution_policy_ref,
+            "rebalance_cadence": self.rebalance_cadence,
+            "promotion_policy_ref": self.promotion_policy_ref,
+            "replay_dependencies": list(self.replay_dependencies),
+            "runtime_parameters": dict(self.runtime_parameters),
+            "source": self.source,
         }
 
 
@@ -74,21 +75,21 @@ class ExperimentSpec:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'experiment_id': self.experiment_id,
-            'hypothesis': self.hypothesis,
-            'parent_experiment_ids': list(self.parent_experiment_ids),
-            'target_universe': dict(self.target_universe),
-            'dataset_snapshot_request': dict(self.dataset_snapshot_request),
-            'feature_view_spec_ref': self.feature_view_spec_ref,
-            'model_family': self.model_family,
-            'training_protocol': dict(self.training_protocol),
-            'validation_protocol': dict(self.validation_protocol),
-            'acceptance_criteria': dict(self.acceptance_criteria),
-            'ablations': [dict(item) for item in self.ablations],
-            'stress_scenarios': list(self.stress_scenarios),
-            'llm_provenance': dict(self.llm_provenance),
-            'lineage': dict(self.lineage),
-            'research_memory': dict(self.research_memory),
+            "experiment_id": self.experiment_id,
+            "hypothesis": self.hypothesis,
+            "parent_experiment_ids": list(self.parent_experiment_ids),
+            "target_universe": dict(self.target_universe),
+            "dataset_snapshot_request": dict(self.dataset_snapshot_request),
+            "feature_view_spec_ref": self.feature_view_spec_ref,
+            "model_family": self.model_family,
+            "training_protocol": dict(self.training_protocol),
+            "validation_protocol": dict(self.validation_protocol),
+            "acceptance_criteria": dict(self.acceptance_criteria),
+            "ablations": [dict(item) for item in self.ablations],
+            "stress_scenarios": list(self.stress_scenarios),
+            "llm_provenance": dict(self.llm_provenance),
+            "lineage": dict(self.lineage),
+            "research_memory": dict(self.research_memory),
         }
 
 
@@ -102,50 +103,50 @@ class CompiledStrategySpec:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'strategy_spec': self.strategy_spec.to_payload(),
-            'evaluator_config': dict(self.evaluator_config),
-            'shadow_runtime_config': dict(self.shadow_runtime_config),
-            'live_runtime_config': dict(self.live_runtime_config),
-            'promotion_metadata': dict(self.promotion_metadata),
+            "strategy_spec": self.strategy_spec.to_payload(),
+            "evaluator_config": dict(self.evaluator_config),
+            "shadow_runtime_config": dict(self.shadow_runtime_config),
+            "live_runtime_config": dict(self.live_runtime_config),
+            "promotion_metadata": dict(self.promotion_metadata),
         }
 
 
 def compile_strategy_spec_v2(spec: StrategySpecV2) -> CompiledStrategySpec:
     strategy_type = _resolved_strategy_type(spec)
     evaluator_config = {
-        'strategy_id': spec.strategy_id,
-        'strategy_type': strategy_type,
-        'semantic_version': spec.semantic_version,
-        'feature_view_spec_ref': spec.feature_view_spec_ref,
-        'dataset_eligibility': dict(spec.dataset_eligibility),
-        'replay_dependencies': list(spec.replay_dependencies),
-        'runtime_parameters': dict(spec.runtime_parameters),
+        "strategy_id": spec.strategy_id,
+        "strategy_type": strategy_type,
+        "semantic_version": spec.semantic_version,
+        "feature_view_spec_ref": spec.feature_view_spec_ref,
+        "dataset_eligibility": dict(spec.dataset_eligibility),
+        "replay_dependencies": list(spec.replay_dependencies),
+        "runtime_parameters": dict(spec.runtime_parameters),
     }
     shared_runtime = {
-        'strategy_id': spec.strategy_id,
-        'strategy_type': strategy_type,
-        'version': spec.semantic_version,
-        'params': dict(spec.runtime_parameters),
-        'base_timeframe': str(spec.universe.get('base_timeframe', '1Min')),
-        'enabled': True,
-        'compiler_source': spec.source,
-        'strategy_spec': spec.to_payload(),
+        "strategy_id": spec.strategy_id,
+        "strategy_type": strategy_type,
+        "version": spec.semantic_version,
+        "params": dict(spec.runtime_parameters),
+        "base_timeframe": str(spec.universe.get("base_timeframe", "1Min")),
+        "enabled": True,
+        "compiler_source": spec.source,
+        "strategy_spec": spec.to_payload(),
     }
     shadow_runtime_config = {
         **shared_runtime,
-        'mode': 'shadow',
+        "mode": "shadow",
     }
     live_runtime_config = {
         **shared_runtime,
-        'mode': 'live',
+        "mode": "live",
     }
     promotion_metadata = {
-        'promotion_policy_ref': spec.promotion_policy_ref,
-        'risk_profile_ref': spec.risk_profile_ref,
-        'execution_policy_ref': spec.execution_policy_ref,
-        'sizing_policy_ref': spec.sizing_policy_ref,
-        'signal_to_probability_transform': spec.signal_to_probability_transform,
-        'replay_dependencies': list(spec.replay_dependencies),
+        "promotion_policy_ref": spec.promotion_policy_ref,
+        "risk_profile_ref": spec.risk_profile_ref,
+        "execution_policy_ref": spec.execution_policy_ref,
+        "sizing_policy_ref": spec.sizing_policy_ref,
+        "signal_to_probability_transform": spec.signal_to_probability_transform,
+        "replay_dependencies": list(spec.replay_dependencies),
     }
     return CompiledStrategySpec(
         strategy_spec=spec,
@@ -162,9 +163,9 @@ def build_strategy_spec_v2(
     strategy_type: str,
     semantic_version: str,
     params: Mapping[str, Any] | None = None,
-    base_timeframe: str = '1Min',
+    base_timeframe: str = "1Min",
     universe_symbols: list[str] | None = None,
-    source: str = 'spec_v2',
+    source: str = "spec_v2",
 ) -> StrategySpecV2:
     normalized_strategy_type = _normalize_strategy_type(strategy_type)
     normalized_params = dict(params or {})
@@ -175,28 +176,28 @@ def build_strategy_spec_v2(
         strategy_id=strategy_id,
         semantic_version=semantic_version or _default_version(normalized_strategy_type),
         universe={
-            'base_timeframe': base_timeframe or '1Min',
-            'symbols': symbols,
-            'strategy_type': normalized_strategy_type,
+            "base_timeframe": base_timeframe or "1Min",
+            "symbols": symbols,
+            "strategy_type": normalized_strategy_type,
         },
         feature_view_spec_ref=feature_ref,
         dataset_eligibility={
-            'source': 'historical_market_replay',
-            'min_history_bars': 240,
-            'base_timeframe': base_timeframe or '1Min',
+            "source": "historical_market_replay",
+            "min_history_bars": 240,
+            "base_timeframe": base_timeframe or "1Min",
         },
         model_ref=model_ref,
         deterministic_rule_ref=deterministic_rule_ref,
-        signal_to_probability_transform='deterministic-confidence-v1',
-        sizing_policy_ref='torghut-sizing/default-v1',
-        risk_profile_ref='torghut-risk/default-v1',
-        execution_policy_ref='torghut-execution/default-v1',
-        rebalance_cadence=base_timeframe or '1Min',
-        promotion_policy_ref='torghut-promotion/vnext-default-v1',
+        signal_to_probability_transform="deterministic-confidence-v1",
+        sizing_policy_ref="torghut-sizing/default-v1",
+        risk_profile_ref="torghut-risk/default-v1",
+        execution_policy_ref="torghut-execution/default-v1",
+        rebalance_cadence=base_timeframe or "1Min",
+        promotion_policy_ref="torghut-promotion/vnext-default-v1",
         replay_dependencies=[
-            'backtest/walkforward-results.json',
-            'reports/evaluation-report.json',
-            'gates/gate-evaluation.json',
+            "backtest/walkforward-results.json",
+            "reports/evaluation-report.json",
+            "gates/gate-evaluation.json",
         ],
         runtime_parameters=normalized_params,
         source=source,
@@ -209,9 +210,9 @@ def build_compiled_strategy_artifacts(
     strategy_type: str,
     semantic_version: str,
     params: Mapping[str, Any] | None = None,
-    base_timeframe: str = '1Min',
+    base_timeframe: str = "1Min",
     universe_symbols: list[str] | None = None,
-    source: str = 'spec_v2',
+    source: str = "spec_v2",
 ) -> CompiledStrategySpec:
     spec = build_strategy_spec_v2(
         strategy_id=strategy_id,
@@ -241,37 +242,37 @@ def build_experiment_spec_from_strategy(
         parent_experiment_ids=list(parent_experiment_ids or []),
         target_universe=dict(strategy_spec.universe),
         dataset_snapshot_request={
-            'source': strategy_spec.dataset_eligibility.get('source'),
-            'base_timeframe': strategy_spec.dataset_eligibility.get('base_timeframe'),
+            "source": strategy_spec.dataset_eligibility.get("source"),
+            "base_timeframe": strategy_spec.dataset_eligibility.get("base_timeframe"),
         },
         feature_view_spec_ref=strategy_spec.feature_view_spec_ref,
         model_family=_resolved_strategy_type(strategy_spec),
         training_protocol={
-            'family': _resolved_strategy_type(strategy_spec),
-            'semantic_version': strategy_spec.semantic_version,
+            "family": _resolved_strategy_type(strategy_spec),
+            "semantic_version": strategy_spec.semantic_version,
         },
         validation_protocol={
-            'walkforward': True,
-            'stress_windows': ['spread', 'volatility', 'liquidity', 'halt'],
+            "walkforward": True,
+            "stress_windows": ["spread", "volatility", "liquidity", "halt"],
         },
         acceptance_criteria={
-            'promotion_policy_ref': strategy_spec.promotion_policy_ref,
-            'risk_profile_ref': strategy_spec.risk_profile_ref,
+            "promotion_policy_ref": strategy_spec.promotion_policy_ref,
+            "risk_profile_ref": strategy_spec.risk_profile_ref,
         },
         ablations=[
             {
-                'name': 'no_feature_ablation',
-                'drop_features': [],
+                "name": "no_feature_ablation",
+                "drop_features": [],
             }
         ],
-        stress_scenarios=['spread', 'volatility', 'liquidity', 'halt'],
-        llm_provenance=dict(llm_provenance or {'mode': 'none'}),
-        lineage=dict(lineage or {'source': 'strategy_spec_v2'}),
+        stress_scenarios=["spread", "volatility", "liquidity", "halt"],
+        llm_provenance=dict(llm_provenance or {"mode": "none"}),
+        lineage=dict(lineage or {"source": "strategy_spec_v2"}),
         research_memory=dict(
             research_memory
             or {
-                'summary': f'{strategy_spec.strategy_id}:{strategy_spec.semantic_version}',
-                'source': strategy_spec.source,
+                "summary": f"{strategy_spec.strategy_id}:{strategy_spec.semantic_version}",
+                "source": strategy_spec.source,
             }
         ),
     )
@@ -284,89 +285,102 @@ def strategy_type_supports_spec_v2(strategy_type: str) -> bool:
 def load_strategy_spec_v2_payload(value: Any) -> StrategySpecV2:
     payload = cast(dict[str, Any], value) if isinstance(value, dict) else {}
     return StrategySpecV2(
-        strategy_id=str(payload.get('strategy_id', '')).strip() or 'unknown-strategy',
-        semantic_version=str(payload.get('semantic_version', '')).strip() or '1.0.0',
-        universe=cast(dict[str, Any], payload.get('universe', {}))
-        if isinstance(payload.get('universe'), dict)
+        strategy_id=str(payload.get("strategy_id", "")).strip() or "unknown-strategy",
+        semantic_version=str(payload.get("semantic_version", "")).strip() or "1.0.0",
+        universe=cast(dict[str, Any], payload.get("universe", {}))
+        if isinstance(payload.get("universe"), dict)
         else {},
-        feature_view_spec_ref=str(payload.get('feature_view_spec_ref', '')).strip() or 'features/unknown',
-        dataset_eligibility=cast(dict[str, Any], payload.get('dataset_eligibility', {}))
-        if isinstance(payload.get('dataset_eligibility'), dict)
+        feature_view_spec_ref=str(payload.get("feature_view_spec_ref", "")).strip()
+        or "features/unknown",
+        dataset_eligibility=cast(dict[str, Any], payload.get("dataset_eligibility", {}))
+        if isinstance(payload.get("dataset_eligibility"), dict)
         else {},
-        model_ref=_nullable_text(payload.get('model_ref')),
-        deterministic_rule_ref=_nullable_text(payload.get('deterministic_rule_ref')),
+        model_ref=_nullable_text(payload.get("model_ref")),
+        deterministic_rule_ref=_nullable_text(payload.get("deterministic_rule_ref")),
         signal_to_probability_transform=str(
-            payload.get('signal_to_probability_transform', 'deterministic-confidence-v1')
+            payload.get(
+                "signal_to_probability_transform", "deterministic-confidence-v1"
+            )
         ),
-        sizing_policy_ref=str(payload.get('sizing_policy_ref', 'torghut-sizing/default-v1')),
-        risk_profile_ref=str(payload.get('risk_profile_ref', 'torghut-risk/default-v1')),
+        sizing_policy_ref=str(
+            payload.get("sizing_policy_ref", "torghut-sizing/default-v1")
+        ),
+        risk_profile_ref=str(
+            payload.get("risk_profile_ref", "torghut-risk/default-v1")
+        ),
         execution_policy_ref=str(
-            payload.get('execution_policy_ref', 'torghut-execution/default-v1')
+            payload.get("execution_policy_ref", "torghut-execution/default-v1")
         ),
-        rebalance_cadence=str(payload.get('rebalance_cadence', '1Min')),
+        rebalance_cadence=str(payload.get("rebalance_cadence", "1Min")),
         promotion_policy_ref=str(
-            payload.get('promotion_policy_ref', 'torghut-promotion/vnext-default-v1')
+            payload.get("promotion_policy_ref", "torghut-promotion/vnext-default-v1")
         ),
         replay_dependencies=[
             str(item)
-            for item in cast(list[Any], payload.get('replay_dependencies', []))
+            for item in cast(list[Any], payload.get("replay_dependencies", []))
             if str(item).strip()
         ],
-        runtime_parameters=cast(dict[str, Any], payload.get('runtime_parameters', {}))
-        if isinstance(payload.get('runtime_parameters'), dict)
+        runtime_parameters=cast(dict[str, Any], payload.get("runtime_parameters", {}))
+        if isinstance(payload.get("runtime_parameters"), dict)
         else {},
-        source=str(payload.get('source', 'spec_v2')),
+        source=str(payload.get("source", "spec_v2")),
     )
 
 
 def _normalize_strategy_type(strategy_type: str) -> str:
     normalized = strategy_type.strip().lower()
-    if normalized in {'intraday_tsmom', 'tsmom_intraday'}:
-        return 'intraday_tsmom_v1'
-    if normalized in {'static', ''}:
-        return 'legacy_macd_rsi'
+    if normalized in {"intraday_tsmom", "tsmom_intraday"}:
+        return "intraday_tsmom_v1"
+    if normalized in {"static", ""}:
+        return "legacy_macd_rsi"
     return normalized
 
 
 def _resolved_strategy_type(spec: StrategySpecV2) -> str:
     if spec.deterministic_rule_ref:
-        return _normalize_strategy_type(spec.deterministic_rule_ref.rsplit('/', 1)[-1])
+        return _normalize_strategy_type(spec.deterministic_rule_ref.rsplit("/", 1)[-1])
     if spec.model_ref:
-        return _normalize_strategy_type(spec.model_ref.rsplit('/', 1)[-1])
-    return _normalize_strategy_type(str(spec.universe.get('strategy_type', 'legacy_macd_rsi')))
+        return _normalize_strategy_type(spec.model_ref.rsplit("/", 1)[-1])
+    return _normalize_strategy_type(
+        str(spec.universe.get("strategy_type", "legacy_macd_rsi"))
+    )
 
 
 def _model_and_rule_refs(strategy_type: str) -> tuple[str | None, str | None]:
-    if strategy_type == 'intraday_tsmom_v1':
-        return None, 'rules/intraday_tsmom_v1'
-    return None, 'rules/legacy_macd_rsi'
+    if strategy_type == "intraday_tsmom_v1":
+        return None, "rules/intraday_tsmom_v1"
+    if strategy_type == "microbar_cross_sectional_pairs_v1":
+        return None, "rules/microbar_cross_sectional_pairs_v1"
+    return None, "rules/legacy_macd_rsi"
 
 
 def _feature_view_spec_ref(strategy_type: str) -> str:
-    if strategy_type == 'intraday_tsmom_v1':
-        return 'features/intraday-momentum-v1'
-    return 'features/legacy-macd-rsi-v1'
+    if strategy_type == "intraday_tsmom_v1":
+        return "features/intraday-momentum-v1"
+    if strategy_type == "microbar_cross_sectional_pairs_v1":
+        return "features/microbar-cross-sectional-pairs-v1"
+    return "features/legacy-macd-rsi-v1"
 
 
 def _default_version(strategy_type: str) -> str:
-    if strategy_type == 'intraday_tsmom_v1':
-        return '1.1.0'
-    return '1.0.0'
+    if strategy_type == "intraday_tsmom_v1":
+        return "1.1.0"
+    return "1.0.0"
 
 
 def _nullable_text(value: Any) -> str | None:
-    text = str(value or '').strip()
+    text = str(value or "").strip()
     return text or None
 
 
 __all__ = [
-    'CompiledStrategySpec',
-    'ExperimentSpec',
-    'StrategySpecV2',
-    'build_compiled_strategy_artifacts',
-    'build_experiment_spec_from_strategy',
-    'build_strategy_spec_v2',
-    'compile_strategy_spec_v2',
-    'load_strategy_spec_v2_payload',
-    'strategy_type_supports_spec_v2',
+    "CompiledStrategySpec",
+    "ExperimentSpec",
+    "StrategySpecV2",
+    "build_compiled_strategy_artifacts",
+    "build_experiment_spec_from_strategy",
+    "build_strategy_spec_v2",
+    "compile_strategy_spec_v2",
+    "load_strategy_spec_v2_payload",
+    "strategy_type_supports_spec_v2",
 ]

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -2488,6 +2488,126 @@ class TestDecisionEngine(TestCase):
         self.assertEqual(position_exit.get("type"), "runtime_signal_exit")
         self.assertEqual(position_exit.get("position_side"), "long")
 
+    def test_scheduler_runtime_microbar_pairs_materializes_aapl_amzn_entries_with_broader_feature_universe(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-cross-sectional-pairs-v1",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_type="microbar_cross_sectional_pairs_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_position_pct_equity=Decimal("6.0"),
+                    max_notional_per_trade=Decimal("100"),
+                    params={
+                        "entry_minute_after_open": "60",
+                        "exit_minute_after_open": "120",
+                        "signal_motif": "vwap_close_continuation",
+                        "rank_feature": "cross_section_vwap_w5m_rank",
+                        "selection_mode": "continuation",
+                        "top_n": "1",
+                        "max_pair_legs": "2",
+                        "position_isolation_mode": "per_strategy",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_position_pct_equity=Decimal("6.0"),
+            max_notional_per_trade=Decimal("100"),
+        )
+        base_payload = {
+            "spread": 0.02,
+            "imbalance_bid_px": 99.99,
+            "imbalance_ask_px": 100.01,
+            "macd": 0.010,
+            "macd_signal": 0.008,
+            "rsi14": 56.4,
+            "vwap_w5m": 100,
+            "session_minutes_elapsed": 60,
+            "cross_section_continuation_breadth": 0.5,
+            "cross_section_session_open_rank": 0.5,
+        }
+        engine = DecisionEngine(price_fetcher=None)
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", False),
+            patch.object(settings, "trading_allow_shorts", True),
+        ):
+            for index, (symbol, price) in enumerate(
+                (
+                    ("INTC", 95),
+                    ("AMZN", 98),
+                    ("AAPL", 102),
+                    ("NVDA", 105),
+                ),
+                start=1,
+            ):
+                engine.evaluate(
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 3, 27, 14, 29, 59, tzinfo=timezone.utc),
+                        symbol=symbol,
+                        timeframe="1Sec",
+                        seq=index,
+                        payload=base_payload | {"price": price},
+                    ),
+                    [strategy],
+                    positions=[],
+                )
+            aapl_decisions = engine.evaluate(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, 27, 14, 30, 0, tzinfo=timezone.utc),
+                    symbol="AAPL",
+                    timeframe="1Sec",
+                    seq=1,
+                    payload=base_payload | {"price": 102},
+                ),
+                [strategy],
+                positions=[],
+            )
+            amzn_decisions = engine.evaluate(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, 27, 14, 30, 1, tzinfo=timezone.utc),
+                    symbol="AMZN",
+                    timeframe="1Sec",
+                    seq=2,
+                    payload=base_payload | {"price": 98},
+                ),
+                [strategy],
+                positions=[],
+            )
+
+        self.assertEqual(len(aapl_decisions), 1)
+        self.assertEqual(len(amzn_decisions), 1)
+        self.assertEqual(aapl_decisions[0].action, "buy")
+        self.assertEqual(amzn_decisions[0].action, "sell")
+        self.assertEqual(aapl_decisions[0].qty, Decimal("1"))
+        self.assertEqual(amzn_decisions[0].qty, Decimal("1"))
+        self.assertIn("pair_side:high_rank", aapl_decisions[0].rationale)
+        self.assertIn("pair_side:low_rank", amzn_decisions[0].rationale)
+        runtime_payload = aapl_decisions[0].params.get("strategy_runtime")
+        assert isinstance(runtime_payload, dict)
+        self.assertEqual(runtime_payload.get("compiler_sources"), ["spec_v2"])
+        source_runtime = runtime_payload.get("source_strategy_runtime")
+        assert isinstance(source_runtime, list)
+        self.assertEqual(
+            source_runtime[0]
+            .get("compiled_targets", {})
+            .get("live_runtime_config", {})
+            .get("strategy_type"),
+            "microbar_cross_sectional_pairs_v1",
+        )
+
     def test_scheduler_runtime_microbar_pairs_signal_exit_covers_short_leg_quantity(
         self,
     ) -> None:

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -21,6 +21,7 @@ from app.trading.research_sleeves import (
     _rank_thresholds,
     evaluate_mean_reversion_exhaustion_short,
 )
+from app.trading.evaluation_trace import GateTrace, StrategyTrace
 from app.trading.strategy_runtime import (
     LegacyMacdRsiPlugin,
     MicrobarCrossSectionalLongPlugin,
@@ -37,6 +38,7 @@ from app.trading.strategy_runtime import (
     _microbar_minutes_elapsed,
     _microbar_rank_thresholds,
     _microbar_universe_size,
+    _trace_suppression_reason,
 )
 
 
@@ -5513,6 +5515,28 @@ class TestStrategyRuntime(TestCase):
             definition.compiled_targets["live_runtime_config"]["strategy_type"],
             "microbar_cross_sectional_pairs_v1",
         )
+
+    def test_trace_suppression_reason_falls_back_to_gate_or_default(self) -> None:
+        trace = StrategyTrace(
+            strategy_id="microbar_cross_sectional_pairs_v1@research",
+            strategy_type="microbar_cross_sectional_pairs_v1",
+            symbol="AAPL",
+            event_ts="2026-03-24T14:30:00+00:00",
+            timeframe="1Sec",
+            passed=False,
+            action=None,
+            gates=(
+                GateTrace(
+                    gate="pair_rank_selection",
+                    category="confirmation",
+                    passed=False,
+                ),
+            ),
+        )
+        empty_trace = trace.with_updates(gates=())
+
+        self.assertEqual(_trace_suppression_reason(trace), "pair_rank_selection")
+        self.assertEqual(_trace_suppression_reason(empty_trace), "no_runtime_intent")
 
 
 class TestStrategyRuntimeMicrobarCoverage(TestCase):

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -5456,6 +5456,64 @@ class TestStrategyRuntime(TestCase):
             "features/intraday-momentum-v1",
         )
 
+    def test_definition_from_strategy_materializes_hpairs_spec_v2_targets(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-cross-sectional-pairs-v1",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_type="microbar_cross_sectional_pairs_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_position_pct_equity=Decimal("6.0"),
+                    max_notional_per_trade=Decimal("75000"),
+                    params={
+                        "entry_minute_after_open": "60",
+                        "exit_minute_after_open": "120",
+                        "rank_feature": "cross_section_vwap_w5m_rank",
+                        "selection_mode": "continuation",
+                        "max_pair_legs": "2",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_position_pct_equity=Decimal("6.0"),
+            max_notional_per_trade=Decimal("75000"),
+        )
+
+        definition = StrategyRuntime.definition_from_strategy(strategy)
+
+        self.assertEqual(definition.compiler_source, "spec_v2")
+        self.assertEqual(
+            definition.declared_strategy_id,
+            "microbar_cross_sectional_pairs_v1@research",
+        )
+        self.assertEqual(
+            definition.strategy_spec["feature_view_spec_ref"],
+            "features/microbar-cross-sectional-pairs-v1",
+        )
+        self.assertEqual(
+            definition.strategy_spec["universe"],
+            {
+                "base_timeframe": "1Sec",
+                "symbols": ["AAPL", "AMZN"],
+                "strategy_type": "microbar_cross_sectional_pairs_v1",
+            },
+        )
+        self.assertEqual(
+            definition.compiled_targets["live_runtime_config"]["strategy_type"],
+            "microbar_cross_sectional_pairs_v1",
+        )
+
 
 class TestStrategyRuntimeMicrobarCoverage(TestCase):
     def _context(
@@ -6073,6 +6131,146 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
             high_rank_exit.intent.rationale,
         )
         self.assertIn("exit_basis:runtime_position", high_rank_exit.intent.rationale)
+
+    def test_microbar_pairs_honors_configured_pair_universe_with_broader_feature_universe(
+        self,
+    ) -> None:
+        plugin = MicrobarCrossSectionalPairsPlugin()
+        params = {
+            "entry_minute_after_open": "60",
+            "signal_motif": "vwap_close_continuation",
+            "rank_feature": "cross_section_vwap_w5m_rank",
+            "selection_mode": "continuation",
+            "top_n": "1",
+            "max_pair_legs": "2",
+        }
+
+        high_rank_entry = plugin.evaluate(
+            self._context(
+                params=params,
+                strategy_type="microbar_cross_sectional_pairs_v1",
+                symbol="AAPL",
+                strategy_spec={"universe_symbols": ["AAPL", "AMZN"]},
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "cross_section_vwap_w5m_rank": Decimal("0.6667"),
+                    "cross_section_vwap_w5m_rank_universe_size": Decimal("4"),
+                },
+                symbol="AAPL",
+            ),
+        )
+        low_rank_entry = plugin.evaluate(
+            self._context(
+                params=params,
+                strategy_type="microbar_cross_sectional_pairs_v1",
+                symbol="AMZN",
+                strategy_spec={"universe_symbols": ["AAPL", "AMZN"]},
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "cross_section_vwap_w5m_rank": Decimal("0.3333"),
+                    "cross_section_vwap_w5m_rank_universe_size": Decimal("4"),
+                },
+                symbol="AMZN",
+            ),
+        )
+        ambiguous_midpoint = plugin.evaluate(
+            self._context(
+                params=params,
+                strategy_type="microbar_cross_sectional_pairs_v1",
+                symbol="AAPL",
+                strategy_spec={"universe_symbols": ["AAPL", "AMZN"]},
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "cross_section_vwap_w5m_rank": Decimal("0.5"),
+                    "cross_section_vwap_w5m_rank_universe_size": Decimal("4"),
+                },
+                symbol="AAPL",
+            ),
+        )
+
+        self.assertIsNotNone(high_rank_entry.intent)
+        self.assertIsNotNone(low_rank_entry.intent)
+        assert high_rank_entry.intent is not None
+        assert low_rank_entry.intent is not None
+        self.assertEqual(high_rank_entry.intent.action, "buy")
+        self.assertEqual(low_rank_entry.intent.action, "sell")
+        assert high_rank_entry.trace is not None
+        self.assertEqual(
+            high_rank_entry.trace.gates[0].context["rank_threshold_basis"],
+            "configured_pair_midpoint",
+        )
+        self.assertEqual(
+            high_rank_entry.trace.gates[0].context["configured_universe_size"],
+            2,
+        )
+        self.assertEqual(
+            high_rank_entry.trace.gates[0].context["observed_rank_universe_size"],
+            4,
+        )
+        self.assertIsNone(ambiguous_midpoint.intent)
+        assert ambiguous_midpoint.trace is not None
+        self.assertEqual(
+            ambiguous_midpoint.trace.gates[0].context["reason"],
+            "ambiguous_pair_rank_midpoint",
+        )
+
+    def test_microbar_pairs_missing_rank_records_actionable_suppression(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-cross-sectional-pairs-v1",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_type="microbar_cross_sectional_pairs_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_position_pct_equity=Decimal("6.0"),
+                    max_notional_per_trade=Decimal("75000"),
+                    params={
+                        "entry_minute_after_open": "60",
+                        "rank_feature": "cross_section_vwap_w5m_rank",
+                        "selection_mode": "continuation",
+                        "max_pair_legs": "2",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_position_pct_equity=Decimal("6.0"),
+            max_notional_per_trade=Decimal("75000"),
+        )
+        runtime = StrategyRuntime(trace_enabled=True)
+
+        evaluation = runtime.evaluate_all(
+            [strategy],
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "price": Decimal("200"),
+                },
+                symbol="AAPL",
+            ),
+            timeframe="1Sec",
+        )
+
+        self.assertEqual(evaluation.raw_intents, [])
+        self.assertIn(
+            f"{strategy.id}|rank_selection:missing_rank_feature",
+            evaluation.observation.strategy_intent_suppression_total,
+        )
 
     def test_microbar_cross_sectional_pairs_plugin_exits_by_position_after_rank_drift(
         self,

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -16,12 +16,12 @@ from app.trading.features import (
     FeatureVectorV3,
     normalize_feature_vector_v3,
 )
+from app.trading.evaluation_trace import GateTrace, StrategyTrace
 from app.trading.models import SignalEnvelope
 from app.trading.research_sleeves import (
     _rank_thresholds,
     evaluate_mean_reversion_exhaustion_short,
 )
-from app.trading.evaluation_trace import GateTrace, StrategyTrace
 from app.trading.strategy_runtime import (
     LegacyMacdRsiPlugin,
     MicrobarCrossSectionalLongPlugin,

--- a/services/torghut/tests/test_strategy_specs.py
+++ b/services/torghut/tests/test_strategy_specs.py
@@ -13,120 +13,165 @@ from app.trading.strategy_runtime import StrategyRuntime
 from app.trading.strategy_specs import (
     build_compiled_strategy_artifacts,
     build_experiment_spec_from_strategy,
+    build_strategy_spec_v2,
+    compile_strategy_spec_v2,
+    load_strategy_spec_v2_payload,
 )
 
 
 class TestStrategySpecs(TestCase):
     def test_compiled_strategy_artifacts_are_stable_for_legacy_macd_rsi(self) -> None:
         compiled = build_compiled_strategy_artifacts(
-            strategy_id='legacy-spec',
-            strategy_type='legacy_macd_rsi',
-            semantic_version='1.0.0',
-            params={'qty': 2, 'buy_rsi_threshold': 33},
-            base_timeframe='1Min',
-            universe_symbols=['AAPL'],
-            source='spec_v2',
+            strategy_id="legacy-spec",
+            strategy_type="legacy_macd_rsi",
+            semantic_version="1.0.0",
+            params={"qty": 2, "buy_rsi_threshold": 33},
+            base_timeframe="1Min",
+            universe_symbols=["AAPL"],
+            source="spec_v2",
         )
 
-        self.assertEqual(compiled.strategy_spec.strategy_id, 'legacy-spec')
+        self.assertEqual(compiled.strategy_spec.strategy_id, "legacy-spec")
         self.assertEqual(
-            compiled.evaluator_config['feature_view_spec_ref'],
-            'features/legacy-macd-rsi-v1',
+            compiled.evaluator_config["feature_view_spec_ref"],
+            "features/legacy-macd-rsi-v1",
         )
         self.assertEqual(
-            compiled.shadow_runtime_config['strategy_type'],
-            'legacy_macd_rsi',
+            compiled.shadow_runtime_config["strategy_type"],
+            "legacy_macd_rsi",
         )
         self.assertEqual(
-            compiled.live_runtime_config['mode'],
-            'live',
+            compiled.live_runtime_config["mode"],
+            "live",
         )
         self.assertEqual(
-            compiled.promotion_metadata['promotion_policy_ref'],
-            'torghut-promotion/vnext-default-v1',
+            compiled.promotion_metadata["promotion_policy_ref"],
+            "torghut-promotion/vnext-default-v1",
         )
 
     def test_compiled_strategy_artifacts_build_experiment_spec(self) -> None:
         compiled = build_compiled_strategy_artifacts(
-            strategy_id='tsmom-spec',
-            strategy_type='intraday_tsmom_v1',
-            semantic_version='1.1.0',
-            params={'qty': 1},
-            base_timeframe='1Min',
-            universe_symbols=['NVDA'],
-            source='spec_v2',
+            strategy_id="tsmom-spec",
+            strategy_type="intraday_tsmom_v1",
+            semantic_version="1.1.0",
+            params={"qty": 1},
+            base_timeframe="1Min",
+            universe_symbols=["NVDA"],
+            source="spec_v2",
         )
 
         experiment = build_experiment_spec_from_strategy(
-            experiment_id='exp-tsmom-spec',
-            hypothesis='intraday continuation',
+            experiment_id="exp-tsmom-spec",
+            hypothesis="intraday continuation",
             strategy_spec=compiled.strategy_spec,
-            llm_provenance={'mode': 'advisory_only'},
+            llm_provenance={"mode": "advisory_only"},
         )
 
-        self.assertEqual(experiment.model_family, 'intraday_tsmom_v1')
+        self.assertEqual(experiment.model_family, "intraday_tsmom_v1")
         self.assertEqual(
             experiment.feature_view_spec_ref,
-            'features/intraday-momentum-v1',
+            "features/intraday-momentum-v1",
         )
         self.assertEqual(
-            experiment.acceptance_criteria['promotion_policy_ref'],
-            'torghut-promotion/vnext-default-v1',
+            experiment.acceptance_criteria["promotion_policy_ref"],
+            "torghut-promotion/vnext-default-v1",
         )
 
-    def test_load_runtime_strategy_config_compiles_supported_strategy_types(self) -> None:
+    def test_compiled_strategy_artifacts_normalize_tsmom_alias_defaults(self) -> None:
+        spec = build_strategy_spec_v2(
+            strategy_id="tsmom-alias",
+            strategy_type="tsmom_intraday",
+            semantic_version="",
+            params={"qty": 1},
+            base_timeframe="1Sec",
+            universe_symbols=["NVDA"],
+        )
+        compiled = compile_strategy_spec_v2(spec)
+
+        self.assertEqual(spec.semantic_version, "1.1.0")
+        self.assertEqual(spec.deterministic_rule_ref, "rules/intraday_tsmom_v1")
+        self.assertEqual(
+            compiled.live_runtime_config["strategy_type"], "intraday_tsmom_v1"
+        )
+        self.assertEqual(
+            compiled.live_runtime_config["strategy_spec"]["feature_view_spec_ref"],
+            "features/intraday-momentum-v1",
+        )
+
+    def test_load_strategy_spec_payload_prefers_model_ref_strategy_type(self) -> None:
+        spec = load_strategy_spec_v2_payload(
+            {
+                "strategy_id": "model-backed",
+                "model_ref": "models/intraday_tsmom",
+                "deterministic_rule_ref": "",
+                "universe": {"strategy_type": "legacy_macd_rsi"},
+            }
+        )
+        compiled = compile_strategy_spec_v2(spec)
+
+        self.assertIsNone(spec.deterministic_rule_ref)
+        self.assertEqual(spec.model_ref, "models/intraday_tsmom")
+        self.assertEqual(
+            compiled.evaluator_config["strategy_type"], "intraday_tsmom_v1"
+        )
+
+    def test_load_runtime_strategy_config_compiles_supported_strategy_types(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            config_path = Path(tmpdir) / 'strategies.json'
+            config_path = Path(tmpdir) / "strategies.json"
             config_path.write_text(
                 json.dumps(
                     {
-                        'strategies': [
+                        "strategies": [
                             {
-                                'strategy_id': 'legacy-a',
-                                'strategy_type': 'legacy_macd_rsi',
-                                'version': '1.0.0',
-                                'params': {'qty': 2},
-                                'base_timeframe': '1Min',
+                                "strategy_id": "legacy-a",
+                                "strategy_type": "legacy_macd_rsi",
+                                "version": "1.0.0",
+                                "params": {"qty": 2},
+                                "base_timeframe": "1Min",
                             },
                             {
-                                'strategy_id': 'tsmom-a',
-                                'strategy_type': 'intraday_tsmom_v1',
-                                'version': '1.1.0',
-                                'params': {'qty': 1},
-                                'base_timeframe': '1Min',
+                                "strategy_id": "tsmom-a",
+                                "strategy_type": "intraday_tsmom_v1",
+                                "version": "1.1.0",
+                                "params": {"qty": 1},
+                                "base_timeframe": "1Min",
                             },
                         ]
                     }
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
 
             configs = load_runtime_strategy_config(config_path)
 
-        self.assertEqual([item.strategy_id for item in configs], ['legacy-a', 'tsmom-a'])
-        self.assertTrue(all(item.compiler_source == 'spec_v2' for item in configs))
+        self.assertEqual(
+            [item.strategy_id for item in configs], ["legacy-a", "tsmom-a"]
+        )
+        self.assertTrue(all(item.compiler_source == "spec_v2" for item in configs))
         self.assertTrue(all(item.strategy_spec for item in configs))
         self.assertTrue(all(item.compiled_targets for item in configs))
 
     def test_strategy_runtime_definition_uses_spec_v2_for_supported_types(self) -> None:
         strategy = Strategy(
             id=uuid.uuid4(),
-            name='intraday-tsmom',
-            description='intraday_tsmom_v1@1.1.0',
+            name="intraday-tsmom",
+            description="intraday_tsmom_v1@1.1.0",
             enabled=True,
-            base_timeframe='1Min',
-            universe_type='intraday_tsmom_v1',
-            universe_symbols=['NVDA'],
-            max_position_pct_equity=Decimal('0.02'),
-            max_notional_per_trade=Decimal('2500'),
+            base_timeframe="1Min",
+            universe_type="intraday_tsmom_v1",
+            universe_symbols=["NVDA"],
+            max_position_pct_equity=Decimal("0.02"),
+            max_notional_per_trade=Decimal("2500"),
         )
 
         definition = StrategyRuntime.definition_from_strategy(strategy)
 
-        self.assertEqual(definition.compiler_source, 'spec_v2')
-        self.assertEqual(definition.version, '1.1.0')
-        self.assertEqual(definition.strategy_type, 'intraday_tsmom_v1')
+        self.assertEqual(definition.compiler_source, "spec_v2")
+        self.assertEqual(definition.version, "1.1.0")
+        self.assertEqual(definition.strategy_type, "intraday_tsmom_v1")
         self.assertEqual(
-            definition.strategy_spec['feature_view_spec_ref'],
-            'features/intraday-momentum-v1',
+            definition.strategy_spec["feature_view_spec_ref"],
+            "features/intraday-momentum-v1",
         )


### PR DESCRIPTION
## Summary

- Materializes spec_v2 runtime strategy/compiled-target artifacts for microbar_cross_sectional_pairs_v1 so H-PAIRS decisions carry concrete target lineage.
- Adjusts H-PAIRS pair-side rank selection to honor configured AAPL/AMZN pair universes when feature ranks are computed over a broader executable universe, while failing closed on ambiguous midpoint ranks.
- Records actionable no-intent runtime suppression reasons from strategy traces for missing/stale/invalid H-PAIRS inputs.
- Adds regression coverage for AAPL/AMZN H-PAIRS entry materialization, broader rank-universe handling, target lineage, missing-rank blockers, and strategy-spec fallback normalization.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass)
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_runtime.py tests/test_decisions.py tests/test_audit_hpairs_signal_liveness.py tests/test_signal_readiness_status.py -q` (pass: 212 passed, 1 warning)
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_runtime.py::TestStrategyRuntime::test_trace_suppression_reason_falls_back_to_gate_or_default tests/test_strategy_specs.py::TestStrategySpecs::test_compiled_strategy_artifacts_normalize_tsmom_alias_defaults tests/test_strategy_specs.py::TestStrategySpecs::test_load_strategy_spec_payload_prefers_model_ref_strategy_type -q` (pass: 3 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/strategy_runtime.py app/trading/strategy_specs.py tests/test_strategy_runtime.py tests/test_strategy_specs.py tests/test_decisions.py` (pass)
- `cd services/torghut && uv run --frozen ruff format --check app/trading/strategy_runtime.py app/trading/strategy_specs.py tests/test_strategy_runtime.py tests/test_strategy_specs.py tests/test_decisions.py` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (pass: 0 errors)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
