### PR TITLE
fix(torghut): drain newest tigerbeetle journal blockers first

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: tigerbeetle-journal-order-events-live
 spec:
-  schedule: "6,36 * * * *"
+  schedule: "*/6 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
@@ -60,7 +60,7 @@ spec:
                     --dsn-env DB_DSN \
                     --sources execution \
                     --batch-size 5 \
-                    --max-batches 1 \
+                    --max-batches 3 \
                     --reconcile-limit 1000 \
                     --skip-reconcile \
                     --fail-on-degraded \
@@ -71,7 +71,7 @@ spec:
                     --dsn-env DB_DSN \
                     --sources execution_tca_metric \
                     --batch-size 5 \
-                    --max-batches 1 \
+                    --max-batches 3 \
                     --reconcile-limit 1000 \
                     --skip-reconcile \
                     --fail-on-degraded \
@@ -81,7 +81,7 @@ spec:
                     --dsn-env DB_DSN \
                     --sources execution_order_event \
                     --batch-size 5 \
-                    --max-batches 1 \
+                    --max-batches 3 \
                     --event-scan-limit 250 \
                     --reconcile-limit 1000 \
                     --skip-reconcile \

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -257,7 +257,7 @@ def _select_unlinked_executions(
             Execution.avg_fill_price.is_not(None),
             Execution.filled_qty > 0,
         )
-        .order_by(Execution.created_at.asc())
+        .order_by(Execution.created_at.desc(), Execution.id.desc())
     )
     if account_label:
         stmt = stmt.where(Execution.alpaca_account_label == account_label)
@@ -287,7 +287,11 @@ def _select_unlinked_tca_metrics(
             ExecutionTCAMetric.shortfall_notional.is_not(None),
             ExecutionTCAMetric.shortfall_notional != 0,
         )
-        .order_by(ExecutionTCAMetric.computed_at.asc())
+        .order_by(
+            ExecutionTCAMetric.computed_at.desc().nullslast(),
+            ExecutionTCAMetric.created_at.desc(),
+            ExecutionTCAMetric.id.desc(),
+        )
     )
     if account_label:
         stmt = stmt.where(ExecutionTCAMetric.alpaca_account_label == account_label)

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import tempfile
 from contextlib import redirect_stderr, redirect_stdout
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
@@ -880,6 +880,56 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
 
         self.assertEqual([row.id for row in executions], [selected.id])
 
+    def test_select_unlinked_executions_prioritizes_reconciliation_window(
+        self,
+    ) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        observed_at = datetime.now(timezone.utc)
+        with Session(self.engine) as session:
+            older = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-older-window",
+                client_order_id="client-older-window",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                status="filled",
+                raw_order={"id": "order-older-window"},
+                created_at=observed_at - timedelta(minutes=5),
+                updated_at=observed_at - timedelta(minutes=5),
+            )
+            newer = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-newer-window",
+                client_order_id="client-newer-window",
+                symbol="MSFT",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("410.50"),
+                status="filled",
+                raw_order={"id": "order-newer-window"},
+                created_at=observed_at,
+                updated_at=observed_at,
+            )
+            session.add_all([older, newer])
+            session.flush()
+
+            executions = script._select_unlinked_executions(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=1,
+            )
+
+        self.assertEqual([row.id for row in executions], [newer.id])
+
     def test_select_unlinked_tca_metrics_uses_direct_ref_fk(self) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
         with Session(self.engine) as session:
@@ -958,6 +1008,78 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             )
 
         self.assertEqual([row.id for row in metrics], [selected.id])
+
+    def test_select_unlinked_tca_metrics_prioritizes_reconciliation_window(
+        self,
+    ) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        observed_at = datetime.now(timezone.utc)
+        with Session(self.engine) as session:
+            older_execution = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-older-tca-window",
+                client_order_id="client-older-tca-window",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.25"),
+                status="filled",
+                raw_order={"id": "order-older-tca-window"},
+            )
+            newer_execution = Execution(
+                alpaca_account_label="paper",
+                alpaca_order_id="order-newer-tca-window",
+                client_order_id="client-newer-tca-window",
+                symbol="MSFT",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("410.50"),
+                status="filled",
+                raw_order={"id": "order-newer-tca-window"},
+            )
+            session.add_all([older_execution, newer_execution])
+            session.flush()
+            older = ExecutionTCAMetric(
+                execution_id=older_execution.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.25"),
+                computed_at=observed_at - timedelta(minutes=5),
+                created_at=observed_at - timedelta(minutes=5),
+                updated_at=observed_at - timedelta(minutes=5),
+            )
+            newer = ExecutionTCAMetric(
+                execution_id=newer_execution.id,
+                alpaca_account_label="paper",
+                symbol="MSFT",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.35"),
+                computed_at=observed_at,
+                created_at=observed_at,
+                updated_at=observed_at,
+            )
+            session.add_all([older, newer])
+            session.flush()
+
+            metrics = script._select_unlinked_tca_metrics(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=1,
+            )
+
+        self.assertEqual([row.id for row in metrics], [newer.id])
 
     def test_select_runtime_buckets_repairs_legacy_ref_missing_bucket_fk(
         self,

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1443,7 +1443,7 @@ class TestLiveConfigManifestContract(TestCase):
             "torghut-tigerbeetle-journal-order-events-sim"
         )
 
-        self.assertEqual(live_spec.get("schedule"), "6,36 * * * *")
+        self.assertEqual(live_spec.get("schedule"), "*/6 * * * *")
         self.assertEqual(sim_spec.get("schedule"), "21,51 * * * *")
         for spec, job_spec, container in (
             (live_spec, live_job_spec, live_container),
@@ -1541,7 +1541,8 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)
         self.assertNotIn("--account-label TORGHUT_SIM", live_args)
         self.assertEqual(live_args.count("--batch-size 5"), 4)
-        self.assertIn("--max-batches 1", live_args)
+        self.assertEqual(live_args.count("--max-batches 3"), 3)
+        self.assertEqual(live_args.count("--max-batches 1"), 1)
         self.assertIn("--event-scan-limit 250", live_args)
         self.assertIn("--reconcile-limit 1000", live_args)
 


### PR DESCRIPTION
## Summary

- Prioritize newest unlinked execution and TCA source rows so the journal worker drains the same live window that reconciliation blocks on.
- Increase live TigerBeetle journal catch-up cadence while preserving batch size 5 and bounded supervised workers.
- Add manifest and selection-order regression coverage.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut > /tmp/torghut-kustomize-render-newest.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
