### PR TITLE
fix(torghut): link order-feed source windows

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -57,6 +57,7 @@ class NormalizedOrderEvent:
     symbol: str | None
     alpaca_order_id: str | None
     client_order_id: str | None
+    execution_correlation_id: str | None
     event_type: str | None
     status: str | None
     qty: Decimal | None
@@ -923,6 +924,9 @@ def _raw_record_source_evidence_payload(
     payload: dict[str, Any] = {
         "alpaca_account_label": account_label,
         "order_identity": order_identity,
+        "execution_correlation_id": _execution_correlation_identity_from_payload(
+            decoded_payload
+        ),
         "lifecycle": lifecycle,
     }
     if explicit_account_label is not None:
@@ -959,6 +963,7 @@ def _order_event_evidence_payload(event: ExecutionOrderEvent) -> dict[str, Any]:
             alpaca_order_id=event.alpaca_order_id,
             client_order_id=event.client_order_id,
         ),
+        "execution_correlation_id": _order_event_execution_correlation_identity(event),
         "execution_order_event_id": linked_refs["execution_order_event_id"],
         "execution_id": linked_refs["execution_id"],
         "trade_decision_id": linked_refs["trade_decision_id"],
@@ -976,11 +981,15 @@ def _order_event_evidence_payload(event: ExecutionOrderEvent) -> dict[str, Any]:
             else "order_feed_lifecycle_unlinked"
         ),
         "source_coverage_complete": source_coverage_complete,
-        "promotion_authority_eligible": source_coverage_complete,
+        "promotion_authority_eligible": False,
+        "promotion_authority_blocker": "order_feed_source_refs_require_runtime_ledger_import",
     }
     if linkage_blockers:
         payload["linkage_blockers"] = linkage_blockers
         payload["linkage_classification"] = linkage_blockers[0]
+    account_alias = _order_event_account_label_alias(event)
+    if account_alias is not None:
+        payload["account_label_alias"] = account_alias
     return payload
 
 
@@ -1033,6 +1042,54 @@ def _order_event_linkage_blockers(event: ExecutionOrderEvent) -> list[str]:
     )
 
 
+def _order_event_account_label_alias(
+    event: ExecutionOrderEvent,
+) -> dict[str, str] | None:
+    raw_event = coerce_json_payload(event.raw_event)
+    if not isinstance(raw_event, Mapping):
+        return None
+    alias = cast(Mapping[object, Any], raw_event).get("_torghut_account_label_alias")
+    if not isinstance(alias, Mapping):
+        return None
+    source_account_label = _coerce_text(
+        cast(Mapping[object, Any], alias).get("source_account_label")
+    )
+    canonical_account_label = _coerce_text(
+        cast(Mapping[object, Any], alias).get("canonical_account_label")
+    )
+    basis = _coerce_text(cast(Mapping[object, Any], alias).get("basis"))
+    if source_account_label is None or canonical_account_label is None:
+        return None
+    return {
+        "source_account_label": source_account_label,
+        "canonical_account_label": canonical_account_label,
+        "basis": basis or "matched_order_identity",
+    }
+
+
+def _mark_order_event_account_alias(
+    event: ExecutionOrderEvent,
+    *,
+    source_account_label: str,
+    canonical_account_label: str,
+    basis: str,
+) -> None:
+    raw_event = coerce_json_payload(event.raw_event)
+    if isinstance(raw_event, Mapping):
+        aliased_raw_event: dict[str, Any] = {
+            str(key): value
+            for key, value in cast(Mapping[object, Any], raw_event).items()
+        }
+    else:
+        aliased_raw_event = {"payload": raw_event}
+    aliased_raw_event["_torghut_account_label_alias"] = {
+        "source_account_label": source_account_label,
+        "canonical_account_label": canonical_account_label,
+        "basis": basis,
+    }
+    event.raw_event = coerce_json_payload(aliased_raw_event)
+
+
 def _order_event_client_identity(event: ExecutionOrderEvent) -> str | None:
     if event.client_order_id:
         return event.client_order_id
@@ -1054,6 +1111,58 @@ def _order_event_client_identity(event: ExecutionOrderEvent) -> str | None:
         or _coerce_text(order.get("executionIdempotencyKey"))
         or _coerce_text(order.get("_execution_idempotency_key"))
     )
+
+
+def _order_event_execution_correlation_identity(
+    event: ExecutionOrderEvent,
+) -> str | None:
+    return _execution_correlation_identity_from_payload(event.raw_event)
+
+
+def _execution_correlation_identity_from_payload(payload: Any) -> str | None:
+    coerced = coerce_json_payload(payload)
+    candidates: list[Any] = []
+    if isinstance(coerced, Mapping):
+        mapping = cast(Mapping[object, Any], coerced)
+        candidates.extend(
+            [
+                mapping.get("execution_correlation_id"),
+                mapping.get("executionCorrelationId"),
+                mapping.get("_execution_correlation_id"),
+            ]
+        )
+        data_payload = _extract_trade_update_payload(mapping)
+        if data_payload is not None:
+            candidates.extend(
+                [
+                    data_payload.get("execution_correlation_id"),
+                    data_payload.get("executionCorrelationId"),
+                    data_payload.get("_execution_correlation_id"),
+                ]
+            )
+            order = _as_mapping(data_payload.get("order"))
+            if order is not None:
+                candidates.extend(
+                    [
+                        order.get("execution_correlation_id"),
+                        order.get("executionCorrelationId"),
+                        order.get("_execution_correlation_id"),
+                    ]
+                )
+        order = _as_mapping(mapping.get("order"))
+        if order is not None:
+            candidates.extend(
+                [
+                    order.get("execution_correlation_id"),
+                    order.get("executionCorrelationId"),
+                    order.get("_execution_correlation_id"),
+                ]
+            )
+    for candidate in candidates:
+        text = _coerce_text(candidate)
+        if text is not None:
+            return text
+    return None
 
 
 def _order_identity_payload(
@@ -1143,6 +1252,7 @@ def normalize_order_feed_record(
         alpaca_order_id = _coerce_text(
             (order or {}).get("order_id") or (order or {}).get("orderId")
         )
+    execution_correlation_id = _execution_correlation_identity_from_payload(payload)
 
     event_type = _coerce_text(data_payload.get("event")) or _coerce_text(
         data_payload.get("event_type")
@@ -1161,7 +1271,11 @@ def normalize_order_feed_record(
         (envelope.get("seq") if envelope else None) or data_payload.get("seq")
     )
 
-    if alpaca_order_id is None and client_order_id is None:
+    if (
+        alpaca_order_id is None
+        and client_order_id is None
+        and execution_correlation_id is None
+    ):
         return NormalizationResult(event=None, drop_reason="missing_order_identity")
 
     qty = _coerce_decimal((order or {}).get("qty"))
@@ -1190,6 +1304,7 @@ def normalize_order_feed_record(
         "alpaca_account_label": account_label,
         "alpaca_order_id": alpaca_order_id,
         "client_order_id": client_order_id,
+        "execution_correlation_id": execution_correlation_id,
         "event_type": event_type,
         "status": status,
         "event_ts": event_ts.isoformat() if event_ts else None,
@@ -1213,6 +1328,7 @@ def normalize_order_feed_record(
         symbol=symbol,
         alpaca_order_id=alpaca_order_id,
         client_order_id=client_order_id,
+        execution_correlation_id=execution_correlation_id,
         event_type=event_type,
         status=status,
         qty=qty,
@@ -1287,6 +1403,7 @@ def _fingerprint_normalized_order_event(
         "alpaca_account_label": account_label or event.alpaca_account_label,
         "alpaca_order_id": event.alpaca_order_id,
         "client_order_id": event.client_order_id,
+        "execution_correlation_id": event.execution_correlation_id,
         "event_type": event.event_type,
         "status": event.status,
         "event_ts": event.event_ts.isoformat() if event.event_ts else None,
@@ -1321,6 +1438,11 @@ def _order_identity_matches_account_scope(
         )
         clauses.append(
             (Execution.execution_idempotency_key == event.client_order_id)
+            & (Execution.alpaca_account_label == account_label)
+        )
+    if event.execution_correlation_id:
+        clauses.append(
+            (Execution.execution_correlation_id == event.execution_correlation_id)
             & (Execution.alpaca_account_label == account_label)
         )
     if clauses and session.scalar(select(exists().where(or_(*clauses)))):
@@ -1369,6 +1491,7 @@ def persist_order_event(
         account_label=event.alpaca_account_label,
         alpaca_order_id=event.alpaca_order_id,
         client_order_id=event.client_order_id,
+        execution_correlation_id=event.execution_correlation_id,
     )
     execution = execution_linkage.execution
     raw_event = event.raw_event
@@ -1602,8 +1725,7 @@ def latest_order_event_for_execution(
     """Fetch newest persisted order event linked to an execution."""
 
     filters: list[ColumnElement[bool]] = [
-        (ExecutionOrderEvent.execution_id == execution.id)
-        & (ExecutionOrderEvent.alpaca_account_label == execution.alpaca_account_label)
+        ExecutionOrderEvent.execution_id == execution.id
     ]
     if execution.alpaca_order_id:
         filters.append(
@@ -1629,7 +1751,6 @@ def latest_order_event_for_execution(
                 == execution.alpaca_account_label
             )
         )
-
     stmt = (
         select(ExecutionOrderEvent)
         .where(or_(*filters))
@@ -1648,33 +1769,30 @@ def link_order_events_to_execution(
     execution: Execution,
     *,
     limit: int | None = None,
+    source_account_label: str | None = None,
 ) -> int:
     """Attach previously ingested order-feed events once their Execution exists."""
 
+    event_account_label = (
+        source_account_label.strip()
+        if source_account_label is not None and source_account_label.strip()
+        else execution.alpaca_account_label
+    )
     clauses: list[ColumnElement[bool]] = []
     if execution.alpaca_order_id:
         clauses.append(
             (ExecutionOrderEvent.alpaca_order_id == execution.alpaca_order_id)
-            & (
-                ExecutionOrderEvent.alpaca_account_label
-                == execution.alpaca_account_label
-            )
+            & (ExecutionOrderEvent.alpaca_account_label == event_account_label)
         )
     if execution.client_order_id:
         clauses.append(
             (ExecutionOrderEvent.client_order_id == execution.client_order_id)
-            & (
-                ExecutionOrderEvent.alpaca_account_label
-                == execution.alpaca_account_label
-            )
+            & (ExecutionOrderEvent.alpaca_account_label == event_account_label)
         )
     if execution.execution_idempotency_key:
         clauses.append(
             (ExecutionOrderEvent.client_order_id == execution.execution_idempotency_key)
-            & (
-                ExecutionOrderEvent.alpaca_account_label
-                == execution.alpaca_account_label
-            )
+            & (ExecutionOrderEvent.alpaca_account_label == event_account_label)
         )
     if not clauses:
         return 0
@@ -1705,9 +1823,10 @@ def link_order_events_to_execution(
     for event in events:
         event_execution_linkage = _resolve_execution_linkage_for_identity(
             session,
-            account_label=event.alpaca_account_label,
+            account_label=execution.alpaca_account_label,
             alpaca_order_id=event.alpaca_order_id,
             client_order_id=_order_event_client_identity(event),
+            execution_correlation_id=_order_event_execution_correlation_identity(event),
         )
         if event_execution_linkage.blockers:
             event.raw_event = _raw_event_with_linkage_blockers(
@@ -1724,6 +1843,14 @@ def link_order_events_to_execution(
         ):
             continue
         changed = False
+        if event.alpaca_account_label != execution.alpaca_account_label:
+            _mark_order_event_account_alias(
+                event,
+                source_account_label=event.alpaca_account_label,
+                canonical_account_label=execution.alpaca_account_label,
+                basis="matched_order_identity",
+            )
+            changed = True
         if event.execution_id is None:
             event.execution_id = execution.id
             changed = True
@@ -1732,7 +1859,7 @@ def link_order_events_to_execution(
             if trade_decision_id is None:
                 decision_linkage = _resolve_trade_decision_linkage_for_identity(
                     session,
-                    account_label=event.alpaca_account_label,
+                    account_label=execution.alpaca_account_label,
                     client_order_id=_order_event_client_identity(event),
                 )
                 if decision_linkage.blockers:
@@ -1768,6 +1895,7 @@ def repair_order_feed_execution_links(
     session: Session,
     *,
     account_label: str | None = None,
+    canonical_account_label: str | None = None,
     limit: int = 1000,
 ) -> dict[str, int]:
     """Attach unlinked order-feed lifecycle rows to matching executions.
@@ -1778,6 +1906,11 @@ def repair_order_feed_execution_links(
     """
 
     bounded_limit = max(1, min(int(limit), 5000))
+    canonical_label = (
+        canonical_account_label.strip()
+        if canonical_account_label is not None and canonical_account_label.strip()
+        else None
+    )
     stmt = (
         select(ExecutionOrderEvent)
         .where(
@@ -1801,7 +1934,7 @@ def repair_order_feed_execution_links(
         stmt = stmt.where(ExecutionOrderEvent.alpaca_account_label == account_label)
 
     events = session.execute(stmt).scalars().all()
-    processed_execution_ids: set[object] = set()
+    processed_execution_ids: set[tuple[object, str]] = set()
     counters = {
         "selected": len(events),
         "executions_matched": 0,
@@ -1811,17 +1944,37 @@ def repair_order_feed_execution_links(
         "decision_events_linked": 0,
         "events_without_execution": 0,
         "events_without_decision": 0,
+        "account_alias_events_linked": 0,
     }
-    processed_decision_ids: set[object] = set()
+    processed_decision_ids: set[tuple[object, str]] = set()
     for event in events:
         if counters["events_linked"] >= bounded_limit:
             break
+        event_client_order_id = _order_event_client_identity(event)
+        event_correlation_id = _order_event_execution_correlation_identity(event)
         execution_linkage = _resolve_execution_linkage_for_identity(
             session,
             account_label=event.alpaca_account_label,
             alpaca_order_id=event.alpaca_order_id,
-            client_order_id=_order_event_client_identity(event),
+            client_order_id=event_client_order_id,
+            execution_correlation_id=event_correlation_id,
         )
+        source_account_label: str | None = None
+        if (
+            execution_linkage.execution is None
+            and canonical_label is not None
+            and canonical_label != event.alpaca_account_label
+        ):
+            canonical_execution_linkage = _resolve_execution_linkage_for_identity(
+                session,
+                account_label=canonical_label,
+                alpaca_order_id=event.alpaca_order_id,
+                client_order_id=event_client_order_id,
+                execution_correlation_id=event_correlation_id,
+            )
+            if canonical_execution_linkage.execution is not None:
+                execution_linkage = canonical_execution_linkage
+                source_account_label = event.alpaca_account_label
         if execution_linkage.blockers:
             event.raw_event = _raw_event_with_linkage_blockers(
                 event.raw_event,
@@ -1839,8 +1992,24 @@ def repair_order_feed_execution_links(
                 decision_linkage = _resolve_trade_decision_linkage_for_identity(
                     session,
                     account_label=event.alpaca_account_label,
-                    client_order_id=_order_event_client_identity(event),
+                    client_order_id=event_client_order_id,
                 )
+                decision_source_account_label: str | None = None
+                if (
+                    decision_linkage.trade_decision is None
+                    and canonical_label is not None
+                    and canonical_label != event.alpaca_account_label
+                ):
+                    canonical_decision_linkage = (
+                        _resolve_trade_decision_linkage_for_identity(
+                            session,
+                            account_label=canonical_label,
+                            client_order_id=event_client_order_id,
+                        )
+                    )
+                    if canonical_decision_linkage.trade_decision is not None:
+                        decision_linkage = canonical_decision_linkage
+                        decision_source_account_label = event.alpaca_account_label
                 if decision_linkage.blockers:
                     event.raw_event = _raw_event_with_linkage_blockers(
                         event.raw_event,
@@ -1855,29 +2024,42 @@ def repair_order_feed_execution_links(
                 else:
                     decision = decision_linkage.trade_decision
                     event.trade_decision_id = decision.id
-                    if decision.id not in processed_decision_ids:
-                        processed_decision_ids.add(decision.id)
+                    decision_key = (decision.id, decision_source_account_label or "")
+                    if decision_key not in processed_decision_ids:
+                        processed_decision_ids.add(decision_key)
                         counters["decisions_matched"] += 1
+                    if decision_source_account_label is not None:
+                        _mark_order_event_account_alias(
+                            event,
+                            source_account_label=decision_source_account_label,
+                            canonical_account_label=decision.alpaca_account_label,
+                            basis="matched_order_identity",
+                        )
+                        counters["account_alias_events_linked"] += 1
                     _ensure_source_window_for_event(session, event)
                     session.add(event)
                     _refresh_source_window_linkage_counts(session, event)
                     counters["decision_events_linked"] += 1
             counters["events_without_execution"] += 1
             continue
-        if execution.id in processed_execution_ids:
+        execution_key = (execution.id, source_account_label or "")
+        if execution_key in processed_execution_ids:
             continue
-        processed_execution_ids.add(execution.id)
+        processed_execution_ids.add(execution_key)
         counters["executions_matched"] += 1
         remaining_event_budget = max(1, bounded_limit - counters["events_linked"])
         linked = link_order_events_to_execution(
             session,
             execution,
             limit=remaining_event_budget,
+            source_account_label=source_account_label,
         )
         if linked <= 0:
             continue
         counters["executions_linked"] += 1
         counters["events_linked"] += linked
+        if source_account_label is not None:
+            counters["account_alias_events_linked"] += linked
     return counters
 
 
@@ -2219,6 +2401,7 @@ def _resolve_execution_linkage_for_identity(
     account_label: str,
     alpaca_order_id: str | None,
     client_order_id: str | None,
+    execution_correlation_id: str | None = None,
 ) -> _ExecutionLinkageResolution:
     clauses: list[ColumnElement[bool]] = []
     if alpaca_order_id:
@@ -2226,6 +2409,8 @@ def _resolve_execution_linkage_for_identity(
     if client_order_id:
         clauses.append(Execution.client_order_id == client_order_id)
         clauses.append(Execution.execution_idempotency_key == client_order_id)
+    if execution_correlation_id:
+        clauses.append(Execution.execution_correlation_id == execution_correlation_id)
     if not clauses:
         return _ExecutionLinkageResolution(
             execution=None,
@@ -2717,7 +2902,10 @@ def _refresh_source_window_linkage_counts(
         and event.source_offset is not None
     )
     payload_dict["source_coverage_complete"] = source_window_complete
-    payload_dict["promotion_authority_eligible"] = source_window_complete
+    payload_dict["promotion_authority_eligible"] = False
+    payload_dict["promotion_authority_blocker"] = (
+        "order_feed_source_refs_require_runtime_ledger_import"
+    )
     payload_dict["authority_class"] = (
         "runtime_order_feed_execution_source"
         if source_window_complete

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -26,6 +26,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--dsn-env", default="DB_DSN")
     parser.add_argument("--account-label", default=None)
+    parser.add_argument("--canonical-account-label", default=None)
     parser.add_argument("--batch-size", type=int, default=1000)
     parser.add_argument("--max-batches", type=int, default=1)
     parser.add_argument(
@@ -84,6 +85,9 @@ def _payload(
         "execution_link_events_without_decision": sum(
             batch["execution_link_events_without_decision"] for batch in batches
         ),
+        "execution_link_account_alias_events_linked": sum(
+            batch["execution_link_account_alias_events_linked"] for batch in batches
+        ),
         "execution_event_backfill_candidates": sum(
             batch["execution_event_backfill_candidates"] for batch in batches
         ),
@@ -128,6 +132,7 @@ def _payload(
         "apply": bool(args.apply),
         "dsn_env": args.dsn_env,
         "account_label": args.account_label,
+        "canonical_account_label": args.canonical_account_label,
         "backfill_execution_events": bool(args.backfill_execution_events),
         "batch_size": max(1, min(int(args.batch_size), 5000)),
         "max_batches": max(1, int(args.max_batches)),
@@ -183,6 +188,7 @@ def main() -> int:
             execution_link_batch = repair_order_feed_execution_links(
                 session,
                 account_label=args.account_label,
+                canonical_account_label=args.canonical_account_label,
                 limit=batch_size,
             )
             execution_event_backfill_batch = (
@@ -228,6 +234,9 @@ def main() -> int:
                 ],
                 "execution_link_events_without_decision": execution_link_batch.get(
                     "events_without_decision", 0
+                ),
+                "execution_link_account_alias_events_linked": execution_link_batch.get(
+                    "account_alias_events_linked", 0
                 ),
                 "execution_event_backfill_candidates": execution_event_backfill_batch[
                     "selected"

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -1016,6 +1016,47 @@ class TestOrderFeed(TestCase):
         self.assertTrue(source_window.payload_json["source_coverage_complete"])
         self.assertFalse(source_window.payload_json["promotion_authority_eligible"])
 
+    def test_order_identity_account_scope_matches_execution_correlation_id(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            self._seed_execution(
+                session,
+                order_id="corr-scope-order",
+                client_order_id="corr-scope-client",
+                execution_correlation_id="corr-scope-1",
+            )
+            event = NormalizedOrderEvent(
+                event_fingerprint="corr-scope-fingerprint",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=40,
+                alpaca_account_label="paper",
+                feed_seq=12,
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=None,
+                client_order_id=None,
+                execution_correlation_id="corr-scope-1",
+                event_type="fill",
+                status="filled",
+                qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                filled_qty_delta=Decimal("1"),
+                avg_fill_price=Decimal("190.2"),
+                filled_notional_delta=Decimal("190.2"),
+                fill_quantity_basis="filled_qty",
+                raw_event={"event": "fill"},
+            )
+
+            in_scope = order_feed_module._order_identity_matches_account_scope(
+                session,
+                event,
+                account_label="paper",
+            )
+
+        self.assertTrue(in_scope)
+
     def test_build_consumer_applies_kafka_security_kwargs(self) -> None:
         captured_kwargs: dict[str, object] = {}
         original_security_protocol = settings.trading_order_feed_security_protocol
@@ -1904,6 +1945,56 @@ class TestOrderFeed(TestCase):
                 },
             },
         )
+        event = ExecutionOrderEvent(
+            event_fingerprint="account-alias-helper-edge",
+            source_topic="torghut.trade-updates.v1",
+            source_partition=0,
+            source_offset=399,
+            alpaca_account_label="paper",
+            event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+            symbol="AAPL",
+            raw_event="raw-event",
+        )
+        self.assertIsNone(order_feed_module._order_event_account_label_alias(event))
+
+        event.raw_event = {
+            "_torghut_account_label_alias": {"source_account_label": "PA3SX7FYNUTF"}
+        }
+        self.assertIsNone(order_feed_module._order_event_account_label_alias(event))
+
+        order_feed_module._mark_order_event_account_alias(
+            event,
+            source_account_label="PA3SX7FYNUTF",
+            canonical_account_label="TORGHUT_SIM",
+            basis="matched_order_identity",
+        )
+        self.assertEqual(
+            event.raw_event,
+            {
+                "_torghut_account_label_alias": {
+                    "source_account_label": "PA3SX7FYNUTF",
+                    "canonical_account_label": "TORGHUT_SIM",
+                    "basis": "matched_order_identity",
+                }
+            },
+        )
+
+        event.raw_event = "raw-event"
+        order_feed_module._mark_order_event_account_alias(
+            event,
+            source_account_label="PA3SX7FYNUTF",
+            canonical_account_label="TORGHUT_SIM",
+            basis="matched_order_identity",
+        )
+        self.assertEqual(event.raw_event["payload"], "raw-event")
+        self.assertEqual(
+            event.raw_event["_torghut_account_label_alias"],
+            {
+                "source_account_label": "PA3SX7FYNUTF",
+                "canonical_account_label": "TORGHUT_SIM",
+                "basis": "matched_order_identity",
+            },
+        )
 
         existing = order_feed_module._raw_event_with_linkage_blockers(
             {"event": "fill", "_torghut_linkage": {"source": "previous"}},
@@ -2183,6 +2274,118 @@ class TestOrderFeed(TestCase):
             source_window.payload_json["authority_class"],
             "order_feed_lifecycle_unlinked",
         )
+
+    def test_repair_order_feed_execution_links_resolves_decision_account_alias_without_execution(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="decision-alias-demo",
+                description="decision-alias-demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="symbols_list",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"side": "buy"},
+                decision_hash="decision-alias-client-1",
+                status="submitted",
+            )
+            session.add(decision)
+            session.flush()
+            decision_id = decision.id
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed-v1",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                alpaca_account_label="PA3SX7FYNUTF",
+                assignment_mode="group",
+                source_revision=ORDER_FEED_SOURCE_REVISION,
+                window_started_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                window_ended_at=datetime(2026, 2, 1, 10, 1, tzinfo=timezone.utc),
+                start_offset=389,
+                end_offset=389,
+                consumed_count=1,
+                inserted_count=1,
+                unlinked_execution_count=1,
+                unlinked_decision_count=1,
+                status="inserted",
+                status_reason="missing_execution_and_decision_links",
+            )
+            session.add(source_window)
+            session.flush()
+            event = ExecutionOrderEvent(
+                event_fingerprint="repair-decision-alias-only-fill",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=389,
+                alpaca_account_label="PA3SX7FYNUTF",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id="missing-execution-order",
+                client_order_id="decision-alias-client-1",
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+                source_window_id=source_window.id,
+            )
+            session.add(event)
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="PA3SX7FYNUTF",
+                canonical_account_label="TORGHUT_SIM",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(event)
+            session.refresh(source_window)
+
+        self.assertEqual(
+            result,
+            {
+                "selected": 1,
+                "executions_matched": 0,
+                "executions_linked": 0,
+                "decisions_matched": 1,
+                "events_linked": 0,
+                "decision_events_linked": 1,
+                "events_without_execution": 1,
+                "events_without_decision": 0,
+                "account_alias_events_linked": 1,
+            },
+        )
+        self.assertIsNone(event.execution_id)
+        self.assertEqual(event.trade_decision_id, decision_id)
+        self.assertEqual(
+            event.raw_event["_torghut_account_label_alias"],
+            {
+                "source_account_label": "PA3SX7FYNUTF",
+                "canonical_account_label": "TORGHUT_SIM",
+                "basis": "matched_order_identity",
+            },
+        )
+        self.assertEqual(source_window.unlinked_execution_count, 1)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
+        self.assertEqual(
+            source_window.payload_json["account_label_alias"],
+            {
+                "source_account_label": "PA3SX7FYNUTF",
+                "canonical_account_label": "TORGHUT_SIM",
+                "basis": "matched_order_identity",
+            },
+        )
+        self.assertFalse(source_window.payload_json["source_coverage_complete"])
 
     def test_repair_order_feed_execution_links_counts_missing_decision_identity(
         self,

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -185,6 +185,7 @@ class TestOrderFeed(TestCase):
         order_id: str = "order-1",
         client_order_id: str = "client-1",
         execution_idempotency_key: str | None = None,
+        execution_correlation_id: str | None = None,
     ) -> Execution:
         strategy = Strategy(
             name="demo",
@@ -221,6 +222,7 @@ class TestOrderFeed(TestCase):
             submitted_qty=Decimal("1"),
             filled_qty=Decimal("0"),
             status="new",
+            execution_correlation_id=execution_correlation_id,
             execution_idempotency_key=execution_idempotency_key,
             raw_order={"id": "order-1"},
             last_update_at=datetime.now(timezone.utc),
@@ -966,6 +968,53 @@ class TestOrderFeed(TestCase):
                 "basis": "matched_order_identity",
             },
         )
+        self.assertFalse(source_window.payload_json["promotion_authority_eligible"])
+
+    def test_order_feed_event_links_by_execution_correlation_id_only(self) -> None:
+        record = FakeRecord(
+            value=(
+                b'{"channel":"trade_updates","payload":{"event":"fill",'
+                b'"timestamp":"2026-02-01T10:00:00Z",'
+                b'"_execution_correlation_id":"corr-order-feed-1",'
+                b'"order":{"symbol":"AAPL","status":"filled","qty":"1",'
+                b'"filled_qty":"1","filled_avg_price":"190.2"}},'
+                b'"seq":12}'
+            ),
+            offset=27,
+        )
+        consumer = FakeConsumer([record])
+        ingestor = OrderFeedIngestor(
+            consumer_factory=lambda: consumer,
+            default_account_label="paper",
+        )
+
+        with Session(self.engine) as session:
+            execution = self._seed_execution(
+                session,
+                order_id="corr-broker-order-1",
+                client_order_id="corr-client-1",
+                execution_correlation_id="corr-order-feed-1",
+            )
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+
+            counters = ingestor.ingest_once(session)
+            event = session.execute(select(ExecutionOrderEvent)).scalar_one()
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(counters["events_persisted_total"], 1)
+        self.assertEqual(counters["unlinked_execution_total"], 0)
+        self.assertEqual(counters["unlinked_decision_total"], 0)
+        self.assertIsNone(event.alpaca_order_id)
+        self.assertIsNone(event.client_order_id)
+        self.assertEqual(event.execution_id, execution_id)
+        self.assertEqual(event.trade_decision_id, trade_decision_id)
+        self.assertEqual(
+            source_window.payload_json["execution_correlation_id"],
+            "corr-order-feed-1",
+        )
+        self.assertTrue(source_window.payload_json["source_coverage_complete"])
+        self.assertFalse(source_window.payload_json["promotion_authority_eligible"])
 
     def test_build_consumer_applies_kafka_security_kwargs(self) -> None:
         captured_kwargs: dict[str, object] = {}
@@ -1629,6 +1678,7 @@ class TestOrderFeed(TestCase):
                 "decision_events_linked": 0,
                 "events_without_execution": 1,
                 "events_without_decision": 1,
+                "account_alias_events_linked": 0,
             },
         )
         self.assertEqual(linkable_event.execution_id, execution_id)
@@ -1747,6 +1797,95 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.unlinked_execution_count, 0)
         self.assertEqual(source_window.unlinked_decision_count, 0)
         self.assertEqual(source_window.payload_json["source_coverage_complete"], True)
+        self.assertFalse(source_window.payload_json["promotion_authority_eligible"])
+
+    def test_repair_order_feed_execution_links_resolves_configured_account_alias(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(
+                session,
+                account_label="TORGHUT_SIM",
+                order_id="sim-alias-order-1",
+                client_order_id="sim-alias-client-1",
+            )
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed-v1",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                alpaca_account_label="PA3SX7FYNUTF",
+                assignment_mode="group",
+                source_revision=ORDER_FEED_SOURCE_REVISION,
+                window_started_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                window_ended_at=datetime(2026, 2, 1, 10, 1, tzinfo=timezone.utc),
+                start_offset=330,
+                end_offset=330,
+                consumed_count=1,
+                inserted_count=1,
+                unlinked_execution_count=1,
+                unlinked_decision_count=1,
+                status="inserted",
+                status_reason="missing_execution_and_decision_links",
+            )
+            session.add(source_window)
+            session.flush()
+            event = ExecutionOrderEvent(
+                event_fingerprint="repair-configured-account-alias",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=330,
+                alpaca_account_label="PA3SX7FYNUTF",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id="sim-alias-order-1",
+                client_order_id="sim-alias-client-1",
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+                source_window_id=source_window.id,
+            )
+            session.add(event)
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="PA3SX7FYNUTF",
+                canonical_account_label="TORGHUT_SIM",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(event)
+            session.refresh(source_window)
+
+        self.assertEqual(result["events_linked"], 1)
+        self.assertEqual(result["account_alias_events_linked"], 1)
+        self.assertEqual(event.alpaca_account_label, "PA3SX7FYNUTF")
+        self.assertEqual(event.execution_id, execution_id)
+        self.assertEqual(event.trade_decision_id, trade_decision_id)
+        self.assertEqual(
+            event.raw_event["_torghut_account_label_alias"],
+            {
+                "source_account_label": "PA3SX7FYNUTF",
+                "canonical_account_label": "TORGHUT_SIM",
+                "basis": "matched_order_identity",
+            },
+        )
+        self.assertEqual(source_window.unlinked_execution_count, 0)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
+        self.assertEqual(
+            source_window.payload_json["account_label_alias"],
+            {
+                "source_account_label": "PA3SX7FYNUTF",
+                "canonical_account_label": "TORGHUT_SIM",
+                "basis": "matched_order_identity",
+            },
+        )
+        self.assertTrue(source_window.payload_json["source_coverage_complete"])
+        self.assertFalse(source_window.payload_json["promotion_authority_eligible"])
 
     def test_linkage_helpers_preserve_actionable_blocker_classifications(
         self,
@@ -2023,6 +2162,7 @@ class TestOrderFeed(TestCase):
                 "decision_events_linked": 1,
                 "events_without_execution": 1,
                 "events_without_decision": 0,
+                "account_alias_events_linked": 0,
             },
         )
         self.assertIsNone(event.execution_id)
@@ -2180,6 +2320,7 @@ class TestOrderFeed(TestCase):
                     symbol="AAPL",
                     alpaca_order_id="missing-execution-order",
                     client_order_id="decision-only-persist-client",
+                    execution_correlation_id=None,
                     event_type="fill",
                     status="filled",
                     qty=Decimal("1"),
@@ -3499,6 +3640,7 @@ class TestOrderFeed(TestCase):
             symbol="AAPL",
             alpaca_order_id=None,
             client_order_id=None,
+            execution_correlation_id=None,
             event_type="fill",
             status="filled",
             qty=Decimal("1"),
@@ -3541,6 +3683,7 @@ class TestOrderFeed(TestCase):
             symbol="AAPL",
             alpaca_order_id="order-1",
             client_order_id="client-1",
+            execution_correlation_id=None,
             event_type="fill",
             status="filled",
             qty=Decimal("2"),

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -148,6 +148,7 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         repair_links.assert_called_once_with(
             fake_session,
             account_label=None,
+            canonical_account_label=None,
             limit=5000,
         )
         backfill_execution_events.assert_not_called()
@@ -283,6 +284,7 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(backfill.call_args.kwargs["limit"], 2)
         self.assertEqual(repair_links.call_count, 2)
         self.assertEqual(repair_links.call_args.kwargs["account_label"], "TORGHUT_SIM")
+        self.assertIsNone(repair_links.call_args.kwargs["canonical_account_label"])
         self.assertEqual(repair_links.call_args.kwargs["limit"], 2)
         backfill_execution_events.assert_not_called()
         self.assertEqual(repair_deltas.call_count, 2)


### PR DESCRIPTION
## Summary

- Link order-feed events to executions by execution correlation id in addition to Alpaca order id, client order id, and execution idempotency key.
- Add explicit canonical account-label alias repair for existing broker-labeled events while preserving fail-closed blockers when no configured alias proves scope.
- Keep linked order-feed source refs available for runtime proof without marking them as final promotion authority.
- Extend the dry-run repair script output with canonical-account alias inputs and exact would-link alias counts.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass after installing the missing local compiler toolchain required to build `crosshair-tool` in this workspace)
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py -q` (pass: 95 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py` (pass)
- `cd services/torghut && uv run --frozen ruff format --check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (pass: 0 errors)
- `cd services/torghut && git diff --check` (pass)

## Screenshots (if applicable)

N/A (backend order-feed linkage and repair-script change; no UI surface).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
