### PR TITLE
feat(torghut): materialize H-PAIRS runtime evidence refs

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -110,6 +110,10 @@ RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
 RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER = (
     "runtime_ledger_authority_class_missing"
 )
+EXECUTION_TCA_MISSING_BLOCKER = "execution_tca_missing"
+RUNTIME_LEDGER_EXECUTION_TCA_REFS_MISSING_BLOCKER = (
+    "runtime_ledger_execution_tca_refs_missing"
+)
 _RUNTIME_LEDGER_PROMOTION_GRADE_AUTHORITY_MARKERS = frozenset(
     {
         "runtime_order_feed_execution_source",
@@ -419,6 +423,28 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
     elif pnl_basis != POST_COST_PNL_BASIS:
         blockers.append("runtime_ledger_pnl_basis_invalid")
     blockers.extend(runtime_ledger_promotion_source_authority_blockers(bucket))
+    source_row_counts = _mapping(bucket.get("source_row_counts"))
+    execution_count = _observation_int(source_row_counts.get("executions"))
+    tca_count = _observation_int(source_row_counts.get("execution_tca_metrics"))
+    execution_tca_ref_count = len(
+        _string_list(bucket.get("execution_tca_metric_ids"))
+        or _string_list(bucket.get("execution_tca_metric_refs"))
+        or _string_list(bucket.get("execution_tca_metrics"))
+    )
+    execution_tca_required = (
+        _observation_bool(
+            bucket.get("execution_tca_required") or bucket.get("requires_execution_tca")
+        )
+        is True
+        or tca_count > 0
+    )
+    if (
+        execution_tca_required
+        and execution_count > 0
+        and (tca_count < execution_count or execution_tca_ref_count < execution_count)
+    ):
+        blockers.append(EXECUTION_TCA_MISSING_BLOCKER)
+        blockers.append(RUNTIME_LEDGER_EXECUTION_TCA_REFS_MISSING_BLOCKER)
     if _observation_int(bucket.get("fill_count")) <= 0:
         blockers.append("runtime_fills_missing")
     if _observation_int(bucket.get("decision_count")) <= 0:
@@ -1572,6 +1598,7 @@ def _runtime_window_import_readback_from_rows(
     source_window_ids: list[str] = []
     execution_order_event_ids: list[str] = []
     execution_ids: list[str] = []
+    execution_tca_metric_ids: list[str] = []
     trade_decision_ids: list[str] = []
     source_offsets: list[dict[str, Any]] = []
     source_offset_keys: set[tuple[str, str, str]] = set()
@@ -1614,6 +1641,13 @@ def _runtime_window_import_readback_from_rows(
             ("execution_refs", execution_ids),
             ("execution_id", execution_ids),
             ("execution_ref", execution_ids),
+            ("execution_tca_metric_ids", execution_tca_metric_ids),
+            ("execution_tca_metric_refs", execution_tca_metric_ids),
+            ("execution_tca_metric_id", execution_tca_metric_ids),
+            ("execution_tca_metric_ref", execution_tca_metric_ids),
+            ("execution_tca_metrics", execution_tca_metric_ids),
+            ("execution_tca_ids", execution_tca_metric_ids),
+            ("execution_tca_id", execution_tca_metric_ids),
             ("trade_decision_ids", trade_decision_ids),
             ("trade_decision_refs", trade_decision_ids),
             ("trade_decision_id", trade_decision_ids),
@@ -1730,6 +1764,8 @@ def _runtime_window_import_readback_from_rows(
         "execution_order_event_ids": execution_order_event_ids,
         "runtime_ledger_execution_order_event_ids": execution_order_event_ids,
         "execution_ids": execution_ids,
+        "execution_tca_metric_ids": execution_tca_metric_ids,
+        "runtime_ledger_execution_tca_metric_ids": execution_tca_metric_ids,
         "trade_decision_ids": trade_decision_ids,
         "source_offsets": source_offsets,
         "authority_classes": authority_classes,

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1129,6 +1129,10 @@ def _runtime_import_target_materialization_ref(
             )
             or _text_list(readback.get("execution_order_event_ids")),
             "execution_ids": _text_list(readback.get("execution_ids")),
+            "execution_tca_metric_ids": _text_list(
+                readback.get("runtime_ledger_execution_tca_metric_ids")
+            )
+            or _text_list(readback.get("execution_tca_metric_ids")),
             "trade_decision_ids": _text_list(readback.get("trade_decision_ids")),
             "source_offsets": _source_offsets(readback.get("source_offsets")),
             "authority_classes": _text_list(readback.get("authority_classes")),
@@ -1416,6 +1420,12 @@ def _runtime_import_readback_blockers(
             blockers.append("runtime_ledger_execution_order_event_refs_missing")
         if not _text_list(readback.get("execution_ids")):
             blockers.append("runtime_ledger_execution_refs_missing")
+        if not (
+            _text_list(readback.get("runtime_ledger_execution_tca_metric_ids"))
+            or _text_list(readback.get("execution_tca_metric_ids"))
+        ):
+            blockers.append("runtime_ledger_execution_tca_refs_missing")
+            blockers.append("execution_tca_missing")
         if not _text_list(readback.get("trade_decision_ids")):
             blockers.append("runtime_ledger_trade_decision_refs_missing")
         if not _source_offsets(readback.get("source_offsets")):

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -80,9 +80,13 @@ EXACT_REPLAY_ARTIFACT_AUTHORITY_BLOCKERS = (
 RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
 RUNTIME_LEDGER_CARRY_IN_LOOKBACK = timedelta(days=5)
 RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
+RUNTIME_LEDGER_EXECUTION_TCA_REFS_MISSING_BLOCKER = (
+    "runtime_ledger_execution_tca_refs_missing"
+)
 RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER = (
     "runtime_ledger_authority_class_missing"
 )
+EXECUTION_TCA_MISSING_BLOCKER = "execution_tca_missing"
 _RUNTIME_LEDGER_PROMOTION_GRADE_AUTHORITY_MARKERS = frozenset(
     {
         "runtime_order_feed_execution_source",
@@ -1064,6 +1068,28 @@ def _runtime_ledger_bucket_profit_proof_blockers(
         add("runtime_ledger_schema_not_supported")
     for blocker in runtime_ledger_promotion_source_authority_blockers(bucket):
         add(blocker)
+    execution_count = _nonnegative_int(
+        _as_mapping(bucket.get("source_row_counts")).get("executions")
+    )
+    tca_count = _nonnegative_int(
+        _as_mapping(bucket.get("source_row_counts")).get("execution_tca_metrics")
+    )
+    execution_tca_ref_count = len(
+        _metadata_text_list(bucket.get("execution_tca_metric_ids"))
+        or _metadata_text_list(bucket.get("execution_tca_metric_refs"))
+        or _metadata_text_list(bucket.get("execution_tca_metrics"))
+    )
+    execution_tca_required = (
+        _first_bool(bucket, "execution_tca_required", "requires_execution_tca") is True
+        or tca_count > 0
+    )
+    if (
+        execution_tca_required
+        and execution_count > 0
+        and (tca_count < execution_count or execution_tca_ref_count < execution_count)
+    ):
+        add(EXECUTION_TCA_MISSING_BLOCKER)
+        add(RUNTIME_LEDGER_EXECUTION_TCA_REFS_MISSING_BLOCKER)
     for blocker in _metadata_text_list(bucket.get("blockers")):
         add(blocker)
     if _first_bool(bucket, "order_feed_lifecycle_complete") is False:
@@ -1213,6 +1239,7 @@ def _with_runtime_ledger_source_authority_context(
     source_row_counts: Mapping[str, int],
     trade_decision_ids: Sequence[object] = (),
     execution_ids: Sequence[object] = (),
+    execution_tca_metric_ids: Sequence[object] = (),
     execution_order_event_ids: Sequence[object] = (),
     source_window_ids: Sequence[object] = (),
     source_offsets: Sequence[Mapping[str, object]] = (),
@@ -1222,6 +1249,7 @@ def _with_runtime_ledger_source_authority_context(
     source_window_gap_ranges: Sequence[Mapping[str, object]] = (),
     order_feed_lifecycle_complete: bool | None = None,
     execution_economics_complete: bool | None = None,
+    execution_tca_required: bool | None = None,
     source_materialization: str | None = None,
     authority_class: str | None = None,
     authority_reason: str | None = None,
@@ -1235,6 +1263,7 @@ def _with_runtime_ledger_source_authority_context(
     for key, values in (
         ("trade_decision_ids", trade_decision_ids),
         ("execution_ids", execution_ids),
+        ("execution_tca_metric_ids", execution_tca_metric_ids),
         ("execution_order_event_ids", execution_order_event_ids),
         ("source_window_ids", source_window_ids),
     ):
@@ -1307,6 +1336,8 @@ def _with_runtime_ledger_source_authority_context(
         payload["order_feed_lifecycle_complete"] = order_feed_lifecycle_complete
     if execution_economics_complete is not None:
         payload["execution_economics_complete"] = execution_economics_complete
+    if execution_tca_required is not None:
+        payload["execution_tca_required"] = execution_tca_required
     if source_materialization:
         payload.setdefault("source_materialization", source_materialization)
     if authority_class:
@@ -1477,6 +1508,30 @@ def _decision_lifecycle_query_row_has_time(row: Sequence[object]) -> bool:
 
 
 def _execution_query_row(row: Sequence[object]) -> dict[str, object]:
+    if len(row) >= 20:
+        return {
+            "execution_id": str(row[0]),
+            "trade_decision_id": str(row[1]),
+            "decision_created_at": row[2],
+            "computed_at": row[3],
+            "execution_event_at": row[3],
+            "execution_created_at": row[4],
+            "symbol": row[5],
+            "side": row[6],
+            "filled_qty": row[7],
+            "avg_fill_price": row[8],
+            "shortfall_notional": row[9],
+            "execution_audit_json": row[10],
+            "raw_order": row[11],
+            "account_label": row[12],
+            "strategy_id": row[13],
+            "decision_hash": row[14],
+            "decision_json": row[15],
+            "alpaca_order_id": row[16],
+            "client_order_id": row[17],
+            "order_status": row[18],
+            "execution_tca_metric_id": str(row[19]) if row[19] is not None else None,
+        }
     if len(row) >= 19:
         return {
             "execution_id": str(row[0]),
@@ -3126,6 +3181,31 @@ def _execution_fill_economics_order_ids(
     return order_ids
 
 
+def _execution_tca_order_ids(
+    rows: Sequence[Mapping[str, object]],
+) -> set[str]:
+    order_ids: set[str] = set()
+    for row in rows:
+        if not _execution_row_has_fill(row):
+            continue
+        if (
+            _first_text(
+                row,
+                "execution_tca_metric_id",
+                "execution_tca_metric_ref",
+                "execution_tca_id",
+                "tca_metric_id",
+                "tca_id",
+            )
+            is None
+        ):
+            continue
+        order_id = _runtime_order_id(row)
+        if order_id is not None:
+            order_ids.add(order_id)
+    return order_ids
+
+
 def _runtime_source_context_for_bucket(
     *,
     bucket: RuntimeLedgerBucket,
@@ -3217,12 +3297,31 @@ def _runtime_source_context_for_bucket(
     execution_fill_order_ids = _execution_fill_economics_order_ids(
         bucket_execution_rows
     )
+    execution_tca_order_ids = _execution_tca_order_ids(bucket_execution_rows)
+    execution_tca_required = any(
+        _execution_row_has_fill(row)
+        and any(
+            key in row
+            for key in (
+                "execution_tca_metric_id",
+                "execution_tca_metric_ref",
+                "execution_tca_id",
+                "tca_metric_id",
+                "tca_id",
+            )
+        )
+        for row in bucket_execution_rows
+    )
     order_feed_fill_economics_complete = bool(
         expected_execution_fill_order_ids
     ) and expected_execution_fill_order_ids.issubset(event_sourced_fill_order_ids)
     execution_fill_economics_complete = bool(
         expected_execution_fill_order_ids
     ) and expected_execution_fill_order_ids.issubset(execution_fill_order_ids)
+    execution_tca_complete = bool(
+        expected_execution_fill_order_ids
+    ) and expected_execution_fill_order_ids.issubset(execution_tca_order_ids)
+    execution_tca_satisfied = (not execution_tca_required) or execution_tca_complete
     source_backed_fill_lifecycle_complete = bool(
         expected_execution_fill_order_ids
     ) and expected_execution_fill_order_ids.issubset(
@@ -3262,11 +3361,21 @@ def _runtime_source_context_for_bucket(
             expected_order_ids=expected_execution_fill_order_ids,
         )
     )
+    execution_tca_metric_ids = _source_identifier_values(
+        bucket_execution_rows,
+        "execution_tca_metric_id",
+        "execution_tca_metric_ref",
+        "execution_tca_id",
+        "tca_metric_id",
+        "tca_id",
+    )
     source_row_counts = {
         "trade_decisions": len(bucket_decision_rows),
         "executions": len(bucket_execution_rows),
         "execution_order_events": required_order_lifecycle_source_row_count,
     }
+    if execution_tca_metric_ids:
+        source_row_counts["execution_tca_metrics"] = len(execution_tca_metric_ids)
     if source_window_ids:
         source_row_counts["order_feed_source_windows"] = len(source_window_ids)
     elif required_order_lifecycle_source_row_count > 0:
@@ -3276,6 +3385,7 @@ def _runtime_source_context_for_bucket(
         for table, ref in (
             ("trade_decisions", "postgres:trade_decisions"),
             ("executions", "postgres:executions"),
+            ("execution_tca_metrics", "postgres:execution_tca_metrics"),
             ("execution_order_events", "postgres:execution_order_events"),
             ("order_feed_source_windows", "postgres:order_feed_source_windows"),
         )
@@ -3300,12 +3410,14 @@ def _runtime_source_context_for_bucket(
         "execution_order_event_id",
     )
     if source_offsets and execution_order_event_ids:
-        if order_feed_fill_economics_complete:
+        if order_feed_fill_economics_complete and execution_tca_satisfied:
             source_materialization = "execution_order_events"
             authority_class = "runtime_order_feed_execution_source"
             authority_reason = "event_sourced_runtime_ledger_profit_proof"
         elif (
-            execution_fill_economics_complete and source_backed_order_lifecycle_complete
+            execution_fill_economics_complete
+            and execution_tca_satisfied
+            and source_backed_order_lifecycle_complete
         ):
             source_materialization = "source_execution_lifecycle"
             authority_class = "source_execution_lifecycle_materialized_runtime_ledger"
@@ -3339,6 +3451,7 @@ def _runtime_source_context_for_bucket(
             [*bucket_execution_rows, *bucket_order_rows],
             "execution_id",
         ),
+        "execution_tca_metric_ids": execution_tca_metric_ids,
         "execution_order_event_ids": execution_order_event_ids,
         "source_window_status_counts": source_window_status_counts,
         "source_window_classification_counts": source_window_classification_counts,
@@ -3350,8 +3463,11 @@ def _runtime_source_context_for_bucket(
         "authority_reason": authority_reason,
         "order_feed_lifecycle_complete": source_backed_order_lifecycle_complete,
         "fill_economics_complete": (
-            order_feed_fill_economics_complete or execution_fill_economics_complete
+            (order_feed_fill_economics_complete or execution_fill_economics_complete)
+            and execution_tca_satisfied
         ),
+        "execution_tca_required": execution_tca_required,
+        "execution_tca_complete": execution_tca_complete,
         "order_feed_fill_lifecycle_blockers": _order_feed_fill_lifecycle_blockers(
             execution_rows=bucket_execution_rows,
             order_lifecycle_rows=bucket_order_rows,
@@ -3911,6 +4027,9 @@ def _build_realized_strategy_pnl_rows(
         source_row_counts = cast(dict[str, int], source_context["source_row_counts"])
         trade_decision_ids = cast(list[str], source_context["trade_decision_ids"])
         execution_ids = cast(list[str], source_context["execution_ids"])
+        execution_tca_metric_ids = cast(
+            list[str], source_context["execution_tca_metric_ids"]
+        )
         execution_order_event_ids = cast(
             list[str], source_context["execution_order_event_ids"]
         )
@@ -3939,9 +4058,30 @@ def _build_realized_strategy_pnl_rows(
             source_context["order_feed_lifecycle_complete"]
         )
         fill_economics_complete = bool(source_context["fill_economics_complete"])
+        execution_tca_required = bool(source_context["execution_tca_required"])
+        execution_tca_complete = bool(source_context["execution_tca_complete"])
         bucket_order_feed_fill_lifecycle_blockers = cast(
             list[str], source_context["order_feed_fill_lifecycle_blockers"]
         )
+        bucket_source_materialization_blockers = list(
+            bucket_order_feed_fill_lifecycle_blockers
+        )
+        if (
+            execution_tca_required
+            and not execution_tca_complete
+            and EXECUTION_TCA_MISSING_BLOCKER
+            not in bucket_source_materialization_blockers
+        ):
+            bucket_source_materialization_blockers.append(EXECUTION_TCA_MISSING_BLOCKER)
+        if (
+            execution_tca_required
+            and not execution_tca_complete
+            and RUNTIME_LEDGER_EXECUTION_TCA_REFS_MISSING_BLOCKER
+            not in bucket_source_materialization_blockers
+        ):
+            bucket_source_materialization_blockers.append(
+                RUNTIME_LEDGER_EXECUTION_TCA_REFS_MISSING_BLOCKER
+            )
         equity_denominator = cast(
             tuple[Decimal, str] | None, source_context["equity_denominator"]
         )
@@ -3994,6 +4134,7 @@ def _build_realized_strategy_pnl_rows(
                 source_row_counts=source_row_counts,
                 trade_decision_ids=trade_decision_ids,
                 execution_ids=execution_ids,
+                execution_tca_metric_ids=execution_tca_metric_ids,
                 execution_order_event_ids=execution_order_event_ids,
                 source_window_ids=source_window_ids,
                 source_offsets=source_offsets,
@@ -4003,6 +4144,7 @@ def _build_realized_strategy_pnl_rows(
                 source_window_gap_ranges=source_window_gap_ranges,
                 order_feed_lifecycle_complete=order_feed_lifecycle_complete,
                 execution_economics_complete=fill_economics_complete,
+                execution_tca_required=execution_tca_required,
                 source_materialization=source_materialization,
                 authority_class=authority_class,
                 authority_reason=authority_reason,
@@ -4011,7 +4153,7 @@ def _build_realized_strategy_pnl_rows(
         source_backed_runtime_ledger = (
             allow_authoritative_runtime_ledger_materialization
             and fill_economics_complete
-            and not bucket_order_feed_fill_lifecycle_blockers
+            and not bucket_source_materialization_blockers
             and isinstance(bucket_payload, Mapping)
             and not runtime_ledger_promotion_source_authority_blockers(bucket_payload)
         )
@@ -4085,7 +4227,7 @@ def _build_realized_strategy_pnl_rows(
                 "execution_reconstruction_not_runtime_ledger_proof"
             )
             blockers = list(row.get("runtime_ledger_blockers") or [])
-            for blocker in bucket_order_feed_fill_lifecycle_blockers:
+            for blocker in bucket_source_materialization_blockers:
                 if blocker not in blockers:
                     blockers.append(blocker)
             if isinstance(bucket_payload, Mapping):
@@ -4998,7 +5140,8 @@ def _query_timestamps(
                     d.decision_json,
                     e.alpaca_order_id,
                     e.client_order_id,
-                    e.status
+                    e.status,
+                    t.id
                 from executions e
                 join trade_decisions d on d.id = e.trade_decision_id
                 join strategies s on s.id = d.strategy_id
@@ -5309,7 +5452,8 @@ def _query_timestamps(
                         d.decision_json,
                         e.alpaca_order_id,
                         e.client_order_id,
-                        e.status
+                        e.status,
+                        t.id
                     from executions e
                     join trade_decisions d on d.id = e.trade_decision_id
                     join strategies s on s.id = d.strategy_id

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -291,6 +291,7 @@ def _runtime_import(
             if authoritative
             else [],
             "execution_ids": ["execution-1"] if authoritative else [],
+            "execution_tca_metric_ids": ["tca-1"] if authoritative else [],
             "trade_decision_ids": ["decision-1"] if authoritative else [],
             "source_offsets": [
                 {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
@@ -610,6 +611,44 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         self.assertEqual(packet._decimal(Decimal("12.5")), Decimal("12.5"))
         self.assertIsNone(packet._decimal("not-a-number"))
+
+    def test_runtime_import_readback_blocks_missing_execution_tca_refs(self) -> None:
+        blockers = packet._runtime_import_readback_blockers(
+            target={
+                "metric_window_count": 0,
+                "promotion_decision_count": 0,
+                "runtime_ledger_bucket_count": 0,
+                "evidence_grade_runtime_ledger_bucket_count": 0,
+            },
+            readback={
+                "schema_version": "torghut.runtime-window-import-readback.v1",
+                "metric_window_count": 0,
+                "promotion_decision_count": 0,
+                "runtime_ledger_bucket_count": 0,
+                "evidence_grade_runtime_ledger_bucket_count": 0,
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "runtime_ledger_source_window_ids": ["source-window-1"],
+                "runtime_ledger_execution_order_event_ids": ["event-1"],
+                "execution_ids": ["execution-1"],
+                "trade_decision_ids": ["decision-1"],
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                ],
+                "source_materializations": ["execution_order_events"],
+                "authority_classes": ["runtime_order_feed_execution_source"],
+                "runtime_ledger_cost_amount": "0.01",
+                "cost_basis_counts": {"broker_reported_commission_and_fees": 1},
+            },
+            profit_proof_count=1,
+        )
+
+        self.assertIn("runtime_ledger_execution_tca_refs_missing", blockers)
+        self.assertIn("execution_tca_missing", blockers)
 
     def test_ceph_client_from_env_uses_direct_empirical_endpoint(self) -> None:
         with patch.dict(
@@ -3149,6 +3188,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                             "runtime_ledger_source_window_ids": ["source-window-1"],
                             "runtime_ledger_execution_order_event_ids": ["event-1"],
                             "execution_ids": ["execution-1"],
+                            "execution_tca_metric_ids": ["tca-1"],
                             "trade_decision_ids": ["decision-1"],
                             "source_offsets": [
                                 {

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -361,6 +361,7 @@ def _complete_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
         "source_row_counts": {
             "trade_decisions": 2,
             "executions": 2,
+            "execution_tca_metrics": 2,
             "execution_order_events": 4,
             "order_feed_source_windows": 4,
         },
@@ -372,6 +373,7 @@ def _complete_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
         ],
         "trade_decision_ids": ["decision-buy", "decision-sell"],
         "execution_ids": ["execution-buy", "execution-sell"],
+        "execution_tca_metric_ids": ["tca-buy", "tca-sell"],
         "execution_order_event_ids": [
             "event-new-buy",
             "event-fill-buy",
@@ -477,6 +479,7 @@ def _source_backed_runtime_split_rows(
                     "execution_event_at": _runtime_split_ts(minute),
                     "execution_created_at": _runtime_split_ts(minute),
                     "execution_id": execution_id,
+                    "execution_tca_metric_id": f"tca-{execution_id}",
                     "side": side,
                     "filled_qty": "1",
                     "avg_fill_price": price,
@@ -1047,6 +1050,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             source_refs=[
                 "postgres:trade_decisions",
                 "postgres:executions",
+                "postgres:execution_tca_metrics",
                 "postgres:execution_order_events",
                 "postgres:order_feed_source_windows",
             ],
@@ -1103,17 +1107,20 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             source_refs=[
                 "postgres:trade_decisions",
                 "postgres:executions",
+                "postgres:execution_tca_metrics",
                 "postgres:execution_order_events",
                 "postgres:order_feed_source_windows",
             ],
             source_row_counts={
                 "trade_decisions": 2,
                 "executions": 2,
+                "execution_tca_metrics": 2,
                 "execution_order_events": 4,
                 "order_feed_source_windows": 4,
             },
             trade_decision_ids=["decision-buy", "decision-sell"],
             execution_ids=["execution-buy", "execution-sell"],
+            execution_tca_metric_ids=["tca-buy", "tca-sell"],
             execution_order_event_ids=[
                 "event-new-buy",
                 "event-fill-buy",
@@ -1142,6 +1149,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             bucket["source_row_counts"],
             {
                 "execution_order_events": 4,
+                "execution_tca_metrics": 2,
                 "executions": 2,
                 "order_feed_source_windows": 4,
                 "trade_decisions": 2,
@@ -1200,6 +1208,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             bucket["source_row_counts"],
             {
                 "execution_order_events": 4,
+                "execution_tca_metrics": 2,
                 "executions": 2,
                 "order_feed_source_windows": 4,
                 "trade_decisions": 2,
@@ -1252,6 +1261,40 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("execution_economics_missing", row["runtime_ledger_blockers"])
         self.assertIn("runtime_fills_missing", row["runtime_ledger_blockers"])
         self.assertNotIn("order_feed_lifecycle_missing", row["runtime_ledger_blockers"])
+
+    def test_source_backed_lifecycle_blocks_missing_execution_tca_refs(
+        self,
+    ) -> None:
+        decision_rows, order_rows, execution_rows = _source_backed_runtime_split_rows()
+        for row in execution_rows:
+            row["execution_tca_metric_id"] = None
+
+        rows = _build_realized_strategy_pnl_rows(
+            execution_rows,
+            decision_lifecycle_rows=decision_rows,
+            order_lifecycle_rows=order_rows,
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertFalse(row["authoritative"])
+        self.assertFalse(row["post_cost_promotion_eligible"])
+        self.assertIn("execution_tca_missing", row["runtime_ledger_blockers"])
+        self.assertIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            row["runtime_ledger_blockers"],
+        )
+        bucket = row["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertTrue(bucket["execution_tca_required"])
+        self.assertIn("execution_tca_missing", bucket["blockers"])
+        self.assertIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            _runtime_ledger_bucket_profit_proof_blockers(bucket),
+        )
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_execution_economics_without_order_lifecycle_blocks_missing_lifecycle(
         self,
@@ -2723,6 +2766,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-buy",
                     "alpaca_order_id": "order-buy",
+                    "execution_tca_metric_id": "tca-buy",
                     "execution_policy_hash": "policy-buy",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
@@ -2739,6 +2783,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-sell",
                     "alpaca_order_id": "order-sell",
+                    "execution_tca_metric_id": "tca-sell",
                     "execution_policy_hash": "policy-sell",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
@@ -2859,6 +2904,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-buy",
                     "alpaca_order_id": "order-buy",
+                    "execution_tca_metric_id": "tca-buy",
                     "execution_policy_hash": "policy-buy",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
@@ -2876,6 +2922,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-sell",
                     "alpaca_order_id": "order-sell",
+                    "execution_tca_metric_id": "tca-sell",
                     "execution_policy_hash": "policy-sell",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
@@ -3038,6 +3085,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             [
                 "postgres:trade_decisions",
                 "postgres:executions",
+                "postgres:execution_tca_metrics",
                 "postgres:execution_order_events",
                 "postgres:order_feed_source_windows",
             ],
@@ -3046,6 +3094,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             bucket["source_row_counts"],
             {
                 "executions": 2,
+                "execution_tca_metrics": 2,
                 "execution_order_events": 4,
                 "order_feed_source_windows": 4,
                 "trade_decisions": 2,
@@ -3069,6 +3118,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "event-fill-sell",
             ],
         )
+        self.assertEqual(bucket["execution_tca_metric_ids"], ["tca-buy", "tca-sell"])
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_build_realized_strategy_pnl_rows_uses_source_backed_carry_in(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -95,11 +95,13 @@ def _runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
         "source_row_counts": {
             "trade_decisions": 2,
             "executions": 2,
+            "execution_tca_metrics": 2,
             "execution_order_events": 2,
             "order_feed_source_windows": 2,
         },
         "trade_decision_ids": ["decision-buy", "decision-sell"],
         "execution_ids": ["execution-buy", "execution-sell"],
+        "execution_tca_metric_ids": ["tca-buy", "tca-sell"],
         "execution_order_event_ids": ["event-fill-buy", "event-fill-sell"],
         "source_window_ids": ["source-window-buy", "source-window-sell"],
         "source_offsets": [
@@ -993,6 +995,88 @@ class TestRuntimeWindowImport(TestCase):
         self.assertTrue(_persisted_runtime_ledger_bucket_evidence_grade(row))
         row.payload_json = {**source_backed_payload, "authority_reason": None}
         self.assertFalse(_persisted_runtime_ledger_bucket_evidence_grade(row))
+
+    def test_runtime_window_readback_counts_only_source_backed_mixed_rows(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        source_backed_payload = _runtime_ledger_bucket()
+        aggregate_only_payload = {
+            key: value
+            for key, value in source_backed_payload.items()
+            if key
+            not in {
+                "trade_decision_ids",
+                "execution_ids",
+                "execution_tca_metric_ids",
+                "execution_order_event_ids",
+                "source_window_ids",
+                "source_offsets",
+                "source_materialization",
+                "authority_class",
+                "authority_reason",
+            }
+        }
+
+        ledger_rows = [
+            StrategyRuntimeLedgerBucket(
+                run_id="mixed-source-runtime",
+                candidate_id="cand",
+                hypothesis_id="hyp",
+                observed_stage="paper",
+                bucket_started_at=window_start,
+                bucket_ended_at=window_end,
+                account_label="TORGHUT_SIM",
+                runtime_strategy_name="strategy",
+                fill_count=2,
+                decision_count=2,
+                submitted_order_count=2,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("200"),
+                gross_strategy_pnl=Decimal("1"),
+                cost_amount=Decimal("0.20"),
+                net_strategy_pnl_after_costs=Decimal("0.80"),
+                post_cost_expectancy_bps=Decimal("40"),
+                pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                execution_policy_hash_counts={"policy-sha": 2},
+                cost_model_hash_counts={"cost-sha": 2},
+                lineage_hash_counts={"lineage-sha": 2},
+                blockers_json=[],
+                payload_json=payload,
+            )
+            for payload in (source_backed_payload, aggregate_only_payload)
+        ]
+
+        readback = _runtime_window_import_readback_from_rows(
+            run_id="mixed-source-runtime",
+            candidate_id="cand",
+            hypothesis_id="hyp",
+            observed_stage="paper",
+            window_start=window_start,
+            window_end=window_end,
+            metric_rows=[],
+            promotion_rows=[],
+            ledger_rows=ledger_rows,
+            runtime_ledger_daily_summary={},
+            proof_blocker_codes=[],
+        )
+
+        self.assertEqual(readback["runtime_ledger_bucket_count"], 2)
+        self.assertEqual(readback["evidence_grade_runtime_ledger_bucket_count"], 1)
+        self.assertEqual(readback["execution_tca_metric_ids"], ["tca-buy", "tca-sell"])
+        distance = readback["runtime_ledger_profit_distance_readback"]
+        assert isinstance(distance, dict)
+        self.assertEqual(
+            distance["source_authority"]["source_backed_bucket_count"],
+            1,
+        )
+        self.assertEqual(
+            distance["source_authority"]["blocked_bucket_count"],
+            1,
+        )
 
     def test_runtime_window_import_readback_normalizes_source_offsets(
         self,


### PR DESCRIPTION
## Summary

- Thread execution TCA metric row references through source-backed runtime-ledger materialization and runtime-window readback.
- Require current source-query execution rows to carry execution TCA refs before H-PAIRS runtime buckets can become promotion-grade evidence.
- Surface exact missing-TCA blockers in importer/proof-packet readback without weakening existing source-window, order-feed, execution, cost, closed-trip, or authority gates.
- Add focused tests for missing TCA blockers and mixed source/aggregate readback counting only source-backed evidence-grade rows.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
