### PR TITLE
fix(torghut): retry bounded H-PAIRS quote routeability

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -2772,6 +2772,10 @@ def _unavailable_source_activity(
             "source_order_lifecycle_refs_missing",
             "source_explicit_costs_missing",
         ],
+        "submitted_order_blockers": [
+            "source_submitted_orders_missing",
+            "source_execution_refs_missing",
+        ],
         "decision_count": lineage_matched_decision_count,
         "execution_count": 0,
         "filled_execution_count": 0,
@@ -2913,9 +2917,13 @@ def _source_activity_lifecycle_summary(
         )
     if len(tca_rows) <= 0 and complete_fill_event_count <= 0:
         lifecycle_blockers.append("source_execution_economics_missing")
+    submitted_order_blockers = (
+        ["source_submitted_orders_missing"] if submitted_order_count <= 0 else []
+    )
     return {
         "schema_version": "torghut.paper-route-source-lifecycle-summary.v1",
         "submitted_order_count": submitted_order_count,
+        "submitted_order_blockers": submitted_order_blockers,
         "execution_status_counts": dict(sorted(execution_status_counts.items())),
         "order_event_status_counts": dict(sorted(order_event_status_counts.items())),
         "order_event_type_counts": dict(sorted(order_event_type_counts.items())),
@@ -3000,6 +3008,7 @@ def _strategy_source_activity(
                 "source_order_lifecycle_refs_missing",
                 "source_explicit_costs_missing",
             ],
+            "submitted_order_blockers": ["source_submitted_orders_missing"],
             "decision_count": 0,
             "execution_count": 0,
             "filled_execution_count": 0,
@@ -3388,6 +3397,12 @@ def _strategy_source_activity(
             *(["source_explicit_costs_missing"] if not tca_metric_refs else []),
         ]
     )
+    submitted_order_blockers = _unique_text_items(
+        [
+            *_unique_text_items(lifecycle_summary.get("submitted_order_blockers")),
+            *(["source_execution_refs_missing"] if not execution_refs else []),
+        ]
+    )
     source_lifecycle_blockers = _unique_text_items(
         [
             *_unique_text_items(lifecycle_summary.get("blockers")),
@@ -3437,6 +3452,7 @@ def _strategy_source_activity(
         "order_lifecycle_refs": order_lifecycle_refs,
         "tca_metric_refs": tca_metric_refs,
         "source_reference_blockers": source_reference_blockers,
+        "submitted_order_blockers": submitted_order_blockers,
         "decision_count": decision_count,
         "execution_count": execution_count,
         "filled_execution_count": filled_execution_count,

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -2937,6 +2937,15 @@ class SimpleTradingPipeline(TradingPipeline):
             mismatches.append("target_plan_symbol_mismatch")
         if target_symbols and symbol not in target_symbols:
             mismatches.append("target_plan_symbol_scope_mismatch")
+        expected_action = SimpleTradingPipeline._target_plan_action_for_symbol(
+            metadata,
+            symbol=symbol,
+        )
+        decision_action = SimpleTradingPipeline._normalize_target_plan_action(
+            decision.action
+        )
+        if expected_action is not None and decision_action != expected_action:
+            mismatches.append("target_plan_side_mismatch")
         if not mismatches:
             return None
         return {
@@ -2944,8 +2953,54 @@ class SimpleTradingPipeline(TradingPipeline):
             "symbol": symbol,
             "metadata_symbol": metadata_symbol,
             "target_symbols": sorted(target_symbols),
+            "decision_action": decision_action,
+            "target_action": expected_action,
             "mismatches": mismatches,
         }
+
+    @staticmethod
+    def _target_plan_action_for_symbol(
+        metadata: Mapping[str, Any],
+        *,
+        symbol: str,
+    ) -> Literal["buy", "sell"] | None:
+        normalized_symbol = symbol.strip().upper()
+        raw_actions = metadata.get("paper_route_probe_symbol_actions")
+        if isinstance(raw_actions, Mapping):
+            for raw_symbol, raw_action in cast(
+                Mapping[object, object], raw_actions
+            ).items():
+                if str(raw_symbol).strip().upper() != normalized_symbol:
+                    continue
+                return SimpleTradingPipeline._normalize_target_plan_action(raw_action)
+        metadata_symbol = _safe_text(metadata.get("symbol"))
+        direct_symbol_matches = (
+            metadata_symbol is None or metadata_symbol.upper() == normalized_symbol
+        )
+        if not direct_symbol_matches:
+            return None
+        for key in (
+            "paper_route_probe_leg_action",
+            "paper_route_probe_action",
+            "probe_action",
+            "action",
+            "side",
+        ):
+            action = SimpleTradingPipeline._normalize_target_plan_action(
+                metadata.get(key)
+            )
+            if action is not None:
+                return action
+        return None
+
+    @staticmethod
+    def _normalize_target_plan_action(value: object) -> Literal["buy", "sell"] | None:
+        normalized = str(value or "").strip().lower()
+        if normalized in {"buy", "long"}:
+            return "buy"
+        if normalized in {"sell", "short"}:
+            return "sell"
+        return None
 
     @staticmethod
     def _paper_route_quote_routeability_payload(
@@ -3002,6 +3057,127 @@ class SimpleTradingPipeline(TradingPipeline):
             if target_mismatch is not None
             else None,
         }
+
+    @staticmethod
+    def _paper_route_quote_routeability_retry_metadata(
+        decision_row: TradeDecision,
+    ) -> dict[str, object] | None:
+        if decision_row.status != "rejected":
+            return None
+        decision_json_raw = decision_row.decision_json
+        if not isinstance(decision_json_raw, Mapping):
+            return None
+        decision_json = cast(Mapping[str, Any], decision_json_raw)
+        params = _mapping_value(decision_json.get("params"))
+        if params is None:
+            return None
+        if not (
+            isinstance(params.get("paper_route_target_plan_source_decision"), Mapping)
+            or isinstance(params.get("paper_route_target_plan"), Mapping)
+            or isinstance(params.get("paper_route_probe"), Mapping)
+        ):
+            return None
+        routeability = _mapping_value(params.get("quote_routeability"))
+        if routeability is None:
+            return None
+        if _safe_text(routeability.get("status")) != "blocked":
+            return None
+        reason = _safe_text(routeability.get("reason"))
+        retryable_reasons = {
+            "absent_snapshot_fallback",
+            "missing_executable_quote",
+            "missing_bid",
+            "missing_ask",
+            "non_positive_price",
+            "non_positive_bid",
+            "non_positive_ask",
+            "crossed_quote",
+            "stale_quote",
+            "spread_bps_exceeded",
+            "wide_spread_midpoint_jump",
+        }
+        if reason not in retryable_reasons:
+            return None
+        retry_attempts = _safe_int(
+            decision_json.get("paper_route_quote_routeability_retry_attempts")
+        )
+        retry_limit = max(
+            _safe_int(settings.trading_simple_paper_route_probe_retry_attempt_limit),
+            0,
+        )
+        if retry_limit <= 0 or retry_attempts >= retry_limit:
+            return None
+        return {
+            "previous_decision_status": "rejected",
+            "previous_submission_stage": "rejected_quote_routeability",
+            "previous_quote_routeability_reason": reason,
+            "previous_quote_routeability": dict(routeability),
+            "previous_retry_attempts": retry_attempts,
+        }
+
+    def _reopen_rejected_paper_route_quote_routeability_decision(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+    ) -> TradeDecision | None:
+        retry_metadata = self._paper_route_quote_routeability_retry_metadata(
+            decision_row
+        )
+        if retry_metadata is None:
+            return None
+        if self.executor.execution_exists(session, decision_row):
+            return None
+
+        self.executor.sync_decision_state(session, decision_row, decision)
+        raw_decision_json = decision_row.decision_json
+        decision_json = (
+            dict(cast(Mapping[str, Any], raw_decision_json))
+            if isinstance(raw_decision_json, Mapping)
+            else {}
+        )
+        retry_attempts = _safe_int(
+            decision_json.get("paper_route_quote_routeability_retry_attempts")
+        )
+        params_mapping = _mapping_value(decision_json.get("params"))
+        params = dict(params_mapping) if params_mapping is not None else {}
+        params.pop("quote_routeability", None)
+        decision_json["params"] = params
+        decision_json["submission_stage"] = (
+            "paper_route_quote_routeability_retry_pending"
+        )
+        decision_json["paper_route_quote_routeability_retry_attempts"] = (
+            retry_attempts + 1
+        )
+        decision_json["paper_route_quote_routeability_retry"] = {
+            **retry_metadata,
+            "submission_stage": "paper_route_quote_routeability_retry_pending",
+            "symbol": decision.symbol.strip().upper(),
+            "strategy_id": decision.strategy_id,
+        }
+        for key in (
+            "risk_reasons",
+            "reject_reason_atomic",
+            "reject_class",
+            "reject_origin",
+            "broker_precheck",
+        ):
+            decision_json.pop(key, None)
+        decision_row.status = "planned"
+        decision_row.created_at = trading_now(account_label=self.account_label)
+        decision_row.decision_json = decision_json
+        session.add(decision_row)
+        session.commit()
+        session.refresh(decision_row)
+        logger.warning(
+            "Reopening paper route target source decision after transient quote routeability failure strategy_id=%s decision_id=%s symbol=%s previous_reason=%s",
+            decision.strategy_id,
+            decision_row.id,
+            decision.symbol,
+            retry_metadata["previous_quote_routeability_reason"],
+        )
+        return decision_row
 
     def _prepare_decision_for_submission(
         self,
@@ -4954,6 +5130,15 @@ class SimpleTradingPipeline(TradingPipeline):
         decision_row = self.executor.ensure_decision(
             session, decision, strategy, self.account_label
         )
+        reopened_quote_routeability = (
+            self._reopen_rejected_paper_route_quote_routeability_decision(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+            )
+        )
+        if reopened_quote_routeability is not None:
+            return reopened_quote_routeability
         if "paper_route_target_plan" in decision.params:
             self.executor.update_decision_params(session, decision_row, decision.params)
             self.executor.sync_decision_state(session, decision_row, decision)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -540,6 +540,14 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertTrue(activity["query_limits"]["decision_truncated"])
         self.assertIn("source_executions_missing", activity["missing_reasons"])
+        self.assertEqual(
+            activity["submitted_order_blockers"],
+            ["source_submitted_orders_missing", "source_execution_refs_missing"],
+        )
+        self.assertIn(
+            "source_submitted_orders_missing",
+            activity["source_lifecycle_blockers"],
+        )
 
     def test_evidence_readback_diagnostics_distinguish_source_lifecycle_and_blockers(
         self,

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -575,6 +575,24 @@ def test_target_plan_source_mismatch_readback_handles_no_metadata_and_symbol_fie
     assert mismatch["metadata_symbol"] == "AMZN"
 
 
+def test_target_plan_source_mismatch_rejects_pair_leg_side_mismatch() -> None:
+    mismatch = SimpleTradingPipeline._paper_route_target_plan_source_mismatch(
+        _routeability_decision(
+            params={
+                "paper_route_target_plan_source_decision": _bounded_hpairs_target(
+                    paper_route_probe_symbol_actions={"AAPL": "sell", "AMZN": "buy"}
+                )
+            }
+        )
+    )
+
+    assert mismatch is not None
+    assert mismatch["mismatches"] == ["target_plan_side_mismatch"]
+    assert mismatch["symbol"] == "AAPL"
+    assert mismatch["decision_action"] == "buy"
+    assert mismatch["target_action"] == "sell"
+
+
 def test_blocked_target_readiness_maps_collection_gate_to_wait_for_fresh_quote() -> (
     None
 ):

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3908,6 +3908,141 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(refreshed_snapshot.get("ask"), "190.14")
         self.assertEqual(row.status, "planned")
 
+    def test_paper_route_quote_routeability_retries_rejected_decision_when_quote_recovers(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 1
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded target strategy",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="paper-route-target-source",
+            params={
+                "paper_route_target_plan": {
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "hypothesis_id": "H-PAIRS-01",
+                    "account_label": "TORGHUT_SIM",
+                    "observed_stage": "paper",
+                    "source_kind": "paper_route_probe_runtime_observed",
+                },
+                "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+                "profit_proof_eligible": True,
+            },
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(
+                Decimal("190.12"),
+                spread=Decimal("0.04"),
+                bid=Decimal("190.10"),
+                ask=Decimal("190.14"),
+            ),
+        )
+
+        with self.session_local() as session:
+            session.add(strategy)
+            session.commit()
+            row = pipeline.executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "TORGHUT_SIM",
+            )
+            row.status = "rejected"
+            decision_json = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], decision_json["params"])
+            params["quote_routeability"] = {
+                "schema_version": "torghut.paper-route-quote-routeability.v1",
+                "status": "blocked",
+                "reason": "missing_executable_quote",
+                "bounded_evidence_collection_ready": False,
+                "promotion_allowed": False,
+                "final_authority_ok": False,
+                "final_promotion_allowed": False,
+            }
+            decision_json["params"] = params
+            decision_json["reject_reason_atomic"] = ["missing_executable_quote"]
+            row.decision_json = decision_json
+            session.add(row)
+            session.commit()
+
+            reopened = pipeline._ensure_pending_decision_row(
+                session=session,
+                decision=decision,
+                strategy=strategy,
+            )
+            assert reopened is not None
+            session.refresh(row)
+            reopened_json = cast(dict[str, Any], row.decision_json)
+            self.assertEqual(row.status, "planned")
+            self.assertEqual(
+                reopened_json.get("submission_stage"),
+                "paper_route_quote_routeability_retry_pending",
+            )
+            self.assertEqual(
+                cast(
+                    dict[str, Any],
+                    reopened_json["paper_route_quote_routeability_retry"],
+                )["previous_quote_routeability_reason"],
+                "missing_executable_quote",
+            )
+
+            prepared = pipeline._prepare_decision_for_submission(
+                session=session,
+                decision=decision,
+                decision_row=row,
+                strategy=strategy,
+                account={
+                    "equity": "100000",
+                    "cash": "100000",
+                    "buying_power": "100000",
+                },
+                positions=[],
+            )
+            session.refresh(row)
+            final_params = cast(
+                dict[str, Any], cast(dict[str, Any], row.decision_json)["params"]
+            )
+            routeability = cast(dict[str, Any], final_params.get("quote_routeability"))
+
+        self.assertIsNotNone(prepared)
+        self.assertEqual(routeability.get("status"), "accepted")
+        self.assertEqual(routeability.get("reason"), "executable_quote_ready")
+        self.assertFalse(routeability.get("promotion_allowed"))
+        self.assertFalse(routeability.get("final_authority_ok"))
+        self.assertEqual(row.status, "planned")
+
     def test_decision_price_uses_existing_executable_quote_without_refetch(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Reopen rejected bounded H-PAIRS/TORGHUT_SIM paper-route decisions for retryable quote-routeability blockers so the next scheduler pass re-evaluates fresh executable bid/ask data before deciding submit eligibility.
- Reject malformed paper-route pair-leg handoffs when the target-plan action for a symbol disagrees with the decision side, with machine-readable `target_plan_side_mismatch` diagnostics.
- Add `submitted_order_blockers` to paper-route evidence readback so zero-submitted-order H-PAIRS windows expose exact lifecycle blockers instead of aggregate-only absence.
- Keep bounded collection separate from promotion authority: accepted routeability still sets `promotion_allowed=false`, `final_promotion_allowed=false`, and `final_authority_ok=false`.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_simple_pipeline.py -q` — passed (433 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py tests/test_simple_pipeline.py tests/test_trading_pipeline.py tests/test_paper_route_evidence.py` — passed
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py tests/test_simple_pipeline.py tests/test_trading_pipeline.py tests/test_paper_route_evidence.py` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed
- `git diff --check` — passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
