### PR TITLE
fix(torghut): keep tigerbeetle cron health non-authoritative

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -63,6 +63,7 @@ spec:
                     --reconcile-limit 1000 \
                     --skip-reconcile \
                     --fail-on-degraded \
+                    --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
                     --json
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
@@ -73,6 +74,7 @@ spec:
                     --event-scan-limit 250 \
                     --reconcile-limit 1000 \
                     --fail-on-degraded \
+                    --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
                     --json
               env:
@@ -168,6 +170,7 @@ spec:
                     --reconcile-limit 500 \
                     --skip-reconcile \
                     --fail-on-degraded \
+                    --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
                     --json
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
@@ -179,6 +182,7 @@ spec:
                     --event-scan-limit 300 \
                     --reconcile-limit 500 \
                     --fail-on-degraded \
+                    --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
                     --json
               env:

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -48,6 +48,11 @@ DEFAULT_SOURCES = (
     SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
 )
+INFRASTRUCTURE_RECONCILIATION_BLOCKERS = frozenset(
+    {
+        "tigerbeetle_client_unavailable",
+    }
+)
 SOURCE_ALIASES = {
     "event": SOURCE_TYPE_EXECUTION_ORDER_EVENT,
     "events": SOURCE_TYPE_EXECUTION_ORDER_EVENT,
@@ -106,6 +111,16 @@ def _parse_args() -> argparse.Namespace:
         "--fail-on-degraded",
         action="store_true",
         help="Exit non-zero when journaling/reconciliation is degraded.",
+    )
+    parser.add_argument(
+        "--allow-data-quality-degraded",
+        action="store_true",
+        help=(
+            "When --fail-on-degraded is set, allow non-authoritative scheduled "
+            "telemetry runs to exit zero for reconciliation/accounting data-quality "
+            "blockers while still failing closed for journal batch failures, "
+            "TigerBeetle infrastructure blockers, timeouts, and unhandled errors."
+        ),
     )
     parser.add_argument(
         "--progress-interval",
@@ -503,11 +518,43 @@ def _payload(
         for batch in batches
         if str(batch.get("stop_reason") or "").strip()
     ]
+    reconciliation_blockers = _reconciliation_blockers(reconciliation)
+    hard_failure_reasons = _hard_failure_reasons(
+        failed=failed,
+        stop_reasons=stop_reasons,
+        reconciliation_blockers=reconciliation_blockers,
+        reconciliation_ok=reconciliation_ok,
+    )
+    accounting_blockers = [
+        blocker
+        for blocker in reconciliation_blockers
+        if blocker not in INFRASTRUCTURE_RECONCILIATION_BLOCKERS
+    ]
+    exit_nonzero = _should_exit_nonzero(
+        status=status,
+        fail_on_degraded=bool(args.fail_on_degraded),
+        allow_data_quality_degraded=bool(
+            getattr(args, "allow_data_quality_degraded", False)
+        ),
+        hard_failure_reasons=hard_failure_reasons,
+    )
     return {
         "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
         "ok": status == "ok",
         "status": status,
+        "authority": "non_authoritative_tigerbeetle_journal_telemetry",
+        "promotion_authority": False,
+        "overrides_runtime_ledger_authority": False,
         "fail_on_degraded": bool(args.fail_on_degraded),
+        "allow_data_quality_degraded": bool(
+            getattr(args, "allow_data_quality_degraded", False)
+        ),
+        "exit_nonzero": exit_nonzero,
+        "exit_policy": (
+            "fail_on_hard_failures_only"
+            if bool(getattr(args, "allow_data_quality_degraded", False))
+            else "fail_on_any_degraded"
+        ),
         "dry_run": bool(args.dry_run),
         "dsn_env": args.dsn_env,
         "account_label": args.account_label,
@@ -522,6 +569,9 @@ def _payload(
         ),
         "stopped_early": bool(stop_reasons),
         "stop_reasons": stop_reasons,
+        "hard_failure_reasons": hard_failure_reasons,
+        "accounting_blockers": accounting_blockers,
+        "reconciliation_blockers": reconciliation_blockers,
         "started_at": started_at.isoformat(),
         "completed_at": datetime.now(timezone.utc).isoformat(),
         "selected": selected,
@@ -531,6 +581,61 @@ def _payload(
         "batches": batches,
         "reconciliation": reconciliation,
     }
+
+
+def _reconciliation_blockers(
+    reconciliation: Mapping[str, object] | None,
+) -> list[str]:
+    if reconciliation is None:
+        return []
+    raw_blockers = reconciliation.get("blockers")
+    if not isinstance(raw_blockers, Sequence) or isinstance(
+        raw_blockers,
+        (str, bytes, bytearray),
+    ):
+        return []
+    return sorted({str(item) for item in raw_blockers if str(item).strip()})
+
+
+def _hard_failure_reasons(
+    *,
+    failed: int,
+    stop_reasons: Sequence[str],
+    reconciliation_blockers: Sequence[str],
+    reconciliation_ok: bool,
+) -> list[str]:
+    reasons: list[str] = []
+    if failed:
+        reasons.append("journal_batch_failures")
+    if (
+        not reconciliation_ok
+        and not reconciliation_blockers
+        and not failed
+        and not stop_reasons
+    ):
+        reasons.append("reconciliation_degraded_without_blockers")
+    for reason in stop_reasons:
+        clean_reason = str(reason).strip()
+        if clean_reason and clean_reason not in reasons:
+            reasons.append(clean_reason)
+    for blocker in reconciliation_blockers:
+        if blocker in INFRASTRUCTURE_RECONCILIATION_BLOCKERS and blocker not in reasons:
+            reasons.append(blocker)
+    return reasons
+
+
+def _should_exit_nonzero(
+    *,
+    status: str,
+    fail_on_degraded: bool,
+    allow_data_quality_degraded: bool,
+    hard_failure_reasons: Sequence[str],
+) -> bool:
+    if not fail_on_degraded or status == "ok":
+        return False
+    if allow_data_quality_degraded:
+        return bool(hard_failure_reasons)
+    return True
 
 
 def _supervised_timeout_payload(
@@ -556,36 +661,24 @@ def _supervised_timeout_payload(
         "stopped_early": True,
         "stop_reason": stop_reason,
     }
-    return {
-        "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
+    reconciliation = {
         "ok": False,
-        "status": "degraded",
-        "fail_on_degraded": bool(args.fail_on_degraded),
-        "dry_run": bool(args.dry_run),
-        "dsn_env": args.dsn_env,
-        "account_label": args.account_label,
-        "batch_size": max(1, min(int(args.batch_size), 5000)),
-        "max_batches": max(1, int(args.max_batches)),
-        "event_scan_limit": getattr(args, "event_scan_limit", None),
-        "sources": list(_parse_sources(getattr(args, "sources", "all"))),
-        "skip_reconcile": bool(getattr(args, "skip_reconcile", False)),
-        "supervised_worker": False,
-        "supervise_timeout_seconds": timeout_seconds,
-        "stopped_early": True,
-        "stop_reasons": [stop_reason],
-        "started_at": started_at.isoformat(),
-        "completed_at": datetime.now(timezone.utc).isoformat(),
-        "selected": 0,
-        "journaled": 0,
-        "skipped": 0,
-        "failed": 1,
-        "batches": [batch],
-        "reconciliation": {
-            "ok": False,
-            "status": "skipped",
-            "reason": stop_reason,
-        },
+        "status": "skipped",
+        "reason": stop_reason,
     }
+    payload = _payload(
+        args=args,
+        started_at=started_at,
+        batches=[batch],
+        reconciliation=reconciliation,
+    )
+    payload.update(
+        {
+            "supervised_worker": False,
+            "supervise_timeout_seconds": timeout_seconds,
+        }
+    )
+    return payload
 
 
 def _supervised_worker_argv() -> list[str]:
@@ -621,7 +714,7 @@ def _run_supervised_worker(args: argparse.Namespace, *, started_at: datetime) ->
             if args.json
             else json.dumps(payload, indent=2)
         )
-        return 1 if args.fail_on_degraded else 0
+        return 1 if bool(payload["exit_nonzero"]) else 0
     return int(completed.returncode)
 
 
@@ -818,7 +911,7 @@ def main() -> int:
         if args.json
         else json.dumps(payload, indent=2)
     )
-    return 1 if args.fail_on_degraded and payload["status"] != "ok" else 0
+    return 1 if bool(payload["exit_nonzero"]) else 0
 
 
 if __name__ == "__main__":

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -287,6 +287,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             sources="all",
             supervised_worker=False,
             supervise_timeout_seconds=0.0,
+            allow_data_quality_degraded=False,
         )
 
         payload = script._payload(
@@ -301,6 +302,66 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(payload["status"], "degraded")
         self.assertEqual(payload["failed"], 0)
         self.assertTrue(payload["fail_on_degraded"])
+        self.assertTrue(payload["exit_nonzero"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["overrides_runtime_ledger_authority"])
+
+    def test_payload_keeps_data_quality_blockers_visible_without_promotion_authority(
+        self,
+    ) -> None:
+        args = argparse.Namespace(
+            dry_run=False,
+            dsn_env="SIM_DB_DSN",
+            account_label="TORGHUT_SIM",
+            batch_size=500,
+            max_batches=1,
+            event_scan_limit=None,
+            fail_on_degraded=True,
+            skip_reconcile=False,
+            sources="all",
+            supervised_worker=False,
+            supervise_timeout_seconds=0.0,
+            allow_data_quality_degraded=True,
+        )
+
+        payload = script._payload(
+            args=args,
+            started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            batches=[
+                {"selected": 0, "journaled": 0, "skipped": 0, "failed": 0},
+            ],
+            reconciliation={
+                "ok": False,
+                "blockers": [
+                    "tigerbeetle_source_amount_mismatch",
+                    "tigerbeetle_unlinked_execution_cost",
+                ],
+                "promotion_authority": False,
+                "overrides_runtime_ledger_authority": False,
+            },
+        )
+
+        self.assertEqual(payload["status"], "degraded")
+        self.assertFalse(payload["ok"])
+        self.assertFalse(payload["exit_nonzero"])
+        self.assertEqual(payload["exit_policy"], "fail_on_hard_failures_only")
+        self.assertEqual(payload["hard_failure_reasons"], [])
+        self.assertEqual(
+            payload["accounting_blockers"],
+            [
+                "tigerbeetle_source_amount_mismatch",
+                "tigerbeetle_unlinked_execution_cost",
+            ],
+        )
+        self.assertEqual(
+            payload["reconciliation_blockers"],
+            [
+                "tigerbeetle_source_amount_mismatch",
+                "tigerbeetle_unlinked_execution_cost",
+            ],
+        )
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["overrides_runtime_ledger_authority"])
 
     def test_supervised_worker_timeout_emits_degraded_payload(self) -> None:
         stdout = io.StringIO()
@@ -349,6 +410,11 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             ["tigerbeetle_journal_worker_timeout"],
         )
         self.assertEqual(payload["failed"], 1)
+        self.assertTrue(payload["exit_nonzero"])
+        self.assertEqual(
+            payload["hard_failure_reasons"],
+            ["journal_batch_failures", "tigerbeetle_journal_worker_timeout"],
+        )
         self.assertEqual(
             payload["reconciliation"]["reason"],
             "tigerbeetle_journal_worker_timeout",
@@ -1247,6 +1313,165 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(payload["status"], "degraded")
         self.assertEqual(payload["failed"], 0)
         self.assertEqual(payload["journaled"], 1)
+
+    def test_main_scheduled_non_authority_allows_data_quality_degraded_exit_zero(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                _add_order_event(session, fingerprint="selected", source_offset=1)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--batch-size",
+                        "10",
+                        "--fail-on-degraded",
+                        "--allow-data-quality-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={
+                        "ok": False,
+                        "blockers": [
+                            "tigerbeetle_source_amount_mismatch",
+                            "tigerbeetle_unlinked_execution_cost",
+                        ],
+                        "promotion_authority": False,
+                        "overrides_runtime_ledger_authority": False,
+                    },
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertFalse(payload["ok"])
+        self.assertFalse(payload["exit_nonzero"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["overrides_runtime_ledger_authority"])
+        self.assertEqual(payload["hard_failure_reasons"], [])
+        self.assertEqual(
+            payload["accounting_blockers"],
+            [
+                "tigerbeetle_source_amount_mismatch",
+                "tigerbeetle_unlinked_execution_cost",
+            ],
+        )
+
+    def test_main_scheduled_non_authority_fails_closed_for_batch_errors(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                _add_order_event(session, fingerprint="fail", source_offset=1)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--batch-size",
+                        "10",
+                        "--fail-on-degraded",
+                        "--allow-data-quality-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={"ok": True, "blockers": []},
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertTrue(payload["exit_nonzero"])
+        self.assertEqual(payload["hard_failure_reasons"], ["journal_batch_failures"])
+
+    def test_main_scheduled_non_authority_fails_closed_for_tigerbeetle_infra_blocker(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                _add_order_event(session, fingerprint="selected", source_offset=1)
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--batch-size",
+                        "10",
+                        "--fail-on-degraded",
+                        "--allow-data-quality-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={
+                        "ok": False,
+                        "blockers": ["tigerbeetle_client_unavailable"],
+                    },
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["status"], "degraded")
+        self.assertTrue(payload["exit_nonzero"])
+        self.assertEqual(
+            payload["hard_failure_reasons"],
+            ["tigerbeetle_client_unavailable"],
+        )
 
     def test_main_requires_dsn_env_var(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- Adds an explicit non-authoritative TigerBeetle journal telemetry exit policy that keeps reconciliation/accounting blockers machine-readable while reporting `promotion_authority=false` and `overrides_runtime_ledger_authority=false`.
- Keeps strict proof-gate behavior unchanged: `--fail-on-degraded` without the telemetry flag still exits nonzero for degraded reconciliation.
- Keeps scheduled telemetry fail-closed for journal batch failures, TigerBeetle infrastructure blockers, timeouts, and unclassified degraded reconciliation results.
- Updates the live and sim TigerBeetle journal CronJobs to use the non-authoritative data-quality-degraded policy so historical blockers do not keep Argo health degraded forever.
- Adds regression tests for visible data-quality blockers, scheduled telemetry exit behavior, strict proof behavior, and infrastructure failure behavior.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass after installing build-essential in the workspace for crosshair-tool build)
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py -q` (pass: 28 passed, 1 warning)
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle*.py tests/test_journal_tigerbeetle_order_events.py -q` (pass: 144 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py` (pass)
- `cd services/torghut && uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (pass)
- `scripts/argo-lint.sh argocd/applications/torghut` (pass after installing the Argo CLI in the workspace)
- `scripts/kubeconform.sh argocd/applications/torghut` (pass after installing kubeconform in the workspace: 108 resources found, 51 valid, 57 skipped)
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -k tigerbeetle_journal_order_events_cronjob -q` (pass: 1 passed, 32 deselected, 1 warning)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.