### PR TITLE
fix(torghut): bound health surface evaluations

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from collections.abc import Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
@@ -221,6 +221,17 @@ LEAN_LANE_MANAGER = LeanLaneManager()
 WHITEPAPER_WORKFLOW = WhitepaperWorkflowService()
 _TRADING_DEPENDENCY_HEALTH_CACHE_LOCK = Lock()
 _TRADING_DEPENDENCY_HEALTH_CACHE: dict[str, dict[str, object]] = {}
+_TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = 3.0
+_TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR = ThreadPoolExecutor(
+    max_workers=2,
+    thread_name_prefix="torghut-health-surface",
+)
+_TRADING_HEALTH_SURFACE_EVALUATION_LOCK = Lock()
+_TRADING_HEALTH_SURFACE_EVALUATIONS: dict[
+    str,
+    Future[tuple[dict[str, object], int]],
+] = {}
+_TRADING_HEALTH_SURFACE_PAYLOAD_CACHE: dict[str, dict[str, object]] = {}
 _OPTIONS_CATALOG_FRESHNESS_CACHE_LOCK = Lock()
 _OPTIONS_CATALOG_FRESHNESS_CACHE: dict[
     tuple[str, ...], tuple[datetime, dict[str, object]]
@@ -850,6 +861,207 @@ def _strip_promotion_authority_claims_for_readiness(value: object) -> object:
             _strip_promotion_authority_claims_for_readiness(item) for item in list_value
         ]
     return value
+
+
+def _trading_health_surface_cache_key(
+    *,
+    include_database_contract: bool,
+    allow_stale_dependency_cache: bool,
+) -> str:
+    return (
+        f"health-surface:{int(include_database_contract)}:"
+        f"{int(allow_stale_dependency_cache)}"
+    )
+
+
+def _cache_completed_trading_health_surface_payload(
+    cache_key: str,
+    payload: dict[str, object],
+    status_code: int,
+) -> None:
+    with _TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+        _TRADING_HEALTH_SURFACE_PAYLOAD_CACHE[cache_key] = {
+            "payload": deepcopy(payload),
+            "status_code": status_code,
+            "checked_at": datetime.now(timezone.utc),
+        }
+
+
+def _record_trading_health_surface_completion(
+    cache_key: str,
+    future: Future[tuple[dict[str, object], int]],
+) -> None:
+    with _TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+        current = _TRADING_HEALTH_SURFACE_EVALUATIONS.get(cache_key)
+        if current is future:
+            _TRADING_HEALTH_SURFACE_EVALUATIONS.pop(cache_key, None)
+
+    try:
+        payload, status_code = future.result()
+    except Exception as exc:  # pragma: no cover - defensive callback surface
+        logger.warning(
+            "Trading health surface evaluation failed asynchronously: %s", exc
+        )
+        return
+
+    _cache_completed_trading_health_surface_payload(cache_key, payload, status_code)
+
+
+def _cached_trading_health_surface_payload(
+    cache_key: str,
+) -> tuple[dict[str, object], datetime] | None:
+    with _TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+        cache_entry = _TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.get(cache_key)
+        if cache_entry is None:
+            return None
+        payload = deepcopy(cast(dict[str, object], cache_entry["payload"]))
+        checked_at = cast(datetime, cache_entry["checked_at"])
+    return payload, checked_at
+
+
+def _fail_closed_health_evaluation_gate(
+    *,
+    reason_code: str,
+    detail: str,
+) -> dict[str, object]:
+    return {
+        "allowed": False,
+        "promotion_authority": False,
+        "promotion_authority_ok": False,
+        "final_authority_ok": False,
+        "final_promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "reason": reason_code,
+        "reason_codes": [reason_code],
+        "blocked_reasons": [reason_code],
+        "detail": detail,
+    }
+
+
+def _health_surface_timeout_fallback_payload(
+    *,
+    cache_key: str,
+    reason_code: str,
+    detail: str,
+) -> dict[str, object]:
+    cached = _cached_trading_health_surface_payload(cache_key)
+    if cached is None:
+        return {
+            "status": "degraded",
+            "reason": reason_code,
+            "reason_codes": [reason_code],
+            "dependencies": {
+                "health_evaluation": {
+                    "ok": False,
+                    "detail": detail,
+                    "reason_codes": [reason_code],
+                }
+            },
+            "live_submission_gate": _fail_closed_health_evaluation_gate(
+                reason_code=reason_code,
+                detail=detail,
+            ),
+        }
+
+    payload, checked_at = cached
+    payload["status"] = "degraded"
+    payload["reason"] = reason_code
+    reason_codes = list(cast(Sequence[object], payload.get("reason_codes") or []))
+    payload["reason_codes"] = _append_unique_reason(reason_codes, reason_code)
+    payload["health_evaluation_timeout"] = {
+        "ok": False,
+        "detail": detail,
+        "reason_codes": [reason_code],
+        "cached_payload_checked_at": checked_at.isoformat(),
+    }
+    dependencies = payload.get("dependencies")
+    if isinstance(dependencies, Mapping):
+        dependencies_payload = deepcopy(dict(cast(Mapping[str, object], dependencies)))
+    else:
+        dependencies_payload = {}
+    dependencies_payload["health_evaluation"] = {
+        "ok": False,
+        "detail": detail,
+        "reason_codes": [reason_code],
+        "cached_payload_checked_at": checked_at.isoformat(),
+    }
+    payload["dependencies"] = dependencies_payload
+    live_submission_gate = payload.get("live_submission_gate")
+    if isinstance(live_submission_gate, Mapping):
+        payload["live_submission_gate"] = _guard_live_submission_gate_for_readiness(
+            cast(Mapping[str, object], live_submission_gate),
+            readiness_dependency_reasons=[reason_code],
+        )
+    else:
+        payload["live_submission_gate"] = _fail_closed_health_evaluation_gate(
+            reason_code=reason_code,
+            detail=detail,
+        )
+    return cast(
+        dict[str, object],
+        _strip_promotion_authority_claims_for_readiness(payload),
+    )
+
+
+def _evaluate_trading_health_payload_bounded(
+    *,
+    include_database_contract: bool = False,
+    allow_stale_dependency_cache: bool = False,
+    surface: str,
+) -> tuple[dict[str, object], int]:
+    cache_key = _trading_health_surface_cache_key(
+        include_database_contract=include_database_contract,
+        allow_stale_dependency_cache=allow_stale_dependency_cache,
+    )
+    with _TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+        future = _TRADING_HEALTH_SURFACE_EVALUATIONS.get(cache_key)
+        if future is None or future.done():
+            future = _TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR.submit(
+                _evaluate_trading_health_payload,
+                include_database_contract=include_database_contract,
+                allow_stale_dependency_cache=allow_stale_dependency_cache,
+            )
+            _TRADING_HEALTH_SURFACE_EVALUATIONS[cache_key] = future
+            future.add_done_callback(
+                lambda completed, key=cache_key: (
+                    _record_trading_health_surface_completion(
+                        key,
+                        completed,
+                    )
+                )
+            )
+
+    timeout_seconds = max(0.1, _TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS)
+    try:
+        payload, status_code = future.result(timeout=timeout_seconds)
+    except TimeoutError:
+        reason_code = f"{surface}_evaluation_timeout"
+        detail = (
+            f"{surface} evaluation exceeded {timeout_seconds:.1f}s; "
+            "returning fail-closed cached/degraded health"
+        )
+        return (
+            _health_surface_timeout_fallback_payload(
+                cache_key=cache_key,
+                reason_code=reason_code,
+                detail=detail,
+            ),
+            503,
+        )
+    except Exception as exc:
+        logger.warning("Trading health surface evaluation failed: %s", exc)
+        reason_code = f"{surface}_evaluation_unavailable"
+        return (
+            _health_surface_timeout_fallback_payload(
+                cache_key=cache_key,
+                reason_code=reason_code,
+                detail=str(exc),
+            ),
+            503,
+        )
+
+    _cache_completed_trading_health_surface_payload(cache_key, payload, status_code)
+    return payload, status_code
 
 
 def _evaluate_trading_health_payload(
@@ -1809,9 +2021,10 @@ def _evaluate_database_contract(session: Session) -> dict[str, object]:
 def readyz() -> JSONResponse:
     """Readiness endpoint with dependency-aware status for rollout safety."""
 
-    payload, status_code = _evaluate_trading_health_payload(
+    payload, status_code = _evaluate_trading_health_payload_bounded(
         include_database_contract=True,
         allow_stale_dependency_cache=True,
+        surface="readyz",
     )
     return JSONResponse(
         status_code=status_code,
@@ -5653,7 +5866,9 @@ def trading_tca(
 def trading_health() -> JSONResponse:
     """Trading loop health including dependency readiness."""
 
-    payload, status_code = _evaluate_trading_health_payload()
+    payload, status_code = _evaluate_trading_health_payload_bounded(
+        surface="trading_health",
+    )
     return JSONResponse(status_code=status_code, content=jsonable_encoder(payload))
 
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import inspect
+import time
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -4553,6 +4554,122 @@ class TestTradingApi(TestCase):
             ),
             [],
         )
+
+    def test_readyz_evaluation_timeout_returns_fail_closed_quickly(self) -> None:
+        original_timeout = main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS
+        main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = 0.01
+        with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+
+        def _slow_health_payload(**_kwargs: object) -> tuple[dict[str, object], int]:
+            time.sleep(0.2)
+            return ({"status": "ok", "live_submission_gate": {"allowed": True}}, 200)
+
+        try:
+            with patch(
+                "app.main._evaluate_trading_health_payload",
+                side_effect=_slow_health_payload,
+            ):
+                started_at = time.monotonic()
+                response = self.client.get("/readyz")
+                elapsed = time.monotonic() - started_at
+            time.sleep(0.25)
+        finally:
+            main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = original_timeout
+            with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+                main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+                main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+
+        self.assertLess(elapsed, 0.5)
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "degraded")
+        self.assertEqual(payload["reason"], "readyz_evaluation_timeout")
+        self.assertIn(
+            "readyz_evaluation_timeout",
+            payload["dependencies"]["health_evaluation"]["reason_codes"],
+        )
+        self.assertFalse(payload["live_submission_gate"]["allowed"])
+        self.assertFalse(payload["live_submission_gate"]["promotion_authority"])
+        self.assertFalse(payload["live_submission_gate"]["final_authority_ok"])
+
+    def test_trading_health_timeout_uses_cached_blockers_fail_closed(self) -> None:
+        original_timeout = main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS
+        main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = 0.01
+        cache_key = main_module._trading_health_surface_cache_key(
+            include_database_contract=False,
+            allow_stale_dependency_cache=False,
+        )
+        cached_payload: dict[str, object] = {
+            "status": "degraded",
+            "dependencies": {
+                "tigerbeetle": {
+                    "ok": False,
+                    "blockers": [
+                        "source_amount_mismatch",
+                        "unlinked_execution_cost",
+                    ],
+                }
+            },
+            "options_catalog_freshness": {
+                "ok": False,
+                "blockers": ["options_catalog_freshness_gap"],
+            },
+            "live_submission_gate": {
+                "allowed": True,
+                "promotion_authority": True,
+                "final_authority_ok": True,
+                "final_promotion_allowed": True,
+            },
+        }
+        with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE[cache_key] = {
+                "payload": cached_payload,
+                "status_code": 503,
+                "checked_at": datetime.now(timezone.utc),
+            }
+
+        def _slow_health_payload(**_kwargs: object) -> tuple[dict[str, object], int]:
+            time.sleep(0.2)
+            return (cached_payload, 503)
+
+        try:
+            with patch(
+                "app.main._evaluate_trading_health_payload",
+                side_effect=_slow_health_payload,
+            ):
+                response = self.client.get("/trading/health")
+            time.sleep(0.25)
+        finally:
+            main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = original_timeout
+            with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+                main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+                main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "degraded")
+        self.assertEqual(payload["reason"], "trading_health_evaluation_timeout")
+        self.assertIn(
+            "source_amount_mismatch",
+            payload["dependencies"]["tigerbeetle"]["blockers"],
+        )
+        self.assertIn(
+            "unlinked_execution_cost",
+            payload["dependencies"]["tigerbeetle"]["blockers"],
+        )
+        self.assertEqual(
+            payload["options_catalog_freshness"]["blockers"],
+            ["options_catalog_freshness_gap"],
+        )
+        live_submission_gate = payload["live_submission_gate"]
+        self.assertFalse(live_submission_gate["allowed"])
+        self.assertFalse(live_submission_gate["promotion_authority"])
+        self.assertFalse(live_submission_gate["final_authority_ok"])
+        self.assertFalse(live_submission_gate["final_promotion_allowed"])
+        self.assertTrue(live_submission_gate["readiness_dependency_guard_active"])
 
     @patch(
         "app.main._evaluate_database_contract",


### PR DESCRIPTION
## Summary

- Adds a bounded shared evaluator for `/readyz` and `/trading/health` so expensive health payload construction returns a fail-closed degraded response after the health-surface deadline instead of timing out callers.
- Reuses the most recent completed health payload when a surface times out, preserving cached TigerBeetle/accounting/options blockers while stripping promotion/final-authority claims and forcing the live-submission gate closed.
- Limits in-flight health-surface evaluations to one worker per readiness/trading-health cache key to avoid request fanout while the original diagnostic evaluation finishes in the background.
- Adds regression coverage for quick `/readyz` timeout fallback and cached `/trading/health` blocker preservation.

## Related Issues

Follow-up to #9687.

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q -k 'evaluation_timeout or timeout_uses_cached_blockers'` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q` — passed, 142 tests
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py` — passed
- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed
- `git diff --check` — passed

## Screenshots (if applicable)

N/A — API health-surface behavior only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
