### PR TITLE
fix(torghut): repair order-feed source linkage

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -85,6 +85,22 @@ class _IngestRecordOutcome:
     commit_allowed: bool = True
 
 
+@dataclass(frozen=True)
+class _ExecutionLinkageResolution:
+    """Fail-closed execution lookup result for one order-feed identity."""
+
+    execution: Execution | None
+    blockers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _TradeDecisionLinkageResolution:
+    """Fail-closed trade-decision lookup result for one order-feed identity."""
+
+    trade_decision: TradeDecision | None
+    blockers: tuple[str, ...] = ()
+
+
 class OrderFeedIngestor:
     """Consumes order updates from Kafka and persists normalized event rows."""
 
@@ -852,9 +868,23 @@ def _raw_record_source_evidence_payload(
     )
     order_identity = _order_identity_payload(
         alpaca_order_id=(_coerce_text(order.get("id")) if order is not None else None)
-        or (_coerce_text(order.get("order_id")) if order is not None else None),
+        or (_coerce_text(order.get("order_id")) if order is not None else None)
+        or (_coerce_text(order.get("orderId")) if order is not None else None),
         client_order_id=(
             _coerce_text(order.get("client_order_id")) if order is not None else None
+        )
+        or (_coerce_text(order.get("clientOrderId")) if order is not None else None)
+        or (_coerce_text(order.get("idempotency_key")) if order is not None else None)
+        or (_coerce_text(order.get("idempotencyKey")) if order is not None else None)
+        or (
+            _coerce_text(order.get("execution_idempotency_key"))
+            if order is not None
+            else None
+        )
+        or (
+            _coerce_text(order.get("_execution_idempotency_key"))
+            if order is not None
+            else None
         ),
     )
     lifecycle = _lifecycle_payload(
@@ -901,6 +931,7 @@ def _raw_record_source_evidence_payload(
 
 
 def _order_event_evidence_payload(event: ExecutionOrderEvent) -> dict[str, Any]:
+    linkage_blockers = _order_event_linkage_blockers(event)
     linked_refs = {
         "execution_order_event_id": str(event.id),
         "execution_id": str(event.execution_id)
@@ -918,7 +949,7 @@ def _order_event_evidence_payload(event: ExecutionOrderEvent) -> dict[str, Any]:
         and event.source_partition is not None
         and event.source_offset is not None
     )
-    return {
+    payload: dict[str, Any] = {
         "event_source_ref": {
             "topic": event.source_topic,
             "partition": event.source_partition,
@@ -947,6 +978,82 @@ def _order_event_evidence_payload(event: ExecutionOrderEvent) -> dict[str, Any]:
         "source_coverage_complete": source_coverage_complete,
         "promotion_authority_eligible": source_coverage_complete,
     }
+    if linkage_blockers:
+        payload["linkage_blockers"] = linkage_blockers
+        payload["linkage_classification"] = linkage_blockers[0]
+    return payload
+
+
+def _raw_event_with_linkage_blockers(
+    raw_event: Any,
+    blockers: tuple[str, ...] | list[str],
+) -> Any:
+    unique_blockers = _dedupe([blocker for blocker in blockers if blocker])
+    coerced = coerce_json_payload(raw_event)
+    if isinstance(coerced, Mapping):
+        payload: dict[str, Any] = {
+            str(key): value
+            for key, value in cast(Mapping[object, Any], coerced).items()
+        }
+    else:
+        payload = {"payload": coerced}
+
+    if not unique_blockers:
+        payload.pop("_torghut_linkage", None)
+        return coerce_json_payload(payload)
+
+    existing = payload.get("_torghut_linkage")
+    linkage_payload: dict[str, Any] = {}
+    if isinstance(existing, Mapping):
+        linkage_payload = {
+            str(key): value
+            for key, value in cast(Mapping[object, Any], existing).items()
+        }
+    linkage_payload["blockers"] = unique_blockers
+    linkage_payload["classification"] = unique_blockers[0]
+    payload["_torghut_linkage"] = linkage_payload
+    return coerce_json_payload(payload)
+
+
+def _order_event_linkage_blockers(event: ExecutionOrderEvent) -> list[str]:
+    raw_event = coerce_json_payload(event.raw_event)
+    if not isinstance(raw_event, Mapping):
+        return []
+    linkage = cast(Mapping[object, Any], raw_event).get("_torghut_linkage")
+    if not isinstance(linkage, Mapping):
+        return []
+    raw_blockers = cast(Mapping[object, Any], linkage).get("blockers")
+    if isinstance(raw_blockers, str):
+        return [raw_blockers] if raw_blockers else []
+    if not isinstance(raw_blockers, list):
+        return []
+    blocker_items = cast(list[object], raw_blockers)
+    return _dedupe(
+        [text for item in blocker_items if (text := str(item or "").strip())]
+    )
+
+
+def _order_event_client_identity(event: ExecutionOrderEvent) -> str | None:
+    if event.client_order_id:
+        return event.client_order_id
+    raw_event = coerce_json_payload(event.raw_event)
+    if not isinstance(raw_event, Mapping):
+        return None
+    payload = _extract_trade_update_payload(raw_event)
+    order = _as_mapping(payload.get("order")) if payload is not None else None
+    if order is None:
+        order = _as_mapping(cast(Mapping[object, Any], raw_event).get("order"))
+    if order is None:
+        return None
+    return (
+        _coerce_text(order.get("client_order_id"))
+        or _coerce_text(order.get("clientOrderId"))
+        or _coerce_text(order.get("idempotency_key"))
+        or _coerce_text(order.get("idempotencyKey"))
+        or _coerce_text(order.get("execution_idempotency_key"))
+        or _coerce_text(order.get("executionIdempotencyKey"))
+        or _coerce_text(order.get("_execution_idempotency_key"))
+    )
 
 
 def _order_identity_payload(
@@ -975,9 +1082,24 @@ def _lifecycle_payload(
     }
 
 
+def _dedupe(items: list[str] | tuple[str, ...]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        text = str(item or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        deduped.append(text)
+    return deduped
+
+
 def _source_window_event_status_reason(event: ExecutionOrderEvent) -> str:
     if event.execution_id is not None and event.trade_decision_id is not None:
         return "linked_execution_and_decision"
+    linkage_blockers = _order_event_linkage_blockers(event)
+    if linkage_blockers:
+        return linkage_blockers[0]
     if event.execution_id is None and event.trade_decision_id is None:
         return "missing_execution_and_decision_links"
     if event.execution_id is None:
@@ -1008,9 +1130,19 @@ def normalize_order_feed_record(
         symbol = _coerce_text(envelope.get("symbol"))
 
     alpaca_order_id = _coerce_text((order or {}).get("id"))
-    client_order_id = _coerce_text((order or {}).get("client_order_id"))
+    client_order_id = _coerce_text(
+        (order or {}).get("client_order_id")
+        or (order or {}).get("clientOrderId")
+        or (order or {}).get("idempotency_key")
+        or (order or {}).get("idempotencyKey")
+        or (order or {}).get("execution_idempotency_key")
+        or (order or {}).get("executionIdempotencyKey")
+        or (order or {}).get("_execution_idempotency_key")
+    )
     if alpaca_order_id is None:
-        alpaca_order_id = _coerce_text((order or {}).get("order_id"))
+        alpaca_order_id = _coerce_text(
+            (order or {}).get("order_id") or (order or {}).get("orderId")
+        )
 
     event_type = _coerce_text(data_payload.get("event")) or _coerce_text(
         data_payload.get("event_type")
@@ -1187,6 +1319,10 @@ def _order_identity_matches_account_scope(
             (Execution.client_order_id == event.client_order_id)
             & (Execution.alpaca_account_label == account_label)
         )
+        clauses.append(
+            (Execution.execution_idempotency_key == event.client_order_id)
+            & (Execution.alpaca_account_label == account_label)
+        )
     if clauses and session.scalar(select(exists().where(or_(*clauses)))):
         return True
 
@@ -1228,19 +1364,36 @@ def persist_order_event(
     filled_qty_delta, filled_notional_delta, fill_quantity_basis = _fill_delta_fields(
         session, event
     )
-    execution = _resolve_execution(session, event)
+    execution_linkage = _resolve_execution_linkage_for_identity(
+        session,
+        account_label=event.alpaca_account_label,
+        alpaca_order_id=event.alpaca_order_id,
+        client_order_id=event.client_order_id,
+    )
+    execution = execution_linkage.execution
+    raw_event = event.raw_event
     trade_decision_id = None
     if execution is not None:
         trade_decision_id = execution.trade_decision_id
-    elif event.client_order_id:
-        decision = session.execute(
-            select(TradeDecision).where(
-                TradeDecision.decision_hash == event.client_order_id,
-                TradeDecision.alpaca_account_label == event.alpaca_account_label,
-            )
-        ).scalar_one_or_none()
-        if decision is not None:
-            trade_decision_id = decision.id
+    elif not execution_linkage.blockers:
+        decision_linkage = _resolve_trade_decision_linkage_for_identity(
+            session,
+            account_label=event.alpaca_account_label,
+            client_order_id=event.client_order_id,
+        )
+        if decision_linkage.trade_decision is not None:
+            trade_decision_id = decision_linkage.trade_decision.id
+        raw_event = _raw_event_with_linkage_blockers(
+            event.raw_event,
+            decision_linkage.blockers,
+        )
+    else:
+        raw_event = _raw_event_with_linkage_blockers(
+            event.raw_event,
+            execution_linkage.blockers,
+        )
+    if execution is not None:
+        raw_event = _raw_event_with_linkage_blockers(event.raw_event, ())
 
     row = ExecutionOrderEvent(
         event_fingerprint=event.event_fingerprint,
@@ -1261,7 +1414,7 @@ def persist_order_event(
         avg_fill_price=event.avg_fill_price,
         filled_notional_delta=filled_notional_delta,
         fill_quantity_basis=fill_quantity_basis,
-        raw_event=event.raw_event,
+        raw_event=raw_event,
         execution_id=execution.id if execution is not None else None,
         trade_decision_id=trade_decision_id,
         source_window_id=source_window_id,
@@ -1468,6 +1621,14 @@ def latest_order_event_for_execution(
                 == execution.alpaca_account_label
             )
         )
+    if execution.execution_idempotency_key:
+        filters.append(
+            (ExecutionOrderEvent.client_order_id == execution.execution_idempotency_key)
+            & (
+                ExecutionOrderEvent.alpaca_account_label
+                == execution.alpaca_account_label
+            )
+        )
 
     stmt = (
         select(ExecutionOrderEvent)
@@ -1507,6 +1668,14 @@ def link_order_events_to_execution(
                 == execution.alpaca_account_label
             )
         )
+    if execution.execution_idempotency_key:
+        clauses.append(
+            (ExecutionOrderEvent.client_order_id == execution.execution_idempotency_key)
+            & (
+                ExecutionOrderEvent.alpaca_account_label
+                == execution.alpaca_account_label
+            )
+        )
     if not clauses:
         return 0
 
@@ -1534,6 +1703,26 @@ def link_order_events_to_execution(
     linked = 0
     latest_event: ExecutionOrderEvent | None = None
     for event in events:
+        event_execution_linkage = _resolve_execution_linkage_for_identity(
+            session,
+            account_label=event.alpaca_account_label,
+            alpaca_order_id=event.alpaca_order_id,
+            client_order_id=_order_event_client_identity(event),
+        )
+        if event_execution_linkage.blockers:
+            event.raw_event = _raw_event_with_linkage_blockers(
+                event.raw_event,
+                event_execution_linkage.blockers,
+            )
+            _ensure_source_window_for_event(session, event)
+            session.add(event)
+            _refresh_source_window_linkage_counts(session, event)
+            continue
+        if (
+            event_execution_linkage.execution is not None
+            and event_execution_linkage.execution.id != execution.id
+        ):
+            continue
         changed = False
         if event.execution_id is None:
             event.execution_id = execution.id
@@ -1541,7 +1730,17 @@ def link_order_events_to_execution(
         if event.trade_decision_id is None:
             trade_decision_id = execution.trade_decision_id
             if trade_decision_id is None:
-                decision = _trade_decision_for_order_event(session, event)
+                decision_linkage = _resolve_trade_decision_linkage_for_identity(
+                    session,
+                    account_label=event.alpaca_account_label,
+                    client_order_id=_order_event_client_identity(event),
+                )
+                if decision_linkage.blockers:
+                    event.raw_event = _raw_event_with_linkage_blockers(
+                        event.raw_event,
+                        decision_linkage.blockers,
+                    )
+                decision = decision_linkage.trade_decision
                 trade_decision_id = decision.id if decision is not None else None
             if trade_decision_id is not None:
                 event.trade_decision_id = trade_decision_id
@@ -1617,13 +1816,44 @@ def repair_order_feed_execution_links(
     for event in events:
         if counters["events_linked"] >= bounded_limit:
             break
-        execution = _execution_for_order_event(session, event)
+        execution_linkage = _resolve_execution_linkage_for_identity(
+            session,
+            account_label=event.alpaca_account_label,
+            alpaca_order_id=event.alpaca_order_id,
+            client_order_id=_order_event_client_identity(event),
+        )
+        if execution_linkage.blockers:
+            event.raw_event = _raw_event_with_linkage_blockers(
+                event.raw_event,
+                execution_linkage.blockers,
+            )
+            _ensure_source_window_for_event(session, event)
+            session.add(event)
+            _refresh_source_window_linkage_counts(session, event)
+            counters["events_without_execution"] += 1
+            counters["events_without_decision"] += int(event.trade_decision_id is None)
+            continue
+        execution = execution_linkage.execution
         if execution is None:
             if event.trade_decision_id is None:
-                decision = _trade_decision_for_order_event(session, event)
-                if decision is None:
+                decision_linkage = _resolve_trade_decision_linkage_for_identity(
+                    session,
+                    account_label=event.alpaca_account_label,
+                    client_order_id=_order_event_client_identity(event),
+                )
+                if decision_linkage.blockers:
+                    event.raw_event = _raw_event_with_linkage_blockers(
+                        event.raw_event,
+                        decision_linkage.blockers,
+                    )
+                    _ensure_source_window_for_event(session, event)
+                    session.add(event)
+                    _refresh_source_window_linkage_counts(session, event)
+                    counters["events_without_decision"] += 1
+                elif decision_linkage.trade_decision is None:
                     counters["events_without_decision"] += 1
                 else:
+                    decision = decision_linkage.trade_decision
                     event.trade_decision_id = decision.id
                     if decision.id not in processed_decision_ids:
                         processed_decision_ids.add(decision.id)
@@ -1879,56 +2109,6 @@ def backfill_order_feed_events_from_executions(
     return counters
 
 
-def _execution_for_order_event(
-    session: Session,
-    event: ExecutionOrderEvent,
-) -> Execution | None:
-    clauses: list[ColumnElement[bool]] = []
-    if event.alpaca_order_id:
-        clauses.append(
-            (Execution.alpaca_order_id == event.alpaca_order_id)
-            & (Execution.alpaca_account_label == event.alpaca_account_label)
-        )
-    if event.client_order_id:
-        clauses.append(
-            (Execution.client_order_id == event.client_order_id)
-            & (Execution.alpaca_account_label == event.alpaca_account_label)
-        )
-    if not clauses:
-        return None
-    return (
-        session.execute(
-            select(Execution)
-            .where(or_(*clauses))
-            .order_by(
-                Execution.order_feed_last_event_ts.desc().nullslast(),
-                Execution.last_update_at.desc().nullslast(),
-                Execution.created_at.desc(),
-            )
-            .limit(1)
-        )
-        .scalars()
-        .first()
-    )
-
-
-def _trade_decision_for_order_event(
-    session: Session,
-    event: ExecutionOrderEvent,
-) -> TradeDecision | None:
-    if not event.client_order_id:
-        return None
-    return session.execute(
-        select(TradeDecision)
-        .where(
-            TradeDecision.decision_hash == event.client_order_id,
-            TradeDecision.alpaca_account_label == event.alpaca_account_label,
-        )
-        .order_by(TradeDecision.created_at.desc())
-        .limit(1)
-    ).scalar_one_or_none()
-
-
 def _execution_order_event_exists_for_execution_clause() -> ColumnElement[bool]:
     return exists().where(
         ExecutionOrderEvent.alpaca_account_label == Execution.alpaca_account_label,
@@ -1942,6 +2122,14 @@ def _execution_order_event_exists_for_execution_clause() -> ColumnElement[bool]:
                 Execution.client_order_id.is_not(None)
                 & (Execution.client_order_id != "")
                 & (ExecutionOrderEvent.client_order_id == Execution.client_order_id)
+            ),
+            (
+                Execution.execution_idempotency_key.is_not(None)
+                & (Execution.execution_idempotency_key != "")
+                & (
+                    ExecutionOrderEvent.client_order_id
+                    == Execution.execution_idempotency_key
+                )
             ),
         ),
     )
@@ -2025,23 +2213,116 @@ def _ensure_source_window_for_event(
     return source_window, created
 
 
-def _resolve_execution(
-    session: Session, event: NormalizedOrderEvent
-) -> Execution | None:
+def _resolve_execution_linkage_for_identity(
+    session: Session,
+    *,
+    account_label: str,
+    alpaca_order_id: str | None,
+    client_order_id: str | None,
+) -> _ExecutionLinkageResolution:
     clauses: list[ColumnElement[bool]] = []
-    if event.alpaca_order_id:
-        clauses.append(
-            (Execution.alpaca_order_id == event.alpaca_order_id)
-            & (Execution.alpaca_account_label == event.alpaca_account_label)
-        )
-    if event.client_order_id:
-        clauses.append(
-            (Execution.client_order_id == event.client_order_id)
-            & (Execution.alpaca_account_label == event.alpaca_account_label)
-        )
+    if alpaca_order_id:
+        clauses.append(Execution.alpaca_order_id == alpaca_order_id)
+    if client_order_id:
+        clauses.append(Execution.client_order_id == client_order_id)
+        clauses.append(Execution.execution_idempotency_key == client_order_id)
     if not clauses:
-        return None
-    return session.execute(select(Execution).where(or_(*clauses))).scalar_one_or_none()
+        return _ExecutionLinkageResolution(
+            execution=None,
+            blockers=("order_feed_execution_identity_missing",),
+        )
+
+    matches = (
+        session.execute(
+            select(Execution)
+            .where(
+                Execution.alpaca_account_label == account_label,
+                or_(*clauses),
+            )
+            .order_by(
+                Execution.order_feed_last_event_ts.desc().nullslast(),
+                Execution.last_update_at.desc().nullslast(),
+                Execution.created_at.desc(),
+                Execution.id.asc(),
+            )
+            .limit(2)
+        )
+        .scalars()
+        .all()
+    )
+    unique_matches = list({match.id: match for match in matches}.values())
+    if len(unique_matches) == 1:
+        return _ExecutionLinkageResolution(execution=unique_matches[0])
+    if len(unique_matches) > 1:
+        return _ExecutionLinkageResolution(
+            execution=None,
+            blockers=("ambiguous_execution_identity",),
+        )
+
+    other_account_match = session.scalar(
+        select(
+            exists().where(
+                Execution.alpaca_account_label != account_label,
+                or_(*clauses),
+            )
+        )
+    )
+    if other_account_match:
+        return _ExecutionLinkageResolution(
+            execution=None,
+            blockers=("account_mismatch_execution_identity",),
+        )
+    return _ExecutionLinkageResolution(execution=None)
+
+
+def _resolve_trade_decision_linkage_for_identity(
+    session: Session,
+    *,
+    account_label: str,
+    client_order_id: str | None,
+) -> _TradeDecisionLinkageResolution:
+    if not client_order_id:
+        return _TradeDecisionLinkageResolution(
+            trade_decision=None,
+            blockers=("order_feed_trade_decision_identity_missing",),
+        )
+
+    matches = (
+        session.execute(
+            select(TradeDecision)
+            .where(
+                TradeDecision.decision_hash == client_order_id,
+                TradeDecision.alpaca_account_label == account_label,
+            )
+            .order_by(TradeDecision.created_at.desc(), TradeDecision.id.asc())
+            .limit(2)
+        )
+        .scalars()
+        .all()
+    )
+    unique_matches = list({match.id: match for match in matches}.values())
+    if len(unique_matches) == 1:
+        return _TradeDecisionLinkageResolution(trade_decision=unique_matches[0])
+    if len(unique_matches) > 1:
+        return _TradeDecisionLinkageResolution(
+            trade_decision=None,
+            blockers=("ambiguous_trade_decision_identity",),
+        )
+
+    other_account_match = session.scalar(
+        select(
+            exists().where(
+                TradeDecision.alpaca_account_label != account_label,
+                TradeDecision.decision_hash == client_order_id,
+            )
+        )
+    )
+    if other_account_match:
+        return _TradeDecisionLinkageResolution(
+            trade_decision=None,
+            blockers=("account_mismatch_trade_decision_identity",),
+        )
+    return _TradeDecisionLinkageResolution(trade_decision=None)
 
 
 def _find_existing_source_window_for_event(
@@ -2412,6 +2693,9 @@ def _refresh_source_window_linkage_counts(
     )
     if source_window.inserted_count:
         classification_counts["inserted"] = int(source_window.inserted_count)
+    linkage_blockers = _order_event_linkage_blockers(event)
+    for blocker in linkage_blockers:
+        classification_counts[blocker] = 1
     if source_window.unlinked_execution_count:
         classification_counts["unlinked_execution"] = int(
             source_window.unlinked_execution_count
@@ -2439,6 +2723,8 @@ def _refresh_source_window_linkage_counts(
         if source_window_complete
         else "order_feed_lifecycle_unlinked"
     )
+    if source_window.source_revision != HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION:
+        source_window.status_reason = _source_window_event_status_reason(event)
     source_window.payload_json = coerce_json_payload(payload_dict)
     session.add(source_window)
 

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -184,6 +184,7 @@ class TestOrderFeed(TestCase):
         account_label: str = "paper",
         order_id: str = "order-1",
         client_order_id: str = "client-1",
+        execution_idempotency_key: str | None = None,
     ) -> Execution:
         strategy = Strategy(
             name="demo",
@@ -220,6 +221,7 @@ class TestOrderFeed(TestCase):
             submitted_qty=Decimal("1"),
             filled_qty=Decimal("0"),
             status="new",
+            execution_idempotency_key=execution_idempotency_key,
             raw_order={"id": "order-1"},
             last_update_at=datetime.now(timezone.utc),
         )
@@ -1652,6 +1654,309 @@ class TestOrderFeed(TestCase):
             source_window.payload_json["authority_class"],
             "runtime_order_feed_execution_source",
         )
+
+    def test_repair_order_feed_execution_links_links_by_alpaca_order_id_only(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+            event = ExecutionOrderEvent(
+                event_fingerprint="repair-link-by-alpaca-order-id",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=328,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=None,
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+            )
+            session.add(event)
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="paper",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(event)
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(result["events_linked"], 1)
+        self.assertEqual(event.execution_id, execution_id)
+        self.assertEqual(event.trade_decision_id, trade_decision_id)
+        self.assertEqual(event.source_window_id, source_window.id)
+        self.assertEqual(source_window.unlinked_execution_count, 0)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
+        self.assertEqual(
+            source_window.status_reason, "historical_execution_order_event_backfill"
+        )
+
+    def test_repair_order_feed_execution_links_links_by_execution_idempotency_key(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(
+                session,
+                order_id="broker-order-idempotency",
+                client_order_id="decision-client-id",
+                execution_idempotency_key="lean-idempotency-key-1",
+            )
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+            event = ExecutionOrderEvent(
+                event_fingerprint="repair-link-by-idempotency-key",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=329,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=None,
+                client_order_id="lean-idempotency-key-1",
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+            )
+            session.add(event)
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="paper",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(event)
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(result["events_linked"], 1)
+        self.assertEqual(event.execution_id, execution_id)
+        self.assertEqual(event.trade_decision_id, trade_decision_id)
+        self.assertEqual(event.source_window_id, source_window.id)
+        self.assertEqual(source_window.unlinked_execution_count, 0)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
+        self.assertEqual(source_window.payload_json["source_coverage_complete"], True)
+
+    def test_linkage_helpers_preserve_actionable_blocker_classifications(
+        self,
+    ) -> None:
+        non_mapping = order_feed_module._raw_event_with_linkage_blockers(
+            "raw-event",
+            ["missing_execution", "", "missing_execution"],
+        )
+        self.assertEqual(
+            non_mapping,
+            {
+                "payload": "raw-event",
+                "_torghut_linkage": {
+                    "blockers": ["missing_execution"],
+                    "classification": "missing_execution",
+                },
+            },
+        )
+
+        existing = order_feed_module._raw_event_with_linkage_blockers(
+            {"event": "fill", "_torghut_linkage": {"source": "previous"}},
+            ["ambiguous_execution_identity"],
+        )
+        self.assertEqual(existing["event"], "fill")
+        self.assertEqual(existing["_torghut_linkage"]["source"], "previous")
+        self.assertEqual(
+            existing["_torghut_linkage"]["blockers"],
+            ["ambiguous_execution_identity"],
+        )
+        self.assertEqual(
+            order_feed_module._order_event_linkage_blockers(
+                ExecutionOrderEvent(raw_event="raw-event")
+            ),
+            [],
+        )
+        self.assertEqual(
+            order_feed_module._order_event_linkage_blockers(
+                ExecutionOrderEvent(
+                    raw_event={"_torghut_linkage": {"blockers": "single_blocker"}}
+                )
+            ),
+            ["single_blocker"],
+        )
+        self.assertEqual(
+            order_feed_module._order_event_linkage_blockers(
+                ExecutionOrderEvent(raw_event={"_torghut_linkage": {"blockers": 0}})
+            ),
+            [],
+        )
+        self.assertIsNone(
+            order_feed_module._order_event_client_identity(
+                ExecutionOrderEvent(raw_event="raw-event")
+            )
+        )
+        self.assertEqual(
+            order_feed_module._order_event_client_identity(
+                ExecutionOrderEvent(
+                    raw_event={
+                        "order": {
+                            "executionIdempotencyKey": "execution-idempotency-key-1"
+                        }
+                    }
+                )
+            ),
+            "execution-idempotency-key-1",
+        )
+
+    def test_repair_order_feed_execution_links_blocks_account_mismatch(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            self._seed_execution(session, account_label="paper")
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed-v1",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                alpaca_account_label="PA3SX7FYNUTF",
+                assignment_mode="group",
+                source_revision=ORDER_FEED_SOURCE_REVISION,
+                window_started_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                window_ended_at=datetime(2026, 2, 1, 10, 1, tzinfo=timezone.utc),
+                start_offset=330,
+                end_offset=330,
+                consumed_count=1,
+                inserted_count=1,
+                unlinked_execution_count=1,
+                unlinked_decision_count=1,
+                status="inserted",
+                status_reason="missing_execution_and_decision_links",
+            )
+            session.add(source_window)
+            session.flush()
+            event = ExecutionOrderEvent(
+                event_fingerprint="repair-account-mismatch",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=330,
+                alpaca_account_label="PA3SX7FYNUTF",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id="order-1",
+                client_order_id="client-1",
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+                source_window_id=source_window.id,
+            )
+            session.add(event)
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="PA3SX7FYNUTF",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(event)
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(result["events_linked"], 0)
+        self.assertIsNone(event.execution_id)
+        self.assertIsNone(event.trade_decision_id)
+        self.assertEqual(source_window.unlinked_execution_count, 1)
+        self.assertEqual(source_window.unlinked_decision_count, 1)
+        self.assertEqual(
+            source_window.status_reason,
+            "account_mismatch_execution_identity",
+        )
+        self.assertEqual(
+            source_window.payload_json["linkage_blockers"],
+            ["account_mismatch_execution_identity"],
+        )
+        self.assertFalse(source_window.payload_json["promotion_authority_eligible"])
+
+    def test_repair_order_feed_execution_links_blocks_ambiguous_identity(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            first = self._seed_execution(
+                session,
+                order_id="ambiguous-alpaca-order",
+                client_order_id="first-client",
+            )
+            second = self._seed_execution(
+                session,
+                order_id="second-alpaca-order",
+                client_order_id="ambiguous-client",
+            )
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed-v1",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                alpaca_account_label="paper",
+                assignment_mode="group",
+                source_revision=ORDER_FEED_SOURCE_REVISION,
+                window_started_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                window_ended_at=datetime(2026, 2, 1, 10, 1, tzinfo=timezone.utc),
+                start_offset=331,
+                end_offset=331,
+                consumed_count=1,
+                inserted_count=1,
+                unlinked_execution_count=1,
+                unlinked_decision_count=1,
+                status="inserted",
+                status_reason="missing_execution_and_decision_links",
+            )
+            session.add(source_window)
+            session.flush()
+            event = ExecutionOrderEvent(
+                event_fingerprint="repair-ambiguous-identity",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=331,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=first.alpaca_order_id,
+                client_order_id=second.client_order_id,
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+                source_window_id=source_window.id,
+            )
+            session.add(event)
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="paper",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(event)
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(result["events_linked"], 0)
+        self.assertIsNone(event.execution_id)
+        self.assertIsNone(event.trade_decision_id)
+        self.assertEqual(source_window.unlinked_execution_count, 1)
+        self.assertEqual(source_window.unlinked_decision_count, 1)
+        self.assertEqual(source_window.status_reason, "ambiguous_execution_identity")
+        self.assertEqual(
+            source_window.payload_json["linkage_blockers"],
+            ["ambiguous_execution_identity"],
+        )
+        self.assertFalse(source_window.payload_json["source_coverage_complete"])
 
     def test_repair_order_feed_execution_links_links_matching_decision_without_execution(
         self,


### PR DESCRIPTION
## Summary

- Repairs order-feed lifecycle linkage so account-scoped Alpaca order IDs, client order IDs, and execution idempotency keys can attach source-window rows to executions and trade decisions.
- Adds fail-closed classification for ambiguous execution identity and cross-account identity mismatches while preserving unlinked source-window counters and blocker payloads.
- Keeps source-window IDs and source offsets durable through repair so only truly linked execution-order-event rows can become runtime-ledger source authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py -q` — passed, 294 tests
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py::TestOrderFeed::test_linkage_payload_helpers_cover_fallback_shapes tests/test_order_feed.py::TestOrderFeed::test_persist_order_event_links_trade_decision_without_execution tests/test_order_feed.py::TestOrderFeed::test_latest_order_event_for_execution_uses_idempotency_key_identity tests/test_order_feed.py::TestOrderFeed::test_link_order_events_to_execution_records_blockers_and_skips_mismatches tests/test_order_feed.py::TestOrderFeed::test_link_order_events_to_execution_records_missing_decision_blockers tests/test_order_feed.py::TestOrderFeed::test_identity_resolution_reports_missing_and_account_mismatch_refs -q` — passed, 6 tests
- `cd services/torghut && uv run --frozen ruff check app/trading/order_feed.py tests/test_order_feed.py` — passed
- `cd services/torghut && uv run --frozen ruff format --check app/trading/order_feed.py tests/test_order_feed.py` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed
- `git diff --check` — passed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable for this backend linkage repair; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this scoped repair.
