### PR TITLE
feat(torghut): add hpairs clusterlob ofi frontier features

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -11,6 +11,10 @@ from typing import Any, Literal, Mapping, Sequence, cast
 from app.trading.discovery.capital_budget import estimate_capital_pressure
 from app.trading.discovery.factor_acceptance import build_factor_acceptance_artifact
 from app.trading.discovery.hypothesis_cards import HypothesisCard
+from app.trading.discovery.replay_tape import (
+    HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
+    build_hpairs_replay_tape_feature_schema_hash,
+)
 from app.trading.semiconductor_universe import (
     LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE as LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE,
     RESEARCHED_SEMICONDUCTOR_TECH_UNIVERSE,
@@ -5839,6 +5843,23 @@ def compile_candidate_specs(
                             "square_root_power_law_prefilter_only_requires_source_backed_adv"
                         ),
                         "ranking_authority": "candidate_discovery_prefilter_only",
+                    }
+                    feature_contract["hpairs_replay_tape_feature_contract"] = {
+                        "schema_version": "torghut.hpairs-replay-tape-candidate-contract.v1",
+                        "feature_schema_version": HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
+                        "feature_schema_hash": build_hpairs_replay_tape_feature_schema_hash(),
+                        "clusterlob_buckets": (
+                            "deterministic_clustered_event_quote_behavior_metadata"
+                        ),
+                        "ofi_memory_regime_slices": [
+                            "instant",
+                            "short",
+                            "medium",
+                            "long",
+                        ],
+                        "ranking_authority": "candidate_discovery_prefilter_only",
+                        "promotion_authority": False,
+                        "runtime_ledger_authority": False,
                     }
                     parameter_space["hpairs_microstructure_prefilter"] = {
                         "enabled": True,

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -367,6 +367,7 @@ class _SymbolTapeStats:
     spread_tail_bps: float
     ofi_pressure_score: float
     ofi_decay_score: float
+    ofi_memory_regime_score: float
     microprice_bias_bps: float
     median_volume: float
     median_price: float
@@ -529,6 +530,11 @@ def _build_symbol_stats(rows: Sequence[SignalEnvelope]) -> dict[str, _SymbolTape
             ofi for row in ordered if (ofi := _extract_ofi_pressure(row)) is not None
         ]
         ofi_array = np.asarray(ofi_values, dtype=np.float64)
+        ofi_memory_regime_values = [
+            score
+            for row in ordered
+            if (score := _extract_ofi_memory_regime_score(row)) is not None
+        ]
         microprice_bias_values = [
             bias
             for row in ordered
@@ -553,7 +559,15 @@ def _build_symbol_stats(rows: Sequence[SignalEnvelope]) -> dict[str, _SymbolTape
             if spread_values
             else 0.0,
             ofi_pressure_score=float(np.mean(ofi_values)) if ofi_values else 0.0,
-            ofi_decay_score=_ofi_decay_score(ofi_array),
+            ofi_decay_score=_combined_ofi_decay_score(
+                ofi_array=ofi_array,
+                ofi_memory_regime_values=ofi_memory_regime_values,
+            ),
+            ofi_memory_regime_score=(
+                float(np.mean(ofi_memory_regime_values))
+                if ofi_memory_regime_values
+                else 0.0
+            ),
             microprice_bias_bps=(
                 float(np.mean(microprice_bias_values))
                 if microprice_bias_values
@@ -1034,6 +1048,26 @@ def _ofi_decay_score(values: NDArray[np.float64]) -> float:
     return float(np.clip(0.65 * short + 0.35 * long, -1.0, 1.0))
 
 
+def _combined_ofi_decay_score(
+    *,
+    ofi_array: NDArray[np.float64],
+    ofi_memory_regime_values: Sequence[float],
+) -> float:
+    tape_score = _ofi_decay_score(ofi_array)
+    if not ofi_memory_regime_values:
+        return tape_score
+    memory_score = float(
+        np.clip(
+            np.mean(np.asarray(ofi_memory_regime_values, dtype=np.float64)),
+            -1.0,
+            1.0,
+        )
+    )
+    if ofi_array.size == 0:
+        return memory_score
+    return float(np.clip(0.55 * tape_score + 0.45 * memory_score, -1.0, 1.0))
+
+
 def _ewma_last(values: NDArray[np.float64], *, half_life: float) -> float:
     if values.size == 0:
         return 0.0
@@ -1339,7 +1373,39 @@ def _extract_ofi_pressure(signal: SignalEnvelope) -> float | None:
         if -1.0 <= mean_value <= 1.0:
             return mean_value
         return float(np.tanh(mean_value / 100.0))
+    hpairs_memory_regime = _mapping(
+        _hpairs_replay_tape_features(signal).get("ofi_memory_regime_slices")
+    )
+    hpairs_memory_horizons = _mapping(hpairs_memory_regime.get("horizons"))
+    memory_values: list[float] = []
+    for horizon in ("instant", "short", "medium", "long"):
+        value = _float_or_none(hpairs_memory_horizons.get(horizon))
+        if value is not None:
+            memory_values.append(value)
+    if memory_values:
+        mean_value = float(np.mean(np.asarray(memory_values, dtype=np.float64)))
+        if -1.0 <= mean_value <= 1.0:
+            return mean_value
+        return float(np.tanh(mean_value / 100.0))
     return _extract_quote_depth_imbalance(signal)
+
+
+def _extract_ofi_memory_regime_score(signal: SignalEnvelope) -> float | None:
+    hpairs_features = _hpairs_replay_tape_features(signal)
+    memory_regime = _mapping(hpairs_features.get("ofi_memory_regime_slices"))
+    for key in ("directional_alignment_score", "memory_score", "shock_score"):
+        value = _float_or_none(memory_regime.get(key))
+        if value is not None:
+            return float(np.clip(value, -1.0, 1.0))
+    decay_memory = _mapping(hpairs_features.get("ofi_decay_memory"))
+    values = [
+        value
+        for item in decay_memory.values()
+        if (value := _float_or_none(item)) is not None
+    ]
+    if not values:
+        return None
+    return float(np.clip(np.mean(np.asarray(values, dtype=np.float64)), -1.0, 1.0))
 
 
 def _extract_quote_depth_imbalance(signal: SignalEnvelope) -> float | None:

--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -23,6 +23,10 @@ REPLAY_TAPE_SCHEMA_VERSION = "torghut.replay-tape.v1"
 REPLAY_TAPE_MANIFEST_SCHEMA_VERSION = "torghut.replay-tape-manifest.v1"
 REPLAY_TAPE_CACHE_IDENTITY_SCHEMA_VERSION = "torghut.replay-tape-cache-identity.v1"
 HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION = "torghut.hpairs-replay-tape-features.v1"
+HPAIRS_REPLAY_TAPE_FEATURE_CONTRACT_SCHEMA_VERSION = (
+    "torghut.hpairs-replay-tape-feature-contract.v1"
+)
+HPAIRS_OFI_MEMORY_REGIME_SCHEMA_VERSION = "torghut.hpairs-ofi-memory-regime-slices.v1"
 _DECIMAL_TAG = "__torghut_decimal__"
 _DATETIME_TAG = "__torghut_datetime__"
 
@@ -205,6 +209,90 @@ def build_source_query_digest(payload: Mapping[str, Any]) -> str:
         separators=(",", ":"),
     )
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def hpairs_replay_tape_feature_contract() -> dict[str, Any]:
+    """Return the stable H-PAIRS replay-tape discovery feature contract.
+
+    The contract is intentionally proof-neutral. Its hash can be supplied as a
+    replay tape ``feature_schema_hash`` so ClusterLOB/OFI discovery features are
+    part of cache lineage without changing runtime-ledger authority.
+    """
+
+    return {
+        "schema_version": HPAIRS_REPLAY_TAPE_FEATURE_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
+        "mechanisms": [
+            "clusterlob_clustered_event_quote_behavior_buckets",
+            "horizon_specific_ofi_memory_regime_slices",
+            "proof_neutral_candidate_discovery_prefilter",
+        ],
+        "cluster_lob": {
+            "event_fields": [
+                "cluster_lob_label",
+                "cluster_label",
+                "order_cluster",
+                "lob_event_type",
+                "event_type",
+            ],
+            "bucket_fields": [
+                "cluster_lob_bucket",
+                "cluster_bucket",
+                "participant_bucket",
+                "behavior_bucket",
+            ],
+            "quote_fields": [
+                "bid_size",
+                "bid_qty",
+                "best_bid_size",
+                "ask_size",
+                "ask_qty",
+                "best_ask_size",
+            ],
+            "bucket_policy": "deterministic_source_bucket_or_event_quote_fallback",
+        },
+        "ofi_memory_regime": {
+            "horizon_slices": ["instant", "short", "medium", "long"],
+            "preferred_horizon_keys": ["instant", "3_events", "12_events", "36_events"],
+            "decay_memory_fields": [
+                "ofi_decay_memory",
+                "ofi_memory",
+                "order_flow_memory",
+                "ofi_decay",
+            ],
+            "regime_fields": [
+                "regime_tags",
+                "regime_tag",
+                "market_regime",
+                "liquidity_regime",
+            ],
+            "stress_fields": [
+                "macro_event_window",
+                "macro_announcement_window",
+                "news_event_window",
+                "stress_veto_window",
+            ],
+        },
+        "lineage": {
+            "serializable": True,
+            "deterministic": True,
+            "hashable": True,
+            "hash_function": "sha256_canonical_json",
+        },
+        "proof_neutrality": {
+            "proof_source": "prefilter_only",
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "runtime_ledger_authority": False,
+            "requires_exact_replay": True,
+            "requires_source_backed_runtime_ledger": True,
+        },
+    }
+
+
+def build_hpairs_replay_tape_feature_schema_hash() -> str:
+    return build_source_query_digest(hpairs_replay_tape_feature_contract())
 
 
 def build_replay_tape_cache_key(
@@ -645,45 +733,30 @@ def hpairs_replay_tape_features(signal: SignalEnvelope) -> dict[str, Any]:
     source_fields: set[str] = set()
     horizon_ofi = _hpairs_ofi_horizons(payload, source_fields=source_fields)
     decay_memory = _hpairs_ofi_decay_memory(payload, source_fields=source_fields)
-    cluster_label = _first_text(
-        payload,
-        (
-            "cluster_lob_label",
-            "cluster_label",
-            "order_cluster",
-            "lob_event_type",
-            "event_type",
-        ),
-        source_fields=source_fields,
-    )
-    cluster_bucket = _first_text(
-        payload,
-        (
-            "cluster_lob_bucket",
-            "cluster_bucket",
-            "participant_bucket",
-            "behavior_bucket",
-        ),
-        source_fields=source_fields,
-    )
     regime_tags = _tag_tuple(
         payload,
         ("regime_tags", "regime_tag", "market_regime", "liquidity_regime"),
         source_fields=source_fields,
     )
     stress_tags = _stress_tag_tuple(payload, source_fields=source_fields)
+    cluster_lob = _hpairs_cluster_lob_payload(payload, source_fields=source_fields)
+    ofi_memory_regime_slices = _hpairs_ofi_memory_regime_slices(
+        horizon_ofi=horizon_ofi,
+        decay_memory=decay_memory,
+        regime_tags=regime_tags,
+        stress_tags=stress_tags,
+    )
     capacity_notional_lineage = _hpairs_capacity_notional_lineage(
         payload,
         source_fields=source_fields,
     )
     return {
         "schema_version": HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
+        "feature_schema_hash": build_hpairs_replay_tape_feature_schema_hash(),
         "order_flow_imbalance_horizons": horizon_ofi,
         "ofi_decay_memory": decay_memory,
-        "cluster_lob": {
-            "label": cluster_label,
-            "bucket": cluster_bucket,
-        },
+        "ofi_memory_regime_slices": ofi_memory_regime_slices,
+        "cluster_lob": cluster_lob,
         "regime_tags": list(regime_tags),
         "stress_tags": list(stress_tags),
         "capacity_notional_lineage": capacity_notional_lineage,
@@ -794,6 +867,251 @@ def _hpairs_ofi_decay_memory(
         source_fields.add(key)
         memory[key] = str(parsed)
     return dict(sorted(memory.items()))
+
+
+def _hpairs_cluster_lob_payload(
+    payload: Mapping[str, Any],
+    *,
+    source_fields: set[str],
+) -> dict[str, Any]:
+    label = _first_text(
+        payload,
+        (
+            "cluster_lob_label",
+            "cluster_label",
+            "order_cluster",
+            "lob_event_type",
+            "event_type",
+        ),
+        source_fields=source_fields,
+    )
+    raw_bucket = _first_text(
+        payload,
+        (
+            "cluster_lob_bucket",
+            "cluster_bucket",
+            "participant_bucket",
+            "behavior_bucket",
+        ),
+        source_fields=source_fields,
+    )
+    behavior_bucket = raw_bucket or _cluster_lob_behavior_bucket(label)
+    quote_behavior_bucket = _quote_behavior_bucket(payload, source_fields=source_fields)
+    return {
+        "label": label,
+        "bucket": behavior_bucket,
+        "source_bucket": raw_bucket,
+        "behavior_bucket": behavior_bucket,
+        "quote_behavior_bucket": quote_behavior_bucket,
+        "bucket_policy": (
+            "source_bucket"
+            if raw_bucket
+            else "deterministic_event_quote_behavior_fallback"
+        ),
+    }
+
+
+def _cluster_lob_behavior_bucket(label: str | None) -> str:
+    text = str(label or "").strip().lower()
+    if not text:
+        return "unknown"
+    if any(token in text for token in ("buy", "bid", "lift", "add_bid")):
+        return "aggressive_buy_pressure"
+    if any(token in text for token in ("sell", "ask", "hit", "add_ask")):
+        return "aggressive_sell_pressure"
+    if any(token in text for token in ("cancel", "delete", "remove", "withdraw")):
+        return "liquidity_withdrawal"
+    if any(token in text for token in ("quote", "replace", "modify", "update")):
+        return "quote_revision"
+    if "trade" in text or "print" in text:
+        return "trade_print"
+    return text.replace(" ", "_")
+
+
+def _quote_behavior_bucket(
+    payload: Mapping[str, Any],
+    *,
+    source_fields: set[str],
+) -> str:
+    bid_size = _first_decimal_with_key(
+        payload,
+        (
+            "bid_size",
+            "bid_qty",
+            "best_bid_size",
+            "best_bid_qty",
+            "bid_depth",
+            "bid_volume",
+        ),
+    )
+    ask_size = _first_decimal_with_key(
+        payload,
+        (
+            "ask_size",
+            "ask_qty",
+            "best_ask_size",
+            "best_ask_qty",
+            "ask_depth",
+            "ask_volume",
+        ),
+    )
+    if bid_size[0] is None or ask_size[0] is None:
+        return "quote_depth_missing"
+    bid_value, bid_key = bid_size
+    ask_value, ask_key = ask_size
+    if bid_key is not None:
+        source_fields.add(bid_key)
+    if ask_key is not None:
+        source_fields.add(ask_key)
+    assert bid_value is not None
+    assert ask_value is not None
+    total = bid_value + ask_value
+    if total <= 0:
+        return "quote_depth_empty"
+    imbalance = (bid_value - ask_value) / total
+    if imbalance >= Decimal("0.20"):
+        return "bid_depth_dominant"
+    if imbalance <= Decimal("-0.20"):
+        return "ask_depth_dominant"
+    return "balanced_quote_depth"
+
+
+def _hpairs_ofi_memory_regime_slices(
+    *,
+    horizon_ofi: Mapping[str, str],
+    decay_memory: Mapping[str, str],
+    regime_tags: Sequence[str],
+    stress_tags: Sequence[str],
+) -> dict[str, Any]:
+    instant = _mean_decimal_for_keys(horizon_ofi, ("instant", "1", "1_events"))
+    short = _mean_decimal_for_token(horizon_ofi, ("short", "3", "5"))
+    medium = _mean_decimal_for_token(horizon_ofi, ("medium", "12", "15"))
+    long = _mean_decimal_for_token(horizon_ofi, ("long", "36", "60"))
+    all_horizon_mean = _mean_decimal(horizon_ofi.values())
+    instant = instant if instant is not None else all_horizon_mean
+    short = short if short is not None else instant
+    medium = medium if medium is not None else short
+    long = long if long is not None else medium
+    memory_score = _mean_decimal(decay_memory.values())
+    if memory_score is None:
+        memory_score = _mean_decimal(
+            value for value in (short, medium, long) if value is not None
+        )
+    bounded_memory_score = _bounded_decimal(memory_score or Decimal("0"))
+    shock_score = _bounded_decimal((short or Decimal("0")) - (long or Decimal("0")))
+    directional_alignment = _bounded_decimal(
+        Decimal("0.60") * shock_score + Decimal("0.40") * bounded_memory_score
+    )
+    return {
+        "schema_version": HPAIRS_OFI_MEMORY_REGIME_SCHEMA_VERSION,
+        "horizons": {
+            "instant": _decimal_text(instant or Decimal("0")),
+            "short": _decimal_text(short or Decimal("0")),
+            "medium": _decimal_text(medium or Decimal("0")),
+            "long": _decimal_text(long or Decimal("0")),
+        },
+        "memory_score": _decimal_text(bounded_memory_score),
+        "shock_score": _decimal_text(shock_score),
+        "directional_alignment_score": _decimal_text(directional_alignment),
+        "regime_bucket": _ofi_regime_bucket(
+            memory_score=bounded_memory_score,
+            shock_score=shock_score,
+            regime_tags=regime_tags,
+            stress_tags=stress_tags,
+        ),
+        "regime_tags": list(regime_tags),
+        "stress_tags": list(stress_tags),
+        "prefilter_only": True,
+        "proof_authority": False,
+        "promotion_authority": False,
+    }
+
+
+def _ofi_regime_bucket(
+    *,
+    memory_score: Decimal,
+    shock_score: Decimal,
+    regime_tags: Sequence[str],
+    stress_tags: Sequence[str],
+) -> str:
+    if stress_tags:
+        return "stress_veto_window"
+    tags = {str(tag).strip().lower() for tag in regime_tags}
+    if any("wide" in tag or "illiquid" in tag for tag in tags):
+        return "wide_spread_liquidity_regime"
+    if any("tight" in tag or "liquid" in tag for tag in tags):
+        return "tight_spread_liquidity_regime"
+    if shock_score >= Decimal("0.20"):
+        return "positive_ofi_shock"
+    if shock_score <= Decimal("-0.20"):
+        return "negative_ofi_shock"
+    if memory_score >= Decimal("0.20"):
+        return "positive_ofi_memory"
+    if memory_score <= Decimal("-0.20"):
+        return "negative_ofi_memory"
+    return "balanced_ofi_memory"
+
+
+def _mean_decimal_for_keys(
+    values: Mapping[str, str],
+    keys: Sequence[str],
+) -> Decimal | None:
+    wanted = {str(key).lower() for key in keys}
+    return _mean_decimal(
+        value for key, value in values.items() if str(key).strip().lower() in wanted
+    )
+
+
+def _mean_decimal_for_token(
+    values: Mapping[str, str],
+    tokens: Sequence[str],
+) -> Decimal | None:
+    lowered_tokens = tuple(str(token).lower() for token in tokens)
+    return _mean_decimal(
+        value
+        for key, value in values.items()
+        if any(
+            _horizon_key_matches_token(str(key).strip().lower(), token)
+            for token in lowered_tokens
+        )
+    )
+
+
+def _horizon_key_matches_token(key: str, token: str) -> bool:
+    if key == token:
+        return True
+    if token in {"short", "medium", "long"}:
+        return token in key
+    return key.startswith(f"{token}_") or key.startswith(f"{token}-")
+
+
+def _mean_decimal(values: Iterable[Any]) -> Decimal | None:
+    parsed = tuple(
+        value
+        for value in (_decimal_or_none(item) for item in values)
+        if value is not None
+    )
+    if not parsed:
+        return None
+    return sum(parsed, Decimal("0")) / Decimal(len(parsed))
+
+
+def _bounded_decimal(value: Decimal) -> Decimal:
+    return max(Decimal("-1"), min(Decimal("1"), value))
+
+
+def _decimal_text(value: Decimal) -> str:
+    return format(value.normalize(), "f")
+
+
+def _first_decimal_with_key(
+    payload: Mapping[str, Any], keys: Sequence[str]
+) -> tuple[Decimal | None, str | None]:
+    for key in keys:
+        value = _decimal_or_none(payload.get(key))
+        if value is not None:
+            return value, key
+    return None, None
 
 
 def _hpairs_capacity_notional_lineage(

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -373,6 +373,29 @@ class TestCandidateSpecs(TestCase):
             "0.60",
         )
         self.assertTrue(specs[0].promotion_contract["requires_lob_event_stream_parity"])
+        hpairs_specs = [
+            spec
+            for spec in specs
+            if spec.family_template_id == "microbar_cross_sectional_pairs_v1"
+        ]
+        self.assertGreater(len(hpairs_specs), 0)
+        replay_tape_contract = hpairs_specs[0].feature_contract[
+            "hpairs_replay_tape_feature_contract"
+        ]
+        self.assertEqual(
+            replay_tape_contract["feature_schema_version"],
+            "torghut.hpairs-replay-tape-features.v1",
+        )
+        self.assertRegex(
+            replay_tape_contract["feature_schema_hash"],
+            r"^[0-9a-f]{64}$",
+        )
+        self.assertEqual(
+            replay_tape_contract["ofi_memory_regime_slices"],
+            ["instant", "short", "medium", "long"],
+        )
+        self.assertFalse(replay_tape_contract["promotion_authority"])
+        self.assertFalse(replay_tape_contract["runtime_ledger_authority"])
 
     def test_nonlinear_market_impact_claim_adds_route_tca_contract(self) -> None:
         cards = build_hypothesis_cards(

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -302,6 +302,39 @@ class TestFastReplayPreview(TestCase):
         self.assertGreater(ofi_pressure, 0.9)
         self.assertLessEqual(ofi_pressure, 1.0)
 
+    def test_ofi_pressure_uses_replay_tape_memory_regime_slices(self) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc),
+            symbol="AAA",
+            timeframe="1Min",
+            seq=1,
+            source="test",
+            payload={
+                "hpairs_replay_tape_features": {
+                    "ofi_memory_regime_slices": {
+                        "horizons": {
+                            "instant": "0.30",
+                            "short": "0.50",
+                            "medium": "0.20",
+                            "long": "0.10",
+                        },
+                        "directional_alignment_score": "0.35",
+                        "regime_bucket": "positive_ofi_shock",
+                        "prefilter_only": True,
+                        "proof_authority": False,
+                    },
+                    "cluster_lob": {"bucket": "aggressive_buy_pressure"},
+                },
+            },
+            ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
+        )
+
+        ofi_pressure = fast_replay._extract_ofi_pressure(signal)
+        ofi_memory = fast_replay._extract_ofi_memory_regime_score(signal)
+
+        self.assertEqual(ofi_pressure, 0.275)
+        self.assertEqual(ofi_memory, 0.35)
+
     def test_target_implied_notional_blocks_non_positive_expectancy(self) -> None:
         with TemporaryDirectory() as tmpdir:
             rows = [

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -17,6 +17,7 @@ from app.trading.discovery.replay_tape import (
     REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
     ReplayTapeCoverageError,
     ReplayTapeManifest,
+    build_hpairs_replay_tape_feature_schema_hash,
     build_replay_tape_cache_identity_diagnostics,
     build_replay_tape_cache_key,
     build_source_query_digest,
@@ -221,9 +222,33 @@ class TestReplayTape(TestCase):
             hpairs_features["ofi_decay_memory"],
             {"half_life_12": "0.21", "half_life_3": "0.55"},
         )
+        self.assertEqual(
+            hpairs_features["feature_schema_hash"],
+            build_hpairs_replay_tape_feature_schema_hash(),
+        )
+        self.assertEqual(
+            hpairs_features["ofi_memory_regime_slices"]["schema_version"],
+            "torghut.hpairs-ofi-memory-regime-slices.v1",
+        )
+        self.assertEqual(
+            hpairs_features["ofi_memory_regime_slices"]["horizons"]["short"],
+            "0.42",
+        )
+        self.assertEqual(
+            hpairs_features["ofi_memory_regime_slices"]["regime_bucket"],
+            "stress_veto_window",
+        )
         self.assertEqual(hpairs_features["cluster_lob"]["label"], "directional")
         self.assertEqual(
             hpairs_features["cluster_lob"]["bucket"], "aggressive_buy_pressure"
+        )
+        self.assertEqual(
+            hpairs_features["cluster_lob"]["behavior_bucket"],
+            "aggressive_buy_pressure",
+        )
+        self.assertEqual(
+            hpairs_features["cluster_lob"]["quote_behavior_bucket"],
+            "quote_depth_missing",
         )
         self.assertEqual(
             hpairs_features["regime_tags"], ["opening_drive", "tight_spread"]
@@ -288,7 +313,93 @@ class TestReplayTape(TestCase):
             hpairs_features["stress_tags"],
             ["fed", "macro_announcement_window"],
         )
+        self.assertEqual(
+            hpairs_features["cluster_lob"]["bucket"],
+            "unknown",
+        )
+        self.assertEqual(
+            hpairs_features["ofi_memory_regime_slices"]["horizons"]["instant"],
+            "0.44",
+        )
         self.assertFalse(hpairs_features["proof_authority"])
+
+    def test_hpairs_replay_tape_features_are_deterministic_and_hashable(
+        self,
+    ) -> None:
+        def signal(seq: int) -> SignalEnvelope:
+            return SignalEnvelope(
+                event_ts=datetime(2026, 3, 26, 14, 31, seq, tzinfo=timezone.utc),
+                symbol="NVDA",
+                timeframe="1Sec",
+                seq=seq,
+                source="ta",
+                payload={
+                    "price": Decimal("900.10"),
+                    "event_type": "cancel",
+                    "bid_size": Decimal("900"),
+                    "ask_size": Decimal("100"),
+                    "ofi_horizons": {
+                        "36_events": Decimal("0.10"),
+                        "3_events": Decimal("0.40"),
+                    },
+                    "ofi_decay_memory": {"half_life_3": Decimal("0.30")},
+                    "regime_tags": ["opening_drive"],
+                },
+                ingest_ts=datetime(2026, 3, 26, 14, 32, tzinfo=timezone.utc),
+            )
+
+        with TemporaryDirectory() as tmpdir:
+            first_path = Path(tmpdir) / "first.jsonl"
+            second_path = Path(tmpdir) / "second.jsonl"
+            materialize_signal_tape(
+                rows=[signal(1)],
+                tape_path=first_path,
+                dataset_snapshot_ref="snapshot-hpairs-deterministic",
+                symbols=("NVDA",),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 26),
+                source_query_digest=build_source_query_digest(
+                    {"window": "hpairs-deterministic"}
+                ),
+                feature_schema_hash=build_hpairs_replay_tape_feature_schema_hash(),
+            )
+            materialize_signal_tape(
+                rows=[signal(1)],
+                tape_path=second_path,
+                dataset_snapshot_ref="snapshot-hpairs-deterministic",
+                symbols=("NVDA",),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 26),
+                source_query_digest=build_source_query_digest(
+                    {"window": "hpairs-deterministic"}
+                ),
+                feature_schema_hash=build_hpairs_replay_tape_feature_schema_hash(),
+            )
+            first_row = json.loads(first_path.read_text(encoding="utf-8"))
+            second_row = json.loads(second_path.read_text(encoding="utf-8"))
+            first_manifest = load_replay_tape(first_path).manifest
+
+        self.assertEqual(first_row["hpairs_features"], second_row["hpairs_features"])
+        self.assertEqual(
+            first_row["hpairs_features"]["feature_schema_hash"],
+            build_hpairs_replay_tape_feature_schema_hash(),
+        )
+        self.assertEqual(
+            first_row["hpairs_features"]["cluster_lob"]["bucket"],
+            "liquidity_withdrawal",
+        )
+        self.assertEqual(
+            first_row["hpairs_features"]["cluster_lob"]["quote_behavior_bucket"],
+            "bid_depth_dominant",
+        )
+        self.assertEqual(
+            first_row["hpairs_features"]["ofi_memory_regime_slices"]["regime_bucket"],
+            "positive_ofi_shock",
+        )
+        self.assertEqual(
+            first_manifest.feature_schema_hash,
+            build_hpairs_replay_tape_feature_schema_hash(),
+        )
 
     def test_materialize_signal_tape_skips_nyse_full_day_holidays(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Adds a stable H-PAIRS replay-tape feature contract and schema hash for proof-neutral ClusterLOB/OFI discovery lineage.
- Normalizes deterministic ClusterLOB event/quote behavior buckets plus horizon-specific OFI memory/regime slices on replay-tape rows.
- Feeds OFI memory/regime slices into fast-preview ranking while preserving bounded exact-replay handoff and non-authority semantics.
- Extends discovery tests for schema hashing, ClusterLOB bucket stability, OFI horizon/regime output, bounded prefilter behavior, and candidate-spec contract wiring.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — pass after installing missing local `gcc` toolchain required to build `crosshair-tool` in this workspace.
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py -q` — pass, 93 tests.
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py` — pass.
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/replay_tape.py app/trading/discovery/fast_replay.py app/trading/discovery/candidate_specs.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py` — pass.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — pass, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — pass, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — pass, 0 errors.
- `git diff --check` — pass.
- Note: the broader requested `uv run --frozen ruff format --check app/trading/discovery tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py` still reports 9 pre-existing unrelated discovery files outside this PR's ownership that would be reformatted; this PR leaves them untouched and validates all touched files with the scoped format command above.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
