### PR TITLE
fix(synthesis): tighten autotrader session detail

### DIFF
--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -568,6 +568,161 @@ describe('synthesis REST auth', () => {
     expect(detailPayload.positionSnapshots[0].capturedAt).toBe(snapshotPayload.positionSnapshot.capturedAt)
   })
 
+  test('links ticket-matched scorecards and returns latest position exposure in session detail', async () => {
+    const authedHeaders = {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    }
+    const priorSessionResponse = await handleAutotraderStartSession(
+      new Request('http://synthesis.test/api/autotrader/sessions', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          agentRunName: 'autonomous-trader-scorecard-source',
+          mode: 'market_open',
+          tradingDate: '2026-05-29',
+          accountId: 'paper-account',
+          goalEquity: '500000',
+          marketOpenAt: '2026-05-29T13:30:00Z',
+          marketCloseAt: '2026-05-29T20:00:00Z',
+        }),
+      }),
+    )
+    const priorSessionId = (await priorSessionResponse.json()).session.id
+    const priorTicketResponse = await handleAutotraderCreateTradeTicket(
+      new Request('http://synthesis.test/api/autotrader/trade-tickets', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId: priorSessionId,
+          idempotencyKey: 'nvda-vwap-prior',
+          symbol: 'NVDA',
+          instrument: 'stock',
+          side: 'buy',
+          setupType: 'vwap_reclaim',
+          setupGrade: 'A',
+          regime: 'regular_session',
+          timeBucket: 'midday',
+          thesis: 'Valid setup with prior result.',
+          entryTrigger: 'VWAP reclaim.',
+          invalidation: 'Lose VWAP.',
+          protectionType: 'bracket',
+          status: 'closed',
+        }),
+      }),
+    )
+    const priorTicketId = (await priorTicketResponse.json()).ticket.id
+    await handleAutotraderFinalizeSession(
+      new Request('http://synthesis.test/api/autotrader/finalize', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId: priorSessionId,
+          terminalReason: 'market_closed',
+          summary: { accountEquity: '38900' },
+          scorecardObservations: [
+            {
+              ticketId: priorTicketId,
+              symbol: 'NVDA',
+              setupType: 'vwap_reclaim',
+              setupGrade: 'A',
+              regime: 'regular_session',
+              timeBucket: 'midday',
+              outcome: 'win',
+              realizedR: '1.5',
+              notes: 'prior NVDA reclaim worked',
+            },
+          ],
+        }),
+      }),
+    )
+
+    const currentSessionResponse = await handleAutotraderStartSession(
+      new Request('http://synthesis.test/api/autotrader/sessions', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          agentRunName: 'autonomous-trader-scorecard-consumer',
+          mode: 'market_open',
+          tradingDate: '2026-06-01',
+          accountId: 'paper-account',
+          goalEquity: '500000',
+          marketOpenAt: '2026-06-01T13:30:00Z',
+          marketCloseAt: '2026-06-01T20:00:00Z',
+        }),
+      }),
+    )
+    const currentSessionId = (await currentSessionResponse.json()).session.id
+    await handleAutotraderCreateTradeTicket(
+      new Request('http://synthesis.test/api/autotrader/trade-tickets', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId: currentSessionId,
+          idempotencyKey: 'nvda-vwap-current',
+          symbol: 'NVDA',
+          instrument: 'stock',
+          side: 'buy',
+          setupType: 'vwap_reclaim',
+          setupGrade: 'A',
+          regime: 'regular_session',
+          timeBucket: 'midday',
+          thesis: 'Current setup should see prior scorecard.',
+          entryTrigger: 'VWAP reclaim.',
+          invalidation: 'Lose VWAP.',
+          protectionType: 'bracket',
+          status: 'validated',
+        }),
+      }),
+    )
+    await handleAutotraderRecordPositionSnapshot(
+      new Request('http://synthesis.test/api/autotrader/position-snapshots', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId: currentSessionId,
+          symbol: 'NVDA',
+          quantity: '1',
+          marketValue: '220',
+          capturedAt: '2026-06-01T14:00:00Z',
+        }),
+      }),
+    )
+    await handleAutotraderRecordPositionSnapshot(
+      new Request('http://synthesis.test/api/autotrader/position-snapshots', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId: currentSessionId,
+          symbol: 'NVDA',
+          quantity: '2',
+          marketValue: '440',
+          capturedAt: '2026-06-01T14:05:00Z',
+        }),
+      }),
+    )
+
+    const detailResponse = await handleAutotraderGetSession(
+      new Request(`http://synthesis.test/api/autotrader/sessions/${currentSessionId}`),
+      currentSessionId,
+    )
+    const detailPayload = await detailResponse.json()
+
+    expect(detailPayload.scorecards[0]).toMatchObject({
+      symbol: 'NVDA',
+      setupType: 'vwap_reclaim',
+      sampleSize: 1,
+      wins: 1,
+    })
+    expect(detailPayload.setupExamples).toHaveLength(0)
+    expect(detailPayload.positionSnapshots).toHaveLength(1)
+    expect(detailPayload.positionSnapshots[0]).toMatchObject({
+      symbol: 'NVDA',
+      quantity: '2',
+      marketValue: '440',
+    })
+  })
+
   test('finalizes idempotently and detaches cross-session ticket references', async () => {
     const authedHeaders = {
       authorization: `Bearer ${token}`,

--- a/apps/synthesis/src/server/autotrader-store.ts
+++ b/apps/synthesis/src/server/autotrader-store.ts
@@ -144,6 +144,18 @@ const scorecardExampleIdFor = (sessionId: string, observation: AutotraderScoreca
     .digest('base64url')
     .slice(0, 40)
 
+const latestPositionSnapshots = <T extends { symbol: string; capturedAt: string }>(snapshots: T[]): T[] => {
+  const latestBySymbol = new Map<string, T>()
+  for (const snapshot of snapshots) {
+    const symbol = normalizedSymbol(snapshot.symbol) ?? snapshot.symbol
+    const existing = latestBySymbol.get(symbol)
+    if (!existing || Date.parse(snapshot.capturedAt) > Date.parse(existing.capturedAt)) {
+      latestBySymbol.set(symbol, snapshot)
+    }
+  }
+  return [...latestBySymbol.values()].sort((left, right) => Date.parse(right.capturedAt) - Date.parse(left.capturedAt))
+}
+
 const sanitizeScorecardObservations = (
   sessionId: string,
   observations: AutotraderScorecardObservation[],
@@ -591,9 +603,9 @@ class InMemoryAutotraderStore implements AutotraderStore {
       riskChecks: [...this.riskChecks.values()].filter((riskCheck) => riskCheck.sessionId === sessionId),
       orders: [...this.orders.values()].filter((order) => order.sessionId === sessionId),
       fills: [...this.fills.values()].filter((fill) => fill.sessionId === sessionId),
-      positionSnapshots: [...this.positions.values()]
-        .filter((snapshot) => snapshot.sessionId === sessionId)
-        .sort((left, right) => Date.parse(right.capturedAt) - Date.parse(left.capturedAt)),
+      positionSnapshots: latestPositionSnapshots(
+        [...this.positions.values()].filter((snapshot) => snapshot.sessionId === sessionId),
+      ),
       scorecards: [...this.scorecards.values()].filter((scorecard) => sessionScorecardKeys.has(scorecard.key)),
       setupExamples: sessionExamples,
     }
@@ -1473,7 +1485,6 @@ class PostgresAutotraderStore implements AutotraderStore {
       orderResult,
       fillResult,
       positionResult,
-      scorecardResult,
       exampleResult,
     ] = await Promise.all([
       this.pool.query<StatusRow>(`SELECT * FROM autotrader.status WHERE session_id = $1`, [sessionId]),
@@ -1493,15 +1504,10 @@ class PostgresAutotraderStore implements AutotraderStore {
         sessionId,
       ]),
       this.pool.query<PositionSnapshotRow>(
-        `SELECT * FROM autotrader.position_snapshots WHERE session_id = $1 ORDER BY captured_at DESC`,
-        [sessionId],
-      ),
-      this.pool.query<ScorecardRow>(
-        `SELECT DISTINCT s.*
-         FROM autotrader.scorecards s
-         JOIN autotrader.setup_examples e ON e.scorecard_key = s.key
-         WHERE e.session_id = $1
-         ORDER BY s.updated_at DESC`,
+        `SELECT DISTINCT ON (symbol) *
+         FROM autotrader.position_snapshots
+         WHERE session_id = $1
+         ORDER BY symbol, captured_at DESC`,
         [sessionId],
       ),
       this.pool.query<SetupExampleRow>(
@@ -1509,17 +1515,46 @@ class PostgresAutotraderStore implements AutotraderStore {
         [sessionId],
       ),
     ])
+    const tickets = ticketResult.rows.map(mapTicket)
+    const setupExamples = exampleResult.rows.map(mapSetupExample)
+    const sessionScorecardKeys = [
+      ...new Set([
+        ...setupExamples.map((example) => example.scorecardKey),
+        ...tickets.map((ticket) =>
+          scorecardKeyFor({
+            symbol: ticket.symbol,
+            setupType: ticket.setupType,
+            setupGrade: ticket.setupGrade,
+            regime: ticket.regime,
+            timeBucket: ticket.timeBucket ?? 'unknown',
+          }),
+        ),
+      ]),
+    ]
+    const scorecards = sessionScorecardKeys.length
+      ? (
+          await this.pool.query<ScorecardRow>(
+            `SELECT *
+             FROM autotrader.scorecards
+             WHERE key = ANY($1::text[])
+             ORDER BY updated_at DESC`,
+            [sessionScorecardKeys],
+          )
+        ).rows.map(mapScorecard)
+      : []
     return {
       session,
       status: statusResult.rows[0] ? mapStatus(statusResult.rows[0]) : null,
       events: eventResult.rows.map(mapEvent),
-      tradeTickets: ticketResult.rows.map(mapTicket),
+      tradeTickets: tickets,
       riskChecks: riskResult.rows.map(mapRiskCheck),
       orders: orderResult.rows.map(mapOrder),
       fills: fillResult.rows.map(mapFill),
-      positionSnapshots: positionResult.rows.map(mapPositionSnapshot),
-      scorecards: scorecardResult.rows.map(mapScorecard),
-      setupExamples: exampleResult.rows.map(mapSetupExample),
+      positionSnapshots: positionResult.rows
+        .map(mapPositionSnapshot)
+        .sort((left, right) => Date.parse(right.capturedAt) - Date.parse(left.capturedAt)),
+      scorecards,
+      setupExamples,
     }
   }
 


### PR DESCRIPTION
## Summary

- Links session detail scorecards through matching trade-ticket setup keys, even when the current session has not written scorecard examples yet.
- Returns only the latest position snapshot per symbol in autotrader session detail to reduce noisy repeated polling payloads.
- Adds a regression covering ticket-matched scorecard visibility and current-position snapshot behavior.

## Related Issues

None

## Testing

- `bun run --filter synthesis test -- src/server/__tests__/api.test.ts`
- `bun run --filter synthesis lint`
- `bun run --filter synthesis build`
- `bunx oxfmt --check apps/synthesis/src/server/autotrader-store.ts apps/synthesis/src/server/__tests__/api.test.ts`
- `git diff --check -- apps/synthesis/src/server/autotrader-store.ts apps/synthesis/src/server/__tests__/api.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
