### PR TITLE
feat(torghut): accelerate hpairs frontier top six

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -14,6 +14,7 @@ from app.trading.discovery.hypothesis_cards import HypothesisCard
 from app.trading.discovery.replay_tape import (
     HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
     build_hpairs_replay_tape_feature_schema_hash,
+    hpairs_replay_tape_feature_versions,
 )
 from app.trading.semiconductor_universe import (
     LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE as LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE,
@@ -5848,6 +5849,7 @@ def compile_candidate_specs(
                         "schema_version": "torghut.hpairs-replay-tape-candidate-contract.v1",
                         "feature_schema_version": HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
                         "feature_schema_hash": build_hpairs_replay_tape_feature_schema_hash(),
+                        "feature_versions": hpairs_replay_tape_feature_versions(),
                         "clusterlob_buckets": (
                             "deterministic_clustered_event_quote_behavior_metadata"
                         ),

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -100,6 +100,9 @@ class FastReplayPreviewRow:
     frontier_dedupe_status: str = "unique"
     duplicate_of_candidate_spec_id: str | None = None
     duplicate_candidate_spec_ids: tuple[str, ...] = ()
+    candidate_lineage: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
 
     def to_payload(self) -> dict[str, Any]:
         observed_post_cost_expectancy_bps = _observed_post_cost_expectancy_bps(self)
@@ -108,6 +111,9 @@ class FastReplayPreviewRow:
         )
         notional_blocked = required_daily_notional is None
         exact_replay_selection_blockers = _exact_replay_selection_blockers_for_row(self)
+        frontier_selection_blockers = _frontier_selection_blockers_for_row(
+            self, exact_replay_selection_blockers=exact_replay_selection_blockers
+        )
         lineage_blockers = _lineage_blockers_for_row(self)
         risk_flags = _risk_flags_for_row(self, lineage_blockers=lineage_blockers)
         prefilter_capacity_lineage = _mapping(
@@ -154,6 +160,26 @@ class FastReplayPreviewRow:
             "frontier_dedupe_status": self.frontier_dedupe_status,
             "duplicate_of_candidate_spec_id": self.duplicate_of_candidate_spec_id,
             "duplicate_candidate_spec_ids": list(self.duplicate_candidate_spec_ids),
+            "candidate_lineage": dict(self.candidate_lineage),
+            "frontier_selection": {
+                "schema_version": "torghut.fast-replay-frontier-selection.v1",
+                "selected": self.selected,
+                "frontier_bucket": self.frontier_bucket,
+                "reason_code": self.selection_reason,
+                "blockers": list(frontier_selection_blockers),
+                "rank": self.rank,
+                "exact_replay_enqueue_allowed": self.selected,
+                "bounded_sim_evidence_enqueue_allowed": self.selected,
+                "resource_scope": "local_offline_bounded_queue_metadata_only",
+                "proof_source": "prefilter_only",
+                "prefilter_only": True,
+                "promotion_proof": False,
+                "proof_authority": False,
+                "promotion_authority": False,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "final_authority_ok": False,
+            },
             "frontier_dedupe_metadata": {
                 "schema_version": "torghut.fast-replay-frontier-dedupe.v1",
                 "status": self.frontier_dedupe_status,
@@ -323,6 +349,7 @@ class FastReplayPreviewResult:
                     "feature_schema_hash",
                     "cost_model_hash",
                     "strategy_family",
+                    "feature_versions",
                     "candidate_frontier_hash",
                 ],
                 "prefilter_only": True,
@@ -344,6 +371,7 @@ class FastReplayPreviewResult:
                 "feature_schema_hash": self.replay_tape_manifest.feature_schema_hash,
                 "cost_model_hash": self.replay_tape_manifest.cost_model_hash,
                 "strategy_family": self.replay_tape_manifest.strategy_family,
+                "feature_versions": dict(self.replay_tape_manifest.feature_versions),
                 "cache_identity": (
                     self.replay_tape_manifest.cache_identity_diagnostics()
                 ),
@@ -352,6 +380,26 @@ class FastReplayPreviewResult:
                 "start_date": self.replay_tape_manifest.start_date.isoformat(),
                 "end_date": self.replay_tape_manifest.end_date.isoformat(),
                 "row_symbols": list(self.replay_tape_manifest.row_symbols),
+            },
+            "bounded_sim_target_queue": {
+                "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v1",
+                "status": "metadata_only_not_dispatched",
+                "queue_scope": "offline_preview_to_exact_replay_or_bounded_sim_handoff",
+                "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
+                "target_candidate_cap": self.exact_replay_candidate_cap,
+                "enqueue_candidate_count": len(self.selected_candidate_spec_ids),
+                "exploitation_candidate_count": self.exploitation_candidate_count,
+                "exploration_candidate_count": self.exploration_candidate_count,
+                "broad_cluster_fanout_allowed": False,
+                "kubernetes_fanout_allowed": False,
+                "db_writes_allowed": False,
+                "proof_packet_upload_allowed": False,
+                "exact_replay_required": True,
+                "source_backed_runtime_ledger_required": True,
+                "bounded_sim_evidence_collection_allowed": True,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "final_authority_ok": False,
             },
         }
 
@@ -643,6 +691,7 @@ def _score_candidate_spec(
             microstructure_prefilter=dict(microstructure_prefilter),
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
+            candidate_lineage=_candidate_lineage(spec),
         )
 
     return_vectors = [stat.returns_bps for stat in matched if stat.returns_bps.size]
@@ -770,6 +819,7 @@ def _score_candidate_spec(
         microstructure_prefilter=dict(microstructure_prefilter),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
+        candidate_lineage=_candidate_lineage(spec),
     )
 
 
@@ -880,8 +930,27 @@ def _select_frontier_buckets(
         (row for row in eligible if row.candidate_spec_id not in selected),
         key=lambda row: (-float(row.exploration_score), row.candidate_spec_id),
     )
-    for row in exploration_pool[:exploration_count]:
-        if len(selected) >= exact_replay_candidate_cap:
+    explored_diversity_keys: set[tuple[str, ...]] = set()
+    deferred_exploration: list[FastReplayPreviewRow] = []
+    for row in exploration_pool:
+        if (
+            len(selected) >= exact_replay_candidate_cap
+            or len([bucket for bucket in selected.values() if bucket == "exploration"])
+            >= exploration_count
+        ):
+            break
+        diversity_key = _row_exploration_diversity_key(row)
+        if diversity_key in explored_diversity_keys:
+            deferred_exploration.append(row)
+            continue
+        selected[row.candidate_spec_id] = "exploration"
+        explored_diversity_keys.add(diversity_key)
+    for row in deferred_exploration:
+        if (
+            len(selected) >= exact_replay_candidate_cap
+            or len([bucket for bucket in selected.values() if bucket == "exploration"])
+            >= exploration_count
+        ):
             break
         selected[row.candidate_spec_id] = "exploration"
     if not selected:
@@ -891,6 +960,23 @@ def _select_frontier_buckets(
     return selected
 
 
+def _row_exploration_diversity_key(row: FastReplayPreviewRow) -> tuple[str, ...]:
+    lineage = row.candidate_lineage
+    symbols = lineage.get("symbol_universe")
+    if isinstance(symbols, Sequence) and not isinstance(
+        symbols, (str, bytes, bytearray)
+    ):
+        raw_symbols = cast(Sequence[object], symbols)
+        symbol_key = ",".join(str(symbol).upper() for symbol in raw_symbols)
+    else:
+        symbol_key = str(symbols or row.candidate_spec_id)
+    return (
+        str(lineage.get("family_template_id") or "unknown_family"),
+        str(lineage.get("runtime_strategy_name") or "unknown_strategy"),
+        symbol_key,
+    )
+
+
 def _row_with_rank_and_selection(
     *, row: FastReplayPreviewRow, rank: int, frontier_bucket: str
 ) -> FastReplayPreviewRow:
@@ -898,10 +984,14 @@ def _row_with_rank_and_selection(
     selection_reason = row.selection_reason
     if selected:
         selection_reason = f"fast_replay_frontier_{frontier_bucket}_selected"
-    elif not _row_frontier_duplicate_filtered(
-        row
-    ) and _row_exact_replay_selection_blocked(row):
+    elif _row_frontier_duplicate_filtered(row):
+        selection_reason = "fast_replay_frontier_duplicate_filtered"
+    elif _row_exact_replay_selection_blocked(row):
         selection_reason = "fast_replay_frontier_lineage_blocked"
+    elif _row_explicitly_non_hpairs(row):
+        selection_reason = "fast_replay_frontier_non_hpairs_skipped"
+    elif row.selection_reason != "insufficient_replay_tape_rows":
+        selection_reason = "fast_replay_frontier_budget_exhausted_skipped"
     return FastReplayPreviewRow(
         candidate_spec_id=row.candidate_spec_id,
         rank=rank,
@@ -937,6 +1027,7 @@ def _row_with_rank_and_selection(
         frontier_dedupe_status=row.frontier_dedupe_status,
         duplicate_of_candidate_spec_id=row.duplicate_of_candidate_spec_id,
         duplicate_candidate_spec_ids=row.duplicate_candidate_spec_ids,
+        candidate_lineage=dict(row.candidate_lineage),
     )
 
 
@@ -985,7 +1076,28 @@ def _row_with_frontier_dedupe(
         frontier_dedupe_status=frontier_dedupe_status,
         duplicate_of_candidate_spec_id=duplicate_of_candidate_spec_id,
         duplicate_candidate_spec_ids=duplicate_candidate_spec_ids,
+        candidate_lineage=dict(row.candidate_lineage),
     )
+
+
+def _frontier_selection_blockers_for_row(
+    row: FastReplayPreviewRow,
+    *,
+    exact_replay_selection_blockers: Sequence[str],
+) -> tuple[str, ...]:
+    if row.selected:
+        return ()
+    if row.selection_reason == "fast_replay_frontier_budget_exhausted_skipped":
+        return ("frontier_budget_exhausted",)
+    if row.selection_reason == "fast_replay_frontier_duplicate_filtered":
+        return ("frontier_duplicate_filtered",)
+    if row.selection_reason == "fast_replay_frontier_non_hpairs_skipped":
+        return ("non_hpairs_candidate",)
+    if row.selection_reason == "insufficient_replay_tape_rows":
+        return ("insufficient_replay_tape_rows",)
+    if row.selection_reason == "fast_replay_frontier_lineage_blocked":
+        return tuple(exact_replay_selection_blockers)
+    return ()
 
 
 def _row_exact_replay_selection_blocked(row: FastReplayPreviewRow) -> bool:
@@ -1232,6 +1344,29 @@ def _candidate_notional(spec: CandidateSpec) -> float:
     return _float_or_none(spec.strategy_overrides.get("max_notional_per_trade")) or 0.0
 
 
+def _candidate_lineage(spec: CandidateSpec) -> dict[str, Any]:
+    return {
+        "schema_version": "torghut.fast-replay-candidate-lineage.v1",
+        "candidate_spec_id": spec.candidate_spec_id,
+        "hypothesis_id": spec.hypothesis_id,
+        "family_template_id": spec.family_template_id,
+        "candidate_kind": spec.candidate_kind,
+        "runtime_family": spec.runtime_family,
+        "runtime_strategy_name": spec.runtime_strategy_name,
+        "symbol_universe": list(_candidate_symbols(spec)),
+        "feature_contract": _json_ready(spec.feature_contract),
+        "objective": _json_ready(spec.objective),
+        "hard_vetoes": _json_ready(spec.hard_vetoes),
+        "promotion_contract": _json_ready(spec.promotion_contract),
+        "candidate_frontier_hash": _candidate_frontier_hash(spec),
+        "lineage_preserved": True,
+        "prefilter_only": True,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_authority_ok": False,
+    }
+
+
 def _candidate_frontier_hash(spec: CandidateSpec) -> str:
     """Hash the exact-replay execution identity, excluding hypothesis lineage.
 
@@ -1270,6 +1405,7 @@ def _exact_replay_frontier_key(
             "feature_schema_hash": replay_tape_manifest.feature_schema_hash,
             "cost_model_hash": replay_tape_manifest.cost_model_hash,
             "strategy_family": replay_tape_manifest.strategy_family,
+            "feature_versions": dict(replay_tape_manifest.feature_versions),
             "candidate_frontier_hash": candidate_frontier_hash,
         }
     )

--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -27,6 +27,8 @@ HPAIRS_REPLAY_TAPE_FEATURE_CONTRACT_SCHEMA_VERSION = (
     "torghut.hpairs-replay-tape-feature-contract.v1"
 )
 HPAIRS_OFI_MEMORY_REGIME_SCHEMA_VERSION = "torghut.hpairs-ofi-memory-regime-slices.v1"
+HPAIRS_CLUSTERLOB_FEATURE_VERSION = "torghut.hpairs-clusterlob-feature-buckets.v1"
+HPAIRS_OFI_FEATURE_VERSION = HPAIRS_OFI_MEMORY_REGIME_SCHEMA_VERSION
 _DECIMAL_TAG = "__torghut_decimal__"
 _DATETIME_TAG = "__torghut_datetime__"
 
@@ -36,6 +38,10 @@ def _empty_row_count_by_trading_day() -> dict[str, int]:
 
 
 def _empty_row_count_by_symbol_trading_day() -> dict[str, dict[str, int]]:
+    return {}
+
+
+def _empty_string_mapping() -> dict[str, str]:
     return {}
 
 
@@ -69,6 +75,7 @@ class ReplayTapeManifest:
     cost_model_hash: str = ""
     strategy_family: str = ""
     replay_cache_key: str = ""
+    feature_versions: Mapping[str, str] = field(default_factory=_empty_string_mapping)
     requested_trading_days: tuple[date, ...] = ()
     observed_trading_days: tuple[date, ...] = ()
     missing_trading_days: tuple[date, ...] = ()
@@ -104,6 +111,7 @@ class ReplayTapeManifest:
             "cost_model_hash": self.cost_model_hash,
             "strategy_family": self.strategy_family,
             "replay_cache_key": self.replay_cache_key,
+            "feature_versions": dict(self.feature_versions),
             "cache_identity": self.cache_identity_diagnostics(),
             "artifact_refs": dict(self.artifact_refs),
             "source_table_versions": dict(self.source_table_versions),
@@ -139,6 +147,7 @@ class ReplayTapeManifest:
             feature_schema_hash=self.feature_schema_hash,
             cost_model_hash=self.cost_model_hash,
             strategy_family=self.strategy_family,
+            feature_versions=self.feature_versions,
             source_table_versions=self.source_table_versions,
         )
 
@@ -174,6 +183,7 @@ class ReplayTapeManifest:
             cost_model_hash=str(payload.get("cost_model_hash") or ""),
             strategy_family=str(payload.get("strategy_family") or ""),
             replay_cache_key=str(payload.get("replay_cache_key") or ""),
+            feature_versions=_string_mapping(payload.get("feature_versions")),
             artifact_refs=_string_mapping(payload.get("artifact_refs")),
             source_table_versions=_string_mapping(payload.get("source_table_versions")),
             created_at=_parse_datetime(str(payload["created_at"])),
@@ -211,6 +221,14 @@ def build_source_query_digest(payload: Mapping[str, Any]) -> str:
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
+def hpairs_replay_tape_feature_versions() -> dict[str, str]:
+    return {
+        "hpairs": HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
+        "cluster_lob": HPAIRS_CLUSTERLOB_FEATURE_VERSION,
+        "ofi_memory_regime": HPAIRS_OFI_FEATURE_VERSION,
+    }
+
+
 def hpairs_replay_tape_feature_contract() -> dict[str, Any]:
     """Return the stable H-PAIRS replay-tape discovery feature contract.
 
@@ -222,6 +240,7 @@ def hpairs_replay_tape_feature_contract() -> dict[str, Any]:
     return {
         "schema_version": HPAIRS_REPLAY_TAPE_FEATURE_CONTRACT_SCHEMA_VERSION,
         "feature_schema_version": HPAIRS_REPLAY_TAPE_FEATURE_SCHEMA_VERSION,
+        "feature_versions": hpairs_replay_tape_feature_versions(),
         "mechanisms": [
             "clusterlob_clustered_event_quote_behavior_buckets",
             "horizon_specific_ofi_memory_regime_slices",
@@ -305,6 +324,7 @@ def build_replay_tape_cache_key(
     feature_schema_hash: str = "",
     cost_model_hash: str = "",
     strategy_family: str = "",
+    feature_versions: Mapping[str, str] | None = None,
     source_table_versions: Mapping[str, str] | None = None,
 ) -> str:
     """Build a stable cache key for a manifest-verified replay tape input set."""
@@ -320,6 +340,7 @@ def build_replay_tape_cache_key(
             "feature_schema_hash": str(feature_schema_hash or ""),
             "cost_model_hash": str(cost_model_hash or ""),
             "strategy_family": str(strategy_family or ""),
+            "feature_versions": _string_mapping(feature_versions),
             "source_table_versions": dict(source_table_versions or {}),
         }
     )
@@ -335,6 +356,7 @@ def build_replay_tape_cache_identity_diagnostics(
     feature_schema_hash: str = "",
     cost_model_hash: str = "",
     strategy_family: str = "",
+    feature_versions: Mapping[str, str] | None = None,
     source_table_versions: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Report whether the replay/cache identity has all local reproducibility keys.
@@ -382,9 +404,29 @@ def build_replay_tape_cache_identity_diagnostics(
             "feature_schema_hash": str(feature_schema_hash or ""),
             "cost_model_hash": str(cost_model_hash or ""),
             "strategy_family": str(strategy_family or ""),
+            "feature_versions": _string_mapping(feature_versions),
             "source_table_versions": dict(source_table_versions or {}),
         },
     }
+
+
+def _resolve_replay_feature_versions(
+    *,
+    feature_schema_hash: str,
+    strategy_family: str,
+    feature_versions: Mapping[str, str] | None,
+) -> dict[str, str]:
+    explicit_versions = _string_mapping(feature_versions)
+    if explicit_versions:
+        return explicit_versions
+    normalized_family = str(strategy_family or "").lower()
+    if (
+        str(feature_schema_hash or "") == build_hpairs_replay_tape_feature_schema_hash()
+        or "hpairs" in normalized_family
+        or "microbar_cross_sectional_pairs" in normalized_family
+    ):
+        return hpairs_replay_tape_feature_versions()
+    return {}
 
 
 def materialize_signal_tape(
@@ -400,6 +442,7 @@ def materialize_signal_tape(
     feature_schema_hash: str = "",
     cost_model_hash: str = "",
     strategy_family: str = "",
+    feature_versions: Mapping[str, str] | None = None,
     source_table_versions: Mapping[str, str] | None = None,
     artifact_refs: Mapping[str, str] | None = None,
     created_at: datetime | None = None,
@@ -447,6 +490,11 @@ def materialize_signal_tape(
     tape_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_ref = manifest_path or default_manifest_path(tape_path)
     manifest_ref.parent.mkdir(parents=True, exist_ok=True)
+    resolved_feature_versions = _resolve_replay_feature_versions(
+        feature_schema_hash=feature_schema_hash,
+        strategy_family=strategy_family,
+        feature_versions=feature_versions,
+    )
 
     content_hash = hashlib.sha256()
     with _open_text_writer(tape_path) as handle:
@@ -471,6 +519,7 @@ def materialize_signal_tape(
         feature_schema_hash=feature_schema_hash,
         cost_model_hash=cost_model_hash,
         strategy_family=strategy_family,
+        feature_versions=resolved_feature_versions,
         source_table_versions=source_table_versions,
     )
     manifest = ReplayTapeManifest(
@@ -492,6 +541,7 @@ def materialize_signal_tape(
         cost_model_hash=str(cost_model_hash or ""),
         strategy_family=str(strategy_family or ""),
         replay_cache_key=replay_cache_key,
+        feature_versions=resolved_feature_versions,
         artifact_refs=resolved_artifact_refs,
         source_table_versions=dict(source_table_versions or {}),
         created_at=created_at or datetime.now(timezone.utc),
@@ -622,6 +672,7 @@ def validate_tape_freshness(
         "feature_schema_hash": manifest.feature_schema_hash,
         "cost_model_hash": manifest.cost_model_hash,
         "strategy_family": manifest.strategy_family,
+        "feature_versions": dict(manifest.feature_versions),
         "replay_cache_key": manifest.replay_cache_key,
         "cache_identity": manifest.cache_identity_diagnostics(),
         "row_count": manifest.row_count,
@@ -1400,7 +1451,7 @@ def _string_tuple(value: Any) -> tuple[str, ...]:
     return tuple(str(item) for item in cast(Sequence[object], value))
 
 
-def _string_mapping(value: Any) -> Mapping[str, str]:
+def _string_mapping(value: Any) -> dict[str, str]:
     if not isinstance(value, Mapping):
         return {}
     return {

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -205,6 +205,29 @@ class TestFastReplayPreview(TestCase):
             payload["replay_tape"]["cache_identity"]["blockers"],
         )
         self.assertFalse(payload["proof_authority"])
+        self.assertEqual(
+            row_payload["candidate_lineage"]["hypothesis_id"], "hyp-spec-good"
+        )
+        self.assertEqual(
+            row_payload["candidate_lineage"]["family_template_id"],
+            "microbar_cross_sectional_pairs_v1",
+        )
+        self.assertTrue(row_payload["candidate_lineage"]["lineage_preserved"])
+        self.assertFalse(row_payload["candidate_lineage"]["final_authority_ok"])
+        self.assertEqual(
+            row_payload["frontier_selection"]["reason_code"],
+            "fast_replay_frontier_exploitation_selected",
+        )
+        self.assertFalse(row_payload["frontier_selection"]["promotion_allowed"])
+        sim_queue = payload["bounded_sim_target_queue"]
+        self.assertEqual(sim_queue["status"], "metadata_only_not_dispatched")
+        self.assertEqual(
+            sim_queue["selected_candidate_spec_ids"], ["spec-good", "spec-stress"]
+        )
+        self.assertFalse(sim_queue["kubernetes_fanout_allowed"])
+        self.assertFalse(sim_queue["db_writes_allowed"])
+        self.assertFalse(sim_queue["proof_packet_upload_allowed"])
+        self.assertFalse(sim_queue["final_authority_ok"])
 
     def test_loaded_hpairs_replay_tape_features_feed_offline_ranking_only(
         self,
@@ -528,6 +551,167 @@ class TestFastReplayPreview(TestCase):
                 "exploration",
                 "exploration",
             ],
+        )
+
+    def test_frontier_selector_defaults_to_four_exploitation_two_diverse_exploration(
+        self,
+    ) -> None:
+        def row(
+            candidate_spec_id: str,
+            *,
+            preview_score: str,
+            exploration_score: str,
+            symbols: list[str],
+        ) -> fast_replay.FastReplayPreviewRow:
+            return fast_replay.FastReplayPreviewRow(
+                candidate_spec_id=candidate_spec_id,
+                rank=0,
+                preview_score=Decimal(preview_score),
+                selected=False,
+                selection_reason="fast_replay_preview_ranked",
+                matched_row_count=10,
+                matched_symbol_count=1,
+                requested_symbol_count=1,
+                trading_day_count=1,
+                signed_return_bps=Decimal("1"),
+                avg_abs_return_bps=Decimal("1"),
+                median_spread_bps=Decimal("1"),
+                activity_score=Decimal("1"),
+                coverage_score=Decimal("1"),
+                ofi_pressure_score=Decimal("1"),
+                microprice_bias_bps=Decimal("0"),
+                spread_tail_bps=Decimal("1"),
+                return_tail_abs_bps=Decimal("1"),
+                impact_liquidity_penalty_bps=Decimal("0"),
+                cluster_lob_activity_score=Decimal("1"),
+                ofi_decay_alignment_score=Decimal("1"),
+                liquidity_regime_score=Decimal("1"),
+                macro_stress_veto_score=Decimal("0"),
+                conformal_tail_risk_penalty_bps=Decimal("0"),
+                square_root_impact_capacity_penalty_bps=Decimal("1"),
+                exploration_score=Decimal(exploration_score),
+                frontier_bucket="not_selected",
+                microstructure_prefilter={
+                    "is_hpairs_candidate": True,
+                    "proof_source": "prefilter_only",
+                    "proof_authority": False,
+                    "promotion_allowed": False,
+                    "final_promotion_allowed": False,
+                },
+                candidate_lineage={
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "symbol_universe": symbols,
+                    "lineage_preserved": True,
+                },
+            )
+
+        ranked = sorted(
+            (
+                row(
+                    "exploit-1",
+                    preview_score="100",
+                    exploration_score="1",
+                    symbols=["AAA"],
+                ),
+                row(
+                    "exploit-2",
+                    preview_score="99",
+                    exploration_score="1",
+                    symbols=["BBB"],
+                ),
+                row(
+                    "exploit-3",
+                    preview_score="98",
+                    exploration_score="1",
+                    symbols=["CCC"],
+                ),
+                row(
+                    "exploit-4",
+                    preview_score="97",
+                    exploration_score="1",
+                    symbols=["DDD"],
+                ),
+                row(
+                    "explore-same-high",
+                    preview_score="10",
+                    exploration_score="100",
+                    symbols=["AAA"],
+                ),
+                row(
+                    "explore-same-deferred",
+                    preview_score="9",
+                    exploration_score="99",
+                    symbols=["AAA"],
+                ),
+                row(
+                    "explore-diverse",
+                    preview_score="8",
+                    exploration_score="98",
+                    symbols=["EEE"],
+                ),
+                row(
+                    "budget-exhausted",
+                    preview_score="7",
+                    exploration_score="97",
+                    symbols=["FFF"],
+                ),
+            ),
+            key=fast_replay._preview_rank_key,
+        )
+
+        selected = fast_replay._select_frontier_buckets(
+            ranked_rows=ranked,
+            exploitation_count=fast_replay.FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
+            exploration_count=fast_replay.FAST_REPLAY_DEFAULT_EXPLORATION_COUNT,
+            exact_replay_candidate_cap=fast_replay.FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP,
+        )
+        final_rows = [
+            fast_replay._row_with_rank_and_selection(
+                row=item,
+                rank=index,
+                frontier_bucket=selected.get(item.candidate_spec_id, "not_selected"),
+            )
+            for index, item in enumerate(ranked, start=1)
+        ]
+        payloads = {item.candidate_spec_id: item.to_payload() for item in final_rows}
+
+        self.assertEqual(
+            [
+                candidate_id
+                for candidate_id, bucket in selected.items()
+                if bucket == "exploitation"
+            ],
+            ["exploit-1", "exploit-2", "exploit-3", "exploit-4"],
+        )
+        self.assertEqual(
+            [
+                candidate_id
+                for candidate_id, bucket in selected.items()
+                if bucket == "exploration"
+            ],
+            ["explore-same-high", "explore-diverse"],
+        )
+        self.assertNotIn("explore-same-deferred", selected)
+        self.assertEqual(len(selected), 6)
+        self.assertEqual(
+            payloads["explore-same-high"]["selection_reason"],
+            "fast_replay_frontier_exploration_selected",
+        )
+        self.assertEqual(
+            payloads["explore-diverse"]["selection_reason"],
+            "fast_replay_frontier_exploration_selected",
+        )
+        self.assertEqual(
+            payloads["explore-same-deferred"]["selection_reason"],
+            "fast_replay_frontier_budget_exhausted_skipped",
+        )
+        self.assertEqual(
+            payloads["budget-exhausted"]["frontier_selection"]["reason_code"],
+            "fast_replay_frontier_budget_exhausted_skipped",
+        )
+        self.assertFalse(
+            payloads["budget-exhausted"]["frontier_selection"]["final_authority_ok"]
         )
 
     def test_missing_cost_capacity_lineage_blocks_exact_replay_selection(

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -18,6 +18,7 @@ from app.trading.discovery.replay_tape import (
     ReplayTapeCoverageError,
     ReplayTapeManifest,
     build_hpairs_replay_tape_feature_schema_hash,
+    hpairs_replay_tape_feature_versions,
     build_replay_tape_cache_identity_diagnostics,
     build_replay_tape_cache_key,
     build_source_query_digest,
@@ -546,6 +547,15 @@ class TestReplayTape(TestCase):
             strategy_family="hpairs-v2",
             source_table_versions={"signals": "v1"},
         )
+        changed_feature_versions_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("AAPL", "NVDA"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=first_digest,
+            feature_versions={"hpairs": "torghut.hpairs-replay-tape-features.v2"},
+            source_table_versions={"signals": "v1"},
+        )
 
         self.assertEqual(first_key, reordered_key)
         self.assertNotEqual(first_key, changed_key)
@@ -554,6 +564,7 @@ class TestReplayTape(TestCase):
         self.assertNotEqual(first_key, changed_feature_schema_key)
         self.assertNotEqual(first_key, changed_cost_model_key)
         self.assertNotEqual(first_key, changed_family_key)
+        self.assertNotEqual(first_key, changed_feature_versions_key)
 
         with TemporaryDirectory() as tmpdir:
             manifest = materialize_signal_tape(
@@ -567,6 +578,7 @@ class TestReplayTape(TestCase):
                 feature_schema_hash="feature-schema-v1",
                 cost_model_hash="cost-model-v1",
                 strategy_family="hpairs-v1",
+                feature_versions=hpairs_replay_tape_feature_versions(),
                 source_table_versions={"signals": "v1"},
             )
 
@@ -579,6 +591,7 @@ class TestReplayTape(TestCase):
             feature_schema_hash="feature-schema-v1",
             cost_model_hash="cost-model-v1",
             strategy_family="hpairs-v1",
+            feature_versions=hpairs_replay_tape_feature_versions(),
             source_table_versions={"signals": "v1"},
         )
         self.assertEqual(manifest.replay_cache_key, expected_materialized_key)
@@ -590,6 +603,10 @@ class TestReplayTape(TestCase):
         )
         self.assertEqual(manifest.to_payload()["cost_model_hash"], "cost-model-v1")
         self.assertEqual(manifest.to_payload()["strategy_family"], "hpairs-v1")
+        self.assertEqual(
+            manifest.to_payload()["feature_versions"],
+            hpairs_replay_tape_feature_versions(),
+        )
 
         validation = validate_tape_freshness(
             manifest,
@@ -603,6 +620,9 @@ class TestReplayTape(TestCase):
         self.assertEqual(validation["feature_schema_hash"], "feature-schema-v1")
         self.assertEqual(validation["cost_model_hash"], "cost-model-v1")
         self.assertEqual(validation["strategy_family"], "hpairs-v1")
+        self.assertEqual(
+            validation["feature_versions"], hpairs_replay_tape_feature_versions()
+        )
         self.assertEqual(validation["cache_identity"]["status"], "complete")
         self.assertEqual(
             validation["cache_identity"]["components"]["date_range"],
@@ -642,10 +662,15 @@ class TestReplayTape(TestCase):
             feature_schema_hash="feature-schema-v1",
             cost_model_hash="cost-model-v1",
             strategy_family="hpairs-v1",
+            feature_versions=hpairs_replay_tape_feature_versions(),
         )
         self.assertEqual(complete["status"], "complete")
         self.assertEqual(complete["missing_components"], [])
         self.assertEqual(complete["components"]["symbol_universe"], ["AAPL", "NVDA"])
+        self.assertEqual(
+            complete["components"]["feature_versions"],
+            hpairs_replay_tape_feature_versions(),
+        )
 
     def test_materialize_manifest_session_window_follows_new_york_dst(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Adds deterministic H-PAIRS fast-replay frontier handoff metadata for the default 4 exploitation + 2 exploration exact-replay budget, including explicit selected/skipped reason codes and blockers.
- Preserves candidate lineage in preview rows while keeping preview/frontier/SIM queue outputs non-authoritative for final promotion.
- Carries H-PAIRS/ClusterLOB/OFI replay feature versions through replay-tape manifests, cache identity diagnostics, cache keys, freshness validation, and candidate contracts.
- Adds bounded SIM target queue metadata that forbids Kubernetes fanout, DB writes, and proof-packet uploads from preview output.
- Extends focused tests for top-six split, exploitation ranking, exploration diversity, cache-key stability, lineage preservation, budget exhaustion blockers, and no preview-only final authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py -q` (94 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_candidate_specs.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
