### PR TITLE
fix(torghut): stop optional tigerbeetle health churn

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5507,7 +5507,25 @@ def _check_tigerbeetle_protocol_health() -> dict[str, object]:
         health = check_tigerbeetle_health(settings)
         payload = health.as_dict()
         payload["protocol_ok"] = True
+        payload["protocol_probe_skipped"] = False
         return payload
+
+    replica_addresses = [
+        item.strip()
+        for item in settings.tigerbeetle_replica_addresses.split(",")
+        if item.strip()
+    ]
+    if not (settings.tigerbeetle_required or settings.tigerbeetle_reconcile_required):
+        return {
+            "enabled": True,
+            "required": settings.tigerbeetle_required,
+            "ok": True,
+            "protocol_ok": False,
+            "protocol_probe_skipped": True,
+            "cluster_id": settings.tigerbeetle_cluster_id,
+            "replica_addresses": replica_addresses,
+            "last_error": None,
+        }
 
     timeout_seconds = max(0.1, float(settings.tigerbeetle_health_timeout_seconds))
     executor = ThreadPoolExecutor(max_workers=1)
@@ -5520,12 +5538,9 @@ def _check_tigerbeetle_protocol_health() -> dict[str, object]:
             "required": settings.tigerbeetle_required,
             "ok": not settings.tigerbeetle_required,
             "protocol_ok": False,
+            "protocol_probe_skipped": False,
             "cluster_id": settings.tigerbeetle_cluster_id,
-            "replica_addresses": [
-                item.strip()
-                for item in settings.tigerbeetle_replica_addresses.split(",")
-                if item.strip()
-            ],
+            "replica_addresses": replica_addresses,
             "last_error": (
                 f"TimeoutError: tigerbeetle protocol health timed out after "
                 f"{timeout_seconds:.2f}s"
@@ -5537,6 +5552,7 @@ def _check_tigerbeetle_protocol_health() -> dict[str, object]:
     payload = health.as_dict()
     protocol_ok = bool(payload.get("ok"))
     payload["protocol_ok"] = protocol_ok
+    payload["protocol_probe_skipped"] = False
     payload["ok"] = protocol_ok or not settings.tigerbeetle_required
     return payload
 
@@ -5623,7 +5639,11 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
         ref_counts.get("runtime_ledger_missing_account_ref_count")
     )
     claimed_by_runtime_evidence = runtime_ledger_ref_count > 0
-    if settings.tigerbeetle_enabled and not bool(protocol.get("protocol_ok")):
+    if (
+        settings.tigerbeetle_enabled
+        and not bool(protocol.get("protocol_ok"))
+        and not bool(protocol.get("protocol_probe_skipped"))
+    ):
         blockers.append("tigerbeetle_protocol_unhealthy")
     reconciliation_ok = True
     reconciliation_required = bool(
@@ -5686,6 +5706,7 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
         "reconciliation_required": reconciliation_required,
         "ok": protocol_gate_ok and reconcile_gate_ok,
         "protocol_ok": bool(protocol.get("protocol_ok")),
+        "protocol_probe_skipped": bool(protocol.get("protocol_probe_skipped")),
         "reconciliation_ok": reconciliation_ok,
         "reconciliation_age_seconds": reconciliation_age_seconds,
         "reconciliation_max_age_seconds": reconciliation_max_age_seconds,

--- a/services/torghut/tests/test_tigerbeetle_status.py
+++ b/services/torghut/tests/test_tigerbeetle_status.py
@@ -66,6 +66,7 @@ class TestTigerBeetleStatus(TestCase):
         self.assertTrue(payload["ok"])
         self.assertFalse(payload["enabled"])
         self.assertTrue(payload["protocol_ok"])
+        self.assertFalse(payload["protocol_probe_skipped"])
         self.assertEqual(payload["blockers"], [])
         self.assertEqual(payload["ref_counts"]["transfer_ref_count"], 0)
 
@@ -131,6 +132,7 @@ class TestTigerBeetleStatus(TestCase):
 
         self.assertFalse(payload["ok"])
         self.assertFalse(payload["protocol_ok"])
+        self.assertFalse(payload["protocol_probe_skipped"])
         self.assertIn("tigerbeetle_protocol_unhealthy", payload["blockers"])
 
     def test_missing_reconciliation_blocks_only_when_required(self) -> None:
@@ -156,10 +158,15 @@ class TestTigerBeetleStatus(TestCase):
         )
 
         with Session(self.engine) as session:
-            with patch("app.main.check_tigerbeetle_health", return_value=health):
+            with patch(
+                "app.main.check_tigerbeetle_health", return_value=health
+            ) as health_mock:
                 payload = _build_tigerbeetle_ledger_status(session)
 
         self.assertTrue(payload["ok"])
+        health_mock.assert_not_called()
+        self.assertTrue(payload["protocol_probe_skipped"])
+        self.assertFalse(payload["protocol_ok"])
         self.assertFalse(payload["reconciliation_required"])
         self.assertNotIn("tigerbeetle_reconciliation_missing", payload["blockers"])
 
@@ -252,16 +259,30 @@ class TestTigerBeetleStatus(TestCase):
             payload["blockers"],
         )
 
-    def test_protocol_timeout_is_nonblocking_until_required(self) -> None:
+    def test_optional_protocol_probe_is_skipped_until_required(self) -> None:
         settings.tigerbeetle_enabled = True
         settings.tigerbeetle_required = False
+        settings.tigerbeetle_health_timeout_seconds = 0.01
+
+        with patch("app.main.check_tigerbeetle_health") as health_mock:
+            payload = _check_tigerbeetle_protocol_health()
+
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["protocol_ok"])
+        self.assertTrue(payload["protocol_probe_skipped"])
+        self.assertIsNone(payload["last_error"])
+        health_mock.assert_not_called()
+
+    def test_required_protocol_timeout_blocks_readiness_dependency(self) -> None:
+        settings.tigerbeetle_enabled = True
+        settings.tigerbeetle_required = True
         settings.tigerbeetle_health_timeout_seconds = 0.01
 
         def slow_health(_settings: object) -> TigerBeetleHealth:
             time.sleep(0.2)
             return TigerBeetleHealth(
                 enabled=True,
-                required=False,
+                required=True,
                 ok=True,
                 cluster_id=2001,
                 replica_addresses=["tb:3000"],
@@ -271,8 +292,9 @@ class TestTigerBeetleStatus(TestCase):
         with patch("app.main.check_tigerbeetle_health", side_effect=slow_health):
             payload = _check_tigerbeetle_protocol_health()
 
-        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["ok"])
         self.assertFalse(payload["protocol_ok"])
+        self.assertFalse(payload["protocol_probe_skipped"])
         self.assertIn("TimeoutError", str(payload["last_error"]))
 
     def test_latest_reconciliation_blockers_are_reported(self) -> None:


### PR DESCRIPTION
## Summary

- Stops optional Torghut HTTP health/status paths from opening live TigerBeetle protocol clients when TigerBeetle is not readiness-required.
- Keeps TigerBeetle reconciliation, ref-count diagnostics, and proof blockers visible from persisted ledger state.
- Preserves fail-closed protocol checks when TigerBeetle is required or reconciliation is required.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_tigerbeetle_status.py -q`
- `uv run --frozen pytest tests/test_tigerbeetle_client.py tests/test_journal_tigerbeetle_order_events.py tests/test_trading_api.py -k 'tigerbeetle or readyz or trading_health or readiness' -q`
- `uv run --frozen ruff format --check app/main.py tests/test_tigerbeetle_status.py`
- `uv run --frozen ruff check app/main.py tests/test_tigerbeetle_status.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
