### PR TITLE
fix(torghut): repair hpairs bounded source collection

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1243,6 +1243,52 @@ def _balanced_pair_probe_symbol_actions(
     return actions
 
 
+def _paper_route_probe_symbol_quantities(
+    target: Mapping[str, object],
+    symbols: Sequence[str],
+) -> dict[str, str]:
+    normalized_symbols = [
+        str(symbol).strip().upper() for symbol in symbols if str(symbol).strip()
+    ]
+    quantities: dict[str, str] = {}
+    for field in (
+        "paper_route_probe_symbol_quantities",
+        "target_symbol_quantities",
+        "symbol_quantities",
+    ):
+        raw_quantities = _as_mapping(target.get(field))
+        for symbol in normalized_symbols:
+            if symbol in quantities:
+                continue
+            quantity = _safe_decimal(raw_quantities.get(symbol))
+            if quantity > 0:
+                quantities[symbol] = _decimal_text(quantity)
+
+    fallback_quantity = Decimal("0")
+    for field in (
+        "paper_route_probe_target_quantity",
+        "target_quantity",
+        "qty",
+        "quantity",
+    ):
+        fallback_quantity = _safe_decimal(target.get(field))
+        if fallback_quantity > 0:
+            break
+    if fallback_quantity <= 0 and normalized_symbols:
+        # The bounded source materializer requires an explicit quantity per leg.
+        # H-PAIRS collection is capped independently by the target notional and
+        # simple-pipeline risk clamps; use the minimum integer probe leg so the
+        # materializer can create auditable source decisions instead of
+        # silently producing a zero-decision packet.
+        fallback_quantity = Decimal("1")
+
+    if fallback_quantity > 0:
+        fallback_text = _decimal_text(fallback_quantity)
+        for symbol in normalized_symbols:
+            quantities.setdefault(symbol, fallback_text)
+    return quantities
+
+
 def _pair_probe_balance_state(actions: Mapping[str, str]) -> str:
     buy_count = sum(1 for action in actions.values() if action == "buy")
     sell_count = sum(1 for action in actions.values() if action == "sell")
@@ -1941,6 +1987,10 @@ def _next_paper_route_runtime_window_targets(
             pair_balance_target,
             target_probe_symbols,
         )
+        pair_symbol_quantities = _paper_route_probe_symbol_quantities(
+            pair_balance_target,
+            target_probe_symbols,
+        )
         pair_balance_state = (
             _pair_probe_balance_state(pair_symbol_actions)
             if pair_balance_required
@@ -2244,6 +2294,19 @@ def _next_paper_route_runtime_window_targets(
             "paper_route_probe_symbol_count": len(target_probe_symbols),
             "paper_route_probe_raw_target_symbols": raw_target_probe_symbols,
             "paper_route_probe_symbol_actions": pair_symbol_actions,
+            "paper_route_probe_symbol_quantities": pair_symbol_quantities,
+            "paper_route_probe_target_quantity": _decimal_text(
+                sum(
+                    (
+                        _safe_decimal(quantity)
+                        for quantity in pair_symbol_quantities.values()
+                    ),
+                    Decimal("0"),
+                )
+            ),
+            "paper_route_probe_symbol_quantity_source": (
+                "target_plan_explicit_or_min_integer_probe"
+            ),
             "paper_route_probe_pair_balance_required": pair_balance_required,
             "paper_route_probe_pair_balance_state": pair_balance_state,
             "paper_route_hpairs_required_symbols": (

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -811,6 +811,38 @@ def _target_probe_symbol_actions(
     }
 
 
+def _target_probe_symbol_quantities(
+    target: Mapping[str, Any],
+    symbols: Sequence[str],
+) -> dict[str, Decimal]:
+    normalized_symbols = [
+        symbol.strip().upper() for symbol in symbols if symbol.strip()
+    ]
+    quantities: dict[str, Decimal] = {}
+    for field in (
+        "paper_route_probe_symbol_quantities",
+        "target_symbol_quantities",
+        "symbol_quantities",
+    ):
+        raw_quantities = target.get(field)
+        if not isinstance(raw_quantities, Mapping):
+            continue
+        for raw_symbol, raw_quantity in cast(
+            Mapping[object, object], raw_quantities
+        ).items():
+            symbol = str(raw_symbol).strip().upper()
+            quantity = _optional_decimal(raw_quantity)
+            if symbol in normalized_symbols and quantity is not None and quantity > 0:
+                quantities.setdefault(symbol, quantity)
+    fallback_quantity = _optional_decimal(
+        target.get("paper_route_probe_target_quantity")
+    ) or _optional_decimal(target.get("target_quantity"))
+    if fallback_quantity is not None and fallback_quantity > 0:
+        for symbol in normalized_symbols:
+            quantities.setdefault(symbol, fallback_quantity)
+    return quantities
+
+
 def _target_pair_balance_state(
     target: Mapping[str, Any],
     symbol_actions: Mapping[str, Literal["buy", "sell"]],
@@ -1886,6 +1918,9 @@ class SimpleTradingPipeline(TradingPipeline):
             return []
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
         if not self._is_market_session_open(now):
+            self._record_bounded_target_plan_blocker(
+                reason="paper_route_session_window_not_open"
+            )
             return []
 
         session_open = regular_session_open_utc_for(now)
@@ -3958,6 +3993,13 @@ class SimpleTradingPipeline(TradingPipeline):
             "paper_route_probe_window_end": window_end.isoformat(),
             "paper_route_probe_next_session_max_notional": str(max_notional),
             "paper_route_probe_effective_max_notional": str(max_notional),
+            "paper_route_probe_symbol_quantities": {
+                item_symbol: str(quantity)
+                for item_symbol, quantity in _target_probe_symbol_quantities(
+                    target,
+                    sorted(_target_symbols(target)),
+                ).items()
+            },
             "paper_route_target_plan_source": "external_target_plan_url",
             "paper_route_probe_scope_authority": "external_target_plan",
             "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
@@ -4137,6 +4179,9 @@ class SimpleTradingPipeline(TradingPipeline):
             return []
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
         if not self._is_market_session_open(now):
+            self._record_bounded_target_plan_blocker(
+                reason="paper_route_session_window_not_open"
+            )
             return []
         target_symbols, target_plan_error, target_plan_targets = (
             self._external_paper_route_target_probe_symbols_cached()
@@ -4202,6 +4247,7 @@ class SimpleTradingPipeline(TradingPipeline):
             if strategy_symbols:
                 symbols = [symbol for symbol in symbols if symbol in strategy_symbols]
             symbol_actions = _target_probe_symbol_actions(target, symbols)
+            symbol_quantities = _target_probe_symbol_quantities(target, symbols)
             pair_balance_state = _target_pair_balance_state(target, symbol_actions)
             if _target_requires_bounded_sim_collection_gate(
                 target
@@ -4291,6 +4337,11 @@ class SimpleTradingPipeline(TradingPipeline):
                     max_notional=target_cap,
                 )
                 metadata["paper_route_probe_symbol_actions"] = dict(symbol_actions)
+                if symbol_quantities:
+                    metadata["paper_route_probe_symbol_quantities"] = {
+                        item_symbol: str(quantity)
+                        for item_symbol, quantity in symbol_quantities.items()
+                    }
                 metadata["paper_route_probe_pair_balance_required"] = (
                     pair_balance_state != "not_required"
                 )
@@ -4333,6 +4384,16 @@ class SimpleTradingPipeline(TradingPipeline):
                     "paper_route_probe_window_start": window_start.isoformat(),
                     "paper_route_probe_window_end": window_end.isoformat(),
                     "paper_route_probe_symbol_actions": dict(symbol_actions),
+                    **(
+                        {
+                            "paper_route_probe_symbol_quantities": {
+                                item_symbol: str(quantity)
+                                for item_symbol, quantity in symbol_quantities.items()
+                            }
+                        }
+                        if symbol_quantities
+                        else {}
+                    ),
                     "paper_route_probe_pair_balance_state": pair_balance_state,
                     "paper_route_probe_leg_action": action,
                     "live_capital_routing_enabled": False,
@@ -4391,7 +4452,7 @@ class SimpleTradingPipeline(TradingPipeline):
                         event_ts=now,
                         timeframe=timeframe,
                         action=action,
-                        qty=Decimal("1"),
+                        qty=symbol_quantities.get(symbol, Decimal("1")),
                         order_type="market",
                         time_in_force="day",
                         rationale="external paper-route target plan source decision",

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -36,6 +36,7 @@ from app.trading.paper_route_evidence import (
     _next_regular_equities_session_window,
     _normalized_open_positions,
     _paper_route_probe_summary,
+    _paper_route_probe_symbol_quantities,
     _pair_probe_balance_state,
     _runtime_ledger_bucket_evidence_grade,
     _runtime_ledger_non_evidence_diagnostic_summary,
@@ -45,6 +46,9 @@ from app.trading.paper_route_evidence import (
     _target_audit_fail_closed,
     build_paper_route_evidence_audit,
     build_paper_route_target_plan_payload,
+)
+from app.trading.paper_route_target_plan import (
+    materialize_bounded_paper_route_target_plan,
 )
 
 
@@ -71,6 +75,20 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
         self.assertEqual(actions, {"AAPL": "buy", "AMZN": "sell"})
         self.assertEqual(_pair_probe_balance_state(actions), "balanced")
+
+    def test_probe_symbol_quantities_preserve_explicit_values_before_fallback(
+        self,
+    ) -> None:
+        quantities = _paper_route_probe_symbol_quantities(
+            {
+                "paper_route_probe_symbol_quantities": {"AAPL": "0.5"},
+                "target_symbol_quantities": {"AAPL": "0.8", "AMZN": "0.7"},
+                "target_quantity": "2",
+            },
+            ["AAPL", "AMZN"],
+        )
+
+        self.assertEqual(quantities, {"AAPL": "0.5", "AMZN": "0.7"})
 
     def test_account_contamination_reason_reports_mixed_foreign_and_unlinked(
         self,
@@ -1538,6 +1556,57 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(clean_readiness["state"], "clean")
         self.assertEqual(clean_readiness["clean_target_count"], 1)
         self.assertEqual(clean_readiness["blockers"], [])
+
+    def test_clean_hpairs_target_plan_materializes_nonzero_source_decisions(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 26, 13, 35, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="paper-route-candidate-v1",
+                    description="clean materialization source strategy",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                )
+            )
+            self._add_account_position_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                as_of=window_start - timedelta(minutes=5),
+                positions=[],
+            )
+            session.commit()
+
+            payload = self._build_basic_paper_route_target_plan(
+                session,
+                generated_at=generated_at,
+            )
+            plan = payload["next_paper_route_runtime_window_targets"]
+            target = plan["targets"][0]
+            self.assertEqual(
+                target["paper_route_probe_symbol_quantities"],
+                {"AAPL": "1", "AMZN": "1"},
+            )
+            self.assertFalse(target["promotion_allowed"])
+            self.assertFalse(target["final_promotion_allowed"])
+
+            materialized = materialize_bounded_paper_route_target_plan(
+                session,
+                plan,
+                generated_at=generated_at,
+                bounded_notional_limit=Decimal("25"),
+            )
+
+        self.assertEqual(materialized["materialized_decision_count"], 2)
+        self.assertEqual(materialized["route_submission_count"], 2)
+        self.assertEqual(materialized["blocked_target_count"], 0)
+        self.assertFalse(materialized["promotion_allowed"])
+        self.assertFalse(materialized["final_promotion_allowed"])
+        self.assertFalse(materialized["live_capital_routing_enabled"])
 
     def test_older_contaminated_window_does_not_poison_later_clean_target_window(
         self,

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -15,6 +15,7 @@ from app.trading.scheduler.simple_pipeline import (
     _bounded_sim_collection_metadata_from_decision,
     _quote_snapshot_matches_symbol,
     _target_metadata_quote_snapshot,
+    _target_probe_symbol_quantities,
 )
 from app.trading.runtime_window_import import (
     _runtime_promotion_blocking_reasons,
@@ -358,6 +359,15 @@ def test_bounded_sim_collection_blocks_missing_source_lineage_prerequisites() ->
     assert "bounded_sim_collection_evidence_collection_not_ready" in blockers
     assert "bounded_sim_collection_source_decision_not_ready" in blockers
     assert "source_strategy_missing" in blockers
+
+
+def test_target_probe_symbol_quantities_apply_target_quantity_fallback() -> None:
+    quantities = _target_probe_symbol_quantities(
+        {"target_quantity": "3"},
+        ["AAPL", "AMZN"],
+    )
+
+    assert quantities == {"AAPL": Decimal("3"), "AMZN": Decimal("3")}
 
 
 def _routeability_decision(
@@ -862,6 +872,7 @@ def test_bounded_source_collection_authorizes_after_runtime_account_audit_readba
             paper_route_probe_window_end="2026-06-01T20:00:00+00:00",
             paper_route_probe_next_session_max_notional="25",
             paper_route_probe_symbol_actions={"AAPL": "buy", "AMZN": "sell"},
+            paper_route_probe_symbol_quantities={"AAPL": "2", "AMZN": "1"},
             evidence_collection_ok=False,
             canary_collection_authorized=False,
             bounded_evidence_collection_authorized=False,
@@ -912,8 +923,16 @@ def test_bounded_source_collection_authorizes_after_runtime_account_audit_readba
         )
 
         assert {decision.symbol for decision in decisions} == {"AAPL", "AMZN"}
+        assert {decision.symbol: decision.qty for decision in decisions} == {
+            "AAPL": Decimal("2"),
+            "AMZN": Decimal("1"),
+        }
         for decision in decisions:
             metadata = decision.params["paper_route_target_plan_source_decision"]
+            assert metadata["paper_route_probe_symbol_quantities"] == {
+                "AAPL": "2",
+                "AMZN": "1",
+            }
             assert metadata["bounded_evidence_collection_authorized"] is True
             assert metadata["bounded_live_paper_collection_authorized"] is True
             assert metadata["canary_collection_authorized"] is True
@@ -934,6 +953,47 @@ def test_bounded_source_collection_authorizes_after_runtime_account_audit_readba
         settings.trading_mode = trading_mode_before
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
         settings.trading_allow_shorts = allow_shorts_before
+
+
+def test_bounded_source_collection_blocks_closed_session_with_explicit_reason(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    try:
+        settings.trading_mode = "paper"
+        settings.trading_simple_paper_route_probe_enabled = True
+        now = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "TORGHUT_SIM"
+        pipeline.state = SimpleNamespace()
+        pipeline._is_market_session_open = lambda _now: False
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+            {"AAPL", "AMZN"},
+            None,
+            [_bounded_hpairs_target()],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[],
+            allowed_symbols={"AAPL", "AMZN"},
+            positions=[],
+            session=None,
+        )
+
+        assert decisions == []
+        blocker = pipeline.state.last_bounded_evidence_collection_blocker
+        assert blocker["reason"] == "paper_route_session_window_not_open"
+        assert blocker["blockers"] == ["paper_route_session_window_not_open"]
+        assert blocker["account_label"] == "TORGHUT_SIM"
+        assert blocker["target_count"] == 0
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
 
 
 def test_bounded_sim_collection_accepts_declared_paper_account_alias() -> None:


### PR DESCRIPTION
## Summary

- Added deterministic H-PAIRS paper-route leg quantities to clean bounded runtime-window targets so source materialization creates auditable nonzero TORGHUT_SIM decisions instead of blocking on missing quantities.
- Taught the simple pipeline to preserve target-provided leg quantities in source-decision metadata and to size emitted H-PAIRS candidate decisions from those quantities.
- Added an explicit bounded-collection blocker for closed market sessions while preserving collection-only promotion state.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_simple_pipeline.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_completion_trace.py -q` — passed: 218 passed, 1 warning
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py tests/test_simple_pipeline.py tests/test_paper_route_evidence.py` — passed
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py tests/test_simple_pipeline.py tests/test_paper_route_evidence.py` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed: 0 errors
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed: 0 errors
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed: 0 errors
- `git diff --check` — passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.