### PR TITLE
chore(synthesis): promote autotrader detail image

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.588.0
+    newTag: autotrader-detail-d0c7a66e
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promotes Synthesis to `registry.ide-newton.ts.net/lab/synthesis:autotrader-detail-d0c7a66e`.
- Rolls out the merged autotrader session-detail fix from PR #9741.
- Uses a manually built image because the GitHub Docker Build and Push workflow is still queued at the `changes` job.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check -- argocd/applications/synthesis/kustomization.yaml`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/synthesis:autotrader-detail-d0c7a66e`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
