### PR TITLE
fix(torghut): seal runtime ledger source authority

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -48,7 +48,7 @@ from .runtime_decision_authority import (
 from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
 from .runtime_ledger_source_authority import (
     build_runtime_ledger_profit_distance_readback,
-    runtime_ledger_promotion_source_authority_blockers,
+    runtime_ledger_promotion_source_authority_blockers as _base_runtime_ledger_promotion_source_authority_blockers,
 )
 from .tigerbeetle_journal import (
     TIGERBEETLE_BLOCKER_JOURNAL_DISABLED,
@@ -105,6 +105,18 @@ RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
     {
         EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
         "torghut.runtime-ledger-bucket.v1",
+    }
+)
+RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER = (
+    "runtime_ledger_authority_class_missing"
+)
+_RUNTIME_LEDGER_PROMOTION_GRADE_AUTHORITY_MARKERS = frozenset(
+    {
+        "runtime_order_feed_execution_source",
+        "event_sourced_runtime_ledger_profit_proof",
+        "source_execution_runtime_ledger_materialized",
+        "execution_order_events_runtime_ledger",
+        "source_execution_lifecycle_materialized_runtime_ledger",
     }
 )
 
@@ -189,6 +201,33 @@ def _text(value: Any) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _promotion_grade_runtime_ledger_authority_marker_present(
+    bucket: Mapping[str, Any],
+    key: str,
+) -> bool:
+    marker = _text(bucket.get(key))
+    return (
+        marker is not None
+        and marker in _RUNTIME_LEDGER_PROMOTION_GRADE_AUTHORITY_MARKERS
+    )
+
+
+def runtime_ledger_promotion_source_authority_blockers(
+    bucket: Mapping[str, Any],
+) -> list[str]:
+    blockers = _base_runtime_ledger_promotion_source_authority_blockers(bucket)
+    if not (
+        _promotion_grade_runtime_ledger_authority_marker_present(
+            bucket, "authority_class"
+        )
+        and _promotion_grade_runtime_ledger_authority_marker_present(
+            bucket, "authority_reason"
+        )
+    ):
+        blockers.append(RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER)
+    return list(dict.fromkeys(blockers))
 
 
 def _post_cost_expectancy_basis(value: Any) -> str:
@@ -1537,6 +1576,7 @@ def _runtime_window_import_readback_from_rows(
     source_offsets: list[dict[str, Any]] = []
     source_offset_keys: set[tuple[str, str, str]] = set()
     authority_classes: list[str] = []
+    authority_reasons: list[str] = []
     source_materializations: list[str] = []
     cost_basis_counts: Counter[str] = Counter()
     blockers: list[str] = []
@@ -1622,6 +1662,11 @@ def _runtime_window_import_readback_from_rows(
             if authority_class not in authority_classes:
                 authority_classes.append(authority_class)
         if (
+            authority_reason := _text(payload_json.get("authority_reason"))
+        ) is not None:
+            if authority_reason not in authority_reasons:
+                authority_reasons.append(authority_reason)
+        if (
             source_materialization := _text(payload_json.get("source_materialization"))
         ) is not None:
             if source_materialization not in source_materializations:
@@ -1688,6 +1733,7 @@ def _runtime_window_import_readback_from_rows(
         "trade_decision_ids": trade_decision_ids,
         "source_offsets": source_offsets,
         "authority_classes": authority_classes,
+        "authority_reasons": authority_reasons,
         "source_materializations": source_materializations,
         "cost_basis_counts": dict(sorted(cost_basis_counts.items())),
         "runtime_ledger_blockers": blockers,

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1221,6 +1221,15 @@ _RUNTIME_LEDGER_PROMOTION_GRADE_SOURCE_MATERIALIZATIONS = frozenset(
         "source_execution_lifecycle",
     }
 )
+_RUNTIME_LEDGER_PROMOTION_GRADE_AUTHORITY_MARKERS = frozenset(
+    {
+        "runtime_order_feed_execution_source",
+        "event_sourced_runtime_ledger_profit_proof",
+        "source_execution_runtime_ledger_materialized",
+        "execution_order_events_runtime_ledger",
+        "source_execution_lifecycle_materialized_runtime_ledger",
+    }
+)
 _RUNTIME_LEDGER_NON_AUTHORITY_MATERIALIZATION_MARKERS = frozenset(
     {
         "aggregate_only",
@@ -1240,6 +1249,27 @@ def _runtime_ledger_non_authority_marker_present(value: object) -> bool:
     return any(
         marker in normalized
         for marker in _RUNTIME_LEDGER_NON_AUTHORITY_MATERIALIZATION_MARKERS
+    )
+
+
+def _runtime_ledger_readback_authority_markers_present(
+    *,
+    authority_classes: Sequence[str],
+    authority_reasons: Sequence[str],
+) -> bool:
+    return (
+        any(
+            authority_class in _RUNTIME_LEDGER_PROMOTION_GRADE_AUTHORITY_MARKERS
+            for authority_class in authority_classes
+        )
+        and any(
+            authority_reason in _RUNTIME_LEDGER_PROMOTION_GRADE_AUTHORITY_MARKERS
+            for authority_reason in authority_reasons
+        )
+        and not any(
+            _runtime_ledger_non_authority_marker_present(marker)
+            for marker in [*authority_classes, *authority_reasons]
+        )
     )
 
 
@@ -1392,7 +1422,12 @@ def _runtime_import_readback_blockers(
             blockers.append("runtime_ledger_source_offsets_missing")
         if not _text_list(readback.get("source_materializations")):
             blockers.append("runtime_ledger_source_materialization_missing")
-        if not _text_list(readback.get("authority_classes")):
+        authority_classes = _text_list(readback.get("authority_classes"))
+        authority_reasons = _text_list(readback.get("authority_reasons"))
+        if not _runtime_ledger_readback_authority_markers_present(
+            authority_classes=authority_classes,
+            authority_reasons=authority_reasons,
+        ):
             blockers.append("runtime_ledger_authority_class_missing")
         cost_amount = _decimal(readback.get("runtime_ledger_cost_amount"))
         if cost_amount is None or (

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -27,8 +27,7 @@ from app.trading.runtime_ledger import (
     build_runtime_ledger_buckets,
 )
 from app.trading.runtime_ledger_source_authority import (
-    runtime_ledger_promotion_source_authority_blockers,
-    runtime_ledger_promotion_source_authority_present,
+    runtime_ledger_promotion_source_authority_blockers as _base_runtime_ledger_promotion_source_authority_blockers,
 )
 from app.trading.runtime_cost_authority import (
     cost_basis_counts_have_non_promotion_grade_costs,
@@ -81,6 +80,18 @@ EXACT_REPLAY_ARTIFACT_AUTHORITY_BLOCKERS = (
 RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
 RUNTIME_LEDGER_CARRY_IN_LOOKBACK = timedelta(days=5)
 RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
+RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER = (
+    "runtime_ledger_authority_class_missing"
+)
+_RUNTIME_LEDGER_PROMOTION_GRADE_AUTHORITY_MARKERS = frozenset(
+    {
+        "runtime_order_feed_execution_source",
+        "event_sourced_runtime_ledger_profit_proof",
+        "source_execution_runtime_ledger_materialized",
+        "execution_order_events_runtime_ledger",
+        "source_execution_lifecycle_materialized_runtime_ledger",
+    }
+)
 _RUNTIME_LEDGER_DECISION_EVENTS = frozenset(
     {"decision", "trade_decision", "signal_decision"}
 )
@@ -314,6 +325,39 @@ def _decimal_or_none(value: Any) -> Decimal | None:
 def _text_or_none(value: Any) -> str | None:
     text = str(value or "").strip()
     return text or None
+
+
+def _promotion_grade_runtime_ledger_authority_marker_present(
+    bucket: Mapping[str, object],
+    key: str,
+) -> bool:
+    marker = _text_or_none(bucket.get(key))
+    return (
+        marker is not None
+        and marker in _RUNTIME_LEDGER_PROMOTION_GRADE_AUTHORITY_MARKERS
+    )
+
+
+def runtime_ledger_promotion_source_authority_blockers(
+    bucket: Mapping[str, object],
+) -> list[str]:
+    blockers = _base_runtime_ledger_promotion_source_authority_blockers(bucket)
+    if not (
+        _promotion_grade_runtime_ledger_authority_marker_present(
+            bucket, "authority_class"
+        )
+        and _promotion_grade_runtime_ledger_authority_marker_present(
+            bucket, "authority_reason"
+        )
+    ):
+        blockers.append(RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER)
+    return list(dict.fromkeys(blockers))
+
+
+def runtime_ledger_promotion_source_authority_present(
+    bucket: Mapping[str, object],
+) -> bool:
+    return not runtime_ledger_promotion_source_authority_blockers(bucket)
 
 
 def _row_payloads(row: Mapping[str, object]) -> list[Mapping[str, object]]:

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -301,6 +301,9 @@ def _runtime_import(
             "authority_classes": ["runtime_order_feed_execution_source"]
             if authoritative
             else [],
+            "authority_reasons": ["event_sourced_runtime_ledger_profit_proof"]
+            if authoritative
+            else [],
             "source_materializations": ["execution_order_events"]
             if authoritative
             else [],
@@ -2494,6 +2497,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
         readback["source_offsets"] = []
         readback["source_materializations"] = []
         readback["authority_classes"] = []
+        readback["authority_reasons"] = []
         readback["runtime_ledger_cost_amount"] = None
         readback["cost_basis_counts"] = {}
 
@@ -2536,6 +2540,40 @@ class TestRuntimeLedgerProofPacket(TestCase):
         )
         self.assertIn(
             "runtime_ledger_explicit_costs_missing", materialization["blockers"]
+        )
+
+    def test_packet_blocks_authority_when_readback_lacks_authority_reason(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        target = runtime_import["imports"][0]["summary"][
+            "runtime_materialization_target"
+        ]
+        assert isinstance(target, dict)
+        readback = target["readback"]
+        assert isinstance(readback, dict)
+        readback["authority_reasons"] = []
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertIn(
+            "runtime_ledger_authority_class_missing", materialization["blockers"]
+        )
+        self.assertIn(
+            "runtime_ledger_authority_class_missing",
+            result["promotion_authority"]["blocking_reasons"],
         )
 
     def test_packet_does_not_treat_promotion_only_import_metadata_as_unmaterialized(
@@ -3125,6 +3163,9 @@ class TestRuntimeLedgerProofPacket(TestCase):
                             },
                             "authority_classes": [
                                 "runtime_order_feed_execution_source"
+                            ],
+                            "authority_reasons": [
+                                "event_sourced_runtime_ledger_profit_proof"
                             ],
                             "source_materializations": ["execution_order_events"],
                         },

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -948,12 +948,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             authority_class=None,
             authority_reason=None,
         )
+        missing_reason = _complete_runtime_ledger_bucket(authority_reason=None)
 
         self.assertIn(
             "runtime_ledger_authority_class_missing",
             _runtime_ledger_bucket_profit_proof_blockers(missing_marker),
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(missing_marker))
+        self.assertIn(
+            "runtime_ledger_authority_class_missing",
+            _runtime_ledger_bucket_profit_proof_blockers(missing_reason),
+        )
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(missing_reason))
 
     def test_runtime_ledger_profit_proof_requires_explicit_cost_basis_and_amount(
         self,

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -957,6 +957,7 @@ class TestRuntimeWindowImport(TestCase):
                 "source_offsets",
                 "source_materialization",
                 "authority_class",
+                "authority_reason",
             }
         }
         row = StrategyRuntimeLedgerBucket(
@@ -990,6 +991,8 @@ class TestRuntimeWindowImport(TestCase):
         self.assertFalse(_persisted_runtime_ledger_bucket_evidence_grade(row))
         row.payload_json = source_backed_payload
         self.assertTrue(_persisted_runtime_ledger_bucket_evidence_grade(row))
+        row.payload_json = {**source_backed_payload, "authority_reason": None}
+        self.assertFalse(_persisted_runtime_ledger_bucket_evidence_grade(row))
 
     def test_runtime_window_import_readback_normalizes_source_offsets(
         self,
@@ -1840,6 +1843,9 @@ class TestRuntimeWindowImport(TestCase):
         self.assertIn("postgres:trade_decisions", readback["source_refs"])
         self.assertIn(
             "runtime_order_feed_execution_source", readback["authority_classes"]
+        )
+        self.assertIn(
+            "event_sourced_runtime_ledger_profit_proof", readback["authority_reasons"]
         )
         self.assertEqual(summary["proof_status"], "ok")
         self.assertEqual(summary["proof_blockers"], [])


### PR DESCRIPTION
## Summary

- Tightened Torghut runtime-ledger source authority so promotion-grade proof requires both runtime/order-feed `authority_class` and `authority_reason` markers in addition to the existing row-level source lineage gates.
- Added runtime-window import readback of authority reasons and made proof-packet final authority reject readbacks without explicit runtime/order-feed authority reasons.
- Added regression coverage for missing authority reasons across import proof blockers, persisted runtime-window readback, and proof-packet final authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q` (294 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py scripts/import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py scripts/import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
