### PR TITLE
fix(arc): cap arm64 runner scale to schedulable capacity

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -27,8 +27,8 @@ spec:
           runnerScaleSetName: arc-arm64
           scaleSetLabels:
             - arc-arm64
-          minRunners: 3
-          maxRunners: 7
+          minRunners: 1
+          maxRunners: 2
           containerMode:
             type: "kubernetes"
             kubernetesModeWorkVolumeClaim:


### PR DESCRIPTION
## Summary

- Cap the GitHub ARC `arc-arm64` runner scale set at the two Docker runners the ARM node can currently schedule.
- Reduce warm `arc-arm64` runners from three to one so the autoscaler does not pin impossible Pending runners.
- Keep runner resources unchanged; this only corrects advertised capacity.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
