### PR TITLE
fix(torghut): bound account scope readiness catalog checks

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -27,7 +27,6 @@ from urllib.parse import urlencode, urlsplit
 from .alpaca_client import TorghutAlpacaClient
 from .config import settings
 from .db import SessionLocal, check_schema_current, ensure_schema, get_session, ping
-from .db import check_account_scope_invariants
 from .metrics import render_trading_metrics
 from .models import (
     Execution,
@@ -1852,13 +1851,268 @@ def _resolve_universe_resolver_for_readiness(scheduler: TradingScheduler) -> Any
     return None
 
 
+_ACCOUNT_SCOPE_STATEMENT_TIMEOUT_MS = 750
+
+
+def _execute_readiness_account_scope_query(
+    session: Session,
+    sql: str,
+    *,
+    table_names: Sequence[str] | None = None,
+) -> list[Mapping[str, object]]:
+    statement = text(sql)
+    params: dict[str, object] = {}
+    if table_names is not None:
+        statement = statement.bindparams(bindparam("table_names", expanding=True))
+        params["table_names"] = list(table_names)
+    return [
+        cast(Mapping[str, object], row)
+        for row in session.execute(statement, params).mappings().all()
+    ]
+
+
+def _check_account_scope_invariants_bounded(session: Session) -> dict[str, object]:
+    """Validate account-scope invariants using bounded catalog reads only.
+
+    SQLAlchemy's generic inspector can reflect PostgreSQL domains while reading
+    unique constraints. In production that path can exceed the readiness
+    statement timeout before /readyz reaches the actual accounting blockers. This
+    helper keeps the same account-scope truth table but queries only the narrow
+    pg_catalog/information_schema rows required by the readiness contract.
+    """
+
+    session.execute(
+        text(f"SET LOCAL statement_timeout = {_ACCOUNT_SCOPE_STATEMENT_TIMEOUT_MS}")
+    )
+    required_columns: dict[str, tuple[str, list[str]]] = {
+        "executions_have_account_label": (
+            "executions",
+            ["alpaca_account_label"],
+        ),
+        "trade_decisions_have_account_label": (
+            "trade_decisions",
+            ["alpaca_account_label"],
+        ),
+        "trade_cursor_has_account_label": ("trade_cursor", ["account_label"]),
+        "execution_order_events_have_account_label": (
+            "execution_order_events",
+            ["alpaca_account_label"],
+        ),
+    }
+    table_names = sorted(
+        {table for table, _columns in required_columns.values()}
+        | {"executions", "trade_decisions", "trade_cursor"}
+    )
+
+    column_rows = _execute_readiness_account_scope_query(
+        session,
+        """
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name IN :table_names
+        """,
+        table_names=table_names,
+    )
+    columns_by_table: dict[str, set[str]] = {}
+    for row in column_rows:
+        table = str(row["table_name"]).strip().lower()
+        column = str(row["column_name"]).strip().lower()
+        columns_by_table.setdefault(table, set()).add(column)
+
+    unique_index_rows = _execute_readiness_account_scope_query(
+        session,
+        """
+        SELECT
+          tbl.relname AS table_name,
+          idx.relname AS index_name,
+          array_agg(att.attname ORDER BY ord.ordinality) AS column_names
+        FROM pg_catalog.pg_index ix
+        JOIN pg_catalog.pg_class idx ON idx.oid = ix.indexrelid
+        JOIN pg_catalog.pg_class tbl ON tbl.oid = ix.indrelid
+        JOIN pg_catalog.pg_namespace ns ON ns.oid = tbl.relnamespace
+        JOIN unnest(ix.indkey) WITH ORDINALITY AS ord(attnum, ordinality) ON true
+        JOIN pg_catalog.pg_attribute att
+          ON att.attrelid = tbl.oid
+         AND att.attnum = ord.attnum
+        WHERE ns.nspname = current_schema()
+          AND tbl.relname IN :table_names
+          AND ix.indisunique
+          AND ix.indpred IS NULL
+        GROUP BY tbl.relname, idx.relname
+        """,
+        table_names=table_names,
+    )
+    unique_indexes_by_table: dict[str, list[tuple[str, set[str]]]] = {}
+    for row in unique_index_rows:
+        table = str(row["table_name"]).strip().lower()
+        index_name = str(row["index_name"]).strip().lower()
+        raw_columns = cast(Sequence[object], row["column_names"] or [])
+        column_names = {str(column).strip().lower() for column in raw_columns}
+        unique_indexes_by_table.setdefault(table, []).append((index_name, column_names))
+
+    all_index_rows = _execute_readiness_account_scope_query(
+        session,
+        """
+        SELECT tablename AS table_name, indexname AS index_name
+        FROM pg_catalog.pg_indexes
+        WHERE schemaname = current_schema()
+          AND tablename IN :table_names
+        """,
+        table_names=table_names,
+    )
+    index_names_by_table: dict[str, list[str]] = {}
+    for row in all_index_rows:
+        table = str(row["table_name"]).strip().lower()
+        index_name = str(row["index_name"]).strip().lower()
+        index_names_by_table.setdefault(table, []).append(index_name)
+
+    legacy_constraint_rows = _execute_readiness_account_scope_query(
+        session,
+        """
+        SELECT tbl.relname AS table_name, con.conname AS constraint_name
+        FROM pg_catalog.pg_constraint con
+        JOIN pg_catalog.pg_class tbl ON tbl.oid = con.conrelid
+        JOIN pg_catalog.pg_namespace ns ON ns.oid = tbl.relnamespace
+        WHERE ns.nspname = current_schema()
+          AND tbl.relname IN :table_names
+          AND con.contype = 'u'
+        """,
+        table_names=table_names,
+    )
+    legacy_constraints_by_table: dict[str, set[str]] = {}
+    for row in legacy_constraint_rows:
+        table = str(row["table_name"]).strip().lower()
+        constraint_name = str(row["constraint_name"]).strip().lower()
+        legacy_constraints_by_table.setdefault(table, set()).add(constraint_name)
+
+    def _has_columns(table: str, columns: Sequence[str]) -> bool:
+        available = columns_by_table.get(table, set())
+        return all(str(column).strip().lower() in available for column in columns)
+
+    def _has_unique_index(table: str, columns: Sequence[str]) -> bool:
+        expected = {str(column).strip().lower() for column in columns}
+        return any(
+            index_columns == expected
+            for _index_name, index_columns in unique_indexes_by_table.get(table, [])
+        )
+
+    def _named_unique_constraint_present(table: str, names: set[str]) -> bool:
+        normalized_names = {name.strip().lower() for name in names}
+        return bool(
+            legacy_constraints_by_table.get(table, set()).intersection(normalized_names)
+        )
+
+    checks: dict[str, object] = {}
+    errors: list[str] = []
+
+    for key, (table, columns) in required_columns.items():
+        ok = _has_columns(table, columns)
+        checks[key] = ok
+        if not ok:
+            errors.append(f"{table} missing required columns: {columns}")
+
+    checks["execution_has_account_scoped_unique_order_id"] = _has_unique_index(
+        "executions",
+        ["alpaca_account_label", "alpaca_order_id"],
+    )
+    if not checks["execution_has_account_scoped_unique_order_id"]:
+        errors.append(
+            "executions missing unique index on (alpaca_account_label, alpaca_order_id)"
+        )
+
+    checks["execution_has_account_scoped_unique_client_order_id"] = _has_unique_index(
+        "executions",
+        ["alpaca_account_label", "client_order_id"],
+    )
+    if not checks["execution_has_account_scoped_unique_client_order_id"]:
+        errors.append(
+            "executions missing unique index on (alpaca_account_label, client_order_id)"
+        )
+
+    checks["trade_decision_has_account_scoped_unique_decision_hash"] = (
+        _has_unique_index(
+            "trade_decisions",
+            ["alpaca_account_label", "decision_hash"],
+        )
+    )
+    if not checks["trade_decision_has_account_scoped_unique_decision_hash"]:
+        errors.append(
+            "trade_decisions missing unique index on "
+            "(alpaca_account_label, decision_hash)"
+        )
+
+    checks["trade_cursor_has_account_scoped_source_index"] = _has_unique_index(
+        "trade_cursor",
+        ["source", "account_label"],
+    )
+    if not checks["trade_cursor_has_account_scoped_source_index"]:
+        errors.append("trade_cursor missing unique index on (source, account_label)")
+
+    checks["legacy_executions_single_account_order_id_index_detected"] = (
+        _has_unique_index("executions", ["alpaca_order_id"])
+        or _named_unique_constraint_present(
+            "executions",
+            {"executions_alpaca_order_id_key"},
+        )
+    )
+    if checks["legacy_executions_single_account_order_id_index_detected"]:
+        errors.append(
+            "legacy unique constraint/index detected for executions.alpaca_order_id"
+        )
+
+    checks["legacy_executions_single_account_client_order_id_index_detected"] = (
+        _has_unique_index("executions", ["client_order_id"])
+        or _named_unique_constraint_present(
+            "executions",
+            {"executions_client_order_id_key"},
+        )
+    )
+    if checks["legacy_executions_single_account_client_order_id_index_detected"]:
+        errors.append(
+            "legacy unique constraint/index detected for executions.client_order_id"
+        )
+
+    checks["legacy_trade_cursor_source_only_source_index_detected"] = _has_unique_index(
+        "trade_cursor", ["source"]
+    ) or _named_unique_constraint_present(
+        "trade_cursor",
+        {"trade_cursor_source_key"},
+    )
+    if checks["legacy_trade_cursor_source_only_source_index_detected"]:
+        errors.append("legacy unique constraint/index detected for trade_cursor.source")
+
+    checks["legacy_executions_single_account_indexes_present"] = (
+        checks["legacy_executions_single_account_order_id_index_detected"]
+        or checks["legacy_executions_single_account_client_order_id_index_detected"]
+    )
+    checks["legacy_trade_cursor_source_only_index_present"] = checks[
+        "legacy_trade_cursor_source_only_source_index_detected"
+    ]
+    checks["account_scope_ready"] = not errors
+    checks["account_scope_index_names"] = {
+        "execution_indexes": sorted(index_names_by_table.get("executions", [])),
+        "trade_decision_indexes": sorted(
+            index_names_by_table.get("trade_decisions", [])
+        ),
+        "trade_cursor_indexes": sorted(index_names_by_table.get("trade_cursor", [])),
+    }
+    checks["account_scope_errors"] = errors
+    checks["account_scope_check_mode"] = "bounded_catalog"
+
+    if errors and not settings.trading_multi_account_enabled:
+        checks["account_scope_ready"] = True
+        checks["account_scope_errors"] = []
+    return checks
+
+
 def _evaluate_database_contract(session: Session) -> dict[str, object]:
     """Collect schema and account-scope readiness checks used by /readyz and /db-check."""
     checked_at = datetime.now(timezone.utc).isoformat()
 
     try:
         schema_status = check_schema_current(session)
-        account_scope_status = check_account_scope_invariants(session)
+        account_scope_status = _check_account_scope_invariants_bounded(session)
     except SQLAlchemyError as exc:
         return {
             "ok": False,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1393,7 +1393,7 @@ class TestTradingApi(TestCase):
         },
     )
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True},
     )
     def test_db_check_reports_schema_heads(
@@ -1447,7 +1447,7 @@ class TestTradingApi(TestCase):
         },
     )
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True},
     )
     def test_db_check_schema_lineage_divergence_returns_503_when_override_disabled(
@@ -1500,7 +1500,7 @@ class TestTradingApi(TestCase):
         },
     )
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True},
     )
     def test_db_check_schema_lineage_warning_returns_200_when_override_enabled(
@@ -1560,7 +1560,7 @@ class TestTradingApi(TestCase):
         },
     )
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True},
     )
     def test_db_check_schema_mismatch_returns_503(
@@ -1590,6 +1590,256 @@ class TestTradingApi(TestCase):
         self.assertEqual(payload["detail"]["schema_head_signature"], "7f8e4d0")
         self.assertIn("checked_at", payload["detail"])
 
+    def test_bounded_account_scope_invariants_uses_catalog_queries(self) -> None:
+        class FakeResult:
+            def __init__(self, rows: list[dict[str, object]]) -> None:
+                self._rows = rows
+
+            def mappings(self) -> "FakeResult":
+                return self
+
+            def all(self) -> list[dict[str, object]]:
+                return self._rows
+
+        class FakeSession:
+            def __init__(self) -> None:
+                self.statements: list[str] = []
+
+            def execute(
+                self,
+                statement: object,
+                _params: dict[str, object] | None = None,
+            ) -> FakeResult:
+                sql = str(statement)
+                self.statements.append(sql)
+                if "SET LOCAL statement_timeout" in sql:
+                    return FakeResult([])
+                if "information_schema.columns" in sql:
+                    return FakeResult(
+                        [
+                            {
+                                "table_name": "executions",
+                                "column_name": "alpaca_account_label",
+                            },
+                            {
+                                "table_name": "trade_decisions",
+                                "column_name": "alpaca_account_label",
+                            },
+                            {
+                                "table_name": "trade_cursor",
+                                "column_name": "account_label",
+                            },
+                            {
+                                "table_name": "execution_order_events",
+                                "column_name": "alpaca_account_label",
+                            },
+                        ]
+                    )
+                if "FROM pg_catalog.pg_index" in sql:
+                    return FakeResult(
+                        [
+                            {
+                                "table_name": "executions",
+                                "index_name": "executions_account_order_uidx",
+                                "column_names": [
+                                    "alpaca_account_label",
+                                    "alpaca_order_id",
+                                ],
+                            },
+                            {
+                                "table_name": "executions",
+                                "index_name": "executions_account_client_uidx",
+                                "column_names": [
+                                    "alpaca_account_label",
+                                    "client_order_id",
+                                ],
+                            },
+                            {
+                                "table_name": "trade_decisions",
+                                "index_name": "trade_decisions_account_hash_uidx",
+                                "column_names": [
+                                    "alpaca_account_label",
+                                    "decision_hash",
+                                ],
+                            },
+                            {
+                                "table_name": "trade_cursor",
+                                "index_name": "trade_cursor_source_account_uidx",
+                                "column_names": ["source", "account_label"],
+                            },
+                        ]
+                    )
+                if "FROM pg_catalog.pg_indexes" in sql:
+                    return FakeResult(
+                        [
+                            {
+                                "table_name": "executions",
+                                "index_name": "executions_account_order_uidx",
+                            },
+                            {
+                                "table_name": "trade_decisions",
+                                "index_name": "trade_decisions_account_hash_uidx",
+                            },
+                            {
+                                "table_name": "trade_cursor",
+                                "index_name": "trade_cursor_source_account_uidx",
+                            },
+                        ]
+                    )
+                if "FROM pg_catalog.pg_constraint" in sql:
+                    return FakeResult([])
+                raise AssertionError(f"unexpected SQL: {sql}")
+
+        fake_session = FakeSession()
+        payload = main_module._check_account_scope_invariants_bounded(fake_session)  # type: ignore[arg-type]
+
+        self.assertTrue(payload["account_scope_ready"])
+        self.assertEqual(payload["account_scope_errors"], [])
+        self.assertEqual(payload["account_scope_check_mode"], "bounded_catalog")
+        joined_sql = "\n".join(fake_session.statements)
+        self.assertIn("SET LOCAL statement_timeout", joined_sql)
+        self.assertNotIn("pg_type", joined_sql)
+
+    def test_bounded_account_scope_invariants_reports_legacy_indexes(self) -> None:
+        class FakeResult:
+            def __init__(self, rows: list[dict[str, object]]) -> None:
+                self._rows = rows
+
+            def mappings(self) -> "FakeResult":
+                return self
+
+            def all(self) -> list[dict[str, object]]:
+                return self._rows
+
+        class FakeSession:
+            def execute(
+                self,
+                statement: object,
+                _params: dict[str, object] | None = None,
+            ) -> FakeResult:
+                sql = str(statement)
+                if "SET LOCAL statement_timeout" in sql:
+                    return FakeResult([])
+                if "information_schema.columns" in sql:
+                    return FakeResult(
+                        [
+                            {
+                                "table_name": "executions",
+                                "column_name": "alpaca_account_label",
+                            },
+                            {
+                                "table_name": "trade_decisions",
+                                "column_name": "alpaca_account_label",
+                            },
+                            {
+                                "table_name": "trade_cursor",
+                                "column_name": "account_label",
+                            },
+                        ]
+                    )
+                if "FROM pg_catalog.pg_index" in sql:
+                    return FakeResult(
+                        [
+                            {
+                                "table_name": "executions",
+                                "index_name": "executions_alpaca_order_id_key",
+                                "column_names": ["alpaca_order_id"],
+                            },
+                            {
+                                "table_name": "executions",
+                                "index_name": "executions_client_order_id_key",
+                                "column_names": ["client_order_id"],
+                            },
+                            {
+                                "table_name": "trade_cursor",
+                                "index_name": "trade_cursor_source_key",
+                                "column_names": ["source"],
+                            },
+                        ]
+                    )
+                if "FROM pg_catalog.pg_indexes" in sql:
+                    return FakeResult(
+                        [
+                            {
+                                "table_name": "executions",
+                                "index_name": "executions_alpaca_order_id_key",
+                            },
+                            {
+                                "table_name": "trade_cursor",
+                                "index_name": "trade_cursor_source_key",
+                            },
+                        ]
+                    )
+                if "FROM pg_catalog.pg_constraint" in sql:
+                    return FakeResult(
+                        [
+                            {
+                                "table_name": "executions",
+                                "constraint_name": "executions_alpaca_order_id_key",
+                            },
+                            {
+                                "table_name": "trade_cursor",
+                                "constraint_name": "trade_cursor_source_key",
+                            },
+                        ]
+                    )
+                raise AssertionError(f"unexpected SQL: {sql}")
+
+        original_multi = settings.trading_multi_account_enabled
+        settings.trading_multi_account_enabled = False
+        try:
+            payload = main_module._check_account_scope_invariants_bounded(FakeSession())  # type: ignore[arg-type]
+        finally:
+            settings.trading_multi_account_enabled = original_multi
+
+        self.assertTrue(payload["account_scope_ready"])
+        self.assertEqual(payload["account_scope_errors"], [])
+        self.assertTrue(
+            payload["legacy_executions_single_account_order_id_index_detected"]
+        )
+        self.assertTrue(
+            payload["legacy_executions_single_account_client_order_id_index_detected"]
+        )
+        self.assertTrue(
+            payload["legacy_trade_cursor_source_only_source_index_detected"]
+        )
+        self.assertFalse(payload["execution_has_account_scoped_unique_order_id"])
+        self.assertFalse(payload["execution_has_account_scoped_unique_client_order_id"])
+        self.assertFalse(
+            payload["trade_decision_has_account_scoped_unique_decision_hash"]
+        )
+        self.assertFalse(payload["trade_cursor_has_account_scoped_source_index"])
+        self.assertFalse(payload["execution_order_events_have_account_label"])
+
+    @patch(
+        "app.main.check_schema_current",
+        return_value={
+            "schema_current": True,
+            "current_heads": ["0011_execution_tca_simulator_divergence"],
+            "expected_heads": ["0011_execution_tca_simulator_divergence"],
+            "schema_head_signature": "7f8e4d0",
+            "schema_missing_heads": [],
+            "schema_unexpected_heads": [],
+            "schema_head_count_expected": 1,
+            "schema_head_count_current": 1,
+            "schema_head_delta_count": 0,
+        },
+    )
+    def test_database_contract_fails_closed_on_account_scope_timeout(
+        self,
+        _mock_check: object,
+    ) -> None:
+        with patch(
+            "app.main._check_account_scope_invariants_bounded",
+            side_effect=SQLAlchemyError("canceling statement due to statement timeout"),
+        ):
+            payload = main_module._evaluate_database_contract(object())  # type: ignore[arg-type]
+
+        self.assertFalse(payload["ok"])
+        self.assertFalse(payload["account_scope_ready"])
+        self.assertIn("statement timeout", payload["account_scope_errors"][0])
+        self.assertEqual(payload["schema_current"], False)
+
     @patch(
         "app.main.check_schema_current",
         return_value={
@@ -1612,7 +1862,7 @@ class TestTradingApi(TestCase):
         settings.trading_multi_account_enabled = True
         try:
             with patch(
-                "app.main.check_account_scope_invariants",
+                "app.main._check_account_scope_invariants_bounded",
                 return_value={
                     "account_scope_ready": False,
                     "account_scope_errors": [
@@ -1655,7 +1905,7 @@ class TestTradingApi(TestCase):
         settings.trading_multi_account_enabled = False
         try:
             with patch(
-                "app.main.check_account_scope_invariants",
+                "app.main._check_account_scope_invariants_bounded",
                 return_value={
                     "account_scope_ready": False,
                     "account_scope_errors": ["legacy unique constraint/index detected"],
@@ -3370,7 +3620,7 @@ class TestTradingApi(TestCase):
                 patch("app.main._check_clickhouse", return_value={"ok": True}),
                 patch("app.main._check_postgres", return_value={"ok": True}),
                 patch(
-                    "app.main.check_account_scope_invariants",
+                    "app.main._check_account_scope_invariants_bounded",
                     return_value={
                         "account_scope_ready": True,
                         "account_scope_errors": [],
@@ -3433,7 +3683,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -3488,7 +3738,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -3554,7 +3804,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -3621,7 +3871,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -3692,7 +3942,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -3761,7 +4011,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -3840,7 +4090,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -4034,7 +4284,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": False, "detail": "down"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -4076,7 +4326,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -4133,7 +4383,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_postgres", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -4189,7 +4439,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_clickhouse", return_value={"ok": True, "detail": "ok"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -4884,7 +5134,7 @@ class TestTradingApi(TestCase):
     @patch("app.main._check_alpaca", return_value={"ok": True, "detail": "ok"})
     @patch("app.main._check_postgres", return_value={"ok": False, "detail": "down"})
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -4944,7 +5194,7 @@ class TestTradingApi(TestCase):
             )
 
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={"account_scope_ready": True, "account_scope_errors": []},
     )
     @patch(
@@ -5076,7 +5326,7 @@ class TestTradingApi(TestCase):
             settings.trading_enabled = original
 
     @patch(
-        "app.main.check_account_scope_invariants",
+        "app.main._check_account_scope_invariants_bounded",
         return_value={
             "account_scope_ready": False,
             "account_scope_errors": ["legacy unique index detected"],


### PR DESCRIPTION
## Summary

- Replace readiness database-contract account-scope reflection with bounded catalog reads for required columns, unique index sets, and legacy unique constraints.
- Keep the check fail-closed under DB/statement-timeout errors while avoiding PostgreSQL `pg_type` domain reflection that made `/readyz` report `dependencies.database.ok=false` during rollout.
- Preserve machine-readable account-scope errors, index names, readiness blockers, and promotion/final-authority suppression semantics.
- Add focused regressions for catalog-only account-scope readiness and fail-closed statement-timeout behavior.

## Related Issues

None. Follow-up to Torghut promotion rollback PR #9715 and runtime readback from release PR #9712.

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q -k 'account_scope or database_contract_fails_closed'`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `git diff --check`

## Screenshots (if applicable)

N/A; backend readiness/health code only.

## Breaking Changes

None. The account-scope readiness check is semantically equivalent but uses bounded direct catalog queries instead of SQLAlchemy reflection.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
