### PR TITLE
feat(torghut): block lineage-blind hpairs replay picks

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -45,6 +45,21 @@ FAST_REPLAY_FRONTIER_IDENTITY_SCHEMA_VERSION = (
 FAST_REPLAY_EXACT_FRONTIER_KEY_SCHEMA_VERSION = (
     "torghut.fast-replay-exact-frontier-key.v1"
 )
+FAST_REPLAY_EXACT_SELECTION_SOURCE_INPUT_BLOCKERS = frozenset(
+    (
+        "missing_price_return_microbar_fields",
+        "missing_ofi_or_depth_fields",
+        "missing_spread_fields",
+        "missing_volume_fields",
+    )
+)
+FAST_REPLAY_EXACT_SELECTION_IMPACT_CAPACITY_BLOCKERS = frozenset(
+    (
+        "candidate_notional_missing",
+        "median_price_missing",
+        "median_volume_missing",
+    )
+)
 
 
 @dataclass(frozen=True)
@@ -92,6 +107,7 @@ class FastReplayPreviewRow:
             observed_post_cost_expectancy_bps
         )
         notional_blocked = required_daily_notional is None
+        exact_replay_selection_blockers = _exact_replay_selection_blockers_for_row(self)
         lineage_blockers = _lineage_blockers_for_row(self)
         risk_flags = _risk_flags_for_row(self, lineage_blockers=lineage_blockers)
         prefilter_capacity_lineage = _mapping(
@@ -144,9 +160,7 @@ class FastReplayPreviewRow:
                 "candidate_frontier_hash": self.candidate_frontier_hash,
                 "exact_replay_frontier_key": self.exact_replay_frontier_key,
                 "duplicate_of_candidate_spec_id": self.duplicate_of_candidate_spec_id,
-                "duplicate_candidate_spec_ids": list(
-                    self.duplicate_candidate_spec_ids
-                ),
+                "duplicate_candidate_spec_ids": list(self.duplicate_candidate_spec_ids),
                 "dedupe_scope": "same_replay_tape_cache_and_execution_identity",
                 "proof_source": "prefilter_only",
                 "prefilter_only": True,
@@ -183,6 +197,8 @@ class FastReplayPreviewRow:
                 "blocked": notional_blocked,
                 "prefilter_only": True,
             },
+            "exact_replay_selection_blocked": bool(exact_replay_selection_blockers),
+            "exact_replay_selection_blockers": list(exact_replay_selection_blockers),
             "cost_impact_lineage": {
                 "status": "preview_prefilter_only",
                 "source": "manifest_verified_replay_tape",
@@ -252,6 +268,11 @@ class FastReplayPreviewResult:
                 "exploitation_slots": FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
                 "exploration_slots": FAST_REPLAY_DEFAULT_EXPLORATION_COUNT,
                 "broad_cluster_fanout_allowed": False,
+                "lineage_filter": "block_exact_replay_selection_when_local_cost_or_capacity_inputs_are_missing",
+                "lineage_filter_blockers": sorted(
+                    FAST_REPLAY_EXACT_SELECTION_SOURCE_INPUT_BLOCKERS
+                    | FAST_REPLAY_EXACT_SELECTION_IMPACT_CAPACITY_BLOCKERS
+                ),
             },
             "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
             "implemented_mechanisms": {
@@ -806,7 +827,11 @@ def _mark_frontier_duplicates(
 
 
 def _frontier_dedupe_key(row: FastReplayPreviewRow) -> str:
-    return row.exact_replay_frontier_key or row.candidate_frontier_hash or row.candidate_spec_id
+    return (
+        row.exact_replay_frontier_key
+        or row.candidate_frontier_hash
+        or row.candidate_spec_id
+    )
 
 
 def _row_frontier_duplicate_filtered(row: FastReplayPreviewRow) -> bool:
@@ -826,6 +851,7 @@ def _select_frontier_buckets(
         if row.selection_reason != "insufficient_replay_tape_rows"
         and not _row_explicitly_non_hpairs(row)
         and not _row_frontier_duplicate_filtered(row)
+        and not _row_exact_replay_selection_blocked(row)
     ]
     selected: dict[str, str] = {}
     for row in eligible[:exploitation_count]:
@@ -840,8 +866,10 @@ def _select_frontier_buckets(
         if len(selected) >= exact_replay_candidate_cap:
             break
         selected[row.candidate_spec_id] = "exploration"
-    if not selected and ranked_rows:
-        selected[ranked_rows[0].candidate_spec_id] = "exploitation_backfill"
+    if not selected:
+        for row in eligible:
+            selected[row.candidate_spec_id] = "exploitation_backfill"
+            break
     return selected
 
 
@@ -852,6 +880,10 @@ def _row_with_rank_and_selection(
     selection_reason = row.selection_reason
     if selected:
         selection_reason = f"fast_replay_frontier_{frontier_bucket}_selected"
+    elif not _row_frontier_duplicate_filtered(
+        row
+    ) and _row_exact_replay_selection_blocked(row):
+        selection_reason = "fast_replay_frontier_lineage_blocked"
     return FastReplayPreviewRow(
         candidate_spec_id=row.candidate_spec_id,
         rank=rank,
@@ -936,6 +968,58 @@ def _row_with_frontier_dedupe(
         duplicate_of_candidate_spec_id=duplicate_of_candidate_spec_id,
         duplicate_candidate_spec_ids=duplicate_candidate_spec_ids,
     )
+
+
+def _row_exact_replay_selection_blocked(row: FastReplayPreviewRow) -> bool:
+    return bool(_exact_replay_selection_blockers_for_row(row))
+
+
+def _exact_replay_selection_blockers_for_row(
+    row: FastReplayPreviewRow,
+) -> tuple[str, ...]:
+    """Block exact-replay handoff when local cost/capacity lineage is incomplete.
+
+    Source-backed ADV remains a downstream promotion-authority blocker. This
+    preview filter blocks only missing local replay-tape inputs that would make
+    the bounded exact-replay frontier ranking cost- or capacity-blind.
+    """
+
+    blockers: set[str] = set()
+    source_input_blockers = set(
+        _string_tuple(row.microstructure_prefilter.get("source_input_blockers"))
+    )
+    blockers.update(
+        source_input_blockers & FAST_REPLAY_EXACT_SELECTION_SOURCE_INPUT_BLOCKERS
+    )
+    if row.avg_abs_return_bps > 0:
+        blockers.discard("missing_price_return_microbar_fields")
+    if row.ofi_pressure_score != 0:
+        blockers.discard("missing_ofi_or_depth_fields")
+    if row.median_spread_bps > 0:
+        blockers.discard("missing_spread_fields")
+    if row.square_root_impact_capacity_penalty_bps > 0:
+        blockers.discard("missing_volume_fields")
+    impact_capacity_lineage = _mapping(
+        row.microstructure_prefilter.get("impact_capacity_lineage")
+    )
+    impact_blockers = set(_string_tuple(impact_capacity_lineage.get("blockers")))
+    blockers.update(
+        impact_blockers & FAST_REPLAY_EXACT_SELECTION_IMPACT_CAPACITY_BLOCKERS
+    )
+    if str(impact_capacity_lineage.get("status") or "") == "missing_inputs":
+        blockers.add("impact_capacity_lineage_missing_inputs")
+    if "missing_spread_fields" in source_input_blockers:
+        if row.median_spread_bps <= 0:
+            blockers.add("cost_lineage_spread_missing")
+    if (
+        "missing_volume_fields" in source_input_blockers
+        or "median_volume_missing" in impact_blockers
+    ):
+        if row.square_root_impact_capacity_penalty_bps <= 0:
+            blockers.add("adv_capacity_lineage_volume_missing")
+    if "candidate_notional_missing" in impact_blockers:
+        blockers.add("candidate_notional_lineage_missing")
+    return tuple(sorted(blockers))
 
 
 def _ofi_decay_score(values: NDArray[np.float64]) -> float:
@@ -1401,6 +1485,7 @@ def _lineage_blockers_for_row(row: FastReplayPreviewRow) -> tuple[str, ...]:
         "exact_replay_required",
         "live_paper_runtime_ledger_required",
     ]
+    blockers.extend(_exact_replay_selection_blockers_for_row(row))
     if _observed_post_cost_expectancy_bps(row) <= 0:
         blockers.append("positive_post_cost_expectancy_missing")
         blockers.append("target_implied_notional_blocked_non_positive_expectancy")
@@ -1437,6 +1522,13 @@ def _mapping(value: Any) -> dict[str, Any]:
         return {}
     mapping = cast(Mapping[Any, Any], value)
     return {str(key): item for key, item in mapping.items()}
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    sequence = cast(Sequence[Any], value)
+    return tuple(str(item) for item in sequence if str(item).strip())
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6604,7 +6604,7 @@ def _apply_fast_replay_preview_narrowing(
         for candidate_spec_id in preview.selected_candidate_spec_ids
         if candidate_spec_id in spec_by_id
     ]
-    if not narrowed_specs and specs:
+    if not narrowed_specs and specs and not preview.rows:
         narrowed_specs = [specs[0]]
 
     selected_ids = {spec.candidate_spec_id for spec in narrowed_specs}
@@ -6654,6 +6654,15 @@ def _apply_fast_replay_preview_narrowing(
             )
             updated["fast_replay_target_implied_notional_context"] = preview_row.get(
                 "target_implied_notional_context"
+            )
+            updated["fast_replay_exact_replay_selection_blocked"] = preview_row.get(
+                "exact_replay_selection_blocked"
+            )
+            updated["fast_replay_exact_replay_selection_blockers"] = list(
+                cast(
+                    Sequence[Any],
+                    preview_row.get("exact_replay_selection_blockers") or (),
+                )
             )
             updated["fast_replay_cost_impact_lineage"] = preview_row.get(
                 "cost_impact_lineage"
@@ -6890,6 +6899,15 @@ def _bounded_sim_target_queue_metadata(
                 "required_daily_notional": row.get("required_daily_notional"),
                 "target_implied_notional_context": row.get(
                     "target_implied_notional_context"
+                ),
+                "exact_replay_selection_blocked": row.get(
+                    "exact_replay_selection_blocked"
+                ),
+                "exact_replay_selection_blockers": list(
+                    cast(
+                        Sequence[Any],
+                        row.get("exact_replay_selection_blockers") or (),
+                    )
                 ),
                 "reproducibility_metadata": {
                     "dataset_snapshot_ref": replay_tape_manifest.dataset_snapshot_ref,

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -494,6 +494,79 @@ class TestFastReplayPreview(TestCase):
             ],
         )
 
+    def test_missing_cost_capacity_lineage_blocks_exact_replay_selection(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            rows = [
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc)
+                    + timedelta(minutes=index),
+                    symbol="AAA",
+                    timeframe="1Min",
+                    seq=index,
+                    source="test",
+                    payload={"price": Decimal(str(100 + index))},
+                    ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
+                )
+                for index in range(1, 4)
+            ]
+            manifest = materialize_signal_tape(
+                rows=rows,
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-lineage-blocked",
+                symbols=("AAA",),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest(
+                    {"window": "lineage-blocked"}
+                ),
+            )
+
+        preview = build_fast_replay_preview(
+            specs=(
+                self._spec(
+                    "spec-lineage-blocked",
+                    symbols=["AAA"],
+                    max_notional_per_trade="0",
+                ),
+            ),
+            rows=rows,
+            replay_tape_manifest=manifest,
+            top_k=1,
+            min_rows_per_candidate=2,
+            exploitation_count=1,
+            exploration_count=0,
+            exact_replay_candidate_cap=1,
+        )
+
+        self.assertEqual(preview.selected_candidate_spec_ids, ())
+        self.assertEqual(preview.exploitation_candidate_count, 0)
+        row = preview.rows[0]
+        payload = row.to_payload()
+        self.assertFalse(payload["selected"])
+        self.assertEqual(
+            payload["selection_reason"], "fast_replay_frontier_lineage_blocked"
+        )
+        self.assertTrue(payload["exact_replay_selection_blocked"])
+        self.assertIn(
+            "cost_lineage_spread_missing",
+            payload["exact_replay_selection_blockers"],
+        )
+        self.assertIn(
+            "adv_capacity_lineage_volume_missing",
+            payload["exact_replay_selection_blockers"],
+        )
+        self.assertIn(
+            "candidate_notional_lineage_missing",
+            payload["exact_replay_selection_blockers"],
+        )
+        self.assertIn("source_backed_adv_missing", payload["lineage_blockers"])
+        self.assertFalse(payload["promotion_proof"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["promotion_allowed"])
+        self.assertFalse(payload["final_promotion_allowed"])
+
     def test_frontier_selection_dedupes_equivalent_exact_replay_targets(
         self,
     ) -> None:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4568,6 +4568,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                         payload={
                             "price": Decimal(price),
                             "spread_bps": Decimal("2"),
+                            "ofi": Decimal("0.25"),
+                            "microbar_volume": Decimal("100000"),
+                            "event_type": "trade",
                         },
                     )
                     for seq, (day, symbol, price) in enumerate(
@@ -4894,6 +4897,93 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn(
             "impact_capacity_lineage",
             first_entry["hpairs_microstructure_prefilter"],
+        )
+
+    def test_fast_replay_preview_does_not_backfill_lineage_blocked_candidates(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            output_dir.mkdir()
+            tape_path = Path(tmpdir) / "blocked-tape.jsonl"
+            rows = [
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 14, 30 + index, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    timeframe="1Min",
+                    seq=index,
+                    source="ta",
+                    payload={"price": Decimal(str(100 + index))},
+                )
+                for index in range(3)
+            ]
+            materialize_signal_tape(
+                rows=rows,
+                tape_path=tape_path,
+                dataset_snapshot_ref="blocked-preview",
+                symbols=("NVDA",),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest({"window": "blocked"}),
+            )
+            base_spec = self._candidate_spec("spec-lineage-blocked")
+            spec = replace(
+                base_spec,
+                strategy_overrides={
+                    **base_spec.strategy_overrides,
+                    "max_notional_per_trade": "0",
+                    "universe_symbols": ["NVDA"],
+                },
+            )
+            args = self._args(output_dir)
+            args.replay_mode = "real"
+            args.full_window_start_date = "2026-02-23"
+            args.full_window_end_date = "2026-02-23"
+            args.symbols = "NVDA"
+            args.replay_tape_path = tape_path
+            args.replay_tape_preview_top_k = 1
+            candidate_selection = {
+                "schema_version": "torghut.whitepaper-autoresearch-selection.v1",
+                "budget": {"selected_count": 1},
+                "selected_candidate_spec_ids": [spec.candidate_spec_id],
+                "rows": [
+                    {
+                        "candidate_spec_id": spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                        "selection_reason": "test",
+                    }
+                ],
+            }
+
+            narrowed_specs, updated_selection = (
+                runner._apply_fast_replay_preview_narrowing(
+                    args=args,
+                    output_dir=output_dir,
+                    specs=[spec],
+                    candidate_selection=candidate_selection,
+                )
+            )
+
+        self.assertEqual(narrowed_specs, [])
+        self.assertEqual(updated_selection["selected_candidate_spec_ids"], [])
+        self.assertEqual(
+            updated_selection["budget"]["fast_replay_preview_selected_count"], 0
+        )
+        self.assertEqual(
+            updated_selection["bounded_sim_target_queue"][
+                "exact_replay_candidate_count"
+            ],
+            0,
+        )
+        updated_row = updated_selection["rows"][0]
+        self.assertFalse(updated_row["selected_for_replay"])
+        self.assertTrue(updated_row["fast_replay_exact_replay_selection_blocked"])
+        self.assertIn(
+            "cost_lineage_spread_missing",
+            updated_row["fast_replay_exact_replay_selection_blockers"],
+        )
+        self.assertEqual(
+            updated_row["selection_reason"], "fast_replay_preview_filtered"
         )
 
     def test_bounded_sim_target_queue_dedupes_duplicate_frontier_keys(self) -> None:


### PR DESCRIPTION
## Summary

- Tightens Torghut H-PAIRS fast-replay narrowing so exact-replay handoff blocks candidates with missing local cost/capacity lineage inputs instead of backfilling lineage-blind picks.
- Exposes exact-replay selection blocker metadata on preview rows, candidate-selection rows, and bounded SIM target queue entries while preserving prefilter-only/non-authority semantics.
- Adds regression coverage for max-6 frontier behavior, no Kubernetes fanout queue semantics, and missing spread/volume/notional lineage blocking replay selection.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py -q` — 379 passed, 1 warning
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/fast_replay.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A — offline discovery/library and script metadata changes only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
