### PR TITLE
fix(torghut): bound tigerbeetle journal source timeouts

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -95,6 +95,7 @@ spec:
                     --max-batches 1 \
                     --reconcile-limit 1000 \
                     --fail-on-degraded \
+                    --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
                     --json || status=1
                   exit "$status"
@@ -226,6 +227,7 @@ spec:
                     --max-batches 4 \
                     --reconcile-limit 500 \
                     --fail-on-degraded \
+                    --allow-data-quality-degraded \
                     --supervise-timeout-seconds 45 \
                     --json || status=1
                   exit "$status"

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -681,20 +681,59 @@ def _supervised_timeout_payload(
     return payload
 
 
-def _supervised_worker_argv() -> list[str]:
+def _without_arg(argv: Sequence[str], option: str) -> list[str]:
+    filtered: list[str] = []
+    skip_next = False
+    for item in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if item == option:
+            skip_next = True
+            continue
+        if item.startswith(f"{option}="):
+            continue
+        filtered.append(item)
+    return filtered
+
+
+def _with_source_arg(argv: Sequence[str], source: str | None) -> list[str]:
+    worker_args = [item for item in argv if item != "--supervised-worker"]
+    if source is None:
+        return worker_args
+    return [*_without_arg(worker_args, "--sources"), "--sources", source]
+
+
+def _args_for_source(
+    args: argparse.Namespace, source: str | None
+) -> argparse.Namespace:
+    if source is None:
+        return args
+    source_args = vars(args).copy()
+    source_args["sources"] = source
+    return argparse.Namespace(**source_args)
+
+
+def _supervised_worker_argv(source: str | None = None) -> list[str]:
     return [
         sys.executable,
         os.path.abspath(__file__),
-        *sys.argv[1:],
+        *_with_source_arg(sys.argv[1:], source),
         "--supervised-worker",
     ]
 
 
-def _run_supervised_worker(args: argparse.Namespace, *, started_at: datetime) -> int:
-    timeout_seconds = max(float(args.supervise_timeout_seconds), 0.001)
+def _run_supervised_worker_once(
+    args: argparse.Namespace,
+    *,
+    started_at: datetime,
+    source: str | None = None,
+) -> int:
+    worker_args = _args_for_source(args, source)
+    timeout_seconds = max(float(worker_args.supervise_timeout_seconds), 0.001)
     try:
         completed = subprocess.run(
-            _supervised_worker_argv(),
+            _supervised_worker_argv(source),
             check=False,
             timeout=timeout_seconds,
         )
@@ -702,20 +741,37 @@ def _run_supervised_worker(args: argparse.Namespace, *, started_at: datetime) ->
         _emit_progress(
             "supervised_worker_timeout",
             timeout_seconds=timeout_seconds,
-            sources=list(_parse_sources(getattr(args, "sources", "all"))),
+            sources=list(_parse_sources(getattr(worker_args, "sources", "all"))),
         )
         payload = _supervised_timeout_payload(
-            args=args,
+            args=worker_args,
             started_at=started_at,
             timeout_seconds=timeout_seconds,
         )
         print(
             json.dumps(payload, separators=(",", ":"))
-            if args.json
+            if worker_args.json
             else json.dumps(payload, indent=2)
         )
         return 1 if bool(payload["exit_nonzero"]) else 0
     return int(completed.returncode)
+
+
+def _run_supervised_worker(args: argparse.Namespace, *, started_at: datetime) -> int:
+    sources = _parse_sources(getattr(args, "sources", "all"))
+    if len(sources) <= 1:
+        return _run_supervised_worker_once(args, started_at=started_at)
+
+    exit_code = 0
+    for source in sources:
+        source_exit_code = _run_supervised_worker_once(
+            args,
+            started_at=started_at,
+            source=source,
+        )
+        if source_exit_code:
+            exit_code = 1
+    return exit_code
 
 
 def main() -> int:

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -4,12 +4,14 @@ import argparse
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
@@ -422,6 +424,113 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertIn("supervised_worker_timeout", stderr.getvalue())
         self.assertIn("--supervised-worker", run_mock.call_args.args[0])
         self.assertEqual(run_mock.call_args.kwargs["timeout"], 0.01)
+
+    def test_supervised_worker_splits_multi_source_timeout_budget(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with (
+            patch.dict(os.environ, {"DB_DSN": "sqlite+pysqlite:///:memory:"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "journal_tigerbeetle_order_events.py",
+                    "--dsn-env",
+                    "DB_DSN",
+                    "--sources",
+                    "execution,execution_tca_metric",
+                    "--batch-size",
+                    "50",
+                    "--max-batches",
+                    "1",
+                    "--fail-on-degraded",
+                    "--allow-data-quality-degraded",
+                    "--json",
+                    "--supervise-timeout-seconds",
+                    "0.01",
+                ],
+            ),
+            patch(
+                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                side_effect=[
+                    subprocess.CompletedProcess(
+                        args=["python", "journal_tigerbeetle_order_events.py"],
+                        returncode=0,
+                    ),
+                    subprocess.TimeoutExpired(
+                        cmd=["python", "journal_tigerbeetle_order_events.py"],
+                        timeout=0.01,
+                    ),
+                ],
+            ) as run_mock,
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            exit_code = script.main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(run_mock.call_count, 2)
+        first_argv = run_mock.call_args_list[0].args[0]
+        second_argv = run_mock.call_args_list[1].args[0]
+        self.assertEqual(
+            first_argv[first_argv.index("--sources") + 1],
+            script.SOURCE_TYPE_EXECUTION,
+        )
+        self.assertEqual(
+            second_argv[second_argv.index("--sources") + 1],
+            script.SOURCE_TYPE_EXECUTION_TCA_METRIC,
+        )
+        self.assertIn("--supervised-worker", first_argv)
+        self.assertIn("--supervised-worker", second_argv)
+        self.assertEqual(run_mock.call_args_list[0].kwargs["timeout"], 0.01)
+        self.assertEqual(run_mock.call_args_list[1].kwargs["timeout"], 0.01)
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["sources"], [script.SOURCE_TYPE_EXECUTION_TCA_METRIC])
+        self.assertFalse(payload["ok"])
+        self.assertTrue(payload["exit_nonzero"])
+        self.assertEqual(
+            payload["hard_failure_reasons"],
+            ["journal_batch_failures", "tigerbeetle_journal_worker_timeout"],
+        )
+        self.assertIn("supervised_worker_timeout", stderr.getvalue())
+        self.assertIn(script.SOURCE_TYPE_EXECUTION_TCA_METRIC, stderr.getvalue())
+        self.assertNotIn(
+            f'"{script.SOURCE_TYPE_EXECUTION}","{script.SOURCE_TYPE_EXECUTION_TCA_METRIC}"',
+            stderr.getvalue(),
+        )
+
+    def test_torghut_cronjob_keeps_live_sources_split_and_honest(self) -> None:
+        manifest = (
+            Path(__file__).resolve().parents[3]
+            / "argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml"
+        ).read_text()
+        for cronjob_name in (
+            "torghut-tigerbeetle-journal-order-events-live",
+            "torghut-tigerbeetle-journal-order-events-sim",
+        ):
+            section = manifest.split(f"name: {cronjob_name}", 1)[1]
+            if "---" in section:
+                section = section.split("---", 1)[0]
+            source_args = re.findall(r"--sources ([a-z_]+)", section)
+            self.assertEqual(
+                source_args,
+                [
+                    script.SOURCE_TYPE_EXECUTION,
+                    script.SOURCE_TYPE_EXECUTION_TCA_METRIC,
+                    script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                    script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                ],
+            )
+            self.assertNotIn("execution,execution_tca_metric", section)
+            self.assertEqual(section.count("--supervise-timeout-seconds 45"), 4)
+            runtime_section = section.split(
+                "--sources strategy_runtime_ledger_bucket",
+                1,
+            )[1]
+            self.assertIn("--fail-on-degraded", runtime_section)
+            self.assertIn("--allow-data-quality-degraded", runtime_section)
 
     def test_process_rows_attaches_runtime_bucket_journal_payload(self) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)


### PR DESCRIPTION
## Summary

- Split supervised TigerBeetle journal workers by source whenever a multi-source invocation is used, so execution and execution_tca_metric no longer share one 45s kill budget.
- Keep scheduled runtime-ledger TigerBeetle telemetry honest by allowing data-quality-degraded exits while preserving `--fail-on-degraded` for hard failures and surfacing reconciliation blockers.
- Add focused tests for per-source timeout behavior and the live/sim CronJob source split, timeout, and data-quality flags.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A; no UI changes.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
