### PR TITLE
fix(torghut): bound tigerbeetle status diagnostics

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5558,10 +5558,58 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
         session,
         cluster_id=settings.tigerbeetle_cluster_id,
     )
-    ref_counts = tigerbeetle_ref_counts(
-        session,
-        cluster_id=settings.tigerbeetle_cluster_id,
-    )
+    blockers: list[str] = []
+    ref_counts: dict[str, object]
+    try:
+        bind = session.get_bind()
+        if bind.dialect.name == "postgresql":
+            session.execute(text("SET LOCAL statement_timeout = 750"))
+        ref_counts = tigerbeetle_ref_counts(
+            session,
+            cluster_id=settings.tigerbeetle_cluster_id,
+            full_ref_scan=False,
+        )
+    except SQLAlchemyError as exc:
+        logger.warning("TigerBeetle ref-count status unavailable: %s", exc)
+        session.rollback()
+        blockers.append("tigerbeetle_ref_counts_unavailable")
+        ref_counts = {
+            "schema_version": "torghut.tigerbeetle-ref-counts.v1",
+            "cluster_id": settings.tigerbeetle_cluster_id,
+            "ref_counts_unavailable": True,
+            "last_error": str(exc),
+            "account_ref_count": 0,
+            "transfer_ref_count": 0,
+            "by_source_type": {},
+            "order_event_ref_count": 0,
+            "execution_ref_count": 0,
+            "cost_ref_count": 0,
+            "runtime_ledger_ref_count": 0,
+            "stable_ref_count": 0,
+            "stable_ref_missing_count": 0,
+            "stable_ref_mismatch_count": 0,
+            "stable_ref_diagnostic_bounded": True,
+            "stable_ref_sample_size": 0,
+            "runtime_ledger_required_bucket_count": 0,
+            "runtime_ledger_signed_ref_count": 0,
+            "runtime_ledger_missing_signed_ref_count": 0,
+            "runtime_ledger_account_ref_count": 0,
+            "runtime_ledger_missing_account_ref_count": 0,
+            "runtime_ledger_missing_account_ids": [],
+            "runtime_ledger_source_ids": [],
+            "runtime_ledger_transfer_ids": [],
+            "runtime_ledger_signed_bucket_ids": [],
+            "runtime_ledger_ref_coverage_bounded": True,
+            "runtime_ledger_ref_sample_size": 0,
+            "source_materialization": {
+                "account_ref_table": "tigerbeetle_account_refs",
+                "transfer_ref_table": "tigerbeetle_transfer_refs",
+                "reconciliation_run_table": "tigerbeetle_reconciliation_runs",
+                "runtime_ledger_source_table": "strategy_runtime_ledger_buckets",
+                "runtime_ledger_source_type": "strategy_runtime_ledger_bucket",
+                "runtime_ledger_transfer_kind": "runtime_net_pnl",
+            },
+        }
     runtime_ledger_ref_count = _tigerbeetle_status_int(
         ref_counts.get("runtime_ledger_ref_count")
     )
@@ -5575,7 +5623,6 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
         ref_counts.get("runtime_ledger_missing_account_ref_count")
     )
     claimed_by_runtime_evidence = runtime_ledger_ref_count > 0
-    blockers: list[str] = []
     if settings.tigerbeetle_enabled and not bool(protocol.get("protocol_ok")):
         blockers.append("tigerbeetle_protocol_unhealthy")
     reconciliation_ok = True

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -481,20 +481,97 @@ def _runtime_ledger_ref_coverage(
     *,
     cluster_id: int,
     sample_limit: int = 50,
+    full_ref_scan: bool = True,
 ) -> dict[str, object]:
-    runtime_refs = (
+    runtime_ref_filter = (
+        TigerBeetleTransferRef.cluster_id == cluster_id,
+        TigerBeetleTransferRef.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+        TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL,
+    )
+    runtime_ref_count = int(
+        session.scalar(
+            select(func.count(TigerBeetleTransferRef.id)).where(*runtime_ref_filter)
+        )
+        or 0
+    )
+    required_runtime_bucket_count = int(
+        session.scalar(
+            select(func.count(StrategyRuntimeLedgerBucket.id)).where(
+                (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
+                | (StrategyRuntimeLedgerBucket.cost_amount != 0)
+            )
+        )
+        or 0
+    )
+    sample_refs = (
         session.execute(
             select(TigerBeetleTransferRef)
-            .where(
-                TigerBeetleTransferRef.cluster_id == cluster_id,
-                TigerBeetleTransferRef.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-                TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL,
-            )
+            .where(*runtime_ref_filter)
             .order_by(TigerBeetleTransferRef.created_at.desc())
+            .limit(sample_limit)
         )
         .scalars()
         .all()
     )
+    if not full_ref_scan:
+        runtime_source_ids = [
+            str(ref.source_id) for ref in sample_refs if ref.source_id is not None
+        ]
+        runtime_transfer_ids = [str(ref.transfer_id) for ref in sample_refs]
+        runtime_account_ids: list[str] = []
+        for ref in sample_refs:
+            for account_id in _runtime_ledger_payload_account_ids(ref):
+                if account_id not in runtime_account_ids:
+                    runtime_account_ids.append(account_id)
+        account_ref_ids: set[str] = (
+            {
+                str(account_id)
+                for account_id in session.execute(
+                    select(TigerBeetleAccountRef.account_id).where(
+                        TigerBeetleAccountRef.cluster_id == cluster_id,
+                        TigerBeetleAccountRef.account_id.in_(runtime_account_ids),
+                    )
+                ).scalars()
+            }
+            if runtime_account_ids
+            else set()
+        )
+        missing_account_ids = [
+            account_id
+            for account_id in runtime_account_ids
+            if account_id not in account_ref_ids
+        ]
+        return {
+            "runtime_ledger_required_bucket_count": required_runtime_bucket_count,
+            "runtime_ledger_ref_count": runtime_ref_count,
+            "runtime_ledger_signed_ref_count": 0,
+            "runtime_ledger_missing_signed_ref_count": max(
+                required_runtime_bucket_count,
+                runtime_ref_count,
+                0,
+            ),
+            "runtime_ledger_account_ref_count": len(runtime_account_ids)
+            - len(missing_account_ids),
+            "runtime_ledger_missing_account_ref_count": len(missing_account_ids),
+            "runtime_ledger_missing_account_ids": missing_account_ids[:sample_limit],
+            "runtime_ledger_source_ids": runtime_source_ids,
+            "runtime_ledger_transfer_ids": runtime_transfer_ids,
+            "runtime_ledger_signed_bucket_ids": [],
+            "runtime_ledger_ref_coverage_bounded": True,
+            "runtime_ledger_ref_sample_size": len(sample_refs),
+        }
+
+    runtime_refs = sample_refs
+    if runtime_ref_count > len(sample_refs):
+        runtime_refs = (
+            session.execute(
+                select(TigerBeetleTransferRef)
+                .where(*runtime_ref_filter)
+                .order_by(TigerBeetleTransferRef.created_at.desc())
+            )
+            .scalars()
+            .all()
+        )
     current_bucket_ids = {
         str(bucket_id)
         for bucket_id in session.execute(
@@ -513,15 +590,6 @@ def _runtime_ledger_ref_coverage(
         )
         or (ref.source_id is not None and ref.source_id in current_bucket_ids)
     ]
-    required_runtime_bucket_count = int(
-        session.scalar(
-            select(func.count(StrategyRuntimeLedgerBucket.id)).where(
-                (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
-                | (StrategyRuntimeLedgerBucket.cost_amount != 0)
-            )
-        )
-        or 0
-    )
     signed_refs = [
         ref for ref in current_runtime_refs if _runtime_ledger_ref_is_signed(ref)
     ]
@@ -569,6 +637,8 @@ def _runtime_ledger_ref_coverage(
         "runtime_ledger_source_ids": runtime_source_ids,
         "runtime_ledger_transfer_ids": runtime_transfer_ids,
         "runtime_ledger_signed_bucket_ids": sorted(signed_bucket_ids)[:sample_limit],
+        "runtime_ledger_ref_coverage_bounded": False,
+        "runtime_ledger_ref_sample_size": len(runtime_refs),
     }
 
 
@@ -617,7 +687,12 @@ def _runtime_ledger_ref_matches_expected_bucket(
     return direction_matches, metadata_matches
 
 
-def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, object]:
+def tigerbeetle_ref_counts(
+    session: Session,
+    *,
+    cluster_id: int,
+    full_ref_scan: bool = True,
+) -> dict[str, object]:
     account_total = session.scalar(
         select(func.count(TigerBeetleAccountRef.id)).where(
             TigerBeetleAccountRef.cluster_id == cluster_id
@@ -639,15 +714,14 @@ def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, ob
             TigerBeetleTransferRef.cluster_id == cluster_id
         )
     )
-    refs = (
-        session.execute(
-            select(TigerBeetleTransferRef).where(
-                TigerBeetleTransferRef.cluster_id == cluster_id
-            )
-        )
-        .scalars()
-        .all()
+    refs_query = (
+        select(TigerBeetleTransferRef)
+        .where(TigerBeetleTransferRef.cluster_id == cluster_id)
+        .order_by(TigerBeetleTransferRef.created_at.desc())
     )
+    if not full_ref_scan:
+        refs_query = refs_query.limit(SAMPLE_LIMIT)
+    refs = session.execute(refs_query).scalars().all()
     stable_ref_count = sum(1 for ref in refs if _stable_ref_payload(ref))
     stable_ref_missing_count = sum(
         1
@@ -660,6 +734,7 @@ def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, ob
     runtime_coverage = _runtime_ledger_ref_coverage(
         session,
         cluster_id=cluster_id,
+        full_ref_scan=full_ref_scan,
     )
     return {
         "schema_version": "torghut.tigerbeetle-ref-counts.v1",
@@ -677,6 +752,8 @@ def tigerbeetle_ref_counts(session: Session, *, cluster_id: int) -> dict[str, ob
         "stable_ref_count": stable_ref_count,
         "stable_ref_missing_count": stable_ref_missing_count,
         "stable_ref_mismatch_count": stable_ref_mismatch_count,
+        "stable_ref_diagnostic_bounded": not full_ref_scan,
+        "stable_ref_sample_size": len(refs),
         "source_materialization": {
             "account_ref_table": "tigerbeetle_account_refs",
             "transfer_ref_table": "tigerbeetle_transfer_refs",

--- a/services/torghut/tests/test_tigerbeetle_status.py
+++ b/services/torghut/tests/test_tigerbeetle_status.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.config import settings
@@ -67,6 +68,41 @@ class TestTigerBeetleStatus(TestCase):
         self.assertTrue(payload["protocol_ok"])
         self.assertEqual(payload["blockers"], [])
         self.assertEqual(payload["ref_counts"]["transfer_ref_count"], 0)
+
+    def test_status_uses_bounded_ref_count_diagnostics(self) -> None:
+        ref_counts = {
+            "schema_version": "torghut.tigerbeetle-ref-counts.v1",
+            "cluster_id": 2001,
+            "account_ref_count": 0,
+            "transfer_ref_count": 0,
+            "by_source_type": {},
+            "runtime_ledger_ref_count": 0,
+            "runtime_ledger_signed_ref_count": 0,
+            "runtime_ledger_missing_signed_ref_count": 0,
+            "runtime_ledger_missing_account_ref_count": 0,
+            "source_materialization": {},
+        }
+
+        with Session(self.engine) as session:
+            with patch(
+                "app.main.tigerbeetle_ref_counts", return_value=ref_counts
+            ) as ref_counts_mock:
+                payload = _build_tigerbeetle_ledger_status(session)
+
+        self.assertTrue(payload["ok"])
+        self.assertEqual(ref_counts_mock.call_args.kwargs["full_ref_scan"], False)
+
+    def test_ref_count_failure_degrades_without_status_exception(self) -> None:
+        with Session(self.engine) as session:
+            with patch(
+                "app.main.tigerbeetle_ref_counts",
+                side_effect=SQLAlchemyError("idle in transaction timeout"),
+            ):
+                payload = _build_tigerbeetle_ledger_status(session)
+
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["ref_counts"]["ref_counts_unavailable"])
+        self.assertIn("tigerbeetle_ref_counts_unavailable", payload["blockers"])
 
     def test_tigerbeetle_status_int_normalizes_bool_strings_and_bad_values(
         self,


### PR DESCRIPTION
## Summary

- Bound `/trading/status` TigerBeetle ref-count diagnostics to sampled refs instead of full transfer-ref scans.
- Add a short PostgreSQL statement timeout and fail-soft fallback so status reports `tigerbeetle_ref_counts_unavailable` instead of throwing a service 503.
- Preserve fail-closed runtime-ledger diagnostics for missing signed refs and sampled account refs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_status.py tests/test_tigerbeetle_reconcile.py -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_status.py tests/test_tigerbeetle_reconcile.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_status.py tests/test_tigerbeetle_reconcile.py`
- `cd services/torghut && git diff --check`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
