### PR TITLE
feat(torghut): label hpairs discovery frontier stages

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -22,8 +22,8 @@ from app.trading.discovery.microstructure_prefilter import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v5"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v6"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v6"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v7"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -114,6 +114,14 @@ class FastReplayPreviewRow:
         frontier_selection_blockers = _frontier_selection_blockers_for_row(
             self, exact_replay_selection_blockers=exact_replay_selection_blockers
         )
+        exact_replay_qualified = self.selected and not exact_replay_selection_blockers
+        discovery_stage_metadata = _discovery_stage_metadata(
+            selected=self.selected,
+            exact_replay_qualified=exact_replay_qualified,
+            evidence_collection_candidate=exact_replay_qualified,
+            frontier_bucket=self.frontier_bucket,
+            blockers=frontier_selection_blockers or exact_replay_selection_blockers,
+        )
         lineage_blockers = _lineage_blockers_for_row(self)
         risk_flags = _risk_flags_for_row(self, lineage_blockers=lineage_blockers)
         prefilter_capacity_lineage = _mapping(
@@ -155,6 +163,7 @@ class FastReplayPreviewRow:
             ),
             "exploration_score": str(self.exploration_score),
             "frontier_bucket": self.frontier_bucket,
+            "discovery_stage_metadata": discovery_stage_metadata,
             "candidate_frontier_hash": self.candidate_frontier_hash,
             "exact_replay_frontier_key": self.exact_replay_frontier_key,
             "frontier_dedupe_status": self.frontier_dedupe_status,
@@ -168,8 +177,9 @@ class FastReplayPreviewRow:
                 "reason_code": self.selection_reason,
                 "blockers": list(frontier_selection_blockers),
                 "rank": self.rank,
-                "exact_replay_enqueue_allowed": self.selected,
-                "bounded_sim_evidence_enqueue_allowed": self.selected,
+                "exact_replay_enqueue_allowed": exact_replay_qualified,
+                "bounded_sim_evidence_enqueue_allowed": exact_replay_qualified,
+                "discovery_stage_metadata": discovery_stage_metadata,
                 "resource_scope": "local_offline_bounded_queue_metadata_only",
                 "proof_source": "prefilter_only",
                 "prefilter_only": True,
@@ -329,6 +339,7 @@ class FastReplayPreviewResult:
             "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
             "selected_candidate_spec_count": len(self.selected_candidate_spec_ids),
             "selected_row_count": self.selected_row_count,
+            "discovery_stage_semantics": _discovery_stage_semantics(),
             "frontier_dedupe_policy": {
                 "schema_version": "torghut.fast-replay-frontier-dedupe-policy.v1",
                 "status": "enabled",
@@ -382,9 +393,10 @@ class FastReplayPreviewResult:
                 "row_symbols": list(self.replay_tape_manifest.row_symbols),
             },
             "bounded_sim_target_queue": {
-                "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v1",
+                "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v2",
                 "status": "metadata_only_not_dispatched",
                 "queue_scope": "offline_preview_to_exact_replay_or_bounded_sim_handoff",
+                "discovery_stage_semantics": _discovery_stage_semantics(),
                 "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
                 "target_candidate_cap": self.exact_replay_candidate_cap,
                 "enqueue_candidate_count": len(self.selected_candidate_spec_ids),
@@ -1098,6 +1110,63 @@ def _frontier_selection_blockers_for_row(
     if row.selection_reason == "fast_replay_frontier_lineage_blocked":
         return tuple(exact_replay_selection_blockers)
     return ()
+
+
+def _discovery_stage_semantics() -> dict[str, Any]:
+    return {
+        "schema_version": "torghut.hpairs-discovery-stage-semantics.v1",
+        "preview_only_status": "preview_only_ranked",
+        "exact_replay_qualified_status": "exact_replay_qualified_frontier",
+        "evidence_collection_candidate_status": (
+            "bounded_sim_evidence_collection_candidate"
+        ),
+        "authority": "candidate_discovery_only",
+        "preview_output_can_authorize_promotion": False,
+        "exact_replay_frontier_can_authorize_promotion": False,
+        "requires_runtime_ledger_for_promotion": True,
+        "requires_live_paper_evidence_for_final_promotion": True,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_authority_ok": False,
+    }
+
+
+def _discovery_stage_metadata(
+    *,
+    selected: bool,
+    exact_replay_qualified: bool,
+    evidence_collection_candidate: bool,
+    frontier_bucket: str,
+    blockers: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "torghut.hpairs-discovery-stage-metadata.v1",
+        "preview_status": "preview_only_ranked",
+        "preview_only": True,
+        "exact_replay_status": (
+            "exact_replay_qualified_frontier"
+            if exact_replay_qualified
+            else "not_exact_replay_qualified"
+        ),
+        "exact_replay_qualified": exact_replay_qualified,
+        "evidence_collection_status": (
+            "bounded_sim_evidence_collection_candidate"
+            if evidence_collection_candidate
+            else "not_evidence_collection_candidate"
+        ),
+        "evidence_collection_candidate": evidence_collection_candidate,
+        "selected_for_bounded_frontier": selected,
+        "frontier_bucket": frontier_bucket,
+        "blockers": list(blockers),
+        "authority": "candidate_discovery_only",
+        "resource_scope": "local_offline_bounded_queue_metadata_only",
+        "promotion_proof": False,
+        "proof_authority": False,
+        "promotion_authority": False,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_authority_ok": False,
+    }
 
 
 def _row_exact_replay_selection_blocked(row: FastReplayPreviewRow) -> bool:

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6689,6 +6689,9 @@ def _apply_fast_replay_preview_narrowing(
                 cast(Sequence[Any], preview_row.get("risk_flags") or ())
             )
             updated["fast_replay_frontier_bucket"] = preview_row["frontier_bucket"]
+            updated["fast_replay_discovery_stage_metadata"] = preview_row.get(
+                "discovery_stage_metadata"
+            )
             updated["fast_replay_candidate_frontier_hash"] = preview_row.get(
                 "candidate_frontier_hash"
             )
@@ -6855,6 +6858,62 @@ def _fast_replay_preview_proof_semantics() -> dict[str, Any]:
     }
 
 
+def _fast_replay_discovery_stage_semantics() -> dict[str, Any]:
+    return {
+        "schema_version": "torghut.hpairs-discovery-stage-semantics.v1",
+        "preview_only_status": "preview_only_ranked",
+        "exact_replay_qualified_status": "exact_replay_qualified_frontier",
+        "evidence_collection_candidate_status": (
+            "bounded_sim_evidence_collection_candidate"
+        ),
+        "authority": "candidate_discovery_only",
+        "preview_output_can_authorize_promotion": False,
+        "exact_replay_frontier_can_authorize_promotion": False,
+        "requires_runtime_ledger_for_promotion": True,
+        "requires_live_paper_evidence_for_final_promotion": True,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_authority_ok": False,
+    }
+
+
+def _fast_replay_queue_stage_metadata(
+    *,
+    frontier_bucket: str,
+    exact_replay_selection_blocked: bool,
+    exact_replay_selection_blockers: Sequence[Any],
+) -> dict[str, Any]:
+    exact_replay_qualified = not exact_replay_selection_blocked
+    return {
+        "schema_version": "torghut.hpairs-discovery-stage-metadata.v1",
+        "preview_status": "preview_only_ranked",
+        "preview_only": True,
+        "exact_replay_status": (
+            "exact_replay_qualified_frontier"
+            if exact_replay_qualified
+            else "not_exact_replay_qualified"
+        ),
+        "exact_replay_qualified": exact_replay_qualified,
+        "evidence_collection_status": (
+            "bounded_sim_evidence_collection_candidate"
+            if exact_replay_qualified
+            else "not_evidence_collection_candidate"
+        ),
+        "evidence_collection_candidate": exact_replay_qualified,
+        "selected_for_bounded_frontier": True,
+        "frontier_bucket": frontier_bucket,
+        "blockers": list(exact_replay_selection_blockers),
+        "authority": "candidate_discovery_only",
+        "resource_scope": "local_offline_bounded_queue_metadata_only",
+        "promotion_proof": False,
+        "proof_authority": False,
+        "promotion_authority": False,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_authority_ok": False,
+    }
+
+
 def _bounded_sim_target_queue_metadata(
     *,
     preview_rows: Sequence[Mapping[str, Any]],
@@ -6888,12 +6947,26 @@ def _bounded_sim_target_queue_metadata(
     for index, row in enumerate(selected_rows, start=1):
         candidate_spec_id = _string(row.get("candidate_spec_id"))
         frontier_bucket = _string(row.get("frontier_bucket"))
+        exact_replay_selection_blockers = list(
+            cast(
+                Sequence[Any],
+                row.get("exact_replay_selection_blockers") or (),
+            )
+        )
+        stage_metadata = _fast_replay_queue_stage_metadata(
+            frontier_bucket=frontier_bucket,
+            exact_replay_selection_blocked=bool(
+                row.get("exact_replay_selection_blocked")
+            ),
+            exact_replay_selection_blockers=exact_replay_selection_blockers,
+        )
         handoff_lineage = _fast_replay_exact_handoff_lineage(
             row=row,
             replay_tape_manifest=replay_tape_manifest,
             queue_priority=index,
             candidate_spec_id=candidate_spec_id,
             frontier_bucket=frontier_bucket,
+            stage_metadata=stage_metadata,
         )
         handoff_lineage_hash = _string(handoff_lineage.get("lineage_hash"))
         entries.append(
@@ -6901,6 +6974,7 @@ def _bounded_sim_target_queue_metadata(
                 "queue_priority": index,
                 "candidate_spec_id": candidate_spec_id,
                 "frontier_bucket": frontier_bucket,
+                "discovery_stage_metadata": stage_metadata,
                 "candidate_frontier_hash": row.get("candidate_frontier_hash"),
                 "exact_replay_frontier_key": row.get("exact_replay_frontier_key"),
                 "frontier_dedupe_status": row.get("frontier_dedupe_status"),
@@ -6917,12 +6991,7 @@ def _bounded_sim_target_queue_metadata(
                 "exact_replay_selection_blocked": row.get(
                     "exact_replay_selection_blocked"
                 ),
-                "exact_replay_selection_blockers": list(
-                    cast(
-                        Sequence[Any],
-                        row.get("exact_replay_selection_blockers") or (),
-                    )
-                ),
+                "exact_replay_selection_blockers": exact_replay_selection_blockers,
                 "reproducibility_metadata": {
                     "dataset_snapshot_ref": replay_tape_manifest.dataset_snapshot_ref,
                     "replay_tape_content_sha256": replay_tape_manifest.content_sha256,
@@ -6968,8 +7037,9 @@ def _bounded_sim_target_queue_metadata(
             }
         )
     return {
-        "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v3",
+        "schema_version": "torghut.fast-replay-bounded-sim-target-queue.v4",
         "status": "metadata_only_preview_to_exact_replay_queue",
+        "discovery_stage_semantics": _fast_replay_discovery_stage_semantics(),
         "authority": "not_promotion_proof",
         "prefilter_only": True,
         "promotion_proof": False,
@@ -7022,6 +7092,7 @@ def _bounded_sim_target_queue_metadata(
             "sim_account_label": "TORGHUT_SIM",
             "live_paper_account_label": "TORGHUT_LIVE_PAPER_AFTER_PROBATION",
             "status": "sim_target_queue_ready_live_paper_blocked",
+            "candidate_stage": "bounded_sim_evidence_collection_candidate",
             "live_paper_blockers": [
                 "exact_replay_probation_required",
                 "source_backed_runtime_ledger_required",
@@ -7062,10 +7133,12 @@ def _fast_replay_exact_handoff_lineage(
     queue_priority: int,
     candidate_spec_id: str,
     frontier_bucket: str,
+    stage_metadata: Mapping[str, Any],
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
-        "schema_version": "torghut.fast-replay-exact-handoff-lineage.v2",
+        "schema_version": "torghut.fast-replay-exact-handoff-lineage.v3",
         "status": "preview_only_exact_replay_handoff",
+        "discovery_stage_metadata": dict(stage_metadata),
         "authority": "not_promotion_proof",
         "prefilter_only": True,
         "promotion_proof": False,

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -218,9 +218,39 @@ class TestFastReplayPreview(TestCase):
             row_payload["frontier_selection"]["reason_code"],
             "fast_replay_frontier_exploitation_selected",
         )
+        self.assertEqual(
+            row_payload["discovery_stage_metadata"]["preview_status"],
+            "preview_only_ranked",
+        )
+        self.assertTrue(
+            row_payload["discovery_stage_metadata"]["exact_replay_qualified"]
+        )
+        self.assertEqual(
+            row_payload["discovery_stage_metadata"]["evidence_collection_status"],
+            "bounded_sim_evidence_collection_candidate",
+        )
+        self.assertFalse(row_payload["discovery_stage_metadata"]["promotion_allowed"])
+        self.assertFalse(
+            row_payload["frontier_selection"]["discovery_stage_metadata"][
+                "final_promotion_allowed"
+            ]
+        )
         self.assertFalse(row_payload["frontier_selection"]["promotion_allowed"])
+        self.assertEqual(
+            payload["discovery_stage_semantics"]["authority"],
+            "candidate_discovery_only",
+        )
+        self.assertFalse(
+            payload["discovery_stage_semantics"][
+                "exact_replay_frontier_can_authorize_promotion"
+            ]
+        )
         sim_queue = payload["bounded_sim_target_queue"]
         self.assertEqual(sim_queue["status"], "metadata_only_not_dispatched")
+        self.assertEqual(
+            sim_queue["discovery_stage_semantics"]["preview_only_status"],
+            "preview_only_ranked",
+        )
         self.assertEqual(
             sim_queue["selected_candidate_spec_ids"], ["spec-good", "spec-stress"]
         )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4788,6 +4788,19 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             queue_payload["proof_semantics"]["label"],
             fast_replay.FAST_REPLAY_PROOF_SEMANTICS_LABEL,
         )
+        self.assertEqual(
+            queue_payload["discovery_stage_semantics"]["preview_only_status"],
+            "preview_only_ranked",
+        )
+        self.assertEqual(
+            queue_payload["discovery_stage_semantics"]["exact_replay_qualified_status"],
+            "exact_replay_qualified_frontier",
+        )
+        self.assertFalse(
+            queue_payload["discovery_stage_semantics"][
+                "preview_output_can_authorize_promotion"
+            ]
+        )
         self.assertTrue(queue_payload["prefilter_only"])
         self.assertFalse(queue_payload["proof_authority"])
         self.assertFalse(queue_payload["promotion_allowed"])
@@ -4819,6 +4832,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             queue_payload["target_queue"]["status"],
             "sim_target_queue_ready_live_paper_blocked",
+        )
+        self.assertEqual(
+            queue_payload["target_queue"]["candidate_stage"],
+            "bounded_sim_evidence_collection_candidate",
         )
         self.assertEqual(
             queue_payload["replay_tape"]["feature_schema_hash"],
@@ -4854,6 +4871,18 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ],
         )
         first_entry = queue_payload["entries"][0]
+        self.assertEqual(
+            first_entry["discovery_stage_metadata"]["preview_status"],
+            "preview_only_ranked",
+        )
+        self.assertTrue(
+            first_entry["discovery_stage_metadata"]["exact_replay_qualified"]
+        )
+        self.assertEqual(
+            first_entry["discovery_stage_metadata"]["evidence_collection_status"],
+            "bounded_sim_evidence_collection_candidate",
+        )
+        self.assertFalse(first_entry["discovery_stage_metadata"]["promotion_allowed"])
         self.assertIn("observed_post_cost_expectancy_bps", first_entry)
         self.assertIn("required_daily_notional", first_entry)
         self.assertFalse(first_entry["proof_authority"])
@@ -4895,6 +4924,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             first_entry["exact_replay_handoff_lineage"]["lineage_hash"],
             first_entry["handoff_lineage_hash"],
+        )
+        self.assertEqual(
+            first_entry["exact_replay_handoff_lineage"]["discovery_stage_metadata"][
+                "evidence_collection_status"
+            ],
+            "bounded_sim_evidence_collection_candidate",
+        )
+        self.assertFalse(
+            first_entry["exact_replay_handoff_lineage"]["discovery_stage_metadata"][
+                "final_promotion_allowed"
+            ]
         )
         self.assertEqual(
             first_entry["exact_replay_handoff_lineage"]["replay_tape"][
@@ -5024,6 +5064,18 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         updated_row = updated_selection["rows"][0]
         self.assertFalse(updated_row["selected_for_replay"])
         self.assertTrue(updated_row["fast_replay_exact_replay_selection_blocked"])
+        self.assertEqual(
+            updated_row["fast_replay_discovery_stage_metadata"]["exact_replay_status"],
+            "not_exact_replay_qualified",
+        )
+        self.assertFalse(
+            updated_row["fast_replay_discovery_stage_metadata"][
+                "evidence_collection_candidate"
+            ]
+        )
+        self.assertFalse(
+            updated_row["fast_replay_discovery_stage_metadata"]["promotion_allowed"]
+        )
         self.assertIn(
             "cost_lineage_spread_missing",
             updated_row["fast_replay_exact_replay_selection_blockers"],
@@ -5123,6 +5175,18 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ["exact-frontier-a", "exact-frontier-c"],
         )
         self.assertEqual(queue_payload["dedupe_policy"]["status"], "enabled")
+        self.assertEqual(
+            queue_payload["entries"][0]["discovery_stage_metadata"][
+                "exact_replay_status"
+            ],
+            "exact_replay_qualified_frontier",
+        )
+        self.assertEqual(
+            queue_payload["entries"][0]["exact_replay_handoff_lineage"][
+                "discovery_stage_metadata"
+            ]["evidence_collection_status"],
+            "bounded_sim_evidence_collection_candidate",
+        )
         self.assertFalse(queue_payload["dedupe_policy"]["proof_authority"])
         self.assertFalse(queue_payload["dedupe_policy"]["promotion_allowed"])
         self.assertFalse(queue_payload["dedupe_policy"]["final_authority_ok"])
@@ -5286,7 +5350,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         manifest_payload = preview.to_manifest_payload()
 
         self.assertEqual(
-            row_payload["schema_version"], "torghut.fast-replay-preview-row.v6"
+            row_payload["schema_version"],
+            fast_replay.FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION,
         )
         self.assertEqual(manifest_payload["status"], "preview_only")
         self.assertFalse(manifest_payload["promotion_proof"])


### PR DESCRIPTION
## Summary

- Adds explicit H-PAIRS discovery stage semantics for preview-only rows, exact-replay-qualified frontier entries, and bounded SIM evidence-collection candidates.
- Propagates stage metadata into the autoresearch fast replay narrowing output, bounded SIM target queue entries, and exact replay handoff lineage while keeping promotion authority fail-closed.
- Preserves the offline/local frontier gate: fast preview ranks many specs, exact replay queue metadata remains capped at six candidates with no Kubernetes fanout, DB writes, proof uploads, or promotion writes.
- Extends focused regression coverage for stage labeling and non-authority flags alongside existing cache identity/frontier cap coverage.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass after installing build-essential in the workspace for crosshair-tool native build)
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` (pass: 225 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_run_whitepaper_autoresearch_profit_target.py` (pass)
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/fast_replay.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_run_whitepaper_autoresearch_profit_target.py` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (pass: 0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (pass: 0 errors)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A - backend/offline metadata change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
