### PR TITLE
feat(torghut): harden hpairs offline frontier authority

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -5664,6 +5664,13 @@ class CandidateSpec:
             "hard_vetoes": dict(self.hard_vetoes),
             "expected_failure_modes": list(self.expected_failure_modes),
             "promotion_contract": dict(self.promotion_contract),
+            "candidate_authority": "discovery_probation_input_only",
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
         }
 
     def to_vnext_experiment_payload(

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -22,8 +22,8 @@ from app.trading.discovery.microstructure_prefilter import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v4"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v5"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v5"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v6"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -169,6 +169,7 @@ class FastReplayPreviewRow:
                 "promotion_authority": False,
                 "promotion_allowed": False,
                 "final_promotion_allowed": False,
+                "final_authority_ok": False,
             },
             "microstructure_prefilter": dict(self.microstructure_prefilter),
             "hpairs_microstructure_prefilter": dict(self.microstructure_prefilter),
@@ -231,6 +232,7 @@ class FastReplayPreviewRow:
             "promotion_authority": False,
             "promotion_allowed": False,
             "final_promotion_allowed": False,
+            "final_authority_ok": False,
             "proof_authority_reason": (
                 "fast_replay_preview_rank_only_exact_replay_and_source_backed_runtime_ledger_required"
             ),
@@ -261,6 +263,7 @@ class FastReplayPreviewResult:
             "promotion_authority": False,
             "promotion_allowed": False,
             "final_promotion_allowed": False,
+            "final_authority_ok": False,
             "authority": "not_promotion_proof",
             "proof_semantics_label": FAST_REPLAY_PROOF_SEMANTICS_LABEL,
             "selection_policy": {
@@ -328,6 +331,7 @@ class FastReplayPreviewResult:
                 "promotion_authority": False,
                 "promotion_allowed": False,
                 "final_promotion_allowed": False,
+                "final_authority_ok": False,
             },
             "replay_tape": {
                 "dataset_snapshot_ref": self.replay_tape_manifest.dataset_snapshot_ref,

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6698,6 +6698,7 @@ def _apply_fast_replay_preview_narrowing(
             updated["fast_replay_promotion_authority"] = False
             updated["fast_replay_promotion_allowed"] = False
             updated["fast_replay_final_promotion_allowed"] = False
+            updated["fast_replay_final_authority_ok"] = False
             microstructure_prefilter = _mapping(
                 preview_row.get("hpairs_microstructure_prefilter")
                 or preview_row.get("microstructure_prefilter")
@@ -6820,6 +6821,7 @@ def _fast_replay_preview_proof_semantics() -> dict[str, Any]:
         "promotion_authority": False,
         "promotion_allowed": False,
         "final_promotion_allowed": False,
+        "final_authority_ok": False,
         "authority": "preview_prefilter_only",
         "prefilter_only": True,
         "no_kubernetes_fanout": True,
@@ -6950,10 +6952,11 @@ def _bounded_sim_target_queue_metadata(
                 "promotion_authority": False,
                 "promotion_allowed": False,
                 "final_promotion_allowed": False,
+                "final_authority_ok": False,
             }
         )
     return {
-        "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v2",
+        "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v3",
         "status": "metadata_only_preview_to_exact_replay_queue",
         "authority": "not_promotion_proof",
         "prefilter_only": True,
@@ -6962,6 +6965,7 @@ def _bounded_sim_target_queue_metadata(
         "promotion_authority": False,
         "promotion_allowed": False,
         "final_promotion_allowed": False,
+        "final_authority_ok": False,
         "proof_semantics": _fast_replay_preview_proof_semantics(),
         "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
         "queue_policy": "top_exploitation_plus_exploration_exact_replay_cap",
@@ -6975,6 +6979,7 @@ def _bounded_sim_target_queue_metadata(
             "promotion_authority": False,
             "promotion_allowed": False,
             "final_promotion_allowed": False,
+            "final_authority_ok": False,
         },
         "runner_policy": {
             "default_shard_timeout_seconds": _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
@@ -6984,6 +6989,22 @@ def _bounded_sim_target_queue_metadata(
             ),
             "kubernetes_fanout_enabled": False,
             "handoff_mode": "metadata_only_no_live_submit",
+        },
+        "exact_replay_command_policy": {
+            "schema_version": "torghut.fast-replay-exact-command-policy.v1",
+            "generation_scope": "bounded_frontier_only",
+            "max_exact_replay_candidates": _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
+            "effective_exact_replay_candidate_cap": exact_replay_candidate_cap,
+            "max_local_workers": _DEFAULT_REAL_REPLAY_SHARD_WORKERS,
+            "shard_timeout_seconds": _DEFAULT_REAL_REPLAY_SHARD_TIMEOUT_SECONDS,
+            "proof_packet_upload_allowed": False,
+            "db_writes_allowed": False,
+            "cluster_fanout_allowed": False,
+            "kubernetes_fanout_allowed": False,
+            "promotion_writes_allowed": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
         },
         "target_queue": {
             "sim_account_label": "TORGHUT_SIM",
@@ -7031,7 +7052,7 @@ def _fast_replay_exact_handoff_lineage(
     frontier_bucket: str,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
-        "schema_version": "torghut.fast-replay-exact-handoff-lineage.v1",
+        "schema_version": "torghut.fast-replay-exact-handoff-lineage.v2",
         "status": "preview_only_exact_replay_handoff",
         "authority": "not_promotion_proof",
         "prefilter_only": True,
@@ -7040,6 +7061,7 @@ def _fast_replay_exact_handoff_lineage(
         "promotion_authority": False,
         "promotion_allowed": False,
         "final_promotion_allowed": False,
+        "final_authority_ok": False,
         "candidate_spec_id": candidate_spec_id,
         "queue_priority": queue_priority,
         "frontier_bucket": frontier_bucket,

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -151,6 +151,8 @@ class TestFastReplayPreview(TestCase):
         self.assertFalse(payload["promotion_proof"])
         self.assertFalse(payload["promotion_allowed"])
         self.assertFalse(payload["final_promotion_allowed"])
+        self.assertFalse(payload["final_authority_ok"])
+        self.assertFalse(row_payload["final_authority_ok"])
         self.assertEqual(
             payload["proof_semantics_label"], FAST_REPLAY_PROOF_SEMANTICS_LABEL
         )
@@ -272,6 +274,7 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertFalse(payload["promotion_allowed"])
         self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["final_authority_ok"])
 
     def test_ofi_pressure_uses_nonstandard_hpair_horizon_values(self) -> None:
         signal = SignalEnvelope(
@@ -566,6 +569,7 @@ class TestFastReplayPreview(TestCase):
         self.assertFalse(payload["promotion_authority"])
         self.assertFalse(payload["promotion_allowed"])
         self.assertFalse(payload["final_promotion_allowed"])
+        self.assertFalse(payload["final_authority_ok"])
 
     def test_frontier_selection_dedupes_equivalent_exact_replay_targets(
         self,
@@ -644,10 +648,16 @@ class TestFastReplayPreview(TestCase):
         self.assertFalse(
             duplicate_payload["frontier_dedupe_metadata"]["promotion_allowed"]
         )
+        self.assertFalse(
+            duplicate_payload["frontier_dedupe_metadata"]["final_authority_ok"]
+        )
         manifest_payload = preview.to_manifest_payload()
         self.assertEqual(
             manifest_payload["frontier_dedupe_policy"]["status"], "enabled"
         )
         self.assertFalse(
             manifest_payload["frontier_dedupe_policy"]["promotion_allowed"]
+        )
+        self.assertFalse(
+            manifest_payload["frontier_dedupe_policy"]["final_authority_ok"]
         )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4627,6 +4627,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             [spec["candidate_spec_id"] for spec in selected_specs],
             ["spec-nvda-continuation"],
         )
+        self.assertFalse(selected_specs[0]["promotion_allowed"])
+        self.assertFalse(selected_specs[0]["final_promotion_allowed"])
+        self.assertFalse(selected_specs[0]["final_authority_ok"])
         self.assertFalse(selection["replay_tape_preview"]["promotion_proof"])
         self.assertIn(
             "exact_replay_required", selection["replay_tape_preview"]["blockers"]
@@ -4650,6 +4653,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertFalse(nvda_row["fast_replay_proof_authority"])
         self.assertFalse(nvda_row["fast_replay_promotion_allowed"])
         self.assertFalse(nvda_row["fast_replay_final_promotion_allowed"])
+        self.assertFalse(nvda_row["fast_replay_final_authority_ok"])
         aapl_row = next(
             row
             for row in selection["rows"]
@@ -4763,8 +4767,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertFalse(queue_payload["proof_authority"])
         self.assertFalse(queue_payload["promotion_allowed"])
         self.assertFalse(queue_payload["final_promotion_allowed"])
+        self.assertFalse(queue_payload["final_authority_ok"])
         self.assertFalse(queue_payload["proof_semantics"]["promotion_allowed"])
         self.assertFalse(queue_payload["proof_semantics"]["final_promotion_allowed"])
+        self.assertFalse(queue_payload["proof_semantics"]["final_authority_ok"])
         self.assertEqual(
             queue_payload["runner_policy"]["default_shard_timeout_seconds"], 900
         )
@@ -4774,6 +4780,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             queue_payload["runner_policy"]["default_parallel_frontier_candidate_cap"],
             6,
         )
+        command_policy = queue_payload["exact_replay_command_policy"]
+        self.assertEqual(command_policy["generation_scope"], "bounded_frontier_only")
+        self.assertEqual(command_policy["max_exact_replay_candidates"], 6)
+        self.assertEqual(command_policy["effective_exact_replay_candidate_cap"], 6)
+        self.assertEqual(command_policy["max_local_workers"], 2)
+        self.assertEqual(command_policy["shard_timeout_seconds"], 900)
+        self.assertFalse(command_policy["proof_packet_upload_allowed"])
+        self.assertFalse(command_policy["db_writes_allowed"])
+        self.assertFalse(command_policy["kubernetes_fanout_allowed"])
+        self.assertFalse(command_policy["promotion_writes_allowed"])
+        self.assertFalse(command_policy["final_authority_ok"])
         self.assertEqual(
             queue_payload["target_queue"]["status"],
             "sim_target_queue_ready_live_paper_blocked",
@@ -4872,12 +4889,16 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertFalse(
             first_entry["exact_replay_handoff_lineage"]["final_promotion_allowed"]
         )
+        self.assertFalse(
+            first_entry["exact_replay_handoff_lineage"]["final_authority_ok"]
+        )
         self.assertEqual(
             first_entry["adv_capacity_context"]["status"], "missing_source_backed_adv"
         )
         self.assertIn("source_backed_adv_missing", first_entry["lineage_blockers"])
         self.assertFalse(first_entry["promotion_allowed"])
         self.assertFalse(first_entry["final_promotion_allowed"])
+        self.assertFalse(first_entry["final_authority_ok"])
         self.assertIn("hpairs_microstructure_prefilter", first_entry)
         self.assertEqual(
             first_entry["hpairs_microstructure_prefilter"]["proof_source"],
@@ -5079,7 +5100,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(queue_payload["dedupe_policy"]["status"], "enabled")
         self.assertFalse(queue_payload["dedupe_policy"]["proof_authority"])
         self.assertFalse(queue_payload["dedupe_policy"]["promotion_allowed"])
+        self.assertFalse(queue_payload["dedupe_policy"]["final_authority_ok"])
         self.assertFalse(queue_payload["promotion_allowed"])
+        self.assertFalse(queue_payload["final_authority_ok"])
         self.assertEqual(
             queue_payload["entries"][0]["exact_replay_handoff_lineage"][
                 "exact_replay_frontier_key"
@@ -5238,10 +5261,11 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         manifest_payload = preview.to_manifest_payload()
 
         self.assertEqual(
-            row_payload["schema_version"], "torghut.fast-replay-preview-row.v5"
+            row_payload["schema_version"], "torghut.fast-replay-preview-row.v6"
         )
         self.assertEqual(manifest_payload["status"], "preview_only")
         self.assertFalse(manifest_payload["promotion_proof"])
+        self.assertFalse(manifest_payload["final_authority_ok"])
         self.assertEqual(
             row_payload["proof_semantics_label"],
             fast_replay.FAST_REPLAY_PROOF_SEMANTICS_LABEL,
@@ -5257,6 +5281,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn("conformal_tail_risk", manifest_payload["implemented_mechanisms"])
         self.assertEqual(row_payload["proof_source"], "prefilter_only")
         self.assertFalse(row_payload["final_promotion_allowed"])
+        self.assertFalse(row_payload["final_authority_ok"])
         self.assertIn("hpairs_microstructure_prefilter", row_payload)
         self.assertEqual(
             row_payload["hpairs_microstructure_prefilter"]["proof_source"],


### PR DESCRIPTION
## Summary

- Mark offline H-PAIRS candidate specs, fast preview rows, preview manifests, dedupe metadata, and exact handoff lineage as discovery/probation input only with `final_authority_ok=false`.
- Add an explicit bounded exact-replay command policy to the SIM target queue: top frontier only, max 6 candidates, max 2 local workers, 900s shard timeout, no proof-packet upload, no DB writes, no Kubernetes/cluster fanout, and no promotion writes.
- Preserve the replay tape cache/frontier selection behavior while strengthening regression coverage for non-authority metadata and bounded handoff defaults.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — pass
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` — pass, 221 passed, 1 warning
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py` — pass
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py` — pass
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — pass, 0 errors
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — pass, 0 errors
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — pass, 0 errors
- `git diff --check` — pass

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
