### PR TITLE
fix(torghut): require source-backed runtime ledger proof

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -280,11 +280,66 @@ def _hash_count(value: Any) -> int:
     return sum(1 for key in mapping.keys() if str(key).strip())
 
 
+def _positive_count_mapping_present(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    for item in cast(Mapping[object, object], value).values():
+        try:
+            parsed = Decimal(str(item))
+        except Exception:
+            continue
+        if parsed.is_finite() and parsed > 0:
+            return True
+    return False
+
+
+def _runtime_ledger_explicit_costs_present(bucket: Mapping[str, Any]) -> bool:
+    """Require explicit cost amount and cost basis for promotion-grade proof."""
+
+    cost_amount = _optional_decimal(
+        bucket.get("cost_amount")
+        if bucket.get("cost_amount") is not None
+        else bucket.get("runtime_ledger_cost_amount")
+    )
+    if cost_amount is None or cost_amount < 0:
+        return False
+    if is_non_promotion_grade_runtime_cost_basis(bucket.get("cost_basis")):
+        return False
+    if cost_basis_counts_have_non_promotion_grade_costs(
+        bucket.get("cost_basis_counts")
+    ) or cost_basis_counts_have_non_promotion_grade_costs(
+        bucket.get("post_cost_basis_counts")
+    ):
+        return False
+    if _positive_count_mapping_present(bucket.get("cost_basis_counts")):
+        return True
+    if _positive_count_mapping_present(bucket.get("post_cost_basis_counts")):
+        return True
+    return (
+        _text(
+            bucket.get("cost_basis")
+            or bucket.get("cost_source")
+            or bucket.get("fee_basis")
+            or bucket.get("commission_basis")
+            or bucket.get("broker_fee_basis")
+        )
+        is not None
+    )
+
+
 def _persisted_runtime_ledger_bucket_evidence_grade(
     row: StrategyRuntimeLedgerBucket,
 ) -> bool:
     blockers = _string_list(row.blockers_json)
     payload_json = _mapping(row.payload_json)
+    cost_payload = {
+        **payload_json,
+        "cost_amount": (
+            payload_json.get("cost_amount")
+            if payload_json.get("cost_amount") is not None
+            else row.cost_amount
+        ),
+    }
     return (
         row.pnl_basis == POST_COST_PNL_BASIS
         and int(row.fill_count or 0) > 0
@@ -296,6 +351,7 @@ def _persisted_runtime_ledger_bucket_evidence_grade(
         and _hash_count(row.execution_policy_hash_counts) > 0
         and _hash_count(row.cost_model_hash_counts) > 0
         and _hash_count(row.lineage_hash_counts) > 0
+        and _runtime_ledger_explicit_costs_present(cost_payload)
         and not cost_basis_counts_have_non_promotion_grade_costs(
             payload_json.get("cost_basis_counts")
         )
@@ -338,6 +394,8 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
         blockers.append("unclosed_position")
     if filled_notional is None or filled_notional <= 0:
         blockers.append("filled_notional_missing")
+    if not _runtime_ledger_explicit_costs_present(bucket):
+        blockers.append("runtime_ledger_explicit_costs_missing")
     if cost_amount is None or cost_amount < 0:
         blockers.append("explicit_cost_missing")
     non_promotion_grade_cost_basis = is_non_promotion_grade_runtime_cost_basis(
@@ -1472,8 +1530,15 @@ def _runtime_window_import_readback_from_rows(
         if _persisted_runtime_ledger_bucket_evidence_grade(row)
     ]
     source_refs: list[str] = []
+    source_window_ids: list[str] = []
+    execution_order_event_ids: list[str] = []
+    execution_ids: list[str] = []
+    trade_decision_ids: list[str] = []
+    source_offsets: list[dict[str, Any]] = []
+    source_offset_keys: set[tuple[str, str, str]] = set()
     authority_classes: list[str] = []
     source_materializations: list[str] = []
+    cost_basis_counts: Counter[str] = Counter()
     blockers: list[str] = []
     source_authority_blockers: list[str] = []
     source_authority_bucket_count = 0
@@ -1491,6 +1556,68 @@ def _runtime_window_import_readback_from_rows(
         for ref in _string_list(payload_json.get("source_refs")):
             if ref not in source_refs:
                 source_refs.append(ref)
+        for key, target in (
+            ("source_window_ids", source_window_ids),
+            ("source_window_refs", source_window_ids),
+            ("runtime_ledger_source_window_ids", source_window_ids),
+            ("runtime_ledger_source_window_refs", source_window_ids),
+            ("source_window_id", source_window_ids),
+            ("source_window_ref", source_window_ids),
+            ("runtime_ledger_source_window_id", source_window_ids),
+            ("runtime_ledger_source_window_ref", source_window_ids),
+            ("execution_order_event_ids", execution_order_event_ids),
+            ("execution_order_event_refs", execution_order_event_ids),
+            ("runtime_ledger_execution_order_event_ids", execution_order_event_ids),
+            ("execution_order_event_id", execution_order_event_ids),
+            ("execution_order_event_ref", execution_order_event_ids),
+            ("execution_ids", execution_ids),
+            ("execution_refs", execution_ids),
+            ("execution_id", execution_ids),
+            ("execution_ref", execution_ids),
+            ("trade_decision_ids", trade_decision_ids),
+            ("trade_decision_refs", trade_decision_ids),
+            ("trade_decision_id", trade_decision_ids),
+            ("trade_decision_ref", trade_decision_ids),
+            ("decision_ids", trade_decision_ids),
+            ("decision_id", trade_decision_ids),
+        ):
+            for value in _string_list(payload_json.get(key)) or [
+                item for item in [_text(payload_json.get(key))] if item is not None
+            ]:
+                if value not in target:
+                    target.append(value)
+        raw_source_offsets: object = payload_json.get("source_offsets")
+        source_offset_items: Sequence[object]
+        if isinstance(raw_source_offsets, Mapping):
+            source_offset_items = [cast(object, raw_source_offsets)]
+        elif isinstance(raw_source_offsets, Sequence) and not isinstance(
+            raw_source_offsets,
+            (str, bytes, bytearray),
+        ):
+            source_offset_items = cast(Sequence[object], raw_source_offsets)
+        else:
+            source_offset_items = ()
+        for raw_offset in source_offset_items:
+            if not isinstance(raw_offset, Mapping):
+                continue
+            typed_offset = cast(Mapping[str, Any], raw_offset)
+            topic = _text(typed_offset.get("topic"))
+            partition: Any = typed_offset.get("partition")
+            source_offset: Any = typed_offset.get("offset")
+            if topic is None or partition is None or source_offset is None:
+                continue
+            offset_key = (topic, str(partition), str(source_offset))
+            if offset_key not in source_offset_keys:
+                source_offsets.append(
+                    {
+                        "topic": topic,
+                        "partition": partition,
+                        "offset": source_offset,
+                    }
+                )
+                source_offset_keys.add(offset_key)
+        for key, value in _mapping(payload_json.get("cost_basis_counts")).items():
+            cost_basis_counts[key] += _observation_int(value)
         if (authority_class := _text(payload_json.get("authority_class"))) is not None:
             if authority_class not in authority_classes:
                 authority_classes.append(authority_class)
@@ -1553,8 +1680,16 @@ def _runtime_window_import_readback_from_rows(
             for row in evidence_grade_ledger_rows
         ],
         "source_refs": source_refs,
+        "source_window_ids": source_window_ids,
+        "runtime_ledger_source_window_ids": source_window_ids,
+        "execution_order_event_ids": execution_order_event_ids,
+        "runtime_ledger_execution_order_event_ids": execution_order_event_ids,
+        "execution_ids": execution_ids,
+        "trade_decision_ids": trade_decision_ids,
+        "source_offsets": source_offsets,
         "authority_classes": authority_classes,
         "source_materializations": source_materializations,
+        "cost_basis_counts": dict(sorted(cost_basis_counts.items())),
         "runtime_ledger_blockers": blockers,
         "runtime_ledger_profit_distance_readback": build_runtime_ledger_profit_distance_readback(
             summary={

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -205,6 +205,35 @@ def _text_list(value: object) -> list[str]:
     return items
 
 
+def _source_offsets(value: object) -> list[dict[str, object]]:
+    raw_items: Sequence[object]
+    if isinstance(value, Mapping):
+        raw_items = [value]
+    else:
+        raw_items = _sequence(value)
+    offsets: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in raw_items:
+        offset = _mapping(item)
+        topic = _text(offset.get("topic"))
+        partition = offset.get("partition")
+        source_offset = offset.get("offset")
+        if topic is None or partition is None or source_offset is None:
+            continue
+        key = (topic, str(partition), str(source_offset))
+        if key in seen:
+            continue
+        offsets.append(
+            {
+                "topic": topic,
+                "partition": partition,
+                "offset": source_offset,
+            }
+        )
+        seen.add(key)
+    return offsets
+
+
 def _extend_unique(items: list[str], additions: Sequence[str]) -> None:
     for item in additions:
         text = _text(item)
@@ -1011,6 +1040,22 @@ def _runtime_import_target_materialization_ref(
                 readback.get("evidence_grade_runtime_ledger_bucket_refs")
             ),
             "source_refs": _text_list(readback.get("source_refs")),
+            "source_window_ids": _text_list(
+                readback.get("runtime_ledger_source_window_ids")
+            )
+            or _text_list(readback.get("source_window_ids")),
+            "execution_order_event_ids": _text_list(
+                readback.get("runtime_ledger_execution_order_event_ids")
+            )
+            or _text_list(readback.get("execution_order_event_ids")),
+            "execution_ids": _text_list(readback.get("execution_ids")),
+            "trade_decision_ids": _text_list(readback.get("trade_decision_ids")),
+            "source_offsets": _source_offsets(readback.get("source_offsets")),
+            "authority_classes": _text_list(readback.get("authority_classes")),
+            "source_materializations": _text_list(
+                readback.get("source_materializations")
+            ),
+            "cost_basis_counts": dict(_mapping(readback.get("cost_basis_counts"))),
         }
         profit_distance_readback = _mapping(
             readback.get("runtime_ledger_profit_distance_readback")
@@ -1245,8 +1290,36 @@ def _runtime_import_readback_blockers(
         readback.get("promotion_decision_refs")
     ):
         blockers.append("runtime_window_import_promotion_decision_ref_readback_missing")
-    if profit_proof_count > 0 and not _text_list(readback.get("source_refs")):
-        blockers.append("runtime_window_import_readback_source_refs_missing")
+    if profit_proof_count > 0:
+        if not _text_list(readback.get("source_refs")):
+            blockers.append("runtime_window_import_readback_source_refs_missing")
+            blockers.append("runtime_ledger_source_refs_missing")
+        if not (
+            _text_list(readback.get("runtime_ledger_source_window_ids"))
+            or _text_list(readback.get("source_window_ids"))
+        ):
+            blockers.append("runtime_ledger_source_window_missing")
+        if not (
+            _text_list(readback.get("runtime_ledger_execution_order_event_ids"))
+            or _text_list(readback.get("execution_order_event_ids"))
+        ):
+            blockers.append("runtime_ledger_execution_order_event_refs_missing")
+        if not _text_list(readback.get("execution_ids")):
+            blockers.append("runtime_ledger_execution_refs_missing")
+        if not _text_list(readback.get("trade_decision_ids")):
+            blockers.append("runtime_ledger_trade_decision_refs_missing")
+        if not _source_offsets(readback.get("source_offsets")):
+            blockers.append("runtime_ledger_source_offsets_missing")
+        if not _text_list(readback.get("source_materializations")):
+            blockers.append("runtime_ledger_source_materialization_missing")
+        if not _text_list(readback.get("authority_classes")):
+            blockers.append("runtime_ledger_authority_class_missing")
+        cost_amount = _decimal(readback.get("runtime_ledger_cost_amount"))
+        if cost_amount is None or (
+            not _mapping(readback.get("cost_basis_counts"))
+            and not _mapping(readback.get("runtime_ledger_cost_basis_counts"))
+        ):
+            blockers.append("runtime_ledger_explicit_costs_missing")
     return list(dict.fromkeys(blockers))
 
 

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -952,6 +952,51 @@ def _mapping_hash_count(value: object) -> int:
     return sum(1 for key in value.keys() if str(key).strip())
 
 
+def _positive_count_mapping_present(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    for item in cast(Mapping[object, object], value).values():
+        try:
+            parsed = Decimal(str(item))
+        except Exception:
+            continue
+        if parsed.is_finite() and parsed > 0:
+            return True
+    return False
+
+
+def _runtime_ledger_explicit_costs_present(bucket: Mapping[str, object]) -> bool:
+    cost_amount = _decimal_or_none(
+        bucket.get("cost_amount")
+        if bucket.get("cost_amount") is not None
+        else bucket.get("runtime_ledger_cost_amount")
+    )
+    if cost_amount is None or cost_amount < 0:
+        return False
+    if is_non_promotion_grade_runtime_cost_basis(bucket.get("cost_basis")):
+        return False
+    if cost_basis_counts_have_non_promotion_grade_costs(
+        bucket.get("cost_basis_counts")
+    ) or cost_basis_counts_have_non_promotion_grade_costs(
+        bucket.get("post_cost_basis_counts")
+    ):
+        return False
+    if _positive_count_mapping_present(bucket.get("cost_basis_counts")):
+        return True
+    if _positive_count_mapping_present(bucket.get("post_cost_basis_counts")):
+        return True
+    return (
+        _text_or_none(
+            bucket.get("cost_basis")
+            or bucket.get("cost_source")
+            or bucket.get("fee_basis")
+            or bucket.get("commission_basis")
+            or bucket.get("broker_fee_basis")
+        )
+        is not None
+    )
+
+
 def _runtime_ledger_bucket_profit_proof_blockers(
     bucket: Mapping[str, object],
 ) -> list[str]:
@@ -989,6 +1034,8 @@ def _runtime_ledger_bucket_profit_proof_blockers(
         add("unclosed_position")
     if filled_notional is None or filled_notional <= 0:
         add("filled_notional_missing")
+    if not _runtime_ledger_explicit_costs_present(bucket):
+        add("runtime_ledger_explicit_costs_missing")
     if cost_amount is None or cost_amount < 0:
         add(
             "runtime_ledger_cost_amount_missing"

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -968,6 +968,27 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["authority_blockers"],
         )
 
+    def test_source_offsets_accept_mapping_and_skip_invalid_or_duplicate_values(
+        self,
+    ) -> None:
+        self.assertEqual(
+            packet._source_offsets(
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+            ),
+            [{"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}],
+        )
+        self.assertEqual(
+            packet._source_offsets(
+                [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42},
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42},
+                    {"topic": "alpaca.trade_updates", "offset": 43},
+                    "alpaca.trade_updates:0:44",
+                ]
+            ),
+            [{"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}],
+        )
+
     def test_authority_packet_fails_each_mechanical_authority_floor(self) -> None:
         cases = [
             (
@@ -2313,6 +2334,10 @@ class TestRuntimeLedgerProofPacket(TestCase):
         readback["execution_ids"] = []
         readback["trade_decision_ids"] = []
         readback["source_offsets"] = []
+        readback["source_materializations"] = []
+        readback["authority_classes"] = []
+        readback["runtime_ledger_cost_amount"] = None
+        readback["cost_basis_counts"] = {}
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
@@ -2343,6 +2368,16 @@ class TestRuntimeLedgerProofPacket(TestCase):
         )
         self.assertIn(
             "runtime_ledger_source_offsets_missing", materialization["blockers"]
+        )
+        self.assertIn(
+            "runtime_ledger_source_materialization_missing",
+            materialization["blockers"],
+        )
+        self.assertIn(
+            "runtime_ledger_authority_class_missing", materialization["blockers"]
+        )
+        self.assertIn(
+            "runtime_ledger_explicit_costs_missing", materialization["blockers"]
         )
 
     def test_packet_does_not_treat_promotion_only_import_metadata_as_unmaterialized(

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -284,6 +284,29 @@ def _runtime_import(
             ]
             if authoritative
             else [],
+            "runtime_ledger_source_window_ids": ["source-window-1"]
+            if authoritative
+            else [],
+            "runtime_ledger_execution_order_event_ids": ["event-1"]
+            if authoritative
+            else [],
+            "execution_ids": ["execution-1"] if authoritative else [],
+            "trade_decision_ids": ["decision-1"] if authoritative else [],
+            "source_offsets": [
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+            ]
+            if authoritative
+            else [],
+            "runtime_ledger_cost_amount": "25" if authoritative else "0",
+            "authority_classes": ["runtime_order_feed_execution_source"]
+            if authoritative
+            else [],
+            "source_materializations": ["execution_order_events"]
+            if authoritative
+            else [],
+            "cost_basis_counts": {"broker_reported_commission_and_fees": 1}
+            if authoritative
+            else {},
             "runtime_ledger_profit_distance_readback": {
                 "schema_version": "torghut.runtime-ledger-profit-distance-readback.v1",
                 "required_daily_net_pnl": "500",
@@ -2275,6 +2298,53 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["promotion_authority"]["blocking_reasons"],
         )
 
+    def test_packet_blocks_authority_when_runtime_import_readback_lacks_row_refs(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        target = runtime_import["imports"][0]["summary"][
+            "runtime_materialization_target"
+        ]
+        assert isinstance(target, dict)
+        readback = target["readback"]
+        assert isinstance(readback, dict)
+        readback["runtime_ledger_source_window_ids"] = []
+        readback["runtime_ledger_execution_order_event_ids"] = []
+        readback["execution_ids"] = []
+        readback["trade_decision_ids"] = []
+        readback["source_offsets"] = []
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertIn(
+            "runtime_ledger_source_window_missing", materialization["blockers"]
+        )
+        self.assertIn(
+            "runtime_ledger_execution_order_event_refs_missing",
+            materialization["blockers"],
+        )
+        self.assertIn(
+            "runtime_ledger_execution_refs_missing", materialization["blockers"]
+        )
+        self.assertIn(
+            "runtime_ledger_trade_decision_refs_missing", materialization["blockers"]
+        )
+        self.assertIn(
+            "runtime_ledger_source_offsets_missing", materialization["blockers"]
+        )
+
     def test_packet_does_not_treat_promotion_only_import_metadata_as_unmaterialized(
         self,
     ) -> None:
@@ -2839,7 +2909,31 @@ class TestRuntimeLedgerProofPacket(TestCase):
                             "evidence_grade_runtime_ledger_bucket_refs": [
                                 "strategy_runtime_ledger_buckets:runtime-ledger-bucket-1"
                             ],
-                            "source_refs": ["postgres:executions"],
+                            "source_refs": [
+                                "postgres:trade_decisions",
+                                "postgres:executions",
+                                "postgres:execution_order_events",
+                                "postgres:order_feed_source_windows",
+                            ],
+                            "runtime_ledger_source_window_ids": ["source-window-1"],
+                            "runtime_ledger_execution_order_event_ids": ["event-1"],
+                            "execution_ids": ["execution-1"],
+                            "trade_decision_ids": ["decision-1"],
+                            "source_offsets": [
+                                {
+                                    "topic": "alpaca.trade_updates",
+                                    "partition": 0,
+                                    "offset": 42,
+                                }
+                            ],
+                            "runtime_ledger_cost_amount": "1250",
+                            "cost_basis_counts": {
+                                "alpaca_2026_equity_fee_schedule": 300
+                            },
+                            "authority_classes": [
+                                "runtime_order_feed_execution_source"
+                            ],
+                            "source_materializations": ["execution_order_events"],
                         },
                     },
                 },

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -858,6 +858,21 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(missing_marker))
 
+    def test_runtime_ledger_profit_proof_requires_explicit_cost_basis_and_amount(
+        self,
+    ) -> None:
+        for bucket in (
+            _complete_runtime_ledger_bucket(cost_amount=None),
+            _complete_runtime_ledger_bucket(cost_basis_counts={}, cost_basis=None),
+            _complete_runtime_ledger_bucket(
+                cost_basis_counts={"modeled_paper_cost_budget": 2},
+                cost_basis=None,
+            ),
+        ):
+            blockers = _runtime_ledger_bucket_profit_proof_blockers(bucket)
+            self.assertIn("runtime_ledger_explicit_costs_missing", blockers)
+            self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
+
     def test_runtime_ledger_profit_proof_blocks_old_exact_replay_empty_blockers(
         self,
     ) -> None:
@@ -1580,16 +1595,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                         "source_decision_mode_counts": {"strategy_signal_paper": 2},
                         "source_window_start": "2026-03-06T14:30:00+00:00",
                         "source_window_end": "2026-03-06T15:00:00+00:00",
-                        "source_refs": [
-                            "postgres:trade_decisions",
-                            "postgres:executions",
-                            "postgres:execution_order_events",
-                        ],
-                        "source_row_counts": {
-                            "trade_decisions": 2,
-                            "executions": 2,
-                            "execution_order_events": 4,
-                        },
+                        "source_refs": [],
+                        "source_row_counts": {},
                         "profit_proof_eligible": True,
                     },
                 )
@@ -1615,6 +1622,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertIn(
             "runtime_ledger_execution_order_event_refs_missing",
+            metadata["runtime_ledger_durable_bucket_profit_proof_blockers"],
+        )
+        self.assertIn(
+            "runtime_ledger_source_refs_missing",
             metadata["runtime_ledger_durable_bucket_profit_proof_blockers"],
         )
         self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
@@ -1742,6 +1753,46 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
         self.assertIn(
             "runtime_ledger_execution_order_event_refs_missing",
+            rows[0]["runtime_ledger_blockers"],
+        )
+
+    def test_runtime_ledger_tca_rows_from_source_dsn_block_no_source_refs(
+        self,
+    ) -> None:
+        cursor = _SourceLedgerCursor()
+        row = list(cursor._results[0][0])
+        payload = dict(cast(Mapping[str, object], row[-1]))
+        payload.update({"source_refs": [], "source_row_counts": {}})
+        row[-1] = payload
+        cursor._results[0] = [tuple(row)]
+        connection = _SourceLedgerConnection(cursor)
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            rows, metadata = _runtime_ledger_tca_rows_from_source_dsn(
+                dsn="postgresql://source",
+                candidate_id="H-TSMOM-LIQ-01",
+                hypothesis_id="H-TSMOM-LIQ-01",
+                observed_stage="paper",
+                strategy_names=["intraday-tsmom-profit-v3"],
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+            )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(metadata["runtime_ledger_source_bucket_profit_proof_count"], 0)
+        self.assertIn(
+            "runtime_ledger_source_refs_missing",
+            metadata["runtime_ledger_source_bucket_profit_proof_blockers"],
+        )
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        self.assertIn(
+            "runtime_ledger_source_refs_missing",
             rows[0]["runtime_ledger_blockers"],
         )
 
@@ -5230,6 +5281,62 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "runtime_ledger_pnl_basis_not_runtime_ledger",
                 "runtime_ledger_source_materialization_missing",
             ],
+        )
+
+    def test_runtime_ledger_tca_materialization_counts_only_source_backed_proof(
+        self,
+    ) -> None:
+        source_backed_bucket = _complete_runtime_ledger_bucket(
+            source_materialization="source_execution_lifecycle",
+            authoritative=True,
+        )
+        exact_replay_artifact = _complete_runtime_ledger_bucket(
+            source_refs=[],
+            source_row_counts={},
+            source_window_ids=[],
+            trade_decision_ids=[],
+            execution_ids=[],
+            execution_order_event_ids=[],
+            source_offsets=[],
+            source_materialization="exact_replay_artifact",
+            authority_class="exact_replay_artifact_only_not_live",
+            authority_reason="exact_replay_artifact_not_runtime_proof",
+            pnl_derivation="exact_replay_artifact_only_not_live",
+            blockers=["exact_replay_artifact_not_runtime_proof"],
+        )
+
+        metadata = _runtime_ledger_tca_materialization_metadata(
+            [
+                {
+                    "authoritative": True,
+                    "authority_reason": "source_execution_runtime_ledger_materialized",
+                    "runtime_ledger_bucket": source_backed_bucket,
+                },
+                {
+                    "authoritative": False,
+                    "authority_reason": "exact_replay_artifact_not_runtime_proof",
+                    "pnl_derivation": "exact_replay_artifact_only_not_live",
+                    "runtime_ledger_blockers": [
+                        "exact_replay_artifact_not_runtime_proof"
+                    ],
+                    "runtime_ledger_bucket": exact_replay_artifact,
+                },
+            ]
+        )
+
+        self.assertEqual(metadata["runtime_ledger_tca_runtime_bucket_row_count"], 2)
+        self.assertEqual(metadata["runtime_ledger_tca_profit_proof_count"], 1)
+        self.assertEqual(
+            metadata["runtime_ledger_source_execution_materialized_bucket_count"],
+            1,
+        )
+        self.assertIn(
+            "exact_replay_artifact_not_runtime_proof",
+            metadata["runtime_ledger_materialization_blockers"],
+        )
+        self.assertIn(
+            "runtime_ledger_source_refs_missing",
+            metadata["runtime_ledger_profit_proof_blockers"],
         )
 
     def test_build_realized_strategy_pnl_rows_normalizes_nested_runtime_payloads(

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -868,10 +868,27 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 cost_basis_counts={"modeled_paper_cost_budget": 2},
                 cost_basis=None,
             ),
+            _complete_runtime_ledger_bucket(
+                cost_basis_counts={"broker_reported": "not-a-number"},
+                cost_basis=None,
+            ),
         ):
             blockers = _runtime_ledger_bucket_profit_proof_blockers(bucket)
             self.assertIn("runtime_ledger_explicit_costs_missing", blockers)
             self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+        post_cost_basis_bucket = _complete_runtime_ledger_bucket(
+            cost_basis_counts={},
+            post_cost_basis_counts={"broker_reported": 2},
+            cost_basis=None,
+        )
+        self.assertNotIn(
+            "runtime_ledger_explicit_costs_missing",
+            _runtime_ledger_bucket_profit_proof_blockers(post_cost_basis_bucket),
+        )
+        self.assertTrue(
+            _runtime_ledger_bucket_profit_proof_present(post_cost_basis_bucket)
+        )
 
     def test_runtime_ledger_profit_proof_blocks_old_exact_replay_empty_blockers(
         self,

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -79,6 +79,7 @@ def _runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
         "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
         "execution_policy_hash_counts": {"policy-sha": 2},
         "cost_model_hash_counts": {"cost-sha": 2},
+        "cost_basis_counts": {"broker_reported_commission_and_fees": 2},
         "lineage_hash_counts": {"lineage-sha": 2},
         "source_decision_mode_counts": {"strategy_signal_paper": 2},
         "profit_proof_eligible": True,
@@ -845,7 +846,11 @@ class TestRuntimeWindowImport(TestCase):
                 )
 
                 self.assertEqual(
-                    blockers, ["runtime_ledger_cost_basis_non_promotion_grade"]
+                    blockers,
+                    [
+                        "runtime_ledger_explicit_costs_missing",
+                        "runtime_ledger_cost_basis_non_promotion_grade",
+                    ],
                 )
 
         self.assertFalse(
@@ -2313,6 +2318,22 @@ class TestRuntimeWindowImport(TestCase):
             "runtime_ledger_authority_class_missing",
             _runtime_ledger_bucket_blockers(bucket),
         )
+
+    def test_runtime_ledger_bucket_requires_explicit_cost_basis_and_amount(
+        self,
+    ) -> None:
+        for bucket in (
+            _runtime_ledger_bucket(cost_amount=None),
+            _runtime_ledger_bucket(cost_basis_counts={}, cost_basis=None),
+            _runtime_ledger_bucket(
+                cost_basis_counts={"modeled_paper_cost_budget": 2},
+                cost_basis=None,
+            ),
+        ):
+            self.assertIn(
+                "runtime_ledger_explicit_costs_missing",
+                _runtime_ledger_bucket_blockers(bucket),
+            )
 
     def test_persist_observed_runtime_windows_allows_authority_grade_live_ledger(
         self,

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -41,6 +41,7 @@ from app.trading.runtime_window_import import (
     _runtime_ledger_bucket_blockers,
     _runtime_ledger_bucket_payloads,
     _runtime_ledger_daily_summary_from_observed_buckets,
+    _runtime_window_import_readback_from_rows,
     _runtime_window_import_proof_blockers,
     build_observed_runtime_buckets,
     build_regular_session_buckets,
@@ -989,6 +990,85 @@ class TestRuntimeWindowImport(TestCase):
         self.assertFalse(_persisted_runtime_ledger_bucket_evidence_grade(row))
         row.payload_json = source_backed_payload
         self.assertTrue(_persisted_runtime_ledger_bucket_evidence_grade(row))
+
+    def test_runtime_window_import_readback_normalizes_source_offsets(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        good_payload = _runtime_ledger_bucket(
+            source_offsets={
+                "topic": "alpaca.trade_updates",
+                "partition": 0,
+                "offset": 100,
+            },
+            cost_basis_counts={"broker_reported_commission_and_fees": "2"},
+        )
+        malformed_payload = _runtime_ledger_bucket(
+            source_offsets=[
+                "alpaca.trade_updates:0:100",
+                {"topic": "alpaca.trade_updates", "offset": 101},
+                {
+                    "topic": "alpaca.trade_updates",
+                    "partition": 0,
+                    "offset": 100,
+                },
+            ],
+            cost_basis_counts={"broker_reported_commission_and_fees": "not-a-number"},
+        )
+        ledger_rows = [
+            StrategyRuntimeLedgerBucket(
+                run_id="readback-source-offsets",
+                candidate_id="cand",
+                hypothesis_id="hyp",
+                observed_stage="paper",
+                bucket_started_at=window_start,
+                bucket_ended_at=window_end,
+                account_label="TORGHUT_SIM",
+                runtime_strategy_name="strategy",
+                fill_count=2,
+                decision_count=2,
+                submitted_order_count=2,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("200"),
+                gross_strategy_pnl=Decimal("1"),
+                cost_amount=Decimal("0.20"),
+                net_strategy_pnl_after_costs=Decimal("0.80"),
+                post_cost_expectancy_bps=Decimal("40"),
+                pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                execution_policy_hash_counts={"policy-sha": 2},
+                cost_model_hash_counts={"cost-sha": 2},
+                lineage_hash_counts={"lineage-sha": 2},
+                blockers_json=[],
+                payload_json=payload,
+            )
+            for payload in (good_payload, malformed_payload)
+        ]
+
+        readback = _runtime_window_import_readback_from_rows(
+            run_id="readback-source-offsets",
+            candidate_id="cand",
+            hypothesis_id="hyp",
+            observed_stage="paper",
+            window_start=window_start,
+            window_end=window_end,
+            metric_rows=[],
+            promotion_rows=[],
+            ledger_rows=ledger_rows,
+            runtime_ledger_daily_summary={},
+            proof_blocker_codes=[],
+        )
+
+        self.assertEqual(
+            readback["source_offsets"],
+            [{"topic": "alpaca.trade_updates", "partition": 0, "offset": 100}],
+        )
+        self.assertEqual(
+            readback["cost_basis_counts"],
+            {"broker_reported_commission_and_fees": 2},
+        )
 
     def test_runtime_ledger_bucket_payloads_accept_single_bucket_payload(
         self,
@@ -2329,11 +2409,25 @@ class TestRuntimeWindowImport(TestCase):
                 cost_basis_counts={"modeled_paper_cost_budget": 2},
                 cost_basis=None,
             ),
+            _runtime_ledger_bucket(cost_basis="modeled_paper_cost_budget"),
+            _runtime_ledger_bucket(
+                cost_basis_counts={"broker_reported_commission_and_fees": "bad"},
+                cost_basis=None,
+            ),
         ):
             self.assertIn(
                 "runtime_ledger_explicit_costs_missing",
                 _runtime_ledger_bucket_blockers(bucket),
             )
+
+        blockers = _runtime_ledger_bucket_blockers(
+            _runtime_ledger_bucket(
+                cost_basis_counts={},
+                post_cost_basis_counts={"broker_reported_commission_and_fees": 2},
+                cost_basis=None,
+            )
+        )
+        self.assertNotIn("runtime_ledger_explicit_costs_missing", blockers)
 
     def test_persist_observed_runtime_windows_allows_authority_grade_live_ledger(
         self,


### PR DESCRIPTION
## Summary

- Require runtime-ledger import/readback evidence to carry source-backed row refs, structured source offsets, explicit cost amount and basis, source materialization, and authority markers before it can count as promotion-grade proof.
- Preserve source-window IDs, execution-order-event IDs, execution IDs, trade-decision IDs, source offsets, cost-basis counts, materializations, and authority classes in runtime-window import readbacks for proof packet materialization.
- Tighten proof-packet materialization to block aggregate-only or under-specified readbacks with precise runtime-ledger blockers while keeping smoke/probation evidence visible and non-promotable.
- Add regressions for durable/source aggregate-only buckets, missing source refs, explicit cost gaps, mixed exact-replay plus source-backed evidence, authority readbacks missing row-level refs, and source-offset/cost-basis edge cases that keep the diff-coverage gate honest.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev` (previously passed after installing the missing local C/C++ build toolchain required to build `crosshair-tool` in this workspace)
- `uv run --frozen pytest tests/test_runtime_window_import.py -q -k 'source_offsets or explicit_cost_basis_and_amount'` (3 passed, 52 deselected, 1 warning)
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q -k 'explicit_cost_basis_and_amount'` (1 passed, 123 deselected, 1 warning)
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q -k 'source_offsets or lacks_row_refs'` (2 passed, 63 deselected, 1 warning)
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q` (286 passed, 1 warning)
- `uv run --frozen ruff check app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py` (passes)
- `uv run --frozen ruff format --check app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py` (passes)
- `uv run --frozen python -m coverage run -m pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q && uv run --frozen python -m coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` (changed-line coverage 125/125, 100.00%)
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (0 errors)
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (0 errors)
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (0 errors)
- `git diff --check` (passes)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Visual evidence is not applicable and Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
