### PR TITLE
fix(torghut): avoid readiness account-scope reflection views

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -247,9 +247,7 @@ _paper_route_target_plan_success_cache: tuple[dict[str, Any], float] | None = No
 class _TradingStatusReadBudget:
     def __init__(self, *, max_seconds: float | None = None):
         configured_seconds = (
-            _TRADING_STATUS_READ_BUDGET_SECONDS
-            if max_seconds is None
-            else max_seconds
+            _TRADING_STATUS_READ_BUDGET_SECONDS if max_seconds is None else max_seconds
         )
         self.max_seconds = max(0.0, float(configured_seconds))
         self._started_at = time.monotonic()
@@ -1939,10 +1937,15 @@ def _check_account_scope_invariants_bounded(session: Session) -> dict[str, objec
     column_rows = _execute_readiness_account_scope_query(
         session,
         """
-        SELECT table_name, column_name
-        FROM information_schema.columns
-        WHERE table_schema = current_schema()
-          AND table_name IN :table_names
+        SELECT tbl.relname AS table_name, att.attname AS column_name
+        FROM pg_catalog.pg_class tbl
+        JOIN pg_catalog.pg_namespace ns ON ns.oid = tbl.relnamespace
+        JOIN pg_catalog.pg_attribute att ON att.attrelid = tbl.oid
+        WHERE ns.nspname = current_schema()
+          AND tbl.relname IN :table_names
+          AND tbl.relkind IN ('r', 'p')
+          AND att.attnum > 0
+          AND NOT att.attisdropped
         """,
         table_names=table_names,
     )

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1614,7 +1614,7 @@ class TestTradingApi(TestCase):
                 self.statements.append(sql)
                 if "SET LOCAL statement_timeout" in sql:
                     return FakeResult([])
-                if "information_schema.columns" in sql:
+                if "FROM pg_catalog.pg_class" in sql and "pg_attribute" in sql:
                     return FakeResult(
                         [
                             {
@@ -1699,6 +1699,7 @@ class TestTradingApi(TestCase):
         joined_sql = "\n".join(fake_session.statements)
         self.assertIn("SET LOCAL statement_timeout", joined_sql)
         self.assertNotIn("pg_type", joined_sql)
+        self.assertNotIn("information_schema.columns", joined_sql)
 
     def test_bounded_account_scope_invariants_reports_legacy_indexes(self) -> None:
         class FakeResult:
@@ -1720,7 +1721,7 @@ class TestTradingApi(TestCase):
                 sql = str(statement)
                 if "SET LOCAL statement_timeout" in sql:
                     return FakeResult([])
-                if "information_schema.columns" in sql:
+                if "FROM pg_catalog.pg_class" in sql and "pg_attribute" in sql:
                     return FakeResult(
                         [
                             {


### PR DESCRIPTION
## Summary

- Replaced the Torghut readiness account-scope column lookup with a narrow `pg_catalog.pg_class`/`pg_attribute` query instead of the slower `information_schema.columns` view that timed out in post-deploy `/readyz`.
- Kept the bounded 750 ms account-scope statement timeout and existing fail-closed database-contract semantics unchanged.
- Updated focused readiness regression coverage to assert the helper avoids both `pg_type` reflection and `information_schema.columns`.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q -k 'bounded_account_scope or database_contract_fails_closed'`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q`
- PASS: `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_trading_api.py`
- PASS: `cd services/torghut && uv run --frozen ruff format --check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_trading_api.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
