### PR TITLE
fix(torghut): bound execution journal batches

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -60,7 +60,7 @@ spec:
                     --dsn-env DB_DSN \
                     --sources execution \
                     --batch-size 5 \
-                    --max-batches 3 \
+                    --max-batches 1 \
                     --reconcile-limit 1000 \
                     --skip-reconcile \
                     --fail-on-degraded \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1541,8 +1541,8 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)
         self.assertNotIn("--account-label TORGHUT_SIM", live_args)
         self.assertEqual(live_args.count("--batch-size 5"), 4)
-        self.assertEqual(live_args.count("--max-batches 3"), 3)
-        self.assertEqual(live_args.count("--max-batches 1"), 1)
+        self.assertEqual(live_args.count("--max-batches 3"), 2)
+        self.assertEqual(live_args.count("--max-batches 1"), 2)
         self.assertIn("--event-scan-limit 250", live_args)
         self.assertIn("--reconcile-limit 1000", live_args)
 


### PR DESCRIPTION
## Summary

- Keeps the live TigerBeetle execution journal pass at one newest-first batch per run after live evidence showed the second execution batch timing out.
- Leaves live TCA and order-event journal passes at three batches so they can keep draining quickly.
- Updates the live manifest contract test to lock the safer split: two `--max-batches 3` passes and two `--max-batches 1` passes.

## Related Issues

None

## Testing

- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut > /tmp/torghut-kustomize-render-exec-batches.yaml`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
