### PR TITLE
fix(torghut): ignore retired context risk flags

### DIFF
--- a/services/torghut/app/trading/llm/dspy_programs/modules.py
+++ b/services/torghut/app/trading/llm/dspy_programs/modules.py
@@ -14,6 +14,10 @@ from .signatures import (
     DSPyTradeReviewInput,
     DSPyTradeReviewOutput,
 )
+from ...market_context_domains import (
+    active_market_context_reasons,
+    is_active_market_context_domain,
+)
 
 try:
     import dspy as _dspy  # type: ignore[import-not-found]
@@ -185,21 +189,23 @@ class LiveDSPyCommitteeProgram:
 def _collect_risk_flags(market_context: dict[str, Any]) -> list[str]:
     flags: set[str] = set()
     if isinstance(market_context.get("risk_flags"), list):
-        for value in cast(list[Any], market_context.get("risk_flags")):
-            text = str(value).strip()
-            if text:
-                flags.add(text)
+        flags.update(
+            active_market_context_reasons(
+                cast(list[Any], market_context.get("risk_flags"))
+            )
+        )
     domains = cast(dict[str, Any], market_context.get("domains") or {})
-    for domain_payload in domains.values():
+    for domain_name, domain_payload in domains.items():
         if not isinstance(domain_payload, dict):
             continue
         domain_payload_dict = cast(dict[str, Any], domain_payload)
+        if not is_active_market_context_domain(
+            domain_payload_dict.get("domain") or domain_name
+        ):
+            continue
         domain_flags = domain_payload_dict.get("risk_flags")
         if isinstance(domain_flags, list):
-            for value in cast(list[Any], domain_flags):
-                text = str(value).strip()
-                if text:
-                    flags.add(text)
+            flags.update(active_market_context_reasons(cast(list[Any], domain_flags)))
     return sorted(flags)
 
 
@@ -274,14 +280,14 @@ def _coerce_dspy_api_base(
         base_path = "/openai/v1"
     elif normalized_path == _DSPY_OPENAI_BASE_PATH:
         base_path = _DSPY_OPENAI_BASE_PATH
-    elif normalized_path == _DSPY_OPENAI_BASE_PATH + _DSPY_OPENAI_CHAT_COMPLETION_SUFFIX:
+    elif (
+        normalized_path == _DSPY_OPENAI_BASE_PATH + _DSPY_OPENAI_CHAT_COMPLETION_SUFFIX
+    ):
         base_path = _DSPY_OPENAI_BASE_PATH
     else:
         raise RuntimeError("dspy_api_base_invalid")
 
-    return (
-        f"{parsed.scheme}://{parsed.netloc}{base_path}"
-    )
+    return f"{parsed.scheme}://{parsed.netloc}{base_path}"
 
 
 def _resolve_dspy_temperature(model_name: str) -> float:

--- a/services/torghut/tests/test_llm_dspy_modules.py
+++ b/services/torghut/tests/test_llm_dspy_modules.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from app.trading.llm.dspy_programs.modules import (
+    HeuristicCommitteeProgram,
     LiveDSPyCommitteeProgram,
     _coerce_dspy_api_base,
 )
@@ -29,6 +30,74 @@ class _StaticPredictor:
 
 
 class TestDSPyTransportHardening(TestCase):
+    def test_heuristic_program_ignores_retired_context_domain_risk_flags(self) -> None:
+        program = HeuristicCommitteeProgram()
+
+        result = program.run(
+            SimpleNamespace(
+                request_json={
+                    "policy": {"adjustment_allowed": True},
+                    "market_context": {
+                        "risk_flags": [
+                            "fundamentals_missing",
+                            "news_missing",
+                        ],
+                        "domains": {
+                            "fundamentals": {
+                                "domain": "fundamentals",
+                                "risk_flags": ["fundamentals_missing"],
+                            },
+                            "news": {
+                                "domain": "news",
+                                "risk_flags": ["news_stale"],
+                            },
+                            "technicals": {
+                                "domain": "technicals",
+                                "risk_flags": [],
+                            },
+                            "regime": {
+                                "domain": "regime",
+                                "risk_flags": [],
+                            },
+                        },
+                    },
+                }
+            )
+        )
+
+        self.assertEqual(result.verdict, "approve")
+        self.assertEqual(result.risk_flags, [])
+
+    def test_heuristic_program_keeps_active_context_domain_risk_flags(self) -> None:
+        program = HeuristicCommitteeProgram()
+
+        result = program.run(
+            SimpleNamespace(
+                request_json={
+                    "policy": {"adjustment_allowed": True},
+                    "market_context": {
+                        "risk_flags": ["market_context_quality_low"],
+                        "domains": {
+                            "technicals": {
+                                "domain": "technicals",
+                                "risk_flags": ["technicals_source_error"],
+                            },
+                            "regime": {
+                                "domain": "regime",
+                                "risk_flags": [],
+                            },
+                        },
+                    },
+                }
+            )
+        )
+
+        self.assertEqual(result.verdict, "veto")
+        self.assertEqual(
+            result.risk_flags,
+            ["market_context_quality_low", "technicals_source_error"],
+        )
+
     def test_coerces_chat_completion_url_to_llm_base(self) -> None:
         self.assertEqual(
             _coerce_dspy_api_base(
@@ -149,7 +218,9 @@ class TestDSPyTransportHardening(TestCase):
             LM=_FakeLM,
             InputField=lambda *_args, **_kwargs: None,
             OutputField=lambda *_args, **_kwargs: None,
-            Predict=lambda *_args, **_kwargs: _StaticPredictor(response_json=["unexpected"]),
+            Predict=lambda *_args, **_kwargs: _StaticPredictor(
+                response_json=["unexpected"]
+            ),
             context=None,
             configure=lambda **_kwargs: None,
         )


### PR DESCRIPTION
## Summary

- Confirmed current Torghut GitOps and cluster scheduled resource names no longer contain context-fundamentals/context-news or codex fundamentals/news job templates.
- Filtered DSPy heuristic market-context risk collection through the active Torghut market-context domain policy so retired fundamentals/news domains cannot veto reviews.
- Added regression coverage proving retired fundamentals/news flags are ignored while active technicals/regime market-context flags still block as designed.

## Related Issues

None

## Testing

- `rg -n "context-fundamentals|context_fundamentals|fundamentals|context-news|context_news|market-context|market_context|news" argocd/applications/torghut services/torghut docs/torghut` (completed; remaining hits are active market-context surfaces, quarantine/regression tests, or historical design/rollout docs)
- `rg -n "context-fundamentals|context_fundamentals|context-news|context_news|fundamentals-context|news-context|codex-fundamentals|codex-news|torghut-fundamentals|torghut-news" argocd/applications/torghut` (passed; no matches)
- `kubectl get schedules.schedules.proompteng.ai -A -o name | rg "context-fundamentals|context-news|fundamentals-context|news-context|codex-fundamentals|codex-news|torghut-fundamentals|torghut-news|market-context-news|market-context-fundamentals"` (passed; no matches)
- `kubectl get cronjobs.batch -A -o name | rg "context-fundamentals|context-news|fundamentals-context|news-context|codex-fundamentals|codex-news|torghut-fundamentals|torghut-news|market-context-news|market-context-fundamentals"` (passed; no matches)
- `kubectl get agentruns.agents.proompteng.ai -A -o name | rg "context-fundamentals|context-news|fundamentals-context|news-context|codex-fundamentals|codex-news|torghut-fundamentals|torghut-news|market-context-news|market-context-fundamentals"` (passed; no matches)
- `kubectl get implementationspecs.agents.proompteng.ai -A -o name | rg "context-fundamentals|context-news|fundamentals-context|news-context|codex-fundamentals|codex-news|torghut-fundamentals|torghut-news|market-context-news|market-context-fundamentals"` (passed; no matches)
- `cd services/torghut && uv sync --frozen --extra dev` (passed after installing build-essential in the runner because crosshair-tool needs cc)
- `cd services/torghut && uv run --frozen pytest tests/test_llm_dspy_modules.py -q` (passed: 12 passed, 1 existing warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/llm/dspy_programs/modules.py tests/test_llm_dspy_modules.py` (passed)
- `cd services/torghut && uv run --frozen ruff format --check app/trading/llm/dspy_programs/modules.py tests/test_llm_dspy_modules.py` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (passed)
- `git diff --check` (passed)

## Screenshots (if applicable)

N/A; backend cleanup only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
