### PR TITLE
fix(torghut): supervise tigerbeetle journal worker

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -63,6 +63,7 @@ spec:
                     --reconcile-limit 1000 \
                     --skip-reconcile \
                     --fail-on-degraded \
+                    --supervise-timeout-seconds 45 \
                     --json
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env DB_DSN \
@@ -72,6 +73,7 @@ spec:
                     --event-scan-limit 250 \
                     --reconcile-limit 1000 \
                     --fail-on-degraded \
+                    --supervise-timeout-seconds 45 \
                     --json
               env:
                 - name: DB_DSN
@@ -166,6 +168,7 @@ spec:
                     --reconcile-limit 500 \
                     --skip-reconcile \
                     --fail-on-degraded \
+                    --supervise-timeout-seconds 45 \
                     --json
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env SIM_DB_DSN \
@@ -176,6 +179,7 @@ spec:
                     --event-scan-limit 300 \
                     --reconcile-limit 500 \
                     --fail-on-degraded \
+                    --supervise-timeout-seconds 45 \
                     --json
               env:
                 - name: TORGHUT_SIM_DB_HOST

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -111,6 +112,21 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=100,
         help="Emit stderr progress every N processed source rows; set 0 to disable.",
+    )
+    parser.add_argument(
+        "--supervise-timeout-seconds",
+        type=float,
+        default=0.0,
+        help=(
+            "Run the journal worker in a child process and kill it after this "
+            "deadline. This bounds native TigerBeetle client calls that cannot "
+            "be interrupted safely from a Python thread."
+        ),
+    )
+    parser.add_argument(
+        "--supervised-worker",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--json", action="store_true")
@@ -500,6 +516,10 @@ def _payload(
         "event_scan_limit": getattr(args, "event_scan_limit", None),
         "sources": list(_parse_sources(getattr(args, "sources", "all"))),
         "skip_reconcile": bool(getattr(args, "skip_reconcile", False)),
+        "supervised_worker": bool(getattr(args, "supervised_worker", False)),
+        "supervise_timeout_seconds": float(
+            getattr(args, "supervise_timeout_seconds", 0.0) or 0.0
+        ),
         "stopped_early": bool(stop_reasons),
         "stop_reasons": stop_reasons,
         "started_at": started_at.isoformat(),
@@ -513,6 +533,98 @@ def _payload(
     }
 
 
+def _supervised_timeout_payload(
+    *,
+    args: argparse.Namespace,
+    started_at: datetime,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    stop_reason = "tigerbeetle_journal_worker_timeout"
+    batch = {
+        "source": "supervised_worker",
+        "selected": 0,
+        "journaled": 0,
+        "skipped": 0,
+        "failed": 1,
+        "error_counts": {stop_reason: 1},
+        "sample_errors": [
+            {
+                "error_type": "TimeoutExpired",
+                "error": f"journal worker exceeded {timeout_seconds:.3f}s",
+            }
+        ],
+        "stopped_early": True,
+        "stop_reason": stop_reason,
+    }
+    return {
+        "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
+        "ok": False,
+        "status": "degraded",
+        "fail_on_degraded": bool(args.fail_on_degraded),
+        "dry_run": bool(args.dry_run),
+        "dsn_env": args.dsn_env,
+        "account_label": args.account_label,
+        "batch_size": max(1, min(int(args.batch_size), 5000)),
+        "max_batches": max(1, int(args.max_batches)),
+        "event_scan_limit": getattr(args, "event_scan_limit", None),
+        "sources": list(_parse_sources(getattr(args, "sources", "all"))),
+        "skip_reconcile": bool(getattr(args, "skip_reconcile", False)),
+        "supervised_worker": False,
+        "supervise_timeout_seconds": timeout_seconds,
+        "stopped_early": True,
+        "stop_reasons": [stop_reason],
+        "started_at": started_at.isoformat(),
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "selected": 0,
+        "journaled": 0,
+        "skipped": 0,
+        "failed": 1,
+        "batches": [batch],
+        "reconciliation": {
+            "ok": False,
+            "status": "skipped",
+            "reason": stop_reason,
+        },
+    }
+
+
+def _supervised_worker_argv() -> list[str]:
+    return [
+        sys.executable,
+        os.path.abspath(__file__),
+        *sys.argv[1:],
+        "--supervised-worker",
+    ]
+
+
+def _run_supervised_worker(args: argparse.Namespace, *, started_at: datetime) -> int:
+    timeout_seconds = max(float(args.supervise_timeout_seconds), 0.001)
+    try:
+        completed = subprocess.run(
+            _supervised_worker_argv(),
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        _emit_progress(
+            "supervised_worker_timeout",
+            timeout_seconds=timeout_seconds,
+            sources=list(_parse_sources(getattr(args, "sources", "all"))),
+        )
+        payload = _supervised_timeout_payload(
+            args=args,
+            started_at=started_at,
+            timeout_seconds=timeout_seconds,
+        )
+        print(
+            json.dumps(payload, separators=(",", ":"))
+            if args.json
+            else json.dumps(payload, indent=2)
+        )
+        return 1 if args.fail_on_degraded else 0
+    return int(completed.returncode)
+
+
 def main() -> int:
     args = _parse_args()
     dsn = os.environ.get(str(args.dsn_env).strip())
@@ -520,6 +632,11 @@ def main() -> int:
         raise SystemExit(f"missing DSN env var: {args.dsn_env}")
 
     started_at = datetime.now(timezone.utc)
+    if float(getattr(args, "supervise_timeout_seconds", 0.0) or 0.0) > 0 and not bool(
+        getattr(args, "supervised_worker", False)
+    ):
+        return _run_supervised_worker(args, started_at=started_at)
+
     batch_size = max(1, min(int(args.batch_size), 5000))
     max_batches = max(1, int(args.max_batches))
     try:

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -4,9 +4,10 @@ import argparse
 import io
 import json
 import os
+import subprocess
 import sys
 import tempfile
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timezone
 from decimal import Decimal
 from types import SimpleNamespace
@@ -280,7 +281,12 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             account_label="paper",
             batch_size=500,
             max_batches=1,
+            event_scan_limit=None,
             fail_on_degraded=True,
+            skip_reconcile=False,
+            sources="all",
+            supervised_worker=False,
+            supervise_timeout_seconds=0.0,
         )
 
         payload = script._payload(
@@ -295,6 +301,61 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(payload["status"], "degraded")
         self.assertEqual(payload["failed"], 0)
         self.assertTrue(payload["fail_on_degraded"])
+
+    def test_supervised_worker_timeout_emits_degraded_payload(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch.dict(os.environ, {"DB_DSN": "sqlite+pysqlite:///:memory:"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "journal_tigerbeetle_order_events.py",
+                    "--dsn-env",
+                    "DB_DSN",
+                    "--sources",
+                    "execution",
+                    "--batch-size",
+                    "50",
+                    "--max-batches",
+                    "1",
+                    "--fail-on-degraded",
+                    "--json",
+                    "--supervise-timeout-seconds",
+                    "0.01",
+                ],
+            ),
+            patch(
+                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(
+                    cmd=["python", "journal_tigerbeetle_order_events.py"],
+                    timeout=0.01,
+                ),
+            ) as run_mock,
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            exit_code = script.main()
+
+        self.assertEqual(exit_code, 1)
+        payload = json.loads(stdout.getvalue())
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["status"], "degraded")
+        self.assertTrue(payload["stopped_early"])
+        self.assertEqual(
+            payload["stop_reasons"],
+            ["tigerbeetle_journal_worker_timeout"],
+        )
+        self.assertEqual(payload["failed"], 1)
+        self.assertEqual(
+            payload["reconciliation"]["reason"],
+            "tigerbeetle_journal_worker_timeout",
+        )
+        self.assertIn("supervised_worker_timeout", stderr.getvalue())
+        self.assertIn("--supervised-worker", run_mock.call_args.args[0])
+        self.assertEqual(run_mock.call_args.kwargs["timeout"], 0.01)
 
     def test_process_rows_attaches_runtime_bucket_journal_payload(self) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1502,6 +1502,7 @@ class TestLiveConfigManifestContract(TestCase):
             )
             self.assertEqual(args.count("--skip-reconcile"), 1)
             self.assertEqual(args.count("--fail-on-degraded"), 2)
+            self.assertEqual(args.count("--supervise-timeout-seconds 45"), 2)
             self.assertIn("--json", args)
             security_context = cast(
                 Mapping[str, object],


### PR DESCRIPTION
## Summary

- Adds a supervised worker mode to the TigerBeetle journal script so native client hangs are killed by the parent process.
- Emits degraded JSON with `tigerbeetle_journal_worker_timeout` when the supervised worker exceeds its deadline.
- Wires live and sim TigerBeetle journal CronJob invocations with `--supervise-timeout-seconds 45`.
- Adds regression and manifest-contract tests for the supervised timeout path.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py tests/test_config.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
