### PR TITLE
fix(synthesis): reduce autotrader runtime alert noise

### DIFF
--- a/apps/synthesis/src/routes/-autotrader-alerts.test.ts
+++ b/apps/synthesis/src/routes/-autotrader-alerts.test.ts
@@ -98,6 +98,63 @@ describe('getAutotraderRuntimeAlerts', () => {
     )
   })
 
+  test('does not bury guard-finalized sessions under stale zero-exposure risk alerts', () => {
+    const base = detailFor()
+    const detail = detailFor({
+      session: {
+        ...base.session,
+        finalizedAt: '2026-06-01T20:00:54.011Z',
+        terminalReason: 'market_closed',
+        summary: {
+          guard: 'autotrader-session-guard',
+          reason: 'market close reached after original AgentRun job completed early',
+          finalOpenOrders: 0,
+          finalPositions: 0,
+        },
+      },
+      orders: [
+        {
+          sessionId: 'session-1',
+          ticketId: null,
+          clientOrderId: 'atr-20260601-stale-SPY-01',
+          brokerOrderId: null,
+          symbol: 'SPY',
+          instrument: 'etf',
+          side: 'buy',
+          quantity: '1',
+          orderType: 'limit',
+          orderClass: null,
+          limitPrice: '500',
+          stopPrice: null,
+          takeProfitLimitPrice: null,
+          stopLossStopPrice: null,
+          stopLossLimitPrice: null,
+          status: 'submitted',
+          rejectReason: null,
+          brokerPayload: {},
+          updatedAt: '2026-06-01T15:59:20Z',
+        },
+      ],
+      positionSnapshots: [
+        {
+          id: 'pos-1',
+          sessionId: 'session-1',
+          symbol: 'SPY',
+          quantity: '1',
+          marketValue: '500',
+          averageEntryPrice: '500',
+          unrealizedPnl: '0',
+          capturedAt: '2026-06-01T15:59:30Z',
+          brokerPayload: {},
+        },
+      ],
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, new Date('2026-06-01T21:00:00Z')).map((alert) => alert.key)).toEqual([
+      'market-session-ended-early',
+    ])
+  })
+
   test('flags market sessions finalized before regular close', () => {
     const base = detailFor()
     const detail = detailFor({
@@ -124,6 +181,38 @@ describe('getAutotraderRuntimeAlerts', () => {
     })
 
     expect(getAutotraderRuntimeAlerts(detail, new Date('2026-05-29T21:00:00Z'))).toEqual([])
+  })
+
+  test('treats replaced orders as terminal for reconciliation alerts', () => {
+    const detail = detailFor({
+      orders: [
+        {
+          sessionId: 'session-1',
+          ticketId: null,
+          clientOrderId: 'atr-20260529-test-1-NVDA-01',
+          brokerOrderId: null,
+          symbol: 'NVDA',
+          instrument: 'stock',
+          side: 'buy',
+          quantity: '1',
+          orderType: 'limit',
+          orderClass: null,
+          limitPrice: '100',
+          stopPrice: null,
+          takeProfitLimitPrice: null,
+          stopLossStopPrice: null,
+          stopLossLimitPrice: null,
+          status: 'replaced',
+          rejectReason: null,
+          brokerPayload: {},
+          updatedAt: '2026-05-29T13:59:20Z',
+        },
+      ],
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, now).map((alert) => alert.key)).not.toContain(
+      'unreconciled-order:atr-20260529-test-1-NVDA-01',
+    )
   })
 
   test('flags nonterminal orders older than 30 seconds', () => {

--- a/apps/synthesis/src/routes/-autotrader-alerts.ts
+++ b/apps/synthesis/src/routes/-autotrader-alerts.ts
@@ -19,6 +19,7 @@ const terminalOrderStatuses = new Set<AutotraderOrder['status']>([
   'rejected',
   'expired',
   'reconciled',
+  'replaced',
 ])
 
 const protectiveOrderClasses = new Set(['bracket', 'oco', 'oto'])
@@ -44,6 +45,18 @@ const parsedTime = (value: string | null | undefined) => {
   const parsed = Date.parse(value)
   return Number.isFinite(parsed) ? parsed : null
 }
+
+const countIsZero = (value: unknown) => {
+  if (Array.isArray(value)) return value.length === 0
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN
+  return Number.isFinite(parsed) && parsed === 0
+}
+
+const finalizedWithNoOpenOrders = (detail: AutotraderSessionDetail) =>
+  Boolean(detail.session.finalizedAt && countIsZero(detail.session.summary.finalOpenOrders))
+
+const finalizedWithNoPositions = (detail: AutotraderSessionDetail) =>
+  Boolean(detail.session.finalizedAt && countIsZero(detail.session.summary.finalPositions))
 
 const truthyRuntimeFlag = (value: unknown) => {
   if (value === true) return true
@@ -193,24 +206,28 @@ export const getAutotraderRuntimeAlerts = (detail: AutotraderSessionDetail, now 
     }
   }
 
-  for (const order of detail.orders) {
-    if (!isAutotraderOrderUnreconciled(order, now)) continue
-    alerts.push({
-      key: `unreconciled-order:${order.clientOrderId}`,
-      severity: 'critical',
-      title: 'Unreconciled order',
-      message: `${order.symbol} order ${order.clientOrderId} is still ${order.status} after 30 seconds.`,
-    })
+  if (!finalizedWithNoOpenOrders(detail)) {
+    for (const order of detail.orders) {
+      if (!isAutotraderOrderUnreconciled(order, now)) continue
+      alerts.push({
+        key: `unreconciled-order:${order.clientOrderId}`,
+        severity: 'critical',
+        title: 'Unreconciled order',
+        message: `${order.symbol} order ${order.clientOrderId} is still ${order.status} after 30 seconds.`,
+      })
+    }
   }
 
-  for (const snapshot of latestPositionSnapshots(detail)) {
-    if (positionHasProtection(detail, snapshot)) continue
-    alerts.push({
-      key: `unprotected-position:${snapshot.symbol}`,
-      severity: 'warning',
-      title: 'Position protection missing',
-      message: `${snapshot.symbol} has a non-zero position without broker-attached protection or an active managed-loop fallback.`,
-    })
+  if (!finalizedWithNoPositions(detail)) {
+    for (const snapshot of latestPositionSnapshots(detail)) {
+      if (positionHasProtection(detail, snapshot)) continue
+      alerts.push({
+        key: `unprotected-position:${snapshot.symbol}`,
+        severity: 'warning',
+        title: 'Position protection missing',
+        message: `${snapshot.symbol} has a non-zero position without broker-attached protection or an active managed-loop fallback.`,
+      })
+    }
   }
 
   return alerts


### PR DESCRIPTION
## Summary

- Treats Alpaca/Synthesis `replaced` orders as terminal for unreconciled-order runtime alerts.
- Suppresses stale order and position risk alerts after a finalized session summary confirms zero final open orders and zero final positions.
- Adds regression coverage using the June 1 guard-finalized failure shape so the operator sees the early-session alert without stale risk noise.

## Related Issues

None

## Testing

- `bun test apps/synthesis/src/routes/-autotrader-alerts.test.ts`
- `bun run --filter synthesis test -- src/routes/-autotrader-alerts.test.ts`
- `bun run --filter synthesis lint`
- `bun run --filter synthesis build`
- Local live-payload probe against `http://synthesis/api/autotrader/sessions/06f25b73-6d06-4bf4-bb64-e5304e409972` now returns only `market-session-ended-early` from `getAutotraderRuntimeAlerts`.

## Screenshots (if applicable)

N/A - runtime alert behavior is covered by focused tests and the live-payload helper probe.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
