### PR TITLE
fix(synthesis): flag early autotrader finalization

### DIFF
--- a/apps/synthesis/src/routes/-autotrader-alerts.test.ts
+++ b/apps/synthesis/src/routes/-autotrader-alerts.test.ts
@@ -79,6 +79,53 @@ describe('getAutotraderRuntimeAlerts', () => {
     expect(getAutotraderRuntimeAlerts(detail, new Date('2026-05-29T13:10:00Z'))).toEqual([])
   })
 
+  test('flags guard-finalized market sessions after the AgentRun ended early', () => {
+    const base = detailFor()
+    const detail = detailFor({
+      session: {
+        ...base.session,
+        finalizedAt: '2026-06-01T20:00:54.011Z',
+        terminalReason: 'market_closed',
+        summary: {
+          guard: 'autotrader-session-guard',
+          reason: 'market close reached after original AgentRun job completed early',
+        },
+      },
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, new Date('2026-06-01T21:00:00Z'))).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'market-session-ended-early', severity: 'critical' })]),
+    )
+  })
+
+  test('flags market sessions finalized before regular close', () => {
+    const base = detailFor()
+    const detail = detailFor({
+      session: {
+        ...base.session,
+        finalizedAt: '2026-05-29T16:09:44.000Z',
+        terminalReason: 'market_closed',
+      },
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, new Date('2026-05-29T21:00:00Z'))).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'market-session-ended-early', severity: 'critical' })]),
+    )
+  })
+
+  test('does not flag target-reached sessions that finish before regular close', () => {
+    const base = detailFor()
+    const detail = detailFor({
+      session: {
+        ...base.session,
+        finalizedAt: '2026-05-29T16:09:44.000Z',
+        terminalReason: 'target_reached',
+      },
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, new Date('2026-05-29T21:00:00Z'))).toEqual([])
+  })
+
   test('flags nonterminal orders older than 30 seconds', () => {
     const detail = detailFor({
       orders: [

--- a/apps/synthesis/src/routes/-autotrader-alerts.ts
+++ b/apps/synthesis/src/routes/-autotrader-alerts.ts
@@ -10,6 +10,9 @@ export type AutotraderRuntimeAlert = {
 const staleHeartbeatMs = 90_000
 const unreconciledOrderMs = 30_000
 
+const marketSessionModes = new Set(['market_open', 'market_session'])
+const acceptedEarlyTerminalReasons = new Set(['target_reached', 'hard_stop'])
+
 const terminalOrderStatuses = new Set<AutotraderOrder['status']>([
   'filled',
   'canceled',
@@ -35,6 +38,12 @@ const isNonZeroQuantity = (value: string) => {
 const normalizeSymbol = (value: string | null | undefined) => value?.trim().toUpperCase() ?? ''
 
 const stringify = (value: unknown) => (typeof value === 'string' ? value.trim().toLowerCase() : '')
+
+const parsedTime = (value: string | null | undefined) => {
+  if (!value) return null
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
 
 const truthyRuntimeFlag = (value: unknown) => {
   if (value === true) return true
@@ -84,11 +93,29 @@ const payloadHasManagedLoop = (payload: Record<string, unknown>, symbol: string)
 
 export const isMarketSessionActive = (detail: AutotraderSessionDetail, now = new Date()) => {
   if (detail.session.finalizedAt) return false
-  const marketOpen = Date.parse(detail.session.marketOpenAt)
-  const marketClose = Date.parse(detail.session.marketCloseAt)
-  if (!Number.isFinite(marketOpen) || !Number.isFinite(marketClose)) return false
+  const marketOpen = parsedTime(detail.session.marketOpenAt)
+  const marketClose = parsedTime(detail.session.marketCloseAt)
+  if (marketOpen == null || marketClose == null) return false
   const current = now.getTime()
   return current >= marketOpen && current <= marketClose
+}
+
+const hasEarlyCompletionGuard = (detail: AutotraderSessionDetail) => {
+  const summary = detail.session.summary
+  const guard = stringify(summary.guard)
+  const reason = stringify(summary.reason)
+  return guard === 'autotrader-session-guard' && reason.includes('completed early')
+}
+
+export const didMarketSessionEndEarly = (detail: AutotraderSessionDetail) => {
+  if (!marketSessionModes.has(detail.session.mode)) return false
+  if (!detail.session.finalizedAt) return false
+  if (detail.session.terminalReason && acceptedEarlyTerminalReasons.has(detail.session.terminalReason)) return false
+  if (hasEarlyCompletionGuard(detail)) return true
+
+  const finalizedAt = parsedTime(detail.session.finalizedAt)
+  const marketClose = parsedTime(detail.session.marketCloseAt)
+  return finalizedAt != null && marketClose != null && finalizedAt < marketClose
 }
 
 export const isAutotraderOrderUnreconciled = (order: AutotraderOrder, now = new Date()) => {
@@ -143,6 +170,16 @@ const positionHasProtection = (
 
 export const getAutotraderRuntimeAlerts = (detail: AutotraderSessionDetail, now = new Date()) => {
   const alerts: AutotraderRuntimeAlert[] = []
+
+  if (didMarketSessionEndEarly(detail)) {
+    alerts.push({
+      key: 'market-session-ended-early',
+      severity: 'critical',
+      title: 'Market session ended early',
+      message:
+        'The market-open AgentRun ended before regular close or required guard finalization; verify the next run stays active through market close.',
+    })
+  }
 
   if (isMarketSessionActive(detail, now)) {
     const heartbeatAgeMs = ageMs(detail.status?.updatedAt, now)


### PR DESCRIPTION
## Summary

- Adds a critical autotrader runtime alert when a market-open session finalizes before regular close.
- Detects the June 1 guard-finalized shape where `autotrader-session-guard` recorded that the original AgentRun job completed early.
- Keeps legitimate `target_reached` and `hard_stop` early terminal cases out of the alert path and covers the behavior with regression tests.

## Related Issues

None

## Testing

- `bun test apps/synthesis/src/routes/-autotrader-alerts.test.ts`
- `bun run --filter synthesis test -- src/routes/-autotrader-alerts.test.ts`
- `bun run --filter synthesis lint`
- `bun run --filter synthesis build`

## Screenshots (if applicable)

N/A - runtime alert logic is covered by unit tests; no visual snapshot required.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
