### PR TITLE
fix(torghut): expose hpairs authority gaps

### DIFF
--- a/services/torghut/app/trading/runtime_authority_verifier.py
+++ b/services/torghut/app/trading/runtime_authority_verifier.py
@@ -21,7 +21,10 @@ from app.trading.runtime_cost_authority import (
     cost_basis_counts_have_non_promotion_grade_costs,
     is_non_promotion_grade_runtime_cost_basis,
 )
-from app.trading.runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
+from app.trading.runtime_ledger import (
+    EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+    POST_COST_PNL_BASIS,
+)
 from app.trading.runtime_ledger_proof_policy import (
     DEFAULT_RUNTIME_LEDGER_PROOF_POLICY,
     RuntimeLedgerProofPolicy,
@@ -42,36 +45,38 @@ from app.trading.runtime_ledger_source_authority import (
     runtime_ledger_source_window_present,
 )
 
-DEFAULT_HPAIRS_HYPOTHESIS_ID = 'H-PAIRS-01'
-DEFAULT_HPAIRS_CANDIDATE_ID = 'c88421d619759b2cfaa6f4d0'
-DEFAULT_HPAIRS_RUNTIME_STRATEGY = 'microbar-cross-sectional-pairs-v1'
-DEFAULT_HPAIRS_ACCOUNT_LABEL = 'TORGHUT_SIM'
-HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION = 'torghut.hpairs-runtime-authority-proof.v1'
+DEFAULT_HPAIRS_HYPOTHESIS_ID = "H-PAIRS-01"
+DEFAULT_HPAIRS_CANDIDATE_ID = "c88421d619759b2cfaa6f4d0"
+DEFAULT_HPAIRS_RUNTIME_STRATEGY = "microbar-cross-sectional-pairs-v1"
+DEFAULT_HPAIRS_ACCOUNT_LABEL = "TORGHUT_SIM"
+HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION = (
+    "torghut.hpairs-runtime-authority-proof.v1"
+)
 
-AUTHORITY_TRADING_DAYS_BLOCKER = 'runtime_ledger_trading_days_below_authority_minimum'
-AUTHORITY_MEAN_PNL_BLOCKER = 'mean_daily_net_pnl_after_costs_below_500'
-AUTHORITY_MEDIAN_PNL_BLOCKER = 'median_daily_net_pnl_after_costs_below_250'
-AUTHORITY_P10_PNL_BLOCKER = 'p10_daily_net_pnl_after_costs_below_floor'
-AUTHORITY_WORST_DAY_BLOCKER = 'worst_day_net_pnl_after_costs_below_floor'
-AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER = 'best_day_concentration_above_25pct'
-AUTHORITY_FILLED_NOTIONAL_BLOCKER = 'filled_notional_below_authority_minimum'
-AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER = 'filled_notional_missing'
-AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER = 'closed_round_trips_below_authority_minimum'
-AUTHORITY_OPEN_POSITIONS_BLOCKER = 'open_positions_present'
-AUTHORITY_EXPLICIT_COSTS_BLOCKER = 'explicit_costs_missing'
-AUTHORITY_BUCKET_BLOCKERS_PRESENT = 'runtime_ledger_bucket_blockers_present'
-AUTHORITY_EVIDENCE_MISSING_BLOCKER = 'runtime_ledger_evidence_missing'
-AUTHORITY_READ_ERROR_BLOCKER = 'runtime_ledger_read_error'
-AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER = 'runtime_fills_missing'
-AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER = 'runtime_decisions_missing'
+AUTHORITY_TRADING_DAYS_BLOCKER = "runtime_ledger_trading_days_below_authority_minimum"
+AUTHORITY_MEAN_PNL_BLOCKER = "mean_daily_net_pnl_after_costs_below_500"
+AUTHORITY_MEDIAN_PNL_BLOCKER = "median_daily_net_pnl_after_costs_below_250"
+AUTHORITY_P10_PNL_BLOCKER = "p10_daily_net_pnl_after_costs_below_floor"
+AUTHORITY_WORST_DAY_BLOCKER = "worst_day_net_pnl_after_costs_below_floor"
+AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER = "best_day_concentration_above_25pct"
+AUTHORITY_FILLED_NOTIONAL_BLOCKER = "filled_notional_below_authority_minimum"
+AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER = "filled_notional_missing"
+AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER = "closed_round_trips_below_authority_minimum"
+AUTHORITY_OPEN_POSITIONS_BLOCKER = "open_positions_present"
+AUTHORITY_EXPLICIT_COSTS_BLOCKER = "explicit_costs_missing"
+AUTHORITY_BUCKET_BLOCKERS_PRESENT = "runtime_ledger_bucket_blockers_present"
+AUTHORITY_EVIDENCE_MISSING_BLOCKER = "runtime_ledger_evidence_missing"
+AUTHORITY_READ_ERROR_BLOCKER = "runtime_ledger_read_error"
+AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER = "runtime_fills_missing"
+AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER = "runtime_decisions_missing"
 AUTHORITY_ORDER_LIFECYCLE_MISSING_BLOCKER = ORDER_FEED_LIFECYCLE_MISSING_BLOCKER
-AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER = 'closed_round_trip_missing'
-AUTHORITY_LEDGER_SCHEMA_BLOCKER = 'runtime_ledger_schema_version_invalid'
-AUTHORITY_PNL_BASIS_BLOCKER = 'runtime_ledger_pnl_basis_invalid'
-AUTHORITY_COST_BASIS_BLOCKER = 'runtime_ledger_cost_basis_non_promotion_grade'
-AUTHORITY_POLICY_HASH_BLOCKER = 'execution_policy_hash_missing'
-AUTHORITY_COST_MODEL_HASH_BLOCKER = 'cost_model_hash_missing'
-AUTHORITY_LINEAGE_HASH_BLOCKER = 'lineage_hash_missing'
+AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER = "closed_round_trip_missing"
+AUTHORITY_LEDGER_SCHEMA_BLOCKER = "runtime_ledger_schema_version_invalid"
+AUTHORITY_PNL_BASIS_BLOCKER = "runtime_ledger_pnl_basis_invalid"
+AUTHORITY_COST_BASIS_BLOCKER = "runtime_ledger_cost_basis_non_promotion_grade"
+AUTHORITY_POLICY_HASH_BLOCKER = "execution_policy_hash_missing"
+AUTHORITY_COST_MODEL_HASH_BLOCKER = "cost_model_hash_missing"
+AUTHORITY_LINEAGE_HASH_BLOCKER = "lineage_hash_missing"
 
 _PROMOTION_GRADE_LEDGER_SCHEMAS = frozenset({EXACT_REPLAY_LEDGER_SCHEMA_VERSION})
 
@@ -115,8 +120,8 @@ class RuntimeAuthorityEvidenceRow:
 @dataclass
 class _DailyAccumulator:
     trading_day: str
-    net_strategy_pnl_after_costs: Decimal = Decimal('0')
-    filled_notional: Decimal = Decimal('0')
+    net_strategy_pnl_after_costs: Decimal = Decimal("0")
+    filled_notional: Decimal = Decimal("0")
     closed_trade_count: int = 0
     open_position_count: int = 0
     fill_count: int = 0
@@ -134,6 +139,10 @@ class _DailyAccumulator:
     authority_class_count: int = 0
     bucket_count: int = 0
     source_authority_bucket_count: int = 0
+    clean_authority_bucket_count: int = 0
+    clean_authority_net_strategy_pnl_after_costs: Decimal = Decimal("0")
+    clean_authority_filled_notional: Decimal = Decimal("0")
+    clean_authority_closed_trade_count: int = 0
     row_refs: list[str] | None = None
     blockers: list[str] | None = None
 
@@ -170,11 +179,17 @@ def load_runtime_authority_rows(
         StrategyRuntimeLedgerBucket.runtime_strategy_name == runtime_strategy_name,
     )
     if observed_stage is not None:
-        statement = statement.where(StrategyRuntimeLedgerBucket.observed_stage == observed_stage)
+        statement = statement.where(
+            StrategyRuntimeLedgerBucket.observed_stage == observed_stage
+        )
     if started_at is not None:
-        statement = statement.where(StrategyRuntimeLedgerBucket.bucket_ended_at >= _utc(started_at))
+        statement = statement.where(
+            StrategyRuntimeLedgerBucket.bucket_ended_at >= _utc(started_at)
+        )
     if ended_at is not None:
-        statement = statement.where(StrategyRuntimeLedgerBucket.bucket_started_at < _utc(ended_at))
+        statement = statement.where(
+            StrategyRuntimeLedgerBucket.bucket_started_at < _utc(ended_at)
+        )
     statement = statement.order_by(
         StrategyRuntimeLedgerBucket.bucket_started_at.asc(),
         StrategyRuntimeLedgerBucket.bucket_ended_at.asc(),
@@ -188,7 +203,7 @@ def load_runtime_authority_rows(
 def build_runtime_authority_report(
     rows: Sequence[RuntimeAuthorityEvidenceRow | Mapping[str, object]],
     *,
-    mode: str = 'authority',
+    mode: str = "authority",
     hypothesis_id: str = DEFAULT_HPAIRS_HYPOTHESIS_ID,
     candidate_id: str = DEFAULT_HPAIRS_CANDIDATE_ID,
     runtime_strategy_name: str = DEFAULT_HPAIRS_RUNTIME_STRATEGY,
@@ -212,26 +227,38 @@ def build_runtime_authority_report(
         policy=policy,
         evidence_read_error=evidence_read_error,
     )
+    final_authority_ok = not blockers
     return {
-        'schema_version': HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION,
-        'mode': proof_mode,
-        'final_authority_ok': not blockers,
-        'identity': {
-            'hypothesis_id': hypothesis_id,
-            'candidate_id': candidate_id,
-            'runtime_strategy_name': runtime_strategy_name,
-            'account_label': account_label,
-            'observed_stage': observed_stage,
+        "schema_version": HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION,
+        "mode": proof_mode,
+        "evidence_source": {
+            "table": "strategy_runtime_ledger_buckets",
+            "writes_performed": False,
+            "synthetic_or_replay_only_authority_allowed": False,
         },
-        'window': {
-            'started_at': _isoformat(started_at) if started_at is not None else None,
-            'ended_at': _isoformat(ended_at) if ended_at is not None else None,
+        "authority_allowed": final_authority_ok,
+        "promotion_allowed": final_authority_ok,
+        "capital_promotion_allowed": final_authority_ok,
+        "final_authority_ok": final_authority_ok,
+        "identity": {
+            "hypothesis_id": hypothesis_id,
+            "candidate_id": candidate_id,
+            "runtime_strategy_name": runtime_strategy_name,
+            "account_label": account_label,
+            "observed_stage": observed_stage,
         },
-        'evidence_read_error': evidence_read_error,
-        'targets': _authority_targets(policy),
-        'trading_days': [_daily_payload(item) for item in daily],
-        'aggregate': aggregate,
-        'blockers': blockers,
+        "window": {
+            "started_at": _isoformat(started_at) if started_at is not None else None,
+            "ended_at": _isoformat(ended_at) if ended_at is not None else None,
+        },
+        "evidence_read_error": evidence_read_error,
+        "targets": _authority_targets(policy),
+        "trading_days": [_daily_payload(item) for item in daily],
+        "aggregate": aggregate,
+        "gaps": _authority_gaps(aggregate, policy=policy),
+        "blocker_counts": _blocker_counts(daily, extra_blockers=blockers),
+        "blockers": blockers,
+        "next_actions": _next_actions(blockers),
     }
 
 
@@ -240,12 +267,16 @@ def runtime_authority_report_json(report: Mapping[str, object]) -> str:
 
     import json
 
-    return json.dumps(report, indent=2, sort_keys=True) + '\n'
+    return json.dumps(report, indent=2, sort_keys=True) + "\n"
 
 
-def _row_from_bucket(bucket: StrategyRuntimeLedgerBucket) -> RuntimeAuthorityEvidenceRow:
+def _row_from_bucket(
+    bucket: StrategyRuntimeLedgerBucket,
+) -> RuntimeAuthorityEvidenceRow:
     payload = _as_mapping(bucket.payload_json)
-    blockers = _string_tuple([*_as_sequence(bucket.blockers_json), *_as_sequence(payload.get('blockers'))])
+    blockers = _string_tuple(
+        [*_as_sequence(bucket.blockers_json), *_as_sequence(payload.get("blockers"))]
+    )
     return RuntimeAuthorityEvidenceRow(
         row_id=str(bucket.id),
         run_id=_text(bucket.run_id),
@@ -280,42 +311,52 @@ def _row_from_bucket(bucket: StrategyRuntimeLedgerBucket) -> RuntimeAuthorityEvi
     )
 
 
-def _normalize_row(row: RuntimeAuthorityEvidenceRow | Mapping[str, object]) -> RuntimeAuthorityEvidenceRow:
+def _normalize_row(
+    row: RuntimeAuthorityEvidenceRow | Mapping[str, object],
+) -> RuntimeAuthorityEvidenceRow:
     if isinstance(row, RuntimeAuthorityEvidenceRow):
         return row
-    bucket_start = _required_datetime(row.get('bucket_started_at'), field_name='bucket_started_at')
-    bucket_end = _required_datetime(row.get('bucket_ended_at'), field_name='bucket_ended_at')
-    payload = _as_mapping(row.get('payload_json') or row.get('payload'))
-    blockers = _string_tuple([*_as_sequence(row.get('blockers_json')), *_as_sequence(row.get('blockers'))])
+    bucket_start = _required_datetime(
+        row.get("bucket_started_at"), field_name="bucket_started_at"
+    )
+    bucket_end = _required_datetime(
+        row.get("bucket_ended_at"), field_name="bucket_ended_at"
+    )
+    payload = _as_mapping(row.get("payload_json") or row.get("payload"))
+    blockers = _string_tuple(
+        [*_as_sequence(row.get("blockers_json")), *_as_sequence(row.get("blockers"))]
+    )
     return RuntimeAuthorityEvidenceRow(
-        row_id=_text(row.get('id') or row.get('row_id')) or '',
-        run_id=_text(row.get('run_id')),
-        candidate_id=_text(row.get('candidate_id')),
-        hypothesis_id=_text(row.get('hypothesis_id')),
-        observed_stage=_text(row.get('observed_stage')),
+        row_id=_text(row.get("id") or row.get("row_id")) or "",
+        run_id=_text(row.get("run_id")),
+        candidate_id=_text(row.get("candidate_id")),
+        hypothesis_id=_text(row.get("hypothesis_id")),
+        observed_stage=_text(row.get("observed_stage")),
         bucket_started_at=bucket_start,
         bucket_ended_at=bucket_end,
-        account_label=_text(row.get('account_label')),
-        runtime_strategy_name=_text(row.get('runtime_strategy_name')),
-        strategy_family=_text(row.get('strategy_family')),
-        fill_count=_int(row.get('fill_count')),
-        decision_count=_int(row.get('decision_count')),
-        submitted_order_count=_int(row.get('submitted_order_count')),
-        cancelled_order_count=_int(row.get('cancelled_order_count')),
-        rejected_order_count=_int(row.get('rejected_order_count')),
-        unfilled_order_count=_int(row.get('unfilled_order_count')),
-        closed_trade_count=_int(row.get('closed_trade_count')),
-        open_position_count=_int(row.get('open_position_count')),
-        filled_notional=_decimal(row.get('filled_notional')),
-        gross_strategy_pnl=_decimal(row.get('gross_strategy_pnl')),
-        cost_amount=_decimal(row.get('cost_amount')),
-        net_strategy_pnl_after_costs=_decimal(row.get('net_strategy_pnl_after_costs')),
-        post_cost_expectancy_bps=_optional_decimal(row.get('post_cost_expectancy_bps')),
-        ledger_schema_version=_text(row.get('ledger_schema_version')),
-        pnl_basis=_text(row.get('pnl_basis')),
-        execution_policy_hash_counts=_as_mapping(row.get('execution_policy_hash_counts')),
-        cost_model_hash_counts=_as_mapping(row.get('cost_model_hash_counts')),
-        lineage_hash_counts=_as_mapping(row.get('lineage_hash_counts')),
+        account_label=_text(row.get("account_label")),
+        runtime_strategy_name=_text(row.get("runtime_strategy_name")),
+        strategy_family=_text(row.get("strategy_family")),
+        fill_count=_int(row.get("fill_count")),
+        decision_count=_int(row.get("decision_count")),
+        submitted_order_count=_int(row.get("submitted_order_count")),
+        cancelled_order_count=_int(row.get("cancelled_order_count")),
+        rejected_order_count=_int(row.get("rejected_order_count")),
+        unfilled_order_count=_int(row.get("unfilled_order_count")),
+        closed_trade_count=_int(row.get("closed_trade_count")),
+        open_position_count=_int(row.get("open_position_count")),
+        filled_notional=_decimal(row.get("filled_notional")),
+        gross_strategy_pnl=_decimal(row.get("gross_strategy_pnl")),
+        cost_amount=_decimal(row.get("cost_amount")),
+        net_strategy_pnl_after_costs=_decimal(row.get("net_strategy_pnl_after_costs")),
+        post_cost_expectancy_bps=_optional_decimal(row.get("post_cost_expectancy_bps")),
+        ledger_schema_version=_text(row.get("ledger_schema_version")),
+        pnl_basis=_text(row.get("pnl_basis")),
+        execution_policy_hash_counts=_as_mapping(
+            row.get("execution_policy_hash_counts")
+        ),
+        cost_model_hash_counts=_as_mapping(row.get("cost_model_hash_counts")),
+        lineage_hash_counts=_as_mapping(row.get("lineage_hash_counts")),
         blockers=blockers,
         payload=payload,
     )
@@ -329,6 +370,7 @@ def _daily_rows(rows: Sequence[RuntimeAuthorityEvidenceRow]) -> list[_DailyAccum
         payload = _promotion_payload(row)
         row_blockers = _row_authority_blockers(row, payload)
         source_blockers = runtime_ledger_promotion_source_authority_blockers(payload)
+        combined_blockers = [*row_blockers, *source_blockers]
         accumulator.net_strategy_pnl_after_costs += row.net_strategy_pnl_after_costs
         accumulator.filled_notional += row.filled_notional
         accumulator.closed_trade_count += max(0, row.closed_trade_count)
@@ -343,34 +385,49 @@ def _daily_rows(rows: Sequence[RuntimeAuthorityEvidenceRow]) -> list[_DailyAccum
             accumulator.source_window_count += 1
         if not source_blockers:
             accumulator.source_authority_bucket_count += 1
+        if not combined_blockers:
+            accumulator.clean_authority_bucket_count += 1
+            accumulator.clean_authority_net_strategy_pnl_after_costs += (
+                row.net_strategy_pnl_after_costs
+            )
+            accumulator.clean_authority_filled_notional += row.filled_notional
+            accumulator.clean_authority_closed_trade_count += max(
+                0, row.closed_trade_count
+            )
         accumulator.source_window_id_count += _ref_count(
             payload,
-            'source_window_ids',
-            'source_window_id',
-            'runtime_ledger_source_window_ids',
-            'runtime_ledger_source_window_id',
+            "source_window_ids",
+            "source_window_id",
+            "runtime_ledger_source_window_ids",
+            "runtime_ledger_source_window_id",
         )
-        accumulator.source_ref_count += _ref_count(payload, 'source_refs', 'source_ref')
+        accumulator.source_ref_count += _ref_count(payload, "source_refs", "source_ref")
         accumulator.source_offset_count += _source_offset_count(payload)
         accumulator.trade_decision_ref_count += _ref_count(
             payload,
-            'trade_decision_ids',
-            'trade_decision_refs',
-            'trade_decision_id',
-            'decision_ids',
-            'decision_id',
+            "trade_decision_ids",
+            "trade_decision_refs",
+            "trade_decision_id",
+            "decision_ids",
+            "decision_id",
         )
-        accumulator.execution_ref_count += _ref_count(payload, 'execution_ids', 'execution_refs', 'execution_id')
+        accumulator.execution_ref_count += _ref_count(
+            payload, "execution_ids", "execution_refs", "execution_id"
+        )
         accumulator.execution_order_event_ref_count += _ref_count(
             payload,
-            'execution_order_event_ids',
-            'execution_order_event_refs',
-            'execution_order_event_id',
+            "execution_order_event_ids",
+            "execution_order_event_refs",
+            "execution_order_event_id",
         )
-        accumulator.source_materialization_count += int(_text(payload.get('source_materialization')) is not None)
-        accumulator.authority_class_count += int(_text(payload.get('authority_class')) is not None)
+        accumulator.source_materialization_count += int(
+            _text(payload.get("source_materialization")) is not None
+        )
+        accumulator.authority_class_count += int(
+            _text(payload.get("authority_class")) is not None
+        )
         accumulator.add_ref(row.row_id)
-        accumulator.add_blockers([*row_blockers, *source_blockers])
+        accumulator.add_blockers(combined_blockers)
     return [accumulators[day] for day in sorted(accumulators)]
 
 
@@ -380,37 +437,128 @@ def _aggregate(
     *,
     policy: RuntimeLedgerProofPolicy,
 ) -> dict[str, object]:
-    daily_net = [item.net_strategy_pnl_after_costs for item in daily]
-    total_net = sum(daily_net, Decimal('0'))
-    positive_total_net = sum((max(item, Decimal('0')) for item in daily_net), Decimal('0'))
-    best_day_net = max(daily_net) if daily_net else Decimal('0')
-    best_day_share = (
-        max(best_day_net, Decimal('0')) / positive_total_net if positive_total_net > 0 else None
+    authority_daily = [item for item in daily if item.clean_authority_bucket_count > 0]
+    clean_daily_net = [
+        item.clean_authority_net_strategy_pnl_after_costs for item in authority_daily
+    ]
+    clean_total_net = sum(clean_daily_net, Decimal("0"))
+    clean_positive_total_net = sum(
+        (max(item, Decimal("0")) for item in clean_daily_net), Decimal("0")
     )
-    max_drawdown = _max_drawdown(daily_net)
-    filled_notional = sum((row.filled_notional for row in rows), Decimal('0'))
-    closed_round_trips = sum((max(0, row.closed_trade_count) for row in rows), 0)
-    cost_amount = sum((row.cost_amount for row in rows), Decimal('0'))
+    clean_best_day_net = max(clean_daily_net) if clean_daily_net else Decimal("0")
+    clean_best_day_share = (
+        max(clean_best_day_net, Decimal("0")) / clean_positive_total_net
+        if clean_positive_total_net > 0
+        else None
+    )
+    clean_max_drawdown = _max_drawdown(clean_daily_net)
+    raw_daily_net = [item.net_strategy_pnl_after_costs for item in daily]
+    raw_total_net = sum(raw_daily_net, Decimal("0"))
+    raw_positive_total_net = sum(
+        (max(item, Decimal("0")) for item in raw_daily_net), Decimal("0")
+    )
+    raw_best_day_net = max(raw_daily_net) if raw_daily_net else Decimal("0")
+    raw_best_day_share = (
+        max(raw_best_day_net, Decimal("0")) / raw_positive_total_net
+        if raw_positive_total_net > 0
+        else None
+    )
+    raw_closed_round_trips = sum((max(0, row.closed_trade_count) for row in rows), 0)
+    raw_filled_notional = sum((row.filled_notional for row in rows), Decimal("0"))
+    clean_filled_notional = sum(
+        (item.clean_authority_filled_notional for item in authority_daily), Decimal("0")
+    )
+    clean_closed_round_trips = sum(
+        (item.clean_authority_closed_trade_count for item in authority_daily), 0
+    )
+    cost_amount = sum((row.cost_amount for row in rows), Decimal("0"))
+    target_implied_notional_gap = max(
+        Decimal("0"), policy.authority_min_filled_notional - clean_filled_notional
+    )
     return {
-        'bucket_count': len(rows),
-        'trading_day_count': len(daily),
-        'mean_daily_net_pnl_after_costs': _decimal_text(_mean(daily_net)),
-        'median_daily_net_pnl_after_costs': _decimal_text(_median(daily_net)),
-        'p10_daily_net_pnl_after_costs': _decimal_text(_p10(daily_net)),
-        'worst_day_net_pnl_after_costs': _decimal_text(min(daily_net) if daily_net else Decimal('0')),
-        'best_day_net_pnl_after_costs': _decimal_text(best_day_net),
-        'best_day_share': _decimal_text(best_day_share) if best_day_share is not None else None,
-        'max_drawdown': _decimal_text(max_drawdown) if daily else None,
-        'total_net_strategy_pnl_after_costs': _decimal_text(total_net),
-        'total_filled_notional': _decimal_text(filled_notional),
-        'total_explicit_costs': _decimal_text(cost_amount),
-        'closed_round_trips': closed_round_trips,
-        'open_position_count': sum((max(0, row.open_position_count) for row in rows), 0),
-        'source_authority_bucket_count': sum(item.source_authority_bucket_count for item in daily),
-        'explicit_cost_bucket_count': sum(item.explicit_cost_bucket_count for item in daily),
-        'authority_min_trading_days': policy.authority_min_trading_days,
-        'authority_min_filled_notional': _decimal_text(policy.authority_min_filled_notional),
-        'authority_min_closed_round_trips': policy.authority_min_closed_round_trips,
+        "bucket_count": len(rows),
+        "runtime_ledger_trading_day_count": len(daily),
+        "trading_day_count": len(daily),
+        "clean_authority_bucket_count": sum(
+            item.clean_authority_bucket_count for item in daily
+        ),
+        "clean_authority_trading_day_count": len(authority_daily),
+        "mean_daily_net_pnl_after_costs": _decimal_text(_mean(raw_daily_net)),
+        "median_daily_net_pnl_after_costs": _decimal_text(_median(raw_daily_net)),
+        "p10_daily_net_pnl_after_costs": _decimal_text(_p10(raw_daily_net)),
+        "worst_day_net_pnl_after_costs": _decimal_text(
+            min(raw_daily_net) if raw_daily_net else Decimal("0")
+        ),
+        "best_day_net_pnl_after_costs": _decimal_text(raw_best_day_net),
+        "best_day_share": _decimal_text(raw_best_day_share)
+        if raw_best_day_share is not None
+        else None,
+        "max_drawdown": _decimal_text(_max_drawdown(raw_daily_net)) if daily else None,
+        "total_net_strategy_pnl_after_costs": _decimal_text(raw_total_net),
+        "total_filled_notional": _decimal_text(raw_filled_notional),
+        "target_implied_notional_gap": _decimal_text(target_implied_notional_gap),
+        "total_explicit_costs": _decimal_text(cost_amount),
+        "closed_round_trips": raw_closed_round_trips,
+        "open_position_count": sum(
+            (max(0, row.open_position_count) for row in rows), 0
+        ),
+        "source_authority_bucket_count": sum(
+            item.source_authority_bucket_count for item in daily
+        ),
+        "explicit_cost_bucket_count": sum(
+            item.explicit_cost_bucket_count for item in daily
+        ),
+        "clean_authority_mean_daily_net_pnl_after_costs": _decimal_text(
+            _mean(clean_daily_net)
+        ),
+        "clean_authority_median_daily_net_pnl_after_costs": _decimal_text(
+            _median(clean_daily_net)
+        ),
+        "clean_authority_p10_daily_net_pnl_after_costs": _decimal_text(
+            _p10(clean_daily_net)
+        ),
+        "clean_authority_worst_day_net_pnl_after_costs": _decimal_text(
+            min(clean_daily_net) if clean_daily_net else Decimal("0")
+        ),
+        "clean_authority_best_day_net_pnl_after_costs": _decimal_text(
+            clean_best_day_net
+        ),
+        "clean_authority_best_day_share": _decimal_text(clean_best_day_share)
+        if clean_best_day_share is not None
+        else None,
+        "clean_authority_max_drawdown": _decimal_text(clean_max_drawdown)
+        if authority_daily
+        else None,
+        "clean_authority_total_net_strategy_pnl_after_costs": _decimal_text(
+            clean_total_net
+        ),
+        "clean_authority_total_filled_notional": _decimal_text(clean_filled_notional),
+        "clean_authority_closed_round_trips": clean_closed_round_trips,
+        "raw_runtime_ledger_total_net_strategy_pnl_after_costs": _decimal_text(
+            raw_total_net
+        ),
+        "raw_runtime_ledger_mean_daily_net_pnl_after_costs": _decimal_text(
+            _mean(raw_daily_net)
+        ),
+        "raw_runtime_ledger_total_filled_notional": _decimal_text(raw_filled_notional),
+        "raw_runtime_ledger_closed_round_trips": raw_closed_round_trips,
+        "concentration": {
+            "best_day_share": _decimal_text(raw_best_day_share)
+            if raw_best_day_share is not None
+            else None,
+            "max_best_day_share": _decimal_text(policy.authority_max_best_day_share),
+        },
+        "clean_authority_concentration": {
+            "best_day_share": _decimal_text(clean_best_day_share)
+            if clean_best_day_share is not None
+            else None,
+            "max_best_day_share": _decimal_text(policy.authority_max_best_day_share),
+        },
+        "authority_min_trading_days": policy.authority_min_trading_days,
+        "authority_min_filled_notional": _decimal_text(
+            policy.authority_min_filled_notional
+        ),
+        "authority_min_closed_round_trips": policy.authority_min_closed_round_trips,
     }
 
 
@@ -427,30 +575,49 @@ def _authority_blockers(
         blockers.append(AUTHORITY_READ_ERROR_BLOCKER)
     if not rows:
         blockers.append(AUTHORITY_EVIDENCE_MISSING_BLOCKER)
-    daily_net = [item.net_strategy_pnl_after_costs for item in daily]
-    if len(daily) < policy.authority_min_trading_days:
+    if (
+        _int(aggregate.get("clean_authority_trading_day_count"))
+        < policy.authority_min_trading_days
+    ):
         blockers.append(AUTHORITY_TRADING_DAYS_BLOCKER)
-    if _mean(daily_net) < policy.authority_min_mean_daily_net_pnl_after_costs:
+    if (
+        _decimal(aggregate.get("clean_authority_mean_daily_net_pnl_after_costs"))
+        < policy.authority_min_mean_daily_net_pnl_after_costs
+    ):
         blockers.append(AUTHORITY_MEAN_PNL_BLOCKER)
-    if _median(daily_net) < policy.authority_min_median_daily_net_pnl_after_costs:
+    if (
+        _decimal(aggregate.get("clean_authority_median_daily_net_pnl_after_costs"))
+        < policy.authority_min_median_daily_net_pnl_after_costs
+    ):
         blockers.append(AUTHORITY_MEDIAN_PNL_BLOCKER)
-    if _p10(daily_net) < policy.authority_min_p10_daily_net_pnl_after_costs:
+    if (
+        _decimal(aggregate.get("clean_authority_p10_daily_net_pnl_after_costs"))
+        < policy.authority_min_p10_daily_net_pnl_after_costs
+    ):
         blockers.append(AUTHORITY_P10_PNL_BLOCKER)
-    if (min(daily_net) if daily_net else Decimal('0')) < policy.authority_min_worst_day_net_pnl_after_costs:
+    if (
+        _decimal(aggregate.get("clean_authority_worst_day_net_pnl_after_costs"))
+    ) < policy.authority_min_worst_day_net_pnl_after_costs:
         blockers.append(AUTHORITY_WORST_DAY_BLOCKER)
-    best_day_share = _optional_decimal(aggregate.get('best_day_share'))
-    if best_day_share is not None and best_day_share > policy.authority_max_best_day_share:
+    best_day_share = _optional_decimal(aggregate.get("clean_authority_best_day_share"))
+    if (
+        best_day_share is not None
+        and best_day_share > policy.authority_max_best_day_share
+    ):
         blockers.append(AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER)
-    filled_notional = _decimal(aggregate.get('total_filled_notional'))
+    filled_notional = _decimal(aggregate.get("clean_authority_total_filled_notional"))
     if filled_notional <= 0:
         blockers.append(AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER)
     if filled_notional < policy.authority_min_filled_notional:
         blockers.append(AUTHORITY_FILLED_NOTIONAL_BLOCKER)
-    if _int(aggregate.get('closed_round_trips')) < policy.authority_min_closed_round_trips:
+    if (
+        _int(aggregate.get("clean_authority_closed_round_trips"))
+        < policy.authority_min_closed_round_trips
+    ):
         blockers.append(AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER)
-    if _int(aggregate.get('open_position_count')) > 0:
+    if _int(aggregate.get("open_position_count")) > 0:
         blockers.append(AUTHORITY_OPEN_POSITIONS_BLOCKER)
-    if rows and _int(aggregate.get('explicit_cost_bucket_count')) < len(rows):
+    if rows and _int(aggregate.get("explicit_cost_bucket_count")) < len(rows):
         blockers.append(AUTHORITY_EXPLICIT_COSTS_BLOCKER)
     for item in daily:
         blockers.extend(item.blockers or [])
@@ -495,113 +662,310 @@ def _promotion_payload(row: RuntimeAuthorityEvidenceRow) -> dict[str, object]:
     payload = dict(row.payload)
     payload.update(
         {
-            'run_id': row.run_id,
-            'candidate_id': row.candidate_id,
-            'hypothesis_id': row.hypothesis_id,
-            'observed_stage': row.observed_stage,
-            'account_label': row.account_label,
-            'runtime_strategy_name': row.runtime_strategy_name,
-            'strategy_family': row.strategy_family,
-            'fill_count': row.fill_count,
-            'decision_count': row.decision_count,
-            'submitted_order_count': row.submitted_order_count,
-            'cancelled_order_count': row.cancelled_order_count,
-            'rejected_order_count': row.rejected_order_count,
-            'unfilled_order_count': row.unfilled_order_count,
-            'closed_trade_count': row.closed_trade_count,
-            'open_position_count': row.open_position_count,
-            'filled_notional': row.filled_notional,
-            'gross_strategy_pnl': row.gross_strategy_pnl,
-            'cost_amount': row.cost_amount,
-            'net_strategy_pnl_after_costs': row.net_strategy_pnl_after_costs,
-            'post_cost_expectancy_bps': row.post_cost_expectancy_bps,
-            'ledger_schema_version': row.ledger_schema_version,
-            'pnl_basis': row.pnl_basis,
-            'execution_policy_hash_counts': row.execution_policy_hash_counts,
-            'cost_model_hash_counts': row.cost_model_hash_counts,
-            'lineage_hash_counts': row.lineage_hash_counts,
+            "run_id": row.run_id,
+            "candidate_id": row.candidate_id,
+            "hypothesis_id": row.hypothesis_id,
+            "observed_stage": row.observed_stage,
+            "account_label": row.account_label,
+            "runtime_strategy_name": row.runtime_strategy_name,
+            "strategy_family": row.strategy_family,
+            "fill_count": row.fill_count,
+            "decision_count": row.decision_count,
+            "submitted_order_count": row.submitted_order_count,
+            "cancelled_order_count": row.cancelled_order_count,
+            "rejected_order_count": row.rejected_order_count,
+            "unfilled_order_count": row.unfilled_order_count,
+            "closed_trade_count": row.closed_trade_count,
+            "open_position_count": row.open_position_count,
+            "filled_notional": row.filled_notional,
+            "gross_strategy_pnl": row.gross_strategy_pnl,
+            "cost_amount": row.cost_amount,
+            "net_strategy_pnl_after_costs": row.net_strategy_pnl_after_costs,
+            "post_cost_expectancy_bps": row.post_cost_expectancy_bps,
+            "ledger_schema_version": row.ledger_schema_version,
+            "pnl_basis": row.pnl_basis,
+            "execution_policy_hash_counts": row.execution_policy_hash_counts,
+            "cost_model_hash_counts": row.cost_model_hash_counts,
+            "lineage_hash_counts": row.lineage_hash_counts,
         }
     )
     return payload
 
 
-def _explicit_costs_present(row: RuntimeAuthorityEvidenceRow, payload: Mapping[str, object]) -> bool:
-    if is_non_promotion_grade_runtime_cost_basis(payload.get('cost_basis')):
+def _explicit_costs_present(
+    row: RuntimeAuthorityEvidenceRow, payload: Mapping[str, object]
+) -> bool:
+    if is_non_promotion_grade_runtime_cost_basis(payload.get("cost_basis")):
         return False
-    if cost_basis_counts_have_non_promotion_grade_costs(payload.get('cost_basis_counts')):
+    if cost_basis_counts_have_non_promotion_grade_costs(
+        payload.get("cost_basis_counts")
+    ):
         return False
-    cost_basis_counts = _as_mapping(payload.get('cost_basis_counts'))
+    cost_basis_counts = _as_mapping(payload.get("cost_basis_counts"))
     return bool(cost_basis_counts) and _positive_hash_count(row.cost_model_hash_counts)
 
 
 def _daily_payload(item: _DailyAccumulator) -> dict[str, object]:
     return {
-        'trading_day': item.trading_day,
-        'net_strategy_pnl_after_costs': _decimal_text(item.net_strategy_pnl_after_costs),
-        'filled_notional': _decimal_text(item.filled_notional),
-        'closed_trade_count': item.closed_trade_count,
-        'open_position_count': item.open_position_count,
-        'fill_count': item.fill_count,
-        'decision_count': item.decision_count,
-        'submitted_order_count': item.submitted_order_count,
-        'bucket_count': item.bucket_count,
-        'explicit_cost_bucket_count': item.explicit_cost_bucket_count,
-        'source_window_count': item.source_window_count,
-        'source_window_id_count': item.source_window_id_count,
-        'source_ref_count': item.source_ref_count,
-        'source_offset_count': item.source_offset_count,
-        'trade_decision_ref_count': item.trade_decision_ref_count,
-        'execution_ref_count': item.execution_ref_count,
-        'execution_order_event_ref_count': item.execution_order_event_ref_count,
-        'source_materialization_count': item.source_materialization_count,
-        'authority_class_count': item.authority_class_count,
-        'source_authority_bucket_count': item.source_authority_bucket_count,
-        'row_refs': sorted(item.row_refs or []),
-        'blockers': sorted(item.blockers or []),
+        "trading_day": item.trading_day,
+        "net_strategy_pnl_after_costs": _decimal_text(
+            item.net_strategy_pnl_after_costs
+        ),
+        "filled_notional": _decimal_text(item.filled_notional),
+        "closed_trade_count": item.closed_trade_count,
+        "open_position_count": item.open_position_count,
+        "fill_count": item.fill_count,
+        "decision_count": item.decision_count,
+        "submitted_order_count": item.submitted_order_count,
+        "bucket_count": item.bucket_count,
+        "explicit_cost_bucket_count": item.explicit_cost_bucket_count,
+        "source_window_count": item.source_window_count,
+        "source_window_id_count": item.source_window_id_count,
+        "source_ref_count": item.source_ref_count,
+        "source_offset_count": item.source_offset_count,
+        "trade_decision_ref_count": item.trade_decision_ref_count,
+        "execution_ref_count": item.execution_ref_count,
+        "execution_order_event_ref_count": item.execution_order_event_ref_count,
+        "source_materialization_count": item.source_materialization_count,
+        "authority_class_count": item.authority_class_count,
+        "source_authority_bucket_count": item.source_authority_bucket_count,
+        "clean_authority_bucket_count": item.clean_authority_bucket_count,
+        "clean_authority_net_strategy_pnl_after_costs": _decimal_text(
+            item.clean_authority_net_strategy_pnl_after_costs
+        ),
+        "clean_authority_filled_notional": _decimal_text(
+            item.clean_authority_filled_notional
+        ),
+        "clean_authority_closed_trade_count": item.clean_authority_closed_trade_count,
+        "row_refs": sorted(item.row_refs or []),
+        "blockers": sorted(item.blockers or []),
     }
 
 
 def _authority_targets(policy: RuntimeLedgerProofPolicy) -> dict[str, object]:
     return {
-        'min_trading_days': policy.authority_min_trading_days,
-        'min_mean_daily_net_pnl_after_costs': _decimal_text(policy.authority_min_mean_daily_net_pnl_after_costs),
-        'min_median_daily_net_pnl_after_costs': _decimal_text(policy.authority_min_median_daily_net_pnl_after_costs),
-        'min_p10_daily_net_pnl_after_costs': _decimal_text(policy.authority_min_p10_daily_net_pnl_after_costs),
-        'min_worst_day_net_pnl_after_costs': _decimal_text(policy.authority_min_worst_day_net_pnl_after_costs),
-        'max_best_day_share': _decimal_text(policy.authority_max_best_day_share),
-        'min_filled_notional': _decimal_text(policy.authority_min_filled_notional),
-        'min_closed_round_trips': policy.authority_min_closed_round_trips,
+        "min_trading_days": policy.authority_min_trading_days,
+        "min_mean_daily_net_pnl_after_costs": _decimal_text(
+            policy.authority_min_mean_daily_net_pnl_after_costs
+        ),
+        "min_median_daily_net_pnl_after_costs": _decimal_text(
+            policy.authority_min_median_daily_net_pnl_after_costs
+        ),
+        "min_p10_daily_net_pnl_after_costs": _decimal_text(
+            policy.authority_min_p10_daily_net_pnl_after_costs
+        ),
+        "min_worst_day_net_pnl_after_costs": _decimal_text(
+            policy.authority_min_worst_day_net_pnl_after_costs
+        ),
+        "max_best_day_share": _decimal_text(policy.authority_max_best_day_share),
+        "min_filled_notional": _decimal_text(policy.authority_min_filled_notional),
+        "min_closed_round_trips": policy.authority_min_closed_round_trips,
     }
+
+
+def _authority_gaps(
+    aggregate: Mapping[str, object],
+    *,
+    policy: RuntimeLedgerProofPolicy,
+) -> dict[str, object]:
+    target_total_net = policy.authority_min_mean_daily_net_pnl_after_costs * Decimal(
+        policy.authority_min_trading_days
+    )
+    observed_total_net = _decimal(
+        aggregate.get("clean_authority_total_net_strategy_pnl_after_costs")
+    )
+    return {
+        "missing_trading_days": max(
+            0,
+            policy.authority_min_trading_days
+            - _int(aggregate.get("clean_authority_trading_day_count")),
+        ),
+        "missing_clean_authority_buckets": max(
+            0,
+            policy.authority_min_trading_days
+            - _int(aggregate.get("clean_authority_bucket_count")),
+        ),
+        "missing_net_pnl_after_costs_to_mean_floor": _decimal_text(
+            max(Decimal("0"), target_total_net - observed_total_net)
+        ),
+        "missing_mean_daily_net_pnl_after_costs": _decimal_text(
+            max(
+                Decimal("0"),
+                policy.authority_min_mean_daily_net_pnl_after_costs
+                - _decimal(
+                    aggregate.get("clean_authority_mean_daily_net_pnl_after_costs")
+                ),
+            )
+        ),
+        "missing_median_daily_net_pnl_after_costs": _decimal_text(
+            max(
+                Decimal("0"),
+                policy.authority_min_median_daily_net_pnl_after_costs
+                - _decimal(
+                    aggregate.get("clean_authority_median_daily_net_pnl_after_costs")
+                ),
+            )
+        ),
+        "missing_p10_daily_net_pnl_after_costs": _decimal_text(
+            max(
+                Decimal("0"),
+                policy.authority_min_p10_daily_net_pnl_after_costs
+                - _decimal(
+                    aggregate.get("clean_authority_p10_daily_net_pnl_after_costs")
+                ),
+            )
+        ),
+        "missing_worst_day_net_pnl_after_costs": _decimal_text(
+            max(
+                Decimal("0"),
+                policy.authority_min_worst_day_net_pnl_after_costs
+                - _decimal(
+                    aggregate.get("clean_authority_worst_day_net_pnl_after_costs")
+                ),
+            )
+        ),
+        "missing_closed_round_trips": max(
+            0,
+            policy.authority_min_closed_round_trips
+            - _int(aggregate.get("clean_authority_closed_round_trips")),
+        ),
+        "missing_filled_notional": _decimal_text(
+            max(
+                Decimal("0"),
+                policy.authority_min_filled_notional
+                - _decimal(aggregate.get("clean_authority_total_filled_notional")),
+            )
+        ),
+        "target_implied_notional_gap": _decimal_text(
+            _decimal(aggregate.get("target_implied_notional_gap"))
+        ),
+    }
+
+
+def _blocker_counts(
+    daily: Sequence[_DailyAccumulator],
+    *,
+    extra_blockers: Sequence[str],
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in daily:
+        for blocker in item.blockers or []:
+            counts[blocker] = counts.get(blocker, 0) + 1
+    for blocker in extra_blockers:
+        counts.setdefault(blocker, 1)
+    return {key: counts[key] for key in sorted(counts)}
+
+
+def _next_actions(blockers: Sequence[str]) -> list[str]:
+    actions: list[str] = []
+
+    def add(action: str) -> None:
+        if action not in actions:
+            actions.append(action)
+
+    for blocker in blockers:
+        if blocker in {
+            RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+            RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+            RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+            RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+            RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+            RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER,
+            RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
+            RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
+        }:
+            add("repair_order_feed_linkage")
+        elif blocker == AUTHORITY_TRADING_DAYS_BLOCKER:
+            add("wait_for_more_authority_days")
+        elif blocker in {
+            AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER,
+            AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER,
+        }:
+            add("collect_closed_round_trips")
+        elif blocker in {
+            AUTHORITY_FILLED_NOTIONAL_BLOCKER,
+            AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER,
+        }:
+            add("increase_filled_notional_after_source_linkage")
+        elif (
+            blocker == AUTHORITY_OPEN_POSITIONS_BLOCKER
+            or "unclosed_position" in blocker
+        ):
+            add("flatten_open_positions")
+        elif blocker == AUTHORITY_PNL_BASIS_BLOCKER or "pnl_basis" in blocker:
+            add("repair_runtime_pnl_basis")
+        elif blocker == AUTHORITY_READ_ERROR_BLOCKER:
+            add("restore_runtime_ledger_database_read_access")
+        elif blocker == AUTHORITY_EXPLICIT_COSTS_BLOCKER:
+            add("repair_explicit_runtime_costs")
+        elif blocker in {
+            AUTHORITY_MEAN_PNL_BLOCKER,
+            AUTHORITY_MEDIAN_PNL_BLOCKER,
+            AUTHORITY_P10_PNL_BLOCKER,
+        }:
+            add("improve_clean_authority_daily_pnl")
+        elif blocker == AUTHORITY_WORST_DAY_BLOCKER:
+            add("reduce_authority_drawdown")
+        elif blocker == AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER:
+            add("reduce_best_day_concentration")
+        elif blocker in {
+            AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
+            AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+        }:
+            add("repair_runtime_decision_execution_linkage")
+        elif blocker == AUTHORITY_ORDER_LIFECYCLE_MISSING_BLOCKER:
+            add("repair_order_feed_linkage")
+        elif blocker == AUTHORITY_LEDGER_SCHEMA_BLOCKER:
+            add("regenerate_exact_replay_runtime_ledger_rows")
+        elif blocker in {
+            AUTHORITY_POLICY_HASH_BLOCKER,
+            AUTHORITY_COST_MODEL_HASH_BLOCKER,
+            AUTHORITY_LINEAGE_HASH_BLOCKER,
+        }:
+            add("repair_runtime_ledger_hash_lineage")
+        elif blocker == EXECUTION_ECONOMICS_MISSING_BLOCKER:
+            add("repair_execution_economics")
+        elif blocker == AUTHORITY_EVIDENCE_MISSING_BLOCKER:
+            add("collect_source_backed_runtime_ledger_rows")
+        elif blocker == AUTHORITY_BUCKET_BLOCKERS_PRESENT:
+            add("resolve_runtime_ledger_bucket_blockers")
+        elif blocker == "runtime_ledger_expectancy_missing":
+            add("repair_runtime_expectancy")
+        elif blocker == "source_decision_mode_not_profit_proof_eligible":
+            add("collect_profit_proof_eligible_source_decisions")
+        elif blocker == "execution_reconstruction_not_runtime_ledger_proof":
+            add("repair_order_feed_linkage")
+    return actions
 
 
 def _mean(values: Sequence[Decimal]) -> Decimal:
     if not values:
-        return Decimal('0')
-    return sum(values, Decimal('0')) / Decimal(len(values))
+        return Decimal("0")
+    return sum(values, Decimal("0")) / Decimal(len(values))
 
 
 def _median(values: Sequence[Decimal]) -> Decimal:
     if not values:
-        return Decimal('0')
+        return Decimal("0")
     sorted_values = sorted(values)
     middle = len(sorted_values) // 2
     if len(sorted_values) % 2:
         return sorted_values[middle]
-    return (sorted_values[middle - 1] + sorted_values[middle]) / Decimal('2')
+    return (sorted_values[middle - 1] + sorted_values[middle]) / Decimal("2")
 
 
 def _p10(values: Sequence[Decimal]) -> Decimal:
     if not values:
-        return Decimal('0')
+        return Decimal("0")
     sorted_values = sorted(values)
     index = max(0, ((len(sorted_values) + 9) // 10) - 1)
     return sorted_values[index]
 
 
 def _max_drawdown(values: Sequence[Decimal]) -> Decimal:
-    cumulative = Decimal('0')
-    peak = Decimal('0')
-    max_drawdown = Decimal('0')
+    cumulative = Decimal("0")
+    peak = Decimal("0")
+    max_drawdown = Decimal("0")
     for value in values:
         cumulative += value
         if cumulative > peak:
@@ -625,7 +989,9 @@ def _ref_count(bucket: Mapping[str, object], *keys: str) -> int:
                     ref_text = _text(ref_key)
                 if ref_text is not None:
                     refs.add(ref_text)
-        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        elif isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
             for item in cast(Sequence[object], value):
                 if (text := _text(item)) is not None:
                     refs.add(text)
@@ -635,30 +1001,40 @@ def _ref_count(bucket: Mapping[str, object], *keys: str) -> int:
 
 
 def _source_offset_count(bucket: Mapping[str, object]) -> int:
-    offsets = bucket.get('source_offsets')
+    offsets = bucket.get("source_offsets")
     if isinstance(offsets, Mapping):
-        return int(_source_offset_triplet_present(cast(Mapping[object, object], offsets)))
-    if isinstance(offsets, Sequence) and not isinstance(offsets, (str, bytes, bytearray)):
+        return int(
+            _source_offset_triplet_present(cast(Mapping[object, object], offsets))
+        )
+    if isinstance(offsets, Sequence) and not isinstance(
+        offsets, (str, bytes, bytearray)
+    ):
         seen: set[tuple[str, str, str]] = set()
         for item in cast(Sequence[object], offsets):
             if not isinstance(item, Mapping):
                 continue
             typed_item = cast(Mapping[object, object], item)
             if _source_offset_triplet_present(typed_item):
-                seen.add((str(typed_item.get('topic')), str(typed_item.get('partition')), str(typed_item.get('offset'))))
+                seen.add(
+                    (
+                        str(typed_item.get("topic")),
+                        str(typed_item.get("partition")),
+                        str(typed_item.get("offset")),
+                    )
+                )
         return len(seen)
     return int(
-        _text(bucket.get('source_topic')) is not None
-        and bucket.get('source_partition') is not None
-        and bucket.get('source_offset') is not None
+        _text(bucket.get("source_topic")) is not None
+        and bucket.get("source_partition") is not None
+        and bucket.get("source_offset") is not None
     )
 
 
 def _source_offset_triplet_present(value: Mapping[object, object]) -> bool:
     return (
-        _text(value.get('topic')) is not None
-        and value.get('partition') is not None
-        and value.get('offset') is not None
+        _text(value.get("topic")) is not None
+        and value.get("partition") is not None
+        and value.get("offset") is not None
     )
 
 
@@ -672,7 +1048,9 @@ def _positive_hash_count(value: Mapping[str, object]) -> bool:
 def _as_mapping(value: object) -> Mapping[str, object]:
     if not isinstance(value, Mapping):
         return {}
-    return {str(key): item for key, item in cast(Mapping[object, object], value).items()}
+    return {
+        str(key): item for key, item in cast(Mapping[object, object], value).items()
+    }
 
 
 def _as_sequence(value: object) -> Sequence[object]:
@@ -701,17 +1079,17 @@ def _text(value: object) -> str | None:
 
 def _int(value: object) -> int:
     try:
-        return int(str(value or '0'))
+        return int(str(value or "0"))
     except (TypeError, ValueError):
         return 0
 
 
 def _decimal(value: object) -> Decimal:
     try:
-        parsed = Decimal(str(value if value is not None else '0'))
+        parsed = Decimal(str(value if value is not None else "0"))
     except (InvalidOperation, ValueError):
-        return Decimal('0')
-    return parsed if parsed.is_finite() else Decimal('0')
+        return Decimal("0")
+    return parsed if parsed.is_finite() else Decimal("0")
 
 
 def _optional_decimal(value: object) -> Decimal | None:
@@ -727,7 +1105,7 @@ def _optional_decimal(value: object) -> Decimal | None:
 def _required_datetime(value: object, *, field_name: str) -> datetime:
     parsed = _parse_datetime(value)
     if parsed is None:
-        raise ValueError(f'{field_name}_invalid')
+        raise ValueError(f"{field_name}_invalid")
     return parsed
 
 
@@ -738,7 +1116,7 @@ def _parse_datetime(value: object) -> datetime | None:
     if text is None:
         return None
     try:
-        return _utc(datetime.fromisoformat(text.replace('Z', '+00:00')))
+        return _utc(datetime.fromisoformat(text.replace("Z", "+00:00")))
     except ValueError:
         return None
 
@@ -750,47 +1128,47 @@ def _utc(value: datetime) -> datetime:
 
 
 def _isoformat(value: datetime) -> str:
-    return _utc(value).isoformat().replace('+00:00', 'Z')
+    return _utc(value).isoformat().replace("+00:00", "Z")
 
 
 def _decimal_text(value: Decimal | None) -> str:
     if value is None:
-        return '0'
-    text = format(value.normalize(), 'f')
-    return text.rstrip('0').rstrip('.') if '.' in text else text
+        return "0"
+    text = format(value.normalize(), "f")
+    return text.rstrip("0").rstrip(".") if "." in text else text
 
 
 __all__ = [
-    'AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER',
-    'AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER',
-    'AUTHORITY_EVIDENCE_MISSING_BLOCKER',
-    'AUTHORITY_EXPLICIT_COSTS_BLOCKER',
-    'AUTHORITY_FILLED_NOTIONAL_BLOCKER',
-    'AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER',
-    'AUTHORITY_MEAN_PNL_BLOCKER',
-    'AUTHORITY_MEDIAN_PNL_BLOCKER',
-    'AUTHORITY_OPEN_POSITIONS_BLOCKER',
-    'AUTHORITY_P10_PNL_BLOCKER',
-    'AUTHORITY_READ_ERROR_BLOCKER',
-    'AUTHORITY_TRADING_DAYS_BLOCKER',
-    'AUTHORITY_WORST_DAY_BLOCKER',
-    'DEFAULT_HPAIRS_ACCOUNT_LABEL',
-    'DEFAULT_HPAIRS_CANDIDATE_ID',
-    'DEFAULT_HPAIRS_HYPOTHESIS_ID',
-    'DEFAULT_HPAIRS_RUNTIME_STRATEGY',
-    'EXECUTION_ECONOMICS_MISSING_BLOCKER',
-    'HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION',
-    'ORDER_FEED_LIFECYCLE_MISSING_BLOCKER',
-    'RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER',
-    'RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER',
-    'RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER',
-    'RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER',
-    'RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER',
-    'RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER',
-    'RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER',
-    'RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER',
-    'RuntimeAuthorityEvidenceRow',
-    'build_runtime_authority_report',
-    'load_runtime_authority_rows',
-    'runtime_authority_report_json',
+    "AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER",
+    "AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER",
+    "AUTHORITY_EVIDENCE_MISSING_BLOCKER",
+    "AUTHORITY_EXPLICIT_COSTS_BLOCKER",
+    "AUTHORITY_FILLED_NOTIONAL_BLOCKER",
+    "AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER",
+    "AUTHORITY_MEAN_PNL_BLOCKER",
+    "AUTHORITY_MEDIAN_PNL_BLOCKER",
+    "AUTHORITY_OPEN_POSITIONS_BLOCKER",
+    "AUTHORITY_P10_PNL_BLOCKER",
+    "AUTHORITY_READ_ERROR_BLOCKER",
+    "AUTHORITY_TRADING_DAYS_BLOCKER",
+    "AUTHORITY_WORST_DAY_BLOCKER",
+    "DEFAULT_HPAIRS_ACCOUNT_LABEL",
+    "DEFAULT_HPAIRS_CANDIDATE_ID",
+    "DEFAULT_HPAIRS_HYPOTHESIS_ID",
+    "DEFAULT_HPAIRS_RUNTIME_STRATEGY",
+    "EXECUTION_ECONOMICS_MISSING_BLOCKER",
+    "HPAIRS_RUNTIME_AUTHORITY_PROOF_SCHEMA_VERSION",
+    "ORDER_FEED_LIFECYCLE_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER",
+    "RuntimeAuthorityEvidenceRow",
+    "build_runtime_authority_report",
+    "load_runtime_authority_rows",
+    "runtime_authority_report_json",
 ]

--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -70,17 +70,17 @@ from app.trading.runtime_ledger_source_authority import (
     RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
 )
 
-SCHEMA_VERSION = 'torghut.hpairs-source-proof-census.v1'
-AUTHORITY_CANDIDATE_READY = 'authority_candidate_ready'
-NO_SOURCE_ACTIVITY = 'no_source_activity'
-LIFECYCLE_MISSING = 'lifecycle_missing'
-ECONOMICS_MISSING = 'economics_missing'
-SOURCE_REFS_MISSING = 'source_refs_missing'
-OPEN_POSITIONS = 'open_positions'
-AUTHORITY_DISTRIBUTION_MISSING = 'authority_distribution_missing'
-LADDER_PASS = 'pass'
-LADDER_MISSING = 'missing'
-LADDER_BLOCKED = 'blocked'
+SCHEMA_VERSION = "torghut.hpairs-source-proof-census.v1"
+AUTHORITY_CANDIDATE_READY = "authority_candidate_ready"
+NO_SOURCE_ACTIVITY = "no_source_activity"
+LIFECYCLE_MISSING = "lifecycle_missing"
+ECONOMICS_MISSING = "economics_missing"
+SOURCE_REFS_MISSING = "source_refs_missing"
+OPEN_POSITIONS = "open_positions"
+AUTHORITY_DISTRIBUTION_MISSING = "authority_distribution_missing"
+LADDER_PASS = "pass"
+LADDER_MISSING = "missing"
+LADDER_BLOCKED = "blocked"
 
 _SOURCE_REF_BLOCKERS = frozenset(
     {
@@ -117,6 +117,12 @@ _LIFECYCLE_BLOCKERS = frozenset(
         ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
     }
 )
+_PRIMARY_LIFECYCLE_BLOCKERS = frozenset(
+    {
+        AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+        AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
+    }
+)
 _ECONOMICS_BLOCKERS = frozenset(
     {
         AUTHORITY_EXPLICIT_COSTS_BLOCKER,
@@ -148,19 +154,25 @@ class CensusSourceRows:
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument('--dsn', help='SQLAlchemy DSN to read with a short read-only session')
-    source.add_argument('--fixture-json', type=Path, help='Fixture JSON containing source row arrays')
-    parser.add_argument('--hypothesis-id', default=DEFAULT_HPAIRS_HYPOTHESIS_ID)
-    parser.add_argument('--candidate-id', default=DEFAULT_HPAIRS_CANDIDATE_ID)
-    parser.add_argument('--runtime-strategy-name', default=DEFAULT_HPAIRS_RUNTIME_STRATEGY)
-    parser.add_argument('--account-label', default=DEFAULT_HPAIRS_ACCOUNT_LABEL)
-    parser.add_argument('--observed-stage', default='paper')
-    parser.add_argument('--start', dest='started_at')
-    parser.add_argument('--end', dest='ended_at')
+    source.add_argument(
+        "--dsn", help="SQLAlchemy DSN to read with a short read-only session"
+    )
+    source.add_argument(
+        "--fixture-json", type=Path, help="Fixture JSON containing source row arrays"
+    )
+    parser.add_argument("--hypothesis-id", default=DEFAULT_HPAIRS_HYPOTHESIS_ID)
+    parser.add_argument("--candidate-id", default=DEFAULT_HPAIRS_CANDIDATE_ID)
     parser.add_argument(
-        '--fail-on-blockers',
-        action='store_true',
-        help='exit non-zero unless the census verdict is authority_candidate_ready',
+        "--runtime-strategy-name", default=DEFAULT_HPAIRS_RUNTIME_STRATEGY
+    )
+    parser.add_argument("--account-label", default=DEFAULT_HPAIRS_ACCOUNT_LABEL)
+    parser.add_argument("--observed-stage", default="paper")
+    parser.add_argument("--start", dest="started_at")
+    parser.add_argument("--end", dest="ended_at")
+    parser.add_argument(
+        "--fail-on-blockers",
+        action="store_true",
+        help="exit non-zero unless the census verdict is authority_candidate_ready",
     )
     return parser.parse_args(argv)
 
@@ -172,7 +184,7 @@ def build_source_proof_census(
     started_at: datetime | None = None,
     ended_at: datetime | None = None,
     read_error: str | None = None,
-    source_kind: str = 'fixture_json',
+    source_kind: str = "fixture_json",
 ) -> dict[str, object]:
     """Build a deterministic source-proof census from already-read rows."""
 
@@ -202,43 +214,43 @@ def build_source_proof_census(
     )
     classification = _classify_verdict(totals, blockers)
     return {
-        'schema_version': SCHEMA_VERSION,
-        'identity': {
-            'hypothesis_id': identity.hypothesis_id,
-            'candidate_id': identity.candidate_id,
-            'runtime_strategy_name': identity.runtime_strategy_name,
-            'account_label': identity.account_label,
-            'observed_stage': identity.observed_stage,
+        "schema_version": SCHEMA_VERSION,
+        "identity": {
+            "hypothesis_id": identity.hypothesis_id,
+            "candidate_id": identity.candidate_id,
+            "runtime_strategy_name": identity.runtime_strategy_name,
+            "account_label": identity.account_label,
+            "observed_stage": identity.observed_stage,
         },
-        'window': {
-            'started_at': _isoformat(started_at) if started_at is not None else None,
-            'ended_at': _isoformat(ended_at) if ended_at is not None else None,
+        "window": {
+            "started_at": _isoformat(started_at) if started_at is not None else None,
+            "ended_at": _isoformat(ended_at) if ended_at is not None else None,
         },
-        'source': {
-            'kind': source_kind,
-            'read_only': True,
-            'writes_proof': False,
-            'modifies_rows': False,
-            'runtime_stage': identity.observed_stage,
-            'replay_outputs_count_as_runtime_proof': False,
-            'synthetic_proof_created': False,
+        "source": {
+            "kind": source_kind,
+            "read_only": True,
+            "writes_proof": False,
+            "modifies_rows": False,
+            "runtime_stage": identity.observed_stage,
+            "replay_outputs_count_as_runtime_proof": False,
+            "synthetic_proof_created": False,
         },
-        'totals': totals,
-        'daily': daily,
-        'runtime_authority': {
-            'final_authority_ok': ledger_report['final_authority_ok'],
-            'blockers': ledger_report['blockers'],
-            'aggregate': ledger_report['aggregate'],
+        "totals": totals,
+        "daily": daily,
+        "runtime_authority": {
+            "final_authority_ok": ledger_report["final_authority_ok"],
+            "blockers": ledger_report["blockers"],
+            "aggregate": ledger_report["aggregate"],
         },
-        'missing_source_ref_categories': missing_source_ref_categories,
-        'missing_requirement_categories': missing_requirement_categories,
-        'blocker_ladder': blocker_ladder,
-        'blockers': blockers,
-        'verdict': {
-            'classification': classification,
-            'authority_candidate_ready': classification == AUTHORITY_CANDIDATE_READY,
-            'next_blocker': _next_ladder_blocker(blocker_ladder),
-            'next_action': _next_action(classification),
+        "missing_source_ref_categories": missing_source_ref_categories,
+        "missing_requirement_categories": missing_requirement_categories,
+        "blocker_ladder": blocker_ladder,
+        "blockers": blockers,
+        "verdict": {
+            "classification": classification,
+            "authority_candidate_ready": classification == AUTHORITY_CANDIDATE_READY,
+            "next_blocker": _next_ladder_blocker(blocker_ladder),
+            "next_action": _next_action(classification),
         },
     }
 
@@ -246,19 +258,23 @@ def build_source_proof_census(
 def census_json(report: Mapping[str, object]) -> str:
     """Serialize a census as stable JSON."""
 
-    return json.dumps(report, indent=2, sort_keys=True) + '\n'
+    return json.dumps(report, indent=2, sort_keys=True) + "\n"
 
 
 def load_fixture_rows(path: Path) -> CensusSourceRows:
     payload = json.loads(path.read_text())
     data = _mapping(payload)
     return CensusSourceRows(
-        trade_decisions=_row_list(data.get('trade_decisions')),
-        executions=_row_list(data.get('executions')),
-        execution_order_events=_row_list(data.get('execution_order_events')),
-        execution_tca_metrics=_row_list(data.get('execution_tca_metrics') or data.get('tca_metrics')),
-        order_feed_source_windows=_row_list(data.get('order_feed_source_windows') or data.get('source_windows')),
-        runtime_ledger_buckets=_row_list(data.get('runtime_ledger_buckets')),
+        trade_decisions=_row_list(data.get("trade_decisions")),
+        executions=_row_list(data.get("executions")),
+        execution_order_events=_row_list(data.get("execution_order_events")),
+        execution_tca_metrics=_row_list(
+            data.get("execution_tca_metrics") or data.get("tca_metrics")
+        ),
+        order_feed_source_windows=_row_list(
+            data.get("order_feed_source_windows") or data.get("source_windows")
+        ),
+        runtime_ledger_buckets=_row_list(data.get("runtime_ledger_buckets")),
     )
 
 
@@ -301,7 +317,9 @@ def _load_session_rows(
     if ended_at is not None:
         decision_stmt = decision_stmt.where(TradeDecision.created_at < ended_at)
     decision_pairs = list(session.execute(decision_stmt).all())
-    decisions = [_decision_row(row, strategy_name) for row, strategy_name in decision_pairs]
+    decisions = [
+        _decision_row(row, strategy_name) for row, strategy_name in decision_pairs
+    ]
     decision_ids = {str(row.id) for row, _strategy_name in decision_pairs}
 
     execution_stmt = (
@@ -314,9 +332,11 @@ def _load_session_rows(
     if ended_at is not None:
         execution_stmt = execution_stmt.where(Execution.created_at < ended_at)
     if decision_ids:
-        execution_stmt = execution_stmt.where(Execution.trade_decision_id.in_(decision_ids))
+        execution_stmt = execution_stmt.where(
+            Execution.trade_decision_id.in_(decision_ids)
+        )
     executions = [_execution_row(row) for row in session.scalars(execution_stmt).all()]
-    execution_ids = {str(row['id']) for row in executions}
+    execution_ids = {str(row["id"]) for row in executions}
 
     event_stmt = (
         select(ExecutionOrderEvent)
@@ -329,16 +349,24 @@ def _load_session_rows(
     )
     if started_at is not None:
         event_stmt = event_stmt.where(
-            or_(ExecutionOrderEvent.event_ts >= started_at, ExecutionOrderEvent.created_at >= started_at)
+            or_(
+                ExecutionOrderEvent.event_ts >= started_at,
+                ExecutionOrderEvent.created_at >= started_at,
+            )
         )
     if ended_at is not None:
         event_stmt = event_stmt.where(
-            or_(ExecutionOrderEvent.event_ts < ended_at, ExecutionOrderEvent.created_at < ended_at)
+            or_(
+                ExecutionOrderEvent.event_ts < ended_at,
+                ExecutionOrderEvent.created_at < ended_at,
+            )
         )
     if decision_ids or execution_ids:
         event_filters = []
         if decision_ids:
-            event_filters.append(ExecutionOrderEvent.trade_decision_id.in_(decision_ids))
+            event_filters.append(
+                ExecutionOrderEvent.trade_decision_id.in_(decision_ids)
+            )
         if execution_ids:
             event_filters.append(ExecutionOrderEvent.execution_id.in_(execution_ids))
         event_stmt = event_stmt.where(or_(*event_filters))
@@ -365,13 +393,22 @@ def _load_session_rows(
     source_window_stmt = (
         select(OrderFeedSourceWindow)
         .where(OrderFeedSourceWindow.alpaca_account_label == identity.account_label)
-        .order_by(OrderFeedSourceWindow.window_started_at.asc(), OrderFeedSourceWindow.id.asc())
+        .order_by(
+            OrderFeedSourceWindow.window_started_at.asc(),
+            OrderFeedSourceWindow.id.asc(),
+        )
     )
     if started_at is not None:
-        source_window_stmt = source_window_stmt.where(OrderFeedSourceWindow.window_ended_at >= started_at)
+        source_window_stmt = source_window_stmt.where(
+            OrderFeedSourceWindow.window_ended_at >= started_at
+        )
     if ended_at is not None:
-        source_window_stmt = source_window_stmt.where(OrderFeedSourceWindow.window_started_at < ended_at)
-    source_windows = [_source_window_row(row) for row in session.scalars(source_window_stmt).all()]
+        source_window_stmt = source_window_stmt.where(
+            OrderFeedSourceWindow.window_started_at < ended_at
+        )
+    source_windows = [
+        _source_window_row(row) for row in session.scalars(source_window_stmt).all()
+    ]
 
     ledger_rows = load_runtime_authority_rows(
         session,
@@ -385,36 +422,36 @@ def _load_session_rows(
     )
     runtime_ledger_buckets = [
         {
-            'id': row.row_id,
-            'run_id': row.run_id,
-            'candidate_id': row.candidate_id,
-            'hypothesis_id': row.hypothesis_id,
-            'observed_stage': row.observed_stage,
-            'bucket_started_at': row.bucket_started_at,
-            'bucket_ended_at': row.bucket_ended_at,
-            'account_label': row.account_label,
-            'runtime_strategy_name': row.runtime_strategy_name,
-            'strategy_family': row.strategy_family,
-            'fill_count': row.fill_count,
-            'decision_count': row.decision_count,
-            'submitted_order_count': row.submitted_order_count,
-            'cancelled_order_count': row.cancelled_order_count,
-            'rejected_order_count': row.rejected_order_count,
-            'unfilled_order_count': row.unfilled_order_count,
-            'closed_trade_count': row.closed_trade_count,
-            'open_position_count': row.open_position_count,
-            'filled_notional': row.filled_notional,
-            'gross_strategy_pnl': row.gross_strategy_pnl,
-            'cost_amount': row.cost_amount,
-            'net_strategy_pnl_after_costs': row.net_strategy_pnl_after_costs,
-            'post_cost_expectancy_bps': row.post_cost_expectancy_bps,
-            'ledger_schema_version': row.ledger_schema_version,
-            'pnl_basis': row.pnl_basis,
-            'execution_policy_hash_counts': dict(row.execution_policy_hash_counts),
-            'cost_model_hash_counts': dict(row.cost_model_hash_counts),
-            'lineage_hash_counts': dict(row.lineage_hash_counts),
-            'blockers': list(row.blockers),
-            'payload': dict(row.payload),
+            "id": row.row_id,
+            "run_id": row.run_id,
+            "candidate_id": row.candidate_id,
+            "hypothesis_id": row.hypothesis_id,
+            "observed_stage": row.observed_stage,
+            "bucket_started_at": row.bucket_started_at,
+            "bucket_ended_at": row.bucket_ended_at,
+            "account_label": row.account_label,
+            "runtime_strategy_name": row.runtime_strategy_name,
+            "strategy_family": row.strategy_family,
+            "fill_count": row.fill_count,
+            "decision_count": row.decision_count,
+            "submitted_order_count": row.submitted_order_count,
+            "cancelled_order_count": row.cancelled_order_count,
+            "rejected_order_count": row.rejected_order_count,
+            "unfilled_order_count": row.unfilled_order_count,
+            "closed_trade_count": row.closed_trade_count,
+            "open_position_count": row.open_position_count,
+            "filled_notional": row.filled_notional,
+            "gross_strategy_pnl": row.gross_strategy_pnl,
+            "cost_amount": row.cost_amount,
+            "net_strategy_pnl_after_costs": row.net_strategy_pnl_after_costs,
+            "post_cost_expectancy_bps": row.post_cost_expectancy_bps,
+            "ledger_schema_version": row.ledger_schema_version,
+            "pnl_basis": row.pnl_basis,
+            "execution_policy_hash_counts": dict(row.execution_policy_hash_counts),
+            "cost_model_hash_counts": dict(row.cost_model_hash_counts),
+            "lineage_hash_counts": dict(row.lineage_hash_counts),
+            "blockers": list(row.blockers),
+            "payload": dict(row.payload),
         }
         for row in ledger_rows
     ]
@@ -428,68 +465,98 @@ def _load_session_rows(
     )
 
 
-def _daily_census(rows: CensusSourceRows, ledger_report: Mapping[str, object]) -> list[dict[str, object]]:
+def _daily_census(
+    rows: CensusSourceRows, ledger_report: Mapping[str, object]
+) -> list[dict[str, object]]:
     days = sorted(
         {
-            *_row_days(rows.trade_decisions, 'created_at'),
-            *_row_days(rows.executions, 'created_at'),
-            *_row_days(rows.execution_order_events, 'event_ts', fallback_key='created_at'),
-            *_row_days(rows.execution_tca_metrics, 'computed_at'),
-            *_row_days(rows.order_feed_source_windows, 'window_started_at'),
+            *_row_days(rows.trade_decisions, "created_at"),
+            *_row_days(rows.executions, "created_at"),
+            *_row_days(
+                rows.execution_order_events, "event_ts", fallback_key="created_at"
+            ),
+            *_row_days(rows.execution_tca_metrics, "computed_at"),
+            *_row_days(rows.order_feed_source_windows, "window_started_at"),
             *_ledger_days(ledger_report),
         }
     )
     return [_daily_payload(day, rows, ledger_report) for day in days]
 
 
-def _daily_payload(day: str, rows: CensusSourceRows, ledger_report: Mapping[str, object]) -> dict[str, object]:
-    day_ledgers = [_mapping(item) for item in _sequence(ledger_report.get('trading_days'))]
-    ledger_by_day = {str(item.get('trading_day')): item for item in day_ledgers}
+def _daily_payload(
+    day: str, rows: CensusSourceRows, ledger_report: Mapping[str, object]
+) -> dict[str, object]:
+    day_ledgers = [
+        _mapping(item) for item in _sequence(ledger_report.get("trading_days"))
+    ]
+    ledger_by_day = {str(item.get("trading_day")): item for item in day_ledgers}
     ledger = ledger_by_day.get(day, {})
-    day_executions = _rows_on_day(rows.executions, day, 'created_at')
-    day_events = _rows_on_day(rows.execution_order_events, day, 'event_ts', fallback_key='created_at')
-    day_tca_metrics = _rows_on_day(rows.execution_tca_metrics, day, 'computed_at')
+    day_executions = _rows_on_day(rows.executions, day, "created_at")
+    day_events = _rows_on_day(
+        rows.execution_order_events, day, "event_ts", fallback_key="created_at"
+    )
+    day_tca_metrics = _rows_on_day(rows.execution_tca_metrics, day, "computed_at")
     return {
-        'trading_day': day,
-        'trade_decision_count': len(_rows_on_day(rows.trade_decisions, day, 'created_at')),
-        'execution_count': len(day_executions),
-        'filled_execution_count': sum(1 for row in day_executions if _filled_execution(row)),
-        'execution_order_event_count': len(day_events),
-        'fill_lifecycle_event_count': sum(1 for row in day_events if _fill_event(row)),
-        'linked_order_event_fill_count': sum(1 for row in day_events if _linked_order_event_fill(row)),
-        'execution_order_events_with_execution_ref_count': sum(
-            1 for row in day_events if _text(row.get('execution_id')) is not None
+        "trading_day": day,
+        "trade_decision_count": len(
+            _rows_on_day(rows.trade_decisions, day, "created_at")
         ),
-        'execution_order_events_with_trade_decision_ref_count': sum(
-            1 for row in day_events if _text(row.get('trade_decision_id')) is not None
+        "execution_count": len(day_executions),
+        "filled_execution_count": sum(
+            1 for row in day_executions if _filled_execution(row)
         ),
-        'execution_order_events_with_filled_notional_delta_count': sum(
-            1 for row in day_events if _decimal(row.get('filled_notional_delta')) > 0
+        "execution_order_event_count": len(day_events),
+        "fill_lifecycle_event_count": sum(1 for row in day_events if _fill_event(row)),
+        "linked_order_event_fill_count": sum(
+            1 for row in day_events if _linked_order_event_fill(row)
         ),
-        'execution_order_events_with_quantity_count': sum(1 for row in day_events if _event_quantity_present(row)),
-        'execution_order_events_with_avg_price_count': sum(
-            1 for row in day_events if _decimal(row.get('avg_fill_price')) > 0
+        "execution_order_events_with_execution_ref_count": sum(
+            1 for row in day_events if _text(row.get("execution_id")) is not None
         ),
-        'tca_cost_row_count': len(day_tca_metrics),
-        'tca_cost_rows_with_execution_ref_count': sum(
-            1 for row in day_tca_metrics if _text(row.get('execution_id')) is not None
+        "execution_order_events_with_trade_decision_ref_count": sum(
+            1 for row in day_events if _text(row.get("trade_decision_id")) is not None
         ),
-        'tca_cost_rows_with_trade_decision_ref_count': sum(
-            1 for row in day_tca_metrics if _text(row.get('trade_decision_id')) is not None
+        "execution_order_events_with_filled_notional_delta_count": sum(
+            1 for row in day_events if _decimal(row.get("filled_notional_delta")) > 0
         ),
-        'source_window_count': len(_rows_on_day(rows.order_feed_source_windows, day, 'window_started_at')),
-        'execution_order_events_with_source_window_count': sum(
-            1 for row in day_events if _text(row.get('source_window_id')) is not None
+        "execution_order_events_with_quantity_count": sum(
+            1 for row in day_events if _event_quantity_present(row)
         ),
-        'execution_order_events_with_source_offset_count': sum(1 for row in day_events if _event_source_offset_present(row)),
-        'runtime_ledger_bucket_count': _int(ledger.get('bucket_count')),
-        'blocker_free_runtime_ledger_bucket_count': _int(ledger.get('source_authority_bucket_count')),
-        'explicit_cost_runtime_ledger_bucket_count': _int(ledger.get('explicit_cost_bucket_count')),
-        'closed_trade_count': _int(ledger.get('closed_trade_count')),
-        'open_position_count': _int(ledger.get('open_position_count')),
-        'filled_notional': _decimal_text(_decimal(ledger.get('filled_notional'))),
-        'post_cost_pnl': _decimal_text(_decimal(ledger.get('net_strategy_pnl_after_costs'))),
-        'blockers': sorted(str(item) for item in _sequence(ledger.get('blockers'))),
+        "execution_order_events_with_avg_price_count": sum(
+            1 for row in day_events if _decimal(row.get("avg_fill_price")) > 0
+        ),
+        "tca_cost_row_count": len(day_tca_metrics),
+        "tca_cost_rows_with_execution_ref_count": sum(
+            1 for row in day_tca_metrics if _text(row.get("execution_id")) is not None
+        ),
+        "tca_cost_rows_with_trade_decision_ref_count": sum(
+            1
+            for row in day_tca_metrics
+            if _text(row.get("trade_decision_id")) is not None
+        ),
+        "source_window_count": len(
+            _rows_on_day(rows.order_feed_source_windows, day, "window_started_at")
+        ),
+        "execution_order_events_with_source_window_count": sum(
+            1 for row in day_events if _text(row.get("source_window_id")) is not None
+        ),
+        "execution_order_events_with_source_offset_count": sum(
+            1 for row in day_events if _event_source_offset_present(row)
+        ),
+        "runtime_ledger_bucket_count": _int(ledger.get("bucket_count")),
+        "blocker_free_runtime_ledger_bucket_count": _int(
+            ledger.get("source_authority_bucket_count")
+        ),
+        "explicit_cost_runtime_ledger_bucket_count": _int(
+            ledger.get("explicit_cost_bucket_count")
+        ),
+        "closed_trade_count": _int(ledger.get("closed_trade_count")),
+        "open_position_count": _int(ledger.get("open_position_count")),
+        "filled_notional": _decimal_text(_decimal(ledger.get("filled_notional"))),
+        "post_cost_pnl": _decimal_text(
+            _decimal(ledger.get("net_strategy_pnl_after_costs"))
+        ),
+        "blockers": sorted(str(item) for item in _sequence(ledger.get("blockers"))),
     }
 
 
@@ -498,55 +565,83 @@ def _totals(
     daily: Sequence[Mapping[str, object]],
     ledger_report: Mapping[str, object],
 ) -> dict[str, object]:
-    aggregate = _mapping(ledger_report.get('aggregate'))
-    source_authority_bucket_count = _int(aggregate.get('source_authority_bucket_count'))
+    aggregate = _mapping(ledger_report.get("aggregate"))
+    source_authority_bucket_count = _int(aggregate.get("source_authority_bucket_count"))
     return {
-        'trade_decision_count': len(rows.trade_decisions),
-        'execution_count': len(rows.executions),
-        'filled_execution_count': sum(1 for row in rows.executions if _filled_execution(row)),
-        'execution_order_event_count': len(rows.execution_order_events),
-        'fill_lifecycle_event_count': sum(1 for row in rows.execution_order_events if _fill_event(row)),
-        'linked_order_event_fill_count': sum(1 for row in rows.execution_order_events if _linked_order_event_fill(row)),
-        'execution_order_events_with_execution_ref_count': sum(
-            1 for row in rows.execution_order_events if _text(row.get('execution_id')) is not None
+        "trade_decision_count": len(rows.trade_decisions),
+        "execution_count": len(rows.executions),
+        "filled_execution_count": sum(
+            1 for row in rows.executions if _filled_execution(row)
         ),
-        'execution_order_events_with_trade_decision_ref_count': sum(
-            1 for row in rows.execution_order_events if _text(row.get('trade_decision_id')) is not None
+        "execution_order_event_count": len(rows.execution_order_events),
+        "fill_lifecycle_event_count": sum(
+            1 for row in rows.execution_order_events if _fill_event(row)
         ),
-        'execution_order_events_with_filled_notional_delta_count': sum(
-            1 for row in rows.execution_order_events if _decimal(row.get('filled_notional_delta')) > 0
+        "linked_order_event_fill_count": sum(
+            1 for row in rows.execution_order_events if _linked_order_event_fill(row)
         ),
-        'execution_order_events_with_quantity_count': sum(
+        "execution_order_events_with_execution_ref_count": sum(
+            1
+            for row in rows.execution_order_events
+            if _text(row.get("execution_id")) is not None
+        ),
+        "execution_order_events_with_trade_decision_ref_count": sum(
+            1
+            for row in rows.execution_order_events
+            if _text(row.get("trade_decision_id")) is not None
+        ),
+        "execution_order_events_with_filled_notional_delta_count": sum(
+            1
+            for row in rows.execution_order_events
+            if _decimal(row.get("filled_notional_delta")) > 0
+        ),
+        "execution_order_events_with_quantity_count": sum(
             1 for row in rows.execution_order_events if _event_quantity_present(row)
         ),
-        'execution_order_events_with_avg_price_count': sum(
-            1 for row in rows.execution_order_events if _decimal(row.get('avg_fill_price')) > 0
+        "execution_order_events_with_avg_price_count": sum(
+            1
+            for row in rows.execution_order_events
+            if _decimal(row.get("avg_fill_price")) > 0
         ),
-        'tca_cost_row_count': len(rows.execution_tca_metrics),
-        'tca_cost_rows_with_execution_ref_count': sum(
-            1 for row in rows.execution_tca_metrics if _text(row.get('execution_id')) is not None
+        "tca_cost_row_count": len(rows.execution_tca_metrics),
+        "tca_cost_rows_with_execution_ref_count": sum(
+            1
+            for row in rows.execution_tca_metrics
+            if _text(row.get("execution_id")) is not None
         ),
-        'tca_cost_rows_with_trade_decision_ref_count': sum(
-            1 for row in rows.execution_tca_metrics if _text(row.get('trade_decision_id')) is not None
+        "tca_cost_rows_with_trade_decision_ref_count": sum(
+            1
+            for row in rows.execution_tca_metrics
+            if _text(row.get("trade_decision_id")) is not None
         ),
-        'source_window_count': len(rows.order_feed_source_windows),
-        'execution_order_events_with_source_window_count': sum(
-            1 for row in rows.execution_order_events if _text(row.get('source_window_id')) is not None
+        "source_window_count": len(rows.order_feed_source_windows),
+        "execution_order_events_with_source_window_count": sum(
+            1
+            for row in rows.execution_order_events
+            if _text(row.get("source_window_id")) is not None
         ),
-        'execution_order_events_with_source_offset_count': sum(
-            1 for row in rows.execution_order_events if _event_source_offset_present(row)
+        "execution_order_events_with_source_offset_count": sum(
+            1
+            for row in rows.execution_order_events
+            if _event_source_offset_present(row)
         ),
-        'runtime_ledger_bucket_count': len(rows.runtime_ledger_buckets),
-        'blocker_free_runtime_ledger_bucket_count': source_authority_bucket_count,
-        'explicit_cost_runtime_ledger_bucket_count': _int(aggregate.get('explicit_cost_bucket_count')),
-        'runtime_ledger_buckets_with_filled_notional_count': sum(
-            1 for row in rows.runtime_ledger_buckets if _decimal(row.get('filled_notional')) > 0
+        "runtime_ledger_bucket_count": len(rows.runtime_ledger_buckets),
+        "blocker_free_runtime_ledger_bucket_count": source_authority_bucket_count,
+        "explicit_cost_runtime_ledger_bucket_count": _int(
+            aggregate.get("explicit_cost_bucket_count")
         ),
-        'closed_trade_count': _int(aggregate.get('closed_round_trips')),
-        'open_position_count': _int(aggregate.get('open_position_count')),
-        'filled_notional': _text(aggregate.get('total_filled_notional'), default='0'),
-        'post_cost_pnl': _text(aggregate.get('total_net_strategy_pnl_after_costs'), default='0'),
-        'trading_day_count': len(daily),
+        "runtime_ledger_buckets_with_filled_notional_count": sum(
+            1
+            for row in rows.runtime_ledger_buckets
+            if _decimal(row.get("filled_notional")) > 0
+        ),
+        "closed_trade_count": _int(aggregate.get("closed_round_trips")),
+        "open_position_count": _int(aggregate.get("open_position_count")),
+        "filled_notional": _text(aggregate.get("total_filled_notional"), default="0"),
+        "post_cost_pnl": _text(
+            aggregate.get("total_net_strategy_pnl_after_costs"), default="0"
+        ),
+        "trading_day_count": len(daily),
     }
 
 
@@ -559,64 +654,66 @@ def _census_blockers(
 ) -> list[str]:
     blockers: list[str] = []
     if read_error is not None:
-        blockers.append('source_proof_census_read_error')
-    if _int(totals.get('trade_decision_count')) <= 0:
+        blockers.append("source_proof_census_read_error")
+    if _int(totals.get("trade_decision_count")) <= 0:
         blockers.extend(
             [
                 AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
                 RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
             ]
         )
-    if _int(totals.get('execution_count')) <= 0:
+    if _int(totals.get("execution_count")) <= 0:
         blockers.append(RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER)
-    if _int(totals.get('filled_execution_count')) <= 0:
+    if _int(totals.get("filled_execution_count")) <= 0:
         blockers.append(AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER)
-    if _int(totals.get('execution_order_event_count')) <= 0:
+    if _int(totals.get("execution_order_event_count")) <= 0:
         blockers.extend(
             [
                 RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
                 ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
             ]
         )
-    if _int(totals.get('fill_lifecycle_event_count')) <= 0:
+    if _int(totals.get("fill_lifecycle_event_count")) <= 0:
         blockers.append(ORDER_FEED_LIFECYCLE_MISSING_BLOCKER)
-    if _int(totals.get('execution_order_events_with_execution_ref_count')) < _int(
-        totals.get('execution_order_event_count')
+    if _int(totals.get("execution_order_events_with_execution_ref_count")) < _int(
+        totals.get("execution_order_event_count")
     ):
         blockers.append(RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER)
-    if _int(totals.get('execution_order_events_with_trade_decision_ref_count')) < _int(
-        totals.get('execution_order_event_count')
+    if _int(totals.get("execution_order_events_with_trade_decision_ref_count")) < _int(
+        totals.get("execution_order_event_count")
     ):
         blockers.append(RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER)
-    if _int(totals.get('execution_order_events_with_filled_notional_delta_count')) < _int(
-        totals.get('fill_lifecycle_event_count')
-    ):
+    if _int(
+        totals.get("execution_order_events_with_filled_notional_delta_count")
+    ) < _int(totals.get("fill_lifecycle_event_count")):
         blockers.append(AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER)
-    if _int(totals.get('tca_cost_row_count')) <= 0:
-        blockers.extend([AUTHORITY_EXPLICIT_COSTS_BLOCKER, EXECUTION_ECONOMICS_MISSING_BLOCKER])
-    if _int(totals.get('source_window_count')) <= 0:
+    if _int(totals.get("tca_cost_row_count")) <= 0:
+        blockers.extend(
+            [AUTHORITY_EXPLICIT_COSTS_BLOCKER, EXECUTION_ECONOMICS_MISSING_BLOCKER]
+        )
+    if _int(totals.get("source_window_count")) <= 0:
         blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER)
-    if _int(totals.get('execution_order_events_with_source_window_count')) < _int(
-        totals.get('execution_order_event_count')
+    if _int(totals.get("execution_order_events_with_source_window_count")) < _int(
+        totals.get("execution_order_event_count")
     ):
         blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER)
-    if _int(totals.get('execution_order_events_with_source_offset_count')) < _int(
-        totals.get('execution_order_event_count')
+    if _int(totals.get("execution_order_events_with_source_offset_count")) < _int(
+        totals.get("execution_order_event_count")
     ):
         blockers.append(RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER)
-    if _int(totals.get('open_position_count')) > 0:
+    if _int(totals.get("open_position_count")) > 0:
         blockers.append(AUTHORITY_OPEN_POSITIONS_BLOCKER)
-    if _int(totals.get('closed_trade_count')) <= 0:
+    if _int(totals.get("closed_trade_count")) <= 0:
         blockers.append(AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER)
-    if _decimal(totals.get('filled_notional')) <= 0:
+    if _decimal(totals.get("filled_notional")) <= 0:
         blockers.append(AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER)
-    if rows.runtime_ledger_buckets and _int(totals.get('explicit_cost_runtime_ledger_bucket_count')) < len(
-        rows.runtime_ledger_buckets
-    ):
+    if rows.runtime_ledger_buckets and _int(
+        totals.get("explicit_cost_runtime_ledger_bucket_count")
+    ) < len(rows.runtime_ledger_buckets):
         blockers.append(AUTHORITY_EXPLICIT_COSTS_BLOCKER)
     if not rows.runtime_ledger_buckets:
         blockers.append(AUTHORITY_EVIDENCE_MISSING_BLOCKER)
-    blockers.extend(str(item) for item in _sequence(ledger_report.get('blockers')))
+    blockers.extend(str(item) for item in _sequence(ledger_report.get("blockers")))
     return sorted(dict.fromkeys(blockers))
 
 
@@ -627,16 +724,18 @@ def _missing_source_ref_categories(blockers: Sequence[str]) -> dict[str, bool]:
 def _missing_requirement_categories(blockers: Sequence[str]) -> dict[str, bool]:
     blocker_set = set(blockers)
     return {
-        'filled_notional': AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER in blocker_set,
-        'explicit_costs': AUTHORITY_EXPLICIT_COSTS_BLOCKER in blocker_set
+        "filled_notional": AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER in blocker_set,
+        "explicit_costs": AUTHORITY_EXPLICIT_COSTS_BLOCKER in blocker_set
         or EXECUTION_ECONOMICS_MISSING_BLOCKER in blocker_set,
-        'closed_round_trip': AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER in blocker_set,
-        'execution_refs': RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in blocker_set,
-        'execution_order_event_refs': RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER in blocker_set,
-        'source_window_refs': RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER in blocker_set
+        "closed_round_trip": AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER in blocker_set,
+        "execution_refs": RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in blocker_set,
+        "execution_order_event_refs": RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER
+        in blocker_set,
+        "source_window_refs": RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER
+        in blocker_set
         or RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER in blocker_set,
-        'source_offsets': RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in blocker_set,
-        'tca_cost_rows': AUTHORITY_EXPLICIT_COSTS_BLOCKER in blocker_set,
+        "source_offsets": RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in blocker_set,
+        "tca_cost_rows": AUTHORITY_EXPLICIT_COSTS_BLOCKER in blocker_set,
     }
 
 
@@ -651,8 +750,10 @@ def _blocker_ladder(
 ) -> list[dict[str, object]]:
     """Return a compact, ordered read-only ladder that points at the next missing proof input."""
 
-    aggregate = _mapping(ledger_report.get('aggregate'))
-    daily_ledger = [_mapping(item) for item in _sequence(ledger_report.get('trading_days'))]
+    aggregate = _mapping(ledger_report.get("aggregate"))
+    daily_ledger = [
+        _mapping(item) for item in _sequence(ledger_report.get("trading_days"))
+    ]
     daily_pnl_blockers = {
         AUTHORITY_TRADING_DAYS_BLOCKER,
         AUTHORITY_MEAN_PNL_BLOCKER,
@@ -663,155 +764,193 @@ def _blocker_ladder(
     }
     return [
         _ladder_step(
-            'decisions',
+            "decisions",
             blockers=blockers,
             step_blockers={
                 AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
                 RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
             },
-            present=_int(totals.get('trade_decision_count')) > 0,
+            present=_int(totals.get("trade_decision_count")) > 0,
             observed={
-                'source_trade_decision_count': _int(totals.get('trade_decision_count')),
-                'runtime_ledger_decision_count': _sum_daily_int(daily_ledger, 'decision_count'),
-                'observed_stage': observed_stage,
+                "source_trade_decision_count": _int(totals.get("trade_decision_count")),
+                "runtime_ledger_decision_count": _sum_daily_int(
+                    daily_ledger, "decision_count"
+                ),
+                "observed_stage": observed_stage,
             },
-            next_action='run the strategy through paper/live routing until durable TradeDecision rows exist',
+            next_action="run the strategy through paper/live routing until durable TradeDecision rows exist",
         ),
         _ladder_step(
-            'executions',
+            "executions",
             blockers=blockers,
-            step_blockers={AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER, RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER},
-            present=_int(totals.get('filled_execution_count')) > 0,
-            observed={
-                'source_execution_count': _int(totals.get('execution_count')),
-                'source_filled_execution_count': _int(totals.get('filled_execution_count')),
-                'runtime_ledger_fill_count': _sum_daily_int(daily_ledger, 'fill_count'),
+            step_blockers={
+                AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
+                RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
             },
-            next_action='connect decisions to broker fills before relying on any replay-only result',
+            present=_int(totals.get("filled_execution_count")) > 0,
+            observed={
+                "source_execution_count": _int(totals.get("execution_count")),
+                "source_filled_execution_count": _int(
+                    totals.get("filled_execution_count")
+                ),
+                "runtime_ledger_fill_count": _sum_daily_int(daily_ledger, "fill_count"),
+            },
+            next_action="connect decisions to broker fills before relying on any replay-only result",
         ),
         _ladder_step(
-            'order_feed_lifecycle',
+            "order_feed_lifecycle",
             blockers=blockers,
             step_blockers={
                 ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
                 RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
             },
-            present=_int(totals.get('linked_order_event_fill_count')) > 0,
+            present=_int(totals.get("linked_order_event_fill_count")) > 0,
             observed={
-                'execution_order_event_count': _int(totals.get('execution_order_event_count')),
-                'fill_lifecycle_event_count': _int(totals.get('fill_lifecycle_event_count')),
-                'linked_order_event_fill_count': _int(totals.get('linked_order_event_fill_count')),
-                'runtime_submitted_order_count': _sum_daily_int(daily_ledger, 'submitted_order_count'),
+                "execution_order_event_count": _int(
+                    totals.get("execution_order_event_count")
+                ),
+                "fill_lifecycle_event_count": _int(
+                    totals.get("fill_lifecycle_event_count")
+                ),
+                "linked_order_event_fill_count": _int(
+                    totals.get("linked_order_event_fill_count")
+                ),
+                "runtime_submitted_order_count": _sum_daily_int(
+                    daily_ledger, "submitted_order_count"
+                ),
             },
-            next_action='materialize order-feed fill lifecycle events linked to executions and decisions',
+            next_action="materialize order-feed fill lifecycle events linked to executions and decisions",
         ),
         _ladder_step(
-            'source_windows_and_refs',
+            "source_windows_and_refs",
             blockers=blockers,
             step_blockers=_SOURCE_REF_BLOCKERS,
-            present=_int(totals.get('source_window_count')) > 0
-            and _int(totals.get('execution_order_events_with_source_window_count'))
-            >= _int(totals.get('execution_order_event_count'))
-            and _int(totals.get('execution_order_events_with_source_offset_count'))
-            >= _int(totals.get('execution_order_event_count')),
+            present=_int(totals.get("source_window_count")) > 0
+            and _int(totals.get("execution_order_events_with_source_window_count"))
+            >= _int(totals.get("execution_order_event_count"))
+            and _int(totals.get("execution_order_events_with_source_offset_count"))
+            >= _int(totals.get("execution_order_event_count")),
             observed={
-                'source_window_count': _int(totals.get('source_window_count')),
-                'events_with_source_window_count': _int(
-                    totals.get('execution_order_events_with_source_window_count')
+                "source_window_count": _int(totals.get("source_window_count")),
+                "events_with_source_window_count": _int(
+                    totals.get("execution_order_events_with_source_window_count")
                 ),
-                'events_with_source_offset_count': _int(totals.get('execution_order_events_with_source_offset_count')),
-                'runtime_source_authority_bucket_count': _int(totals.get('blocker_free_runtime_ledger_bucket_count')),
+                "events_with_source_offset_count": _int(
+                    totals.get("execution_order_events_with_source_offset_count")
+                ),
+                "runtime_source_authority_bucket_count": _int(
+                    totals.get("blocker_free_runtime_ledger_bucket_count")
+                ),
             },
-            next_action='backfill runtime-ledger source windows, offsets, refs, materialization, and authority class',
+            next_action="backfill runtime-ledger source windows, offsets, refs, materialization, and authority class",
         ),
         _ladder_step(
-            'runtime_ledger_buckets',
+            "runtime_ledger_buckets",
             blockers=blockers,
             step_blockers={
                 AUTHORITY_EVIDENCE_MISSING_BLOCKER,
                 AUTHORITY_READ_ERROR_BLOCKER,
                 AUTHORITY_BUCKET_BLOCKERS_PRESENT,
             },
-            present=_int(totals.get('runtime_ledger_bucket_count')) > 0,
+            present=_int(totals.get("runtime_ledger_bucket_count")) > 0,
             observed={
-                'runtime_ledger_bucket_count': _int(totals.get('runtime_ledger_bucket_count')),
-                'blocker_free_runtime_ledger_bucket_count': _int(
-                    totals.get('blocker_free_runtime_ledger_bucket_count')
+                "runtime_ledger_bucket_count": _int(
+                    totals.get("runtime_ledger_bucket_count")
                 ),
-                'source_kind': source_kind,
-                'read_only': True,
-                'writes_proof': False,
+                "blocker_free_runtime_ledger_bucket_count": _int(
+                    totals.get("blocker_free_runtime_ledger_bucket_count")
+                ),
+                "source_kind": source_kind,
+                "read_only": True,
+                "writes_proof": False,
             },
-            next_action='emit durable runtime-ledger buckets from paper/live runtime rows without synthetic proof',
+            next_action="emit durable runtime-ledger buckets from paper/live runtime rows without synthetic proof",
         ),
         _ladder_step(
-            'closed_round_trips',
+            "closed_round_trips",
             blockers=blockers,
-            step_blockers={AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER, AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER},
-            present=_int(totals.get('closed_trade_count')) > 0,
-            observed={
-                'closed_round_trip_count': _int(totals.get('closed_trade_count')),
-                'authority_min_closed_round_trips': _int(aggregate.get('authority_min_closed_round_trips')),
+            step_blockers={
+                AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER,
+                AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER,
             },
-            next_action='wait for source-backed entry and exit fills that close round trips',
+            present=_int(totals.get("closed_trade_count")) > 0,
+            observed={
+                "closed_round_trip_count": _int(totals.get("closed_trade_count")),
+                "authority_min_closed_round_trips": _int(
+                    aggregate.get("authority_min_closed_round_trips")
+                ),
+            },
+            next_action="wait for source-backed entry and exit fills that close round trips",
         ),
         _ladder_step(
-            'open_positions',
+            "open_positions",
             blockers=blockers,
             step_blockers={AUTHORITY_OPEN_POSITIONS_BLOCKER},
-            present=_int(totals.get('open_position_count')) == 0,
-            observed={'open_position_count': _int(totals.get('open_position_count'))},
-            next_action='flatten or let paper/live positions close before promotion',
+            present=_int(totals.get("open_position_count")) == 0,
+            observed={"open_position_count": _int(totals.get("open_position_count"))},
+            next_action="flatten or let paper/live positions close before promotion",
         ),
         _ladder_step(
-            'explicit_costs',
+            "explicit_costs",
             blockers=blockers,
-            step_blockers={AUTHORITY_EXPLICIT_COSTS_BLOCKER, EXECUTION_ECONOMICS_MISSING_BLOCKER},
-            present=_int(totals.get('tca_cost_row_count')) > 0
-            and _int(totals.get('explicit_cost_runtime_ledger_bucket_count')) > 0,
-            observed={
-                'tca_cost_row_count': _int(totals.get('tca_cost_row_count')),
-                'explicit_cost_runtime_ledger_bucket_count': _int(
-                    totals.get('explicit_cost_runtime_ledger_bucket_count')
-                ),
-                'total_explicit_costs': _text(aggregate.get('total_explicit_costs'), default='0'),
+            step_blockers={
+                AUTHORITY_EXPLICIT_COSTS_BLOCKER,
+                EXECUTION_ECONOMICS_MISSING_BLOCKER,
             },
-            next_action='record broker/TCA costs and promotion-grade runtime cost bases for every bucket',
+            present=_int(totals.get("tca_cost_row_count")) > 0
+            and _int(totals.get("explicit_cost_runtime_ledger_bucket_count")) > 0,
+            observed={
+                "tca_cost_row_count": _int(totals.get("tca_cost_row_count")),
+                "explicit_cost_runtime_ledger_bucket_count": _int(
+                    totals.get("explicit_cost_runtime_ledger_bucket_count")
+                ),
+                "total_explicit_costs": _text(
+                    aggregate.get("total_explicit_costs"), default="0"
+                ),
+            },
+            next_action="record broker/TCA costs and promotion-grade runtime cost bases for every bucket",
         ),
         _ladder_step(
-            'filled_notional',
+            "filled_notional",
             blockers=blockers,
-            step_blockers={AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER, AUTHORITY_FILLED_NOTIONAL_BLOCKER},
-            present=_decimal(totals.get('filled_notional')) > 0,
-            observed={
-                'filled_notional': _text(totals.get('filled_notional'), default='0'),
-                'buckets_with_filled_notional_count': _int(
-                    totals.get('runtime_ledger_buckets_with_filled_notional_count')
-                ),
-                'authority_min_filled_notional': _text(aggregate.get('authority_min_filled_notional'), default='0'),
+            step_blockers={
+                AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER,
+                AUTHORITY_FILLED_NOTIONAL_BLOCKER,
             },
-            next_action='accumulate source-backed filled notional, not replay-only simulated volume',
+            present=_decimal(totals.get("filled_notional")) > 0,
+            observed={
+                "filled_notional": _text(totals.get("filled_notional"), default="0"),
+                "buckets_with_filled_notional_count": _int(
+                    totals.get("runtime_ledger_buckets_with_filled_notional_count")
+                ),
+                "authority_min_filled_notional": _text(
+                    aggregate.get("authority_min_filled_notional"), default="0"
+                ),
+            },
+            next_action="accumulate source-backed filled notional, not replay-only simulated volume",
         ),
         _ladder_step(
-            'daily_post_cost_pnl',
+            "daily_post_cost_pnl",
             blockers=blockers,
             step_blockers=daily_pnl_blockers,
             present=len(daily) > 0,
             observed={
-                'trading_day_count': _int(totals.get('trading_day_count')),
-                'post_cost_pnl': _text(totals.get('post_cost_pnl'), default='0'),
-                'mean_daily_net_pnl_after_costs': _text(
-                    aggregate.get('mean_daily_net_pnl_after_costs'), default='0'
+                "trading_day_count": _int(totals.get("trading_day_count")),
+                "post_cost_pnl": _text(totals.get("post_cost_pnl"), default="0"),
+                "mean_daily_net_pnl_after_costs": _text(
+                    aggregate.get("mean_daily_net_pnl_after_costs"), default="0"
                 ),
-                'median_daily_net_pnl_after_costs': _text(
-                    aggregate.get('median_daily_net_pnl_after_costs'), default='0'
+                "median_daily_net_pnl_after_costs": _text(
+                    aggregate.get("median_daily_net_pnl_after_costs"), default="0"
                 ),
-                'p10_daily_net_pnl_after_costs': _text(aggregate.get('p10_daily_net_pnl_after_costs'), default='0'),
-                'worst_day_net_pnl_after_costs': _text(
-                    aggregate.get('worst_day_net_pnl_after_costs'), default='0'
+                "p10_daily_net_pnl_after_costs": _text(
+                    aggregate.get("p10_daily_net_pnl_after_costs"), default="0"
+                ),
+                "worst_day_net_pnl_after_costs": _text(
+                    aggregate.get("worst_day_net_pnl_after_costs"), default="0"
                 ),
             },
-            next_action='continue source-backed paper/live runtime until post-cost daily PnL clears gates',
+            next_action="continue source-backed paper/live runtime until post-cost daily PnL clears gates",
         ),
     ]
 
@@ -833,22 +972,24 @@ def _ladder_step(
     else:
         status = LADDER_MISSING
     return {
-        'step': step,
-        'status': status,
-        'observed': dict(observed),
-        'blocker_codes': blocker_codes,
-        'next_action': next_action if status != LADDER_PASS else None,
+        "step": step,
+        "status": status,
+        "observed": dict(observed),
+        "blocker_codes": blocker_codes,
+        "next_action": next_action if status != LADDER_PASS else None,
     }
 
 
-def _next_ladder_blocker(ladder: Sequence[Mapping[str, object]]) -> dict[str, object] | None:
+def _next_ladder_blocker(
+    ladder: Sequence[Mapping[str, object]],
+) -> dict[str, object] | None:
     for step in ladder:
-        if step.get('status') != LADDER_PASS:
+        if step.get("status") != LADDER_PASS:
             return {
-                'step': step.get('step'),
-                'status': step.get('status'),
-                'blocker_codes': list(_sequence(step.get('blocker_codes'))),
-                'next_action': step.get('next_action'),
+                "step": step.get("step"),
+                "status": step.get("status"),
+                "blocker_codes": list(_sequence(step.get("blocker_codes"))),
+                "next_action": step.get("next_action"),
             }
     return None
 
@@ -860,15 +1001,15 @@ def _sum_daily_int(daily: Sequence[Mapping[str, object]], key: str) -> int:
 def _classify_verdict(totals: Mapping[str, object], blockers: Sequence[str]) -> str:
     blocker_set = set(blockers)
     source_activity = (
-        _int(totals.get('trade_decision_count'))
-        + _int(totals.get('execution_count'))
-        + _int(totals.get('execution_order_event_count'))
-        + _int(totals.get('tca_cost_row_count'))
-        + _int(totals.get('runtime_ledger_bucket_count'))
+        _int(totals.get("trade_decision_count"))
+        + _int(totals.get("execution_count"))
+        + _int(totals.get("execution_order_event_count"))
+        + _int(totals.get("tca_cost_row_count"))
+        + _int(totals.get("runtime_ledger_bucket_count"))
     )
     if source_activity <= 0:
         return NO_SOURCE_ACTIVITY
-    if blocker_set.intersection(_LIFECYCLE_BLOCKERS):
+    if blocker_set.intersection(_PRIMARY_LIFECYCLE_BLOCKERS):
         return LIFECYCLE_MISSING
     if blocker_set.intersection(_SOURCE_REF_BLOCKERS):
         return SOURCE_REFS_MISSING
@@ -876,6 +1017,8 @@ def _classify_verdict(totals: Mapping[str, object], blockers: Sequence[str]) -> 
         return ECONOMICS_MISSING
     if AUTHORITY_OPEN_POSITIONS_BLOCKER in blocker_set:
         return OPEN_POSITIONS
+    if blocker_set.intersection(_LIFECYCLE_BLOCKERS):
+        return LIFECYCLE_MISSING
     if blocker_set.intersection(_DISTRIBUTION_BLOCKERS):
         return AUTHORITY_DISTRIBUTION_MISSING
     if blocker_set:
@@ -885,17 +1028,19 @@ def _classify_verdict(totals: Mapping[str, object], blockers: Sequence[str]) -> 
 
 def _next_action(classification: str) -> str:
     return {
-        NO_SOURCE_ACTIVITY: 'collect bounded paper-route source rows before treating replay output as authority',
-        LIFECYCLE_MISSING: 'materialize linked decisions, executions, order events, fills, and closed round trips',
-        ECONOMICS_MISSING: 'materialize execution TCA/cost rows and explicit runtime cost bases',
-        SOURCE_REFS_MISSING: 'backfill runtime-ledger source refs, source windows, offsets, materialization, and authority class',
-        OPEN_POSITIONS: 'flatten or wait for source-backed closed round trips before authority promotion',
-        AUTHORITY_DISTRIBUTION_MISSING: 'continue source-backed paper runtime until authority distribution thresholds are met',
-        AUTHORITY_CANDIDATE_READY: 'assemble authority proof packet from the same source-backed runtime rows',
+        NO_SOURCE_ACTIVITY: "collect bounded paper-route source rows before treating replay output as authority",
+        LIFECYCLE_MISSING: "materialize linked decisions, executions, order events, fills, and closed round trips",
+        ECONOMICS_MISSING: "materialize execution TCA/cost rows and explicit runtime cost bases",
+        SOURCE_REFS_MISSING: "backfill runtime-ledger source refs, source windows, offsets, materialization, and authority class",
+        OPEN_POSITIONS: "flatten or wait for source-backed closed round trips before authority promotion",
+        AUTHORITY_DISTRIBUTION_MISSING: "continue source-backed paper runtime until authority distribution thresholds are met",
+        AUTHORITY_CANDIDATE_READY: "assemble authority proof packet from the same source-backed runtime rows",
     }[classification]
 
 
-def _row_days(rows: Sequence[Mapping[str, object]], key: str, *, fallback_key: str | None = None) -> set[str]:
+def _row_days(
+    rows: Sequence[Mapping[str, object]], key: str, *, fallback_key: str | None = None
+) -> set[str]:
     days: set[str] = set()
     for row in rows:
         timestamp = _parse_timestamp(row.get(key))
@@ -909,8 +1054,8 @@ def _row_days(rows: Sequence[Mapping[str, object]], key: str, *, fallback_key: s
 def _ledger_days(ledger_report: Mapping[str, object]) -> set[str]:
     return {
         text
-        for item in _sequence(ledger_report.get('trading_days'))
-        if (text := _text(_mapping(item).get('trading_day'))) is not None
+        for item in _sequence(ledger_report.get("trading_days"))
+        if (text := _text(_mapping(item).get("trading_day"))) is not None
     }
 
 
@@ -932,128 +1077,145 @@ def _rows_on_day(
 
 
 def _filled_execution(row: Mapping[str, object]) -> bool:
-    status = (_text(row.get('status')) or '').lower()
-    return status in {'filled', 'partially_filled'} or _decimal(row.get('filled_qty')) > 0
+    status = (_text(row.get("status")) or "").lower()
+    return (
+        status in {"filled", "partially_filled"} or _decimal(row.get("filled_qty")) > 0
+    )
 
 
 def _fill_event(row: Mapping[str, object]) -> bool:
-    event_type = (_text(row.get('event_type')) or '').lower()
-    status = (_text(row.get('status')) or '').lower()
-    return 'fill' in event_type or status in {'filled', 'partially_filled'} or _decimal(row.get('filled_qty_delta')) > 0
+    event_type = (_text(row.get("event_type")) or "").lower()
+    status = (_text(row.get("status")) or "").lower()
+    return (
+        "fill" in event_type
+        or status in {"filled", "partially_filled"}
+        or _decimal(row.get("filled_qty_delta")) > 0
+    )
 
 
 def _event_quantity_present(row: Mapping[str, object]) -> bool:
-    return any(_decimal(row.get(key)) > 0 for key in ('filled_qty_delta', 'filled_qty', 'qty', 'quantity'))
+    return any(
+        _decimal(row.get(key)) > 0
+        for key in ("filled_qty_delta", "filled_qty", "qty", "quantity")
+    )
 
 
 def _linked_order_event_fill(row: Mapping[str, object]) -> bool:
     return (
         _fill_event(row)
-        and _text(row.get('execution_id')) is not None
-        and _text(row.get('trade_decision_id')) is not None
-        and _text(row.get('source_window_id')) is not None
+        and _text(row.get("execution_id")) is not None
+        and _text(row.get("trade_decision_id")) is not None
+        and _text(row.get("source_window_id")) is not None
         and _event_source_offset_present(row)
         and _event_quantity_present(row)
-        and _decimal(row.get('avg_fill_price')) > 0
-        and _decimal(row.get('filled_notional_delta')) > 0
+        and _decimal(row.get("avg_fill_price")) > 0
+        and _decimal(row.get("filled_notional_delta")) > 0
     )
 
 
 def _event_source_offset_present(row: Mapping[str, object]) -> bool:
     return (
-        _text(row.get('source_topic')) is not None
-        and row.get('source_partition') is not None
-        and row.get('source_offset') is not None
+        _text(row.get("source_topic")) is not None
+        and row.get("source_partition") is not None
+        and row.get("source_offset") is not None
     )
 
 
 def _decision_row(row: TradeDecision, strategy_name: str | None) -> dict[str, object]:
     return {
-        'id': str(row.id),
-        'strategy_id': str(row.strategy_id),
-        'strategy_name': strategy_name,
-        'alpaca_account_label': row.alpaca_account_label,
-        'symbol': row.symbol,
-        'status': row.status,
-        'decision_hash': row.decision_hash,
-        'created_at': row.created_at,
-        'executed_at': row.executed_at,
+        "id": str(row.id),
+        "strategy_id": str(row.strategy_id),
+        "strategy_name": strategy_name,
+        "alpaca_account_label": row.alpaca_account_label,
+        "symbol": row.symbol,
+        "status": row.status,
+        "decision_hash": row.decision_hash,
+        "created_at": row.created_at,
+        "executed_at": row.executed_at,
     }
 
 
 def _execution_row(row: Execution) -> dict[str, object]:
     return {
-        'id': str(row.id),
-        'trade_decision_id': str(row.trade_decision_id) if row.trade_decision_id is not None else None,
-        'alpaca_account_label': row.alpaca_account_label,
-        'alpaca_order_id': row.alpaca_order_id,
-        'client_order_id': row.client_order_id,
-        'symbol': row.symbol,
-        'side': row.side,
-        'status': row.status,
-        'filled_qty': row.filled_qty,
-        'avg_fill_price': row.avg_fill_price,
-        'created_at': row.created_at,
-        'updated_at': row.updated_at,
-        'order_feed_last_event_ts': row.order_feed_last_event_ts,
+        "id": str(row.id),
+        "trade_decision_id": str(row.trade_decision_id)
+        if row.trade_decision_id is not None
+        else None,
+        "alpaca_account_label": row.alpaca_account_label,
+        "alpaca_order_id": row.alpaca_order_id,
+        "client_order_id": row.client_order_id,
+        "symbol": row.symbol,
+        "side": row.side,
+        "status": row.status,
+        "filled_qty": row.filled_qty,
+        "avg_fill_price": row.avg_fill_price,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+        "order_feed_last_event_ts": row.order_feed_last_event_ts,
     }
 
 
 def _order_event_row(row: ExecutionOrderEvent) -> dict[str, object]:
     return {
-        'id': str(row.id),
-        'source_topic': row.source_topic,
-        'source_partition': row.source_partition,
-        'source_offset': row.source_offset,
-        'alpaca_account_label': row.alpaca_account_label,
-        'event_ts': row.event_ts,
-        'created_at': row.created_at,
-        'symbol': row.symbol,
-        'alpaca_order_id': row.alpaca_order_id,
-        'client_order_id': row.client_order_id,
-        'event_type': row.event_type,
-        'status': row.status,
-        'filled_qty': row.filled_qty,
-        'filled_qty_delta': row.filled_qty_delta,
-        'avg_fill_price': row.avg_fill_price,
-        'filled_notional_delta': row.filled_notional_delta,
-        'execution_id': str(row.execution_id) if row.execution_id is not None else None,
-        'trade_decision_id': str(row.trade_decision_id) if row.trade_decision_id is not None else None,
-        'source_window_id': str(row.source_window_id) if row.source_window_id is not None else None,
+        "id": str(row.id),
+        "source_topic": row.source_topic,
+        "source_partition": row.source_partition,
+        "source_offset": row.source_offset,
+        "alpaca_account_label": row.alpaca_account_label,
+        "event_ts": row.event_ts,
+        "created_at": row.created_at,
+        "symbol": row.symbol,
+        "alpaca_order_id": row.alpaca_order_id,
+        "client_order_id": row.client_order_id,
+        "event_type": row.event_type,
+        "status": row.status,
+        "filled_qty": row.filled_qty,
+        "filled_qty_delta": row.filled_qty_delta,
+        "avg_fill_price": row.avg_fill_price,
+        "filled_notional_delta": row.filled_notional_delta,
+        "execution_id": str(row.execution_id) if row.execution_id is not None else None,
+        "trade_decision_id": str(row.trade_decision_id)
+        if row.trade_decision_id is not None
+        else None,
+        "source_window_id": str(row.source_window_id)
+        if row.source_window_id is not None
+        else None,
     }
 
 
 def _tca_row(row: ExecutionTCAMetric) -> dict[str, object]:
     return {
-        'id': str(row.id),
-        'execution_id': str(row.execution_id),
-        'trade_decision_id': str(row.trade_decision_id) if row.trade_decision_id is not None else None,
-        'strategy_id': str(row.strategy_id) if row.strategy_id is not None else None,
-        'alpaca_account_label': row.alpaca_account_label,
-        'symbol': row.symbol,
-        'side': row.side,
-        'filled_qty': row.filled_qty,
-        'shortfall_notional': row.shortfall_notional,
-        'realized_shortfall_bps': row.realized_shortfall_bps,
-        'computed_at': row.computed_at,
+        "id": str(row.id),
+        "execution_id": str(row.execution_id),
+        "trade_decision_id": str(row.trade_decision_id)
+        if row.trade_decision_id is not None
+        else None,
+        "strategy_id": str(row.strategy_id) if row.strategy_id is not None else None,
+        "alpaca_account_label": row.alpaca_account_label,
+        "symbol": row.symbol,
+        "side": row.side,
+        "filled_qty": row.filled_qty,
+        "shortfall_notional": row.shortfall_notional,
+        "realized_shortfall_bps": row.realized_shortfall_bps,
+        "computed_at": row.computed_at,
     }
 
 
 def _source_window_row(row: OrderFeedSourceWindow) -> dict[str, object]:
     return {
-        'id': str(row.id),
-        'consumer_group': row.consumer_group,
-        'source_topic': row.source_topic,
-        'source_partition': row.source_partition,
-        'alpaca_account_label': row.alpaca_account_label,
-        'window_started_at': row.window_started_at,
-        'window_ended_at': row.window_ended_at,
-        'start_offset': row.start_offset,
-        'end_offset': row.end_offset,
-        'consumed_count': row.consumed_count,
-        'inserted_count': row.inserted_count,
-        'gap_count': row.gap_count,
-        'status': row.status,
+        "id": str(row.id),
+        "consumer_group": row.consumer_group,
+        "source_topic": row.source_topic,
+        "source_partition": row.source_partition,
+        "alpaca_account_label": row.alpaca_account_label,
+        "window_started_at": row.window_started_at,
+        "window_ended_at": row.window_ended_at,
+        "start_offset": row.start_offset,
+        "end_offset": row.end_offset,
+        "consumed_count": row.consumed_count,
+        "inserted_count": row.inserted_count,
+        "gap_count": row.gap_count,
+        "status": row.status,
     }
 
 
@@ -1063,7 +1225,12 @@ def _row_list(value: object) -> list[Mapping[str, object]]:
     rows: list[Mapping[str, object]] = []
     for item in cast(Sequence[object], value):
         if isinstance(item, Mapping):
-            rows.append({str(key): _json_value(raw) for key, raw in cast(Mapping[object, object], item).items()})
+            rows.append(
+                {
+                    str(key): _json_value(raw)
+                    for key, raw in cast(Mapping[object, object], item).items()
+                }
+            )
     return rows
 
 
@@ -1072,7 +1239,10 @@ def _json_value(value: object) -> object:
         parsed = _parse_timestamp(value)
         return parsed if parsed is not None else value
     if isinstance(value, Mapping):
-        return {str(key): _json_value(raw) for key, raw in cast(Mapping[object, object], value).items()}
+        return {
+            str(key): _json_value(raw)
+            for key, raw in cast(Mapping[object, object], value).items()
+        }
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return [_json_value(item) for item in cast(Sequence[object], value)]
     return value
@@ -1083,7 +1253,7 @@ def _parse_cli_timestamp(value: str | None) -> datetime | None:
         return None
     parsed = _parse_timestamp(value)
     if parsed is None:
-        raise ValueError(f'invalid timestamp: {value}')
+        raise ValueError(f"invalid timestamp: {value}")
     return parsed
 
 
@@ -1094,14 +1264,16 @@ def _parse_timestamp(value: object) -> datetime | None:
     if text is None:
         return None
     try:
-        return _utc(datetime.fromisoformat(text.replace('Z', '+00:00')))
+        return _utc(datetime.fromisoformat(text.replace("Z", "+00:00")))
     except ValueError:
         return None
 
 
 def _mapping(value: object) -> Mapping[str, object]:
     if isinstance(value, Mapping):
-        return {str(key): item for key, item in cast(Mapping[object, object], value).items()}
+        return {
+            str(key): item for key, item in cast(Mapping[object, object], value).items()
+        }
     return {}
 
 
@@ -1120,22 +1292,22 @@ def _text(value: object, *, default: str | None = None) -> str | None:
 
 def _int(value: object) -> int:
     try:
-        return int(str(value if value is not None else '0'))
+        return int(str(value if value is not None else "0"))
     except (TypeError, ValueError):
         return 0
 
 
 def _decimal(value: object) -> Decimal:
     try:
-        parsed = Decimal(str(value if value is not None else '0'))
+        parsed = Decimal(str(value if value is not None else "0"))
     except (InvalidOperation, ValueError):
-        return Decimal('0')
-    return parsed if parsed.is_finite() else Decimal('0')
+        return Decimal("0")
+    return parsed if parsed.is_finite() else Decimal("0")
 
 
 def _decimal_text(value: Decimal) -> str:
-    text = format(value.normalize(), 'f')
-    return text.rstrip('0').rstrip('.') if '.' in text else text
+    text = format(value.normalize(), "f")
+    return text.rstrip("0").rstrip(".") if "." in text else text
 
 
 def _utc(value: datetime) -> datetime:
@@ -1145,7 +1317,7 @@ def _utc(value: datetime) -> datetime:
 
 
 def _isoformat(value: datetime) -> str:
-    return _utc(value).isoformat().replace('+00:00', 'Z')
+    return _utc(value).isoformat().replace("+00:00", "Z")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1163,7 +1335,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.fixture_json is not None:
             rows = load_fixture_rows(args.fixture_json)
-            source_kind = 'fixture_json'
+            source_kind = "fixture_json"
         else:
             rows = load_dsn_rows(
                 args.dsn,
@@ -1171,11 +1343,13 @@ def main(argv: list[str] | None = None) -> int:
                 started_at=started_at,
                 ended_at=ended_at,
             )
-            source_kind = 'sqlalchemy_dsn'
+            source_kind = "sqlalchemy_dsn"
     except Exception as exc:  # noqa: BLE001 - readback must fail closed into JSON diagnostics.
         rows = CensusSourceRows()
         read_error = str(exc)
-        source_kind = 'fixture_json' if args.fixture_json is not None else 'sqlalchemy_dsn'
+        source_kind = (
+            "fixture_json" if args.fixture_json is not None else "sqlalchemy_dsn"
+        )
     report = build_source_proof_census(
         rows,
         identity=identity,
@@ -1185,9 +1359,14 @@ def main(argv: list[str] | None = None) -> int:
         source_kind=source_kind,
     )
     sys.stdout.write(census_json(report))
-    verdict = _mapping(report.get('verdict'))
-    return 1 if args.fail_on_blockers and verdict.get('authority_candidate_ready') is not True else 0
+    verdict = _mapping(report.get("verdict"))
+    return (
+        1
+        if args.fail_on_blockers
+        and verdict.get("authority_candidate_ready") is not True
+        else 0
+    )
 
 
-if __name__ == '__main__':  # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -17,162 +17,175 @@ from app.trading.runtime_authority_verifier import (
     RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
     RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
 )
-from app.trading.runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
+from app.trading.runtime_ledger import (
+    EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+    POST_COST_PNL_BASIS,
+)
 from scripts import audit_hpairs_source_proof_census as census
 
 
 def _iso(day_index: int, hour: int = 14) -> str:
-    return (datetime(2026, 5, 1, hour, tzinfo=timezone.utc) + timedelta(days=day_index)).isoformat().replace(
-        '+00:00', 'Z'
+    return (
+        (datetime(2026, 5, 1, hour, tzinfo=timezone.utc) + timedelta(days=day_index))
+        .isoformat()
+        .replace("+00:00", "Z")
     )
 
 
 def _source_payload(day_index: int) -> dict[str, object]:
     return {
-        'source_window_start': _iso(day_index, 14),
-        'source_window_end': _iso(day_index, 21),
-        'source_refs': [
-            'postgres:trade_decisions',
-            'postgres:executions',
-            'postgres:execution_order_events',
-            'postgres:order_feed_source_windows',
+        "source_window_start": _iso(day_index, 14),
+        "source_window_end": _iso(day_index, 21),
+        "source_refs": [
+            "postgres:trade_decisions",
+            "postgres:executions",
+            "postgres:execution_order_events",
+            "postgres:order_feed_source_windows",
         ],
-        'source_row_counts': {
-            'trade_decisions': 1,
-            'executions': 1,
-            'execution_order_events': 1,
-            'order_feed_source_windows': 1,
+        "source_row_counts": {
+            "trade_decisions": 1,
+            "executions": 1,
+            "execution_order_events": 1,
+            "order_feed_source_windows": 1,
         },
-        'trade_decision_ids': [f'decision-{day_index}'],
-        'execution_ids': [f'execution-{day_index}'],
-        'execution_order_event_ids': [f'event-{day_index}'],
-        'source_window_ids': [f'window-{day_index}'],
-        'source_offsets': [{'topic': 'alpaca.trade_updates', 'partition': 0, 'offset': day_index}],
-        'source_materialization': 'execution_order_events',
-        'authority_class': 'runtime_order_feed_execution_source',
-        'order_feed_lifecycle_complete': True,
-        'execution_economics_complete': True,
-        'cost_basis_counts': {'explicit_broker_fee_runtime': 1},
+        "trade_decision_ids": [f"decision-{day_index}"],
+        "execution_ids": [f"execution-{day_index}"],
+        "execution_order_event_ids": [f"event-{day_index}"],
+        "source_window_ids": [f"window-{day_index}"],
+        "source_offsets": [
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": day_index}
+        ],
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
+        "order_feed_lifecycle_complete": True,
+        "execution_economics_complete": True,
+        "cost_basis_counts": {"explicit_broker_fee_runtime": 1},
     }
 
 
-def _ledger_bucket(day_index: int, *, source_backed: bool = True, open_positions: int = 0) -> dict[str, object]:
+def _ledger_bucket(
+    day_index: int, *, source_backed: bool = True, open_positions: int = 0
+) -> dict[str, object]:
     start = _iso(day_index, 14)
     return {
-        'id': f'ledger-{day_index}',
-        'run_id': 'hpairs-runtime-run',
-        'candidate_id': DEFAULT_HPAIRS_CANDIDATE_ID,
-        'hypothesis_id': DEFAULT_HPAIRS_HYPOTHESIS_ID,
-        'observed_stage': 'paper',
-        'bucket_started_at': start,
-        'bucket_ended_at': _iso(day_index, 21),
-        'account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
-        'runtime_strategy_name': DEFAULT_HPAIRS_RUNTIME_STRATEGY,
-        'strategy_family': 'pairs',
-        'fill_count': 20,
-        'decision_count': 20,
-        'submitted_order_count': 20,
-        'cancelled_order_count': 0,
-        'rejected_order_count': 0,
-        'unfilled_order_count': 0,
-        'closed_trade_count': 20,
-        'open_position_count': open_positions,
-        'filled_notional': '600000',
-        'gross_strategy_pnl': '610',
-        'cost_amount': '10',
-        'net_strategy_pnl_after_costs': '600',
-        'post_cost_expectancy_bps': '10',
-        'ledger_schema_version': EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
-        'pnl_basis': POST_COST_PNL_BASIS,
-        'execution_policy_hash_counts': {'policy-hash': 1},
-        'cost_model_hash_counts': {'cost-hash': 1},
-        'lineage_hash_counts': {'lineage-hash': 1},
-        'blockers': [],
-        'payload': _source_payload(day_index) if source_backed else {},
+        "id": f"ledger-{day_index}",
+        "run_id": "hpairs-runtime-run",
+        "candidate_id": DEFAULT_HPAIRS_CANDIDATE_ID,
+        "hypothesis_id": DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        "observed_stage": "paper",
+        "bucket_started_at": start,
+        "bucket_ended_at": _iso(day_index, 21),
+        "account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        "runtime_strategy_name": DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        "strategy_family": "pairs",
+        "fill_count": 20,
+        "decision_count": 20,
+        "submitted_order_count": 20,
+        "cancelled_order_count": 0,
+        "rejected_order_count": 0,
+        "unfilled_order_count": 0,
+        "closed_trade_count": 20,
+        "open_position_count": open_positions,
+        "filled_notional": "600000",
+        "gross_strategy_pnl": "610",
+        "cost_amount": "10",
+        "net_strategy_pnl_after_costs": "600",
+        "post_cost_expectancy_bps": "10",
+        "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        "pnl_basis": POST_COST_PNL_BASIS,
+        "execution_policy_hash_counts": {"policy-hash": 1},
+        "cost_model_hash_counts": {"cost-hash": 1},
+        "lineage_hash_counts": {"lineage-hash": 1},
+        "blockers": [],
+        "payload": _source_payload(day_index) if source_backed else {},
     }
 
 
 def _fixture(*, days: int = 20, source_backed: bool = True) -> dict[str, object]:
     return {
-        'trade_decisions': [
+        "trade_decisions": [
             {
-                'id': f'decision-{day}',
-                'strategy_name': DEFAULT_HPAIRS_RUNTIME_STRATEGY,
-                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
-                'status': 'executed',
-                'created_at': _iso(day, 14),
+                "id": f"decision-{day}",
+                "strategy_name": DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "status": "executed",
+                "created_at": _iso(day, 14),
             }
             for day in range(days)
         ],
-        'executions': [
+        "executions": [
             {
-                'id': f'execution-{day}',
-                'trade_decision_id': f'decision-{day}',
-                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
-                'status': 'filled',
-                'filled_qty': '10',
-                'avg_fill_price': '100',
-                'created_at': _iso(day, 15),
+                "id": f"execution-{day}",
+                "trade_decision_id": f"decision-{day}",
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "status": "filled",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "created_at": _iso(day, 15),
             }
             for day in range(days)
         ],
-        'execution_order_events': [
+        "execution_order_events": [
             {
-                'id': f'event-{day}',
-                'execution_id': f'execution-{day}',
-                'trade_decision_id': f'decision-{day}',
-                'source_window_id': f'window-{day}',
-                'source_topic': 'alpaca.trade_updates',
-                'source_partition': 0,
-                'source_offset': day,
-                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
-                'event_type': 'fill',
-                'status': 'filled',
-                'filled_qty_delta': '10',
-                'avg_fill_price': '100',
-                'filled_notional_delta': '1000',
-                'event_ts': _iso(day, 15),
+                "id": f"event-{day}",
+                "execution_id": f"execution-{day}",
+                "trade_decision_id": f"decision-{day}",
+                "source_window_id": f"window-{day}",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": day,
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "event_type": "fill",
+                "status": "filled",
+                "filled_qty_delta": "10",
+                "avg_fill_price": "100",
+                "filled_notional_delta": "1000",
+                "event_ts": _iso(day, 15),
             }
             for day in range(days)
         ],
-        'execution_tca_metrics': [
+        "execution_tca_metrics": [
             {
-                'id': f'tca-{day}',
-                'execution_id': f'execution-{day}',
-                'trade_decision_id': f'decision-{day}',
-                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
-                'filled_qty': '10',
-                'shortfall_notional': '1',
-                'computed_at': _iso(day, 16),
+                "id": f"tca-{day}",
+                "execution_id": f"execution-{day}",
+                "trade_decision_id": f"decision-{day}",
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "filled_qty": "10",
+                "shortfall_notional": "1",
+                "computed_at": _iso(day, 16),
             }
             for day in range(days)
         ],
-        'order_feed_source_windows': [
+        "order_feed_source_windows": [
             {
-                'id': f'window-{day}',
-                'alpaca_account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
-                'source_topic': 'alpaca.trade_updates',
-                'source_partition': 0,
-                'window_started_at': _iso(day, 14),
-                'window_ended_at': _iso(day, 21),
-                'start_offset': day,
-                'end_offset': day + 1,
-                'status': 'complete',
+                "id": f"window-{day}",
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "window_started_at": _iso(day, 14),
+                "window_ended_at": _iso(day, 21),
+                "start_offset": day,
+                "end_offset": day + 1,
+                "status": "complete",
             }
             for day in range(days)
         ],
-        'runtime_ledger_buckets': [_ledger_bucket(day, source_backed=source_backed) for day in range(days)],
+        "runtime_ledger_buckets": [
+            _ledger_bucket(day, source_backed=source_backed) for day in range(days)
+        ],
     }
 
 
 def _report(payload: dict[str, object]) -> dict[str, object]:
     rows = census.CensusSourceRows(
-        trade_decisions=census._row_list(payload.get('trade_decisions')),
-        executions=census._row_list(payload.get('executions')),
-        execution_order_events=census._row_list(payload.get('execution_order_events')),
-        execution_tca_metrics=census._row_list(payload.get('execution_tca_metrics')),
-        order_feed_source_windows=census._row_list(payload.get('order_feed_source_windows')),
-        runtime_ledger_buckets=census._row_list(payload.get('runtime_ledger_buckets')),
+        trade_decisions=census._row_list(payload.get("trade_decisions")),
+        executions=census._row_list(payload.get("executions")),
+        execution_order_events=census._row_list(payload.get("execution_order_events")),
+        execution_tca_metrics=census._row_list(payload.get("execution_tca_metrics")),
+        order_feed_source_windows=census._row_list(
+            payload.get("order_feed_source_windows")
+        ),
+        runtime_ledger_buckets=census._row_list(payload.get("runtime_ledger_buckets")),
     )
     return census.build_source_proof_census(
         rows,
@@ -181,206 +194,237 @@ def _report(payload: dict[str, object]) -> dict[str, object]:
             candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
             runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
             account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
-            observed_stage='paper',
+            observed_stage="paper",
         ),
     )
 
 
 def _ladder_step(report: dict[str, object], step: str) -> dict[str, object]:
-    ladder = report['blocker_ladder']
+    ladder = report["blocker_ladder"]
     assert isinstance(ladder, list)
     for item in ladder:
         assert isinstance(item, dict)
-        if item['step'] == step:
+        if item["step"] == step:
             return item
-    raise AssertionError(f'missing ladder step {step}')
+    raise AssertionError(f"missing ladder step {step}")
 
 
 def test_full_source_backed_census_is_authority_candidate_ready() -> None:
     report = _report(_fixture())
 
-    assert report['verdict']['classification'] == census.AUTHORITY_CANDIDATE_READY
-    assert report['blockers'] == []
-    assert report['totals']['trade_decision_count'] == 20
-    assert report['totals']['execution_count'] == 20
-    assert report['totals']['filled_execution_count'] == 20
-    assert report['totals']['execution_order_event_count'] == 20
-    assert report['totals']['fill_lifecycle_event_count'] == 20
-    assert report['totals']['linked_order_event_fill_count'] == 20
-    assert report['totals']['execution_order_events_with_execution_ref_count'] == 20
-    assert report['totals']['execution_order_events_with_filled_notional_delta_count'] == 20
-    assert report['totals']['tca_cost_row_count'] == 20
-    assert report['totals']['source_window_count'] == 20
-    assert report['totals']['runtime_ledger_bucket_count'] == 20
-    assert report['totals']['blocker_free_runtime_ledger_bucket_count'] == 20
-    assert report['totals']['closed_trade_count'] == 400
-    assert report['totals']['filled_notional'] == '12000000'
-    assert report['totals']['post_cost_pnl'] == '12000'
-    assert report['source']['runtime_stage'] == 'paper'
-    assert report['source']['replay_outputs_count_as_runtime_proof'] is False
-    assert report['source']['synthetic_proof_created'] is False
-    assert report['verdict']['next_blocker'] is None
-    assert _ladder_step(report, 'source_windows_and_refs')['status'] == census.LADDER_PASS
-    assert _ladder_step(report, 'runtime_ledger_buckets')['status'] == census.LADDER_PASS
-    assert _ladder_step(report, 'daily_post_cost_pnl')['status'] == census.LADDER_PASS
+    assert report["verdict"]["classification"] == census.AUTHORITY_CANDIDATE_READY
+    assert report["blockers"] == []
+    assert report["totals"]["trade_decision_count"] == 20
+    assert report["totals"]["execution_count"] == 20
+    assert report["totals"]["filled_execution_count"] == 20
+    assert report["totals"]["execution_order_event_count"] == 20
+    assert report["totals"]["fill_lifecycle_event_count"] == 20
+    assert report["totals"]["linked_order_event_fill_count"] == 20
+    assert report["totals"]["execution_order_events_with_execution_ref_count"] == 20
+    assert (
+        report["totals"]["execution_order_events_with_filled_notional_delta_count"]
+        == 20
+    )
+    assert report["totals"]["tca_cost_row_count"] == 20
+    assert report["totals"]["source_window_count"] == 20
+    assert report["totals"]["runtime_ledger_bucket_count"] == 20
+    assert report["totals"]["blocker_free_runtime_ledger_bucket_count"] == 20
+    assert report["totals"]["closed_trade_count"] == 400
+    assert report["totals"]["filled_notional"] == "12000000"
+    assert report["totals"]["post_cost_pnl"] == "12000"
+    assert report["source"]["runtime_stage"] == "paper"
+    assert report["source"]["replay_outputs_count_as_runtime_proof"] is False
+    assert report["source"]["synthetic_proof_created"] is False
+    assert report["verdict"]["next_blocker"] is None
+    assert (
+        _ladder_step(report, "source_windows_and_refs")["status"] == census.LADDER_PASS
+    )
+    assert (
+        _ladder_step(report, "runtime_ledger_buckets")["status"] == census.LADDER_PASS
+    )
+    assert _ladder_step(report, "daily_post_cost_pnl")["status"] == census.LADDER_PASS
 
 
 def test_missing_decisions_reports_exact_trade_decision_ref_gap() -> None:
     payload = _fixture()
-    payload['trade_decisions'] = []
-    for bucket in payload['runtime_ledger_buckets']:
-        bucket['decision_count'] = 0
-        bucket['payload']['trade_decision_ids'] = []
+    payload["trade_decisions"] = []
+    for bucket in payload["runtime_ledger_buckets"]:
+        bucket["decision_count"] = 0
+        bucket["payload"]["trade_decision_ids"] = []
 
     report = _report(payload)
 
-    assert report['verdict']['classification'] == census.LIFECYCLE_MISSING
-    assert AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER in report['blockers']
-    assert RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER in report['blockers']
-    assert report['missing_source_ref_categories'][RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER] is True
+    assert report["verdict"]["classification"] == census.LIFECYCLE_MISSING
+    assert AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER in report["blockers"]
+    assert RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER in report["blockers"]
+    assert (
+        report["missing_source_ref_categories"][
+            RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER
+        ]
+        is True
+    )
 
 
 def test_missing_executions_reports_fill_and_execution_ref_gap() -> None:
     payload = _fixture()
-    payload['executions'] = []
-    for bucket in payload['runtime_ledger_buckets']:
-        bucket['fill_count'] = 0
-        bucket['payload']['execution_ids'] = []
+    payload["executions"] = []
+    for bucket in payload["runtime_ledger_buckets"]:
+        bucket["fill_count"] = 0
+        bucket["payload"]["execution_ids"] = []
 
     report = _report(payload)
 
-    assert report['verdict']['classification'] == census.LIFECYCLE_MISSING
-    assert AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER in report['blockers']
-    assert census.RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in report['blockers']
+    assert report["verdict"]["classification"] == census.LIFECYCLE_MISSING
+    assert AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER in report["blockers"]
+    assert census.RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in report["blockers"]
 
 
-def test_missing_order_event_refs_and_source_offsets_are_exact_source_ref_gaps() -> None:
+def test_missing_order_event_refs_and_source_offsets_are_exact_source_ref_gaps() -> (
+    None
+):
     payload = _fixture()
-    for event in payload['execution_order_events']:
-        event.pop('source_offset')
-        event.pop('source_window_id')
-        event.pop('filled_notional_delta')
-    for bucket in payload['runtime_ledger_buckets']:
-        bucket['payload']['execution_order_event_ids'] = []
-        bucket['payload']['source_offsets'] = []
-        bucket['payload']['source_window_ids'] = []
+    for event in payload["execution_order_events"]:
+        event.pop("source_offset")
+        event.pop("source_window_id")
+        event.pop("filled_notional_delta")
+    for bucket in payload["runtime_ledger_buckets"]:
+        bucket["payload"]["execution_order_event_ids"] = []
+        bucket["payload"]["source_offsets"] = []
+        bucket["payload"]["source_window_ids"] = []
 
     report = _report(payload)
 
-    assert report['verdict']['classification'] == census.SOURCE_REFS_MISSING
-    assert RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER in report['blockers']
-    assert RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in report['blockers']
-    assert report['missing_source_ref_categories'][RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER] is True
+    assert report["verdict"]["classification"] == census.SOURCE_REFS_MISSING
+    assert (
+        RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER in report["blockers"]
+    )
+    assert RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER in report["blockers"]
+    assert (
+        report["missing_source_ref_categories"][
+            RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER
+        ]
+        is True
+    )
 
 
-def test_order_events_missing_execution_and_decision_refs_are_exact_source_ref_gaps() -> None:
+def test_order_events_missing_execution_and_decision_refs_are_exact_source_ref_gaps() -> (
+    None
+):
     payload = _fixture()
-    for event in payload['execution_order_events']:
-        event.pop('execution_id')
-        event.pop('trade_decision_id')
+    for event in payload["execution_order_events"]:
+        event.pop("execution_id")
+        event.pop("trade_decision_id")
 
     report = _report(payload)
 
-    assert report['verdict']['classification'] == census.SOURCE_REFS_MISSING
-    assert census.RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in report['blockers']
-    assert RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER in report['blockers']
+    assert report["verdict"]["classification"] == census.SOURCE_REFS_MISSING
+    assert census.RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in report["blockers"]
+    assert RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER in report["blockers"]
 
 
 def test_missing_tca_costs_are_economics_missing() -> None:
     payload = _fixture()
-    payload['execution_tca_metrics'] = []
-    for bucket in payload['runtime_ledger_buckets']:
-        bucket['cost_amount'] = '0'
-        bucket['cost_model_hash_counts'] = {}
-        bucket['payload']['execution_economics_complete'] = False
-        bucket['payload']['cost_basis_counts'] = {}
+    payload["execution_tca_metrics"] = []
+    for bucket in payload["runtime_ledger_buckets"]:
+        bucket["cost_amount"] = "0"
+        bucket["cost_model_hash_counts"] = {}
+        bucket["payload"]["execution_economics_complete"] = False
+        bucket["payload"]["cost_basis_counts"] = {}
 
     report = _report(payload)
 
-    assert report['verdict']['classification'] == census.ECONOMICS_MISSING
-    assert AUTHORITY_EXPLICIT_COSTS_BLOCKER in report['blockers']
-    assert census.EXECUTION_ECONOMICS_MISSING_BLOCKER in report['blockers']
+    assert report["verdict"]["classification"] == census.ECONOMICS_MISSING
+    assert AUTHORITY_EXPLICIT_COSTS_BLOCKER in report["blockers"]
+    assert census.EXECUTION_ECONOMICS_MISSING_BLOCKER in report["blockers"]
 
 
 def test_open_positions_are_called_out_after_source_and_economics_are_present() -> None:
     payload = _fixture()
-    payload['runtime_ledger_buckets'][-1] = _ledger_bucket(19, open_positions=1)
+    payload["runtime_ledger_buckets"][-1] = _ledger_bucket(19, open_positions=1)
 
     report = _report(payload)
 
-    assert report['verdict']['classification'] == census.OPEN_POSITIONS
-    assert AUTHORITY_OPEN_POSITIONS_BLOCKER in report['blockers']
-    assert report['totals']['open_position_count'] == 1
+    assert report["verdict"]["classification"] == census.OPEN_POSITIONS
+    assert AUTHORITY_OPEN_POSITIONS_BLOCKER in report["blockers"]
+    assert report["totals"]["open_position_count"] == 1
 
 
 def test_runtime_bucket_aggregate_only_is_source_refs_missing() -> None:
     report = _report(_fixture(source_backed=False))
 
-    assert report['verdict']['classification'] == census.SOURCE_REFS_MISSING
-    assert report['totals']['blocker_free_runtime_ledger_bucket_count'] == 0
-    assert census.RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER in report['blockers']
-    assert census.RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER in report['blockers']
+    assert report["verdict"]["classification"] == census.SOURCE_REFS_MISSING
+    assert report["totals"]["blocker_free_runtime_ledger_bucket_count"] == 0
+    assert census.RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER in report["blockers"]
+    assert (
+        census.RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER
+        in report["blockers"]
+    )
 
 
 def test_json_output_is_stable_and_cli_reads_fixture(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
-    path = tmp_path / 'fixture.json'
+    path = tmp_path / "fixture.json"
     path.write_text(json.dumps(_fixture()))
 
-    exit_code = census.main(['--fixture-json', str(path), '--fail-on-blockers'])
+    exit_code = census.main(["--fixture-json", str(path), "--fail-on-blockers"])
     first = capsys.readouterr().out
     report = json.loads(first)
 
     assert exit_code == 0
     assert first == census.census_json(report)
     assert list(report) == sorted(report)
-    assert report['schema_version'] == census.SCHEMA_VERSION
-    assert report['source']['read_only'] is True
-    assert report['source']['writes_proof'] is False
-    assert report['source']['modifies_rows'] is False
+    assert report["schema_version"] == census.SCHEMA_VERSION
+    assert report["source"]["read_only"] is True
+    assert report["source"]["writes_proof"] is False
+    assert report["source"]["modifies_rows"] is False
 
 
 def test_empty_fixture_has_no_source_activity_verdict() -> None:
     report = _report({})
 
-    assert report['verdict']['classification'] == census.NO_SOURCE_ACTIVITY
-    assert report['totals']['runtime_ledger_bucket_count'] == 0
-    assert _ladder_step(report, 'decisions')['status'] == census.LADDER_BLOCKED
-    assert report['verdict']['next_blocker'] == {
-        'step': 'decisions',
-        'status': census.LADDER_BLOCKED,
-        'blocker_codes': [
+    assert report["verdict"]["classification"] == census.NO_SOURCE_ACTIVITY
+    assert report["totals"]["runtime_ledger_bucket_count"] == 0
+    assert _ladder_step(report, "decisions")["status"] == census.LADDER_BLOCKED
+    assert report["verdict"]["next_blocker"] == {
+        "step": "decisions",
+        "status": census.LADDER_BLOCKED,
+        "blocker_codes": [
             AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
             RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
         ],
-        'next_action': 'run the strategy through paper/live routing until durable TradeDecision rows exist',
+        "next_action": "run the strategy through paper/live routing until durable TradeDecision rows exist",
     }
 
 
 def test_partial_evidence_ladder_points_at_order_feed_lifecycle() -> None:
     full = _fixture()
     payload = {
-        'trade_decisions': full['trade_decisions'],
-        'executions': full['executions'],
-        'execution_order_events': [],
-        'execution_tca_metrics': [],
-        'order_feed_source_windows': [],
-        'runtime_ledger_buckets': [],
+        "trade_decisions": full["trade_decisions"],
+        "executions": full["executions"],
+        "execution_order_events": [],
+        "execution_tca_metrics": [],
+        "order_feed_source_windows": [],
+        "runtime_ledger_buckets": [],
     }
 
     report = _report(payload)
 
-    assert _ladder_step(report, 'decisions')['status'] == census.LADDER_PASS
-    assert _ladder_step(report, 'executions')['status'] == census.LADDER_PASS
-    assert _ladder_step(report, 'order_feed_lifecycle')['status'] == census.LADDER_BLOCKED
-    assert report['verdict']['next_blocker']['step'] == 'order_feed_lifecycle'
-    assert census.ORDER_FEED_LIFECYCLE_MISSING_BLOCKER in report['verdict']['next_blocker']['blocker_codes']
+    assert _ladder_step(report, "decisions")["status"] == census.LADDER_PASS
+    assert _ladder_step(report, "executions")["status"] == census.LADDER_PASS
+    assert (
+        _ladder_step(report, "order_feed_lifecycle")["status"] == census.LADDER_BLOCKED
+    )
+    assert report["verdict"]["next_blocker"]["step"] == "order_feed_lifecycle"
+    assert (
+        census.ORDER_FEED_LIFECYCLE_MISSING_BLOCKER
+        in report["verdict"]["next_blocker"]["blocker_codes"]
+    )
 
 
 def test_too_few_source_backed_days_are_distribution_missing() -> None:
     report = _report(_fixture(days=5))
 
-    assert report['verdict']['classification'] == census.AUTHORITY_DISTRIBUTION_MISSING
-    assert census.AUTHORITY_TRADING_DAYS_BLOCKER in report['blockers']
+    assert report["verdict"]["classification"] == census.AUTHORITY_DISTRIBUTION_MISSING
+    assert census.AUTHORITY_TRADING_DAYS_BLOCKER in report["blockers"]
 
 
 def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -389,68 +433,68 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
     start = datetime(2026, 5, 1, 14, tzinfo=timezone.utc)
     end = start + timedelta(hours=7)
     decision = SimpleNamespace(
-        id='decision-0',
-        strategy_id='strategy-0',
+        id="decision-0",
+        strategy_id="strategy-0",
         alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
-        symbol='AAA',
-        status='executed',
-        decision_hash='decision-hash',
+        symbol="AAA",
+        status="executed",
+        decision_hash="decision-hash",
         created_at=start,
         executed_at=start + timedelta(minutes=1),
     )
     execution = SimpleNamespace(
-        id='execution-0',
-        trade_decision_id='decision-0',
+        id="execution-0",
+        trade_decision_id="decision-0",
         alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
-        alpaca_order_id='order-0',
-        client_order_id='decision-hash',
-        symbol='AAA',
-        side='buy',
-        status='filled',
-        filled_qty='10',
-        avg_fill_price='100',
+        alpaca_order_id="order-0",
+        client_order_id="decision-hash",
+        symbol="AAA",
+        side="buy",
+        status="filled",
+        filled_qty="10",
+        avg_fill_price="100",
         created_at=start + timedelta(minutes=2),
         updated_at=start + timedelta(minutes=3),
         order_feed_last_event_ts=start + timedelta(minutes=3),
     )
     event = SimpleNamespace(
-        id='event-0',
-        source_topic='alpaca.trade_updates',
+        id="event-0",
+        source_topic="alpaca.trade_updates",
         source_partition=0,
         source_offset=11,
         alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
         event_ts=start + timedelta(minutes=3),
         created_at=start + timedelta(minutes=3),
-        symbol='AAA',
-        alpaca_order_id='order-0',
-        client_order_id='decision-hash',
-        event_type='fill',
-        status='filled',
-        filled_qty='10',
-        filled_qty_delta='10',
-        avg_fill_price='100',
-        filled_notional_delta='1000',
-        execution_id='execution-0',
-        trade_decision_id='decision-0',
-        source_window_id='window-0',
+        symbol="AAA",
+        alpaca_order_id="order-0",
+        client_order_id="decision-hash",
+        event_type="fill",
+        status="filled",
+        filled_qty="10",
+        filled_qty_delta="10",
+        avg_fill_price="100",
+        filled_notional_delta="1000",
+        execution_id="execution-0",
+        trade_decision_id="decision-0",
+        source_window_id="window-0",
     )
     tca = SimpleNamespace(
-        id='tca-0',
-        execution_id='execution-0',
-        trade_decision_id='decision-0',
-        strategy_id='strategy-0',
+        id="tca-0",
+        execution_id="execution-0",
+        trade_decision_id="decision-0",
+        strategy_id="strategy-0",
         alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
-        symbol='AAA',
-        side='buy',
-        filled_qty='10',
-        shortfall_notional='1',
-        realized_shortfall_bps='1',
+        symbol="AAA",
+        side="buy",
+        filled_qty="10",
+        shortfall_notional="1",
+        realized_shortfall_bps="1",
         computed_at=start + timedelta(minutes=4),
     )
     source_window = SimpleNamespace(
-        id='window-0',
-        consumer_group='torghut-order-feed',
-        source_topic='alpaca.trade_updates',
+        id="window-0",
+        consumer_group="torghut-order-feed",
+        source_topic="alpaca.trade_updates",
         source_partition=0,
         alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
         window_started_at=start,
@@ -460,19 +504,19 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
         consumed_count=2,
         inserted_count=1,
         gap_count=0,
-        status='complete',
+        status="complete",
     )
     ledger_bucket = SimpleNamespace(
-        row_id='ledger-0',
-        run_id='run-0',
+        row_id="ledger-0",
+        run_id="run-0",
         candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
         hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
-        observed_stage='paper',
+        observed_stage="paper",
         bucket_started_at=start,
         bucket_ended_at=end,
         account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
         runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
-        strategy_family='pairs',
+        strategy_family="pairs",
         fill_count=20,
         decision_count=20,
         submitted_order_count=20,
@@ -481,16 +525,16 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
         unfilled_order_count=0,
         closed_trade_count=20,
         open_position_count=0,
-        filled_notional='600000',
-        gross_strategy_pnl='610',
-        cost_amount='10',
-        net_strategy_pnl_after_costs='600',
-        post_cost_expectancy_bps='10',
+        filled_notional="600000",
+        gross_strategy_pnl="610",
+        cost_amount="10",
+        net_strategy_pnl_after_costs="600",
+        post_cost_expectancy_bps="10",
         ledger_schema_version=EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
         pnl_basis=POST_COST_PNL_BASIS,
-        execution_policy_hash_counts={'policy': 1},
-        cost_model_hash_counts={'cost': 1},
-        lineage_hash_counts={'lineage': 1},
+        execution_policy_hash_counts={"policy": 1},
+        cost_model_hash_counts={"cost": 1},
+        lineage_hash_counts={"lineage": 1},
         blockers=(),
         payload=_source_payload(0),
     )
@@ -518,7 +562,9 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
             assert statement is not None
             return ScalarResult(self.scalar_results.pop(0))
 
-    monkeypatch.setattr(census, 'load_runtime_authority_rows', lambda *args, **kwargs: [ledger_bucket])
+    monkeypatch.setattr(
+        census, "load_runtime_authority_rows", lambda *args, **kwargs: [ledger_bucket]
+    )
 
     rows = census._load_session_rows(
         FakeSession(),  # type: ignore[arg-type]
@@ -527,18 +573,18 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
             candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
             runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
             account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
-            observed_stage='paper',
+            observed_stage="paper",
         ),
         started_at=start,
         ended_at=end,
     )
 
-    assert rows.trade_decisions[0]['id'] == 'decision-0'
-    assert rows.executions[0]['id'] == 'execution-0'
-    assert rows.execution_order_events[0]['source_offset'] == 11
-    assert rows.execution_tca_metrics[0]['id'] == 'tca-0'
-    assert rows.order_feed_source_windows[0]['id'] == 'window-0'
-    assert rows.runtime_ledger_buckets[0]['id'] == 'ledger-0'
+    assert rows.trade_decisions[0]["id"] == "decision-0"
+    assert rows.executions[0]["id"] == "execution-0"
+    assert rows.execution_order_events[0]["source_offset"] == 11
+    assert rows.execution_tca_metrics[0]["id"] == "tca-0"
+    assert rows.order_feed_source_windows[0]["id"] == "window-0"
+    assert rows.runtime_ledger_buckets[0]["id"] == "ledger-0"
 
 
 def test_dsn_loader_opens_session_and_delegates(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -547,50 +593,52 @@ def test_dsn_loader_opens_session_and_delegates(monkeypatch) -> None:  # type: i
         candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
         runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
         account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
-        observed_stage='paper',
+        observed_stage="paper",
     )
-    expected = census.CensusSourceRows(trade_decisions=[{'id': 'decision'}])
+    expected = census.CensusSourceRows(trade_decisions=[{"id": "decision"}])
 
     class FakeSession:
-        def __enter__(self) -> 'FakeSession':
+        def __enter__(self) -> "FakeSession":
             return self
 
         def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
             return None
 
-    monkeypatch.setattr(census, 'create_engine', lambda dsn: f'engine:{dsn}')
-    monkeypatch.setattr(census, 'sessionmaker', lambda bind: lambda: FakeSession())
-    monkeypatch.setattr(census, '_load_session_rows', lambda *args, **kwargs: expected)
+    monkeypatch.setattr(census, "create_engine", lambda dsn: f"engine:{dsn}")
+    monkeypatch.setattr(census, "sessionmaker", lambda bind: lambda: FakeSession())
+    monkeypatch.setattr(census, "_load_session_rows", lambda *args, **kwargs: expected)
 
-    rows = census.load_dsn_rows('sqlite:///:memory:', identity=identity, started_at=None, ended_at=None)
+    rows = census.load_dsn_rows(
+        "sqlite:///:memory:", identity=identity, started_at=None, ended_at=None
+    )
 
     assert rows is expected
 
 
 def test_main_reports_read_errors_as_json(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
-    missing = tmp_path / 'missing.json'
+    missing = tmp_path / "missing.json"
 
-    exit_code = census.main(['--fixture-json', str(missing)])
+    exit_code = census.main(["--fixture-json", str(missing)])
     payload = json.loads(capsys.readouterr().out)
 
     assert exit_code == 0
-    assert 'source_proof_census_read_error' in payload['blockers']
-    assert payload['verdict']['classification'] == census.NO_SOURCE_ACTIVITY
+    assert "source_proof_census_read_error" in payload["blockers"]
+    assert payload["verdict"]["classification"] == census.NO_SOURCE_ACTIVITY
 
 
 def test_normalizers_fail_closed_on_invalid_shapes() -> None:
-    assert census._row_list({'not': 'a list'}) == []
+    assert census._row_list({"not": "a list"}) == []
     assert census._parse_cli_timestamp(None) is None
-    assert census._parse_timestamp('not-a-timestamp') is None
-    assert census._sequence('not-a-sequence') == ()
-    assert census._mapping('not-a-mapping') == {}
-    assert census._int('not-an-int') == 0
-    assert census._decimal('not-a-decimal') == 0
+    assert census._parse_timestamp("not-a-timestamp") is None
+    assert census._sequence("not-a-sequence") == ()
+    assert census._mapping("not-a-mapping") == {}
+    assert census._int("not-an-int") == 0
+    assert census._decimal("not-a-decimal") == 0
     assert census._utc(datetime(2026, 5, 1)).tzinfo is timezone.utc
 
     try:
-        census._parse_cli_timestamp('not-a-timestamp')
+        census._parse_cli_timestamp("not-a-timestamp")
     except ValueError as exc:
-        assert 'invalid timestamp' in str(exc)
+        assert "invalid timestamp" in str(exc)
     else:  # pragma: no cover
-        raise AssertionError('invalid timestamp should fail')
+        raise AssertionError("invalid timestamp should fail")

--- a/services/torghut/tests/test_verify_hpairs_runtime_authority.py
+++ b/services/torghut/tests/test_verify_hpairs_runtime_authority.py
@@ -15,6 +15,7 @@ from app.trading.runtime_authority_verifier import (
     AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER,
     AUTHORITY_BUCKET_BLOCKERS_PRESENT,
     AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER,
+    AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER,
     AUTHORITY_COST_MODEL_HASH_BLOCKER,
     AUTHORITY_EVIDENCE_MISSING_BLOCKER,
     AUTHORITY_EXPLICIT_COSTS_BLOCKER,
@@ -46,131 +47,165 @@ from app.trading.runtime_authority_verifier import (
     load_runtime_authority_rows,
     runtime_authority_report_json,
 )
-from app.trading.runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
+from app.trading.runtime_ledger import (
+    EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+    POST_COST_PNL_BASIS,
+)
 from scripts import verify_hpairs_runtime_authority as cli
 
 
 def _source_payload(day_index: int) -> dict[str, object]:
     return {
-        'source_window_start': f'2026-05-{day_index + 1:02d}T14:30:00Z',
-        'source_window_end': f'2026-05-{day_index + 1:02d}T21:00:00Z',
-        'source_refs': [
-            'postgres:trade_decisions',
-            'postgres:executions',
-            'postgres:execution_order_events',
-            'postgres:order_feed_source_windows',
+        "source_window_start": f"2026-05-{day_index + 1:02d}T14:30:00Z",
+        "source_window_end": f"2026-05-{day_index + 1:02d}T21:00:00Z",
+        "source_refs": [
+            "postgres:trade_decisions",
+            "postgres:executions",
+            "postgres:execution_order_events",
+            "postgres:order_feed_source_windows",
         ],
-        'source_row_counts': {
-            'trade_decisions': 20,
-            'executions': 20,
-            'execution_order_events': 20,
-            'order_feed_source_windows': 20,
+        "source_row_counts": {
+            "trade_decisions": 20,
+            "executions": 20,
+            "execution_order_events": 20,
+            "order_feed_source_windows": 20,
         },
-        'trade_decision_ids': [f'decision-{day_index}-{item}' for item in range(20)],
-        'execution_ids': [f'execution-{day_index}-{item}' for item in range(20)],
-        'execution_order_event_ids': [f'event-{day_index}-{item}' for item in range(20)],
-        'source_window_ids': [f'window-{day_index}-{item}' for item in range(20)],
-        'source_offsets': [
-            {'topic': 'alpaca.trade_updates', 'partition': 0, 'offset': day_index * 100 + item}
+        "trade_decision_ids": [f"decision-{day_index}-{item}" for item in range(20)],
+        "execution_ids": [f"execution-{day_index}-{item}" for item in range(20)],
+        "execution_order_event_ids": [
+            f"event-{day_index}-{item}" for item in range(20)
+        ],
+        "source_window_ids": [f"window-{day_index}-{item}" for item in range(20)],
+        "source_offsets": [
+            {
+                "topic": "alpaca.trade_updates",
+                "partition": 0,
+                "offset": day_index * 100 + item,
+            }
             for item in range(20)
         ],
-        'source_materialization': 'execution_order_events',
-        'authority_class': 'runtime_order_feed_execution_source',
-        'order_feed_lifecycle_complete': True,
-        'execution_economics_complete': True,
-        'cost_basis_counts': {'explicit_broker_fee_runtime': 20},
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
+        "order_feed_lifecycle_complete": True,
+        "execution_economics_complete": True,
+        "cost_basis_counts": {"explicit_broker_fee_runtime": 20},
     }
 
 
-def _row(day_index: int, *, pnl: str = '600', open_positions: int = 0, source_backed: bool = True) -> dict[str, object]:
+def _row(
+    day_index: int,
+    *,
+    pnl: str = "600",
+    open_positions: int = 0,
+    source_backed: bool = True,
+    closed_trade_count: int = 20,
+    filled_notional: str = "600000",
+    blockers: list[str] | None = None,
+) -> dict[str, object]:
     start = datetime(2026, 5, 1, tzinfo=timezone.utc) + timedelta(days=day_index)
     payload = _source_payload(day_index) if source_backed else {}
     return {
-        'id': f'row-{day_index:02d}',
-        'run_id': 'runtime-run',
-        'candidate_id': DEFAULT_HPAIRS_CANDIDATE_ID,
-        'hypothesis_id': DEFAULT_HPAIRS_HYPOTHESIS_ID,
-        'observed_stage': 'paper',
-        'bucket_started_at': start,
-        'bucket_ended_at': start + timedelta(hours=6),
-        'account_label': DEFAULT_HPAIRS_ACCOUNT_LABEL,
-        'runtime_strategy_name': DEFAULT_HPAIRS_RUNTIME_STRATEGY,
-        'strategy_family': 'pairs',
-        'fill_count': 20,
-        'decision_count': 20,
-        'submitted_order_count': 20,
-        'cancelled_order_count': 0,
-        'rejected_order_count': 0,
-        'unfilled_order_count': 0,
-        'closed_trade_count': 20,
-        'open_position_count': open_positions,
-        'filled_notional': Decimal('600000'),
-        'gross_strategy_pnl': Decimal(pnl) + Decimal('10'),
-        'cost_amount': Decimal('10'),
-        'net_strategy_pnl_after_costs': Decimal(pnl),
-        'post_cost_expectancy_bps': Decimal('10'),
-        'ledger_schema_version': EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
-        'pnl_basis': POST_COST_PNL_BASIS,
-        'execution_policy_hash_counts': {'policy-hash': 20},
-        'cost_model_hash_counts': {'cost-hash': 20},
-        'lineage_hash_counts': {'lineage-hash': 20},
-        'blockers': [],
-        'payload': payload,
+        "id": f"row-{day_index:02d}",
+        "run_id": "runtime-run",
+        "candidate_id": DEFAULT_HPAIRS_CANDIDATE_ID,
+        "hypothesis_id": DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        "observed_stage": "paper",
+        "bucket_started_at": start,
+        "bucket_ended_at": start + timedelta(hours=6),
+        "account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        "runtime_strategy_name": DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        "strategy_family": "pairs",
+        "fill_count": 20,
+        "decision_count": 20,
+        "submitted_order_count": 20,
+        "cancelled_order_count": 0,
+        "rejected_order_count": 0,
+        "unfilled_order_count": 0,
+        "closed_trade_count": closed_trade_count,
+        "open_position_count": open_positions,
+        "filled_notional": Decimal(filled_notional),
+        "gross_strategy_pnl": Decimal(pnl) + Decimal("10"),
+        "cost_amount": Decimal("10"),
+        "net_strategy_pnl_after_costs": Decimal(pnl),
+        "post_cost_expectancy_bps": Decimal("10"),
+        "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        "pnl_basis": POST_COST_PNL_BASIS,
+        "execution_policy_hash_counts": {"policy-hash": 20},
+        "cost_model_hash_counts": {"cost-hash": 20},
+        "lineage_hash_counts": {"lineage-hash": 20},
+        "blockers": [] if blockers is None else blockers,
+        "payload": payload,
     }
 
 
 def _bucket(day_index: int) -> SimpleNamespace:
     row = _row(day_index)
     return SimpleNamespace(
-        id=row['id'],
-        run_id=row['run_id'],
-        candidate_id=row['candidate_id'],
-        hypothesis_id=row['hypothesis_id'],
-        observed_stage=row['observed_stage'],
-        bucket_started_at=row['bucket_started_at'],
-        bucket_ended_at=row['bucket_ended_at'],
-        account_label=row['account_label'],
-        runtime_strategy_name=row['runtime_strategy_name'],
-        strategy_family=row['strategy_family'],
-        fill_count=row['fill_count'],
-        decision_count=row['decision_count'],
-        submitted_order_count=row['submitted_order_count'],
-        cancelled_order_count=row['cancelled_order_count'],
-        rejected_order_count=row['rejected_order_count'],
-        unfilled_order_count=row['unfilled_order_count'],
-        closed_trade_count=row['closed_trade_count'],
-        open_position_count=row['open_position_count'],
-        filled_notional=row['filled_notional'],
-        gross_strategy_pnl=row['gross_strategy_pnl'],
-        cost_amount=row['cost_amount'],
-        net_strategy_pnl_after_costs=row['net_strategy_pnl_after_costs'],
-        post_cost_expectancy_bps=row['post_cost_expectancy_bps'],
-        ledger_schema_version=row['ledger_schema_version'],
-        pnl_basis=row['pnl_basis'],
-        execution_policy_hash_counts=row['execution_policy_hash_counts'],
-        cost_model_hash_counts=row['cost_model_hash_counts'],
-        lineage_hash_counts=row['lineage_hash_counts'],
-        blockers_json=row['blockers'],
-        payload_json=row['payload'],
-        created_at=row['bucket_started_at'],
-        updated_at=row['bucket_ended_at'],
+        id=row["id"],
+        run_id=row["run_id"],
+        candidate_id=row["candidate_id"],
+        hypothesis_id=row["hypothesis_id"],
+        observed_stage=row["observed_stage"],
+        bucket_started_at=row["bucket_started_at"],
+        bucket_ended_at=row["bucket_ended_at"],
+        account_label=row["account_label"],
+        runtime_strategy_name=row["runtime_strategy_name"],
+        strategy_family=row["strategy_family"],
+        fill_count=row["fill_count"],
+        decision_count=row["decision_count"],
+        submitted_order_count=row["submitted_order_count"],
+        cancelled_order_count=row["cancelled_order_count"],
+        rejected_order_count=row["rejected_order_count"],
+        unfilled_order_count=row["unfilled_order_count"],
+        closed_trade_count=row["closed_trade_count"],
+        open_position_count=row["open_position_count"],
+        filled_notional=row["filled_notional"],
+        gross_strategy_pnl=row["gross_strategy_pnl"],
+        cost_amount=row["cost_amount"],
+        net_strategy_pnl_after_costs=row["net_strategy_pnl_after_costs"],
+        post_cost_expectancy_bps=row["post_cost_expectancy_bps"],
+        ledger_schema_version=row["ledger_schema_version"],
+        pnl_basis=row["pnl_basis"],
+        execution_policy_hash_counts=row["execution_policy_hash_counts"],
+        cost_model_hash_counts=row["cost_model_hash_counts"],
+        lineage_hash_counts=row["lineage_hash_counts"],
+        blockers_json=row["blockers"],
+        payload_json=row["payload"],
+        created_at=row["bucket_started_at"],
+        updated_at=row["bucket_ended_at"],
     )
 
 
 def test_empty_evidence_is_blocked() -> None:
     report = build_runtime_authority_report([])
 
-    assert report['final_authority_ok'] is False
-    assert AUTHORITY_EVIDENCE_MISSING_BLOCKER in report['blockers']
-    assert AUTHORITY_TRADING_DAYS_BLOCKER in report['blockers']
-    assert report['trading_days'] == []
+    assert report["final_authority_ok"] is False
+    assert report["authority_allowed"] is False
+    assert report["capital_promotion_allowed"] is False
+    assert AUTHORITY_EVIDENCE_MISSING_BLOCKER in report["blockers"]
+    assert AUTHORITY_TRADING_DAYS_BLOCKER in report["blockers"]
+    assert report["evidence_source"] == {
+        "table": "strategy_runtime_ledger_buckets",
+        "writes_performed": False,
+        "synthetic_or_replay_only_authority_allowed": False,
+    }
+    assert report["trading_days"] == []
 
 
 def test_aggregate_only_bucket_is_blocked() -> None:
     report = build_runtime_authority_report([_row(0, source_backed=False)])
 
-    blockers = set(report['blockers'])
-    assert report['final_authority_ok'] is False
+    blockers = set(report["blockers"])
+    assert report["final_authority_ok"] is False
+    assert report["aggregate"]["clean_authority_bucket_count"] == 0
+    assert (
+        report["aggregate"]["clean_authority_total_net_strategy_pnl_after_costs"] == "0"
+    )
+    assert report["aggregate"]["total_net_strategy_pnl_after_costs"] == "600"
+    assert (
+        report["aggregate"]["raw_runtime_ledger_total_net_strategy_pnl_after_costs"]
+        == "600"
+    )
     assert RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER in blockers
     assert RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER in blockers
     assert RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER in blockers
@@ -193,34 +228,34 @@ def test_bucket_loader_applies_identity_and_window_filters() -> None:
     session = FakeSession()
     rows = load_runtime_authority_rows(
         session,  # type: ignore[arg-type]
-        observed_stage='paper',
+        observed_stage="paper",
         started_at=datetime(2026, 5, 1, 12, 0),
         ended_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
     )
 
     assert len(rows) == 1
-    assert rows[0].row_id == 'row-00'
+    assert rows[0].row_id == "row-00"
     assert rows[0].bucket_started_at.tzinfo is timezone.utc
     assert session.statement is not None
 
 
 def test_runtime_authority_row_instances_are_accepted() -> None:
     dict_report = build_runtime_authority_report([_row(0)])
-    row_payload = dict_report['trading_days'][0]
-    assert row_payload['row_refs'] == ['row-00']
+    row_payload = dict_report["trading_days"][0]
+    assert row_payload["row_refs"] == ["row-00"]
 
     row_data = _row(0)
     row = RuntimeAuthorityEvidenceRow(
-        row_id=str(row_data['id']),
-        run_id=str(row_data['run_id']),
-        candidate_id=str(row_data['candidate_id']),
-        hypothesis_id=str(row_data['hypothesis_id']),
-        observed_stage=str(row_data['observed_stage']),
-        bucket_started_at=row_data['bucket_started_at'],  # type: ignore[arg-type]
-        bucket_ended_at=row_data['bucket_ended_at'],  # type: ignore[arg-type]
-        account_label=str(row_data['account_label']),
-        runtime_strategy_name=str(row_data['runtime_strategy_name']),
-        strategy_family=str(row_data['strategy_family']),
+        row_id=str(row_data["id"]),
+        run_id=str(row_data["run_id"]),
+        candidate_id=str(row_data["candidate_id"]),
+        hypothesis_id=str(row_data["hypothesis_id"]),
+        observed_stage=str(row_data["observed_stage"]),
+        bucket_started_at=row_data["bucket_started_at"],  # type: ignore[arg-type]
+        bucket_ended_at=row_data["bucket_ended_at"],  # type: ignore[arg-type]
+        account_label=str(row_data["account_label"]),
+        runtime_strategy_name=str(row_data["runtime_strategy_name"]),
+        strategy_family=str(row_data["strategy_family"]),
         fill_count=20,
         decision_count=20,
         submitted_order_count=20,
@@ -229,48 +264,48 @@ def test_runtime_authority_row_instances_are_accepted() -> None:
         unfilled_order_count=0,
         closed_trade_count=20,
         open_position_count=0,
-        filled_notional=Decimal('600000'),
-        gross_strategy_pnl=Decimal('610'),
-        cost_amount=Decimal('10'),
-        net_strategy_pnl_after_costs=Decimal('600'),
-        post_cost_expectancy_bps=Decimal('10'),
+        filled_notional=Decimal("600000"),
+        gross_strategy_pnl=Decimal("610"),
+        cost_amount=Decimal("10"),
+        net_strategy_pnl_after_costs=Decimal("600"),
+        post_cost_expectancy_bps=Decimal("10"),
         ledger_schema_version=EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
         pnl_basis=POST_COST_PNL_BASIS,
-        execution_policy_hash_counts={'policy-hash': 20},
-        cost_model_hash_counts={'cost-hash': 20},
-        lineage_hash_counts={'lineage-hash': 20},
+        execution_policy_hash_counts={"policy-hash": 20},
+        cost_model_hash_counts={"cost-hash": 20},
+        lineage_hash_counts={"lineage-hash": 20},
         blockers=(),
-        payload=row_data['payload'],  # type: ignore[arg-type]
+        payload=row_data["payload"],  # type: ignore[arg-type]
     )
     object_report = build_runtime_authority_report([row])
 
-    assert object_report['trading_days'][0]['row_refs'] == ['row-00']
+    assert object_report["trading_days"][0]["row_refs"] == ["row-00"]
 
 
 def test_bad_runtime_bucket_surfaces_all_row_level_blockers() -> None:
     bad_row = _row(0)
     bad_row.update(
         {
-            'fill_count': 0,
-            'decision_count': 0,
-            'submitted_order_count': 0,
-            'closed_trade_count': 0,
-            'filled_notional': Decimal('0'),
-            'ledger_schema_version': 'synthetic-schema',
-            'pnl_basis': 'gross_only',
-            'execution_policy_hash_counts': {},
-            'cost_model_hash_counts': {},
-            'lineage_hash_counts': {'lineage-hash': 0},
-            'blockers': ['source_bucket_has_prior_blocker'],
-            'payload': {
+            "fill_count": 0,
+            "decision_count": 0,
+            "submitted_order_count": 0,
+            "closed_trade_count": 0,
+            "filled_notional": Decimal("0"),
+            "ledger_schema_version": "synthetic-schema",
+            "pnl_basis": "gross_only",
+            "execution_policy_hash_counts": {},
+            "cost_model_hash_counts": {},
+            "lineage_hash_counts": {"lineage-hash": 0},
+            "blockers": ["source_bucket_has_prior_blocker"],
+            "payload": {
                 **_source_payload(0),
-                'cost_basis': 'execution_reconstructed_non_promotion_grade',
+                "cost_basis": "execution_reconstructed_non_promotion_grade",
             },
         }
     )
 
     report = build_runtime_authority_report([bad_row])
-    blockers = set(report['blockers'])
+    blockers = set(report["blockers"])
 
     assert AUTHORITY_BUCKET_BLOCKERS_PRESENT in blockers
     assert AUTHORITY_LEDGER_SCHEMA_BLOCKER in blockers
@@ -288,67 +323,156 @@ def test_bad_runtime_bucket_surfaces_all_row_level_blockers() -> None:
 
 def test_source_refs_accept_mapping_and_scalar_offset_forms() -> None:
     row = _row(0)
-    row['payload'] = {
+    row["payload"] = {
         **_source_payload(0),
-        'source_refs': {'trade_decisions': True, 'ignored': False, 'executions': 'custom-exec-ref'},
-        'source_window_ids': {'primary': True, 'secondary': 'window-explicit'},
-        'trade_decision_ids': {'one': 'decision-explicit'},
-        'execution_ids': {'execution-explicit': True},
-        'execution_order_event_ids': {'event': None, 'event-explicit': True},
-        'source_offsets': {'topic': 'alpaca.trade_updates', 'partition': 0, 'offset': 123},
+        "source_refs": {
+            "trade_decisions": True,
+            "ignored": False,
+            "executions": "custom-exec-ref",
+        },
+        "source_window_ids": {"primary": True, "secondary": "window-explicit"},
+        "trade_decision_ids": {"one": "decision-explicit"},
+        "execution_ids": {"execution-explicit": True},
+        "execution_order_event_ids": {"event": None, "event-explicit": True},
+        "source_offsets": {
+            "topic": "alpaca.trade_updates",
+            "partition": 0,
+            "offset": 123,
+        },
     }
     scalar_offset_row = _row(1)
     scalar_offset_payload = _source_payload(1)
-    scalar_offset_payload.pop('source_offsets')
-    scalar_offset_payload.update({'source_topic': 'alpaca.trade_updates', 'source_partition': 0, 'source_offset': 456})
-    scalar_offset_row['payload'] = scalar_offset_payload
+    scalar_offset_payload.pop("source_offsets")
+    scalar_offset_payload.update(
+        {
+            "source_topic": "alpaca.trade_updates",
+            "source_partition": 0,
+            "source_offset": 456,
+        }
+    )
+    scalar_offset_row["payload"] = scalar_offset_payload
 
     report = build_runtime_authority_report([row, scalar_offset_row])
-    daily = report['trading_days'][0]
-    scalar_daily = report['trading_days'][1]
+    daily = report["trading_days"][0]
+    scalar_daily = report["trading_days"][1]
 
-    assert daily['source_ref_count'] == 2
-    assert daily['source_window_id_count'] == 2
-    assert daily['trade_decision_ref_count'] == 1
-    assert daily['execution_ref_count'] == 1
-    assert daily['execution_order_event_ref_count'] == 1
-    assert daily['source_offset_count'] == 1
-    assert scalar_daily['source_offset_count'] == 1
+    assert daily["source_ref_count"] == 2
+    assert daily["source_window_id_count"] == 2
+    assert daily["trade_decision_ref_count"] == 1
+    assert daily["execution_ref_count"] == 1
+    assert daily["execution_order_event_ref_count"] == 1
+    assert daily["source_offset_count"] == 1
+    assert scalar_daily["source_offset_count"] == 1
 
 
 def test_invalid_normalized_values_fail_closed() -> None:
     row = _row(0)
     row.update(
         {
-            'bucket_started_at': 'not-a-date',
-            'bucket_ended_at': '2026-05-01T21:00:00Z',
+            "bucket_started_at": "not-a-date",
+            "bucket_ended_at": "2026-05-01T21:00:00Z",
         }
     )
 
-    with pytest.raises(ValueError, match='bucket_started_at_invalid'):
+    with pytest.raises(ValueError, match="bucket_started_at_invalid"):
         build_runtime_authority_report([row])
 
     invalid_number_row = _row(0)
     invalid_number_row.update(
         {
-            'fill_count': 'not-an-int',
-            'net_strategy_pnl_after_costs': 'not-a-decimal',
-            'post_cost_expectancy_bps': 'not-a-decimal',
+            "fill_count": "not-an-int",
+            "net_strategy_pnl_after_costs": "not-a-decimal",
+            "post_cost_expectancy_bps": "not-a-decimal",
         }
     )
 
     report = build_runtime_authority_report([invalid_number_row])
 
-    assert report['aggregate']['mean_daily_net_pnl_after_costs'] == '0'
-    assert AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER in report['blockers']
+    assert report["aggregate"]["mean_daily_net_pnl_after_costs"] == "0"
+    assert AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER in report["blockers"]
 
 
 def test_source_backed_too_few_days_is_blocked() -> None:
     report = build_runtime_authority_report([_row(day) for day in range(5)])
 
-    assert report['final_authority_ok'] is False
-    assert AUTHORITY_TRADING_DAYS_BLOCKER in report['blockers']
-    assert report['aggregate']['trading_day_count'] == 5
+    assert report["final_authority_ok"] is False
+    assert AUTHORITY_TRADING_DAYS_BLOCKER in report["blockers"]
+    assert report["aggregate"]["trading_day_count"] == 5
+    assert report["gaps"]["missing_trading_days"] == 15
+    assert "wait_for_more_authority_days" in report["next_actions"]
+
+
+def test_small_clean_rows_below_500_day_report_deterministic_gaps() -> None:
+    report = build_runtime_authority_report([_row(day, pnl="100") for day in range(20)])
+
+    blockers = set(report["blockers"])
+    assert report["final_authority_ok"] is False
+    assert report["authority_allowed"] is False
+    assert report["capital_promotion_allowed"] is False
+    assert AUTHORITY_MEAN_PNL_BLOCKER in blockers
+    assert report["aggregate"]["clean_authority_bucket_count"] == 20
+    assert report["aggregate"]["clean_authority_trading_day_count"] == 20
+    assert (
+        report["aggregate"]["clean_authority_mean_daily_net_pnl_after_costs"] == "100"
+    )
+    assert (
+        report["aggregate"]["clean_authority_total_net_strategy_pnl_after_costs"]
+        == "2000"
+    )
+    assert report["gaps"] == {
+        "missing_trading_days": 0,
+        "missing_clean_authority_buckets": 0,
+        "missing_net_pnl_after_costs_to_mean_floor": "8000",
+        "missing_mean_daily_net_pnl_after_costs": "400",
+        "missing_median_daily_net_pnl_after_costs": "150",
+        "missing_p10_daily_net_pnl_after_costs": "0",
+        "missing_worst_day_net_pnl_after_costs": "0",
+        "missing_closed_round_trips": 0,
+        "missing_filled_notional": "0",
+        "target_implied_notional_gap": "0",
+    }
+    assert report["next_actions"] == ["improve_clean_authority_daily_pnl"]
+
+
+def test_larger_blocked_rows_do_not_count_as_authority() -> None:
+    rows = [_row(day, pnl="100") for day in range(20)]
+    rows.extend(
+        _row(
+            day,
+            pnl="1000",
+            blockers=["unclosed_position", "runtime_ledger_pnl_basis_invalid"],
+        )
+        for day in range(20, 40)
+    )
+
+    report = build_runtime_authority_report(rows)
+
+    blockers = set(report["blockers"])
+    assert report["final_authority_ok"] is False
+    assert report["aggregate"]["bucket_count"] == 40
+    assert report["aggregate"]["runtime_ledger_trading_day_count"] == 40
+    assert report["aggregate"]["clean_authority_bucket_count"] == 20
+    assert report["aggregate"]["trading_day_count"] == 40
+    assert report["aggregate"]["clean_authority_trading_day_count"] == 20
+    assert report["aggregate"]["total_net_strategy_pnl_after_costs"] == "22000"
+    assert (
+        report["aggregate"]["clean_authority_total_net_strategy_pnl_after_costs"]
+        == "2000"
+    )
+    assert (
+        report["aggregate"]["raw_runtime_ledger_total_net_strategy_pnl_after_costs"]
+        == "22000"
+    )
+    assert report["aggregate"]["mean_daily_net_pnl_after_costs"] == "550"
+    assert (
+        report["aggregate"]["clean_authority_mean_daily_net_pnl_after_costs"] == "100"
+    )
+    assert AUTHORITY_BUCKET_BLOCKERS_PRESENT in blockers
+    assert "unclosed_position" in blockers
+    assert "runtime_ledger_pnl_basis_invalid" in blockers
+    assert report["gaps"]["missing_net_pnl_after_costs_to_mean_floor"] == "8000"
+    assert "flatten_open_positions" in report["next_actions"]
+    assert "repair_runtime_pnl_basis" in report["next_actions"]
 
 
 def test_open_positions_are_blocked() -> None:
@@ -357,57 +481,103 @@ def test_open_positions_are_blocked() -> None:
 
     report = build_runtime_authority_report(rows)
 
-    assert report['final_authority_ok'] is False
-    assert AUTHORITY_OPEN_POSITIONS_BLOCKER in report['blockers']
-    assert report['aggregate']['open_position_count'] == 1
+    assert report["final_authority_ok"] is False
+    assert AUTHORITY_OPEN_POSITIONS_BLOCKER in report["blockers"]
+    assert report["aggregate"]["open_position_count"] == 1
+    assert report["aggregate"]["clean_authority_bucket_count"] == 19
+    assert report["gaps"]["missing_trading_days"] == 1
+    assert "flatten_open_positions" in report["next_actions"]
 
 
-def test_distribution_risk_gates_are_blocked() -> None:
-    rows = [_row(day, pnl='600') for day in range(20)]
-    rows[0] = _row(0, pnl='8000')
-    rows[1] = _row(1, pnl='-1200')
-    rows[2] = _row(2, pnl='-500')
-    for day in range(3, 20):
-        rows[day] = _row(day, pnl='100')
+def test_source_refs_missing_and_open_positions_fail_closed_with_specific_actions() -> (
+    None
+):
+    rows = [_row(day) for day in range(20)]
+    rows[0] = _row(
+        0,
+        source_backed=False,
+        open_positions=1,
+        closed_trade_count=0,
+        filled_notional="0",
+    )
 
     report = build_runtime_authority_report(rows)
 
-    blockers = set(report['blockers'])
-    assert report['final_authority_ok'] is False
+    blockers = set(report["blockers"])
+    assert report["final_authority_ok"] is False
+    assert report["authority_allowed"] is False
+    assert report["capital_promotion_allowed"] is False
+    assert RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER in blockers
+    assert AUTHORITY_OPEN_POSITIONS_BLOCKER in blockers
+    assert AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER in blockers
+    assert report["aggregate"]["clean_authority_bucket_count"] == 19
+    assert report["aggregate"]["closed_round_trips"] == 380
+    assert report["aggregate"]["total_filled_notional"] == "11400000"
+    assert report["gaps"]["missing_trading_days"] == 1
+    assert report["gaps"]["missing_filled_notional"] == "0"
+    assert "repair_order_feed_linkage" in report["next_actions"]
+    assert "flatten_open_positions" in report["next_actions"]
+
+
+def test_closed_round_trip_gap_is_deterministic_and_actionable() -> None:
+    report = build_runtime_authority_report(
+        [_row(day, closed_trade_count=5) for day in range(20)]
+    )
+
+    assert report["final_authority_ok"] is False
+    assert AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER in report["blockers"]
+    assert report["aggregate"]["clean_authority_bucket_count"] == 20
+    assert report["aggregate"]["closed_round_trips"] == 100
+    assert report["gaps"]["missing_closed_round_trips"] == 200
+    assert "collect_closed_round_trips" in report["next_actions"]
+
+
+def test_distribution_risk_gates_are_blocked() -> None:
+    rows = [_row(day, pnl="600") for day in range(20)]
+    rows[0] = _row(0, pnl="8000")
+    rows[1] = _row(1, pnl="-1200")
+    rows[2] = _row(2, pnl="-500")
+    for day in range(3, 20):
+        rows[day] = _row(day, pnl="100")
+
+    report = build_runtime_authority_report(rows)
+
+    blockers = set(report["blockers"])
+    assert report["final_authority_ok"] is False
     assert AUTHORITY_MEAN_PNL_BLOCKER in blockers
     assert AUTHORITY_P10_PNL_BLOCKER in blockers
     assert AUTHORITY_WORST_DAY_BLOCKER in blockers
     assert AUTHORITY_BEST_DAY_CONCENTRATION_BLOCKER in blockers
-    assert report['aggregate']['max_drawdown'] == '1700'
+    assert report["aggregate"]["max_drawdown"] == "1700"
 
 
 def test_row_level_runtime_authority_blockers_are_reported() -> None:
     row = _row(0)
     row.update(
         {
-            'fill_count': 0,
-            'decision_count': 0,
-            'submitted_order_count': 0,
-            'closed_trade_count': 0,
-            'open_position_count': 1,
-            'filled_notional': 0,
-            'ledger_schema_version': 'artifact-only',
-            'pnl_basis': 'gross_strategy_pnl',
-            'execution_policy_hash_counts': {},
-            'cost_model_hash_counts': {},
-            'lineage_hash_counts': {},
-            'blockers': ['upstream_bucket_blocker'],
-            'payload': {
+            "fill_count": 0,
+            "decision_count": 0,
+            "submitted_order_count": 0,
+            "closed_trade_count": 0,
+            "open_position_count": 1,
+            "filled_notional": 0,
+            "ledger_schema_version": "artifact-only",
+            "pnl_basis": "gross_strategy_pnl",
+            "execution_policy_hash_counts": {},
+            "cost_model_hash_counts": {},
+            "lineage_hash_counts": {},
+            "blockers": ["upstream_bucket_blocker"],
+            "payload": {
                 **_source_payload(0),
-                'cost_basis': 'synthetic_estimated_costs',
-                'cost_basis_counts': {'synthetic_estimated_costs': 1},
+                "cost_basis": "synthetic_estimated_costs",
+                "cost_basis_counts": {"synthetic_estimated_costs": 1},
             },
         }
     )
 
     report = build_runtime_authority_report([row])
 
-    blockers = set(report['blockers'])
+    blockers = set(report["blockers"])
     assert AUTHORITY_BUCKET_BLOCKERS_PRESENT in blockers
     assert AUTHORITY_LEDGER_SCHEMA_BLOCKER in blockers
     assert AUTHORITY_PNL_BASIS_BLOCKER in blockers
@@ -419,7 +589,7 @@ def test_row_level_runtime_authority_blockers_are_reported() -> None:
     assert AUTHORITY_POLICY_HASH_BLOCKER in blockers
     assert AUTHORITY_COST_MODEL_HASH_BLOCKER in blockers
     assert AUTHORITY_LINEAGE_HASH_BLOCKER in blockers
-    assert 'upstream_bucket_blocker' in blockers
+    assert "upstream_bucket_blocker" in blockers
 
 
 def test_ref_counting_accepts_mapping_and_scalar_offset_shapes() -> None:
@@ -427,39 +597,50 @@ def test_ref_counting_accepts_mapping_and_scalar_offset_shapes() -> None:
     payload = _source_payload(0)
     payload.update(
         {
-            'source_window_ids': {'window-a': True, 'window-b': False, 'window-c': 'window-c-alias'},
-            'trade_decision_ids': {'decision-a': True, 'decision-b': 'decision-b-alias'},
-            'execution_ids': {'execution-a': True},
-            'execution_order_event_ids': {'event-a': True},
-            'source_refs': {'orders': True, 'ignored': False},
-            'source_offsets': {'topic': 'alpaca.trade_updates', 'partition': 0, 'offset': 33},
+            "source_window_ids": {
+                "window-a": True,
+                "window-b": False,
+                "window-c": "window-c-alias",
+            },
+            "trade_decision_ids": {
+                "decision-a": True,
+                "decision-b": "decision-b-alias",
+            },
+            "execution_ids": {"execution-a": True},
+            "execution_order_event_ids": {"event-a": True},
+            "source_refs": {"orders": True, "ignored": False},
+            "source_offsets": {
+                "topic": "alpaca.trade_updates",
+                "partition": 0,
+                "offset": 33,
+            },
         }
     )
-    row['payload'] = payload
+    row["payload"] = payload
 
     report = build_runtime_authority_report([row])
-    day = cast(dict[str, object], report['trading_days'][0])
+    day = cast(dict[str, object], report["trading_days"][0])
 
-    assert day['source_window_id_count'] == 2
-    assert day['trade_decision_ref_count'] == 2
-    assert day['execution_ref_count'] == 1
-    assert day['execution_order_event_ref_count'] == 1
-    assert day['source_ref_count'] == 1
-    assert day['source_offset_count'] == 1
+    assert day["source_window_id_count"] == 2
+    assert day["trade_decision_ref_count"] == 2
+    assert day["execution_ref_count"] == 1
+    assert day["execution_order_event_ref_count"] == 1
+    assert day["source_ref_count"] == 1
+    assert day["source_offset_count"] == 1
 
 
 def test_dataclass_rows_and_invalid_scalar_values_normalize_fail_closed() -> None:
     row = RuntimeAuthorityEvidenceRow(
-        row_id='dataclass-row',
-        run_id='runtime-run',
+        row_id="dataclass-row",
+        run_id="runtime-run",
         candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
         hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
-        observed_stage='paper',
+        observed_stage="paper",
         bucket_started_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
         bucket_ended_at=datetime(2026, 5, 1, 6, tzinfo=timezone.utc),
         account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
         runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
-        strategy_family='pairs',
+        strategy_family="pairs",
         fill_count=20,
         decision_count=20,
         submitted_order_count=20,
@@ -468,32 +649,32 @@ def test_dataclass_rows_and_invalid_scalar_values_normalize_fail_closed() -> Non
         unfilled_order_count=0,
         closed_trade_count=20,
         open_position_count=0,
-        filled_notional=Decimal('600000'),
-        gross_strategy_pnl=Decimal('610'),
-        cost_amount=Decimal('10'),
-        net_strategy_pnl_after_costs=Decimal('0'),
+        filled_notional=Decimal("600000"),
+        gross_strategy_pnl=Decimal("610"),
+        cost_amount=Decimal("10"),
+        net_strategy_pnl_after_costs=Decimal("0"),
         post_cost_expectancy_bps=None,
         ledger_schema_version=EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
         pnl_basis=POST_COST_PNL_BASIS,
-        execution_policy_hash_counts={'policy': 'not-a-number'},
-        cost_model_hash_counts={'cost': '1'},
-        lineage_hash_counts={'lineage': '1'},
+        execution_policy_hash_counts={"policy": "not-a-number"},
+        cost_model_hash_counts={"cost": "1"},
+        lineage_hash_counts={"lineage": "1"},
         blockers=(),
         payload=_source_payload(0),
     )
 
     report = build_runtime_authority_report([row])
 
-    assert report['final_authority_ok'] is False
-    assert AUTHORITY_POLICY_HASH_BLOCKER in report['blockers']
-    assert report['aggregate']['total_net_strategy_pnl_after_costs'] == '0'
+    assert report["final_authority_ok"] is False
+    assert AUTHORITY_POLICY_HASH_BLOCKER in report["blockers"]
+    assert report["aggregate"]["total_net_strategy_pnl_after_costs"] == "0"
 
 
 def test_invalid_mapping_timestamps_are_rejected() -> None:
     row = _row(0)
-    row['bucket_started_at'] = 'not-a-timestamp'
+    row["bucket_started_at"] = "not-a-timestamp"
 
-    with pytest.raises(ValueError, match='bucket_started_at_invalid'):
+    with pytest.raises(ValueError, match="bucket_started_at_invalid"):
         build_runtime_authority_report([row])
 
 
@@ -517,66 +698,78 @@ def test_load_runtime_authority_rows_filters_and_normalizes_bucket() -> None:
 
     start = datetime(2026, 5, 1, tzinfo=timezone.utc)
     bucket = SimpleNamespace(
-        id='bucket-1',
-        run_id='runtime-run',
+        id="bucket-1",
+        run_id="runtime-run",
         candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
         hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
-        observed_stage='paper',
+        observed_stage="paper",
         bucket_started_at=start,
         bucket_ended_at=start + timedelta(hours=6),
         account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
         runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
-        strategy_family='pairs',
-        fill_count='2',
-        decision_count='2',
-        submitted_order_count='2',
+        strategy_family="pairs",
+        fill_count="2",
+        decision_count="2",
+        submitted_order_count="2",
         cancelled_order_count=0,
         rejected_order_count=0,
         unfilled_order_count=0,
         closed_trade_count=1,
         open_position_count=0,
-        filled_notional='1000.50',
-        gross_strategy_pnl='11',
-        cost_amount='1',
-        net_strategy_pnl_after_costs='10',
-        post_cost_expectancy_bps='8',
+        filled_notional="1000.50",
+        gross_strategy_pnl="11",
+        cost_amount="1",
+        net_strategy_pnl_after_costs="10",
+        post_cost_expectancy_bps="8",
         ledger_schema_version=EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
         pnl_basis=POST_COST_PNL_BASIS,
-        execution_policy_hash_counts={'policy': 1},
-        cost_model_hash_counts={'cost': 1},
-        lineage_hash_counts={'lineage': 1},
-        blockers_json=['stored_blocker'],
-        payload_json={**_source_payload(0), 'blockers': ['payload_blocker']},
+        execution_policy_hash_counts={"policy": 1},
+        cost_model_hash_counts={"cost": 1},
+        lineage_hash_counts={"lineage": 1},
+        blockers_json=["stored_blocker"],
+        payload_json={**_source_payload(0), "blockers": ["payload_blocker"]},
         created_at=start,
     )
     session = FakeSession(bucket)
 
     rows = load_runtime_authority_rows(
         cast(Session, session),
-        observed_stage='paper',
+        observed_stage="paper",
         started_at=start,
         ended_at=start + timedelta(days=1),
     )
 
     assert session.statement is not None
-    assert rows[0].row_id == 'bucket-1'
-    assert rows[0].filled_notional == Decimal('1000.50')
-    assert rows[0].blockers == ('stored_blocker', 'payload_blocker')
+    assert rows[0].row_id == "bucket-1"
+    assert rows[0].filled_notional == Decimal("1000.50")
+    assert rows[0].blockers == ("stored_blocker", "payload_blocker")
 
 
 def test_positive_20_day_source_backed_distribution_passes_thresholds() -> None:
     report = build_runtime_authority_report([_row(day) for day in range(20)])
 
-    assert report['final_authority_ok'] is True
-    assert report['blockers'] == []
-    assert report['aggregate']['trading_day_count'] == 20
-    assert report['aggregate']['mean_daily_net_pnl_after_costs'] == '600'
-    assert report['aggregate']['median_daily_net_pnl_after_costs'] == '600'
-    assert report['aggregate']['p10_daily_net_pnl_after_costs'] == '600'
-    assert report['aggregate']['worst_day_net_pnl_after_costs'] == '600'
-    assert report['aggregate']['best_day_share'] == '0.05'
-    assert report['aggregate']['total_filled_notional'] == '12000000'
-    assert report['aggregate']['closed_round_trips'] == 400
+    assert report["final_authority_ok"] is True
+    assert report["authority_allowed"] is True
+    assert report["capital_promotion_allowed"] is True
+    assert report["blockers"] == []
+    assert report["next_actions"] == []
+    assert report["aggregate"]["trading_day_count"] == 20
+    assert report["aggregate"]["clean_authority_bucket_count"] == 20
+    assert report["aggregate"]["source_authority_bucket_count"] == 20
+    assert report["aggregate"]["explicit_cost_bucket_count"] == 20
+    assert report["aggregate"]["mean_daily_net_pnl_after_costs"] == "600"
+    assert report["aggregate"]["median_daily_net_pnl_after_costs"] == "600"
+    assert report["aggregate"]["p10_daily_net_pnl_after_costs"] == "600"
+    assert report["aggregate"]["worst_day_net_pnl_after_costs"] == "600"
+    assert report["aggregate"]["best_day_share"] == "0.05"
+    assert report["aggregate"]["concentration"] == {
+        "best_day_share": "0.05",
+        "max_best_day_share": "0.25",
+    }
+    assert report["aggregate"]["total_filled_notional"] == "12000000"
+    assert report["aggregate"]["target_implied_notional_gap"] == "0"
+    assert report["aggregate"]["closed_round_trips"] == 400
+    assert report["gaps"]["missing_net_pnl_after_costs_to_mean_floor"] == "0"
 
 
 def test_output_is_stable_json() -> None:
@@ -586,65 +779,71 @@ def test_output_is_stable_json() -> None:
     assert encoded == runtime_authority_report_json(report)
     decoded = json.loads(encoded)
     assert list(decoded) == sorted(decoded)
-    assert decoded['schema_version'] == 'torghut.hpairs-runtime-authority-proof.v1'
+    assert decoded["schema_version"] == "torghut.hpairs-runtime-authority-proof.v1"
 
 
 def test_cli_parses_window_filters_and_fail_on_blockers(capsys) -> None:  # type: ignore[no-untyped-def]
     class FakeSession:
-        def __enter__(self) -> 'FakeSession':
+        def __enter__(self) -> "FakeSession":
             return self
 
         def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
             return None
 
     with (
-        patch.object(cli, 'SessionLocal', return_value=FakeSession()),
-        patch.object(cli, 'load_runtime_authority_rows', return_value=[]) as load_rows,
+        patch.object(cli, "SessionLocal", return_value=FakeSession()),
+        patch.object(cli, "load_runtime_authority_rows", return_value=[]) as load_rows,
     ):
         exit_code = cli.main(
             [
-                '--mode',
-                'authority',
-                '--observed-stage',
-                'paper',
-                '--start',
-                '2026-05-01T14:30:00',
-                '--end',
-                '2026-05-02T21:00:00Z',
-                '--fail-on-blockers',
+                "--mode",
+                "authority",
+                "--observed-stage",
+                "paper",
+                "--start",
+                "2026-05-01T14:30:00",
+                "--end",
+                "2026-05-02T21:00:00Z",
+                "--fail-on-blockers",
             ]
         )
 
     assert exit_code == 1
     kwargs = load_rows.call_args.kwargs
-    assert kwargs['observed_stage'] == 'paper'
-    assert kwargs['started_at'] == datetime(2026, 5, 1, 14, 30, tzinfo=timezone.utc)
-    assert kwargs['ended_at'] == datetime(2026, 5, 2, 21, tzinfo=timezone.utc)
+    assert kwargs["observed_stage"] == "paper"
+    assert kwargs["started_at"] == datetime(2026, 5, 1, 14, 30, tzinfo=timezone.utc)
+    assert kwargs["ended_at"] == datetime(2026, 5, 2, 21, tzinfo=timezone.utc)
     payload = json.loads(capsys.readouterr().out)
-    assert payload['final_authority_ok'] is False
+    assert payload["final_authority_ok"] is False
 
 
 def test_cli_reports_database_read_errors(capsys) -> None:  # type: ignore[no-untyped-def]
-    with patch.object(cli, 'SessionLocal', side_effect=SQLAlchemyError('db unavailable')):
-        exit_code = cli.main(['--fail-on-blockers'])
+    with patch.object(
+        cli, "SessionLocal", side_effect=SQLAlchemyError("db unavailable")
+    ):
+        exit_code = cli.main(["--fail-on-blockers"])
 
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
-    assert payload['evidence_read_error'] == 'db unavailable'
-    assert AUTHORITY_READ_ERROR_BLOCKER in payload['blockers']
+    assert payload["evidence_read_error"] == "db unavailable"
+    assert AUTHORITY_READ_ERROR_BLOCKER in payload["blockers"]
 
 
 def test_cli_emits_read_only_report_from_session_fixture(capsys) -> None:  # type: ignore[no-untyped-def]
     class FakeSession:
-        def __enter__(self) -> 'FakeSession':
+        def __enter__(self) -> "FakeSession":
             return self
 
         def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
             return None
 
     with (
-        patch.object(cli, 'SessionLocal', return_value=FakeSession()) as session_local,
-        patch.object(cli, 'load_runtime_authority_rows', return_value=[_row(day) for day in range(20)]) as load_rows,
+        patch.object(cli, "SessionLocal", return_value=FakeSession()) as session_local,
+        patch.object(
+            cli,
+            "load_runtime_authority_rows",
+            return_value=[_row(day) for day in range(20)],
+        ) as load_rows,
     ):
         exit_code = cli.main([])
 
@@ -652,52 +851,52 @@ def test_cli_emits_read_only_report_from_session_fixture(capsys) -> None:  # typ
     session_local.assert_called_once_with()
     load_rows.assert_called_once()
     payload = json.loads(capsys.readouterr().out)
-    assert payload['final_authority_ok'] is True
+    assert payload["final_authority_ok"] is True
 
 
 def test_cli_parses_window_arguments_and_fails_on_blockers(capsys) -> None:  # type: ignore[no-untyped-def]
     class FakeSession:
-        def __enter__(self) -> 'FakeSession':
+        def __enter__(self) -> "FakeSession":
             return self
 
         def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
             return None
 
     with (
-        patch.object(cli, 'SessionLocal', return_value=FakeSession()),
-        patch.object(cli, 'load_runtime_authority_rows', return_value=[]),
+        patch.object(cli, "SessionLocal", return_value=FakeSession()),
+        patch.object(cli, "load_runtime_authority_rows", return_value=[]),
     ):
         exit_code = cli.main(
             [
-                '--observed-stage',
-                'paper',
-                '--start',
-                '2026-05-01T09:30:00',
-                '--end',
-                '2026-05-02T16:00:00Z',
-                '--fail-on-blockers',
+                "--observed-stage",
+                "paper",
+                "--start",
+                "2026-05-01T09:30:00",
+                "--end",
+                "2026-05-02T16:00:00Z",
+                "--fail-on-blockers",
             ]
         )
 
     assert exit_code == 1
     payload = json.loads(capsys.readouterr().out)
-    assert payload['identity']['observed_stage'] == 'paper'
-    assert payload['window']['started_at'] == '2026-05-01T09:30:00Z'
-    assert payload['window']['ended_at'] == '2026-05-02T16:00:00Z'
+    assert payload["identity"]["observed_stage"] == "paper"
+    assert payload["window"]["started_at"] == "2026-05-01T09:30:00Z"
+    assert payload["window"]["ended_at"] == "2026-05-02T16:00:00Z"
 
 
 def test_cli_reports_read_error_as_blocker(capsys) -> None:  # type: ignore[no-untyped-def]
     class FakeSession:
-        def __enter__(self) -> 'FakeSession':
-            raise SQLAlchemyError('database unavailable')
+        def __enter__(self) -> "FakeSession":
+            raise SQLAlchemyError("database unavailable")
 
         def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
             return None
 
-    with patch.object(cli, 'SessionLocal', return_value=FakeSession()):
+    with patch.object(cli, "SessionLocal", return_value=FakeSession()):
         exit_code = cli.main([])
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
-    assert AUTHORITY_READ_ERROR_BLOCKER in payload['blockers']
-    assert payload['evidence_read_error'] == 'database unavailable'
+    assert AUTHORITY_READ_ERROR_BLOCKER in payload["blockers"]
+    assert payload["evidence_read_error"] == "database unavailable"


### PR DESCRIPTION
## Summary

- Adds explicit read-only H-PAIRS runtime authority verdict fields, evidence-source metadata, blocker counts, and blocker-derived next actions.
- Separates clean authority buckets from raw runtime-ledger rows so blocked high-PnL rows no longer count toward authority floors while remaining visible in raw metrics.
- Reports deterministic authority gaps for trading days, clean buckets, net PnL, closed round trips, filled notional, best-day concentration, and target-implied notional.
- Extends focused regression coverage for low clean PnL, blocked large rows, source-link/open-position failures, closed-round-trip gaps, and passing 20-day source-backed authority rows.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_verify_hpairs_runtime_authority.py tests/test_runtime_ledger_source_authority.py tests/test_audit_hpairs_source_proof_census.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_authority_verifier.py tests/test_verify_hpairs_runtime_authority.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_authority_verifier.py tests/test_verify_hpairs_runtime_authority.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `cd services/torghut && uv run --frozen python scripts/verify_hpairs_runtime_authority.py --fail-on-blockers` (read-only local diagnostic; failed closed because local PostgreSQL on 127.0.0.1:15438 was unavailable, and emitted explicit read-error gaps/actions.)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
