### PR TITLE
fix(torghut): keep autoresearch code lineage resolvable

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -181,6 +181,10 @@ spec:
                 key: torghut_password
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
+          - name: TORGHUT_COMMIT
+            value: 763a30074766b8979bf2f7d5587ca24588073daa
+          - name: TORGHUT_IMAGE_DIGEST
+            value: sha256:2ee7a8a25e45162bf037f55a3ce6e0141c9e938daece15212152fb58d42a5ec3
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -107,6 +107,12 @@ spec:
     tigerBeetleSmokeManifestPath,
     tigerBeetleJournalOrderEventsManifestPath,
   ]) {
+    const metadataEnv =
+      path === whitepaperAutoresearchWorkflowManifestPath
+        ? `            - name: TORGHUT_COMMIT
+              value: old-commit
+`
+        : ''
     writeFileSync(
       path,
       `apiVersion: v1
@@ -118,7 +124,7 @@ spec:
         - name: torghut
           image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111
           env:
-            - name: TORGHUT_IMAGE_DIGEST
+${metadataEnv}            - name: TORGHUT_IMAGE_DIGEST
               value: sha256:1111111111111111111111111111111111111111111111111111111111111111
 `,
       'utf8',
@@ -346,6 +352,7 @@ describe('update-manifests', () => {
       )
       expect(manifest).toContain('value: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e')
     }
+    expect(whitepaperAutoresearchWorkflowManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     expect(
       tigerBeetleJournalOrderEventsManifest.match(
         /image: registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e/g,

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -230,6 +230,7 @@ const updateImageOnlyManifest = (options: UpdateManifestsOptions, manifestPathVa
     /(- name:\s*TORGHUT_IMAGE_DIGEST\s*\n\s*value:\s*)([^\n]+)/g,
     `$1${options.digest}`,
   )
+  updated = replaceAllIfPresent(updated, /(- name:\s*TORGHUT_COMMIT\s*\n\s*value:\s*)([^\n]+)/g, `$1${options.commit}`)
 
   if (updated !== source) {
     writeFileSync(manifestPath, updated, 'utf8')

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -172,6 +172,9 @@ _REJECTED_SIGNAL_OUTCOME_REQUIRED_FIELDS = (
 )
 _CODE_COMMIT_ENV_VARS = (
     "TORGHUT_CODE_COMMIT",
+    "TORGHUT_COMMIT",
+    "TORGHUT_SOURCE_CI_REF",
+    "TORGHUT_IMAGE_COMMIT",
     "GITHUB_SHA",
     "BUILDKITE_COMMIT",
     "SOURCE_COMMIT",
@@ -1786,7 +1789,16 @@ def _current_code_commit() -> str:
         if value:
             return value
 
-    repo_root = Path(__file__).resolve().parents[3]
+    script_path = Path(__file__).resolve()
+    fallback_repo_root = (
+        script_path.parents[3]
+        if len(script_path.parents) > 3
+        else script_path.parents[-1]
+    )
+    repo_root = next(
+        (parent for parent in script_path.parents if (parent / ".git").exists()),
+        fallback_repo_root,
+    )
     try:
         rev = subprocess.run(
             ("git", "-C", str(repo_root), "rev-parse", "HEAD"),

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -3768,6 +3768,31 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
 
         run.assert_not_called()
 
+    def test_current_code_commit_handles_short_container_script_path(
+        self,
+    ) -> None:
+        bad_rev_parse = runner.subprocess.CompletedProcess(
+            args=("git", "rev-parse", "HEAD"),
+            returncode=128,
+            stdout="",
+        )
+        with (
+            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(
+                runner,
+                "__file__",
+                "/app/scripts/run_whitepaper_autoresearch_profit_target.py",
+            ),
+            patch.object(
+                runner.subprocess,
+                "run",
+                return_value=bad_rev_parse,
+            ) as run,
+        ):
+            self.assertEqual(runner._current_code_commit(), "unknown")
+
+        self.assertEqual(run.call_args.args[0][0:3], ("git", "-C", "/"))
+
     def test_current_code_commit_marks_dirty_or_unknown_git_state(self) -> None:
         rev_parse = runner.subprocess.CompletedProcess(
             args=("git", "rev-parse", "HEAD"),


### PR DESCRIPTION
## Summary

- Fixed `_current_code_commit()` so the whitepaper autoresearch workflow no longer crashes when the container path is `/app/scripts/...` and no `.git` parent exists.
- Recognized Torghut release metadata env vars such as `TORGHUT_COMMIT` as code lineage sources before falling back to git.
- Added `TORGHUT_COMMIT` and `TORGHUT_IMAGE_DIGEST` to the whitepaper autoresearch workflow template, and taught the release manifest updater to keep `TORGHUT_COMMIT` current when present.
- Added regression coverage for short container script paths and manifest update behavior.

## Related Issues

None

## Testing

- `cd services/torghut && .venv/bin/python -m pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q -k current_code_commit`
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `node_modules/.bin/oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `node_modules/.bin/oxlint --config .oxlintrc.json packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `git diff --check origin/main..HEAD`
- `bun run lint:argocd`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 .venv/bin/pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 .venv/bin/pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 .venv/bin/pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
