### PR TITLE
fix(torghut): repair hpairs bounded evidence routeability

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -2839,6 +2839,62 @@ def _order_event_signed_filled_qty(row: ExecutionOrderEvent) -> Decimal:
     return qty.copy_abs()
 
 
+def _source_decision_reject_reason_values(row: TradeDecision) -> list[str]:
+    decision_json = _as_mapping(row.decision_json)
+    params = _as_mapping(decision_json.get("params"))
+    routeability = _as_mapping(params.get("quote_routeability"))
+    raw_values: list[object] = [
+        decision_json.get("risk_reasons"),
+        decision_json.get("reject_reason_atomic"),
+        decision_json.get("reject_reason"),
+    ]
+    if _safe_text(routeability.get("status")) == "blocked":
+        raw_values.append(routeability.get("reason"))
+
+    reasons: list[str] = []
+    for raw_value in raw_values:
+        raw_items: Sequence[object]
+        if isinstance(raw_value, str):
+            raw_items = raw_value.replace(";", ",").split(",")
+        elif isinstance(raw_value, Sequence) and not isinstance(
+            raw_value, (bytes, bytearray)
+        ):
+            raw_items = cast(Sequence[object], raw_value)
+        else:
+            raw_items = ()
+        for raw_item in raw_items:
+            reason = _safe_text(raw_item)
+            if reason and reason not in reasons:
+                reasons.append(reason)
+    return reasons
+
+
+def _source_decision_rejection_summary(
+    decision_rows: Sequence[TradeDecision],
+) -> dict[str, object]:
+    reason_counts: Counter[str] = Counter()
+    decision_refs: list[str] = []
+    for row in decision_rows:
+        if _safe_text(row.status) != "rejected":
+            continue
+        row_reasons = _source_decision_reject_reason_values(row)
+        if not row_reasons:
+            row_reasons = ["source_decision_rejected_without_reason"]
+        decision_refs.append(str(row.id))
+        for reason in row_reasons:
+            reason_counts[reason] += 1
+    blockers = [f"source_reject_{reason}" for reason in sorted(reason_counts)]
+    return {
+        "rejected_decision_count": len(decision_refs),
+        "decision_refs": decision_refs[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT],
+        "reason_counts": [
+            {"reason": reason, "count": count}
+            for reason, count in sorted(reason_counts.items())
+        ],
+        "blockers": blockers,
+    }
+
+
 def _source_activity_lifecycle_summary(
     *,
     execution_rows: Sequence[Execution],
@@ -3349,11 +3405,16 @@ def _strategy_source_activity(
     complete_fill_order_event_count = sum(
         int(_order_event_has_complete_fill_lifecycle(row)) for row in order_event_rows
     )
+    decision_rejection_summary = _source_decision_rejection_summary(decision_rows)
+    decision_reject_blockers = _unique_text_items(
+        decision_rejection_summary.get("blockers")
+    )
     missing_reasons: list[str] = []
     if decision_count <= 0:
         missing_reasons.append("source_decisions_missing")
     if execution_count <= 0:
         missing_reasons.append("source_executions_missing")
+        missing_reasons.extend(decision_reject_blockers)
     if tca_sample_count <= 0 and complete_fill_order_event_count <= 0:
         missing_reasons.append("source_tca_missing")
     missing_reasons.extend(lineage_blockers)
@@ -3401,12 +3462,22 @@ def _strategy_source_activity(
         [
             *_unique_text_items(lifecycle_summary.get("submitted_order_blockers")),
             *(["source_execution_refs_missing"] if not execution_refs else []),
+            *(
+                decision_reject_blockers
+                if execution_count <= 0 and decision_reject_blockers
+                else []
+            ),
         ]
     )
     source_lifecycle_blockers = _unique_text_items(
         [
             *_unique_text_items(lifecycle_summary.get("blockers")),
             *source_reference_blockers,
+            *(
+                decision_reject_blockers
+                if execution_count <= 0 and decision_reject_blockers
+                else []
+            ),
             *(
                 ["source_activity_readback_truncated"]
                 if decision_truncated
@@ -3447,6 +3518,8 @@ def _strategy_source_activity(
         "lineage_matched_decision_count": decision_count,
         "lineage_blockers": lineage_blockers,
         "source_lineage_observation": source_lineage_observation,
+        "source_decision_rejection_summary": decision_rejection_summary,
+        "source_decision_reject_blockers": decision_reject_blockers,
         "decision_refs": decision_refs,
         "execution_refs": execution_refs,
         "order_lifecycle_refs": order_lifecycle_refs,

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -2656,8 +2656,19 @@ class SimpleTradingPipeline(TradingPipeline):
             decision.params,
             symbol=decision.symbol,
         )
+        snapshot_has_executable_quote = (
+            snapshot is not None
+            and snapshot.bid is not None
+            and snapshot.ask is not None
+            and snapshot.bid > 0
+            and snapshot.ask >= snapshot.bid
+        )
         if (
-            (snapshot is None or snapshot.price is None)
+            (
+                snapshot is None
+                or snapshot.price is None
+                or (requires_executable_quote and not snapshot_has_executable_quote)
+            )
             and target_snapshot is not None
             and _snapshot_has_executable_quote(target_snapshot)
         ):
@@ -2797,6 +2808,11 @@ class SimpleTradingPipeline(TradingPipeline):
             params,
             symbol=decision.symbol,
         )
+        target_price_snapshot: Mapping[str, Any] = (
+            target_quote_snapshot
+            if target_quote_snapshot is not None
+            else cast(Mapping[str, Any], {})
+        )
         if not price_snapshot and target_quote_snapshot is not None:
             price_snapshot = target_quote_snapshot
 
@@ -2806,27 +2822,48 @@ class SimpleTradingPipeline(TradingPipeline):
             price_snapshot,
             ("price", "mid", "mid_price", "midpoint"),
         )
-        price = _first_decimal(snapshot_price, payload_price, params_price)
+        target_payload_price = _decimal_from_mapping(
+            target_price_snapshot,
+            ("price", "mid", "mid_price", "midpoint"),
+        )
+        price = _first_decimal(
+            snapshot_price,
+            payload_price,
+            target_payload_price,
+            params_price,
+        )
 
         snapshot_bid = snapshot.bid if snapshot is not None else None
         payload_bid = _decimal_from_mapping(
             price_snapshot,
             ("bid", "bid_px", "bid_price", "bp"),
         )
+        target_payload_bid = _decimal_from_mapping(
+            target_price_snapshot,
+            ("bid", "bid_px", "bid_price", "bp"),
+        )
         params_bid = _optional_decimal(params.get("imbalance_bid_px"))
-        bid = _first_decimal(snapshot_bid, payload_bid, params_bid)
+        bid = _first_decimal(snapshot_bid, payload_bid, target_payload_bid, params_bid)
 
         snapshot_ask = snapshot.ask if snapshot is not None else None
         payload_ask = _decimal_from_mapping(
             price_snapshot,
             ("ask", "ask_px", "ask_price", "ap"),
         )
+        target_payload_ask = _decimal_from_mapping(
+            target_price_snapshot,
+            ("ask", "ask_px", "ask_price", "ap"),
+        )
         params_ask = _optional_decimal(params.get("imbalance_ask_px"))
-        ask = _first_decimal(snapshot_ask, payload_ask, params_ask)
+        ask = _first_decimal(snapshot_ask, payload_ask, target_payload_ask, params_ask)
 
         snapshot_spread = snapshot.spread if snapshot is not None else None
         payload_spread = _decimal_from_mapping(
             price_snapshot,
+            ("spread", "imbalance_spread"),
+        )
+        target_payload_spread = _decimal_from_mapping(
+            target_price_snapshot,
             ("spread", "imbalance_spread"),
         )
         params_spread = _optional_decimal(params.get("spread"))
@@ -2834,29 +2871,62 @@ class SimpleTradingPipeline(TradingPipeline):
         spread = _first_decimal(
             snapshot_spread,
             payload_spread,
+            target_payload_spread,
             params_spread,
             computed_spread,
         )
-        quote_as_of = (
-            snapshot.quote_as_of
-            if snapshot is not None and snapshot.quote_as_of is not None
-            else _parse_target_datetime(price_snapshot.get("quote_as_of"))
+        using_target_executable_quote = (
+            target_quote_snapshot is not None
+            and snapshot_bid is None
+            and snapshot_ask is None
+            and payload_bid is None
+            and payload_ask is None
+            and target_payload_bid is not None
+            and target_payload_ask is not None
+        )
+        target_quote_as_of = (
+            _parse_target_datetime(target_price_snapshot.get("quote_as_of"))
+            or _parse_target_datetime(target_price_snapshot.get("as_of"))
+            or _parse_target_datetime(target_price_snapshot.get("timestamp"))
+        )
+        price_snapshot_quote_as_of = (
+            _parse_target_datetime(price_snapshot.get("quote_as_of"))
             or _parse_target_datetime(price_snapshot.get("as_of"))
             or _parse_target_datetime(price_snapshot.get("timestamp"))
         )
+        quote_as_of = (
+            target_quote_as_of
+            if using_target_executable_quote and target_quote_as_of is not None
+            else (
+                snapshot.quote_as_of
+                if snapshot is not None and snapshot.quote_as_of is not None
+                else price_snapshot_quote_as_of or target_quote_as_of
+            )
+        )
+        target_source = _text_from_mapping(
+            target_price_snapshot,
+            ("quote_source", "source", "feed"),
+        )
+        price_snapshot_source = _text_from_mapping(
+            price_snapshot,
+            ("quote_source", "source", "feed"),
+        )
         source = (
-            str(
-                (
-                    snapshot.quote_source
-                    if snapshot is not None and snapshot.quote_source is not None
-                    else price_snapshot.get("quote_source")
-                    or price_snapshot.get("source")
-                    or price_snapshot.get("feed")
-                    or (snapshot.source if snapshot is not None else "")
-                )
-                or ""
-            ).strip()
-            or None
+            target_source
+            if using_target_executable_quote and target_source is not None
+            else (
+                str(
+                    (
+                        snapshot.quote_source
+                        if snapshot is not None and snapshot.quote_source is not None
+                        else price_snapshot_source
+                        or target_source
+                        or (snapshot.source if snapshot is not None else "")
+                    )
+                    or ""
+                ).strip()
+                or None
+            )
         )
         quality_payload: dict[str, object] = {
             "price": price,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -4752,6 +4752,135 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertIn("source_reject_spread_bps_exceeded", import_audit["blockers"])
 
+    def test_source_activity_readback_exposes_rejected_decision_submit_blocker(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                description="H-PAIRS paper route source strategy",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            session.add(
+                TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    timeframe="1Sec",
+                    decision_json={
+                        "action": "buy",
+                        "qty": "1",
+                        "source_candidate_ids": ["c88421d619759b2cfaa6f4d0"],
+                        "source_hypothesis_ids": ["H-PAIRS-01"],
+                        "source_strategy_names": ["microbar-cross-sectional-pairs-v1"],
+                        "risk_reasons": ["missing_executable_quote"],
+                        "reject_reason_atomic": ["missing_executable_quote"],
+                        "params": {
+                            "quote_routeability": {
+                                "status": "blocked",
+                                "reason": "missing_executable_quote",
+                                "readiness": {
+                                    "state": "blocked",
+                                    "blockers": ["missing_executable_quote"],
+                                },
+                            }
+                        },
+                    },
+                    rationale="target source decision rejected before submit",
+                    status="rejected",
+                    created_at=window_start + timedelta(minutes=20),
+                )
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "runtime_strategy_name": (
+                                    "microbar-cross-sectional-pairs-v1"
+                                ),
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": (
+                                    "config/trading/hypotheses/h-pairs-01.json"
+                                ),
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                                "paper_route_probe_symbol_actions": {
+                                    "AAPL": "buy",
+                                    "AMZN": "sell",
+                                },
+                                "paper_probation_authorized": True,
+                                "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "25",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_active_symbols": ["AAPL", "AMZN"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 2,
+                    },
+                },
+                generated_at=datetime(2026, 5, 26, 21, tzinfo=timezone.utc),
+            )
+
+        target_audit = payload["next_runtime_window_target_audits"][0]
+        source_activity = target_audit["source_activity"]
+        self.assertEqual(source_activity["decision_count"], 1)
+        self.assertEqual(source_activity["submitted_order_count"], 0)
+        self.assertIn(
+            "source_reject_missing_executable_quote",
+            source_activity["submitted_order_blockers"],
+        )
+        self.assertIn(
+            "source_reject_missing_executable_quote",
+            source_activity["missing_reasons"],
+        )
+        self.assertIn(
+            "source_reject_missing_executable_quote",
+            target_audit["readiness"]["blockers"],
+        )
+
     def test_hpairs_zero_activity_diagnostics_report_market_window_blocker(
         self,
     ) -> None:

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -460,6 +460,50 @@ def test_paper_route_quote_routeability_prefers_executable_snapshot_price() -> N
     assert routeability["readiness"]["state"] == "ready"
 
 
+def test_paper_route_quote_routeability_uses_target_quote_when_snapshot_price_only() -> (
+    None
+):
+    pipeline = object.__new__(SimpleTradingPipeline)
+    target = _bounded_hpairs_target(
+        paper_route_probe_symbol_quotes={
+            "AAPL": {
+                "price": "190.01",
+                "bid": "190.00",
+                "ask": "190.02",
+                "quote_as_of": "2026-06-01T14:29:59+00:00",
+                "quote_source": "target_plan_h_pairs_quote",
+            }
+        }
+    )
+    decision = _routeability_decision(
+        params={
+            "price_snapshot": {
+                "price": "190.01",
+                "as_of": "2026-06-01T14:30:00+00:00",
+                "source": "price_only_snapshot",
+            },
+            "paper_route_target_plan_source_decision": target,
+            "source_decision_mode": "bounded_paper_route_collection",
+            "promotion_allowed": False,
+            "final_authority_ok": False,
+        }
+    )
+
+    status, routeability = pipeline._paper_route_quote_routeability(
+        decision,
+        snapshot=None,
+    )
+
+    assert status.valid is True
+    assert status.bid == Decimal("190.00")
+    assert status.ask == Decimal("190.02")
+    assert status.source == "target_plan_h_pairs_quote"
+    assert routeability["quote_as_of"] == "2026-06-01T14:29:59+00:00"
+    assert routeability["bounded_evidence_collection_ready"] is True
+    assert routeability["promotion_allowed"] is False
+    assert routeability["final_promotion_allowed"] is False
+
+
 def test_paper_route_quote_helpers_read_target_snapshot_fallbacks() -> None:
     direct_snapshot = {
         "symbol": "AAPL",
@@ -546,6 +590,44 @@ def test_ensure_decision_price_backfills_target_quote_when_snapshot_missing() ->
         "ask": "190.02",
         "spread": "0.02",
     }
+
+
+def test_ensure_decision_price_backfills_target_quote_when_snapshot_price_only() -> (
+    None
+):
+    pipeline = object.__new__(SimpleTradingPipeline)
+    pipeline.price_fetcher = SimpleNamespace(
+        fetch_market_snapshot=lambda _signal: MarketSnapshot(
+            symbol="AAPL",
+            as_of=datetime(2026, 6, 1, 14, 30, tzinfo=timezone.utc),
+            price=Decimal("190.01"),
+            spread=None,
+            source="price_only_snapshot",
+        )
+    )
+    decision = _routeability_decision(
+        params={
+            "paper_route_target_plan_source_decision": _bounded_hpairs_target(
+                paper_route_probe_symbol_quotes={
+                    "AAPL": {
+                        "bid": "190.00",
+                        "ask": "190.02",
+                        "timestamp": "2026-06-01T14:29:59+00:00",
+                        "feed": "target_feed",
+                    }
+                }
+            )
+        }
+    )
+
+    updated, snapshot = pipeline._ensure_decision_price(decision, signal_price=None)
+
+    assert snapshot is None
+    assert updated.params["price"] == Decimal("190.01")
+    assert updated.params["imbalance_bid_px"] == Decimal("190.00")
+    assert updated.params["imbalance_ask_px"] == Decimal("190.02")
+    assert updated.params["spread"] == Decimal("0.02")
+    assert updated.params["price_snapshot"]["source"] == "target_feed"
 
 
 def test_target_plan_source_mismatch_readback_handles_no_metadata_and_symbol_field() -> (


### PR DESCRIPTION
## Summary

- Backfill bounded H-PAIRS paper-route decisions from target-plan executable bid/ask quotes when a fetched market snapshot only contains a price, so valid target quotes can reach paper submission gates.
- Preserve quote safety gates by still running freshness, spread, crossed-quote, side/symbol mismatch, and final-promotion blocking checks before any bounded collection submit.
- Add paper-route evidence readback for rejected source decisions so zero submitted-order windows expose exact `source_reject_*` blockers such as `source_reject_missing_executable_quote`.
- Cover the repaired routeability and readback paths with focused regressions.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_simple_pipeline.py tests/test_submission_council.py tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py tests/test_simple_pipeline.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py tests/test_simple_pipeline.py tests/test_paper_route_evidence.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
