### PR TITLE
fix(torghut): bound trading status late readbacks

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -236,12 +236,44 @@ _OPTIONS_CATALOG_FRESHNESS_CACHE_LOCK = Lock()
 _OPTIONS_CATALOG_FRESHNESS_CACHE: dict[
     tuple[str, ...], tuple[datetime, dict[str, object]]
 ] = {}
+_TRADING_STATUS_READ_BUDGET_SECONDS = 12.0
 _ALPACA_HEALTH_CACHE_LOCK = Lock()
 _ALPACA_HEALTH_STATE: dict[str, object] = {}
 _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS = 600
 _PAPER_ROUTE_TARGET_PLAN_SUCCESS_CACHE_LOCK = Lock()
 _PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL = "TORGHUT_SIM"
 _paper_route_target_plan_success_cache: tuple[dict[str, Any], float] | None = None
+
+
+class _TradingStatusReadBudget:
+    def __init__(self, *, max_seconds: float | None = None):
+        configured_seconds = (
+            _TRADING_STATUS_READ_BUDGET_SECONDS
+            if max_seconds is None
+            else max_seconds
+        )
+        self.max_seconds = max(0.0, float(configured_seconds))
+        self._started_at = time.monotonic()
+        self.skipped_reads: list[str] = []
+
+    def elapsed_seconds(self) -> float:
+        return max(0.0, time.monotonic() - self._started_at)
+
+    def exhausted(self) -> bool:
+        return self.elapsed_seconds() >= self.max_seconds
+
+    def skip_reason(self, read_name: str) -> str:
+        if read_name not in self.skipped_reads:
+            self.skipped_reads.append(read_name)
+        return f"{read_name}_status_read_budget_exhausted"
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "max_seconds": self.max_seconds,
+            "elapsed_seconds": round(self.elapsed_seconds(), 3),
+            "exhausted": self.exhausted(),
+            "skipped_reads": list(self.skipped_reads),
+        }
 
 
 def _extract_bearer_token(authorization_header: str | None) -> str | None:
@@ -3025,6 +3057,7 @@ def search_whitepapers(
 def trading_status() -> dict[str, object]:
     """Return trading loop status and metrics."""
 
+    status_read_budget = _TradingStatusReadBudget()
     scheduler: TradingScheduler | None = getattr(app.state, "trading_scheduler", None)
     if scheduler is None:
         scheduler = TradingScheduler()
@@ -3037,6 +3070,7 @@ def trading_status() -> dict[str, object]:
     )
     forecast_service_status = _forecast_service_status(empirical_jobs)
     lean_authority_status = _lean_authority_status()
+    clickhouse_ta_status = _load_clickhouse_ta_status(scheduler)
     with SessionLocal() as session:
         llm_evaluation = _load_llm_evaluation(session)
         tca_summary = _load_tca_summary(session, scheduler=scheduler)
@@ -3053,6 +3087,7 @@ def trading_status() -> dict[str, object]:
             scheduler,
             tca_summary=tca_summary,
             market_context_status=market_context_status,
+            feature_readiness=clickhouse_ta_status,
         )
     )
     shadow_first_runtime = _build_shadow_first_runtime_payload(
@@ -3066,24 +3101,40 @@ def trading_status() -> dict[str, object]:
     )
     shorting_metadata_status = scheduler.shorting_metadata_status()
     rejection_alert_status = scheduler.rejection_alert_status()
-    with SessionLocal() as session:
-        last_decision_at = _load_last_decision_at(session)
-    with SessionLocal() as session:
-        persisted_rejected_signal_outcome_learning = (
-            _load_rejected_signal_outcome_learning_summary(session)
-        )
-    with SessionLocal() as session:
-        live_submission_gate = _build_live_submission_gate_payload(
-            state,
-            session=session,
-            hypothesis_summary=hypothesis_payload,
+    last_decision_at = None
+    if not status_read_budget.exhausted():
+        with SessionLocal() as session:
+            last_decision_at = _load_last_decision_at(session)
+    else:
+        status_read_budget.skip_reason("last_decision")
+    persisted_rejected_signal_outcome_learning = None
+    if not status_read_budget.exhausted():
+        with SessionLocal() as session:
+            persisted_rejected_signal_outcome_learning = (
+                _load_rejected_signal_outcome_learning_summary(session)
+            )
+    else:
+        status_read_budget.skip_reason("rejected_signal_outcome_learning")
+    if status_read_budget.exhausted():
+        live_submission_gate = _budget_exhausted_live_submission_gate_payload(
+            reason=status_read_budget.skip_reason("live_submission_gate"),
             empirical_jobs_status=empirical_jobs,
-            dspy_runtime_status=cast(
-                dict[str, object],
-                scheduler.llm_status().get("dspy_runtime", {}),
-            ),
             quant_health_status=quant_evidence,
         )
+    else:
+        with SessionLocal() as session:
+            live_submission_gate = _build_live_submission_gate_payload(
+                state,
+                session=session,
+                hypothesis_summary=hypothesis_payload,
+                empirical_jobs_status=empirical_jobs,
+                dspy_runtime_status=cast(
+                    dict[str, object],
+                    scheduler.llm_status().get("dspy_runtime", {}),
+                ),
+                quant_health_status=quant_evidence,
+                clickhouse_ta_status=clickhouse_ta_status,
+            )
     simple_lane_reject_reason_totals = _simple_lane_reject_reason_totals(state)
     simple_lane_status = _build_simple_lane_status_payload()
     proof_floor = _build_profitability_proof_floor_payload(
@@ -3123,11 +3174,18 @@ def trading_status() -> dict[str, object]:
         route_reacquisition_board=route_reacquisition_board,
         live_submission_gate=live_submission_gate,
     )
-    with SessionLocal() as session:
-        options_catalog_freshness = _load_options_catalog_freshness_summary(
-            session,
-            route_symbols=_route_claim_symbols(profit_signal_quorum),
+    route_claim_symbols = _route_claim_symbols(profit_signal_quorum)
+    if status_read_budget.exhausted():
+        options_catalog_freshness = _budget_exhausted_options_catalog_freshness_payload(
+            reason=status_read_budget.skip_reason("options_catalog_freshness"),
+            route_symbols=route_claim_symbols,
         )
+    else:
+        with SessionLocal() as session:
+            options_catalog_freshness = _load_options_catalog_freshness_summary(
+                session,
+                route_symbols=route_claim_symbols,
+            )
     capital_replay_projection = _build_capital_replay_projection_payload(
         torghut_revision=str(shadow_first_runtime["active_revision"]),
         dependency_quorum=hypothesis_dependency_quorum.as_payload(),
@@ -3196,7 +3254,6 @@ def trading_status() -> dict[str, object]:
         "image_digest": BUILD_IMAGE_DIGEST,
         "active_revision": shadow_first_runtime["active_revision"],
     }
-    clickhouse_ta_status = _load_clickhouse_ta_status(scheduler)
     profit_freshness_frontier = _build_profit_freshness_frontier_payload(
         torghut_revision=cast(str | None, shadow_first_runtime["active_revision"]),
         dependency_quorum=hypothesis_dependency_quorum.as_payload(),
@@ -3330,6 +3387,7 @@ def trading_status() -> dict[str, object]:
         "execution_lane": settings.trading_pipeline_mode,
         "kill_switch_enabled": settings.trading_kill_switch_enabled,
         "build": build_payload,
+        "status_read_budget": status_read_budget.as_payload(),
         "shadow_first": shadow_first_runtime,
         "execution_advisor": {
             "enabled": settings.trading_execution_advisor_enabled,
@@ -6688,6 +6746,114 @@ def _load_clickhouse_ta_status(
     return ClickHouseSignalIngestor(
         account_label=settings.trading_account_label
     ).latest_signal_status()
+
+
+def _budget_exhausted_live_submission_gate_payload(
+    *,
+    reason: str,
+    empirical_jobs_status: Mapping[str, Any],
+    quant_health_status: Mapping[str, Any],
+) -> dict[str, object]:
+    simple_lane_blockers = [reason]
+    if settings.trading_pipeline_mode == "simple":
+        if not settings.trading_simple_submit_enabled:
+            simple_lane_blockers.append("simple_submit_disabled")
+    return {
+        "allowed": False,
+        "reason": reason,
+        "blocked_reasons": list(dict.fromkeys(simple_lane_blockers)),
+        "reason_codes": [reason],
+        "read_model_unavailable": True,
+        "read_model_status": "timeout",
+        "capital_stage": "shadow",
+        "active_capital_stage": "shadow",
+        "capital_state": "observe",
+        "configured_live_promotion": bool(
+            settings.trading_autonomy_allow_live_promotion
+        ),
+        "autonomy_promotion_eligible": False,
+        "autonomy_promotion_action": None,
+        "drift_live_promotion_eligible": False,
+        "promotion_eligible_total": 0,
+        "paper_probation_eligible_total": 0,
+        "dependency_quorum_decision": "unknown",
+        "continuity_ok": False,
+        "continuity_reason": reason,
+        "drift_ok": False,
+        "drift_reason": reason,
+        "empirical_jobs_ready": empirical_jobs_status.get("ready"),
+        "dspy_live_ready": None,
+        "critical_toggle_parity": _build_shadow_first_toggle_parity(),
+        "critical_toggle_parity_blocking_mismatches": [],
+        "quant_evidence": dict(quant_health_status),
+        "quant_health_ref": {
+            "account": quant_health_status.get("account"),
+            "window": quant_health_status.get("window"),
+            "status": quant_health_status.get("status"),
+            "source_url": quant_health_status.get("source_url"),
+        },
+        "segment_summary": {
+            "state": "blocked",
+            "reason_codes": [reason],
+            "read_model_unavailable": True,
+        },
+        "lineage_ref": {
+            "source": "trading_status",
+            "status": "unavailable",
+            "reason_codes": [reason],
+            "read_model_unavailable": True,
+        },
+        "evaluated_tuples": [],
+        "runtime_ledger_repair_candidates": [],
+        "runtime_ledger_paper_probation_candidates": [],
+        "runtime_ledger_source_collection_candidates": [],
+        "runtime_ledger_source_collection_candidate_total": 0,
+        "runtime_ledger_paper_probation_eligible_total": 0,
+        "runtime_ledger_paper_probation_import_plan": {
+            "state": "unavailable",
+            "reason_codes": [reason],
+            "read_model_unavailable": True,
+        },
+        "profit_window_contract": {
+            "state": "blocked",
+            "reason_codes": [reason],
+            "read_model_unavailable": True,
+        },
+        "profit_lease_projection": {
+            "state": "blocked",
+            "blocking_reason_codes": [reason],
+            "read_model_unavailable": True,
+        },
+        "pipeline_mode": settings.trading_pipeline_mode,
+        "simple_lane": {
+            "submit_enabled": settings.trading_simple_submit_enabled,
+            "shared_gate_enforced": True,
+            "blocked_reasons": simple_lane_blockers,
+        },
+    }
+
+
+def _budget_exhausted_options_catalog_freshness_payload(
+    *,
+    reason: str,
+    route_symbols: Sequence[str],
+) -> dict[str, object]:
+    scoped_symbols = tuple(
+        sorted(
+            {
+                str(symbol).strip().upper()
+                for symbol in route_symbols
+                if str(symbol).strip()
+            }
+        )
+    )
+    return {
+        "status": "unavailable",
+        "scope": "route_symbols" if scoped_symbols else "global",
+        "route_symbols": list(scoped_symbols),
+        "reason_codes": [reason],
+        "read_model_unavailable": True,
+    }
 
 
 def _route_claim_symbols(profit_signal_quorum: Mapping[str, Any]) -> tuple[str, ...]:

--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -3083,6 +3083,7 @@ class AutoresearchPortfolioCandidate(Base, TimestampMixin):
     __table_args__ = (
         Index("ix_autoresearch_portfolio_candidates_epoch_id", "epoch_id"),
         Index("ix_autoresearch_portfolio_candidates_status", "status"),
+        Index("ix_autoresearch_portfolio_candidates_created", "created_at"),
         Index(
             "ix_autoresearch_portfolio_candidates_status_created",
             "status",

--- a/services/torghut/migrations/versions/0046_autoresearch_portfolio_latest_index.py
+++ b/services/torghut/migrations/versions/0046_autoresearch_portfolio_latest_index.py
@@ -1,0 +1,42 @@
+"""Add latest-row index for autoresearch portfolio status reads.
+
+Revision ID: 0046_autoresearch_portfolio_latest_index
+Revises: 0045_paper_route_audit_bounded_read_indexes
+Create Date: 2026-06-02 00:35:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0046_autoresearch_portfolio_latest_index"
+down_revision = "0045_paper_route_audit_bounded_read_indexes"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_autoresearch_portfolio_candidates_created"
+TABLE_NAME = "autoresearch_portfolio_candidates"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(TABLE_NAME):
+        return
+    existing_indexes = {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
+    if INDEX_NAME in existing_indexes:
+        return
+    op.create_index(INDEX_NAME, TABLE_NAME, ["created_at"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(TABLE_NAME):
+        return
+    existing_indexes = {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
+    if INDEX_NAME not in existing_indexes:
+        return
+    op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/services/torghut/tests/test_autoresearch_portfolio_latest_index_migration.py
+++ b/services/torghut/tests/test_autoresearch_portfolio_latest_index_migration.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0046_autoresearch_portfolio_latest_index.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0046", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0046")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestAutoresearchPortfolioLatestIndexMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(module.revision, "0046_autoresearch_portfolio_latest_index")
+        self.assertEqual(
+            module.down_revision,
+            "0045_paper_route_audit_bounded_read_indexes",
+        )
+
+    def test_upgrade_adds_created_at_index(self) -> None:
+        module = _load_migration_module()
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_indexes.return_value = []
+
+        with (
+            patch.object(module.op, "get_bind", return_value=object()),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "create_index") as create_index,
+        ):
+            module.upgrade()
+
+        create_index.assert_called_once_with(
+            "ix_autoresearch_portfolio_candidates_created",
+            "autoresearch_portfolio_candidates",
+            ["created_at"],
+        )
+
+    def test_downgrade_drops_existing_index(self) -> None:
+        module = _load_migration_module()
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_indexes.return_value = [
+            {"name": "ix_autoresearch_portfolio_candidates_created"}
+        ]
+
+        with (
+            patch.object(module.op, "get_bind", return_value=object()),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "drop_index") as drop_index,
+        ):
+            module.downgrade()
+
+        drop_index.assert_called_once_with(
+            "ix_autoresearch_portfolio_candidates_created",
+            table_name="autoresearch_portfolio_candidates",
+        )

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -2533,6 +2533,60 @@ class TestTradingApi(TestCase):
         self.assertIsNot(observed_sessions[0], observed_sessions[2])
         self.assertIsNot(observed_sessions[2], observed_sessions[3])
 
+    def test_trading_status_reuses_clickhouse_signal_status_once(self) -> None:
+        with patch(
+            "app.main._load_clickhouse_ta_status",
+            return_value={
+                "state": "current",
+                "latest_signal_at": datetime(2026, 6, 1, tzinfo=timezone.utc),
+                "source_ref": "clickhouse:ta_signals",
+                "signal_rows": 10,
+                "symbol_count": 1,
+            },
+        ) as load_clickhouse:
+            response = self.client.get("/trading/status")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(load_clickhouse.call_count, 1)
+        payload = response.json()
+        self.assertIn("status_read_budget", payload)
+
+    def test_trading_status_fails_closed_late_reads_after_budget_exhausted(
+        self,
+    ) -> None:
+        with (
+            patch("app.main._TRADING_STATUS_READ_BUDGET_SECONDS", 0.0),
+            patch(
+                "app.main._load_clickhouse_ta_status",
+                return_value={
+                    "state": "current",
+                    "latest_signal_at": datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    "source_ref": "clickhouse:ta_signals",
+                },
+            ),
+            patch("app.main._build_live_submission_gate_payload") as live_gate,
+        ):
+            response = self.client.get("/trading/status")
+
+        self.assertEqual(response.status_code, 200)
+        live_gate.assert_not_called()
+        payload = response.json()
+        self.assertFalse(payload["live_submission_gate"]["allowed"])
+        self.assertEqual(
+            payload["live_submission_gate"]["reason"],
+            "live_submission_gate_status_read_budget_exhausted",
+        )
+        self.assertTrue(payload["live_submission_gate"]["read_model_unavailable"])
+        self.assertTrue(payload["status_read_budget"]["exhausted"])
+        self.assertIn(
+            "live_submission_gate",
+            payload["status_read_budget"]["skipped_reads"],
+        )
+        self.assertIn(
+            "options_catalog_freshness",
+            payload["status_read_budget"]["skipped_reads"],
+        )
+
     def test_readiness_checks_external_dependencies_before_postgres_session(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Reuses one ClickHouse TA status read throughout `/trading/status` so hypothesis readiness, live submission gate, and freshness projections stop repeating the same slow evidence query.
- Adds a `/trading/status` read budget that fails closed with explicit unavailable blockers for late promotion readbacks instead of letting stacked status-only reads push the endpoint past the live proof SLA.
- Adds the missing autoresearch portfolio latest-row index used by the promotion table sampling query, with model and migration coverage.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_api.py tests/test_autoresearch_portfolio_latest_index_migration.py tests/test_status_readiness_bounded_read_indexes_migration.py tests/test_paper_route_audit_bounded_read_indexes_migration.py`
- `uv run --frozen ruff check app/main.py app/models/entities.py tests/test_trading_api.py tests/test_autoresearch_portfolio_latest_index_migration.py migrations/versions/0046_autoresearch_portfolio_latest_index.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds Alembic migration `0046_autoresearch_portfolio_latest_index`; no breaking API changes.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
