### PR TITLE
feat(torghut): sharpen hpairs source proof census readback

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -220,6 +220,8 @@ def _hpairs_source_proof_census_status(
             "authority_source": False,
             "promotion_allowed": False,
             "final_authority_ok": False,
+            "runtime_authority_final_ok": False,
+            "census_ready": False,
             "blockers": [],
             "attachment_blockers": ["hpairs_source_proof_census_missing"],
             "blocker_ladder": [],
@@ -237,6 +239,8 @@ def _hpairs_source_proof_census_status(
     attachment_blockers = _hpairs_source_proof_census_attachment_blockers(payload)
     _extend_unique(blockers, attachment_blockers)
     next_blocker = _mapping(verdict.get("next_blocker"))
+    runtime_authority_final_ok = bool(runtime_authority.get("final_authority_ok"))
+    census_ready = bool(verdict.get("authority_candidate_ready")) and not blockers
     return {
         "schema_version": HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION,
         "present": True,
@@ -248,8 +252,9 @@ def _hpairs_source_proof_census_status(
         "classification": verdict.get("classification"),
         "authority_candidate_ready": bool(verdict.get("authority_candidate_ready")),
         "promotion_allowed": False,
-        "final_authority_ok": bool(runtime_authority.get("final_authority_ok"))
-        and not blockers,
+        "final_authority_ok": False,
+        "runtime_authority_final_ok": runtime_authority_final_ok,
+        "census_ready": census_ready,
         "blockers": blockers,
         "attachment_blockers": attachment_blockers,
         "missing_requirement_categories": dict(
@@ -2861,9 +2866,8 @@ def build_runtime_ledger_proof_packet(
         hpairs_source_proof_census_status.get("blockers")
     )
     hpairs_census_present = bool(hpairs_source_proof_census_status.get("present"))
-    hpairs_census_ok = (not hpairs_census_present) or (
-        not hpairs_census_blockers
-        and bool(hpairs_source_proof_census_status.get("final_authority_ok"))
+    hpairs_census_ok = (not hpairs_census_present) or bool(
+        hpairs_source_proof_census_status.get("census_ready")
     )
     _check(
         checks,

--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -78,6 +78,7 @@ ECONOMICS_MISSING = "economics_missing"
 SOURCE_REFS_MISSING = "source_refs_missing"
 OPEN_POSITIONS = "open_positions"
 AUTHORITY_DISTRIBUTION_MISSING = "authority_distribution_missing"
+CANDIDATE_CONFIG_MISMATCH_BLOCKER = "candidate_config_mismatch"
 LADDER_PASS = "pass"
 LADDER_MISSING = "missing"
 LADDER_BLOCKED = "blocked"
@@ -202,7 +203,13 @@ def build_source_proof_census(
         evidence_read_error=read_error,
     )
     daily = _daily_census(rows, ledger_report)
-    totals = _totals(rows, daily, ledger_report)
+    candidate_config_match = _candidate_config_match(rows, identity, ledger_report)
+    totals = _totals(
+        rows,
+        daily,
+        ledger_report,
+        candidate_config_match=candidate_config_match,
+    )
     blockers = _census_blockers(rows, totals, ledger_report, read_error=read_error)
     missing_source_ref_categories = _missing_source_ref_categories(blockers)
     missing_requirement_categories = _missing_requirement_categories(blockers)
@@ -238,6 +245,7 @@ def build_source_proof_census(
             "synthetic_proof_created": False,
         },
         "totals": totals,
+        "candidate_config_match": candidate_config_match,
         "daily": daily,
         "runtime_authority": {
             "final_authority_ok": ledger_report["final_authority_ok"],
@@ -566,14 +574,21 @@ def _totals(
     rows: CensusSourceRows,
     daily: Sequence[Mapping[str, object]],
     ledger_report: Mapping[str, object],
+    *,
+    candidate_config_match: Mapping[str, object],
 ) -> dict[str, object]:
     aggregate = _mapping(ledger_report.get("aggregate"))
     daily_ledger = [
         _mapping(item) for item in _sequence(ledger_report.get("trading_days"))
     ]
     source_authority_bucket_count = _int(aggregate.get("source_authority_bucket_count"))
+    runtime_ledger_bucket_count = len(rows.runtime_ledger_buckets)
+    explicit_cost_runtime_ledger_bucket_count = _int(
+        aggregate.get("explicit_cost_bucket_count")
+    )
     return {
         "trade_decision_count": len(rows.trade_decisions),
+        "matched_trade_decision_count": len(rows.trade_decisions),
         "execution_count": len(rows.executions),
         "filled_execution_count": sum(
             1 for row in rows.executions if _filled_execution(row)
@@ -630,8 +645,21 @@ def _totals(
             for row in rows.execution_order_events
             if _event_source_offset_present(row)
         ),
-        "runtime_ledger_bucket_count": len(rows.runtime_ledger_buckets),
+        "execution_order_events_with_source_window_and_offset_count": sum(
+            1
+            for row in rows.execution_order_events
+            if _text(row.get("source_window_id")) is not None
+            and _event_source_offset_present(row)
+        ),
+        "execution_tca_metric_count": len(rows.execution_tca_metrics),
+        "runtime_ledger_bucket_count": runtime_ledger_bucket_count,
         "blocker_free_runtime_ledger_bucket_count": source_authority_bucket_count,
+        "runtime_ledger_evidence_grade_bucket_count": _int(
+            aggregate.get("clean_authority_bucket_count")
+        ),
+        "runtime_ledger_aggregate_only_bucket_count": max(
+            0, runtime_ledger_bucket_count - source_authority_bucket_count
+        ),
         "runtime_submitted_order_count": _sum_daily_int(
             daily_ledger, "submitted_order_count"
         ),
@@ -641,9 +669,10 @@ def _totals(
         "runtime_ledger_clean_authority_trading_day_count": _int(
             aggregate.get("clean_authority_trading_day_count")
         ),
-        "explicit_cost_runtime_ledger_bucket_count": _int(
-            aggregate.get("explicit_cost_bucket_count")
-        ),
+        "explicit_cost_runtime_ledger_bucket_count": explicit_cost_runtime_ledger_bucket_count,
+        "explicit_cost_required_bucket_count": runtime_ledger_bucket_count,
+        "explicit_cost_coverage_complete": runtime_ledger_bucket_count == 0
+        or explicit_cost_runtime_ledger_bucket_count >= runtime_ledger_bucket_count,
         "runtime_ledger_buckets_with_filled_notional_count": sum(
             1
             for row in rows.runtime_ledger_buckets
@@ -659,6 +688,92 @@ def _totals(
             aggregate.get("total_net_strategy_pnl_after_costs"), default="0"
         ),
         "trading_day_count": len(daily),
+        "candidate_config_match": bool(candidate_config_match.get("matches")),
+        "candidate_config_mismatch_count": _int(
+            candidate_config_match.get("mismatch_count")
+        ),
+        "candidate_matched_runtime_ledger_bucket_count": _int(
+            candidate_config_match.get("matched_runtime_ledger_bucket_count")
+        ),
+        "candidate_mismatched_runtime_ledger_bucket_count": _int(
+            candidate_config_match.get("mismatched_runtime_ledger_bucket_count")
+        ),
+    }
+
+
+def _candidate_config_match(
+    rows: CensusSourceRows,
+    identity: CensusIdentity,
+    ledger_report: Mapping[str, object],
+) -> dict[str, object]:
+    """Summarize whether read rows match the requested H-PAIRS candidate/config."""
+
+    trade_decision_mismatches = sum(
+        1
+        for row in rows.trade_decisions
+        if _text(row.get("strategy_name")) not in (None, identity.runtime_strategy_name)
+        or _text(row.get("alpaca_account_label")) not in (None, identity.account_label)
+    )
+    execution_mismatches = sum(
+        1
+        for row in rows.executions
+        if _text(row.get("alpaca_account_label")) not in (None, identity.account_label)
+    )
+    order_event_mismatches = sum(
+        1
+        for row in rows.execution_order_events
+        if _text(row.get("alpaca_account_label")) not in (None, identity.account_label)
+    )
+    tca_metric_mismatches = sum(
+        1
+        for row in rows.execution_tca_metrics
+        if _text(row.get("alpaca_account_label")) not in (None, identity.account_label)
+    )
+    source_window_mismatches = sum(
+        1
+        for row in rows.order_feed_source_windows
+        if _text(row.get("alpaca_account_label")) not in (None, identity.account_label)
+    )
+    ledger_mismatches = [
+        row
+        for row in rows.runtime_ledger_buckets
+        if _text(row.get("candidate_id")) not in (None, identity.candidate_id)
+        or _text(row.get("hypothesis_id")) not in (None, identity.hypothesis_id)
+        or _text(row.get("runtime_strategy_name"))
+        not in (None, identity.runtime_strategy_name)
+        or _text(row.get("account_label")) not in (None, identity.account_label)
+        or _text(row.get("observed_stage")) not in (None, identity.observed_stage)
+    ]
+    aggregate = _mapping(ledger_report.get("aggregate"))
+    runtime_ledger_bucket_count = len(rows.runtime_ledger_buckets)
+    mismatch_count = (
+        trade_decision_mismatches
+        + execution_mismatches
+        + order_event_mismatches
+        + tca_metric_mismatches
+        + source_window_mismatches
+        + len(ledger_mismatches)
+    )
+    return {
+        "matches": mismatch_count == 0,
+        "mismatch_count": mismatch_count,
+        "requested": {
+            "hypothesis_id": identity.hypothesis_id,
+            "candidate_id": identity.candidate_id,
+            "runtime_strategy_name": identity.runtime_strategy_name,
+            "account_label": identity.account_label,
+            "observed_stage": identity.observed_stage,
+        },
+        "trade_decision_mismatch_count": trade_decision_mismatches,
+        "execution_mismatch_count": execution_mismatches,
+        "execution_order_event_mismatch_count": order_event_mismatches,
+        "execution_tca_metric_mismatch_count": tca_metric_mismatches,
+        "order_feed_source_window_mismatch_count": source_window_mismatches,
+        "matched_runtime_ledger_bucket_count": max(
+            0, runtime_ledger_bucket_count - len(ledger_mismatches)
+        ),
+        "mismatched_runtime_ledger_bucket_count": len(ledger_mismatches),
+        "runtime_authority_aggregate_bucket_count": _int(aggregate.get("bucket_count")),
     }
 
 
@@ -672,6 +787,8 @@ def _census_blockers(
     blockers: list[str] = []
     if read_error is not None:
         blockers.append("source_proof_census_read_error")
+    if _int(totals.get("candidate_config_mismatch_count")) > 0:
+        blockers.append(CANDIDATE_CONFIG_MISMATCH_BLOCKER)
     if _int(totals.get("trade_decision_count")) <= 0:
         blockers.extend(
             [
@@ -789,6 +906,26 @@ def _blocker_ladder(
     }
     return [
         _ladder_step(
+            "candidate_config_match",
+            blockers=blockers,
+            step_blockers={CANDIDATE_CONFIG_MISMATCH_BLOCKER},
+            present=bool(totals.get("candidate_config_match")),
+            observed={
+                "candidate_config_match": bool(totals.get("candidate_config_match")),
+                "candidate_config_mismatch_count": _int(
+                    totals.get("candidate_config_mismatch_count")
+                ),
+                "matched_runtime_ledger_bucket_count": _int(
+                    totals.get("candidate_matched_runtime_ledger_bucket_count")
+                ),
+                "mismatched_runtime_ledger_bucket_count": _int(
+                    totals.get("candidate_mismatched_runtime_ledger_bucket_count")
+                ),
+                "observed_stage": observed_stage,
+            },
+            next_action="rerun the read-only census with the intended H-PAIRS candidate/config and paper account",
+        ),
+        _ladder_step(
             "decisions_present",
             blockers=blockers,
             step_blockers={
@@ -890,6 +1027,11 @@ def _blocker_ladder(
                 "events_with_source_offset_count": _int(
                     totals.get("execution_order_events_with_source_offset_count")
                 ),
+                "events_with_source_window_and_offset_count": _int(
+                    totals.get(
+                        "execution_order_events_with_source_window_and_offset_count"
+                    )
+                ),
                 "runtime_source_authority_bucket_count": _int(
                     totals.get("blocker_free_runtime_ledger_bucket_count")
                 ),
@@ -912,6 +1054,12 @@ def _blocker_ladder(
             observed={
                 "runtime_ledger_bucket_count": _int(
                     totals.get("runtime_ledger_bucket_count")
+                ),
+                "runtime_ledger_evidence_grade_bucket_count": _int(
+                    totals.get("runtime_ledger_evidence_grade_bucket_count")
+                ),
+                "runtime_ledger_aggregate_only_bucket_count": _int(
+                    totals.get("runtime_ledger_aggregate_only_bucket_count")
                 ),
                 "runtime_ledger_source_materialization_count": _int(
                     totals.get("runtime_ledger_source_materialization_count")
@@ -952,8 +1100,17 @@ def _blocker_ladder(
             and _int(totals.get("explicit_cost_runtime_ledger_bucket_count")) > 0,
             observed={
                 "tca_cost_row_count": _int(totals.get("tca_cost_row_count")),
+                "execution_tca_metric_count": _int(
+                    totals.get("execution_tca_metric_count")
+                ),
                 "explicit_cost_runtime_ledger_bucket_count": _int(
                     totals.get("explicit_cost_runtime_ledger_bucket_count")
+                ),
+                "explicit_cost_required_bucket_count": _int(
+                    totals.get("explicit_cost_required_bucket_count")
+                ),
+                "explicit_cost_coverage_complete": bool(
+                    totals.get("explicit_cost_coverage_complete")
                 ),
                 "total_explicit_costs": _text(
                     aggregate.get("total_explicit_costs"), default="0"

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -617,6 +617,8 @@ def _hpairs_source_proof_census_status(
             "authority_source": False,
             "promotion_allowed": False,
             "final_authority_ok": False,
+            "runtime_authority_final_ok": False,
+            "census_ready": False,
             "blockers": [],
             "attachment_blockers": ["hpairs_source_proof_census_missing"],
             "blocker_ladder": [],
@@ -638,6 +640,8 @@ def _hpairs_source_proof_census_status(
     attachment_blockers = _hpairs_source_proof_census_attachment_blockers(payload)
     blockers = _extend_unique_text_items(blockers, attachment_blockers)
     next_blocker = _as_dict(verdict.get("next_blocker"))
+    runtime_authority_final_ok = bool(runtime_authority.get("final_authority_ok"))
+    census_ready = bool(verdict.get("authority_candidate_ready")) and not blockers
     return {
         "schema_version": HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION,
         "present": True,
@@ -649,8 +653,9 @@ def _hpairs_source_proof_census_status(
         "classification": verdict.get("classification"),
         "authority_candidate_ready": bool(verdict.get("authority_candidate_ready")),
         "promotion_allowed": False,
-        "final_authority_ok": bool(runtime_authority.get("final_authority_ok"))
-        and not blockers,
+        "final_authority_ok": False,
+        "runtime_authority_final_ok": runtime_authority_final_ok,
+        "census_ready": census_ready,
         "blockers": blockers,
         "attachment_blockers": attachment_blockers,
         "missing_requirement_categories": _as_dict(
@@ -2721,9 +2726,6 @@ def main() -> int:
     hpairs_source_proof_census_status = _hpairs_source_proof_census_status(
         hpairs_source_proof_census
     )
-    hpairs_source_proof_census_blockers = _as_text_list(
-        hpairs_source_proof_census_status.get("blockers")
-    )
 
     with SessionLocal() as session:
         rows = (
@@ -2768,9 +2770,10 @@ def main() -> int:
         "manifest_path": str(manifest_path),
         "output_dir": str(output_dir),
         "promotion_allowed": False,
-        "final_authority_ok": False
-        if hpairs_source_proof_census_blockers
-        else bool(hpairs_source_proof_census_status.get("final_authority_ok")),
+        "final_authority_ok": False,
+        "hpairs_source_proof_census_runtime_authority_final_ok": bool(
+            hpairs_source_proof_census_status.get("runtime_authority_final_ok")
+        ),
         "hpairs_source_proof_census": hpairs_source_proof_census_status,
         "empirical_promotion": json.loads(result.stdout),
         "runtime_window_import": runtime_window_import,

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -808,6 +808,32 @@ class TestRuntimeLedgerProofPacket(TestCase):
             census_status["next_blocker"]["step"], "submitted_orders_present"
         )
 
+    def test_hpairs_source_proof_census_ready_status_does_not_grant_authority(
+        self,
+    ) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(blockers=["live_gate_blocked"]),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            hpairs_source_proof_census=_hpairs_source_proof_census(),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        census_status = result["evidence"]["hpairs_source_proof_census"]
+        self.assertTrue(census_status["present"])
+        self.assertTrue(census_status["census_ready"])
+        self.assertTrue(census_status["runtime_authority_final_ok"])
+        self.assertFalse(census_status["promotion_allowed"])
+        self.assertFalse(census_status["final_authority_ok"])
+        self.assertFalse(result["final_authority_ok"])
+        self.assertFalse(result["promotion_allowed"])
+        self.assertIn("live_gate_blocked", result["authority_blockers"])
+
     def test_hpairs_source_proof_census_attachment_blockers_block_authority(
         self,
     ) -> None:

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -215,6 +215,7 @@ def test_full_source_backed_census_is_authority_candidate_ready() -> None:
     assert report["verdict"]["classification"] == census.AUTHORITY_CANDIDATE_READY
     assert report["blockers"] == []
     assert report["totals"]["trade_decision_count"] == 20
+    assert report["totals"]["matched_trade_decision_count"] == 20
     assert report["totals"]["execution_count"] == 20
     assert report["totals"]["filled_execution_count"] == 20
     assert report["totals"]["execution_order_event_count"] == 20
@@ -225,18 +226,30 @@ def test_full_source_backed_census_is_authority_candidate_ready() -> None:
         report["totals"]["execution_order_events_with_filled_notional_delta_count"]
         == 20
     )
+    assert (
+        report["totals"]["execution_order_events_with_source_window_and_offset_count"]
+        == 20
+    )
     assert report["totals"]["tca_cost_row_count"] == 20
+    assert report["totals"]["execution_tca_metric_count"] == 20
     assert report["totals"]["source_window_count"] == 20
     assert report["totals"]["runtime_ledger_bucket_count"] == 20
     assert report["totals"]["blocker_free_runtime_ledger_bucket_count"] == 20
+    assert report["totals"]["runtime_ledger_evidence_grade_bucket_count"] == 20
+    assert report["totals"]["runtime_ledger_aggregate_only_bucket_count"] == 0
     assert report["totals"]["runtime_submitted_order_count"] == 400
     assert report["totals"]["runtime_ledger_source_materialization_count"] == 20
     assert report["totals"]["runtime_ledger_clean_authority_trading_day_count"] == 20
     assert report["totals"]["closed_trade_count"] == 400
+    assert report["totals"]["open_position_count"] == 0
     assert report["totals"]["filled_notional"] == "12000000"
+    assert report["totals"]["explicit_cost_required_bucket_count"] == 20
+    assert report["totals"]["explicit_cost_coverage_complete"] is True
     assert report["totals"]["target_implied_notional_gap"] == "0"
     assert report["totals"]["post_cost_pnl"] == "12000"
     assert report["source"]["runtime_stage"] == "paper"
+    assert report["candidate_config_match"]["matches"] is True
+    assert report["candidate_config_match"]["mismatch_count"] == 0
     assert report["source"]["replay_outputs_count_as_runtime_proof"] is False
     assert report["source"]["synthetic_proof_created"] is False
     assert report["verdict"]["next_blocker"] is None
@@ -255,6 +268,7 @@ def test_full_source_backed_census_is_authority_candidate_ready() -> None:
         == census.LADDER_PASS
     )
     assert [item["step"] for item in report["blocker_ladder"]] == [
+        "candidate_config_match",
         "decisions_present",
         "submitted_orders_present",
         "fill_lifecycle_present",
@@ -403,6 +417,7 @@ def test_runtime_bucket_aggregate_only_is_source_refs_missing() -> None:
 
     assert report["verdict"]["classification"] == census.SOURCE_REFS_MISSING
     assert report["totals"]["blocker_free_runtime_ledger_bucket_count"] == 0
+    assert report["totals"]["runtime_ledger_aggregate_only_bucket_count"] == 20
     assert report["totals"]["runtime_ledger_source_materialization_count"] == 0
     assert census.RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER in report["blockers"]
     assert (
@@ -447,6 +462,21 @@ def test_empty_fixture_has_no_source_activity_verdict() -> None:
         ],
         "next_action": "run the strategy through paper/live routing until durable TradeDecision rows exist",
     }
+
+
+def test_candidate_config_mismatch_is_first_ladder_blocker() -> None:
+    payload = _fixture()
+    payload["runtime_ledger_buckets"][0]["candidate_id"] = "other-candidate"
+    payload["trade_decisions"][0]["strategy_name"] = "other-strategy"
+
+    report = _report(payload)
+
+    assert report["candidate_config_match"]["matches"] is False
+    assert report["totals"]["candidate_config_mismatch_count"] == 2
+    assert census.CANDIDATE_CONFIG_MISMATCH_BLOCKER in report["blockers"]
+    next_blocker = report["verdict"]["next_blocker"]
+    assert isinstance(next_blocker, dict)
+    assert next_blocker["step"] == "candidate_config_match"
 
 
 def test_partial_evidence_ladder_points_at_order_feed_lifecycle() -> None:

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -175,6 +175,8 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
         self.assertTrue(status["non_authority_status_only"])
         self.assertFalse(status["promotion_allowed"])
         self.assertFalse(status["final_authority_ok"])
+        self.assertFalse(status["runtime_authority_final_ok"])
+        self.assertFalse(status["census_ready"])
         self.assertEqual(
             status["blockers"],
             ["runtime_ledger_source_materialization_missing"],
@@ -230,9 +232,52 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
         self.assertTrue(status["present"])
         self.assertFalse(status["promotion_allowed"])
         self.assertFalse(status["final_authority_ok"])
+        self.assertTrue(status["runtime_authority_final_ok"])
+        self.assertFalse(status["census_ready"])
         self.assertEqual(status["attachment_blockers"], blockers)
         for blocker in blockers:
             self.assertIn(blocker, status["blockers"])
+
+    def test_hpairs_source_proof_census_ready_status_does_not_grant_renewal_authority(
+        self,
+    ) -> None:
+        status = renew._hpairs_source_proof_census_status(
+            {
+                "schema_version": "torghut.hpairs-source-proof-census.v1",
+                "identity": {"hypothesis_id": "H-PAIRS-01"},
+                "window": {},
+                "source": {
+                    "kind": "fixture_json",
+                    "read_only": True,
+                    "writes_proof": False,
+                    "modifies_rows": False,
+                    "runtime_stage": "paper",
+                    "replay_outputs_count_as_runtime_proof": False,
+                    "synthetic_proof_created": False,
+                },
+                "runtime_authority": {
+                    "final_authority_ok": True,
+                    "blockers": [],
+                },
+                "missing_requirement_categories": {},
+                "missing_source_ref_categories": {},
+                "blocker_ladder": [],
+                "blockers": [],
+                "verdict": {
+                    "classification": "authority_candidate_ready",
+                    "authority_candidate_ready": True,
+                    "next_blocker": None,
+                    "next_action": "assemble authority proof packet",
+                },
+                "totals": {},
+            }
+        )
+
+        self.assertTrue(status["present"])
+        self.assertTrue(status["census_ready"])
+        self.assertTrue(status["runtime_authority_final_ok"])
+        self.assertFalse(status["promotion_allowed"])
+        self.assertFalse(status["final_authority_ok"])
 
     def test_runtime_bucket_materialization_rerun_is_idempotent_for_same_scope(
         self,


### PR DESCRIPTION
## Summary

- Added an explicit H-PAIRS candidate/config match readback and first ladder step so mismatched candidate/config evidence fails closed before proof interpretation.
- Extended the read-only census totals/ladder with matched TradeDecision, source-window+offset event, TCA metric, evidence-grade bucket, aggregate-only bucket, explicit-cost coverage, position, notional, and blocker diagnostics.
- Kept proof-packet and renewal census attachments status-only by exposing `runtime_authority_final_ok`/`census_ready` while forcing census-local `promotion_allowed` and `final_authority_ok` to remain false.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed after installing local build tooling required for `crosshair-tool`.
- `cd services/torghut && uv run --frozen pytest tests/test_audit_hpairs_source_proof_census.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_renew_latest_empirical_promotion_jobs.py -q -k 'hpairs_source_proof_census or source_proof_census or census'` — passed, 24 passed / 68 deselected / 1 existing deprecation warning.
- `cd services/torghut && uv run --frozen ruff check scripts/audit_hpairs_source_proof_census.py scripts/assemble_runtime_ledger_proof_packet.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_audit_hpairs_source_proof_census.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_renew_latest_empirical_promotion_jobs.py` — passed.
- `cd services/torghut && uv run --frozen ruff format --check scripts/audit_hpairs_source_proof_census.py scripts/assemble_runtime_ledger_proof_packet.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_audit_hpairs_source_proof_census.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_renew_latest_empirical_promotion_jobs.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed, 0 errors / 0 warnings / 0 informations.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed, 0 errors / 0 warnings / 0 informations.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed, 0 errors / 0 warnings / 0 informations.
- `git diff --check` — passed.
- Read-only live census against `torghut_sim_default` via `scripts/audit_hpairs_source_proof_census.py --dsn ... --observed-stage paper` — passed without DB writes; classification `source_refs_missing`, next blocker `decisions_present` / `runtime_ledger_trade_decision_refs_missing`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
