### PR TITLE
chore(synthesis): restore autotrader alert image

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.580.13
+    newTag: autotrader-alerts-1b28424ec
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Restores the Synthesis GitOps image tag to `autotrader-alerts-1b28424ec` on current `main`.
- Prevents a later Argo refresh from rolling the live Synthesis deployment back to `0.580.13`.
- Keeps the rollout on the already-pushed image digest used by the live deployment.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check -- argocd/applications/synthesis/kustomization.yaml`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/synthesis:autotrader-alerts-1b28424ec`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
