### PR TITLE
feat(torghut): attach hpairs source proof census status

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -234,6 +234,8 @@ def _hpairs_source_proof_census_status(
     runtime_authority = _mapping(payload.get("runtime_authority"))
     blockers = _text_list(payload.get("blockers"))
     _extend_unique(blockers, _text_list(runtime_authority.get("blockers")))
+    attachment_blockers = _hpairs_source_proof_census_attachment_blockers(payload)
+    _extend_unique(blockers, attachment_blockers)
     next_blocker = _mapping(verdict.get("next_blocker"))
     return {
         "schema_version": HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION,
@@ -249,6 +251,7 @@ def _hpairs_source_proof_census_status(
         "final_authority_ok": bool(runtime_authority.get("final_authority_ok"))
         and not blockers,
         "blockers": blockers,
+        "attachment_blockers": attachment_blockers,
         "missing_requirement_categories": dict(
             _mapping(payload.get("missing_requirement_categories"))
         ),
@@ -260,6 +263,26 @@ def _hpairs_source_proof_census_status(
         "next_action": verdict.get("next_action"),
         "totals": dict(_mapping(payload.get("totals"))),
     }
+
+
+def _hpairs_source_proof_census_attachment_blockers(
+    payload: Mapping[str, Any],
+) -> list[str]:
+    blockers: list[str] = []
+    if _text(payload.get("schema_version")) != "torghut.hpairs-source-proof-census.v1":
+        blockers.append("hpairs_source_proof_census_schema_mismatch")
+    source = _mapping(payload.get("source"))
+    if source.get("read_only") is not True:
+        blockers.append("hpairs_source_proof_census_not_read_only")
+    if source.get("writes_proof") is not False:
+        blockers.append("hpairs_source_proof_census_writes_proof")
+    if source.get("modifies_rows") is not False:
+        blockers.append("hpairs_source_proof_census_modifies_rows")
+    if source.get("replay_outputs_count_as_runtime_proof") is not False:
+        blockers.append("hpairs_source_proof_census_replay_outputs_claim_runtime_proof")
+    if source.get("synthetic_proof_created") is not False:
+        blockers.append("hpairs_source_proof_census_synthetic_proof_created")
+    return blockers
 
 
 def _source_offsets(value: object) -> list[dict[str, object]]:

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -43,6 +43,9 @@ STATUS_ENDPOINT = "/trading/status"
 PAPER_ROUTE_EVIDENCE_ENDPOINT = "/trading/paper-route-evidence"
 COMPLETION_DOC29_ENDPOINT = "/trading/completion/doc29"
 ARTIFACT_SCHEMA_VERSION = "torghut.runtime-ledger-proof-packet-artifact.v1"
+HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION = (
+    "torghut.hpairs-source-proof-census-status.v1"
+)
 CAPITAL_PROMOTION_STATUS_BLOCKERS = frozenset(
     {
         "alpha_hypothesis_not_promotion_eligible",
@@ -203,6 +206,60 @@ def _text_list(value: object) -> list[str]:
         if text and text not in items:
             items.append(text)
     return items
+
+
+def _hpairs_source_proof_census_status(
+    census: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    payload = _mapping(census)
+    if not payload:
+        return {
+            "schema_version": HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION,
+            "present": False,
+            "non_authority_status_only": True,
+            "authority_source": False,
+            "promotion_allowed": False,
+            "final_authority_ok": False,
+            "blockers": [],
+            "attachment_blockers": ["hpairs_source_proof_census_missing"],
+            "blocker_ladder": [],
+            "next_blocker": {
+                "step": "hpairs_source_proof_census",
+                "status": "missing",
+                "blocker_codes": ["hpairs_source_proof_census_missing"],
+                "next_action": "attach a fresh read-only H-PAIRS source-proof census artifact",
+            },
+        }
+    verdict = _mapping(payload.get("verdict"))
+    runtime_authority = _mapping(payload.get("runtime_authority"))
+    blockers = _text_list(payload.get("blockers"))
+    _extend_unique(blockers, _text_list(runtime_authority.get("blockers")))
+    next_blocker = _mapping(verdict.get("next_blocker"))
+    return {
+        "schema_version": HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION,
+        "present": True,
+        "non_authority_status_only": True,
+        "authority_source": False,
+        "source_schema_version": payload.get("schema_version"),
+        "identity": dict(_mapping(payload.get("identity"))),
+        "window": dict(_mapping(payload.get("window"))),
+        "classification": verdict.get("classification"),
+        "authority_candidate_ready": bool(verdict.get("authority_candidate_ready")),
+        "promotion_allowed": False,
+        "final_authority_ok": bool(runtime_authority.get("final_authority_ok"))
+        and not blockers,
+        "blockers": blockers,
+        "missing_requirement_categories": dict(
+            _mapping(payload.get("missing_requirement_categories"))
+        ),
+        "missing_source_ref_categories": dict(
+            _mapping(payload.get("missing_source_ref_categories"))
+        ),
+        "blocker_ladder": list(_sequence(payload.get("blocker_ladder"))),
+        "next_blocker": dict(next_blocker) if next_blocker else None,
+        "next_action": verdict.get("next_action"),
+        "totals": dict(_mapping(payload.get("totals"))),
+    }
 
 
 def _source_offsets(value: object) -> list[dict[str, object]]:
@@ -1896,6 +1953,7 @@ def build_runtime_ledger_proof_packet(
     paper_route_evidence: Mapping[str, Any] | None = None,
     runtime_window_import: Mapping[str, Any] | None = None,
     completion_status: Mapping[str, Any] | None = None,
+    hpairs_source_proof_census: Mapping[str, Any] | None = None,
     min_runtime_ledger_net_pnl: Decimal = (
         DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.min_net_pnl_after_costs
     ),
@@ -2738,6 +2796,44 @@ def build_runtime_ledger_proof_packet(
     )
     _extend_unique(blockers, risk_blockers)
 
+    hpairs_source_proof_census_status = _hpairs_source_proof_census_status(
+        hpairs_source_proof_census
+    )
+    hpairs_census_blockers = _text_list(
+        hpairs_source_proof_census_status.get("blockers")
+    )
+    hpairs_census_present = bool(hpairs_source_proof_census_status.get("present"))
+    hpairs_census_ok = (not hpairs_census_present) or (
+        not hpairs_census_blockers
+        and bool(hpairs_source_proof_census_status.get("final_authority_ok"))
+    )
+    _check(
+        checks,
+        "hpairs_source_proof_census_status",
+        passed=hpairs_census_ok,
+        observed=hpairs_source_proof_census_status,
+        expected=(
+            "attached read-only H-PAIRS source-proof census with no blockers; "
+            "census is evidence/status only and cannot grant authority by itself"
+        ),
+        blockers=hpairs_census_blockers
+        or (
+            []
+            if hpairs_census_ok or not hpairs_census_present
+            else ["hpairs_source_proof_census_not_ready"]
+        ),
+        status="non_authority_evidence_status",
+    )
+    _extend_unique(
+        blockers,
+        hpairs_census_blockers
+        or (
+            []
+            if hpairs_census_ok or not hpairs_census_present
+            else ["hpairs_source_proof_census_not_ready"]
+        ),
+    )
+
     tigerbeetle_status = _mapping(
         status.get("tigerbeetle_ledger") or status.get("tigerbeetle")
     )
@@ -3040,6 +3136,7 @@ def build_runtime_ledger_proof_packet(
                 "strategy_runtime_ledger_bucket_refs": ledger_refs,
                 "unbacked_metric_window_refs": unbacked_refs,
             },
+            "hpairs_source_proof_census": hpairs_source_proof_census_status,
         },
     }
 
@@ -3085,6 +3182,15 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--runtime-window-import-url",
         help="URL returning runtime-window import JSON output.",
+    )
+    parser.add_argument(
+        "--hpairs-source-proof-census-file",
+        type=Path,
+        help="Path to a read-only audit_hpairs_source_proof_census.py JSON artifact.",
+    )
+    parser.add_argument(
+        "--hpairs-source-proof-census-url",
+        help="URL returning a read-only H-PAIRS source-proof census JSON artifact.",
     )
     parser.add_argument(
         "--completion-file",
@@ -3237,6 +3343,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         url=args.runtime_window_import_url,
         timeout_seconds=args.timeout_seconds,
     )
+    hpairs_source_proof_census = _load_optional_json_object(
+        path=args.hpairs_source_proof_census_file,
+        url=args.hpairs_source_proof_census_url,
+        timeout_seconds=args.timeout_seconds,
+    )
     completion_status = _load_optional_json_object(
         path=args.completion_file,
         url=args.completion_url,
@@ -3249,6 +3360,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         proof_mode=args.proof_mode,
         paper_route_evidence=paper_route_evidence,
         runtime_window_import=runtime_window_import,
+        hpairs_source_proof_census=hpairs_source_proof_census,
         completion_status=completion_status,
         min_runtime_ledger_net_pnl=min_net_pnl,
         min_runtime_ledger_daily_net_pnl=min_daily_net_pnl,
@@ -3279,6 +3391,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             "runtime_window_import_source": _source_kind(
                 args.runtime_window_import_file,
                 args.runtime_window_import_url,
+            ),
+            "hpairs_source_proof_census_source": _source_kind(
+                args.hpairs_source_proof_census_file,
+                args.hpairs_source_proof_census_url,
             ),
             "completion_source": _source_kind(
                 args.completion_file, args.completion_url

--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -81,6 +81,7 @@ AUTHORITY_DISTRIBUTION_MISSING = "authority_distribution_missing"
 LADDER_PASS = "pass"
 LADDER_MISSING = "missing"
 LADDER_BLOCKED = "blocked"
+SUBMITTED_ORDERS_MISSING_BLOCKER = "submitted_orders_missing"
 
 _SOURCE_REF_BLOCKERS = frozenset(
     {
@@ -115,6 +116,7 @@ _LIFECYCLE_BLOCKERS = frozenset(
         AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
         AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER,
         ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+        SUBMITTED_ORDERS_MISSING_BLOCKER,
     }
 )
 _PRIMARY_LIFECYCLE_BLOCKERS = frozenset(
@@ -566,6 +568,9 @@ def _totals(
     ledger_report: Mapping[str, object],
 ) -> dict[str, object]:
     aggregate = _mapping(ledger_report.get("aggregate"))
+    daily_ledger = [
+        _mapping(item) for item in _sequence(ledger_report.get("trading_days"))
+    ]
     source_authority_bucket_count = _int(aggregate.get("source_authority_bucket_count"))
     return {
         "trade_decision_count": len(rows.trade_decisions),
@@ -627,6 +632,15 @@ def _totals(
         ),
         "runtime_ledger_bucket_count": len(rows.runtime_ledger_buckets),
         "blocker_free_runtime_ledger_bucket_count": source_authority_bucket_count,
+        "runtime_submitted_order_count": _sum_daily_int(
+            daily_ledger, "submitted_order_count"
+        ),
+        "runtime_ledger_source_materialization_count": _sum_daily_int(
+            daily_ledger, "source_materialization_count"
+        ),
+        "runtime_ledger_clean_authority_trading_day_count": _int(
+            aggregate.get("clean_authority_trading_day_count")
+        ),
         "explicit_cost_runtime_ledger_bucket_count": _int(
             aggregate.get("explicit_cost_bucket_count")
         ),
@@ -638,6 +652,9 @@ def _totals(
         "closed_trade_count": _int(aggregate.get("closed_round_trips")),
         "open_position_count": _int(aggregate.get("open_position_count")),
         "filled_notional": _text(aggregate.get("total_filled_notional"), default="0"),
+        "target_implied_notional_gap": _text(
+            aggregate.get("target_implied_notional_gap"), default="0"
+        ),
         "post_cost_pnl": _text(
             aggregate.get("total_net_strategy_pnl_after_costs"), default="0"
         ),
@@ -666,6 +683,8 @@ def _census_blockers(
         blockers.append(RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER)
     if _int(totals.get("filled_execution_count")) <= 0:
         blockers.append(AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER)
+    if _int(totals.get("runtime_submitted_order_count")) <= 0:
+        blockers.append(SUBMITTED_ORDERS_MISSING_BLOCKER)
     if _int(totals.get("execution_order_event_count")) <= 0:
         blockers.extend(
             [
@@ -713,6 +732,10 @@ def _census_blockers(
         blockers.append(AUTHORITY_EXPLICIT_COSTS_BLOCKER)
     if not rows.runtime_ledger_buckets:
         blockers.append(AUTHORITY_EVIDENCE_MISSING_BLOCKER)
+    elif _int(totals.get("runtime_ledger_source_materialization_count")) < len(
+        rows.runtime_ledger_buckets
+    ):
+        blockers.append(RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER)
     blockers.extend(str(item) for item in _sequence(ledger_report.get("blockers")))
     return sorted(dict.fromkeys(blockers))
 
@@ -725,6 +748,8 @@ def _missing_requirement_categories(blockers: Sequence[str]) -> dict[str, bool]:
     blocker_set = set(blockers)
     return {
         "filled_notional": AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER in blocker_set,
+        "submitted_orders": SUBMITTED_ORDERS_MISSING_BLOCKER in blocker_set
+        or ORDER_FEED_LIFECYCLE_MISSING_BLOCKER in blocker_set,
         "explicit_costs": AUTHORITY_EXPLICIT_COSTS_BLOCKER in blocker_set
         or EXECUTION_ECONOMICS_MISSING_BLOCKER in blocker_set,
         "closed_round_trip": AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER in blocker_set,
@@ -764,7 +789,7 @@ def _blocker_ladder(
     }
     return [
         _ladder_step(
-            "decisions",
+            "decisions_present",
             blockers=blockers,
             step_blockers={
                 AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
@@ -781,11 +806,28 @@ def _blocker_ladder(
             next_action="run the strategy through paper/live routing until durable TradeDecision rows exist",
         ),
         _ladder_step(
-            "executions",
+            "submitted_orders_present",
+            blockers=blockers,
+            step_blockers={
+                SUBMITTED_ORDERS_MISSING_BLOCKER,
+                ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+            },
+            present=_int(totals.get("runtime_submitted_order_count")) > 0,
+            observed={
+                "runtime_submitted_order_count": _int(
+                    totals.get("runtime_submitted_order_count")
+                ),
+                "source_execution_count": _int(totals.get("execution_count")),
+                "observed_stage": observed_stage,
+            },
+            next_action="route selected H-PAIRS decisions as submitted paper/live orders before proof review",
+        ),
+        _ladder_step(
+            "fill_lifecycle_present",
             blockers=blockers,
             step_blockers={
                 AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
-                RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+                ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
             },
             present=_int(totals.get("filled_execution_count")) > 0,
             observed={
@@ -798,11 +840,12 @@ def _blocker_ladder(
             next_action="connect decisions to broker fills before relying on any replay-only result",
         ),
         _ladder_step(
-            "order_feed_lifecycle",
+            "linked_executions_present",
             blockers=blockers,
             step_blockers={
-                ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
                 RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+                RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+                RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
             },
             present=_int(totals.get("linked_order_event_fill_count")) > 0,
             observed={
@@ -815,16 +858,25 @@ def _blocker_ladder(
                 "linked_order_event_fill_count": _int(
                     totals.get("linked_order_event_fill_count")
                 ),
-                "runtime_submitted_order_count": _sum_daily_int(
-                    daily_ledger, "submitted_order_count"
+                "events_with_execution_ref_count": _int(
+                    totals.get("execution_order_events_with_execution_ref_count")
+                ),
+                "events_with_trade_decision_ref_count": _int(
+                    totals.get("execution_order_events_with_trade_decision_ref_count")
                 ),
             },
             next_action="materialize order-feed fill lifecycle events linked to executions and decisions",
         ),
         _ladder_step(
-            "source_windows_and_refs",
+            "source_windows_refs_offsets_present",
             blockers=blockers,
-            step_blockers=_SOURCE_REF_BLOCKERS,
+            step_blockers={
+                RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
+                RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+                RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER,
+                RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+                ORDER_FEED_SOURCE_WINDOW_GAP_BLOCKER,
+            },
             present=_int(totals.get("source_window_count")) > 0
             and _int(totals.get("execution_order_events_with_source_window_count"))
             >= _int(totals.get("execution_order_event_count"))
@@ -845,17 +897,24 @@ def _blocker_ladder(
             next_action="backfill runtime-ledger source windows, offsets, refs, materialization, and authority class",
         ),
         _ladder_step(
-            "runtime_ledger_buckets",
+            "runtime_ledger_source_materialization_present",
             blockers=blockers,
             step_blockers={
                 AUTHORITY_EVIDENCE_MISSING_BLOCKER,
                 AUTHORITY_READ_ERROR_BLOCKER,
                 AUTHORITY_BUCKET_BLOCKERS_PRESENT,
+                RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
+                RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER,
             },
-            present=_int(totals.get("runtime_ledger_bucket_count")) > 0,
+            present=_int(totals.get("runtime_ledger_bucket_count")) > 0
+            and _int(totals.get("runtime_ledger_source_materialization_count"))
+            >= _int(totals.get("runtime_ledger_bucket_count")),
             observed={
                 "runtime_ledger_bucket_count": _int(
                     totals.get("runtime_ledger_bucket_count")
+                ),
+                "runtime_ledger_source_materialization_count": _int(
+                    totals.get("runtime_ledger_source_materialization_count")
                 ),
                 "blocker_free_runtime_ledger_bucket_count": _int(
                     totals.get("blocker_free_runtime_ledger_bucket_count")
@@ -867,7 +926,7 @@ def _blocker_ladder(
             next_action="emit durable runtime-ledger buckets from paper/live runtime rows without synthetic proof",
         ),
         _ladder_step(
-            "closed_round_trips",
+            "closed_round_trips_present",
             blockers=blockers,
             step_blockers={
                 AUTHORITY_CLOSED_ROUND_TRIP_MISSING_BLOCKER,
@@ -883,15 +942,7 @@ def _blocker_ladder(
             next_action="wait for source-backed entry and exit fills that close round trips",
         ),
         _ladder_step(
-            "open_positions",
-            blockers=blockers,
-            step_blockers={AUTHORITY_OPEN_POSITIONS_BLOCKER},
-            present=_int(totals.get("open_position_count")) == 0,
-            observed={"open_position_count": _int(totals.get("open_position_count"))},
-            next_action="flatten or let paper/live positions close before promotion",
-        ),
-        _ladder_step(
-            "explicit_costs",
+            "explicit_costs_present",
             blockers=blockers,
             step_blockers={
                 AUTHORITY_EXPLICIT_COSTS_BLOCKER,
@@ -911,13 +962,14 @@ def _blocker_ladder(
             next_action="record broker/TCA costs and promotion-grade runtime cost bases for every bucket",
         ),
         _ladder_step(
-            "filled_notional",
+            "filled_notional_present_and_target_implied",
             blockers=blockers,
             step_blockers={
                 AUTHORITY_FILLED_NOTIONAL_MISSING_BLOCKER,
                 AUTHORITY_FILLED_NOTIONAL_BLOCKER,
             },
-            present=_decimal(totals.get("filled_notional")) > 0,
+            present=_decimal(totals.get("filled_notional")) > 0
+            and _decimal(totals.get("target_implied_notional_gap")) <= 0,
             observed={
                 "filled_notional": _text(totals.get("filled_notional"), default="0"),
                 "buckets_with_filled_notional_count": _int(
@@ -926,16 +978,34 @@ def _blocker_ladder(
                 "authority_min_filled_notional": _text(
                     aggregate.get("authority_min_filled_notional"), default="0"
                 ),
+                "target_implied_notional_gap": _text(
+                    totals.get("target_implied_notional_gap"), default="0"
+                ),
             },
-            next_action="accumulate source-backed filled notional, not replay-only simulated volume",
+            next_action="accumulate source-backed filled notional, including target-implied scale, not replay-only simulated volume",
         ),
         _ladder_step(
-            "daily_post_cost_pnl",
+            "flat_no_open_positions_after_grace",
+            blockers=blockers,
+            step_blockers={AUTHORITY_OPEN_POSITIONS_BLOCKER},
+            present=_int(totals.get("open_position_count")) == 0,
+            observed={"open_position_count": _int(totals.get("open_position_count"))},
+            next_action="flatten or let paper/live positions close before promotion",
+        ),
+        _ladder_step(
+            "twenty_authority_grade_trading_days_daily_post_cost_distribution",
             blockers=blockers,
             step_blockers=daily_pnl_blockers,
-            present=len(daily) > 0,
+            present=_int(totals.get("runtime_ledger_clean_authority_trading_day_count"))
+            >= _int(aggregate.get("authority_min_trading_days")),
             observed={
                 "trading_day_count": _int(totals.get("trading_day_count")),
+                "clean_authority_trading_day_count": _int(
+                    totals.get("runtime_ledger_clean_authority_trading_day_count")
+                ),
+                "authority_min_trading_days": _int(
+                    aggregate.get("authority_min_trading_days")
+                ),
                 "post_cost_pnl": _text(totals.get("post_cost_pnl"), default="0"),
                 "mean_daily_net_pnl_after_costs": _text(
                     aggregate.get("mean_daily_net_pnl_after_costs"), default="0"

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -635,6 +635,8 @@ def _hpairs_source_proof_census_status(
         for item in _as_text_list(runtime_authority.get("blockers"))
         if item not in blockers
     )
+    attachment_blockers = _hpairs_source_proof_census_attachment_blockers(payload)
+    blockers = _extend_unique_text_items(blockers, attachment_blockers)
     next_blocker = _as_dict(verdict.get("next_blocker"))
     return {
         "schema_version": HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION,
@@ -650,6 +652,7 @@ def _hpairs_source_proof_census_status(
         "final_authority_ok": bool(runtime_authority.get("final_authority_ok"))
         and not blockers,
         "blockers": blockers,
+        "attachment_blockers": attachment_blockers,
         "missing_requirement_categories": _as_dict(
             payload.get("missing_requirement_categories")
         ),
@@ -661,6 +664,29 @@ def _hpairs_source_proof_census_status(
         "next_action": verdict.get("next_action"),
         "totals": _as_dict(payload.get("totals")),
     }
+
+
+def _hpairs_source_proof_census_attachment_blockers(
+    payload: Mapping[str, Any],
+) -> list[str]:
+    blockers: list[str] = []
+    if (
+        _as_text(payload.get("schema_version"))
+        != "torghut.hpairs-source-proof-census.v1"
+    ):
+        blockers.append("hpairs_source_proof_census_schema_mismatch")
+    source = _as_dict(payload.get("source"))
+    if source.get("read_only") is not True:
+        blockers.append("hpairs_source_proof_census_not_read_only")
+    if source.get("writes_proof") is not False:
+        blockers.append("hpairs_source_proof_census_writes_proof")
+    if source.get("modifies_rows") is not False:
+        blockers.append("hpairs_source_proof_census_modifies_rows")
+    if source.get("replay_outputs_count_as_runtime_proof") is not False:
+        blockers.append("hpairs_source_proof_census_replay_outputs_claim_runtime_proof")
+    if source.get("synthetic_proof_created") is not False:
+        blockers.append("hpairs_source_proof_census_synthetic_proof_created")
+    return blockers
 
 
 def _read_runtime_window_target_plan(ref: str) -> dict[str, Any]:

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -131,6 +131,9 @@ RUNTIME_WINDOW_TARGET_PLAN_IMPORT_BLOCKED_STATES = frozenset(
     )
 )
 OFFLINE_REPLAY_TRIAGE_CANDIDATE_LIMIT = 5
+HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION = (
+    "torghut.hpairs-source-proof-census-status.v1"
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -299,6 +302,15 @@ def _parse_args() -> argparse.Namespace:
         default="microbar-cross-sectional-pairs-v1",
     )
     parser.add_argument("--runtime-window-account-label", default="TORGHUT_SIM")
+    parser.add_argument(
+        "--hpairs-source-proof-census-file",
+        type=Path,
+        default=None,
+        help=(
+            "Optional read-only audit_hpairs_source_proof_census.py JSON artifact "
+            "to attach as non-authority renewal status evidence."
+        ),
+    )
     parser.add_argument(
         "--runtime-window-observed-stage",
         default="paper",
@@ -591,6 +603,64 @@ def _read_json_mapping(path: Path) -> dict[str, Any]:
     except Exception:
         return {}
     return _as_dict(payload)
+
+
+def _hpairs_source_proof_census_status(
+    census: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    payload = _as_dict(census)
+    if not payload:
+        return {
+            "schema_version": HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION,
+            "present": False,
+            "non_authority_status_only": True,
+            "authority_source": False,
+            "promotion_allowed": False,
+            "final_authority_ok": False,
+            "blockers": [],
+            "attachment_blockers": ["hpairs_source_proof_census_missing"],
+            "blocker_ladder": [],
+            "next_blocker": {
+                "step": "hpairs_source_proof_census",
+                "status": "missing",
+                "blocker_codes": ["hpairs_source_proof_census_missing"],
+                "next_action": "attach a fresh read-only H-PAIRS source-proof census artifact",
+            },
+        }
+    verdict = _as_dict(payload.get("verdict"))
+    runtime_authority = _as_dict(payload.get("runtime_authority"))
+    blockers = _as_text_list(payload.get("blockers"))
+    blockers.extend(
+        item
+        for item in _as_text_list(runtime_authority.get("blockers"))
+        if item not in blockers
+    )
+    next_blocker = _as_dict(verdict.get("next_blocker"))
+    return {
+        "schema_version": HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION,
+        "present": True,
+        "non_authority_status_only": True,
+        "authority_source": False,
+        "source_schema_version": payload.get("schema_version"),
+        "identity": _as_dict(payload.get("identity")),
+        "window": _as_dict(payload.get("window")),
+        "classification": verdict.get("classification"),
+        "authority_candidate_ready": bool(verdict.get("authority_candidate_ready")),
+        "promotion_allowed": False,
+        "final_authority_ok": bool(runtime_authority.get("final_authority_ok"))
+        and not blockers,
+        "blockers": blockers,
+        "missing_requirement_categories": _as_dict(
+            payload.get("missing_requirement_categories")
+        ),
+        "missing_source_ref_categories": _as_dict(
+            payload.get("missing_source_ref_categories")
+        ),
+        "blocker_ladder": list(_as_sequence(payload.get("blocker_ladder"))),
+        "next_blocker": dict(next_blocker) if next_blocker else None,
+        "next_action": verdict.get("next_action"),
+        "totals": _as_dict(payload.get("totals")),
+    }
 
 
 def _read_runtime_window_target_plan(ref: str) -> dict[str, Any]:
@@ -2614,6 +2684,20 @@ def main() -> int:
     output_dir = Path(args.output_dir) / run_id
     output_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = output_dir / "empirical-promotion-manifest.yaml"
+    hpairs_source_proof_census_file = getattr(
+        args, "hpairs_source_proof_census_file", None
+    )
+    hpairs_source_proof_census = (
+        _read_json_mapping(hpairs_source_proof_census_file)
+        if hpairs_source_proof_census_file is not None
+        else None
+    )
+    hpairs_source_proof_census_status = _hpairs_source_proof_census_status(
+        hpairs_source_proof_census
+    )
+    hpairs_source_proof_census_blockers = _as_text_list(
+        hpairs_source_proof_census_status.get("blockers")
+    )
 
     with SessionLocal() as session:
         rows = (
@@ -2657,6 +2741,11 @@ def main() -> int:
         "run_id": run_id,
         "manifest_path": str(manifest_path),
         "output_dir": str(output_dir),
+        "promotion_allowed": False,
+        "final_authority_ok": False
+        if hpairs_source_proof_census_blockers
+        else bool(hpairs_source_proof_census_status.get("final_authority_ok")),
+        "hpairs_source_proof_census": hpairs_source_proof_census_status,
         "empirical_promotion": json.loads(result.stdout),
         "runtime_window_import": runtime_window_import,
     }

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -512,6 +512,77 @@ def _completion(
     }
 
 
+def _hpairs_source_proof_census(
+    *,
+    blockers: list[str] | None = None,
+    final_authority_ok: bool = True,
+) -> dict[str, object]:
+    blocker_list = blockers or []
+    return {
+        "schema_version": "torghut.hpairs-source-proof-census.v1",
+        "identity": {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "account_label": "TORGHUT_SIM",
+            "observed_stage": "paper",
+        },
+        "window": {
+            "started_at": "2026-05-01T14:00:00+00:00",
+            "ended_at": "2026-05-29T21:00:00+00:00",
+        },
+        "runtime_authority": {
+            "final_authority_ok": final_authority_ok,
+            "blockers": blocker_list,
+            "aggregate": {},
+        },
+        "missing_requirement_categories": {
+            "submitted_orders": "submitted_orders_missing" in blocker_list,
+        },
+        "missing_source_ref_categories": {},
+        "blocker_ladder": [
+            {
+                "step": "submitted_orders_present",
+                "status": "blocked" if blocker_list else "pass",
+                "blocker_codes": blocker_list,
+                "next_action": (
+                    "route selected H-PAIRS decisions as submitted paper/live orders "
+                    "before proof review"
+                )
+                if blocker_list
+                else None,
+            }
+        ],
+        "blockers": blocker_list,
+        "verdict": {
+            "classification": "authority_candidate_ready"
+            if not blocker_list
+            else "lifecycle_missing",
+            "authority_candidate_ready": not blocker_list,
+            "next_blocker": None
+            if not blocker_list
+            else {
+                "step": "submitted_orders_present",
+                "status": "blocked",
+                "blocker_codes": blocker_list,
+                "next_action": (
+                    "route selected H-PAIRS decisions as submitted paper/live orders "
+                    "before proof review"
+                ),
+            },
+            "next_action": (
+                "assemble authority proof packet from the same source-backed runtime rows"
+            )
+            if not blocker_list
+            else (
+                "materialize linked decisions, executions, order events, fills, "
+                "and closed round trips"
+            ),
+        },
+        "totals": {"runtime_submitted_order_count": 0 if blocker_list else 20},
+    }
+
+
 class TestRuntimeLedgerProofPacket(TestCase):
     def test_scalar_normalizers_handle_runtime_json_variants(self) -> None:
         self.assertTrue(packet._bool(Decimal("1")))
@@ -633,6 +704,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
             ],
             "0.02",
         )
+
         self.assertEqual(
             result["checks"]["runtime_ledger_daily_distribution_authority"]["observed"][
                 "median_daily_net_pnl_after_costs"
@@ -691,6 +763,37 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 "postgres:tigerbeetle_account_refs",
                 "postgres:tigerbeetle_transfer_refs",
             ],
+        )
+
+    def test_hpairs_source_proof_census_blockers_are_non_authority_packet_blockers(
+        self,
+    ) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            hpairs_source_proof_census=_hpairs_source_proof_census(
+                blockers=["submitted_orders_missing"],
+                final_authority_ok=False,
+            ),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertFalse(result["final_authority_ok"])
+        self.assertFalse(result["promotion_allowed"])
+        self.assertIn("submitted_orders_missing", result["authority_blockers"])
+        census_status = result["evidence"]["hpairs_source_proof_census"]
+        self.assertTrue(census_status["present"])
+        self.assertTrue(census_status["non_authority_status_only"])
+        self.assertFalse(census_status["promotion_allowed"])
+        self.assertEqual(
+            census_status["next_blocker"]["step"], "submitted_orders_present"
         )
 
     def test_packet_prefers_importable_paper_route_plan_over_next_session_plan(

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -531,6 +531,15 @@ def _hpairs_source_proof_census(
             "started_at": "2026-05-01T14:00:00+00:00",
             "ended_at": "2026-05-29T21:00:00+00:00",
         },
+        "source": {
+            "kind": "fixture_json",
+            "read_only": True,
+            "writes_proof": False,
+            "modifies_rows": False,
+            "runtime_stage": "paper",
+            "replay_outputs_count_as_runtime_proof": False,
+            "synthetic_proof_created": False,
+        },
         "runtime_authority": {
             "final_authority_ok": final_authority_ok,
             "blockers": blocker_list,
@@ -795,6 +804,42 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(
             census_status["next_blocker"]["step"], "submitted_orders_present"
         )
+
+    def test_hpairs_source_proof_census_attachment_blockers_block_authority(
+        self,
+    ) -> None:
+        census = _hpairs_source_proof_census()
+        census["source"] = {
+            "kind": "fixture_json",
+            "read_only": False,
+            "writes_proof": False,
+            "modifies_rows": False,
+            "runtime_stage": "paper",
+            "replay_outputs_count_as_runtime_proof": False,
+            "synthetic_proof_created": False,
+        }
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            hpairs_source_proof_census=census,
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        blocker = "hpairs_source_proof_census_not_read_only"
+        self.assertFalse(result["ok"])
+        self.assertFalse(result["final_authority_ok"])
+        self.assertFalse(result["promotion_allowed"])
+        self.assertIn(blocker, result["authority_blockers"])
+        census_status = result["evidence"]["hpairs_source_proof_census"]
+        self.assertEqual(census_status["attachment_blockers"], [blocker])
+        self.assertIn(blocker, census_status["blockers"])
 
     def test_packet_prefers_importable_paper_route_plan_over_next_session_plan(
         self,

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -809,14 +809,15 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self,
     ) -> None:
         census = _hpairs_source_proof_census()
+        census["schema_version"] = "torghut.hpairs-source-proof-census.v0"
         census["source"] = {
             "kind": "fixture_json",
             "read_only": False,
-            "writes_proof": False,
-            "modifies_rows": False,
+            "writes_proof": True,
+            "modifies_rows": True,
             "runtime_stage": "paper",
-            "replay_outputs_count_as_runtime_proof": False,
-            "synthetic_proof_created": False,
+            "replay_outputs_count_as_runtime_proof": True,
+            "synthetic_proof_created": True,
         }
 
         result = packet.build_runtime_ledger_proof_packet(
@@ -832,14 +833,23 @@ class TestRuntimeLedgerProofPacket(TestCase):
             generated_at="2026-05-26T21:05:00+00:00",
         )
 
-        blocker = "hpairs_source_proof_census_not_read_only"
+        blockers = [
+            "hpairs_source_proof_census_schema_mismatch",
+            "hpairs_source_proof_census_not_read_only",
+            "hpairs_source_proof_census_writes_proof",
+            "hpairs_source_proof_census_modifies_rows",
+            "hpairs_source_proof_census_replay_outputs_claim_runtime_proof",
+            "hpairs_source_proof_census_synthetic_proof_created",
+        ]
         self.assertFalse(result["ok"])
         self.assertFalse(result["final_authority_ok"])
         self.assertFalse(result["promotion_allowed"])
-        self.assertIn(blocker, result["authority_blockers"])
+        for blocker in blockers:
+            self.assertIn(blocker, result["authority_blockers"])
         census_status = result["evidence"]["hpairs_source_proof_census"]
-        self.assertEqual(census_status["attachment_blockers"], [blocker])
-        self.assertIn(blocker, census_status["blockers"])
+        self.assertEqual(census_status["attachment_blockers"], blockers)
+        for blocker in blockers:
+            self.assertIn(blocker, census_status["blockers"])
 
     def test_packet_prefers_importable_paper_route_plan_over_next_session_plan(
         self,

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -229,20 +229,69 @@ def test_full_source_backed_census_is_authority_candidate_ready() -> None:
     assert report["totals"]["source_window_count"] == 20
     assert report["totals"]["runtime_ledger_bucket_count"] == 20
     assert report["totals"]["blocker_free_runtime_ledger_bucket_count"] == 20
+    assert report["totals"]["runtime_submitted_order_count"] == 400
+    assert report["totals"]["runtime_ledger_source_materialization_count"] == 20
+    assert report["totals"]["runtime_ledger_clean_authority_trading_day_count"] == 20
     assert report["totals"]["closed_trade_count"] == 400
     assert report["totals"]["filled_notional"] == "12000000"
+    assert report["totals"]["target_implied_notional_gap"] == "0"
     assert report["totals"]["post_cost_pnl"] == "12000"
     assert report["source"]["runtime_stage"] == "paper"
     assert report["source"]["replay_outputs_count_as_runtime_proof"] is False
     assert report["source"]["synthetic_proof_created"] is False
     assert report["verdict"]["next_blocker"] is None
     assert (
-        _ladder_step(report, "source_windows_and_refs")["status"] == census.LADDER_PASS
+        _ladder_step(report, "source_windows_refs_offsets_present")["status"]
+        == census.LADDER_PASS
     )
     assert (
-        _ladder_step(report, "runtime_ledger_buckets")["status"] == census.LADDER_PASS
+        _ladder_step(report, "runtime_ledger_source_materialization_present")["status"]
+        == census.LADDER_PASS
     )
-    assert _ladder_step(report, "daily_post_cost_pnl")["status"] == census.LADDER_PASS
+    assert (
+        _ladder_step(
+            report, "twenty_authority_grade_trading_days_daily_post_cost_distribution"
+        )["status"]
+        == census.LADDER_PASS
+    )
+    assert [item["step"] for item in report["blocker_ladder"]] == [
+        "decisions_present",
+        "submitted_orders_present",
+        "fill_lifecycle_present",
+        "linked_executions_present",
+        "source_windows_refs_offsets_present",
+        "runtime_ledger_source_materialization_present",
+        "closed_round_trips_present",
+        "explicit_costs_present",
+        "filled_notional_present_and_target_implied",
+        "flat_no_open_positions_after_grace",
+        "twenty_authority_grade_trading_days_daily_post_cost_distribution",
+    ]
+
+
+def test_missing_submitted_orders_and_fills_are_machine_readable_blockers() -> None:
+    payload = _fixture()
+    payload["executions"] = []
+    payload["execution_order_events"] = []
+    for bucket in payload["runtime_ledger_buckets"]:
+        bucket["submitted_order_count"] = 0
+        bucket["fill_count"] = 0
+        bucket["payload"]["execution_ids"] = []
+        bucket["payload"]["execution_order_event_ids"] = []
+
+    report = _report(payload)
+
+    assert report["verdict"]["classification"] == census.LIFECYCLE_MISSING
+    assert census.SUBMITTED_ORDERS_MISSING_BLOCKER in report["blockers"]
+    assert AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER in report["blockers"]
+    assert (
+        _ladder_step(report, "submitted_orders_present")["status"]
+        == census.LADDER_BLOCKED
+    )
+    assert (
+        _ladder_step(report, "fill_lifecycle_present")["status"]
+        == census.LADDER_BLOCKED
+    )
 
 
 def test_missing_decisions_reports_exact_trade_decision_ref_gap() -> None:
@@ -354,10 +403,15 @@ def test_runtime_bucket_aggregate_only_is_source_refs_missing() -> None:
 
     assert report["verdict"]["classification"] == census.SOURCE_REFS_MISSING
     assert report["totals"]["blocker_free_runtime_ledger_bucket_count"] == 0
+    assert report["totals"]["runtime_ledger_source_materialization_count"] == 0
     assert census.RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER in report["blockers"]
     assert (
         census.RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER
         in report["blockers"]
+    )
+    assert (
+        _ladder_step(report, "runtime_ledger_source_materialization_present")["status"]
+        == census.LADDER_BLOCKED
     )
 
 
@@ -383,9 +437,9 @@ def test_empty_fixture_has_no_source_activity_verdict() -> None:
 
     assert report["verdict"]["classification"] == census.NO_SOURCE_ACTIVITY
     assert report["totals"]["runtime_ledger_bucket_count"] == 0
-    assert _ladder_step(report, "decisions")["status"] == census.LADDER_BLOCKED
+    assert _ladder_step(report, "decisions_present")["status"] == census.LADDER_BLOCKED
     assert report["verdict"]["next_blocker"] == {
-        "step": "decisions",
+        "step": "decisions_present",
         "status": census.LADDER_BLOCKED,
         "blocker_codes": [
             AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
@@ -408,12 +462,16 @@ def test_partial_evidence_ladder_points_at_order_feed_lifecycle() -> None:
 
     report = _report(payload)
 
-    assert _ladder_step(report, "decisions")["status"] == census.LADDER_PASS
-    assert _ladder_step(report, "executions")["status"] == census.LADDER_PASS
+    assert _ladder_step(report, "decisions_present")["status"] == census.LADDER_PASS
     assert (
-        _ladder_step(report, "order_feed_lifecycle")["status"] == census.LADDER_BLOCKED
+        _ladder_step(report, "submitted_orders_present")["status"]
+        == census.LADDER_BLOCKED
     )
-    assert report["verdict"]["next_blocker"]["step"] == "order_feed_lifecycle"
+    assert (
+        _ladder_step(report, "fill_lifecycle_present")["status"]
+        == census.LADDER_BLOCKED
+    )
+    assert report["verdict"]["next_blocker"]["step"] == "submitted_orders_present"
     assert (
         census.ORDER_FEED_LIFECYCLE_MISSING_BLOCKER
         in report["verdict"]["next_blocker"]["blocker_codes"]

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -13,6 +13,7 @@ from app.trading.runtime_window_import import (
     build_observed_runtime_buckets,
     persist_observed_runtime_windows,
 )
+from scripts import renew_latest_empirical_promotion_jobs as renew
 
 
 def _runtime_pnl_basis() -> dict[str, object]:
@@ -120,6 +121,60 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
             bind=engine, expire_on_commit=False, future=True
         )
 
+    def test_hpairs_source_proof_census_status_is_non_authority_renewal_evidence(
+        self,
+    ) -> None:
+        status = renew._hpairs_source_proof_census_status(
+            {
+                "schema_version": "torghut.hpairs-source-proof-census.v1",
+                "identity": {"hypothesis_id": "H-PAIRS-01"},
+                "window": {},
+                "runtime_authority": {
+                    "final_authority_ok": False,
+                    "blockers": ["runtime_ledger_source_materialization_missing"],
+                },
+                "missing_requirement_categories": {
+                    "submitted_orders": False,
+                    "filled_notional": False,
+                },
+                "missing_source_ref_categories": {
+                    "runtime_ledger_source_materialization_missing": True,
+                },
+                "blocker_ladder": [
+                    {
+                        "step": "runtime_ledger_source_materialization_present",
+                        "status": "blocked",
+                        "blocker_codes": [
+                            "runtime_ledger_source_materialization_missing"
+                        ],
+                    }
+                ],
+                "blockers": ["runtime_ledger_source_materialization_missing"],
+                "verdict": {
+                    "classification": "source_refs_missing",
+                    "authority_candidate_ready": False,
+                    "next_blocker": {
+                        "step": "runtime_ledger_source_materialization_present"
+                    },
+                    "next_action": "backfill runtime-ledger source refs",
+                },
+                "totals": {"runtime_ledger_source_materialization_count": 0},
+            }
+        )
+
+        self.assertTrue(status["present"])
+        self.assertTrue(status["non_authority_status_only"])
+        self.assertFalse(status["promotion_allowed"])
+        self.assertFalse(status["final_authority_ok"])
+        self.assertEqual(
+            status["blockers"],
+            ["runtime_ledger_source_materialization_missing"],
+        )
+        self.assertEqual(
+            status["next_blocker"]["step"],
+            "runtime_ledger_source_materialization_present",
+        )
+
     def test_runtime_bucket_materialization_rerun_is_idempotent_for_same_scope(
         self,
     ) -> None:
@@ -162,14 +217,14 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
                 },
             )
             session.commit()
-            rows = (
-                session.execute(select(StrategyRuntimeLedgerBucket))
-                .scalars()
-                .all()
-            )
+            rows = session.execute(select(StrategyRuntimeLedgerBucket)).scalars().all()
 
-        self.assertEqual(first_summary["current_runtime_ledger_bucket_replacement_count"], 0)
-        self.assertEqual(second_summary["current_runtime_ledger_bucket_replacement_count"], 1)
+        self.assertEqual(
+            first_summary["current_runtime_ledger_bucket_replacement_count"], 0
+        )
+        self.assertEqual(
+            second_summary["current_runtime_ledger_bucket_replacement_count"], 1
+        )
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0].account_label, "TORGHUT_SIM")
         self.assertEqual(
@@ -240,7 +295,9 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
                 .all()
             )
 
-        self.assertEqual([row.account_label for row in rows], ["TORGHUT_SIM", "TORGHUT_SIM_ALT"])
+        self.assertEqual(
+            [row.account_label for row in rows], ["TORGHUT_SIM", "TORGHUT_SIM_ALT"]
+        )
         self.assertEqual(
             [row.observed_stage for row in rows],
             ["paper", "paper"],

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -129,6 +129,15 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
                 "schema_version": "torghut.hpairs-source-proof-census.v1",
                 "identity": {"hypothesis_id": "H-PAIRS-01"},
                 "window": {},
+                "source": {
+                    "kind": "fixture_json",
+                    "read_only": True,
+                    "writes_proof": False,
+                    "modifies_rows": False,
+                    "runtime_stage": "paper",
+                    "replay_outputs_count_as_runtime_proof": False,
+                    "synthetic_proof_created": False,
+                },
                 "runtime_authority": {
                     "final_authority_ok": False,
                     "blockers": ["runtime_ledger_source_materialization_missing"],
@@ -174,6 +183,48 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
             status["next_blocker"]["step"],
             "runtime_ledger_source_materialization_present",
         )
+
+    def test_hpairs_source_proof_census_attachment_blockers_block_renewal_authority(
+        self,
+    ) -> None:
+        status = renew._hpairs_source_proof_census_status(
+            {
+                "schema_version": "torghut.hpairs-source-proof-census.v1",
+                "identity": {"hypothesis_id": "H-PAIRS-01"},
+                "window": {},
+                "source": {
+                    "kind": "fixture_json",
+                    "read_only": False,
+                    "writes_proof": False,
+                    "modifies_rows": False,
+                    "runtime_stage": "paper",
+                    "replay_outputs_count_as_runtime_proof": False,
+                    "synthetic_proof_created": False,
+                },
+                "runtime_authority": {
+                    "final_authority_ok": True,
+                    "blockers": [],
+                },
+                "missing_requirement_categories": {},
+                "missing_source_ref_categories": {},
+                "blocker_ladder": [],
+                "blockers": [],
+                "verdict": {
+                    "classification": "authority_candidate_ready",
+                    "authority_candidate_ready": True,
+                    "next_blocker": None,
+                    "next_action": "assemble authority proof packet",
+                },
+                "totals": {},
+            }
+        )
+
+        blocker = "hpairs_source_proof_census_not_read_only"
+        self.assertTrue(status["present"])
+        self.assertFalse(status["promotion_allowed"])
+        self.assertFalse(status["final_authority_ok"])
+        self.assertEqual(status["attachment_blockers"], [blocker])
+        self.assertIn(blocker, status["blockers"])
 
     def test_runtime_bucket_materialization_rerun_is_idempotent_for_same_scope(
         self,

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -189,17 +189,17 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
     ) -> None:
         status = renew._hpairs_source_proof_census_status(
             {
-                "schema_version": "torghut.hpairs-source-proof-census.v1",
+                "schema_version": "torghut.hpairs-source-proof-census.v0",
                 "identity": {"hypothesis_id": "H-PAIRS-01"},
                 "window": {},
                 "source": {
                     "kind": "fixture_json",
                     "read_only": False,
-                    "writes_proof": False,
-                    "modifies_rows": False,
+                    "writes_proof": True,
+                    "modifies_rows": True,
                     "runtime_stage": "paper",
-                    "replay_outputs_count_as_runtime_proof": False,
-                    "synthetic_proof_created": False,
+                    "replay_outputs_count_as_runtime_proof": True,
+                    "synthetic_proof_created": True,
                 },
                 "runtime_authority": {
                     "final_authority_ok": True,
@@ -219,12 +219,20 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
             }
         )
 
-        blocker = "hpairs_source_proof_census_not_read_only"
+        blockers = [
+            "hpairs_source_proof_census_schema_mismatch",
+            "hpairs_source_proof_census_not_read_only",
+            "hpairs_source_proof_census_writes_proof",
+            "hpairs_source_proof_census_modifies_rows",
+            "hpairs_source_proof_census_replay_outputs_claim_runtime_proof",
+            "hpairs_source_proof_census_synthetic_proof_created",
+        ]
         self.assertTrue(status["present"])
         self.assertFalse(status["promotion_allowed"])
         self.assertFalse(status["final_authority_ok"])
-        self.assertEqual(status["attachment_blockers"], [blocker])
-        self.assertIn(blocker, status["blockers"])
+        self.assertEqual(status["attachment_blockers"], blockers)
+        for blocker in blockers:
+            self.assertIn(blocker, status["blockers"])
 
     def test_runtime_bucket_materialization_rerun_is_idempotent_for_same_scope(
         self,

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -4500,6 +4500,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                     output_dir=str(self.tmp_dir),
                     strategy_spec_ref="strategy@paper",
                     run_id_prefix="renew-prefix",
+                    hpairs_source_proof_census_file=None,
                     json=True,
                 ),
             ),


### PR DESCRIPTION
## Summary

- Added an explicit H-PAIRS source-proof blocker ladder covering submitted orders, fill lifecycle, linked executions, source refs/offsets/materialization, costs, notional/target gap, flatness, and 20-day daily post-cost authority distribution.
- Added read-only census status attachments to renewal output and runtime-ledger proof packets as non-authority evidence that can block when census blockers are present but cannot grant promotion authority.
- Made attached H-PAIRS census artifacts fail closed when their schema or source flags are not read-only, proof-neutral, and non-synthetic.
- Added regression coverage for clean, missing submitted-order/fill, missing source materialization, no-authority, and invalid census attachment paths.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_audit_hpairs_source_proof_census.py tests/test_renew_latest_empirical_promotion_jobs.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_audit_hpairs_source_proof_census.py tests/test_renew_latest_empirical_promotion_jobs.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_run_empirical_promotion_jobs.py::TestRunEmpiricalPromotionJobs::test_main_writes_manifest_and_runs_empirical_promotion_job -q`
- `cd services/torghut && uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py::TestRunEmpiricalPromotionJobs::test_main_writes_manifest_and_runs_empirical_promotion_job -q`
- `cd services/torghut && uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
