### PR TITLE
fix(torghut): reconcile legacy tigerbeetle source refs

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -303,16 +303,36 @@ def _source_ref_exists(
     source_type: str,
     source_id: str,
     transfer_kind: str,
+    source_pk: UUID | None = None,
 ) -> bool:
+    source_clauses = [
+        (TigerBeetleTransferRef.source_type == source_type)
+        & (TigerBeetleTransferRef.source_id == source_id)
+    ]
+    if source_pk is not None:
+        if source_type == SOURCE_TYPE_EXECUTION:
+            source_clauses.append(
+                (TigerBeetleTransferRef.source_type == source_type)
+                & (TigerBeetleTransferRef.execution_id == source_pk)
+            )
+        elif source_type == SOURCE_TYPE_EXECUTION_TCA_METRIC:
+            source_clauses.append(
+                (TigerBeetleTransferRef.source_type == source_type)
+                & (TigerBeetleTransferRef.execution_tca_metric_id == source_pk)
+            )
+        elif source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET:
+            source_clauses.append(
+                (TigerBeetleTransferRef.source_type == source_type)
+                & (TigerBeetleTransferRef.runtime_ledger_bucket_id == source_pk)
+            )
     return (
         session.scalar(
             select(TigerBeetleTransferRef.id)
             .where(
                 TigerBeetleTransferRef.cluster_id
                 == settings_obj.tigerbeetle_cluster_id,
-                TigerBeetleTransferRef.source_type == source_type,
-                TigerBeetleTransferRef.source_id == source_id,
                 TigerBeetleTransferRef.transfer_kind == transfer_kind,
+                or_(*source_clauses),
             )
             .limit(1)
         )
@@ -411,10 +431,6 @@ def _archived_source_amount_micros(ref: TigerBeetleTransferRef) -> Decimal | Non
     if ref.source_type not in {SOURCE_TYPE_EXECUTION, SOURCE_TYPE_EXECUTION_TCA_METRIC}:
         return None
     payload = _payload_mapping(ref)
-    if ":" not in str(ref.source_id or "") and not payload.get(
-        "source_economic_fingerprint"
-    ):
-        return None
     raw_amount = payload.get("amount_source")
     if raw_amount is None:
         return None
@@ -422,6 +438,17 @@ def _archived_source_amount_micros(ref: TigerBeetleTransferRef) -> Decimal | Non
         return _usd_to_micros(Decimal(str(raw_amount)))
     except (InvalidOperation, ValueError):
         return None
+
+
+def _legacy_unversioned_source_ref(ref: TigerBeetleTransferRef) -> bool:
+    if ref.source_type not in {SOURCE_TYPE_EXECUTION, SOURCE_TYPE_EXECUTION_TCA_METRIC}:
+        return False
+    payload = _payload_mapping(ref)
+    return (
+        ":" not in str(ref.source_id or "")
+        and payload.get("amount_source") is None
+        and payload.get("source_economic_fingerprint") is None
+    )
 
 
 def _expected_source_amount_micros(
@@ -862,6 +889,9 @@ def _latest_run_payload(
         "source_amount_mismatch_count": _payload_int(
             payload, "source_amount_mismatch_count"
         ),
+        "legacy_source_amount_unverifiable_count": _payload_int(
+            payload, "legacy_source_amount_unverifiable_count"
+        ),
         "runtime_ledger_checked_transfer_count": _payload_int(
             payload, "runtime_ledger_checked_transfer_count"
         ),
@@ -913,6 +943,10 @@ def _latest_run_payload(
         "mismatched_refs": payload.get("mismatched_refs") or [],
         "missing_source_rows": payload.get("missing_source_rows") or [],
         "unlinked_refs": payload.get("unlinked_refs") or [],
+        "legacy_source_amount_unverifiable_refs": payload.get(
+            "legacy_source_amount_unverifiable_refs"
+        )
+        or [],
         "blocker_details": payload.get("blocker_details") or {},
         "ref_counts": payload.get("ref_counts") or {},
         "started_at": row.started_at.isoformat(),
@@ -965,6 +999,7 @@ def reconcile_tigerbeetle_transfers(
     mismatched_transfer_count = 0
     source_row_missing_count = 0
     source_amount_mismatch_count = 0
+    legacy_source_amount_unverifiable_count = 0
     runtime_ledger_checked_transfer_count = 0
     runtime_ledger_signed_transfer_count = 0
     runtime_ledger_missing_signed_ref_count = 0
@@ -978,6 +1013,7 @@ def reconcile_tigerbeetle_transfers(
     missing_transfer_refs: list[dict[str, object]] = []
     missing_source_rows: list[dict[str, object]] = []
     unlinked_refs: list[dict[str, object]] = []
+    legacy_source_amount_unverifiable_refs: list[dict[str, object]] = []
 
     transfer_lookup: dict[str, object] = {}
     owned_client = client is None
@@ -1133,17 +1169,31 @@ def reconcile_tigerbeetle_transfers(
                         ),
                     )
             elif ref.amount != expected_source_amount:
-                source_amount_mismatch_count += 1
-                blockers.append(BLOCKER_SOURCE_AMOUNT_MISMATCH)
-                _append_sample(
-                    mismatched_refs,
-                    _ref_sample(
-                        ref,
-                        blocker=BLOCKER_SOURCE_AMOUNT_MISMATCH,
-                        reason="source_amount_micros_differs_from_transfer_ref",
-                        actual=actual,
-                    ),
-                )
+                if _legacy_unversioned_source_ref(ref):
+                    legacy_source_amount_unverifiable_count += 1
+                    _append_sample(
+                        legacy_source_amount_unverifiable_refs,
+                        _ref_sample(
+                            ref,
+                            blocker="tigerbeetle_legacy_source_amount_unverifiable",
+                            reason=(
+                                "legacy_source_ref_lacks_revision_or_archived_amount"
+                            ),
+                            actual=actual,
+                        ),
+                    )
+                else:
+                    source_amount_mismatch_count += 1
+                    blockers.append(BLOCKER_SOURCE_AMOUNT_MISMATCH)
+                    _append_sample(
+                        mismatched_refs,
+                        _ref_sample(
+                            ref,
+                            blocker=BLOCKER_SOURCE_AMOUNT_MISMATCH,
+                            reason="source_amount_micros_differs_from_transfer_ref",
+                            actual=actual,
+                        ),
+                    )
         if ref.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET:
             runtime_ledger_checked_transfer_count += 1
             source_uuid = _uuid_or_none(ref.source_id)
@@ -1241,6 +1291,7 @@ def reconcile_tigerbeetle_transfers(
             source_type=SOURCE_TYPE_EXECUTION,
             source_id=str(execution.id),
             transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+            source_pk=execution.id,
         ):
             continue
         unlinked_execution_count += 1
@@ -1277,6 +1328,7 @@ def reconcile_tigerbeetle_transfers(
             source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
             source_id=execution_tca_metric_source_id(metric),
             transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+            source_pk=metric.id,
         ):
             continue
         unlinked_cost_count += 1
@@ -1313,6 +1365,7 @@ def reconcile_tigerbeetle_transfers(
             source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             source_id=str(bucket.id),
             transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+            source_pk=bucket.id,
         ):
             continue
         unlinked_runtime_ledger_count += 1
@@ -1391,6 +1444,9 @@ def reconcile_tigerbeetle_transfers(
         "source_row_missing_count": source_row_missing_count,
         "missing_source_row_count": source_row_missing_count,
         "source_amount_mismatch_count": source_amount_mismatch_count,
+        "legacy_source_amount_unverifiable_count": (
+            legacy_source_amount_unverifiable_count
+        ),
         "runtime_ledger_checked_transfer_count": runtime_ledger_checked_transfer_count,
         "runtime_ledger_signed_transfer_count": runtime_ledger_signed_transfer_count,
         "runtime_ledger_ref_count": _payload_int(
@@ -1436,11 +1492,17 @@ def reconcile_tigerbeetle_transfers(
         "mismatched_refs": mismatched_refs,
         "missing_source_rows": missing_source_rows,
         "unlinked_refs": unlinked_refs,
+        "legacy_source_amount_unverifiable_refs": (
+            legacy_source_amount_unverifiable_refs
+        ),
         "blocker_details": {
             "missing_transfer_refs": missing_transfer_refs,
             "mismatched_refs": mismatched_refs,
             "missing_source_rows": missing_source_rows,
             "unlinked_refs": unlinked_refs,
+            "legacy_source_amount_unverifiable_refs": (
+                legacy_source_amount_unverifiable_refs
+            ),
         },
         "blockers": unique_blockers,
     }

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -21,6 +21,8 @@ from app.models import (
 )
 from app.trading.tigerbeetle_client import FakeTigerBeetleClient
 from app.trading.tigerbeetle_journal import (
+    SOURCE_TYPE_EXECUTION,
+    SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_EXECUTION_ORDER_EVENT,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
     build_order_event_transfer_plan,
@@ -34,6 +36,8 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_CODE_FILL_POST,
     TRANSFER_CODE_RUNTIME_NET_PNL,
     TRANSFER_CODE_SUBMITTED_PENDING,
+    TRANSFER_KIND_EXECUTION_COST,
+    TRANSFER_KIND_EXECUTION_FILL,
     TRANSFER_KIND_SUBMITTED_PENDING,
     TRANSFER_KIND_RUNTIME_NET_PNL,
     TigerBeetleTransferSpec,
@@ -306,7 +310,7 @@ class TestTigerBeetleReconcile(TestCase):
                     status="created",
                     execution_id=execution.id,
                     source_type="execution",
-                    source_id=str(execution.id),
+                    source_id=f"{execution.id}:current",
                 )
             )
             session.flush()
@@ -328,6 +332,65 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertFalse(payload["ok"])
             self.assertIn(BLOCKER_SOURCE_AMOUNT_MISMATCH, payload["blockers"])
             self.assertEqual(payload["source_amount_mismatch_count"], 1)
+
+    def test_reconciliation_reports_legacy_unversioned_source_amount_without_blocking(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-legacy-source",
+                client_order_id="client-legacy-source",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                status="filled",
+                raw_order={"id": "order-legacy-source"},
+            )
+            session.add(execution)
+            session.flush()
+            ref = TigerBeetleTransferRef(
+                cluster_id=2001,
+                transfer_id="1004",
+                transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_EXECUTION_FILL,
+                amount=Decimal("1"),
+                status="created",
+                execution_id=execution.id,
+                source_type=SOURCE_TYPE_EXECUTION,
+                source_id=str(execution.id),
+            )
+            session.add(ref)
+            session.flush()
+            client = FakeTigerBeetleClient()
+            client.transfers[1004] = TigerBeetleTransferSpec(
+                transfer_id=1004,
+                transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+                debit_account_id=11,
+                credit_account_id=12,
+                amount=1,
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_EXECUTION_FILL,
+            )
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertTrue(payload["ok"])
+            self.assertNotIn(BLOCKER_SOURCE_AMOUNT_MISMATCH, payload["blockers"])
+            self.assertEqual(payload["source_amount_mismatch_count"], 0)
+            self.assertEqual(payload["legacy_source_amount_unverifiable_count"], 1)
+            legacy_refs = payload["legacy_source_amount_unverifiable_refs"]
+            assert isinstance(legacy_refs, list)
+            self.assertEqual(legacy_refs[0]["row_id"], str(ref.id))
 
     def test_reconciliation_blocks_source_row_missing(self) -> None:
         with Session(self.engine) as session:
@@ -1158,6 +1221,97 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertFalse(payload["ok"])
             self.assertIn(BLOCKER_UNLINKED_COST, payload["blockers"])
             self.assertEqual(payload["unlinked_cost_count"], 1)
+
+    def test_reconciliation_treats_fk_linked_cost_ref_as_linked(self) -> None:
+        with Session(self.engine) as session:
+            execution = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-linked-cost",
+                client_order_id="client-linked-cost",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                status="filled",
+                raw_order={"id": "order-linked-cost"},
+            )
+            session.add(execution)
+            session.flush()
+            metric = ExecutionTCAMetric(
+                execution_id=execution.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.25"),
+                computed_at=datetime.now(timezone.utc),
+            )
+            session.add(metric)
+            session.flush()
+            session.add_all(
+                [
+                    TigerBeetleTransferRef(
+                        cluster_id=2001,
+                        transfer_id="1005",
+                        transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+                        ledger=LEDGER_USD_MICRO,
+                        code=TRANSFER_CODE_EXECUTION_FILL,
+                        amount=Decimal("190250000"),
+                        status="created",
+                        execution_id=execution.id,
+                        source_type=SOURCE_TYPE_EXECUTION,
+                        source_id=str(execution.id),
+                        payload_json={"amount_source": "190.25"},
+                    ),
+                    TigerBeetleTransferRef(
+                        cluster_id=2001,
+                        transfer_id="1006",
+                        transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+                        ledger=LEDGER_USD_MICRO,
+                        code=TRANSFER_CODE_EXECUTION_FILL,
+                        amount=Decimal("250000"),
+                        status="created",
+                        execution_id=execution.id,
+                        execution_tca_metric_id=metric.id,
+                        source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
+                        source_id=str(metric.id),
+                    ),
+                ]
+            )
+            session.flush()
+            client = FakeTigerBeetleClient()
+            client.transfers[1005] = TigerBeetleTransferSpec(
+                transfer_id=1005,
+                transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+                debit_account_id=11,
+                credit_account_id=12,
+                amount=190250000,
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_EXECUTION_FILL,
+            )
+            client.transfers[1006] = TigerBeetleTransferSpec(
+                transfer_id=1006,
+                transfer_kind=TRANSFER_KIND_EXECUTION_COST,
+                debit_account_id=11,
+                credit_account_id=13,
+                amount=250000,
+                ledger=LEDGER_USD_MICRO,
+                code=TRANSFER_CODE_EXECUTION_FILL,
+            )
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertTrue(payload["ok"])
+            self.assertEqual(payload["unlinked_cost_count"], 0)
+            self.assertNotIn(BLOCKER_UNLINKED_COST, payload["blockers"])
 
     def test_reconciliation_blocks_unlinked_runtime_ledger_ref(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Treat TigerBeetle source linkage as present when a ref matches either the exact source id or the typed source foreign key for execution, TCA cost, and runtime-ledger refs.
- Report legacy base-id execution/TCA refs that lack archived economics as non-authoritative `legacy_source_amount_unverifiable_*` diagnostics instead of current-source amount blockers.
- Keep revisioned/current source amount mismatches blocking and add regression coverage for FK-linked cost refs plus legacy unversioned source refs.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_tigerbeetle_reconcile.py -q`
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py -q`
- `uv run --frozen ruff format --check app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_reconcile.py`
- `uv run --frozen ruff check app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_reconcile.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
