### PR TITLE
fix(torghut): bound live tigerbeetle journal scans

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -58,17 +58,17 @@ spec:
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env DB_DSN \
                     --sources execution,execution_tca_metric \
-                    --batch-size 500 \
-                    --max-batches 2 \
+                    --batch-size 50 \
+                    --max-batches 1 \
                     --reconcile-limit 1000 \
                     --skip-reconcile \
                     --json
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env DB_DSN \
                     --sources execution_order_event,strategy_runtime_ledger_bucket \
-                    --batch-size 125 \
-                    --max-batches 2 \
-                    --event-scan-limit 1000 \
+                    --batch-size 50 \
+                    --max-batches 1 \
+                    --event-scan-limit 250 \
                     --reconcile-limit 1000 \
                     --json
               env:

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, cast
 
-from sqlalchemy import String, create_engine, or_, select
+from sqlalchemy import String, create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from app.config import Settings
@@ -195,29 +195,6 @@ def _select_unlinked_events(
     return OrderEventSelection(rows=events, scan_failed=scan_failed)
 
 
-def _source_ref_exists(
-    session: Any,
-    *,
-    settings_obj: Settings,
-    source_type: str,
-    source_id_column: Any,
-    transfer_kind: str,
-) -> Any:
-    return (
-        select(TigerBeetleTransferRef.id)
-        .where(
-            TigerBeetleTransferRef.cluster_id == settings_obj.tigerbeetle_cluster_id,
-            TigerBeetleTransferRef.source_type == source_type,
-            or_(
-                TigerBeetleTransferRef.source_id == source_id_column,
-                TigerBeetleTransferRef.source_id.like(source_id_column + ":%"),
-            ),
-            TigerBeetleTransferRef.transfer_kind == transfer_kind,
-        )
-        .exists()
-    )
-
-
 def _select_unlinked_executions(
     session: Any,
     *,
@@ -225,12 +202,14 @@ def _select_unlinked_executions(
     account_label: str | None,
     limit: int,
 ) -> list[Execution]:
-    linked_ref = _source_ref_exists(
-        session,
-        settings_obj=settings_obj,
-        source_type=SOURCE_TYPE_EXECUTION,
-        source_id_column=Execution.id.cast(String),
-        transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+    linked_ref = (
+        select(TigerBeetleTransferRef.id)
+        .where(
+            TigerBeetleTransferRef.cluster_id == settings_obj.tigerbeetle_cluster_id,
+            TigerBeetleTransferRef.execution_id == Execution.id,
+            TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_EXECUTION_FILL,
+        )
+        .exists()
     )
     stmt = (
         select(Execution)
@@ -253,12 +232,14 @@ def _select_unlinked_tca_metrics(
     account_label: str | None,
     limit: int,
 ) -> list[ExecutionTCAMetric]:
-    linked_ref = _source_ref_exists(
-        session,
-        settings_obj=settings_obj,
-        source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
-        source_id_column=ExecutionTCAMetric.id.cast(String),
-        transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+    linked_ref = (
+        select(TigerBeetleTransferRef.id)
+        .where(
+            TigerBeetleTransferRef.cluster_id == settings_obj.tigerbeetle_cluster_id,
+            TigerBeetleTransferRef.execution_tca_metric_id == ExecutionTCAMetric.id,
+            TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_EXECUTION_COST,
+        )
+        .exists()
     )
     stmt = (
         select(ExecutionTCAMetric)

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -27,6 +27,8 @@ from app.models import (
 )
 from app.trading.tigerbeetle_ledger_model import (
     LEDGER_USD_MICRO,
+    TRANSFER_KIND_EXECUTION_COST,
+    TRANSFER_KIND_EXECUTION_FILL,
     TRANSFER_CODE_FILL_POST,
     TRANSFER_KIND_FILL_POST,
     TRANSFER_KIND_RUNTIME_NET_PNL,
@@ -550,6 +552,141 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
 
         self.assertEqual([event.id for event in events.rows], [selected.id])
         self.assertEqual(events.scan_failed, 0)
+
+    def test_select_unlinked_executions_uses_direct_ref_fk(self) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        with Session(self.engine) as session:
+            linked = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-linked",
+                client_order_id="client-linked",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                status="filled",
+                raw_order={"id": "order-linked"},
+            )
+            selected = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-selected",
+                client_order_id="client-selected",
+                symbol="MSFT",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("410.50"),
+                status="filled",
+                raw_order={"id": "order-selected"},
+            )
+            session.add_all([linked, selected])
+            session.flush()
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=settings_obj.tigerbeetle_cluster_id,
+                    transfer_id="12001",
+                    transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+                    ledger=LEDGER_USD_MICRO,
+                    code=TRANSFER_CODE_FILL_POST,
+                    amount=Decimal("190250000"),
+                    status="created",
+                    execution_id=linked.id,
+                )
+            )
+            session.flush()
+
+            executions = script._select_unlinked_executions(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=10,
+            )
+
+        self.assertEqual([row.id for row in executions], [selected.id])
+
+    def test_select_unlinked_tca_metrics_uses_direct_ref_fk(self) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        with Session(self.engine) as session:
+            linked_execution = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-tca-linked",
+                client_order_id="client-tca-linked",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                status="filled",
+                raw_order={"id": "order-tca-linked"},
+            )
+            selected_execution = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-tca-selected",
+                client_order_id="client-tca-selected",
+                symbol="MSFT",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("410.50"),
+                status="filled",
+                raw_order={"id": "order-tca-selected"},
+            )
+            session.add_all([linked_execution, selected_execution])
+            session.flush()
+            linked = ExecutionTCAMetric(
+                execution_id=linked_execution.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.25"),
+                computed_at=datetime.now(timezone.utc),
+            )
+            selected = ExecutionTCAMetric(
+                execution_id=selected_execution.id,
+                alpaca_account_label="paper",
+                symbol="MSFT",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.35"),
+                computed_at=datetime.now(timezone.utc),
+            )
+            session.add_all([linked, selected])
+            session.flush()
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=settings_obj.tigerbeetle_cluster_id,
+                    transfer_id="12002",
+                    transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+                    ledger=LEDGER_USD_MICRO,
+                    code=TRANSFER_CODE_FILL_POST,
+                    amount=Decimal("250000"),
+                    status="created",
+                    execution_id=linked_execution.id,
+                    execution_tca_metric_id=linked.id,
+                )
+            )
+            session.flush()
+
+            metrics = script._select_unlinked_tca_metrics(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=10,
+            )
+
+        self.assertEqual([row.id for row in metrics], [selected.id])
 
     def test_select_runtime_buckets_repairs_legacy_ref_missing_bucket_fk(
         self,

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1531,9 +1531,9 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--dsn-env DB_DSN", live_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)
         self.assertNotIn("--account-label TORGHUT_SIM", live_args)
-        self.assertIn("--batch-size 500", live_args)
-        self.assertIn("--batch-size 125", live_args)
-        self.assertIn("--event-scan-limit 1000", live_args)
+        self.assertIn("--batch-size 50", live_args)
+        self.assertIn("--max-batches 1", live_args)
+        self.assertIn("--event-scan-limit 250", live_args)
         self.assertIn("--reconcile-limit 1000", live_args)
 
         sim_env = {


### PR DESCRIPTION
## Summary

- Use direct TigerBeetle transfer-ref foreign keys for execution and TCA unlinked selectors instead of text source-id prefix matching.
- Bound the live TigerBeetle journal CronJob batch sizes and event scan limit so scheduled live runs can make progress under the active deadline.
- Add selector regression tests and manifest contract coverage for the live journal bounds.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
