### PR TITLE
fix(torghut): reserve trading status read budget

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -258,18 +258,42 @@ class _TradingStatusReadBudget:
     def elapsed_seconds(self) -> float:
         return max(0.0, time.monotonic() - self._started_at)
 
+    def remaining_seconds(self) -> float:
+        return max(0.0, self.max_seconds - self.elapsed_seconds())
+
     def exhausted(self) -> bool:
         return self.elapsed_seconds() >= self.max_seconds
 
-    def skip_reason(self, read_name: str) -> str:
+    def skip_reason(
+        self,
+        read_name: str,
+        *,
+        reason_code: str = "status_read_budget_exhausted",
+    ) -> str:
         if read_name not in self.skipped_reads:
             self.skipped_reads.append(read_name)
-        return f"{read_name}_status_read_budget_exhausted"
+        return f"{read_name}_{reason_code}"
+
+    def skip_reason_if_unavailable(
+        self,
+        read_name: str,
+        *,
+        min_remaining_seconds: float = 0.0,
+    ) -> str | None:
+        if self.exhausted():
+            return self.skip_reason(read_name)
+        if self.remaining_seconds() < max(0.0, min_remaining_seconds):
+            return self.skip_reason(
+                read_name,
+                reason_code="status_read_budget_insufficient_remaining",
+            )
+        return None
 
     def as_payload(self) -> dict[str, object]:
         return {
             "max_seconds": self.max_seconds,
             "elapsed_seconds": round(self.elapsed_seconds(), 3),
+            "remaining_seconds": round(self.remaining_seconds(), 3),
             "exhausted": self.exhausted(),
             "skipped_reads": list(self.skipped_reads),
         }
@@ -3356,22 +3380,32 @@ def trading_status() -> dict[str, object]:
     shorting_metadata_status = scheduler.shorting_metadata_status()
     rejection_alert_status = scheduler.rejection_alert_status()
     last_decision_at = None
-    if not status_read_budget.exhausted():
+    last_decision_skip_reason = status_read_budget.skip_reason_if_unavailable(
+        "last_decision",
+        min_remaining_seconds=0.25,
+    )
+    if last_decision_skip_reason is None:
         with SessionLocal() as session:
             last_decision_at = _load_last_decision_at(session)
-    else:
-        status_read_budget.skip_reason("last_decision")
     persisted_rejected_signal_outcome_learning = None
-    if not status_read_budget.exhausted():
+    rejected_signal_outcome_learning_skip_reason = (
+        status_read_budget.skip_reason_if_unavailable(
+            "rejected_signal_outcome_learning",
+            min_remaining_seconds=0.5,
+        )
+    )
+    if rejected_signal_outcome_learning_skip_reason is None:
         with SessionLocal() as session:
             persisted_rejected_signal_outcome_learning = (
                 _load_rejected_signal_outcome_learning_summary(session)
             )
-    else:
-        status_read_budget.skip_reason("rejected_signal_outcome_learning")
-    if status_read_budget.exhausted():
+    live_submission_gate_skip_reason = status_read_budget.skip_reason_if_unavailable(
+        "live_submission_gate",
+        min_remaining_seconds=4.0,
+    )
+    if live_submission_gate_skip_reason is not None:
         live_submission_gate = _budget_exhausted_live_submission_gate_payload(
-            reason=status_read_budget.skip_reason("live_submission_gate"),
+            reason=live_submission_gate_skip_reason,
             empirical_jobs_status=empirical_jobs,
             quant_health_status=quant_evidence,
         )
@@ -3429,9 +3463,13 @@ def trading_status() -> dict[str, object]:
         live_submission_gate=live_submission_gate,
     )
     route_claim_symbols = _route_claim_symbols(profit_signal_quorum)
-    if status_read_budget.exhausted():
+    options_catalog_freshness_skip_reason = status_read_budget.skip_reason_if_unavailable(
+        "options_catalog_freshness",
+        min_remaining_seconds=2.0,
+    )
+    if options_catalog_freshness_skip_reason is not None:
         options_catalog_freshness = _budget_exhausted_options_catalog_freshness_payload(
-            reason=status_read_budget.skip_reason("options_catalog_freshness"),
+            reason=options_catalog_freshness_skip_reason,
             route_symbols=route_claim_symbols,
         )
     else:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -2837,6 +2837,63 @@ class TestTradingApi(TestCase):
             payload["status_read_budget"]["skipped_reads"],
         )
 
+    def test_trading_status_skips_expensive_reads_when_budget_remaining_is_low(
+        self,
+    ) -> None:
+        class ManualBudget(main_module._TradingStatusReadBudget):
+            def __init__(self) -> None:
+                super().__init__(max_seconds=10.0)
+                self.current_elapsed = 1.0
+
+            def elapsed_seconds(self) -> float:
+                return self.current_elapsed
+
+        budget = ManualBudget()
+
+        def _load_rejected_signal_outcome_learning_summary(
+            _session: Session,
+        ) -> dict[str, object]:
+            budget.current_elapsed = 8.5
+            return {}
+
+        with (
+            patch("app.main._TradingStatusReadBudget", return_value=budget),
+            patch(
+                "app.main._load_clickhouse_ta_status",
+                return_value={
+                    "state": "current",
+                    "latest_signal_at": datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    "source_ref": "clickhouse:ta_signals",
+                },
+            ),
+            patch(
+                "app.main._load_rejected_signal_outcome_learning_summary",
+                side_effect=_load_rejected_signal_outcome_learning_summary,
+            ),
+            patch("app.main._build_live_submission_gate_payload") as live_gate,
+        ):
+            response = self.client.get("/trading/status")
+
+        self.assertEqual(response.status_code, 200)
+        live_gate.assert_not_called()
+        payload = response.json()
+        self.assertFalse(payload["live_submission_gate"]["allowed"])
+        self.assertEqual(
+            payload["live_submission_gate"]["reason"],
+            "live_submission_gate_status_read_budget_insufficient_remaining",
+        )
+        self.assertTrue(payload["live_submission_gate"]["read_model_unavailable"])
+        self.assertFalse(payload["status_read_budget"]["exhausted"])
+        self.assertEqual(payload["status_read_budget"]["remaining_seconds"], 1.5)
+        self.assertIn(
+            "live_submission_gate",
+            payload["status_read_budget"]["skipped_reads"],
+        )
+        self.assertIn(
+            "options_catalog_freshness",
+            payload["status_read_budget"]["skipped_reads"],
+        )
+
     def test_readiness_checks_external_dependencies_before_postgres_session(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Reserve enough `/trading/status` read budget before starting late, expensive reads.
- Fail closed with explicit `status_read_budget_insufficient_remaining` reasons when `live_submission_gate` or options freshness cannot safely fit inside the remaining budget.
- Expose `remaining_seconds` in `status_read_budget` and add regression coverage for low-remaining-budget skips.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
