### PR TITLE
fix(torghut): isolate tigerbeetle journal sources

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -55,9 +55,10 @@ spec:
                 - |
                   set -euo pipefail
                   cd /app
+                  status=0
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env DB_DSN \
-                    --sources execution,execution_tca_metric \
+                    --sources execution \
                     --batch-size 50 \
                     --max-batches 1 \
                     --reconcile-limit 1000 \
@@ -65,10 +66,20 @@ spec:
                     --fail-on-degraded \
                     --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
-                    --json
+                    --json || status=1
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env DB_DSN \
-                    --sources execution_order_event,strategy_runtime_ledger_bucket \
+                    --sources execution_tca_metric \
+                    --batch-size 50 \
+                    --max-batches 1 \
+                    --reconcile-limit 1000 \
+                    --skip-reconcile \
+                    --fail-on-degraded \
+                    --supervise-timeout-seconds 45 \
+                    --json || status=1
+                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
+                    --dsn-env DB_DSN \
+                    --sources execution_order_event \
                     --batch-size 50 \
                     --max-batches 1 \
                     --event-scan-limit 250 \
@@ -76,7 +87,17 @@ spec:
                     --fail-on-degraded \
                     --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
-                    --json
+                    --json || status=1
+                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
+                    --dsn-env DB_DSN \
+                    --sources strategy_runtime_ledger_bucket \
+                    --batch-size 50 \
+                    --max-batches 1 \
+                    --reconcile-limit 1000 \
+                    --fail-on-degraded \
+                    --supervise-timeout-seconds 45 \
+                    --json || status=1
+                  exit "$status"
               env:
                 - name: DB_DSN
                   valueFrom:
@@ -161,10 +182,11 @@ spec:
                 - |
                   set -euo pipefail
                   cd /app
+                  status=0
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
-                    --sources execution,execution_tca_metric \
+                    --sources execution \
                     --batch-size 250 \
                     --max-batches 2 \
                     --reconcile-limit 500 \
@@ -172,11 +194,22 @@ spec:
                     --fail-on-degraded \
                     --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
-                    --json
+                    --json || status=1
                   /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
-                    --sources execution_order_event,strategy_runtime_ledger_bucket \
+                    --sources execution_tca_metric \
+                    --batch-size 250 \
+                    --max-batches 2 \
+                    --reconcile-limit 500 \
+                    --skip-reconcile \
+                    --fail-on-degraded \
+                    --supervise-timeout-seconds 45 \
+                    --json || status=1
+                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --sources execution_order_event \
                     --batch-size 75 \
                     --max-batches 4 \
                     --event-scan-limit 300 \
@@ -184,7 +217,18 @@ spec:
                     --fail-on-degraded \
                     --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
-                    --json
+                    --json || status=1
+                  /opt/venv/bin/python scripts/journal_tigerbeetle_order_events.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --sources strategy_runtime_ledger_bucket \
+                    --batch-size 75 \
+                    --max-batches 4 \
+                    --reconcile-limit 500 \
+                    --fail-on-degraded \
+                    --supervise-timeout-seconds 45 \
+                    --json || status=1
+                  exit "$status"
               env:
                 - name: TORGHUT_SIM_DB_HOST
                   valueFrom:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1498,11 +1498,18 @@ class TestLiveConfigManifestContract(TestCase):
             self.assertNotIn("scripts/repair_order_feed_source_windows.py", args)
             self.assertEqual(
                 args.count("scripts/journal_tigerbeetle_order_events.py"),
-                2,
+                4,
             )
-            self.assertEqual(args.count("--skip-reconcile"), 1)
-            self.assertEqual(args.count("--fail-on-degraded"), 2)
-            self.assertEqual(args.count("--supervise-timeout-seconds 45"), 2)
+            self.assertIn("status=0", args)
+            self.assertEqual(args.count("|| status=1"), 4)
+            self.assertIn('exit "$status"', args)
+            self.assertIn("--sources execution", args)
+            self.assertIn("--sources execution_tca_metric", args)
+            self.assertIn("--sources execution_order_event", args)
+            self.assertIn("--sources strategy_runtime_ledger_bucket", args)
+            self.assertEqual(args.count("--skip-reconcile"), 2)
+            self.assertEqual(args.count("--fail-on-degraded"), 4)
+            self.assertEqual(args.count("--supervise-timeout-seconds 45"), 4)
             self.assertIn("--json", args)
             security_context = cast(
                 Mapping[str, object],
@@ -1530,6 +1537,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("SIM_DB_DSN", live_env)
         live_args = "\n".join(str(item) for item in live_container.get("args", []))
         self.assertIn("--dsn-env DB_DSN", live_args)
+        self.assertEqual(live_args.count("--dsn-env DB_DSN"), 4)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)
         self.assertNotIn("--account-label TORGHUT_SIM", live_args)
         self.assertIn("--batch-size 50", live_args)
@@ -1561,6 +1569,8 @@ class TestLiveConfigManifestContract(TestCase):
         sim_args = "\n".join(str(item) for item in sim_container.get("args", []))
         self.assertIn("--dsn-env SIM_DB_DSN", sim_args)
         self.assertIn("--account-label TORGHUT_SIM", sim_args)
+        self.assertEqual(sim_args.count("--dsn-env SIM_DB_DSN"), 4)
+        self.assertEqual(sim_args.count("--account-label TORGHUT_SIM"), 4)
         self.assertIn("--batch-size 250", sim_args)
         self.assertIn("--batch-size 75", sim_args)
         self.assertIn("--max-batches 4", sim_args)


### PR DESCRIPTION
## Summary

- Split live and sim TigerBeetle journal CronJobs into one bounded invocation per source.
- Preserve fail-closed behavior while allowing later sources to run after an earlier source degrades.
- Update the manifest contract test to require four supervised journal attempts and aggregate job exit status.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py tests/test_journal_tigerbeetle_order_events.py -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `bun run lint:argocd`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
