### PR TITLE
feat(torghut): add hpairs clusterlob ofi feature lane

### DIFF
--- a/services/torghut/app/trading/discovery/cluster_lob_features.py
+++ b/services/torghut/app/trading/discovery/cluster_lob_features.py
@@ -1,0 +1,375 @@
+"""ClusterLOB-style replay-tape feature extraction for H-PAIRS discovery.
+
+The extractor accepts replay ``SignalEnvelope`` rows or plain fixture mappings.
+It never reaches live cluster services and its payloads are explicitly
+preview-only research-ranking metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from math import isfinite, log
+from typing import Any, cast
+
+from app.trading.discovery.order_flow_features import (
+    DEFAULT_OFI_HORIZON_BUCKETS,
+    HPAIRS_ORDER_FLOW_FEATURE_SCHEMA_VERSION,
+    ReplayFeatureRecord,
+    build_order_flow_feature_schema_hash,
+    extract_order_flow_features,
+)
+from app.trading.models import SignalEnvelope
+
+HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION = "torghut.hpairs-clusterlob-features.v1"
+HPAIRS_CLUSTER_LOB_FEATURE_CONTRACT_SCHEMA_VERSION = (
+    "torghut.hpairs-clusterlob-feature-contract.v1"
+)
+HPAIRS_CLUSTER_LOB_PROOF_SEMANTICS_LABEL = "hpairs_clusterlob_order_flow_features_preview_only_exact_replay_and_runtime_ledger_required"
+
+_EXPLICIT_CLUSTER_FIELDS: tuple[str, ...] = (
+    "cluster_lob_bucket",
+    "cluster_bucket",
+    "participant_bucket",
+    "behavior_bucket",
+    "cluster_lob_label",
+    "cluster_label",
+    "order_cluster",
+)
+_EVENT_FIELDS: tuple[str, ...] = (
+    "lob_event_type",
+    "event_type",
+    "order_event_type",
+    "side",
+    "aggressor_side",
+    "trade_side",
+    "liquidity_side",
+)
+
+
+@dataclass(frozen=True)
+class ClusterLOBFeatureSet:
+    row_count: int
+    symbol_count: int
+    source_fields: tuple[str, ...]
+    warnings: tuple[str, ...]
+    cluster_bins: Mapping[str, int]
+    dominant_cluster_bin: str
+    cluster_entropy: float
+    cluster_switch_rate: float
+    order_flow_payload: Mapping[str, Any]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        ranking_features = self.ranking_features()
+        return {
+            "schema_version": HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_research_ranking",
+            "row_count": self.row_count,
+            "symbol_count": self.symbol_count,
+            "source_fields": list(self.source_fields),
+            "warnings": list(self.warnings),
+            "cluster_bins": dict(sorted(self.cluster_bins.items())),
+            "dominant_cluster_bin": self.dominant_cluster_bin,
+            "cluster_entropy": _stable_float(self.cluster_entropy),
+            "cluster_switch_rate": _stable_float(self.cluster_switch_rate),
+            "order_flow": dict(self.order_flow_payload),
+            "ranking_features": ranking_features,
+            "prefilter_only": True,
+            "research_ranking_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": HPAIRS_CLUSTER_LOB_PROOF_SEMANTICS_LABEL,
+        }
+
+    def ranking_features(self) -> dict[str, Any]:
+        order_flow_ranking = _mapping(self.order_flow_payload.get("ranking_features"))
+        directional_alignment = _float_or_zero(
+            order_flow_ranking.get("directional_alignment_score")
+        )
+        imbalance_abs_mean = _float_or_zero(
+            order_flow_ranking.get("imbalance_abs_mean")
+        )
+        missing_penalty = _float_or_zero(order_flow_ranking.get("missing_data_penalty"))
+        return {
+            "directional_alignment_score": _stable_float(directional_alignment),
+            "imbalance_abs_mean": _stable_float(imbalance_abs_mean),
+            "cluster_entropy": _stable_float(self.cluster_entropy),
+            "cluster_switch_rate": _stable_float(self.cluster_switch_rate),
+            "missing_data_penalty": _stable_float(missing_penalty),
+            "preview_rank_feature_score": _stable_float(
+                (abs(directional_alignment) * 18.0)
+                + (imbalance_abs_mean * 10.0)
+                + (self.cluster_entropy * 4.0)
+                + (self.cluster_switch_rate * 2.0)
+                - (missing_penalty * 8.0)
+            ),
+        }
+
+
+def cluster_lob_feature_contract(
+    *, horizons: Sequence[int] = DEFAULT_OFI_HORIZON_BUCKETS
+) -> dict[str, Any]:
+    return {
+        "schema_version": HPAIRS_CLUSTER_LOB_FEATURE_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION,
+        "order_flow_schema_version": HPAIRS_ORDER_FLOW_FEATURE_SCHEMA_VERSION,
+        "order_flow_schema_hash": build_order_flow_feature_schema_hash(
+            horizons=horizons
+        ),
+        "horizon_buckets": [int(item) for item in horizons],
+        "explicit_cluster_fields": list(_EXPLICIT_CLUSTER_FIELDS),
+        "event_fields": list(_EVENT_FIELDS),
+        "bin_policy": "deterministic_explicit_bucket_or_order_event_fallback",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_runtime_ledger": True,
+        },
+    }
+
+
+def build_cluster_lob_feature_schema_hash(
+    *, horizons: Sequence[int] = DEFAULT_OFI_HORIZON_BUCKETS
+) -> str:
+    return _stable_hash(cluster_lob_feature_contract(horizons=horizons))
+
+
+def extract_cluster_lob_features(
+    records: Sequence[ReplayFeatureRecord],
+    *,
+    horizons: Sequence[int] = DEFAULT_OFI_HORIZON_BUCKETS,
+) -> ClusterLOBFeatureSet:
+    ordered = tuple(sorted(records, key=_record_sort_key))
+    source_fields: set[str] = set()
+    bins = tuple(
+        _cluster_bin(record, source_fields=source_fields) for record in ordered
+    )
+    counts: Counter[str] = Counter(bins)
+    order_flow = extract_order_flow_features(ordered, horizons=horizons)
+    warnings = list(order_flow.warnings)
+    if not ordered:
+        warnings.append("empty_cluster_lob_records")
+    if "unknown_event_cluster" in counts:
+        warnings.append("missing_cluster_lob_inputs")
+    symbols = {
+        symbol
+        for record in ordered
+        if (symbol := str(_record_value(record, "symbol") or "").strip().upper())
+    }
+    return ClusterLOBFeatureSet(
+        row_count=len(ordered),
+        symbol_count=len(symbols),
+        source_fields=tuple(sorted(source_fields | set(order_flow.source_fields))),
+        warnings=tuple(dict.fromkeys(warnings)),
+        cluster_bins=dict(counts),
+        dominant_cluster_bin=_dominant_bin(counts),
+        cluster_entropy=_normalized_entropy(counts),
+        cluster_switch_rate=_switch_rate(bins),
+        order_flow_payload=order_flow.to_payload(),
+        feature_schema_hash=build_cluster_lob_feature_schema_hash(horizons=horizons),
+    )
+
+
+def _cluster_bin(record: ReplayFeatureRecord, *, source_fields: set[str]) -> str:
+    for key in _EXPLICIT_CLUSTER_FIELDS:
+        raw = _record_value(record, key)
+        text = _normalize_label(raw)
+        if text:
+            source_fields.add(key)
+            return text
+
+    event_text = ""
+    for key in _EVENT_FIELDS:
+        raw = _record_value(record, key)
+        text = _normalize_label(raw)
+        if text:
+            source_fields.add(key)
+            event_text = text
+            break
+
+    side = _side_label(record, source_fields=source_fields)
+    if event_text in {"trade", "fill", "execution"} and side == "buy":
+        return "aggressive_buy_trade"
+    if event_text in {"trade", "fill", "execution"} and side == "sell":
+        return "aggressive_sell_trade"
+    if event_text in {"add", "new", "open", "quote"} and side == "buy":
+        return "bid_liquidity_add"
+    if event_text in {"add", "new", "open", "quote"} and side == "sell":
+        return "ask_liquidity_add"
+    if event_text in {"cancel", "delete", "remove"} and side == "buy":
+        return "bid_liquidity_remove"
+    if event_text in {"cancel", "delete", "remove"} and side == "sell":
+        return "ask_liquidity_remove"
+    if event_text:
+        return f"event_{event_text}"
+
+    depth_imbalance = _quote_depth_imbalance(record, source_fields=source_fields)
+    if depth_imbalance > 0.25:
+        return "bid_depth_dominant"
+    if depth_imbalance < -0.25:
+        return "ask_depth_dominant"
+    if depth_imbalance != 0.0:
+        return "balanced_depth"
+    return "unknown_event_cluster"
+
+
+def _dominant_bin(counts: Counter[str]) -> str:
+    if not counts:
+        return "none"
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _normalized_entropy(counts: Counter[str]) -> float:
+    total = sum(counts.values())
+    if total <= 0 or len(counts) <= 1:
+        return 0.0
+    entropy = 0.0
+    for count in counts.values():
+        probability = count / total
+        entropy -= probability * log(probability)
+    return min(1.0, entropy / log(len(counts)))
+
+
+def _switch_rate(bins: Sequence[str]) -> float:
+    if len(bins) <= 1:
+        return 0.0
+    switches = sum(
+        1 for previous, current in zip(bins, bins[1:]) if previous != current
+    )
+    return switches / float(len(bins) - 1)
+
+
+def _record_sort_key(record: ReplayFeatureRecord) -> tuple[str, str, int]:
+    event_ts = _record_value(record, "event_ts")
+    seq = _record_value(record, "seq")
+    symbol = str(_record_value(record, "symbol") or "").upper()
+    event_key = (
+        event_ts.isoformat() if hasattr(event_ts, "isoformat") else str(event_ts or "")
+    )
+    seq_value = int(seq) if isinstance(seq, int) else 0
+    return (event_key, symbol, seq_value)
+
+
+def _record_value(record: ReplayFeatureRecord, key: str) -> Any:
+    if isinstance(record, SignalEnvelope):
+        if key == "event_ts":
+            return record.event_ts
+        if key == "symbol":
+            return record.symbol
+        if key == "seq":
+            return record.seq
+        return record.payload.get(key)
+    if key in record:
+        return record.get(key)
+    payload = record.get("payload")
+    if isinstance(payload, Mapping):
+        payload_mapping = cast(Mapping[str, Any], payload)
+        return payload_mapping.get(key)
+    return None
+
+
+def _side_label(record: ReplayFeatureRecord, *, source_fields: set[str]) -> str:
+    for key in ("side", "aggressor_side", "trade_side", "liquidity_side"):
+        text = _normalize_label(_record_value(record, key))
+        if not text:
+            continue
+        source_fields.add(key)
+        if text in {"buy", "bid", "b", "long", "ask_lift", "lift"}:
+            return "buy"
+        if text in {"sell", "ask", "s", "short", "bid_hit", "hit"}:
+            return "sell"
+    return ""
+
+
+def _quote_depth_imbalance(
+    record: ReplayFeatureRecord, *, source_fields: set[str]
+) -> float:
+    bid_size = _first_float(
+        record, ("bid_size", "bid_qty", "best_bid_size"), source_fields=source_fields
+    )
+    ask_size = _first_float(
+        record, ("ask_size", "ask_qty", "best_ask_size"), source_fields=source_fields
+    )
+    if bid_size is None or ask_size is None:
+        return 0.0
+    total = bid_size + ask_size
+    if total <= 0.0:
+        return 0.0
+    return (bid_size - ask_size) / total
+
+
+def _first_float(
+    record: ReplayFeatureRecord, keys: Sequence[str], *, source_fields: set[str]
+) -> float | None:
+    for key in keys:
+        value = _float_or_none(_record_value(record, key))
+        if value is not None:
+            source_fields.add(key)
+            return value
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+    elif isinstance(value, Decimal):
+        parsed = float(value)
+    else:
+        try:
+            parsed = float(str(value).strip())
+        except ValueError:
+            return None
+    return parsed if isfinite(parsed) else None
+
+
+def _float_or_zero(value: Any) -> float:
+    parsed = _float_or_none(value)
+    return parsed if parsed is not None else 0.0
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _normalize_label(value: Any) -> str:
+    text = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return "_".join(part for part in text.split("_") if part)
+
+
+def _stable_float(value: float) -> str:
+    if not isfinite(value):
+        return "0"
+    return f"{value:.12g}"
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION",
+    "HPAIRS_CLUSTER_LOB_PROOF_SEMANTICS_LABEL",
+    "ClusterLOBFeatureSet",
+    "build_cluster_lob_feature_schema_hash",
+    "cluster_lob_feature_contract",
+    "extract_cluster_lob_features",
+]

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -14,6 +14,10 @@ import numpy as np
 from numpy.typing import NDArray
 
 from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.discovery.cluster_lob_features import (
+    HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION,
+    extract_cluster_lob_features,
+)
 from app.trading.discovery.microstructure_prefilter import (
     HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
     HPAIRS_PREFILTER_PROOF_SOURCE,
@@ -22,8 +26,8 @@ from app.trading.discovery.microstructure_prefilter import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v6"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v7"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v7"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v8"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -34,6 +38,7 @@ FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP = 6
 FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "cluster_lob_event_clustering_proxy",
     "bounded_hpairs_clusterlob_ofi_candidate_prefilter",
+    "offline_clusterlob_order_flow_feature_lane",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -92,6 +97,9 @@ class FastReplayPreviewRow:
     exploration_score: Decimal
     frontier_bucket: str
     microstructure_prefilter: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    clusterlob_order_flow_features: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -207,6 +215,10 @@ class FastReplayPreviewRow:
                 "final_promotion_allowed": False,
                 "final_authority_ok": False,
             },
+            "clusterlob_order_flow_features": dict(self.clusterlob_order_flow_features),
+            "hpairs_clusterlob_order_flow_feature_lane": dict(
+                self.clusterlob_order_flow_features
+            ),
             "microstructure_prefilter": dict(self.microstructure_prefilter),
             "hpairs_microstructure_prefilter": dict(self.microstructure_prefilter),
             "hpairs_macro_window_stress": prefilter_macro_window_stress,
@@ -289,6 +301,9 @@ class FastReplayPreviewResult:
     hpairs_microstructure_prefilter: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
+    clusterlob_order_flow_feature_lane: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
 
     def to_manifest_payload(self) -> dict[str, Any]:
         return {
@@ -316,6 +331,7 @@ class FastReplayPreviewResult:
             "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
             "implemented_mechanisms": {
                 "hpairs_clusterlob_ofi_prefilter": "deterministic bounded H-PAIRS candidate prefilter metadata only; never promotion authority",
+                "clusterlob_order_flow_feature_lane": "offline replay-tape/fixture ClusterLOB and horizon OFI features for preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -330,6 +346,12 @@ class FastReplayPreviewResult:
             ],
             "hpairs_microstructure_prefilter": dict(
                 self.hpairs_microstructure_prefilter
+            ),
+            "clusterlob_order_flow_feature_lane": dict(
+                self.clusterlob_order_flow_feature_lane
+            ),
+            "hpairs_clusterlob_order_flow_feature_lane": dict(
+                self.clusterlob_order_flow_feature_lane
             ),
             "requested_top_k": self.requested_top_k,
             "exact_replay_candidate_cap": self.exact_replay_candidate_cap,
@@ -496,6 +518,7 @@ def build_fast_replay_preview(
         ),
     )
     symbol_stats = _build_symbol_stats(rows)
+    clusterlob_feature_lane_by_symbol = _build_clusterlob_feature_lane_by_symbol(rows)
     hpairs_prefilter = build_hpairs_microstructure_prefilter(
         specs=specs,
         rows=rows,
@@ -517,6 +540,10 @@ def build_fast_replay_preview(
                 min_rows_per_candidate=max(1, int(min_rows_per_candidate)),
                 microstructure_prefilter=hpairs_prefilter_payload_by_spec.get(
                     spec.candidate_spec_id, {}
+                ),
+                clusterlob_order_flow_features=_candidate_clusterlob_feature_lane(
+                    requested_symbols=_candidate_symbols(spec),
+                    feature_lane_by_symbol=clusterlob_feature_lane_by_symbol,
                 ),
                 replay_tape_manifest=replay_tape_manifest,
             )
@@ -557,6 +584,9 @@ def build_fast_replay_preview(
         ),
         exact_replay_candidate_cap=bounded_top_k,
         hpairs_microstructure_prefilter=hpairs_prefilter.to_manifest_payload(),
+        clusterlob_order_flow_feature_lane=_clusterlob_feature_lane_manifest(
+            feature_lane_by_symbol=clusterlob_feature_lane_by_symbol
+        ),
     )
 
 
@@ -649,12 +679,197 @@ def _build_symbol_stats(rows: Sequence[SignalEnvelope]) -> dict[str, _SymbolTape
     return stats
 
 
+def _build_clusterlob_feature_lane_by_symbol(
+    rows: Sequence[SignalEnvelope],
+) -> dict[str, Mapping[str, Any]]:
+    rows_by_symbol: dict[str, list[SignalEnvelope]] = {}
+    for row in rows:
+        symbol = row.symbol.strip().upper()
+        if symbol:
+            rows_by_symbol.setdefault(symbol, []).append(row)
+    return {
+        symbol: extract_cluster_lob_features(symbol_rows).to_payload()
+        for symbol, symbol_rows in rows_by_symbol.items()
+    }
+
+
+def _candidate_clusterlob_feature_lane(
+    *,
+    requested_symbols: Sequence[str],
+    feature_lane_by_symbol: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    matched_symbols = tuple(
+        symbol for symbol in requested_symbols if symbol in feature_lane_by_symbol
+    )
+    symbol_features = {
+        symbol: dict(feature_lane_by_symbol[symbol]) for symbol in matched_symbols
+    }
+    row_counts = [
+        int(_float_or_none(payload.get("row_count")) or 0.0)
+        for payload in symbol_features.values()
+    ]
+    weights = [max(1, row_count) for row_count in row_counts]
+    ranking_payloads = [
+        _mapping(payload.get("ranking_features"))
+        for payload in symbol_features.values()
+    ]
+    directional_alignment_score = _weighted_average(
+        [
+            (
+                _float_or_none(ranking.get("directional_alignment_score")) or 0.0,
+                weight,
+            )
+            for ranking, weight in zip(ranking_payloads, weights)
+        ]
+    )
+    imbalance_abs_mean = _weighted_average(
+        [
+            (_float_or_none(ranking.get("imbalance_abs_mean")) or 0.0, weight)
+            for ranking, weight in zip(ranking_payloads, weights)
+        ]
+    )
+    cluster_entropy = _weighted_average(
+        [
+            (_float_or_none(ranking.get("cluster_entropy")) or 0.0, weight)
+            for ranking, weight in zip(ranking_payloads, weights)
+        ]
+    )
+    cluster_switch_rate = _weighted_average(
+        [
+            (_float_or_none(ranking.get("cluster_switch_rate")) or 0.0, weight)
+            for ranking, weight in zip(ranking_payloads, weights)
+        ]
+    )
+    missing_penalty = _weighted_average(
+        [
+            (_float_or_none(ranking.get("missing_data_penalty")) or 0.0, weight)
+            for ranking, weight in zip(ranking_payloads, weights)
+        ]
+    )
+    preview_rank_feature_score = (
+        abs(directional_alignment_score) * 18.0
+        + imbalance_abs_mean * 10.0
+        + cluster_entropy * 4.0
+        + cluster_switch_rate * 2.0
+        - missing_penalty * 8.0
+    )
+    feature_schema_hashes = tuple(
+        sorted(
+            {
+                str(payload.get("feature_schema_hash") or "")
+                for payload in symbol_features.values()
+                if str(payload.get("feature_schema_hash") or "")
+            }
+        )
+    )
+    warnings = tuple(
+        sorted(
+            {
+                str(warning)
+                for payload in symbol_features.values()
+                for warning in _string_tuple(payload.get("warnings"))
+            }
+        )
+    )
+    return {
+        "schema_version": "torghut.fast-replay-clusterlob-order-flow-feature-lane.v1",
+        "feature_schema_version": HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION,
+        "status": "preview_only_research_ranking",
+        "matched_symbols": list(matched_symbols),
+        "requested_symbols": list(requested_symbols),
+        "matched_symbol_count": len(matched_symbols),
+        "requested_symbol_count": len(requested_symbols),
+        "row_count": sum(row_counts),
+        "feature_schema_hashes": list(feature_schema_hashes),
+        "warnings": list(warnings),
+        "ranking_features": {
+            "directional_alignment_score": _decimal_string_from_float(
+                directional_alignment_score
+            ),
+            "imbalance_abs_mean": _decimal_string_from_float(imbalance_abs_mean),
+            "cluster_entropy": _decimal_string_from_float(cluster_entropy),
+            "cluster_switch_rate": _decimal_string_from_float(cluster_switch_rate),
+            "missing_data_penalty": _decimal_string_from_float(missing_penalty),
+            "preview_rank_feature_score": _decimal_string_from_float(
+                preview_rank_feature_score
+            ),
+        },
+        "symbol_features": symbol_features,
+        "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+        "research_ranking_only": True,
+        "prefilter_only": True,
+        "promotion_proof": False,
+        "proof_authority": False,
+        "promotion_authority": False,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_authority_ok": False,
+    }
+
+
+def _clusterlob_feature_lane_manifest(
+    *, feature_lane_by_symbol: Mapping[str, Mapping[str, Any]]
+) -> dict[str, Any]:
+    feature_schema_hashes = tuple(
+        sorted(
+            {
+                str(payload.get("feature_schema_hash") or "")
+                for payload in feature_lane_by_symbol.values()
+                if str(payload.get("feature_schema_hash") or "")
+            }
+        )
+    )
+    return {
+        "schema_version": "torghut.fast-replay-clusterlob-order-flow-feature-lane-manifest.v1",
+        "feature_schema_version": HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION,
+        "status": "preview_only_research_ranking",
+        "symbol_count": len(feature_lane_by_symbol),
+        "feature_schema_hashes": list(feature_schema_hashes),
+        "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+        "research_ranking_only": True,
+        "prefilter_only": True,
+        "promotion_proof": False,
+        "proof_authority": False,
+        "promotion_authority": False,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_authority_ok": False,
+    }
+
+
+def _clusterlob_feature_lane_score(
+    payload: Mapping[str, Any], *, direction: float
+) -> float:
+    ranking_features = _mapping(payload.get("ranking_features"))
+    directional_alignment_score = (
+        _float_or_none(ranking_features.get("directional_alignment_score")) or 0.0
+    )
+    imbalance_abs_mean = (
+        _float_or_none(ranking_features.get("imbalance_abs_mean")) or 0.0
+    )
+    cluster_entropy = _float_or_none(ranking_features.get("cluster_entropy")) or 0.0
+    cluster_switch_rate = (
+        _float_or_none(ranking_features.get("cluster_switch_rate")) or 0.0
+    )
+    missing_penalty = (
+        _float_or_none(ranking_features.get("missing_data_penalty")) or 0.0
+    )
+    return (
+        direction * directional_alignment_score * 30.0
+        + imbalance_abs_mean * 8.0
+        + cluster_entropy * 3.0
+        + cluster_switch_rate * 2.0
+        - missing_penalty * 12.0
+    )
+
+
 def _score_candidate_spec(
     *,
     spec: CandidateSpec,
     symbol_stats: Mapping[str, _SymbolTapeStats],
     min_rows_per_candidate: int,
     microstructure_prefilter: Mapping[str, Any],
+    clusterlob_order_flow_features: Mapping[str, Any],
     replay_tape_manifest: ReplayTapeManifest,
 ) -> FastReplayPreviewRow:
     candidate_frontier_hash = _candidate_frontier_hash(spec)
@@ -701,6 +916,7 @@ def _score_candidate_spec(
             exploration_score=Decimal("0"),
             frontier_bucket="not_selected",
             microstructure_prefilter=dict(microstructure_prefilter),
+            clusterlob_order_flow_features=dict(clusterlob_order_flow_features),
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -786,9 +1002,15 @@ def _score_candidate_spec(
     )
     if macro_window_concentration is not None:
         preview_score -= macro_window_concentration * 6.0
+    clusterlob_lane_score = _clusterlob_feature_lane_score(
+        clusterlob_order_flow_features,
+        direction=direction,
+    )
+    preview_score += clusterlob_lane_score * 0.20
     exploration_score = (
         cluster_lob_activity_score * 4.0
         + abs(ofi_decay_alignment_score) * 5.0
+        + abs(clusterlob_lane_score) * 0.12
         + liquidity_regime_score * 2.0
         + coverage_score * 6.0
         - macro_stress_veto_score * 8.0
@@ -829,6 +1051,7 @@ def _score_candidate_spec(
         exploration_score=_decimal_from_float(exploration_score),
         frontier_bucket="not_selected",
         microstructure_prefilter=dict(microstructure_prefilter),
+        clusterlob_order_flow_features=dict(clusterlob_order_flow_features),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1033,6 +1256,7 @@ def _row_with_rank_and_selection(
         exploration_score=row.exploration_score,
         frontier_bucket=frontier_bucket,
         microstructure_prefilter=dict(row.microstructure_prefilter),
+        clusterlob_order_flow_features=dict(row.clusterlob_order_flow_features),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -1082,6 +1306,7 @@ def _row_with_frontier_dedupe(
         exploration_score=row.exploration_score,
         frontier_bucket=row.frontier_bucket,
         microstructure_prefilter=dict(row.microstructure_prefilter),
+        clusterlob_order_flow_features=dict(row.clusterlob_order_flow_features),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -1738,6 +1963,10 @@ def _hpairs_replay_tape_features(signal: SignalEnvelope) -> dict[str, Any]:
 
 def _decimal_from_float(value: float) -> Decimal:
     return Decimal(str(round(float(value), 8)))
+
+
+def _decimal_string_from_float(value: float) -> str:
+    return str(_decimal_from_float(value))
 
 
 def _observed_post_cost_expectancy_bps(row: FastReplayPreviewRow) -> Decimal:

--- a/services/torghut/app/trading/discovery/order_flow_features.py
+++ b/services/torghut/app/trading/discovery/order_flow_features.py
@@ -1,0 +1,534 @@
+"""Deterministic H-PAIRS order-flow feature primitives for replay tapes.
+
+These features are offline candidate-discovery metadata only.  They are cheap
+enough for local fast-preview ranking, deterministic for fixture/replay rows,
+and deliberately carry no promotion or runtime-ledger authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from math import exp, isfinite, tanh
+from typing import Any, TypeAlias, cast
+
+from app.trading.models import SignalEnvelope
+
+HPAIRS_ORDER_FLOW_FEATURE_SCHEMA_VERSION = "torghut.hpairs-order-flow-features.v1"
+HPAIRS_ORDER_FLOW_FEATURE_CONTRACT_SCHEMA_VERSION = (
+    "torghut.hpairs-order-flow-feature-contract.v1"
+)
+HPAIRS_ORDER_FLOW_PROOF_SEMANTICS_LABEL = (
+    "hpairs_order_flow_features_preview_only_exact_replay_and_runtime_ledger_required"
+)
+DEFAULT_OFI_HORIZON_BUCKETS: tuple[int, ...] = (1, 3, 12, 36)
+
+ReplayFeatureRecord: TypeAlias = SignalEnvelope | Mapping[str, Any]
+
+_OFI_FIELDS: tuple[str, ...] = (
+    "ofi_pressure_score",
+    "order_flow_imbalance",
+    "ofi",
+    "signed_order_flow_imbalance",
+    "queue_imbalance",
+    "book_imbalance",
+    "depth_imbalance",
+)
+_SIGNED_VOLUME_FIELDS: tuple[str, ...] = (
+    "signed_volume",
+    "signed_qty",
+    "signed_quantity",
+    "signed_size",
+    "aggressor_signed_volume",
+)
+_VOLUME_FIELDS: tuple[str, ...] = (
+    "microbar_volume",
+    "volume",
+    "qty",
+    "quantity",
+    "size",
+    "trade_size",
+    "last_size",
+)
+_BID_SIZE_FIELDS: tuple[str, ...] = ("bid_size", "bid_qty", "best_bid_size")
+_ASK_SIZE_FIELDS: tuple[str, ...] = ("ask_size", "ask_qty", "best_ask_size")
+
+
+@dataclass(frozen=True)
+class OrderFlowEvent:
+    index: int
+    signed_volume: float
+    absolute_volume: float
+    normalized_imbalance: float
+    source_fields: tuple[str, ...]
+    missing: bool
+
+
+@dataclass(frozen=True)
+class OrderFlowHorizonBucket:
+    horizon: int
+    bucket_index: int
+    row_count: int
+    signed_volume: float
+    absolute_volume: float
+    imbalance: float
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "horizon": self.horizon,
+            "bucket_index": self.bucket_index,
+            "row_count": self.row_count,
+            "signed_volume": _stable_float(self.signed_volume),
+            "absolute_volume": _stable_float(self.absolute_volume),
+            "imbalance": _stable_float(self.imbalance),
+        }
+
+
+@dataclass(frozen=True)
+class OrderFlowHorizonSummary:
+    horizon: int
+    bucket_count: int
+    observed_event_count: int
+    signed_volume: float
+    absolute_volume: float
+    mean_bucket_imbalance: float
+    tail_bucket_imbalance: float
+    decayed_imbalance: float
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "horizon": self.horizon,
+            "bucket_count": self.bucket_count,
+            "observed_event_count": self.observed_event_count,
+            "signed_volume": _stable_float(self.signed_volume),
+            "absolute_volume": _stable_float(self.absolute_volume),
+            "mean_bucket_imbalance": _stable_float(self.mean_bucket_imbalance),
+            "tail_bucket_imbalance": _stable_float(self.tail_bucket_imbalance),
+            "decayed_imbalance": _stable_float(self.decayed_imbalance),
+        }
+
+
+@dataclass(frozen=True)
+class OrderFlowFeatureSet:
+    row_count: int
+    horizons: tuple[int, ...]
+    source_fields: tuple[str, ...]
+    warnings: tuple[str, ...]
+    signed_volume_total: float
+    absolute_volume_total: float
+    imbalance_mean: float
+    imbalance_abs_mean: float
+    directional_alignment_score: float
+    horizon_summaries: tuple[OrderFlowHorizonSummary, ...]
+    horizon_buckets: tuple[OrderFlowHorizonBucket, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": HPAIRS_ORDER_FLOW_FEATURE_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_research_ranking",
+            "row_count": self.row_count,
+            "horizons": list(self.horizons),
+            "source_fields": list(self.source_fields),
+            "warnings": list(self.warnings),
+            "signed_volume_total": _stable_float(self.signed_volume_total),
+            "absolute_volume_total": _stable_float(self.absolute_volume_total),
+            "imbalance_mean": _stable_float(self.imbalance_mean),
+            "imbalance_abs_mean": _stable_float(self.imbalance_abs_mean),
+            "directional_alignment_score": _stable_float(
+                self.directional_alignment_score
+            ),
+            "horizon_summaries": [
+                summary.to_payload() for summary in self.horizon_summaries
+            ],
+            "horizon_buckets": [bucket.to_payload() for bucket in self.horizon_buckets],
+            "ranking_features": {
+                "directional_alignment_score": _stable_float(
+                    self.directional_alignment_score
+                ),
+                "imbalance_abs_mean": _stable_float(self.imbalance_abs_mean),
+                "missing_data_penalty": _stable_float(
+                    1.0 if "missing_order_flow_inputs" in self.warnings else 0.0
+                ),
+            },
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": HPAIRS_ORDER_FLOW_PROOF_SEMANTICS_LABEL,
+        }
+
+
+def order_flow_feature_contract(
+    *, horizons: Sequence[int] = DEFAULT_OFI_HORIZON_BUCKETS
+) -> dict[str, Any]:
+    normalized_horizons = _normalize_horizons(horizons)
+    return {
+        "schema_version": HPAIRS_ORDER_FLOW_FEATURE_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": HPAIRS_ORDER_FLOW_FEATURE_SCHEMA_VERSION,
+        "horizon_buckets": list(normalized_horizons),
+        "ofi_fields": list(_OFI_FIELDS),
+        "signed_volume_fields": list(_SIGNED_VOLUME_FIELDS),
+        "volume_fields": list(_VOLUME_FIELDS),
+        "quote_depth_fields": {
+            "bid": list(_BID_SIZE_FIELDS),
+            "ask": list(_ASK_SIZE_FIELDS),
+        },
+        "bucket_policy": "deterministic_non_overlapping_event_count_buckets",
+        "decay_policy": "deterministic_exponential_tail_weighted_imbalance",
+        "proof_neutrality": {
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_runtime_ledger": True,
+        },
+    }
+
+
+def build_order_flow_feature_schema_hash(
+    *, horizons: Sequence[int] = DEFAULT_OFI_HORIZON_BUCKETS
+) -> str:
+    return _stable_hash(order_flow_feature_contract(horizons=horizons))
+
+
+def extract_order_flow_features(
+    records: Sequence[ReplayFeatureRecord],
+    *,
+    horizons: Sequence[int] = DEFAULT_OFI_HORIZON_BUCKETS,
+) -> OrderFlowFeatureSet:
+    """Extract deterministic horizon/bucket OFI features from replay records."""
+
+    normalized_horizons = _normalize_horizons(horizons)
+    ordered = tuple(sorted(records, key=_record_sort_key))
+    events = tuple(
+        _order_flow_event(index=index, record=record)
+        for index, record in enumerate(ordered)
+    )
+    source_fields = tuple(
+        sorted({field for event in events for field in event.source_fields})
+    )
+    warnings: list[str] = []
+    if any(event.missing for event in events):
+        warnings.append("missing_order_flow_inputs")
+    if not events:
+        warnings.append("empty_order_flow_records")
+
+    signed_total = sum(event.signed_volume for event in events)
+    absolute_total = sum(event.absolute_volume for event in events)
+    imbalances = [event.normalized_imbalance for event in events if not event.missing]
+    imbalance_mean = _safe_mean(imbalances)
+    imbalance_abs_mean = _safe_mean([abs(value) for value in imbalances])
+    horizon_buckets: list[OrderFlowHorizonBucket] = []
+    horizon_summaries: list[OrderFlowHorizonSummary] = []
+    for horizon in normalized_horizons:
+        buckets = _horizon_buckets(events=events, horizon=horizon)
+        horizon_buckets.extend(buckets)
+        horizon_summaries.append(
+            _horizon_summary(events=events, horizon=horizon, buckets=buckets)
+        )
+
+    directional_alignment_score = _directional_alignment_score(horizon_summaries)
+    return OrderFlowFeatureSet(
+        row_count=len(ordered),
+        horizons=normalized_horizons,
+        source_fields=source_fields,
+        warnings=tuple(warnings),
+        signed_volume_total=signed_total,
+        absolute_volume_total=absolute_total,
+        imbalance_mean=imbalance_mean,
+        imbalance_abs_mean=imbalance_abs_mean,
+        directional_alignment_score=directional_alignment_score,
+        horizon_summaries=tuple(horizon_summaries),
+        horizon_buckets=tuple(horizon_buckets),
+        feature_schema_hash=build_order_flow_feature_schema_hash(
+            horizons=normalized_horizons
+        ),
+    )
+
+
+def _horizon_buckets(
+    *, events: Sequence[OrderFlowEvent], horizon: int
+) -> tuple[OrderFlowHorizonBucket, ...]:
+    buckets: list[OrderFlowHorizonBucket] = []
+    for bucket_index, start in enumerate(range(0, len(events), horizon)):
+        bucket_events = events[start : start + horizon]
+        signed_volume = sum(event.signed_volume for event in bucket_events)
+        absolute_volume = sum(event.absolute_volume for event in bucket_events)
+        buckets.append(
+            OrderFlowHorizonBucket(
+                horizon=horizon,
+                bucket_index=bucket_index,
+                row_count=len(bucket_events),
+                signed_volume=signed_volume,
+                absolute_volume=absolute_volume,
+                imbalance=_ratio(signed_volume, absolute_volume),
+            )
+        )
+    return tuple(buckets)
+
+
+def _horizon_summary(
+    *,
+    events: Sequence[OrderFlowEvent],
+    horizon: int,
+    buckets: Sequence[OrderFlowHorizonBucket],
+) -> OrderFlowHorizonSummary:
+    signed_volume = sum(bucket.signed_volume for bucket in buckets)
+    absolute_volume = sum(bucket.absolute_volume for bucket in buckets)
+    return OrderFlowHorizonSummary(
+        horizon=horizon,
+        bucket_count=len(buckets),
+        observed_event_count=len(events),
+        signed_volume=signed_volume,
+        absolute_volume=absolute_volume,
+        mean_bucket_imbalance=_safe_mean([bucket.imbalance for bucket in buckets]),
+        tail_bucket_imbalance=buckets[-1].imbalance if buckets else 0.0,
+        decayed_imbalance=_decayed_imbalance(events=events, horizon=horizon),
+    )
+
+
+def _decayed_imbalance(*, events: Sequence[OrderFlowEvent], horizon: int) -> float:
+    if not events:
+        return 0.0
+    half_life = max(1.0, float(horizon) / 2.0)
+    weighted_signed = 0.0
+    weighted_absolute = 0.0
+    newest_index = len(events) - 1
+    for index, event in enumerate(events):
+        age = newest_index - index
+        weight = exp(-float(age) / half_life)
+        weighted_signed += event.signed_volume * weight
+        weighted_absolute += event.absolute_volume * weight
+    return _ratio(weighted_signed, weighted_absolute)
+
+
+def _directional_alignment_score(
+    summaries: Sequence[OrderFlowHorizonSummary],
+) -> float:
+    if not summaries:
+        return 0.0
+    by_horizon = {summary.horizon: summary for summary in summaries}
+    shortest = by_horizon[min(by_horizon)]
+    longest = by_horizon[max(by_horizon)]
+    short_signal = (
+        0.55 * shortest.decayed_imbalance + 0.45 * shortest.tail_bucket_imbalance
+    )
+    long_signal = (
+        0.50 * longest.decayed_imbalance + 0.50 * longest.mean_bucket_imbalance
+    )
+    return _clip((short_signal * 0.65) + (long_signal * 0.35), -1.0, 1.0)
+
+
+def _order_flow_event(*, index: int, record: ReplayFeatureRecord) -> OrderFlowEvent:
+    source_fields: list[str] = []
+    signed_volume = _first_float(
+        record, _SIGNED_VOLUME_FIELDS, source_fields=source_fields
+    )
+    if signed_volume is not None:
+        absolute_volume = abs(signed_volume)
+        explicit_abs = _first_float(record, _VOLUME_FIELDS, source_fields=source_fields)
+        if explicit_abs is not None:
+            absolute_volume = max(absolute_volume, abs(explicit_abs))
+        return OrderFlowEvent(
+            index=index,
+            signed_volume=signed_volume,
+            absolute_volume=max(absolute_volume, 1.0),
+            normalized_imbalance=_clip(
+                _ratio(signed_volume, max(absolute_volume, 1.0)), -1.0, 1.0
+            ),
+            source_fields=tuple(source_fields),
+            missing=False,
+        )
+
+    ofi = _first_float(record, _OFI_FIELDS, source_fields=source_fields)
+    volume = _first_float(record, _VOLUME_FIELDS, source_fields=source_fields)
+    if ofi is not None:
+        normalized = _normalize_imbalance(ofi)
+        absolute_volume = max(abs(volume) if volume is not None else 1.0, 1.0)
+        return OrderFlowEvent(
+            index=index,
+            signed_volume=normalized * absolute_volume,
+            absolute_volume=absolute_volume,
+            normalized_imbalance=normalized,
+            source_fields=tuple(source_fields),
+            missing=False,
+        )
+
+    side_sign = _side_sign(record, source_fields=source_fields)
+    if side_sign is not None and volume is not None:
+        absolute_volume = max(abs(volume), 1.0)
+        return OrderFlowEvent(
+            index=index,
+            signed_volume=side_sign * absolute_volume,
+            absolute_volume=absolute_volume,
+            normalized_imbalance=side_sign,
+            source_fields=tuple(source_fields),
+            missing=False,
+        )
+
+    bid_size = _first_float(record, _BID_SIZE_FIELDS, source_fields=source_fields)
+    ask_size = _first_float(record, _ASK_SIZE_FIELDS, source_fields=source_fields)
+    if (
+        bid_size is not None
+        and ask_size is not None
+        and bid_size >= 0.0
+        and ask_size >= 0.0
+    ):
+        absolute_depth = max(bid_size + ask_size, 1.0)
+        imbalance = _ratio(bid_size - ask_size, absolute_depth)
+        return OrderFlowEvent(
+            index=index,
+            signed_volume=imbalance * absolute_depth,
+            absolute_volume=absolute_depth,
+            normalized_imbalance=_clip(imbalance, -1.0, 1.0),
+            source_fields=tuple(source_fields),
+            missing=False,
+        )
+
+    return OrderFlowEvent(
+        index=index,
+        signed_volume=0.0,
+        absolute_volume=0.0,
+        normalized_imbalance=0.0,
+        source_fields=tuple(source_fields),
+        missing=True,
+    )
+
+
+def _normalize_horizons(horizons: Sequence[int]) -> tuple[int, ...]:
+    normalized = tuple(sorted({max(1, int(item)) for item in horizons}))
+    return normalized or DEFAULT_OFI_HORIZON_BUCKETS
+
+
+def _record_sort_key(record: ReplayFeatureRecord) -> tuple[str, str, int]:
+    event_ts = _record_value(record, "event_ts")
+    seq = _record_value(record, "seq")
+    symbol = str(_record_value(record, "symbol") or "").upper()
+    if isinstance(event_ts, datetime):
+        event_key = event_ts.isoformat()
+    else:
+        event_key = str(event_ts or "")
+    seq_value = int(seq) if isinstance(seq, int) else 0
+    return (event_key, symbol, seq_value)
+
+
+def _record_value(record: ReplayFeatureRecord, key: str) -> Any:
+    if isinstance(record, SignalEnvelope):
+        if key == "event_ts":
+            return record.event_ts
+        if key == "symbol":
+            return record.symbol
+        if key == "seq":
+            return record.seq
+        return record.payload.get(key)
+    if key in record:
+        return record.get(key)
+    payload = record.get("payload")
+    if isinstance(payload, Mapping):
+        payload_mapping = cast(Mapping[str, Any], payload)
+        return payload_mapping.get(key)
+    return None
+
+
+def _first_float(
+    record: ReplayFeatureRecord,
+    keys: Sequence[str],
+    *,
+    source_fields: list[str],
+) -> float | None:
+    for key in keys:
+        value = _float_or_none(_record_value(record, key))
+        if value is not None:
+            source_fields.append(key)
+            return value
+    return None
+
+
+def _side_sign(
+    record: ReplayFeatureRecord, *, source_fields: list[str]
+) -> float | None:
+    for key in ("side", "aggressor_side", "trade_side", "liquidity_side"):
+        raw = _record_value(record, key)
+        text = str(raw or "").strip().lower()
+        if not text:
+            continue
+        source_fields.append(key)
+        if text in {"buy", "bid", "b", "long", "ask_lift", "lift"}:
+            return 1.0
+        if text in {"sell", "ask", "s", "short", "bid_hit", "hit"}:
+            return -1.0
+    trade_sign = _float_or_none(_record_value(record, "trade_sign"))
+    if trade_sign is not None:
+        source_fields.append("trade_sign")
+        return 1.0 if trade_sign > 0.0 else -1.0 if trade_sign < 0.0 else 0.0
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+    elif isinstance(value, Decimal):
+        parsed = float(value)
+    else:
+        try:
+            parsed = float(str(value).strip())
+        except ValueError:
+            return None
+    return parsed if isfinite(parsed) else None
+
+
+def _normalize_imbalance(value: float) -> float:
+    if -1.0 <= value <= 1.0:
+        return value
+    return tanh(value / 100.0)
+
+
+def _ratio(numerator: float, denominator: float) -> float:
+    if denominator <= 0.0:
+        return 0.0
+    return numerator / denominator
+
+
+def _safe_mean(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / float(len(values))
+
+
+def _clip(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _stable_float(value: float) -> str:
+    if not isfinite(value):
+        return "0"
+    return f"{value:.12g}"
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "DEFAULT_OFI_HORIZON_BUCKETS",
+    "HPAIRS_ORDER_FLOW_FEATURE_SCHEMA_VERSION",
+    "HPAIRS_ORDER_FLOW_PROOF_SEMANTICS_LABEL",
+    "OrderFlowFeatureSet",
+    "ReplayFeatureRecord",
+    "build_order_flow_feature_schema_hash",
+    "extract_order_flow_features",
+    "order_flow_feature_contract",
+]

--- a/services/torghut/tests/test_cluster_lob_features.py
+++ b/services/torghut/tests/test_cluster_lob_features.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.cluster_lob_features import (
+    build_cluster_lob_feature_schema_hash,
+    extract_cluster_lob_features,
+)
+from app.trading.discovery.order_flow_features import (
+    build_order_flow_feature_schema_hash,
+    extract_order_flow_features,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestClusterLOBFeatures(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        symbol: str = "AAA",
+        ofi: str | None = None,
+        volume: str = "100",
+        event_type: str = "trade",
+        side: str = "buy",
+        bid_size: str = "700",
+        ask_size: str = "300",
+    ) -> SignalEnvelope:
+        payload: dict[str, object] = {
+            "event_type": event_type,
+            "side": side,
+            "microbar_volume": Decimal(volume),
+            "bid_size": Decimal(bid_size),
+            "ask_size": Decimal(ask_size),
+        }
+        if ofi is not None:
+            payload["ofi"] = Decimal(ofi)
+        return SignalEnvelope(
+            event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset),
+            symbol=symbol,
+            timeframe="1Min",
+            seq=offset,
+            source="fixture",
+            payload=payload,
+            ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
+        )
+
+    def test_order_flow_extraction_is_deterministic_for_replay_rows(self) -> None:
+        rows = [
+            self._row(offset=2, ofi="0.25", side="buy"),
+            self._row(offset=1, ofi="-0.10", side="sell"),
+            self._row(offset=3, ofi="0.50", side="buy"),
+        ]
+
+        first = extract_order_flow_features(rows).to_payload()
+        second = extract_order_flow_features(tuple(reversed(rows))).to_payload()
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["status"], "preview_only_research_ranking")
+        self.assertFalse(first["promotion_allowed"])
+        self.assertFalse(first["final_authority_ok"])
+        self.assertGreater(float(first["directional_alignment_score"]), 0)
+
+    def test_schema_hash_is_stable_and_invalidates_on_horizon_change(self) -> None:
+        default_hash = build_order_flow_feature_schema_hash()
+        same_hash = build_order_flow_feature_schema_hash(horizons=(36, 12, 3, 1))
+        changed_hash = build_order_flow_feature_schema_hash(horizons=(1, 3, 12, 36, 72))
+        cluster_hash = build_cluster_lob_feature_schema_hash()
+
+        self.assertEqual(default_hash, same_hash)
+        self.assertNotEqual(default_hash, changed_hash)
+        self.assertEqual(cluster_hash, build_cluster_lob_feature_schema_hash())
+        self.assertNotEqual(
+            cluster_hash,
+            build_cluster_lob_feature_schema_hash(horizons=(1, 3, 12, 36, 72)),
+        )
+
+    def test_horizon_buckets_and_decay_reflect_tail_order_flow(self) -> None:
+        rows = [
+            self._row(offset=1, ofi="-0.50"),
+            self._row(offset=2, ofi="-0.50"),
+            self._row(offset=3, ofi="0.80"),
+            self._row(offset=4, ofi="0.80"),
+        ]
+
+        features = extract_order_flow_features(rows, horizons=(2, 4)).to_payload()
+        summaries = {item["horizon"]: item for item in features["horizon_summaries"]}
+
+        self.assertEqual(summaries[2]["bucket_count"], 2)
+        self.assertLess(float(summaries[2]["mean_bucket_imbalance"]), 0.2)
+        self.assertGreater(float(summaries[2]["tail_bucket_imbalance"]), 0.7)
+        self.assertGreater(float(summaries[2]["decayed_imbalance"]), 0)
+        self.assertGreater(
+            float(features["ranking_features"]["directional_alignment_score"]), 0
+        )
+
+    def test_cluster_bin_assignment_is_stable_for_fixture_records(self) -> None:
+        fixture_rows = [
+            {
+                "event_ts": "2026-02-23T14:30:01+00:00",
+                "symbol": "AAA",
+                "payload": {
+                    "event_type": "trade",
+                    "side": "buy",
+                    "ofi": "0.4",
+                    "microbar_volume": "100",
+                },
+            },
+            {
+                "event_ts": "2026-02-23T14:30:02+00:00",
+                "symbol": "AAA",
+                "payload": {
+                    "event_type": "cancel",
+                    "side": "sell",
+                    "ofi": "-0.2",
+                    "microbar_volume": "50",
+                },
+            },
+            {
+                "event_ts": "2026-02-23T14:30:03+00:00",
+                "symbol": "AAA",
+                "payload": {"cluster_lob_bucket": "Directional Buy"},
+            },
+        ]
+
+        payload = extract_cluster_lob_features(fixture_rows).to_payload()
+
+        self.assertEqual(payload["cluster_bins"]["aggressive_buy_trade"], 1)
+        self.assertEqual(payload["cluster_bins"]["ask_liquidity_remove"], 1)
+        self.assertEqual(payload["cluster_bins"]["directional_buy"], 1)
+        self.assertGreater(float(payload["cluster_entropy"]), 0.9)
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["final_promotion_allowed"])
+
+    def test_missing_partial_data_is_marked_without_authority(self) -> None:
+        payload = extract_cluster_lob_features(
+            [
+                {
+                    "event_ts": "2026-02-23T14:30:01+00:00",
+                    "symbol": "AAA",
+                    "payload": {"price": "100"},
+                }
+            ]
+        ).to_payload()
+
+        self.assertIn("missing_order_flow_inputs", payload["warnings"])
+        self.assertIn("missing_cluster_lob_inputs", payload["warnings"])
+        self.assertEqual(payload["dominant_cluster_bin"], "unknown_event_cluster")
+        self.assertTrue(payload["prefilter_only"])
+        self.assertFalse(payload["promotion_proof"])
+        self.assertFalse(payload["proof_authority"])

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -177,6 +177,25 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn("hpairs_macro_window_stress", row_payload)
         self.assertFalse(row_payload["hpairs_macro_window_stress"]["proof_authority"])
+        self.assertIn("hpairs_clusterlob_order_flow_feature_lane", row_payload)
+        feature_lane = row_payload["hpairs_clusterlob_order_flow_feature_lane"]
+        self.assertEqual(feature_lane["status"], "preview_only_research_ranking")
+        self.assertEqual(
+            feature_lane["resource_scope"],
+            "local_offline_replay_tape_or_fixture_rows_only",
+        )
+        self.assertFalse(feature_lane["promotion_allowed"])
+        self.assertFalse(feature_lane["promotion_authority"])
+        self.assertFalse(feature_lane["final_authority_ok"])
+        self.assertIn("feature_schema_hashes", feature_lane)
+        self.assertIn(
+            "hpairs_clusterlob_order_flow_feature_lane",
+            payload,
+        )
+        manifest_lane = payload["hpairs_clusterlob_order_flow_feature_lane"]
+        self.assertEqual(manifest_lane["status"], "preview_only_research_ranking")
+        self.assertFalse(manifest_lane["promotion_allowed"])
+        self.assertFalse(manifest_lane["final_authority_ok"])
         self.assertEqual(
             row_payload["adv_capacity_context"]["status"], "missing_source_backed_adv"
         )


### PR DESCRIPTION
## Summary

- Adds deterministic offline H-PAIRS order-flow feature extraction with horizon buckets, signed volume/imbalance summaries, decay behavior, and stable schema hashes.
- Adds ClusterLOB-style deterministic event/bin assignment over replay-tape rows or fixture mappings, including entropy/switch-rate ranking metadata and no-authority semantics.
- Wires the ClusterLOB/order-flow feature lane into `fast_replay` preview ranking only, with row and manifest metadata marked `preview_only_research_ranking` and all promotion/final authority fields false.
- Adds focused tests for determinism, schema hash invalidation, horizon bucket/decay behavior, stable cluster/bin assignment, missing data handling, and no promotion authority.

## Related Issues

None.

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed.
- `cd services/torghut && uv run --frozen pytest tests/test_cluster_lob_features.py tests/test_fast_replay.py -q` — passed: 15 tests, 1 existing deprecation warning from `tests/conftest.py`.
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/order_flow_features.py app/trading/discovery/cluster_lob_features.py app/trading/discovery/fast_replay.py tests/test_cluster_lob_features.py tests/test_fast_replay.py` — passed.
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/order_flow_features.py app/trading/discovery/cluster_lob_features.py app/trading/discovery/fast_replay.py tests/test_cluster_lob_features.py tests/test_fast_replay.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed: 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed: 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed: 0 errors.
- `cd services/torghut && git diff --check` — passed.

## Screenshots (if applicable)

N/A — backend/offline feature extraction and ranking metadata only.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
