### PR TITLE
fix(torghut): honor tigerbeetle journal safe exits

### DIFF
--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -727,6 +727,89 @@ def _supervised_worker_argv(source: str | None = None) -> list[str]:
     ]
 
 
+def _write_supervised_output(value: str | bytes | None, *, stream: Any) -> str:
+    if value is None:
+        return ""
+    text = (
+        value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
+    )
+    if text:
+        stream.write(text)
+        stream.flush()
+    return text
+
+
+def _last_journal_payload(text: str) -> dict[str, Any] | None:
+    payload: dict[str, Any] | None = None
+    for line in text.splitlines():
+        clean_line = line.strip()
+        if not clean_line.startswith("{"):
+            continue
+        try:
+            candidate = json.loads(clean_line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            isinstance(candidate, dict)
+            and candidate.get("schema_version")
+            == "torghut.tigerbeetle-journal-order-events.v1"
+        ):
+            payload = candidate
+    return payload
+
+
+def _safe_payload_allows_success(payload: Mapping[str, Any] | None) -> bool:
+    if not payload:
+        return False
+    if payload.get("schema_version") != "torghut.tigerbeetle-journal-order-events.v1":
+        return False
+    if bool(payload.get("exit_nonzero", True)):
+        return False
+    if bool(payload.get("promotion_authority", True)):
+        return False
+    if bool(payload.get("overrides_runtime_ledger_authority", True)):
+        return False
+    if int(payload.get("failed") or 0) != 0:
+        return False
+    for key in ("hard_failure_reasons", "stop_reasons"):
+        raw_value = payload.get(key)
+        if isinstance(raw_value, Sequence) and not isinstance(
+            raw_value,
+            (str, bytes, bytearray),
+        ):
+            if any(str(item).strip() for item in raw_value):
+                return False
+        elif raw_value:
+            return False
+    return True
+
+
+def _normalize_supervised_returncode(
+    *,
+    returncode: int,
+    payload: Mapping[str, Any] | None,
+    worker_args: argparse.Namespace,
+) -> int:
+    if returncode == 0:
+        return 0
+    if not _safe_payload_allows_success(payload):
+        return returncode
+    assert payload is not None
+    _emit_progress(
+        "supervised_worker_exit_mismatch_normalized",
+        returncode=returncode,
+        sources=list(_parse_sources(getattr(worker_args, "sources", "all"))),
+        status=str(payload.get("status", "")),
+        accounting_blockers=list(
+            cast(Sequence[object], payload.get("accounting_blockers") or [])
+        ),
+        reconciliation_blockers=list(
+            cast(Sequence[object], payload.get("reconciliation_blockers") or [])
+        ),
+    )
+    return 0
+
+
 def _run_supervised_worker_once(
     args: argparse.Namespace,
     *,
@@ -735,13 +818,19 @@ def _run_supervised_worker_once(
 ) -> int:
     worker_args = _args_for_source(args, source)
     timeout_seconds = max(float(worker_args.supervise_timeout_seconds), 0.001)
+    stdout_text = ""
+    stderr_text = ""
     try:
         completed = subprocess.run(
             _supervised_worker_argv(source),
             check=False,
             timeout=timeout_seconds,
+            capture_output=True,
+            text=True,
         )
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as exc:
+        stdout_text += _write_supervised_output(exc.stdout, stream=sys.stdout)
+        stderr_text += _write_supervised_output(exc.stderr, stream=sys.stderr)
         _emit_progress(
             "supervised_worker_timeout",
             timeout_seconds=timeout_seconds,
@@ -758,7 +847,16 @@ def _run_supervised_worker_once(
             else json.dumps(payload, indent=2)
         )
         return 1 if bool(payload["exit_nonzero"]) else 0
-    return int(completed.returncode)
+    stdout_text += _write_supervised_output(completed.stdout, stream=sys.stdout)
+    stderr_text += _write_supervised_output(completed.stderr, stream=sys.stderr)
+    payload = _last_journal_payload(stdout_text)
+    if payload is None:
+        payload = _last_journal_payload(stderr_text)
+    return _normalize_supervised_returncode(
+        returncode=int(completed.returncode),
+        payload=payload,
+        worker_args=worker_args,
+    )
 
 
 def _run_supervised_worker(args: argparse.Namespace, *, started_at: datetime) -> int:

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -635,6 +635,66 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(json.loads(stdout.getvalue()), unsafe_payload)
         self.assertEqual(stderr.getvalue(), "")
 
+    def test_last_journal_payload_skips_worker_noise_and_invalid_json(self) -> None:
+        first_payload = {
+            "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
+            "status": "stale",
+        }
+        final_payload = {
+            "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
+            "status": "degraded",
+            "exit_nonzero": False,
+        }
+
+        payload = script._last_journal_payload(
+            "\n".join(
+                [
+                    "worker booted before json output",
+                    "{invalid-json",
+                    json.dumps({"schema_version": "unrelated.worker.v1"}),
+                    json.dumps(first_payload, separators=(",", ":")),
+                    "worker flushed trailing progress",
+                    json.dumps(final_payload, separators=(",", ":")),
+                ]
+            )
+        )
+
+        self.assertEqual(payload, final_payload)
+
+    def test_safe_payload_rejects_unsafe_supervised_exit_mismatches(self) -> None:
+        safe_payload = {
+            "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
+            "promotion_authority": False,
+            "overrides_runtime_ledger_authority": False,
+            "exit_nonzero": False,
+            "failed": 0,
+            "hard_failure_reasons": [],
+            "stop_reasons": [],
+        }
+        unsafe_cases = [
+            ("missing_payload", None),
+            ("wrong_schema", {**safe_payload, "schema_version": "unrelated.worker.v1"}),
+            ("promotion_authority", {**safe_payload, "promotion_authority": True}),
+            (
+                "runtime_ledger_authority_override",
+                {**safe_payload, "overrides_runtime_ledger_authority": True},
+            ),
+            ("failed_rows", {**safe_payload, "failed": 2}),
+            (
+                "hard_failure_reasons",
+                {**safe_payload, "hard_failure_reasons": ["journal_batch_failures"]},
+            ),
+            (
+                "scalar_stop_reason",
+                {**safe_payload, "stop_reasons": "tigerbeetle_rpc_timeout"},
+            ),
+        ]
+
+        self.assertTrue(script._safe_payload_allows_success(safe_payload))
+        for label, payload in unsafe_cases:
+            with self.subTest(label=label):
+                self.assertFalse(script._safe_payload_allows_success(payload))
+
     def test_torghut_cronjob_keeps_live_sources_split_and_honest(self) -> None:
         manifest = (
             Path(__file__).resolve().parents[3]

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -424,6 +424,8 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertIn("supervised_worker_timeout", stderr.getvalue())
         self.assertIn("--supervised-worker", run_mock.call_args.args[0])
         self.assertEqual(run_mock.call_args.kwargs["timeout"], 0.01)
+        self.assertTrue(run_mock.call_args.kwargs["capture_output"])
+        self.assertTrue(run_mock.call_args.kwargs["text"])
 
     def test_supervised_worker_splits_multi_source_timeout_budget(self) -> None:
         stdout = io.StringIO()
@@ -485,6 +487,8 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertIn("--supervised-worker", second_argv)
         self.assertEqual(run_mock.call_args_list[0].kwargs["timeout"], 0.01)
         self.assertEqual(run_mock.call_args_list[1].kwargs["timeout"], 0.01)
+        self.assertTrue(run_mock.call_args_list[0].kwargs["capture_output"])
+        self.assertTrue(run_mock.call_args_list[1].kwargs["capture_output"])
 
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload["sources"], [script.SOURCE_TYPE_EXECUTION_TCA_METRIC])
@@ -500,6 +504,136 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             f'"{script.SOURCE_TYPE_EXECUTION}","{script.SOURCE_TYPE_EXECUTION_TCA_METRIC}"',
             stderr.getvalue(),
         )
+
+    def test_supervised_worker_normalizes_safe_payload_exit_mismatch(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        safe_payload = {
+            "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
+            "ok": False,
+            "status": "degraded",
+            "authority": "non_authoritative_tigerbeetle_journal_telemetry",
+            "promotion_authority": False,
+            "overrides_runtime_ledger_authority": False,
+            "exit_nonzero": False,
+            "failed": 0,
+            "hard_failure_reasons": [],
+            "stop_reasons": [],
+            "accounting_blockers": ["tigerbeetle_unlinked_execution"],
+            "reconciliation_blockers": ["tigerbeetle_unlinked_execution"],
+            "sources": [script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET],
+        }
+
+        with (
+            patch.dict(os.environ, {"DB_DSN": "sqlite+pysqlite:///:memory:"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "journal_tigerbeetle_order_events.py",
+                    "--dsn-env",
+                    "DB_DSN",
+                    "--sources",
+                    script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    "--batch-size",
+                    "5",
+                    "--max-batches",
+                    "1",
+                    "--fail-on-degraded",
+                    "--allow-data-quality-degraded",
+                    "--json",
+                    "--supervise-timeout-seconds",
+                    "0.01",
+                ],
+            ),
+            patch(
+                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["python", "journal_tigerbeetle_order_events.py"],
+                    returncode=1,
+                    stdout=json.dumps(safe_payload, separators=(",", ":")) + "\n",
+                    stderr="",
+                ),
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            exit_code = script.main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stdout.getvalue()), safe_payload)
+        progress = json.loads(stderr.getvalue())
+        self.assertEqual(
+            progress["event"],
+            "supervised_worker_exit_mismatch_normalized",
+        )
+        self.assertEqual(progress["returncode"], 1)
+        self.assertEqual(
+            progress["sources"],
+            [script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET],
+        )
+        self.assertEqual(
+            progress["accounting_blockers"],
+            ["tigerbeetle_unlinked_execution"],
+        )
+
+    def test_supervised_worker_keeps_unsafe_payload_exit_nonzero(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        unsafe_payload = {
+            "schema_version": "torghut.tigerbeetle-journal-order-events.v1",
+            "ok": False,
+            "status": "degraded",
+            "authority": "non_authoritative_tigerbeetle_journal_telemetry",
+            "promotion_authority": False,
+            "overrides_runtime_ledger_authority": False,
+            "exit_nonzero": True,
+            "failed": 1,
+            "hard_failure_reasons": ["journal_batch_failures"],
+            "stop_reasons": [],
+            "accounting_blockers": [],
+            "reconciliation_blockers": [],
+            "sources": [script.SOURCE_TYPE_EXECUTION],
+        }
+
+        with (
+            patch.dict(os.environ, {"DB_DSN": "sqlite+pysqlite:///:memory:"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "journal_tigerbeetle_order_events.py",
+                    "--dsn-env",
+                    "DB_DSN",
+                    "--sources",
+                    script.SOURCE_TYPE_EXECUTION,
+                    "--batch-size",
+                    "5",
+                    "--max-batches",
+                    "1",
+                    "--fail-on-degraded",
+                    "--json",
+                    "--supervise-timeout-seconds",
+                    "0.01",
+                ],
+            ),
+            patch(
+                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["python", "journal_tigerbeetle_order_events.py"],
+                    returncode=1,
+                    stdout=json.dumps(unsafe_payload, separators=(",", ":")) + "\n",
+                    stderr="",
+                ),
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            exit_code = script.main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(json.loads(stdout.getvalue()), unsafe_payload)
+        self.assertEqual(stderr.getvalue(), "")
 
     def test_torghut_cronjob_keeps_live_sources_split_and_honest(self) -> None:
         manifest = (


### PR DESCRIPTION
## Summary

- Normalizes supervised TigerBeetle journal child-process return-code mismatches only when the emitted journal payload is explicitly safe to treat as success.
- Requires `exit_nonzero=false`, no hard failures, no stopped batches, no failed rows, and non-authoritative telemetry flags before converting a nonzero child return to success.
- Emits `supervised_worker_exit_mismatch_normalized` progress events with sources/status/blockers so accounting diagnostics remain visible instead of being hidden.
- Adds focused regression coverage for worker-output noise parsing and unsafe safe-exit payload guard branches that previously left changed lines uncovered.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py -q --cov=scripts --cov-branch --cov-report=xml --cov-fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
