### PR TITLE
fix(torghut): fail closed on tigerbeetle journal timeouts

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -62,6 +62,7 @@ spec:
                     --max-batches 2 \
                     --reconcile-limit 1000 \
                     --skip-reconcile \
+                    --fail-on-degraded \
                     --json
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env DB_DSN \
@@ -70,6 +71,7 @@ spec:
                     --max-batches 2 \
                     --event-scan-limit 1000 \
                     --reconcile-limit 1000 \
+                    --fail-on-degraded \
                     --json
               env:
                 - name: DB_DSN
@@ -163,6 +165,7 @@ spec:
                     --max-batches 2 \
                     --reconcile-limit 500 \
                     --skip-reconcile \
+                    --fail-on-degraded \
                     --json
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env SIM_DB_DSN \
@@ -172,6 +175,7 @@ spec:
                     --max-batches 4 \
                     --event-scan-limit 300 \
                     --reconcile-limit 500 \
+                    --fail-on-degraded \
                     --json
               env:
                 - name: TORGHUT_SIM_DB_HOST

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from collections.abc import Sequence
+import sys
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -32,6 +33,7 @@ from app.trading.tigerbeetle_journal import (
     build_order_event_transfer_plan,
     tigerbeetle_runtime_ledger_journal_payload,
 )
+from app.trading.tigerbeetle_client import TigerBeetleClientTimeoutError
 from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_EXECUTION_COST,
     TRANSFER_KIND_EXECUTION_FILL,
@@ -103,6 +105,12 @@ def _parse_args() -> argparse.Namespace:
         "--fail-on-degraded",
         action="store_true",
         help="Exit non-zero when journaling/reconciliation is degraded.",
+    )
+    parser.add_argument(
+        "--progress-interval",
+        type=int,
+        default=100,
+        help="Emit stderr progress every N processed source rows; set 0 to disable.",
     )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--json", action="store_true")
@@ -324,7 +332,15 @@ def _journal_source_batch(
         "failed": 0,
         "error_counts": {},
         "sample_errors": [],
+        "stopped_early": False,
+        "stop_reason": None,
     }
+    progress_interval = max(0, int(getattr(args, "progress_interval", 100) or 0))
+    _emit_progress(
+        "source_batch_start",
+        source=source,
+        selected=len(rows),
+    )
     for row in rows:
         try:
             if args.dry_run:
@@ -355,7 +371,58 @@ def _journal_source_batch(
                         "error": str(exc),
                     }
                 )
+            if isinstance(exc, TigerBeetleClientTimeoutError):
+                batch["stopped_early"] = True
+                batch["stop_reason"] = "tigerbeetle_rpc_timeout"
+                _emit_progress(
+                    "source_batch_stopped",
+                    source=source,
+                    reason=batch["stop_reason"],
+                    failed=batch["failed"],
+                    journaled=batch["journaled"],
+                    skipped=batch["skipped"],
+                )
+                break
+        processed = (
+            int(batch["journaled"]) + int(batch["skipped"]) + int(batch["failed"])
+        )
+        if progress_interval and processed and processed % progress_interval == 0:
+            _emit_progress(
+                "source_batch_progress",
+                source=source,
+                processed=processed,
+                selected=batch["selected"],
+                journaled=batch["journaled"],
+                skipped=batch["skipped"],
+                failed=batch["failed"],
+            )
+    _emit_progress(
+        "source_batch_complete",
+        source=source,
+        selected=batch["selected"],
+        journaled=batch["journaled"],
+        skipped=batch["skipped"],
+        failed=batch["failed"],
+        stopped_early=batch["stopped_early"],
+        stop_reason=batch["stop_reason"],
+    )
     return batch
+
+
+def _emit_progress(event: str, **fields: object) -> None:
+    payload = {
+        "schema_version": "torghut.tigerbeetle-journal-progress.v1",
+        "event": event,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        **fields,
+    }
+    print(json.dumps(payload, separators=(",", ":")), file=sys.stderr, flush=True)
+
+
+def _batch_requested_stop(batch: Mapping[str, Any]) -> bool:
+    return bool(batch.get("stopped_early")) and bool(
+        str(batch.get("stop_reason") or "")
+    )
 
 
 def _attach_runtime_bucket_journal_payload(
@@ -434,6 +501,11 @@ def _payload(
         else bool(reconciliation.get("ok", reconciliation.get("status") == "ok"))
     )
     status = "ok" if failed == 0 and reconciliation_ok else "degraded"
+    stop_reasons = [
+        str(batch.get("stop_reason"))
+        for batch in batches
+        if str(batch.get("stop_reason") or "").strip()
+    ]
     return {
         "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
         "ok": status == "ok",
@@ -447,6 +519,8 @@ def _payload(
         "event_scan_limit": getattr(args, "event_scan_limit", None),
         "sources": list(_parse_sources(getattr(args, "sources", "all"))),
         "skip_reconcile": bool(getattr(args, "skip_reconcile", False)),
+        "stopped_early": bool(stop_reasons),
+        "stop_reasons": stop_reasons,
         "started_at": started_at.isoformat(),
         "completed_at": datetime.now(timezone.utc).isoformat(),
         "selected": selected,
@@ -486,6 +560,7 @@ def main() -> int:
     )
     batches: list[dict[str, Any]] = []
     reconciliation: dict[str, object] | None = None
+    stop_journaling = False
 
     with (
         session_factory() as session,
@@ -495,7 +570,10 @@ def main() -> int:
     ):
         for _ in range(max_batches):
             batch_lengths: list[int] = []
-            if SOURCE_TYPE_EXECUTION_ORDER_EVENT in enabled_sources:
+            if (
+                SOURCE_TYPE_EXECUTION_ORDER_EVENT in enabled_sources
+                and not stop_journaling
+            ):
                 events = _select_unlinked_events(
                     session,
                     settings_obj=settings_obj,
@@ -520,93 +598,108 @@ def main() -> int:
                     event_batch["scan_failed"] = events.scan_failed
                 batches.append(event_batch)
                 batch_lengths.append(len(events.rows))
-            if SOURCE_TYPE_EXECUTION in enabled_sources:
+                stop_journaling = _batch_requested_stop(event_batch)
+            if SOURCE_TYPE_EXECUTION in enabled_sources and not stop_journaling:
                 executions = _select_unlinked_executions(
                     session,
                     settings_obj=settings_obj,
                     account_label=args.account_label,
                     limit=batch_size,
                 )
-                batches.append(
-                    _journal_source_batch(
+                execution_batch = _journal_source_batch(
+                    session,
+                    args=args,
+                    source=SOURCE_TYPE_EXECUTION,
+                    rows=executions,
+                    journal_one=lambda execution: journal.journal_execution(
                         session,
-                        args=args,
-                        source=SOURCE_TYPE_EXECUTION,
-                        rows=executions,
-                        journal_one=lambda execution: journal.journal_execution(
-                            session,
-                            execution,
-                        ),
-                    )
+                        execution,
+                    ),
                 )
+                batches.append(execution_batch)
                 batch_lengths.append(len(executions))
-            if SOURCE_TYPE_EXECUTION_TCA_METRIC in enabled_sources:
+                stop_journaling = _batch_requested_stop(execution_batch)
+            if (
+                SOURCE_TYPE_EXECUTION_TCA_METRIC in enabled_sources
+                and not stop_journaling
+            ):
                 tca_metrics = _select_unlinked_tca_metrics(
                     session,
                     settings_obj=settings_obj,
                     account_label=args.account_label,
                     limit=batch_size,
                 )
-                batches.append(
-                    _journal_source_batch(
+                tca_batch = _journal_source_batch(
+                    session,
+                    args=args,
+                    source=SOURCE_TYPE_EXECUTION_TCA_METRIC,
+                    rows=tca_metrics,
+                    journal_one=lambda metric: journal.journal_execution_tca_metric(
                         session,
-                        args=args,
-                        source=SOURCE_TYPE_EXECUTION_TCA_METRIC,
-                        rows=tca_metrics,
-                        journal_one=lambda metric: journal.journal_execution_tca_metric(
-                            session,
-                            metric,
-                        ),
-                    )
+                        metric,
+                    ),
                 )
+                batches.append(tca_batch)
                 batch_lengths.append(len(tca_metrics))
-            if SOURCE_TYPE_RUNTIME_LEDGER_BUCKET in enabled_sources:
+                stop_journaling = _batch_requested_stop(tca_batch)
+            if (
+                SOURCE_TYPE_RUNTIME_LEDGER_BUCKET in enabled_sources
+                and not stop_journaling
+            ):
                 runtime_buckets = _select_unlinked_runtime_buckets(
                     session,
                     settings_obj=settings_obj,
                     account_label=args.account_label,
                     limit=batch_size,
                 )
-                batches.append(
-                    _journal_source_batch(
+                runtime_batch = _journal_source_batch(
+                    session,
+                    args=args,
+                    source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    rows=runtime_buckets,
+                    journal_one=lambda bucket: journal.journal_runtime_ledger_bucket(
                         session,
-                        args=args,
-                        source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-                        rows=runtime_buckets,
-                        journal_one=lambda bucket: (
-                            journal.journal_runtime_ledger_bucket(
-                                session,
-                                bucket,
-                            )
-                        ),
-                    )
+                        bucket,
+                    ),
                 )
+                batches.append(runtime_batch)
                 batch_lengths.append(len(runtime_buckets))
+                stop_journaling = _batch_requested_stop(runtime_batch)
             if args.dry_run:
                 session.rollback()
                 _reset_session_identity_map(session)
                 break
-            stable_ref_backfill = journal.backfill_stable_ref_payloads(
-                session,
-                limit=batch_size,
-            )
-            batches.append(
-                {
-                    "source": "tigerbeetle_stable_ref_payload",
-                    "selected": int(stable_ref_backfill["selected"]),
-                    "journaled": int(stable_ref_backfill["updated"]),
-                    "skipped": int(stable_ref_backfill["skipped"]),
-                    "failed": 0,
-                    "error_counts": {},
-                    "sample_errors": [],
-                }
-            )
+            if not stop_journaling:
+                stable_ref_backfill = journal.backfill_stable_ref_payloads(
+                    session,
+                    limit=batch_size,
+                )
+                batches.append(
+                    {
+                        "source": "tigerbeetle_stable_ref_payload",
+                        "selected": int(stable_ref_backfill["selected"]),
+                        "journaled": int(stable_ref_backfill["updated"]),
+                        "skipped": int(stable_ref_backfill["skipped"]),
+                        "failed": 0,
+                        "error_counts": {},
+                        "sample_errors": [],
+                        "stopped_early": False,
+                        "stop_reason": None,
+                    }
+                )
             session.commit()
             _reset_session_identity_map(session)
+            if stop_journaling:
+                reconciliation = {
+                    "ok": False,
+                    "status": "skipped",
+                    "reason": "tigerbeetle_journal_stopped_early",
+                }
+                break
             if batch_lengths and all(length < batch_size for length in batch_lengths):
                 break
 
-        if not args.dry_run and not args.skip_reconcile:
+        if not args.dry_run and not args.skip_reconcile and not stop_journaling:
             reconciliation = reconcile_tigerbeetle_transfers(
                 session,
                 settings_obj=settings_obj,

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -31,6 +31,7 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_FILL_POST,
     TRANSFER_KIND_RUNTIME_NET_PNL,
 )
+from app.trading.tigerbeetle_client import TigerBeetleClientTimeoutError
 from scripts import journal_tigerbeetle_order_events as script
 
 
@@ -159,6 +160,10 @@ class FakeJournal:
             return None
         if event.event_fingerprint == "fail":
             raise RuntimeError("journal failed")
+        if event.event_fingerprint == "timeout":
+            raise TigerBeetleClientTimeoutError(
+                "tigerbeetle_create_transfers_timeout:10.000s"
+            )
         return SimpleNamespace(transfer_id="1")
 
     def journal_execution(
@@ -380,6 +385,36 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         )
         self.assertFalse(
             payload["tigerbeetle_journal_parity"]["promotion_authority"],
+        )
+
+    def test_source_batch_stops_on_tigerbeetle_timeout(self) -> None:
+        rows = [SimpleNamespace(id="first"), SimpleNamespace(id="second")]
+        seen: list[str] = []
+
+        def journal_one(row: SimpleNamespace) -> object:
+            seen.append(str(row.id))
+            raise TigerBeetleClientTimeoutError(
+                "tigerbeetle_create_transfers_timeout:10.000s"
+            )
+
+        with Session(self.engine) as session:
+            batch = script._journal_source_batch(
+                session,
+                args=argparse.Namespace(dry_run=False, progress_interval=0),
+                source=script.SOURCE_TYPE_EXECUTION,
+                rows=rows,
+                journal_one=journal_one,
+            )
+
+        self.assertEqual(seen, ["first"])
+        self.assertEqual(batch["failed"], 1)
+        self.assertTrue(batch["stopped_early"])
+        self.assertEqual(batch["stop_reason"], "tigerbeetle_rpc_timeout")
+        self.assertEqual(
+            batch["error_counts"],
+            {
+                "TigerBeetleClientTimeoutError:tigerbeetle_create_transfers_timeout:10.000s": 1
+            },
         )
 
     def test_select_unlinked_events_filters_to_journalable_account_rows(self) -> None:
@@ -882,6 +917,56 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertTrue(sample_errors[0]["row_id"])
         self.assertEqual(sample_errors[0]["error_type"], "RuntimeError")
         self.assertEqual(sample_errors[0]["error"], "journal failed")
+
+    def test_main_stops_journaling_after_tigerbeetle_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                _add_order_event(session, fingerprint="timeout", source_offset=1)
+                _add_real_source_rows(session)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--batch-size",
+                        "10",
+                        "--fail-on-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={"ok": True},
+                ) as reconcile,
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertTrue(payload["stopped_early"])
+        self.assertEqual(payload["stop_reasons"], ["tigerbeetle_rpc_timeout"])
+        self.assertEqual(payload["failed"], 1)
+        self.assertEqual(payload["reconciliation"]["status"], "skipped")
+        reconcile.assert_not_called()
+        fake_journal = FakeJournal.instances[-1]
+        self.assertEqual(fake_journal.events, ["timeout"])
+        self.assertEqual(fake_journal.executions, [])
+        self.assertEqual(fake_journal.tca_metrics, [])
 
     def test_main_can_fail_closed_for_degraded_batch(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1501,7 +1501,7 @@ class TestLiveConfigManifestContract(TestCase):
                 2,
             )
             self.assertEqual(args.count("--skip-reconcile"), 1)
-            self.assertNotIn("--fail-on-degraded", args)
+            self.assertEqual(args.count("--fail-on-degraded"), 2)
             self.assertIn("--json", args)
             security_context = cast(
                 Mapping[str, object],


### PR DESCRIPTION
## Summary

- Stops the TigerBeetle journal source batch immediately when the bounded client reports an RPC timeout, records `stopped_early` and `stop_reasons`, and skips reconciliation as degraded.
- Emits flushed stderr progress events for source batch start, progress, stop, and completion so live CronJob logs show where the runner is spending time.
- Makes the live and sim TigerBeetle journal CronJobs pass `--fail-on-degraded` so timeout or degraded ledger runs fail operationally instead of reporting success.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py tests/test_config.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

CronJob runs now fail non-zero on degraded TigerBeetle journal or reconciliation results. No schema migration is required.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
