### PR TITLE
fix(torghut): use target-implied discovery notional gates

### DIFF
--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -42,6 +42,19 @@ _ACCEPTED_DELAY_ADJUSTED_DEPTH_STRESS_MODELS = frozenset(
         "portfolio_latency_depth_haircut",
     }
 )
+_POST_COST_EXPECTANCY_BPS_KEYS = (
+    "observed_post_cost_expectancy_bps",
+    "post_cost_expectancy_bps",
+    "portfolio_post_cost_expectancy_bps",
+    "realized_post_cost_expectancy_bps",
+)
+_AVG_FILLED_NOTIONAL_PER_DAY_KEYS = (
+    "avg_filled_notional_per_day",
+    "average_filled_notional_per_day",
+    "avg_daily_filled_notional",
+    "filled_notional_per_day",
+    "avg_filled_notional_per_window_weekday",
+)
 
 
 @dataclass(frozen=True)
@@ -304,6 +317,120 @@ def _numeric_check(
         "operator": operator,
         "threshold": str(threshold),
         "passed": passed,
+    }
+
+
+def _decimal_payload(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    return format(value, "f")
+
+
+def _first_positive_decimal(
+    scorecard: Mapping[str, Any], keys: tuple[str, ...]
+) -> tuple[Decimal, str]:
+    for key in keys:
+        value = _decimal(scorecard.get(key))
+        if value > 0:
+            return value, key
+    return Decimal("0"), ""
+
+
+def _first_decimal_or_none(
+    scorecard: Mapping[str, Any], keys: tuple[str, ...]
+) -> tuple[Decimal | None, str]:
+    for key in keys:
+        raw_value = scorecard.get(key)
+        if raw_value is None or (isinstance(raw_value, str) and not raw_value.strip()):
+            continue
+        return _decimal(raw_value), key
+    return None, ""
+
+
+def _target_implied_notional_gate_payload(
+    *,
+    scorecard: Mapping[str, Any],
+    target_net_pnl_per_day: Decimal,
+    baseline_min_avg_filled_notional_per_day: Decimal,
+    post_cost_net_pnl_per_day: Decimal,
+    post_cost_pnl_basis: str,
+    post_cost_pnl_source: str,
+) -> dict[str, Any]:
+    avg_filled_notional_per_day, avg_filled_notional_source = _first_positive_decimal(
+        scorecard, _AVG_FILLED_NOTIONAL_PER_DAY_KEYS
+    )
+    explicit_expectancy_bps, explicit_expectancy_source = _first_decimal_or_none(
+        scorecard, _POST_COST_EXPECTANCY_BPS_KEYS
+    )
+    blockers: list[str] = []
+    post_cost_basis_ok = post_cost_pnl_basis in _ACCEPTED_LEDGER_PNL_BASES
+    post_cost_source_ok = post_cost_pnl_source in _ACCEPTED_LEDGER_PNL_SOURCES
+    if not post_cost_basis_ok:
+        blockers.append("target_implied_post_cost_pnl_basis_missing_or_unsupported")
+    if not post_cost_source_ok:
+        blockers.append("target_implied_post_cost_pnl_source_missing_or_unsupported")
+    if avg_filled_notional_per_day <= 0:
+        blockers.append(
+            "target_implied_avg_filled_notional_per_day_missing_or_non_positive"
+        )
+
+    observed_expectancy_bps: Decimal | None = None
+    observed_expectancy_source = ""
+    if post_cost_basis_ok and post_cost_source_ok and avg_filled_notional_per_day > 0:
+        if explicit_expectancy_bps is not None:
+            observed_expectancy_bps = explicit_expectancy_bps
+            observed_expectancy_source = explicit_expectancy_source
+        elif post_cost_net_pnl_per_day > 0:
+            observed_expectancy_bps = (
+                post_cost_net_pnl_per_day
+                / avg_filled_notional_per_day
+                * Decimal("10000")
+            )
+            observed_expectancy_source = (
+                "derived_from_post_cost_net_pnl_per_day_and_avg_filled_notional_per_day"
+            )
+
+    if observed_expectancy_bps is None or observed_expectancy_bps <= 0:
+        blockers.append(
+            "target_implied_post_cost_expectancy_bps_missing_or_non_positive"
+        )
+
+    target_implied_min_avg_filled_notional_per_day: Decimal | None = None
+    if observed_expectancy_bps is not None and observed_expectancy_bps > 0:
+        target_implied_min_avg_filled_notional_per_day = (
+            target_net_pnl_per_day * Decimal("10000") / observed_expectancy_bps
+        )
+    effective_min_avg_filled_notional_per_day = baseline_min_avg_filled_notional_per_day
+    if target_implied_min_avg_filled_notional_per_day is not None:
+        effective_min_avg_filled_notional_per_day = max(
+            baseline_min_avg_filled_notional_per_day,
+            target_implied_min_avg_filled_notional_per_day,
+        )
+
+    return {
+        "target_daily_net_pnl": _decimal_payload(target_net_pnl_per_day),
+        "post_cost_net_pnl_per_day": _decimal_payload(post_cost_net_pnl_per_day),
+        "post_cost_pnl_basis": post_cost_pnl_basis,
+        "post_cost_pnl_source": post_cost_pnl_source,
+        "post_cost_basis_accepted": post_cost_basis_ok,
+        "post_cost_source_accepted": post_cost_source_ok,
+        "avg_filled_notional_per_day": _decimal_payload(avg_filled_notional_per_day),
+        "avg_filled_notional_per_day_source": avg_filled_notional_source,
+        "observed_post_cost_expectancy_bps": _decimal_payload(observed_expectancy_bps),
+        "observed_post_cost_expectancy_bps_source": observed_expectancy_source,
+        "baseline_min_avg_filled_notional_per_day": _decimal_payload(
+            baseline_min_avg_filled_notional_per_day
+        ),
+        "target_implied_min_avg_filled_notional_per_day": _decimal_payload(
+            target_implied_min_avg_filled_notional_per_day
+        ),
+        "effective_min_avg_filled_notional_per_day": _decimal_payload(
+            effective_min_avg_filled_notional_per_day
+        ),
+        "target_implied_min_notional_formula": (
+            "target_daily_net_pnl / (observed_post_cost_expectancy_bps / 10000)"
+        ),
+        "blockers": blockers,
     }
 
 
@@ -624,6 +751,43 @@ def evaluate_profit_target_oracle(
         total_net_pnl=total_net_pnl,
         worst_day_loss=worst_day_loss,
     )
+    portfolio_post_cost_net_pnl_basis = _first_normalized_scorecard_text(
+        scorecard,
+        "portfolio_post_cost_net_pnl_basis",
+        "portfolio_post_cost_net_pnl_per_day_basis",
+        "post_cost_net_pnl_basis",
+        "net_pnl_basis",
+        "runtime_ledger_pnl_basis",
+        "exact_replay_ledger_pnl_basis",
+        "post_cost_expectancy_basis",
+        "pnl_basis",
+    )
+    portfolio_post_cost_net_pnl_source = _first_normalized_scorecard_text(
+        scorecard,
+        "portfolio_post_cost_net_pnl_source",
+        "portfolio_post_cost_net_pnl_per_day_source",
+        "post_cost_net_pnl_source",
+        "net_pnl_source",
+        "runtime_ledger_pnl_source",
+        "exact_replay_ledger_pnl_source",
+        "post_cost_expectancy_source",
+        "pnl_source",
+    )
+    target_implied_notional_gate = _target_implied_notional_gate_payload(
+        scorecard=scorecard,
+        target_net_pnl_per_day=target_net_pnl_per_day,
+        baseline_min_avg_filled_notional_per_day=policy.min_avg_filled_notional_per_day,
+        post_cost_net_pnl_per_day=net_pnl,
+        post_cost_pnl_basis=portfolio_post_cost_net_pnl_basis,
+        post_cost_pnl_source=portfolio_post_cost_net_pnl_source,
+    )
+    effective_min_avg_filled_notional_per_day = _decimal(
+        target_implied_notional_gate.get("effective_min_avg_filled_notional_per_day"),
+        default=str(policy.min_avg_filled_notional_per_day),
+    )
+    observed_post_cost_expectancy_bps = _decimal(
+        target_implied_notional_gate.get("observed_post_cost_expectancy_bps")
+    )
     checks = [
         _numeric_check(
             metric="portfolio_post_cost_net_pnl_per_day",
@@ -782,7 +946,37 @@ def evaluate_profit_target_oracle(
             metric="avg_filled_notional_per_day",
             observed=_decimal(scorecard.get("avg_filled_notional_per_day")),
             operator="gte",
-            threshold=policy.min_avg_filled_notional_per_day,
+            threshold=effective_min_avg_filled_notional_per_day,
+        ),
+        {
+            "metric": "target_implied_post_cost_pnl_basis",
+            "observed": target_implied_notional_gate["post_cost_pnl_basis"],
+            "operator": "in",
+            "threshold": sorted(_ACCEPTED_LEDGER_PNL_BASES),
+            "source_marker": "target_implied_discovery_notional_gate",
+            "passed": bool(target_implied_notional_gate["post_cost_basis_accepted"]),
+        },
+        {
+            "metric": "target_implied_post_cost_pnl_source",
+            "observed": target_implied_notional_gate["post_cost_pnl_source"],
+            "operator": "in",
+            "threshold": sorted(_ACCEPTED_LEDGER_PNL_SOURCES),
+            "source_marker": "target_implied_discovery_notional_gate",
+            "passed": bool(target_implied_notional_gate["post_cost_source_accepted"]),
+        },
+        _numeric_check(
+            metric="target_implied_avg_filled_notional_per_day",
+            observed=_decimal(
+                target_implied_notional_gate.get("avg_filled_notional_per_day")
+            ),
+            operator="gt",
+            threshold=Decimal("0"),
+        ),
+        _numeric_check(
+            metric="target_implied_post_cost_expectancy_bps",
+            observed=observed_post_cost_expectancy_bps,
+            operator="gt",
+            threshold=Decimal("0"),
         ),
         _numeric_check(
             metric="regime_slice_pass_rate",
@@ -906,28 +1100,6 @@ def evaluate_profit_target_oracle(
     exact_replay_ledger_fill_count = _nonnegative_int(
         scorecard.get("exact_replay_ledger_artifact_fill_count")
         or scorecard.get("runtime_ledger_artifact_fill_count")
-    )
-    portfolio_post_cost_net_pnl_basis = _first_normalized_scorecard_text(
-        scorecard,
-        "portfolio_post_cost_net_pnl_basis",
-        "portfolio_post_cost_net_pnl_per_day_basis",
-        "post_cost_net_pnl_basis",
-        "net_pnl_basis",
-        "runtime_ledger_pnl_basis",
-        "exact_replay_ledger_pnl_basis",
-        "post_cost_expectancy_basis",
-        "pnl_basis",
-    )
-    portfolio_post_cost_net_pnl_source = _first_normalized_scorecard_text(
-        scorecard,
-        "portfolio_post_cost_net_pnl_source",
-        "portfolio_post_cost_net_pnl_per_day_source",
-        "post_cost_net_pnl_source",
-        "net_pnl_source",
-        "runtime_ledger_pnl_source",
-        "exact_replay_ledger_pnl_source",
-        "post_cost_expectancy_source",
-        "pnl_source",
     )
     checks.extend(
         (
@@ -2211,6 +2383,16 @@ def evaluate_profit_target_oracle(
     return {
         "schema_version": PROFIT_TARGET_ORACLE_SCHEMA_VERSION,
         "policy": policy.to_payload(),
+        "target_implied_notional_gate": target_implied_notional_gate,
+        "target_implied_min_avg_filled_notional_per_day": target_implied_notional_gate[
+            "target_implied_min_avg_filled_notional_per_day"
+        ],
+        "effective_min_avg_filled_notional_per_day": target_implied_notional_gate[
+            "effective_min_avg_filled_notional_per_day"
+        ],
+        "observed_post_cost_expectancy_bps": target_implied_notional_gate[
+            "observed_post_cost_expectancy_bps"
+        ],
         "passed": not blockers,
         "checks": checks,
         "blockers": blockers,

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -2784,7 +2784,16 @@ class TestPortfolioOptimizer(TestCase):
             portfolio.objective_scorecard["profit_target_oracle"]["blockers"],
             [
                 "portfolio_post_cost_net_pnl_per_day_failed",
+                "avg_filled_notional_per_day_failed",
             ],
+        )
+        self.assertEqual(
+            Decimal(
+                portfolio.objective_scorecard["profit_target_oracle"][
+                    "effective_min_avg_filled_notional_per_day"
+                ]
+            ),
+            Decimal("364583.3333333333333333333334"),
         )
 
     def test_optimizer_prefers_lower_concentration_before_raw_pnl_when_blocked(

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -94,6 +94,16 @@ def _passing_scorecard() -> dict[str, object]:
     }
 
 
+def _check_by_metric(result: dict[str, object], metric: str) -> dict[str, object]:
+    checks = result["checks"]
+    assert isinstance(checks, list)
+    for check in checks:
+        assert isinstance(check, dict)
+        if check.get("metric") == metric:
+            return check
+    raise AssertionError(f"missing check: {metric}")
+
+
 class TestProfitTargetOracle(TestCase):
     def test_profit_target_oracle_accepts_full_doc71_contract(self) -> None:
         result = evaluate_profit_target_oracle(
@@ -103,6 +113,147 @@ class TestProfitTargetOracle(TestCase):
 
         self.assertTrue(result["passed"])
         self.assertEqual(result["blockers"], [])
+
+    def test_profit_target_oracle_uses_target_implied_floor_for_8_bps_edge(
+        self,
+    ) -> None:
+        scorecard = {
+            **_passing_scorecard(),
+            "avg_filled_notional_per_day": "625000",
+            "observed_post_cost_expectancy_bps": "8",
+        }
+
+        result = evaluate_profit_target_oracle(
+            scorecard,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(
+            Decimal(str(result["target_implied_min_avg_filled_notional_per_day"])),
+            Decimal("625000"),
+        )
+        self.assertEqual(
+            Decimal(str(result["effective_min_avg_filled_notional_per_day"])),
+            Decimal("625000"),
+        )
+        scale_check = _check_by_metric(result, "avg_filled_notional_per_day")
+        self.assertEqual(Decimal(str(scale_check["threshold"])), Decimal("625000"))
+        self.assertEqual(result["observed_post_cost_expectancy_bps"], "8")
+        gate = result["target_implied_notional_gate"]
+        self.assertIsInstance(gate, dict)
+        self.assertEqual(
+            gate["observed_post_cost_expectancy_bps_source"],
+            "observed_post_cost_expectancy_bps",
+        )
+        for key in (
+            "promotion_allowed",
+            "final_promotion_allowed",
+            "final_authority_ok",
+            "runtime_ledger_authority",
+        ):
+            self.assertIsNot(result.get(key), True)
+            self.assertIsNot(gate.get(key), True)
+
+    def test_profit_target_oracle_uses_target_implied_floor_for_5_bps_edge(
+        self,
+    ) -> None:
+        scorecard = {
+            **_passing_scorecard(),
+            "avg_filled_notional_per_day": "1000000",
+            "observed_post_cost_expectancy_bps": "5",
+        }
+
+        result = evaluate_profit_target_oracle(
+            scorecard,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(
+            Decimal(str(result["target_implied_min_avg_filled_notional_per_day"])),
+            Decimal("1000000"),
+        )
+        self.assertEqual(
+            Decimal(str(result["effective_min_avg_filled_notional_per_day"])),
+            Decimal("1000000"),
+        )
+
+    def test_profit_target_oracle_rejects_missing_or_non_positive_expectancy(
+        self,
+    ) -> None:
+        for expectancy_bps in ("0", "-1"):
+            with self.subTest(expectancy_bps=expectancy_bps):
+                scorecard = {
+                    **_passing_scorecard(),
+                    "observed_post_cost_expectancy_bps": expectancy_bps,
+                }
+
+                result = evaluate_profit_target_oracle(
+                    scorecard,
+                    target_net_pnl_per_day=Decimal("500"),
+                )
+
+                self.assertFalse(result["passed"])
+                self.assertIn(
+                    "target_implied_post_cost_expectancy_bps_failed",
+                    result["blockers"],
+                )
+                gate = result["target_implied_notional_gate"]
+                self.assertIsInstance(gate, dict)
+                self.assertIn(
+                    "target_implied_post_cost_expectancy_bps_missing_or_non_positive",
+                    gate["blockers"],
+                )
+
+        scorecard_without_notional = {
+            key: value
+            for key, value in _passing_scorecard().items()
+            if key != "avg_filled_notional_per_day"
+        }
+        result = evaluate_profit_target_oracle(
+            scorecard_without_notional,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn(
+            "target_implied_avg_filled_notional_per_day_failed",
+            result["blockers"],
+        )
+        self.assertIn(
+            "target_implied_post_cost_expectancy_bps_failed",
+            result["blockers"],
+        )
+
+    def test_profit_target_oracle_keeps_strong_fixed_floor_as_lower_bound(
+        self,
+    ) -> None:
+        scorecard = {
+            **_passing_scorecard(),
+            "avg_filled_notional_per_day": "700000",
+            "observed_post_cost_expectancy_bps": "8",
+        }
+        result = evaluate_profit_target_oracle(
+            scorecard,
+            target_net_pnl_per_day=Decimal("500"),
+            policy=ProfitTargetOraclePolicy(
+                min_avg_filled_notional_per_day=Decimal("750000")
+            ),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn("avg_filled_notional_per_day_failed", result["blockers"])
+        self.assertEqual(
+            Decimal(str(result["target_implied_min_avg_filled_notional_per_day"])),
+            Decimal("625000"),
+        )
+        self.assertEqual(
+            Decimal(str(result["effective_min_avg_filled_notional_per_day"])),
+            Decimal("750000"),
+        )
+        scale_check = _check_by_metric(result, "avg_filled_notional_per_day")
+        self.assertEqual(Decimal(str(scale_check["threshold"])), Decimal("750000"))
 
     def test_profit_target_oracle_rejects_missing_fill_survival(self) -> None:
         scorecard = {


### PR DESCRIPTION
## Summary

- Replaces the profit-target oracle's fixed average filled-notional scale gate with an effective daily-notional floor derived from the target daily net PnL and observed post-cost expectancy bps.
- Keeps the configured fixed floor as a lower bound while failing closed when post-cost basis/source, average filled notional, or positive expectancy evidence is missing.
- Exposes target-implied, effective, basis, source, and formula fields in the oracle payload without granting promotion or runtime-ledger authority.
- Adds regression coverage for 8 bps, 5 bps, non-positive or missing evidence, strong fixed-floor lower bounds, and authority-field separation.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_profit_target_oracle.py tests/test_discovery_harness_v2.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_portfolio_optimizer.py::TestPortfolioOptimizer::test_optimizer_prefers_nearest_promotion_candidate_over_raw_target_met -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/profit_target_oracle.py app/trading/discovery/mlx_training_data.py tests/test_profit_target_oracle.py tests/test_discovery_harness_v2.py tests/test_mlx_training_data.py tests/test_portfolio_optimizer.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/profit_target_oracle.py app/trading/discovery/mlx_training_data.py tests/test_profit_target_oracle.py tests/test_discovery_harness_v2.py tests/test_mlx_training_data.py tests/test_portfolio_optimizer.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
