### PR TITLE
chore(synthesis): promote autotrader alert image

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.580.13
+    newTag: autotrader-alerts-1b28424ec
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promotes Synthesis to the manually built GitOps image `registry.ide-newton.ts.net/lab/synthesis:autotrader-alerts-1b28424ec` from current main commit `1b28424ec`.
- Includes the merged autotrader runtime alert fixes from PRs `#9722` and `#9728` while CI Docker builds remain queued on `arc-arm64`.
- Keeps rollout GitOps-only by changing the Argo kustomization tag; no direct cluster apply is included.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/synthesis:autotrader-alerts-1b28424ec`

Image digest: `sha256:c4eee74629a3b64b36d30ebeaf1a5996b245048be7de27b2f3664a2689b6b5c2`

## Screenshots (if applicable)

N/A - GitOps image promotion only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
