### PR TITLE
feat(torghut): add hpairs runtime evidence census

### DIFF
--- a/services/torghut/scripts/inspect_hpairs_runtime_evidence.py
+++ b/services/torghut/scripts/inspect_hpairs_runtime_evidence.py
@@ -1,0 +1,984 @@
+#!/usr/bin/env python
+"""Read-only H-PAIRS runtime/live-paper evidence census.
+
+The command measures durable runtime DB rows and optional status-service state for
+H-PAIRS without submitting orders, uploading proof packets, or mutating the DB.
+It deliberately separates configuration, route/submission evidence,
+runtime-ledger source authority, and final profitability proof so blockers are
+reported as machine-readable facts rather than collapsed into one green status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import cast
+
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.db import SessionLocal
+from app.trading.runtime_authority_verifier import (
+    AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER,
+    AUTHORITY_EVIDENCE_MISSING_BLOCKER,
+    AUTHORITY_EXPLICIT_COSTS_BLOCKER,
+    AUTHORITY_FILLED_NOTIONAL_BLOCKER,
+    AUTHORITY_MEAN_PNL_BLOCKER,
+    AUTHORITY_MEDIAN_PNL_BLOCKER,
+    AUTHORITY_OPEN_POSITIONS_BLOCKER,
+    AUTHORITY_P10_PNL_BLOCKER,
+    AUTHORITY_READ_ERROR_BLOCKER,
+    AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+    AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
+    AUTHORITY_TRADING_DAYS_BLOCKER,
+    AUTHORITY_WORST_DAY_BLOCKER,
+    DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+)
+from app.trading.runtime_ledger_source_authority import (
+    ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+    RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
+    RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+)
+from scripts import audit_hpairs_source_proof_census as source_census
+
+SCHEMA_VERSION = "torghut.hpairs-runtime-live-paper-evidence-census.v1"
+SUBMITTED_ORDERS_MISSING_BLOCKER = source_census.SUBMITTED_ORDERS_MISSING_BLOCKER
+STATUS_SERVICE_NOT_PROVIDED_BLOCKER = "status_service_not_provided"
+STATUS_SERVICE_READ_ERROR_BLOCKER = "status_service_read_error"
+CONFIGURED_CANDIDATE_MISSING_BLOCKER = "configured_candidate_missing"
+CONFIGURED_CANDIDATE_MISMATCH_BLOCKER = "configured_candidate_mismatch"
+AGGREGATE_ONLY_RUNTIME_LEDGER_BLOCKER = (
+    "runtime_ledger_aggregate_only_buckets_not_authority"
+)
+RUNTIME_LEDGER_BUCKETS_MISSING_BLOCKER = AUTHORITY_EVIDENCE_MISSING_BLOCKER
+
+_ROUTE_BLOCKERS = frozenset(
+    {
+        AUTHORITY_RUNTIME_DECISIONS_MISSING_BLOCKER,
+        AUTHORITY_RUNTIME_FILLS_MISSING_BLOCKER,
+        SUBMITTED_ORDERS_MISSING_BLOCKER,
+        ORDER_FEED_LIFECYCLE_MISSING_BLOCKER,
+        RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+    }
+)
+_SOURCE_AUTHORITY_BLOCKERS = frozenset(
+    {
+        AUTHORITY_EVIDENCE_MISSING_BLOCKER,
+        AUTHORITY_READ_ERROR_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
+        AGGREGATE_ONLY_RUNTIME_LEDGER_BLOCKER,
+    }
+)
+_FINAL_PROOF_BLOCKERS = frozenset(
+    {
+        AUTHORITY_TRADING_DAYS_BLOCKER,
+        AUTHORITY_MEAN_PNL_BLOCKER,
+        AUTHORITY_MEDIAN_PNL_BLOCKER,
+        AUTHORITY_P10_PNL_BLOCKER,
+        AUTHORITY_WORST_DAY_BLOCKER,
+        AUTHORITY_FILLED_NOTIONAL_BLOCKER,
+        AUTHORITY_CLOSED_ROUND_TRIPS_BLOCKER,
+        AUTHORITY_OPEN_POSITIONS_BLOCKER,
+        AUTHORITY_EXPLICIT_COSTS_BLOCKER,
+        AUTHORITY_EVIDENCE_MISSING_BLOCKER,
+    }
+)
+_ROUTE_FLAG_KEYS = (
+    "route_enabled",
+    "route_eligible",
+    "paper_route_enabled",
+    "paper_route_eligible",
+    "order_route_enabled",
+    "order_route_eligible",
+    "submit_enabled",
+    "simple_submit_enabled",
+    "trading_simple_submit_enabled",
+)
+
+
+@dataclass(frozen=True)
+class RuntimeEvidenceIdentity:
+    hypothesis_id: str
+    candidate_id: str
+    runtime_strategy_name: str
+    account_label: str
+    observed_stage: str | None
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "--dsn", help="SQLAlchemy DSN to read with one bounded read-only session"
+    )
+    source.add_argument(
+        "--fixture-json",
+        type=Path,
+        help="Fixture JSON containing source row arrays for tests",
+    )
+    parser.add_argument("--hypothesis-id", default=DEFAULT_HPAIRS_HYPOTHESIS_ID)
+    parser.add_argument("--candidate-id", default=DEFAULT_HPAIRS_CANDIDATE_ID)
+    parser.add_argument(
+        "--runtime-strategy-name", default=DEFAULT_HPAIRS_RUNTIME_STRATEGY
+    )
+    parser.add_argument("--account-label", default=DEFAULT_HPAIRS_ACCOUNT_LABEL)
+    parser.add_argument("--observed-stage", default="paper")
+    parser.add_argument("--start", dest="started_at")
+    parser.add_argument("--end", dest="ended_at")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit stable JSON (the default and only output format)",
+    )
+    parser.add_argument(
+        "--output-json", type=Path, help="write JSON to this path instead of stdout"
+    )
+    parser.add_argument(
+        "--status-service-url",
+        help="optional bounded HTTP GET for live service/config status JSON",
+    )
+    parser.add_argument(
+        "--status-fixture-json",
+        type=Path,
+        help="fixture JSON for status-service payloads; intended for tests and local dry-runs",
+    )
+    parser.add_argument("--status-timeout-seconds", type=float, default=5.0)
+    return parser.parse_args(argv)
+
+
+def stable_json(report: Mapping[str, object]) -> str:
+    return json.dumps(report, default=_json_default, indent=2, sort_keys=True) + "\n"
+
+
+def build_runtime_evidence_census(
+    rows: source_census.CensusSourceRows,
+    *,
+    identity: RuntimeEvidenceIdentity,
+    started_at: datetime | None = None,
+    ended_at: datetime | None = None,
+    source_kind: str = "fixture_json",
+    read_error: str | None = None,
+    status_payload: Mapping[str, object] | None = None,
+    status_source: str | None = None,
+    status_read_error: str | None = None,
+) -> dict[str, object]:
+    source_report = source_census.build_source_proof_census(
+        rows,
+        identity=source_census.CensusIdentity(
+            hypothesis_id=identity.hypothesis_id,
+            candidate_id=identity.candidate_id,
+            runtime_strategy_name=identity.runtime_strategy_name,
+            account_label=identity.account_label,
+            observed_stage=identity.observed_stage,
+        ),
+        started_at=started_at,
+        ended_at=ended_at,
+        read_error=read_error,
+        source_kind=source_kind,
+    )
+    totals = _mapping(source_report.get("totals"))
+    runtime_authority = _mapping(source_report.get("runtime_authority"))
+    runtime_aggregate = _mapping(runtime_authority.get("aggregate"))
+    daily_rows = _daily_rows(source_report)
+    identifier_counts = _identifier_counts(rows, runtime_authority)
+    aggregate_summary = _aggregate_summary(
+        totals,
+        runtime_aggregate,
+        identifier_counts=identifier_counts,
+    )
+    all_source_blockers = _text_list(source_report.get("blockers"))
+    status = status_payload or {}
+    configured = _configured_candidate_truth(
+        status,
+        totals=totals,
+        identity=identity,
+        status_source=status_source,
+        status_read_error=status_read_error,
+    )
+    routeability = _routeability_truth(
+        status,
+        totals=totals,
+        blockers=all_source_blockers,
+        identifier_counts=identifier_counts,
+    )
+    source_authority = _source_authority_truth(
+        totals,
+        runtime_authority=runtime_authority,
+        blockers=all_source_blockers,
+        identifier_counts=identifier_counts,
+    )
+    final_proof = _final_profitability_truth(runtime_authority, runtime_aggregate)
+    blockers = _top_level_blockers(
+        configured=configured,
+        routeability=routeability,
+        source_authority=source_authority,
+        final_proof=final_proof,
+        source_blockers=all_source_blockers,
+    )
+    aggregate_summary["blockers"] = blockers
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "read_only": True,
+        "writes_performed": False,
+        "submits_orders": False,
+        "uploads_proof_packets": False,
+        "mutates_database": False,
+        "profitability_claimed": False,
+        "identity": {
+            "hypothesis_id": identity.hypothesis_id,
+            "candidate_id": identity.candidate_id,
+            "runtime_strategy_name": identity.runtime_strategy_name,
+            "account_label": identity.account_label,
+            "observed_stage": identity.observed_stage,
+        },
+        "window": {
+            "started_at": _isoformat(started_at) if started_at is not None else None,
+            "ended_at": _isoformat(ended_at) if ended_at is not None else None,
+        },
+        "sources": {
+            "runtime_db": {
+                "kind": source_kind,
+                "read_only": True,
+                "read_error": read_error,
+            },
+            "status_service": {
+                "source": status_source,
+                "provided": bool(status_source),
+                "read_error": status_read_error,
+            },
+        },
+        "truths": {
+            "merged_configured_candidate": configured,
+            "routeability_submission_evidence": routeability,
+            "runtime_ledger_source_authority_evidence": source_authority,
+            "final_500_day_profitability_proof": final_proof,
+        },
+        "aggregate_summary": aggregate_summary,
+        "daily_rows": daily_rows,
+        "blockers": blockers,
+        "upstream_source_proof_census": {
+            "schema_version": source_report.get("schema_version"),
+            "verdict": source_report.get("verdict"),
+            "blocker_ladder": source_report.get("blocker_ladder"),
+        },
+    }
+
+
+def load_dsn_rows(
+    dsn: str,
+    *,
+    identity: RuntimeEvidenceIdentity,
+    started_at: datetime | None,
+    ended_at: datetime | None,
+) -> source_census.CensusSourceRows:
+    engine = create_engine(dsn)
+    session_factory = sessionmaker(bind=engine)
+    with session_factory() as session:
+        return source_census._load_session_rows(  # noqa: SLF001 - existing script helper is the repo's bounded reader.
+            cast(Session, session),
+            identity=source_census.CensusIdentity(
+                hypothesis_id=identity.hypothesis_id,
+                candidate_id=identity.candidate_id,
+                runtime_strategy_name=identity.runtime_strategy_name,
+                account_label=identity.account_label,
+                observed_stage=identity.observed_stage,
+            ),
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+
+
+def load_default_session_rows(
+    *,
+    identity: RuntimeEvidenceIdentity,
+    started_at: datetime | None,
+    ended_at: datetime | None,
+) -> source_census.CensusSourceRows:
+    with SessionLocal() as session:
+        return source_census._load_session_rows(  # noqa: SLF001 - existing script helper is the repo's bounded reader.
+            cast(Session, session),
+            identity=source_census.CensusIdentity(
+                hypothesis_id=identity.hypothesis_id,
+                candidate_id=identity.candidate_id,
+                runtime_strategy_name=identity.runtime_strategy_name,
+                account_label=identity.account_label,
+                observed_stage=identity.observed_stage,
+            ),
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+
+
+def load_status_payload(
+    *,
+    status_fixture_json: Path | None,
+    status_service_url: str | None,
+    timeout_seconds: float,
+) -> tuple[Mapping[str, object], str | None, str | None]:
+    if status_fixture_json is not None:
+        loaded = json.loads(status_fixture_json.read_text())
+        if not isinstance(loaded, Mapping):
+            return (
+                {},
+                f"fixture_json:{status_fixture_json}",
+                "status_fixture_json_not_object",
+            )
+        return (
+            cast(Mapping[str, object], loaded),
+            f"fixture_json:{status_fixture_json}",
+            None,
+        )
+    if status_service_url is None:
+        return {}, None, None
+    try:
+        request = urllib.request.Request(status_service_url, method="GET")
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310 - explicit read-only URL supplied by operator.
+            loaded = json.loads(response.read().decode("utf-8"))
+    except (OSError, json.JSONDecodeError, urllib.error.URLError) as exc:
+        return {}, status_service_url, str(exc)
+    if not isinstance(loaded, Mapping):
+        return {}, status_service_url, "status_service_payload_not_object"
+    return cast(Mapping[str, object], loaded), status_service_url, None
+
+
+def _configured_candidate_truth(
+    status_payload: Mapping[str, object],
+    *,
+    totals: Mapping[str, object],
+    identity: RuntimeEvidenceIdentity,
+    status_source: str | None,
+    status_read_error: str | None,
+) -> dict[str, object]:
+    target = _target_from_status(status_payload, identity)
+    observed_runtime_rows = any(
+        _int(totals.get(key)) > 0
+        for key in (
+            "trade_decision_count",
+            "execution_count",
+            "execution_order_event_count",
+            "runtime_ledger_bucket_count",
+        )
+    )
+    blockers: list[str] = []
+    if status_source is None:
+        blockers.append(STATUS_SERVICE_NOT_PROVIDED_BLOCKER)
+    if status_read_error is not None:
+        blockers.append(STATUS_SERVICE_READ_ERROR_BLOCKER)
+    if status_payload and not target:
+        blockers.append(CONFIGURED_CANDIDATE_MISSING_BLOCKER)
+    if target and not _target_matches(target, identity):
+        blockers.append(CONFIGURED_CANDIDATE_MISMATCH_BLOCKER)
+    configured_or_observed = (
+        bool(target and _target_matches(target, identity)) or observed_runtime_rows
+    )
+    return {
+        "configured_or_observed": configured_or_observed,
+        "status_service_target_found": bool(target),
+        "observed_in_runtime_rows": observed_runtime_rows,
+        "expected": {
+            "hypothesis_id": identity.hypothesis_id,
+            "candidate_id": identity.candidate_id,
+            "runtime_strategy_name": identity.runtime_strategy_name,
+            "account_label": identity.account_label,
+        },
+        "matched_status_target": dict(target) if target else None,
+        "blockers": sorted(dict.fromkeys(blockers)),
+    }
+
+
+def _routeability_truth(
+    status_payload: Mapping[str, object],
+    *,
+    totals: Mapping[str, object],
+    blockers: Sequence[str],
+    identifier_counts: Mapping[str, int],
+) -> dict[str, object]:
+    route_flags = _route_flags(status_payload)
+    disabled_flags = [key for key, value in route_flags.items() if value is False]
+    route_blockers = [code for code in blockers if code in _ROUTE_BLOCKERS]
+    if disabled_flags:
+        route_blockers.append("routeability_flags_disabled")
+    return {
+        "source_backed_decisions_present": _int(totals.get("trade_decision_count")) > 0,
+        "submitted_order_lifecycle_present": _int(
+            totals.get("runtime_submitted_order_count")
+        )
+        > 0,
+        "fill_lifecycle_present": _int(totals.get("fill_lifecycle_event_count")) > 0,
+        "executions_present": _int(totals.get("execution_count")) > 0,
+        "trade_decision_ids_count": identifier_counts["trade_decision_ids_count"],
+        "execution_ids_count": identifier_counts["execution_ids_count"],
+        "execution_order_event_ids_count": identifier_counts[
+            "execution_order_event_ids_count"
+        ],
+        "fill_lifecycle_count": _int(totals.get("fill_lifecycle_event_count")),
+        "runtime_submitted_order_count": _int(
+            totals.get("runtime_submitted_order_count")
+        ),
+        "route_flags": route_flags,
+        "disabled_route_flags": disabled_flags,
+        "blockers": sorted(dict.fromkeys(route_blockers)),
+    }
+
+
+def _source_authority_truth(
+    totals: Mapping[str, object],
+    *,
+    runtime_authority: Mapping[str, object],
+    blockers: Sequence[str],
+    identifier_counts: Mapping[str, int],
+) -> dict[str, object]:
+    aggregate = _mapping(runtime_authority.get("aggregate"))
+    bucket_count = _int(totals.get("runtime_ledger_bucket_count"))
+    source_authority_bucket_count = _int(
+        totals.get("blocker_free_runtime_ledger_bucket_count")
+    )
+    aggregate_only_bucket_count = max(0, bucket_count - source_authority_bucket_count)
+    source_blockers = [code for code in blockers if code in _SOURCE_AUTHORITY_BLOCKERS]
+    if bucket_count <= 0:
+        source_blockers.append(RUNTIME_LEDGER_BUCKETS_MISSING_BLOCKER)
+    if aggregate_only_bucket_count > 0:
+        source_blockers.append(AGGREGATE_ONLY_RUNTIME_LEDGER_BLOCKER)
+    return {
+        "runtime_ledger_bucket_count": bucket_count,
+        "source_authority_bucket_count": source_authority_bucket_count,
+        "clean_authority_bucket_count": _int(
+            aggregate.get("clean_authority_bucket_count")
+        ),
+        "aggregate_only_bucket_count": aggregate_only_bucket_count,
+        "aggregate_only_buckets_count_as_authority": False,
+        "source_window_ids_count": identifier_counts["source_window_ids_count"],
+        "execution_order_event_ids_count": identifier_counts[
+            "execution_order_event_ids_count"
+        ],
+        "execution_ids_count": identifier_counts["execution_ids_count"],
+        "trade_decision_ids_count": identifier_counts["trade_decision_ids_count"],
+        "runtime_ledger_source_materialization_count": _int(
+            totals.get("runtime_ledger_source_materialization_count")
+        ),
+        "explicit_cost_runtime_ledger_bucket_count": _int(
+            totals.get("explicit_cost_runtime_ledger_bucket_count")
+        ),
+        "blockers": sorted(dict.fromkeys(source_blockers)),
+    }
+
+
+def _final_profitability_truth(
+    runtime_authority: Mapping[str, object], runtime_aggregate: Mapping[str, object]
+) -> dict[str, object]:
+    blockers = _text_list(runtime_authority.get("blockers"))
+    final_blockers = [
+        code
+        for code in blockers
+        if code in _FINAL_PROOF_BLOCKERS or code.startswith("runtime_")
+    ]
+    return {
+        "authority_proof_passed": runtime_authority.get("final_authority_ok") is True,
+        "profitability_claimed_by_census": False,
+        "measurement_only": True,
+        "daily_post_cost_pnl_threshold": "500",
+        "trading_days": _int(
+            runtime_aggregate.get("clean_authority_trading_day_count")
+        ),
+        "mean_daily_net_pnl_after_costs": _text(
+            runtime_aggregate.get("clean_authority_mean_daily_net_pnl_after_costs"),
+            default="0",
+        ),
+        "median_daily_net_pnl_after_costs": _text(
+            runtime_aggregate.get("clean_authority_median_daily_net_pnl_after_costs"),
+            default="0",
+        ),
+        "p10_daily_net_pnl_after_costs": _text(
+            runtime_aggregate.get("clean_authority_p10_daily_net_pnl_after_costs"),
+            default="0",
+        ),
+        "worst_daily_net_pnl_after_costs": _text(
+            runtime_aggregate.get("clean_authority_worst_day_net_pnl_after_costs"),
+            default="0",
+        ),
+        "filled_notional": _text(
+            runtime_aggregate.get("clean_authority_total_filled_notional"), default="0"
+        ),
+        "closed_trade_count": _int(
+            runtime_aggregate.get("clean_authority_closed_round_trips")
+        ),
+        "open_position_count": _int(runtime_aggregate.get("open_position_count")),
+        "blockers": sorted(dict.fromkeys(final_blockers)),
+    }
+
+
+def _aggregate_summary(
+    totals: Mapping[str, object],
+    runtime_aggregate: Mapping[str, object],
+    *,
+    identifier_counts: Mapping[str, int],
+) -> dict[str, object]:
+    bucket_count = _int(totals.get("runtime_ledger_bucket_count"))
+    explicit_bucket_count = _int(
+        totals.get("explicit_cost_runtime_ledger_bucket_count")
+    )
+    return {
+        "trading_days": _int(runtime_aggregate.get("trading_day_count")),
+        "clean_authority_trading_days": _int(
+            runtime_aggregate.get("clean_authority_trading_day_count")
+        ),
+        "mean_daily_net_pnl_after_costs": _text(
+            runtime_aggregate.get("mean_daily_net_pnl_after_costs"), default="0"
+        ),
+        "median_daily_net_pnl_after_costs": _text(
+            runtime_aggregate.get("median_daily_net_pnl_after_costs"), default="0"
+        ),
+        "p10_daily_net_pnl_after_costs": _text(
+            runtime_aggregate.get("p10_daily_net_pnl_after_costs"), default="0"
+        ),
+        "worst_daily_net_pnl_after_costs": _text(
+            runtime_aggregate.get("worst_day_net_pnl_after_costs"), default="0"
+        ),
+        "max_drawdown": runtime_aggregate.get("max_drawdown"),
+        "filled_notional": _text(
+            runtime_aggregate.get("total_filled_notional"), default="0"
+        ),
+        "closed_trade_count": _int(runtime_aggregate.get("closed_round_trips")),
+        "open_position_count": _int(runtime_aggregate.get("open_position_count")),
+        "source_window_ids_count": identifier_counts["source_window_ids_count"],
+        "execution_order_event_ids_count": identifier_counts[
+            "execution_order_event_ids_count"
+        ],
+        "execution_ids_count": identifier_counts["execution_ids_count"],
+        "trade_decision_ids_count": identifier_counts["trade_decision_ids_count"],
+        "fill_lifecycle_count": _int(totals.get("fill_lifecycle_event_count")),
+        "runtime_ledger_bucket_count": bucket_count,
+        "runtime_ledger_source_bucket_count": _int(
+            totals.get("blocker_free_runtime_ledger_bucket_count")
+        ),
+        "explicit_cost_coverage": {
+            "runtime_ledger_buckets_with_explicit_cost_count": explicit_bucket_count,
+            "runtime_ledger_bucket_count": bucket_count,
+            "coverage_ratio": _ratio_text(explicit_bucket_count, bucket_count),
+        },
+        "blockers": [],
+    }
+
+
+def _daily_rows(source_report: Mapping[str, object]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for item in _sequence(source_report.get("daily")):
+        row = _mapping(item)
+        rows.append(
+            {
+                "trading_day": _text(row.get("trading_day"), default=""),
+                "net_pnl_after_costs": _text(row.get("post_cost_pnl"), default="0"),
+                "filled_notional": _text(row.get("filled_notional"), default="0"),
+                "closed_trade_count": _int(row.get("closed_trade_count")),
+                "open_position_count": _int(row.get("open_position_count")),
+                "source_window_count": _int(row.get("source_window_count")),
+                "execution_order_event_count": _int(
+                    row.get("execution_order_event_count")
+                ),
+                "execution_count": _int(row.get("execution_count")),
+                "trade_decision_count": _int(row.get("trade_decision_count")),
+                "fill_lifecycle_count": _int(row.get("fill_lifecycle_event_count")),
+                "runtime_ledger_bucket_count": _int(
+                    row.get("runtime_ledger_bucket_count")
+                ),
+                "explicit_cost_runtime_ledger_bucket_count": _int(
+                    row.get("explicit_cost_runtime_ledger_bucket_count")
+                ),
+                "blockers": _text_list(row.get("blockers")),
+            }
+        )
+    return rows
+
+
+def _identifier_counts(
+    rows: source_census.CensusSourceRows, runtime_authority: Mapping[str, object]
+) -> dict[str, int]:
+    source_window_ids = _unique_ids(
+        [
+            *(row.get("id") for row in rows.order_feed_source_windows),
+            *(row.get("source_window_id") for row in rows.execution_order_events),
+            *_ledger_payload_values(
+                runtime_authority,
+                "source_window_ids",
+                "source_window_id",
+                "runtime_ledger_source_window_ids",
+            ),
+        ]
+    )
+    execution_order_event_ids = _unique_ids(
+        [
+            *(row.get("id") for row in rows.execution_order_events),
+            *_ledger_payload_values(
+                runtime_authority,
+                "execution_order_event_ids",
+                "execution_order_event_id",
+            ),
+        ]
+    )
+    execution_ids = _unique_ids(
+        [
+            *(row.get("id") for row in rows.executions),
+            *(row.get("execution_id") for row in rows.execution_order_events),
+            *(row.get("execution_id") for row in rows.execution_tca_metrics),
+            *_ledger_payload_values(runtime_authority, "execution_ids", "execution_id"),
+        ]
+    )
+    trade_decision_ids = _unique_ids(
+        [
+            *(row.get("id") for row in rows.trade_decisions),
+            *(row.get("trade_decision_id") for row in rows.executions),
+            *(row.get("trade_decision_id") for row in rows.execution_order_events),
+            *(row.get("trade_decision_id") for row in rows.execution_tca_metrics),
+            *_ledger_payload_values(
+                runtime_authority,
+                "trade_decision_ids",
+                "trade_decision_id",
+                "decision_ids",
+            ),
+        ]
+    )
+    ledger_daily = [
+        _mapping(item) for item in _sequence(runtime_authority.get("trading_days"))
+    ]
+    return {
+        "source_window_ids_count": max(
+            len(source_window_ids), _sum_int(ledger_daily, "source_window_id_count")
+        ),
+        "execution_order_event_ids_count": max(
+            len(execution_order_event_ids),
+            _sum_int(ledger_daily, "execution_order_event_ref_count"),
+        ),
+        "execution_ids_count": max(
+            len(execution_ids), _sum_int(ledger_daily, "execution_ref_count")
+        ),
+        "trade_decision_ids_count": max(
+            len(trade_decision_ids), _sum_int(ledger_daily, "trade_decision_ref_count")
+        ),
+    }
+
+
+def _ledger_payload_values(
+    runtime_authority: Mapping[str, object], *keys: str
+) -> list[object]:
+    values: list[object] = []
+    # The runtime-authority daily report intentionally exposes counts and row refs, not the original payload values.
+    # Source-row IDs above provide exact live DB identifiers; keep this hook for forward-compatible payloads.
+    for bucket in _sequence(runtime_authority.get("runtime_ledger_buckets")):
+        payload = _mapping(_mapping(bucket).get("payload"))
+        for key in keys:
+            values.extend(_as_values(payload.get(key)))
+    return values
+
+
+def _sum_int(rows: Sequence[Mapping[str, object]], key: str) -> int:
+    return sum(_int(row.get(key)) for row in rows)
+
+
+def _top_level_blockers(
+    *,
+    configured: Mapping[str, object],
+    routeability: Mapping[str, object],
+    source_authority: Mapping[str, object],
+    final_proof: Mapping[str, object],
+    source_blockers: Sequence[str],
+) -> list[str]:
+    blockers: list[str] = []
+    blockers.extend(_text_list(configured.get("blockers")))
+    blockers.extend(_text_list(routeability.get("blockers")))
+    blockers.extend(_text_list(source_authority.get("blockers")))
+    blockers.extend(_text_list(final_proof.get("blockers")))
+    blockers.extend(source_blockers)
+    return sorted(dict.fromkeys(blockers))
+
+
+def _target_from_status(
+    source: Mapping[str, object], identity: RuntimeEvidenceIdentity
+) -> Mapping[str, object]:
+    for key in (
+        "target",
+        "target_candidate",
+        "target_candidate_identity",
+        "configured_candidate",
+        "hpairs_candidate",
+    ):
+        candidate = _mapping(source.get(key))
+        if candidate:
+            return candidate
+    for key in (
+        "targets",
+        "planned_targets",
+        "target_candidates",
+        "configured_candidates",
+    ):
+        candidates = [_mapping(item) for item in _sequence(source.get(key))]
+        for candidate in candidates:
+            if candidate and _target_matches(candidate, identity):
+                return candidate
+        for candidate in candidates:
+            if candidate:
+                return candidate
+    return {}
+
+
+def _target_matches(
+    candidate: Mapping[str, object], identity: RuntimeEvidenceIdentity
+) -> bool:
+    candidate_id = _text(
+        candidate.get("candidate_id") or candidate.get("target_candidate_id")
+    )
+    hypothesis_id = _text(candidate.get("hypothesis_id") or candidate.get("hypothesis"))
+    account_label = _text(
+        candidate.get("account_label") or candidate.get("alpaca_account_label")
+    )
+    runtime_strategy = _text(
+        candidate.get("runtime_strategy_name")
+        or candidate.get("runtime_strategy")
+        or candidate.get("strategy_name")
+        or candidate.get("strategy")
+    )
+    if candidate_id is not None and candidate_id != identity.candidate_id:
+        return False
+    if hypothesis_id is not None and hypothesis_id != identity.hypothesis_id:
+        return False
+    if account_label is not None and account_label != identity.account_label:
+        return False
+    if (
+        runtime_strategy is not None
+        and runtime_strategy != identity.runtime_strategy_name
+    ):
+        return False
+    return (
+        candidate_id == identity.candidate_id or hypothesis_id == identity.hypothesis_id
+    )
+
+
+def _route_flags(status_payload: Mapping[str, object]) -> dict[str, bool]:
+    flags: dict[str, bool] = {}
+    sources = [
+        status_payload,
+        _mapping(status_payload.get("target")),
+        _mapping(status_payload.get("route")),
+        _mapping(status_payload.get("status")),
+        _mapping(status_payload.get("routing")),
+    ]
+    for source in sources:
+        for key in _ROUTE_FLAG_KEYS:
+            parsed = _bool_or_none(source.get(key))
+            if parsed is not None and key not in flags:
+                flags[key] = parsed
+    return flags
+
+
+def _parse_cli_timestamp(value: str | None) -> datetime | None:
+    if value is None or not value.strip():
+        return None
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        raise ValueError(f"invalid timestamp: {value}")
+    return parsed
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return _utc(value)
+    text = _text(value)
+    if text is None:
+        return None
+    try:
+        return _utc(datetime.fromisoformat(text.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return {
+            str(key): raw for key, raw in cast(Mapping[object, object], value).items()
+        }
+    return {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _as_values(value: object) -> list[object]:
+    if isinstance(value, Mapping):
+        return list(value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return list(cast(Sequence[object], value))
+    if value is None:
+        return []
+    return [value]
+
+
+def _unique_ids(values: Iterable[object]) -> set[str]:
+    ids: set[str] = set()
+    for value in values:
+        for item in _as_values(value):
+            text = _text(item)
+            if text is not None:
+                ids.add(text)
+    return ids
+
+
+def _text_list(value: object) -> list[str]:
+    items = _as_values(value)
+    return sorted(
+        dict.fromkeys(text for item in items if (text := _text(item)) is not None)
+    )
+
+
+def _text(value: object, *, default: str | None = None) -> str | None:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _int(value: object) -> int:
+    try:
+        return int(str(value if value is not None else "0"))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _decimal(value: object) -> Decimal:
+    try:
+        parsed = Decimal(str(value if value is not None else "0"))
+    except (InvalidOperation, ValueError):
+        return Decimal("0")
+    return parsed if parsed.is_finite() else Decimal("0")
+
+
+def _ratio_text(numerator: int, denominator: int) -> str:
+    if denominator <= 0:
+        return "0"
+    return _decimal_text(Decimal(numerator) / Decimal(denominator))
+
+
+def _decimal_text(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    return text.rstrip("0").rstrip(".") if "." in text else text
+
+
+def _bool_or_none(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "t", "yes", "y", "enabled", "ready", "ok"}:
+            return True
+        if normalized in {"0", "false", "f", "no", "n", "disabled", "blocked"}:
+            return False
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return bool(value)
+    return None
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _isoformat(value: datetime) -> str:
+    return _utc(value).isoformat().replace("+00:00", "Z")
+
+
+def _json_default(value: object) -> str:
+    if isinstance(value, Decimal):
+        return _decimal_text(value)
+    if isinstance(value, datetime):
+        return _isoformat(value)
+    return str(value)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    started_at = _parse_cli_timestamp(args.started_at)
+    ended_at = _parse_cli_timestamp(args.ended_at)
+    identity = RuntimeEvidenceIdentity(
+        hypothesis_id=args.hypothesis_id,
+        candidate_id=args.candidate_id,
+        runtime_strategy_name=args.runtime_strategy_name,
+        account_label=args.account_label,
+        observed_stage=args.observed_stage,
+    )
+    read_error = None
+    try:
+        if args.fixture_json is not None:
+            rows = source_census.load_fixture_rows(args.fixture_json)
+            source_kind = "fixture_json"
+        elif args.dsn:
+            rows = load_dsn_rows(
+                args.dsn, identity=identity, started_at=started_at, ended_at=ended_at
+            )
+            source_kind = "sqlalchemy_dsn"
+        else:
+            rows = load_default_session_rows(
+                identity=identity, started_at=started_at, ended_at=ended_at
+            )
+            source_kind = "app_db_session"
+    except (SQLAlchemyError, OSError, ValueError) as exc:
+        rows = source_census.CensusSourceRows()
+        read_error = str(exc)
+        source_kind = (
+            "fixture_json"
+            if args.fixture_json is not None
+            else "sqlalchemy_dsn"
+            if args.dsn
+            else "app_db_session"
+        )
+    status_payload, status_source, status_read_error = load_status_payload(
+        status_fixture_json=args.status_fixture_json,
+        status_service_url=args.status_service_url,
+        timeout_seconds=args.status_timeout_seconds,
+    )
+    report = build_runtime_evidence_census(
+        rows,
+        identity=identity,
+        started_at=started_at,
+        ended_at=ended_at,
+        source_kind=source_kind,
+        read_error=read_error,
+        status_payload=status_payload,
+        status_source=status_source,
+        status_read_error=status_read_error,
+    )
+    payload = stable_json(report)
+    if args.output_json is not None:
+        args.output_json.write_text(payload)
+    else:
+        sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/services/torghut/tests/test_inspect_hpairs_runtime_evidence.py
+++ b/services/torghut/tests/test_inspect_hpairs_runtime_evidence.py
@@ -353,3 +353,277 @@ def test_json_output_is_stable(tmp_path: Path) -> None:
         "routeability_submission_evidence",
         "runtime_ledger_source_authority_evidence",
     ]
+
+
+def test_status_payload_loader_fail_closed_cases(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    non_object = tmp_path / "status-list.json"
+    non_object.write_text("[]")
+    payload, source, error = census.load_status_payload(
+        status_fixture_json=non_object,
+        status_service_url=None,
+        timeout_seconds=0.1,
+    )
+    assert payload == {}
+    assert source == f"fixture_json:{non_object}"
+    assert error == "status_fixture_json_not_object"
+
+    payload, source, error = census.load_status_payload(
+        status_fixture_json=None,
+        status_service_url=None,
+        timeout_seconds=0.1,
+    )
+    assert payload == {}
+    assert source is None
+    assert error is None
+
+    class _FailingUrlopen:
+        def __call__(self, *_args: object, **_kwargs: object) -> object:
+            raise OSError("offline")
+
+    monkeypatch.setattr(census.urllib.request, "urlopen", _FailingUrlopen())
+    payload, source, error = census.load_status_payload(
+        status_fixture_json=None,
+        status_service_url="https://status.invalid/hpairs",
+        timeout_seconds=0.1,
+    )
+    assert payload == {}
+    assert source == "https://status.invalid/hpairs"
+    assert error == "offline"
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def test_status_url_non_object_payload_blocks(monkeypatch: object) -> None:
+    monkeypatch.setattr(
+        census.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _FakeResponse(b"[]"),
+    )
+
+    payload, source, error = census.load_status_payload(
+        status_fixture_json=None,
+        status_service_url="https://status.invalid/hpairs",
+        timeout_seconds=0.1,
+    )
+
+    assert payload == {}
+    assert source == "https://status.invalid/hpairs"
+    assert error == "status_service_payload_not_object"
+
+
+def test_configuration_route_and_target_blocker_branches() -> None:
+    identity = census.RuntimeEvidenceIdentity(
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        observed_stage="paper",
+    )
+    totals = {
+        "trade_decision_count": 0,
+        "execution_count": 0,
+        "execution_order_event_count": 0,
+        "runtime_ledger_bucket_count": 0,
+        "runtime_submitted_order_count": 0,
+        "fill_lifecycle_event_count": 0,
+    }
+
+    no_status = census._configured_candidate_truth(
+        {},
+        totals=totals,
+        identity=identity,
+        status_source=None,
+        status_read_error="timeout",
+    )
+    assert census.STATUS_SERVICE_NOT_PROVIDED_BLOCKER in no_status["blockers"]
+    assert census.STATUS_SERVICE_READ_ERROR_BLOCKER in no_status["blockers"]
+
+    missing_target = census._configured_candidate_truth(
+        {"unrelated": True},
+        totals=totals,
+        identity=identity,
+        status_source="fixture_json:status.json",
+        status_read_error=None,
+    )
+    assert census.CONFIGURED_CANDIDATE_MISSING_BLOCKER in missing_target["blockers"]
+
+    mismatch = census._configured_candidate_truth(
+        {"target": {"candidate_id": "other-candidate"}},
+        totals=totals,
+        identity=identity,
+        status_source="fixture_json:status.json",
+        status_read_error=None,
+    )
+    assert census.CONFIGURED_CANDIDATE_MISMATCH_BLOCKER in mismatch["blockers"]
+
+    route = census._routeability_truth(
+        {"route": {"route_enabled": False}, "status": {"simple_submit_enabled": "yes"}},
+        totals=totals,
+        blockers=[census.SUBMITTED_ORDERS_MISSING_BLOCKER],
+        identifier_counts={
+            "trade_decision_ids_count": 0,
+            "execution_ids_count": 0,
+            "execution_order_event_ids_count": 0,
+            "source_window_ids_count": 0,
+        },
+    )
+    assert "routeability_flags_disabled" in route["blockers"]
+    assert route["route_flags"] == {
+        "route_enabled": False,
+        "simple_submit_enabled": True,
+    }
+
+
+def test_target_sequence_matching_and_mismatch_branches() -> None:
+    identity = census.RuntimeEvidenceIdentity(
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        observed_stage="paper",
+    )
+
+    first_match = census._target_from_status(
+        {
+            "targets": [
+                {"candidate_id": "wrong"},
+                {"hypothesis_id": DEFAULT_HPAIRS_HYPOTHESIS_ID},
+            ]
+        },
+        identity,
+    )
+    assert first_match == {"hypothesis_id": DEFAULT_HPAIRS_HYPOTHESIS_ID}
+
+    fallback_first = census._target_from_status(
+        {"targets": [{"candidate_id": "wrong"}]}, identity
+    )
+    assert fallback_first == {"candidate_id": "wrong"}
+    assert census._target_from_status({"targets": []}, identity) == {}
+
+    assert census._target_matches({"candidate_id": "wrong"}, identity) is False
+    assert census._target_matches({"hypothesis_id": "wrong"}, identity) is False
+    assert census._target_matches({"account_label": "ALPACA_PAPER"}, identity) is False
+    assert census._target_matches({"runtime_strategy_name": "other"}, identity) is False
+
+
+def test_low_level_json_and_parse_helpers_cover_fail_closed_branches() -> None:
+    aware = datetime(2026, 6, 2, 12, 0, tzinfo=timezone.utc)
+    naive = datetime(2026, 6, 2, 12, 0)
+
+    assert census._parse_cli_timestamp(None) is None
+    assert census._parse_cli_timestamp("2026-06-02T12:00:00Z") == aware
+    try:
+        census._parse_cli_timestamp("not-a-timestamp")
+    except ValueError as exc:
+        assert "invalid timestamp" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("invalid timestamp should raise")
+
+    assert census._parse_timestamp(aware) == aware
+    assert census._parse_timestamp(None) is None
+    assert census._parse_timestamp("bad") is None
+    assert census._as_values({"a": 1}) == [1]
+    assert census._as_values(None) == []
+    assert census._text(None, default="missing") == "missing"
+    assert census._int("nan") == 0
+    assert census._decimal("nan") == census.Decimal("0")
+    assert census._bool_or_none("enabled") is True
+    assert census._bool_or_none("disabled") is False
+    assert census._bool_or_none(1) is True
+    assert census._utc(naive).tzinfo is timezone.utc
+    assert census._isoformat(aware) == "2026-06-02T12:00:00Z"
+    assert census._json_default(census.Decimal("1.20")) == "1.2"
+    assert census._json_default(aware) == "2026-06-02T12:00:00Z"
+    assert census._json_default(Path("x")) == "x"
+
+
+def test_identifier_counts_include_forward_compatible_runtime_payload_values() -> None:
+    rows = source_census.CensusSourceRows()
+    counts = census._identifier_counts(
+        rows,
+        {
+            "trading_days": [
+                {
+                    "source_window_id_count": 1,
+                    "execution_order_event_ref_count": 1,
+                    "execution_ref_count": 1,
+                    "trade_decision_ref_count": 1,
+                }
+            ],
+            "runtime_ledger_buckets": [
+                {
+                    "payload": {
+                        "source_window_ids": ["window-a", "window-b"],
+                        "execution_order_event_ids": ["event-a"],
+                        "execution_ids": ["execution-a"],
+                        "trade_decision_ids": ["decision-a"],
+                    }
+                }
+            ],
+        },
+    )
+
+    assert counts == {
+        "source_window_ids_count": 2,
+        "execution_order_event_ids_count": 1,
+        "execution_ids_count": 1,
+        "trade_decision_ids_count": 1,
+    }
+
+
+def test_main_stdout_dsn_default_and_read_error_paths(
+    monkeypatch: object, capsys: object
+) -> None:
+    fixture_rows = _rows(_fixture(days=1, include_buckets=False))
+
+    monkeypatch.setattr(
+        census.source_census, "load_fixture_rows", lambda _path: fixture_rows
+    )
+    assert census.main(["--fixture-json", "fixture.json"]) == 0
+    stdout = capsys.readouterr().out
+    assert "torghut.hpairs-runtime-live-paper-evidence-census.v1" in stdout
+
+    calls: list[str] = []
+
+    def _fake_load_dsn_rows(
+        *_args: object, **_kwargs: object
+    ) -> source_census.CensusSourceRows:
+        calls.append("dsn")
+        return fixture_rows
+
+    def _fake_load_default_session_rows(
+        *_args: object, **_kwargs: object
+    ) -> source_census.CensusSourceRows:
+        calls.append("default")
+        return fixture_rows
+
+    monkeypatch.setattr(census, "load_dsn_rows", _fake_load_dsn_rows)
+    monkeypatch.setattr(
+        census, "load_default_session_rows", _fake_load_default_session_rows
+    )
+    assert census.main(["--dsn", "sqlite:///:memory:"]) == 0
+    assert census.main([]) == 0
+    assert calls == ["dsn", "default"]
+
+    def _raise_load_dsn_rows(
+        *_args: object, **_kwargs: object
+    ) -> source_census.CensusSourceRows:
+        raise ValueError("missing table")
+
+    monkeypatch.setattr(census, "load_dsn_rows", _raise_load_dsn_rows)
+    assert census.main(["--dsn", "sqlite:///:memory:"]) == 0
+    assert "missing table" in capsys.readouterr().out

--- a/services/torghut/tests/test_inspect_hpairs_runtime_evidence.py
+++ b/services/torghut/tests/test_inspect_hpairs_runtime_evidence.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from app.trading.runtime_authority_verifier import (
+    AUTHORITY_EVIDENCE_MISSING_BLOCKER,
+    AUTHORITY_FILLED_NOTIONAL_BLOCKER,
+    AUTHORITY_MEAN_PNL_BLOCKER,
+    AUTHORITY_OPEN_POSITIONS_BLOCKER,
+    AUTHORITY_TRADING_DAYS_BLOCKER,
+    DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    DEFAULT_HPAIRS_CANDIDATE_ID,
+    DEFAULT_HPAIRS_HYPOTHESIS_ID,
+    DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+)
+from app.trading.runtime_ledger import (
+    EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+    POST_COST_PNL_BASIS,
+)
+from scripts import audit_hpairs_source_proof_census as source_census
+from scripts import inspect_hpairs_runtime_evidence as census
+
+
+def _iso(day_index: int, hour: int = 14) -> str:
+    return (
+        (datetime(2026, 5, 1, hour, tzinfo=timezone.utc) + timedelta(days=day_index))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _source_payload(day_index: int) -> dict[str, object]:
+    return {
+        "source_window_start": _iso(day_index, 14),
+        "source_window_end": _iso(day_index, 21),
+        "source_refs": [
+            "postgres:trade_decisions",
+            "postgres:executions",
+            "postgres:execution_order_events",
+            "postgres:order_feed_source_windows",
+        ],
+        "source_row_counts": {
+            "trade_decisions": 1,
+            "executions": 1,
+            "execution_order_events": 1,
+            "order_feed_source_windows": 1,
+        },
+        "trade_decision_ids": [f"decision-{day_index}"],
+        "execution_ids": [f"execution-{day_index}"],
+        "execution_order_event_ids": [f"event-{day_index}"],
+        "source_window_ids": [f"window-{day_index}"],
+        "source_offsets": [
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": day_index}
+        ],
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
+        "order_feed_lifecycle_complete": True,
+        "execution_economics_complete": True,
+        "cost_basis_counts": {"explicit_broker_fee_runtime": 1},
+    }
+
+
+def _ledger_bucket(
+    day_index: int,
+    *,
+    source_backed: bool = True,
+    open_positions: int = 0,
+    net_pnl: str = "600",
+    filled_notional: str = "600000",
+    closed_trades: int = 20,
+) -> dict[str, object]:
+    return {
+        "id": f"ledger-{day_index}",
+        "run_id": "hpairs-runtime-run",
+        "candidate_id": DEFAULT_HPAIRS_CANDIDATE_ID,
+        "hypothesis_id": DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        "observed_stage": "paper",
+        "bucket_started_at": _iso(day_index, 14),
+        "bucket_ended_at": _iso(day_index, 21),
+        "account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        "runtime_strategy_name": DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        "strategy_family": "pairs",
+        "fill_count": 20,
+        "decision_count": 20,
+        "submitted_order_count": 20,
+        "cancelled_order_count": 0,
+        "rejected_order_count": 0,
+        "unfilled_order_count": 0,
+        "closed_trade_count": closed_trades,
+        "open_position_count": open_positions,
+        "filled_notional": filled_notional,
+        "gross_strategy_pnl": str(int(net_pnl) + 10),
+        "cost_amount": "10",
+        "net_strategy_pnl_after_costs": net_pnl,
+        "post_cost_expectancy_bps": "10",
+        "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        "pnl_basis": POST_COST_PNL_BASIS,
+        "execution_policy_hash_counts": {"policy-hash": 1},
+        "cost_model_hash_counts": {"cost-hash": 1},
+        "lineage_hash_counts": {"lineage-hash": 1},
+        "blockers": [],
+        "payload": _source_payload(day_index) if source_backed else {},
+    }
+
+
+def _fixture(
+    *,
+    days: int = 20,
+    source_backed: bool = True,
+    open_positions: int = 0,
+    net_pnl: str = "600",
+    filled_notional: str = "600000",
+    include_buckets: bool = True,
+) -> dict[str, object]:
+    return {
+        "trade_decisions": [
+            {
+                "id": f"decision-{day}",
+                "strategy_name": DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "status": "executed",
+                "created_at": _iso(day, 14),
+            }
+            for day in range(days)
+        ],
+        "executions": [
+            {
+                "id": f"execution-{day}",
+                "trade_decision_id": f"decision-{day}",
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "status": "filled",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "created_at": _iso(day, 15),
+            }
+            for day in range(days)
+        ],
+        "execution_order_events": [
+            {
+                "id": f"event-{day}",
+                "execution_id": f"execution-{day}",
+                "trade_decision_id": f"decision-{day}",
+                "source_window_id": f"window-{day}",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": day,
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "event_type": "fill",
+                "status": "filled",
+                "filled_qty_delta": "10",
+                "avg_fill_price": "100",
+                "filled_notional_delta": "1000",
+                "event_ts": _iso(day, 15),
+            }
+            for day in range(days)
+        ],
+        "execution_tca_metrics": [
+            {
+                "id": f"tca-{day}",
+                "execution_id": f"execution-{day}",
+                "trade_decision_id": f"decision-{day}",
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "filled_qty": "10",
+                "shortfall_notional": "1",
+                "computed_at": _iso(day, 16),
+            }
+            for day in range(days)
+        ],
+        "order_feed_source_windows": [
+            {
+                "id": f"window-{day}",
+                "alpaca_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "window_started_at": _iso(day, 14),
+                "window_ended_at": _iso(day, 21),
+                "start_offset": day,
+                "end_offset": day + 1,
+                "status": "complete",
+            }
+            for day in range(days)
+        ],
+        "runtime_ledger_buckets": [
+            _ledger_bucket(
+                day,
+                source_backed=source_backed,
+                open_positions=open_positions if day == days - 1 else 0,
+                net_pnl=net_pnl,
+                filled_notional=filled_notional,
+            )
+            for day in range(days)
+        ]
+        if include_buckets
+        else [],
+    }
+
+
+def _status() -> dict[str, object]:
+    return {
+        "target": {
+            "hypothesis_id": DEFAULT_HPAIRS_HYPOTHESIS_ID,
+            "candidate_id": DEFAULT_HPAIRS_CANDIDATE_ID,
+            "runtime_strategy_name": DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+            "account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            "route_enabled": True,
+        },
+        "route": {"paper_route_eligible": True},
+        "status": {"simple_submit_enabled": True},
+    }
+
+
+def _rows(payload: dict[str, object]) -> source_census.CensusSourceRows:
+    return source_census.CensusSourceRows(
+        trade_decisions=source_census._row_list(payload.get("trade_decisions")),
+        executions=source_census._row_list(payload.get("executions")),
+        execution_order_events=source_census._row_list(
+            payload.get("execution_order_events")
+        ),
+        execution_tca_metrics=source_census._row_list(
+            payload.get("execution_tca_metrics")
+        ),
+        order_feed_source_windows=source_census._row_list(
+            payload.get("order_feed_source_windows")
+        ),
+        runtime_ledger_buckets=source_census._row_list(
+            payload.get("runtime_ledger_buckets")
+        ),
+    )
+
+
+def _report(
+    payload: dict[str, object], status: dict[str, object] | None = None
+) -> dict[str, object]:
+    return census.build_runtime_evidence_census(
+        _rows(payload),
+        identity=census.RuntimeEvidenceIdentity(
+            hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+            candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+            runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+            account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            observed_stage="paper",
+        ),
+        status_payload=status or _status(),
+        status_source="fixture_json:status.json",
+    )
+
+
+def test_no_runtime_ledger_buckets_emit_blockers() -> None:
+    report = _report(_fixture(include_buckets=False))
+
+    assert (
+        report["truths"]["runtime_ledger_source_authority_evidence"][
+            "runtime_ledger_bucket_count"
+        ]
+        == 0
+    )
+    assert AUTHORITY_EVIDENCE_MISSING_BLOCKER in report["blockers"]
+    assert (
+        report["truths"]["final_500_day_profitability_proof"]["authority_proof_passed"]
+        is False
+    )
+
+
+def test_aggregate_only_buckets_are_not_authority() -> None:
+    report = _report(_fixture(source_backed=False))
+    source_authority = report["truths"]["runtime_ledger_source_authority_evidence"]
+
+    assert source_authority["aggregate_only_buckets_count_as_authority"] is False
+    assert source_authority["aggregate_only_bucket_count"] == 20
+    assert census.AGGREGATE_ONLY_RUNTIME_LEDGER_BLOCKER in source_authority["blockers"]
+    assert (
+        report["truths"]["final_500_day_profitability_proof"]["authority_proof_passed"]
+        is False
+    )
+
+
+def test_source_backed_rows_with_fills_and_costs_produce_evidence_fields() -> None:
+    report = _report(_fixture())
+
+    assert (
+        report["truths"]["routeability_submission_evidence"][
+            "source_backed_decisions_present"
+        ]
+        is True
+    )
+    assert (
+        report["truths"]["routeability_submission_evidence"]["fill_lifecycle_present"]
+        is True
+    )
+    assert report["aggregate_summary"]["trading_days"] == 20
+    assert report["aggregate_summary"]["mean_daily_net_pnl_after_costs"] == "600"
+    assert report["aggregate_summary"]["source_window_ids_count"] == 20
+    assert report["aggregate_summary"]["execution_order_event_ids_count"] == 20
+    assert report["aggregate_summary"]["execution_ids_count"] == 20
+    assert report["aggregate_summary"]["trade_decision_ids_count"] == 20
+    assert (
+        report["aggregate_summary"]["explicit_cost_coverage"]["coverage_ratio"] == "1"
+    )
+    assert (
+        report["truths"]["final_500_day_profitability_proof"]["authority_proof_passed"]
+        is True
+    )
+    assert report["profitability_claimed"] is False
+
+
+def test_open_positions_block_final_proof() -> None:
+    report = _report(_fixture(open_positions=1))
+
+    final_proof = report["truths"]["final_500_day_profitability_proof"]
+    assert final_proof["authority_proof_passed"] is False
+    assert final_proof["open_position_count"] == 1
+    assert AUTHORITY_OPEN_POSITIONS_BLOCKER in final_proof["blockers"]
+
+
+def test_insufficient_days_profit_and_notional_block_final_proof() -> None:
+    report = _report(_fixture(days=2, net_pnl="100", filled_notional="1000"))
+
+    final_blockers = report["truths"]["final_500_day_profitability_proof"]["blockers"]
+    assert AUTHORITY_TRADING_DAYS_BLOCKER in final_blockers
+    assert AUTHORITY_MEAN_PNL_BLOCKER in final_blockers
+    assert AUTHORITY_FILLED_NOTIONAL_BLOCKER in final_blockers
+
+
+def test_json_output_is_stable(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "fixture.json"
+    status_path = tmp_path / "status.json"
+    fixture_path.write_text(json.dumps(_fixture(days=2), sort_keys=True))
+    status_path.write_text(json.dumps(_status(), sort_keys=True))
+
+    output_path = tmp_path / "out.json"
+    exit_code = census.main(
+        [
+            "--fixture-json",
+            str(fixture_path),
+            "--status-fixture-json",
+            str(status_path),
+            "--output-json",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    first = output_path.read_text()
+    second = census.stable_json(json.loads(first))
+    assert first == second
+    loaded = json.loads(first)
+    assert loaded["schema_version"] == census.SCHEMA_VERSION
+    assert list(loaded["truths"].keys()) == [
+        "final_500_day_profitability_proof",
+        "merged_configured_candidate",
+        "routeability_submission_evidence",
+        "runtime_ledger_source_authority_evidence",
+    ]


### PR DESCRIPTION
## Summary

- Added a read-only H-PAIRS runtime/live-paper evidence census CLI for runtime DB rows, fixture JSON, and optional status-service JSON.
- Separates merged/configured candidate, routeability/submission evidence, runtime-ledger source authority, and final $500/day proof instead of collapsing them into one status.
- Emits stable JSON daily rows, aggregate PnL/notional/trade/source-ref counts, explicit cost coverage, and machine-readable blockers without DB mutation, order submission, proof uploads, or Kubernetes fanout.
- Added focused regression coverage for missing buckets, aggregate-only buckets, source-backed fills/costs, open positions, insufficient proof gates, and stable JSON output.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed after installing the missing system C compiler needed to build the locked `crosshair-tool` dev dependency in this workspace.
- `cd services/torghut && uv run --frozen pytest tests/test_inspect_hpairs_runtime_evidence.py -q` — passed, 13 tests, 1 existing `tests/conftest.py` deprecation warning.
- `cd services/torghut && uv run --frozen ruff check scripts/inspect_hpairs_runtime_evidence.py tests/test_inspect_hpairs_runtime_evidence.py` — passed.
- `cd services/torghut && uv run --frozen ruff format --check scripts/inspect_hpairs_runtime_evidence.py tests/test_inspect_hpairs_runtime_evidence.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed.
- `git diff --check` — passed.
- `cd services/torghut && uv run --frozen coverage run -m pytest tests/test_inspect_hpairs_runtime_evidence.py -q && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` — passed at 97.22% changed-line coverage for the new script.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
