### PR TITLE
fix(torghut): reconcile hpairs source accounts

### DIFF
--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -365,6 +365,10 @@ def _load_session_rows(
         )
     executions = [_execution_row(row) for row in session.scalars(execution_stmt).all()]
     execution_ids = {str(row["id"]) for row in executions}
+    execution_order_ids = _row_text_values(executions, "alpaca_order_id")
+    client_order_ids = _row_text_values(
+        executions, "client_order_id"
+    ) | _row_text_values(decisions, "decision_hash")
 
     event_stmt = (
         select(ExecutionOrderEvent)
@@ -389,7 +393,7 @@ def _load_session_rows(
                 ExecutionOrderEvent.created_at < ended_at,
             )
         )
-    if decision_ids or execution_ids:
+    if decision_ids or execution_ids or execution_order_ids or client_order_ids:
         event_filters = []
         if decision_ids:
             event_filters.append(
@@ -397,6 +401,14 @@ def _load_session_rows(
             )
         if execution_ids:
             event_filters.append(ExecutionOrderEvent.execution_id.in_(execution_ids))
+        if execution_order_ids:
+            event_filters.append(
+                ExecutionOrderEvent.alpaca_order_id.in_(execution_order_ids)
+            )
+        if client_order_ids:
+            event_filters.append(
+                ExecutionOrderEvent.client_order_id.in_(client_order_ids)
+            )
         event_stmt = event_stmt.where(or_(*event_filters))
     else:
         event_stmt = event_stmt.where(
@@ -559,6 +571,10 @@ def _authority_scope_rows(
     )
     canonical_decision_ids = scoped_decision_ids | ledger_decision_ids
     canonical_execution_ids = scoped_execution_ids | ledger_execution_ids
+    canonical_order_ids = _row_text_values(scoped_executions, "alpaca_order_id")
+    canonical_client_order_ids = _row_text_values(
+        scoped_executions, "client_order_id"
+    ) | _row_text_values(scoped_trade_decisions, "decision_hash")
     scoped_events = [
         row
         for row in rows.execution_order_events
@@ -569,6 +585,8 @@ def _authority_scope_rows(
             target_account_label=target_account_label,
             canonical_decision_ids=canonical_decision_ids,
             canonical_execution_ids=canonical_execution_ids,
+            canonical_order_ids=canonical_order_ids,
+            canonical_client_order_ids=canonical_client_order_ids,
         )
     ]
     scoped_event_source_window_ids = {
@@ -608,6 +626,8 @@ def _source_event_row_matches_identity(
     target_account_label: str,
     canonical_decision_ids: set[str],
     canonical_execution_ids: set[str],
+    canonical_order_ids: set[str],
+    canonical_client_order_ids: set[str],
 ) -> bool:
     account_label = _row_account_label(row)
     if account_label in (None, target_account_label):
@@ -623,6 +643,14 @@ def _source_event_row_matches_identity(
         return True
     if _row_ref_matches(row, "execution_id", canonical_execution_ids):
         return True
+    if _row_has_any_ref(row, "trade_decision_id", "decision_id", "execution_id"):
+        return False
+    if _row_ref_matches(row, "alpaca_order_id", canonical_order_ids):
+        return True
+    if _row_ref_matches(row, "client_order_id", canonical_client_order_ids):
+        return True
+    if _row_has_any_ref(row, "alpaca_order_id", "client_order_id"):
+        return False
     return _row_aliases_target_account(row, identity.account_label)
 
 
@@ -646,6 +674,8 @@ def _source_window_row_matches_identity(
         return True
     if _row_ref_matches(row, "source_window_id", canonical_source_window_ids):
         return True
+    if _row_has_any_ref(row, "id", "source_window_id"):
+        return False
     return _row_aliases_target_account(row, identity.account_label)
 
 
@@ -671,6 +701,10 @@ def _row_ids(rows: Sequence[Mapping[str, object]]) -> set[str]:
     return {row_id for row in rows if (row_id := _text(row.get("id"))) is not None}
 
 
+def _row_text_values(rows: Sequence[Mapping[str, object]], key: str) -> set[str]:
+    return {value for row in rows if (value := _text(row.get(key))) is not None}
+
+
 def _optional_row_ref_matches(
     row: Mapping[str, object],
     key: str,
@@ -687,6 +721,10 @@ def _row_ref_matches(
 ) -> bool:
     value = _text(row.get(key))
     return value is not None and value in candidates
+
+
+def _row_has_any_ref(row: Mapping[str, object], *keys: str) -> bool:
+    return any(_text(row.get(key)) is not None for key in keys)
 
 
 def _payload_identifier_values(
@@ -1696,6 +1734,7 @@ def _order_event_row(row: ExecutionOrderEvent) -> dict[str, object]:
         "filled_qty_delta": row.filled_qty_delta,
         "avg_fill_price": row.avg_fill_price,
         "filled_notional_delta": row.filled_notional_delta,
+        "raw_event": row.raw_event,
         "execution_id": str(row.execution_id) if row.execution_id is not None else None,
         "trade_decision_id": str(row.trade_decision_id)
         if row.trade_decision_id is not None

--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -142,6 +142,7 @@ class CensusIdentity:
     runtime_strategy_name: str
     account_label: str
     observed_stage: str | None
+    source_account_label: str | None = None
 
 
 @dataclass
@@ -169,6 +170,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--runtime-strategy-name", default=DEFAULT_HPAIRS_RUNTIME_STRATEGY
     )
     parser.add_argument("--account-label", default=DEFAULT_HPAIRS_ACCOUNT_LABEL)
+    parser.add_argument(
+        "--source-account-label",
+        default="",
+        help=(
+            "Optional source/broker account label to reconcile against the logical "
+            "--account-label. Source-account rows only count when linked to the "
+            "logical account by durable decision/execution refs or alias payloads."
+        ),
+    )
     parser.add_argument("--observed-stage", default="paper")
     parser.add_argument("--start", dest="started_at")
     parser.add_argument("--end", dest="ended_at")
@@ -191,8 +201,9 @@ def build_source_proof_census(
 ) -> dict[str, object]:
     """Build a deterministic source-proof census from already-read rows."""
 
+    scoped_rows = _authority_scope_rows(rows, identity)
     ledger_report = build_runtime_authority_report(
-        rows.runtime_ledger_buckets,
+        scoped_rows.runtime_ledger_buckets,
         hypothesis_id=identity.hypothesis_id,
         candidate_id=identity.candidate_id,
         runtime_strategy_name=identity.runtime_strategy_name,
@@ -202,15 +213,17 @@ def build_source_proof_census(
         ended_at=ended_at,
         evidence_read_error=read_error,
     )
-    daily = _daily_census(rows, ledger_report)
+    daily = _daily_census(scoped_rows, ledger_report)
     candidate_config_match = _candidate_config_match(rows, identity, ledger_report)
     totals = _totals(
-        rows,
+        scoped_rows,
         daily,
         ledger_report,
         candidate_config_match=candidate_config_match,
     )
-    blockers = _census_blockers(rows, totals, ledger_report, read_error=read_error)
+    blockers = _census_blockers(
+        scoped_rows, totals, ledger_report, read_error=read_error
+    )
     missing_source_ref_categories = _missing_source_ref_categories(blockers)
     missing_requirement_categories = _missing_requirement_categories(blockers)
     blocker_ladder = _blocker_ladder(
@@ -229,6 +242,7 @@ def build_source_proof_census(
             "candidate_id": identity.candidate_id,
             "runtime_strategy_name": identity.runtime_strategy_name,
             "account_label": identity.account_label,
+            "source_account_label": _source_account_label(identity),
             "observed_stage": identity.observed_stage,
         },
         "window": {
@@ -241,6 +255,8 @@ def build_source_proof_census(
             "writes_proof": False,
             "modifies_rows": False,
             "runtime_stage": identity.observed_stage,
+            "account_label": identity.account_label,
+            "source_account_label": _source_account_label(identity),
             "replay_outputs_count_as_runtime_proof": False,
             "synthetic_proof_created": False,
         },
@@ -315,6 +331,8 @@ def _load_session_rows(
     started_at: datetime | None,
     ended_at: datetime | None,
 ) -> CensusSourceRows:
+    source_account_label = _source_account_label(identity)
+    account_labels = sorted({identity.account_label, source_account_label})
     decision_stmt = (
         select(TradeDecision, Strategy.name)
         .join(Strategy, TradeDecision.strategy_id == Strategy.id)
@@ -350,7 +368,7 @@ def _load_session_rows(
 
     event_stmt = (
         select(ExecutionOrderEvent)
-        .where(ExecutionOrderEvent.alpaca_account_label == identity.account_label)
+        .where(ExecutionOrderEvent.alpaca_account_label.in_(account_labels))
         .order_by(
             ExecutionOrderEvent.event_ts.asc().nulls_last(),
             ExecutionOrderEvent.created_at.asc(),
@@ -380,7 +398,16 @@ def _load_session_rows(
         if execution_ids:
             event_filters.append(ExecutionOrderEvent.execution_id.in_(execution_ids))
         event_stmt = event_stmt.where(or_(*event_filters))
+    else:
+        event_stmt = event_stmt.where(
+            ExecutionOrderEvent.alpaca_account_label == identity.account_label
+        )
     order_events = [_order_event_row(row) for row in session.scalars(event_stmt).all()]
+    order_event_source_window_ids = {
+        source_window_id
+        for row in order_events
+        if (source_window_id := _text(row.get("source_window_id"))) is not None
+    }
 
     tca_stmt = (
         select(ExecutionTCAMetric)
@@ -400,14 +427,19 @@ def _load_session_rows(
         tca_stmt = tca_stmt.where(or_(*tca_filters))
     tca_metrics = [_tca_row(row) for row in session.scalars(tca_stmt).all()]
 
-    source_window_stmt = (
-        select(OrderFeedSourceWindow)
-        .where(OrderFeedSourceWindow.alpaca_account_label == identity.account_label)
-        .order_by(
-            OrderFeedSourceWindow.window_started_at.asc(),
-            OrderFeedSourceWindow.id.asc(),
-        )
+    source_window_stmt = select(OrderFeedSourceWindow).order_by(
+        OrderFeedSourceWindow.window_started_at.asc(),
+        OrderFeedSourceWindow.id.asc(),
     )
+    source_window_account_filters = [
+        OrderFeedSourceWindow.alpaca_account_label == identity.account_label
+    ]
+    if source_account_label != identity.account_label and order_event_source_window_ids:
+        source_window_account_filters.append(
+            (OrderFeedSourceWindow.alpaca_account_label == source_account_label)
+            & OrderFeedSourceWindow.id.in_(order_event_source_window_ids)
+        )
+    source_window_stmt = source_window_stmt.where(or_(*source_window_account_filters))
     if started_at is not None:
         source_window_stmt = source_window_stmt.where(
             OrderFeedSourceWindow.window_ended_at >= started_at
@@ -473,6 +505,266 @@ def _load_session_rows(
         order_feed_source_windows=source_windows,
         runtime_ledger_buckets=runtime_ledger_buckets,
     )
+
+
+def _source_account_label(identity: CensusIdentity) -> str:
+    return (identity.source_account_label or "").strip() or identity.account_label
+
+
+def _authority_scope_rows(
+    rows: CensusSourceRows,
+    identity: CensusIdentity,
+) -> CensusSourceRows:
+    """Return only rows allowed to contribute proof for the requested identity."""
+
+    source_account_label = _source_account_label(identity)
+    target_account_label = identity.account_label
+    scoped_trade_decisions = [
+        row
+        for row in rows.trade_decisions
+        if _row_account_label(row) in (None, target_account_label)
+        and _text(row.get("strategy_name")) in (None, identity.runtime_strategy_name)
+    ]
+    scoped_decision_ids = _row_ids(scoped_trade_decisions)
+    scoped_executions = [
+        row
+        for row in rows.executions
+        if _row_account_label(row) in (None, target_account_label)
+        and _optional_row_ref_matches(row, "trade_decision_id", scoped_decision_ids)
+    ]
+    scoped_execution_ids = _row_ids(scoped_executions)
+    scoped_tca_metrics = [
+        row
+        for row in rows.execution_tca_metrics
+        if _row_account_label(row) in (None, target_account_label)
+        and _optional_row_ref_matches(row, "trade_decision_id", scoped_decision_ids)
+        and _optional_row_ref_matches(row, "execution_id", scoped_execution_ids)
+    ]
+    ledger_rows = [
+        row
+        for row in rows.runtime_ledger_buckets
+        if _ledger_row_matches_identity(row, identity)
+    ]
+    ledger_decision_ids = _payload_identifier_values(
+        ledger_rows,
+        "trade_decision_ids",
+        "decision_ids",
+        "decision_hashes",
+    )
+    ledger_execution_ids = _payload_identifier_values(ledger_rows, "execution_ids")
+    ledger_source_window_ids = _payload_identifier_values(
+        ledger_rows,
+        "source_window_ids",
+        "runtime_ledger_source_window_ids",
+    )
+    canonical_decision_ids = scoped_decision_ids | ledger_decision_ids
+    canonical_execution_ids = scoped_execution_ids | ledger_execution_ids
+    scoped_events = [
+        row
+        for row in rows.execution_order_events
+        if _source_event_row_matches_identity(
+            row,
+            identity=identity,
+            source_account_label=source_account_label,
+            target_account_label=target_account_label,
+            canonical_decision_ids=canonical_decision_ids,
+            canonical_execution_ids=canonical_execution_ids,
+        )
+    ]
+    scoped_event_source_window_ids = {
+        source_window_id
+        for row in scoped_events
+        if (source_window_id := _text(row.get("source_window_id"))) is not None
+    }
+    canonical_source_window_ids = (
+        scoped_event_source_window_ids | ledger_source_window_ids
+    )
+    scoped_source_windows = [
+        row
+        for row in rows.order_feed_source_windows
+        if _source_window_row_matches_identity(
+            row,
+            identity=identity,
+            source_account_label=source_account_label,
+            target_account_label=target_account_label,
+            canonical_source_window_ids=canonical_source_window_ids,
+        )
+    ]
+    return CensusSourceRows(
+        trade_decisions=scoped_trade_decisions,
+        executions=scoped_executions,
+        execution_order_events=scoped_events,
+        execution_tca_metrics=scoped_tca_metrics,
+        order_feed_source_windows=scoped_source_windows,
+        runtime_ledger_buckets=ledger_rows,
+    )
+
+
+def _source_event_row_matches_identity(
+    row: Mapping[str, object],
+    *,
+    identity: CensusIdentity,
+    source_account_label: str,
+    target_account_label: str,
+    canonical_decision_ids: set[str],
+    canonical_execution_ids: set[str],
+) -> bool:
+    account_label = _row_account_label(row)
+    if account_label in (None, target_account_label):
+        return True
+    if (
+        account_label != source_account_label
+        or source_account_label == target_account_label
+    ):
+        return False
+    if _row_ref_matches(row, "trade_decision_id", canonical_decision_ids):
+        return True
+    if _row_ref_matches(row, "decision_id", canonical_decision_ids):
+        return True
+    if _row_ref_matches(row, "execution_id", canonical_execution_ids):
+        return True
+    return _row_aliases_target_account(row, identity.account_label)
+
+
+def _source_window_row_matches_identity(
+    row: Mapping[str, object],
+    *,
+    identity: CensusIdentity,
+    source_account_label: str,
+    target_account_label: str,
+    canonical_source_window_ids: set[str],
+) -> bool:
+    account_label = _row_account_label(row)
+    if account_label in (None, target_account_label):
+        return True
+    if (
+        account_label != source_account_label
+        or source_account_label == target_account_label
+    ):
+        return False
+    if _row_ref_matches(row, "id", canonical_source_window_ids):
+        return True
+    if _row_ref_matches(row, "source_window_id", canonical_source_window_ids):
+        return True
+    return _row_aliases_target_account(row, identity.account_label)
+
+
+def _ledger_row_matches_identity(
+    row: Mapping[str, object],
+    identity: CensusIdentity,
+) -> bool:
+    return (
+        _text(row.get("candidate_id")) in (None, identity.candidate_id)
+        and _text(row.get("hypothesis_id")) in (None, identity.hypothesis_id)
+        and _text(row.get("runtime_strategy_name"))
+        in (None, identity.runtime_strategy_name)
+        and _text(row.get("account_label")) in (None, identity.account_label)
+        and _text(row.get("observed_stage")) in (None, identity.observed_stage)
+    )
+
+
+def _row_account_label(row: Mapping[str, object]) -> str | None:
+    return _text(row.get("alpaca_account_label")) or _text(row.get("account_label"))
+
+
+def _row_ids(rows: Sequence[Mapping[str, object]]) -> set[str]:
+    return {row_id for row in rows if (row_id := _text(row.get("id"))) is not None}
+
+
+def _optional_row_ref_matches(
+    row: Mapping[str, object],
+    key: str,
+    candidates: set[str],
+) -> bool:
+    value = _text(row.get(key))
+    return value is None or not candidates or value in candidates
+
+
+def _row_ref_matches(
+    row: Mapping[str, object],
+    key: str,
+    candidates: set[str],
+) -> bool:
+    value = _text(row.get(key))
+    return value is not None and value in candidates
+
+
+def _payload_identifier_values(
+    rows: Sequence[Mapping[str, object]],
+    *keys: str,
+) -> set[str]:
+    values: set[str] = set()
+    for row in rows:
+        payload = _mapping(row.get("payload"))
+        for source in (row, payload):
+            for key in keys:
+                values.update(_text_values(source.get(key)))
+    return values
+
+
+def _text_values(value: object) -> set[str]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return {item_text for item in value if (item_text := _text(item)) is not None}
+    text = _text(value)
+    if text is not None:
+        return {text}
+    return set()
+
+
+def _row_aliases_target_account(
+    row: Mapping[str, object],
+    target_account_label: str,
+) -> bool:
+    return _mapping_aliases_target(row, target_account_label, alias_context=False)
+
+
+def _mapping_aliases_target(
+    payload: Mapping[str, object],
+    target_account_label: str,
+    *,
+    alias_context: bool,
+) -> bool:
+    for key, value in payload.items():
+        normalized_key = str(key).lower()
+        next_alias_context = alias_context or any(
+            marker in normalized_key
+            for marker in (
+                "alias",
+                "canonical",
+                "logical",
+                "materialized",
+                "target_account",
+            )
+        )
+        if next_alias_context and _value_mentions_text(value, target_account_label):
+            return True
+        if isinstance(value, Mapping) and _mapping_aliases_target(
+            value,
+            target_account_label,
+            alias_context=next_alias_context,
+        ):
+            return True
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            for item in value:
+                if isinstance(item, Mapping) and _mapping_aliases_target(
+                    item,
+                    target_account_label,
+                    alias_context=next_alias_context,
+                ):
+                    return True
+    return False
+
+
+def _value_mentions_text(value: object, expected: str) -> bool:
+    if _text(value) == expected:
+        return True
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return any(_text(item) == expected for item in value)
+    if isinstance(value, Mapping):
+        return any(_value_mentions_text(item, expected) for item in value.values())
+    return False
 
 
 def _daily_census(
@@ -708,6 +1000,9 @@ def _candidate_config_match(
 ) -> dict[str, object]:
     """Summarize whether read rows match the requested H-PAIRS candidate/config."""
 
+    scoped_rows = _authority_scope_rows(rows, identity)
+    scoped_order_event_ids = _row_ids(scoped_rows.execution_order_events)
+    scoped_source_window_ids = _row_ids(scoped_rows.order_feed_source_windows)
     trade_decision_mismatches = sum(
         1
         for row in rows.trade_decisions
@@ -722,7 +1017,7 @@ def _candidate_config_match(
     order_event_mismatches = sum(
         1
         for row in rows.execution_order_events
-        if _text(row.get("alpaca_account_label")) not in (None, identity.account_label)
+        if _text(row.get("id")) not in scoped_order_event_ids
     )
     tca_metric_mismatches = sum(
         1
@@ -732,7 +1027,7 @@ def _candidate_config_match(
     source_window_mismatches = sum(
         1
         for row in rows.order_feed_source_windows
-        if _text(row.get("alpaca_account_label")) not in (None, identity.account_label)
+        if _text(row.get("id")) not in scoped_source_window_ids
     )
     ledger_mismatches = [
         row
@@ -762,6 +1057,7 @@ def _candidate_config_match(
             "candidate_id": identity.candidate_id,
             "runtime_strategy_name": identity.runtime_strategy_name,
             "account_label": identity.account_label,
+            "source_account_label": _source_account_label(identity),
             "observed_stage": identity.observed_stage,
         },
         "trade_decision_mismatch_count": trade_decision_mismatches,
@@ -1556,6 +1852,7 @@ def main(argv: list[str] | None = None) -> int:
         candidate_id=args.candidate_id,
         runtime_strategy_name=args.runtime_strategy_name,
         account_label=args.account_label,
+        source_account_label=args.source_account_label,
         observed_stage=args.observed_stage,
     )
     read_error = None

--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -626,9 +626,11 @@ def _source_event_row_matches_identity(
     target_account_label: str,
     canonical_decision_ids: set[str],
     canonical_execution_ids: set[str],
-    canonical_order_ids: set[str],
-    canonical_client_order_ids: set[str],
+    canonical_order_ids: set[str] | None = None,
+    canonical_client_order_ids: set[str] | None = None,
 ) -> bool:
+    canonical_order_ids = canonical_order_ids or set()
+    canonical_client_order_ids = canonical_client_order_ids or set()
     account_label = _row_account_label(row)
     if account_label in (None, target_account_label):
         return True
@@ -1734,7 +1736,7 @@ def _order_event_row(row: ExecutionOrderEvent) -> dict[str, object]:
         "filled_qty_delta": row.filled_qty_delta,
         "avg_fill_price": row.avg_fill_price,
         "filled_notional_delta": row.filled_notional_delta,
-        "raw_event": row.raw_event,
+        "raw_event": getattr(row, "raw_event", None),
         "execution_id": str(row.execution_id) if row.execution_id is not None else None,
         "trade_decision_id": str(row.trade_decision_id)
         if row.trade_decision_id is not None

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -4929,11 +4929,12 @@ def _retarget_source_rows_for_materialization(
     retargeted: list[dict[str, object]] = []
     for row in rows:
         payload = dict(row)
-        payload.setdefault(
-            "source_account_label",
+        source_row_account_label = (
             _first_text(payload, "account_label", "alpaca_account_label")
-            or source_account_label,
+            or source_account_label
         )
+        payload.setdefault("source_row_account_label", source_row_account_label)
+        payload["source_account_label"] = source_account_label
         payload["account_label"] = target_account_label
         retargeted.append(payload)
     return retargeted
@@ -4950,17 +4951,19 @@ def _retarget_runtime_ledger_tca_rows(
     retargeted: list[dict[str, object]] = []
     for row in rows:
         payload = dict(row)
-        payload.setdefault(
-            "source_account_label",
+        source_row_account_label = (
             _first_text(payload, "account_label", "alpaca_account_label")
-            or source_account_label,
+            or source_account_label
         )
+        payload.setdefault("source_row_account_label", source_row_account_label)
+        payload["source_account_label"] = source_account_label
         if "account_label" in payload:
             payload["account_label"] = target_account_label
         bucket = _as_mapping(payload.get("runtime_ledger_bucket"))
         if bucket:
             source_bucket_label = (
-                _text_or_none(bucket.get("account_label")) or source_account_label
+                _text_or_none(bucket.get("source_account_label"))
+                or source_account_label
             )
             payload["runtime_ledger_bucket"] = {
                 **bucket,
@@ -4992,6 +4995,7 @@ def _query_timestamps(
     materialized_account_label = (
         str(target_account_label or "").strip() or source_account_label
     )
+    canonical_account_label = materialized_account_label
     decisions: list[datetime] = []
     executions: list[datetime] = []
     tca_rows: list[dict[str, object]] = []
@@ -5074,7 +5078,7 @@ def _query_timestamps(
                 """,
                 (
                     strategy_names,
-                    account_label,
+                    canonical_account_label,
                     list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
                     window_start,
                     window_end,
@@ -5171,8 +5175,8 @@ def _query_timestamps(
                 """,
                 (
                     strategy_names,
-                    account_label,
-                    account_label,
+                    canonical_account_label,
+                    canonical_account_label,
                     window_start,
                     window_end,
                     *execution_symbol_params,
@@ -5272,8 +5276,7 @@ def _query_timestamps(
                             array_agg(e_match.id order by e_match.created_at, e_match.id) as ids,
                             count(*) as match_count
                         from executions e_match
-                        where coalesce(e_match.alpaca_account_label, oe.alpaca_account_label)
-                              = oe.alpaca_account_label
+                        where e_match.alpaca_account_label = %s
                           and (
                                 (
                                     oe.execution_id is not null
@@ -5299,7 +5302,7 @@ def _query_timestamps(
                             array_agg(d_match.id order by d_match.created_at, d_match.id) as ids,
                             count(*) as match_count
                         from trade_decisions d_match
-                        where d_match.alpaca_account_label = oe.alpaca_account_label
+                        where d_match.alpaca_account_label = %s
                           and nullif(oe.client_order_id, '') is not null
                           and d_match.decision_hash = oe.client_order_id
                     ) exact_decision_match
@@ -5318,9 +5321,11 @@ def _query_timestamps(
                 order by coalesce(oe.event_ts, oe.created_at), oe.created_at
                 """,
                 (
+                    canonical_account_label,
+                    canonical_account_label,
                     strategy_names,
-                    account_label,
-                    account_label,
+                    canonical_account_label,
+                    source_account_label,
                     window_start,
                     window_end,
                     *order_event_symbol_params,
@@ -5391,7 +5396,7 @@ def _query_timestamps(
                     """,
                     (
                         strategy_names,
-                        account_label,
+                        canonical_account_label,
                         list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
                         carry_in_window_start,
                         window_start,
@@ -5483,8 +5488,8 @@ def _query_timestamps(
                     """,
                     (
                         strategy_names,
-                        account_label,
-                        account_label,
+                        canonical_account_label,
+                        canonical_account_label,
                         carry_in_window_start,
                         window_start,
                         *execution_symbol_params,
@@ -5587,8 +5592,7 @@ def _query_timestamps(
                                 array_agg(e_match.id order by e_match.created_at, e_match.id) as ids,
                                 count(*) as match_count
                             from executions e_match
-                            where coalesce(e_match.alpaca_account_label, oe.alpaca_account_label)
-                                  = oe.alpaca_account_label
+                            where e_match.alpaca_account_label = %s
                               and (
                                     (
                                         oe.execution_id is not null
@@ -5614,7 +5618,7 @@ def _query_timestamps(
                                 array_agg(d_match.id order by d_match.created_at, d_match.id) as ids,
                                 count(*) as match_count
                             from trade_decisions d_match
-                            where d_match.alpaca_account_label = oe.alpaca_account_label
+                            where d_match.alpaca_account_label = %s
                               and nullif(oe.client_order_id, '') is not null
                               and d_match.decision_hash = oe.client_order_id
                         ) exact_decision_match
@@ -5633,9 +5637,11 @@ def _query_timestamps(
                     order by coalesce(oe.event_ts, oe.created_at), oe.created_at
                     """,
                     (
+                        canonical_account_label,
+                        canonical_account_label,
                         strategy_names,
-                        account_label,
-                        account_label,
+                        canonical_account_label,
+                        source_account_label,
                         carry_in_window_start,
                         window_start,
                         *order_event_symbol_params,
@@ -5741,8 +5747,7 @@ def _query_timestamps(
                                 array_agg(e_match.id order by e_match.created_at, e_match.id) as ids,
                                 count(*) as match_count
                             from executions e_match
-                            where coalesce(e_match.alpaca_account_label, oe.alpaca_account_label)
-                                  = oe.alpaca_account_label
+                            where e_match.alpaca_account_label = %s
                               and (
                                     (
                                         oe.execution_id is not null
@@ -5768,7 +5773,7 @@ def _query_timestamps(
                                 array_agg(d_match.id order by d_match.created_at, d_match.id) as ids,
                                 count(*) as match_count
                             from trade_decisions d_match
-                            where d_match.alpaca_account_label = oe.alpaca_account_label
+                            where d_match.alpaca_account_label = %s
                               and nullif(oe.client_order_id, '') is not null
                               and d_match.decision_hash = oe.client_order_id
                         ) exact_decision_match
@@ -5792,7 +5797,9 @@ def _query_timestamps(
                     order by coalesce(oe.event_ts, oe.created_at), oe.created_at
                     """,
                     (
-                        account_label,
+                        canonical_account_label,
+                        canonical_account_label,
+                        source_account_label,
                         window_start,
                         window_end,
                         *([symbol_filter] if symbol_filter else []),
@@ -5908,8 +5915,8 @@ def _query_timestamps(
                 """,
                 (
                     strategy_names,
-                    account_label,
-                    account_label,
+                    canonical_account_label,
+                    canonical_account_label,
                     window_start,
                     window_end,
                     *execution_symbol_params,

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -320,6 +320,7 @@ def test_load_session_rows_adds_linked_source_account_windows() -> None:
         filled_qty_delta="1",
         avg_fill_price="100",
         filled_notional_delta="100",
+        raw_event=None,
         created_at=datetime(2026, 5, 1, 15, tzinfo=timezone.utc),
     )
     session = _FakeReadSession(
@@ -356,6 +357,8 @@ def test_source_account_matching_helpers_cover_alias_and_mismatch_paths() -> Non
             target_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
             canonical_decision_ids={"decision-1"},
             canonical_execution_ids={"execution-1"},
+            canonical_order_ids=set(),
+            canonical_client_order_ids=set(),
         )
         is False
     )
@@ -367,6 +370,8 @@ def test_source_account_matching_helpers_cover_alias_and_mismatch_paths() -> Non
             target_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
             canonical_decision_ids={"decision-1"},
             canonical_execution_ids=set(),
+            canonical_order_ids=set(),
+            canonical_client_order_ids=set(),
         )
         is True
     )
@@ -378,6 +383,8 @@ def test_source_account_matching_helpers_cover_alias_and_mismatch_paths() -> Non
             target_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
             canonical_decision_ids=set(),
             canonical_execution_ids={"execution-1"},
+            canonical_order_ids=set(),
+            canonical_client_order_ids=set(),
         )
         is True
     )
@@ -549,6 +556,12 @@ def test_unrelated_source_account_rows_remain_mismatches_not_proof() -> None:
             "filled_qty_delta": "10",
             "avg_fill_price": "100",
             "filled_notional_delta": "1000",
+            "raw_event": {
+                "_torghut_account_label_alias": {
+                    "logical_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                    "source_account_label": "PA3SX7FYNUTF",
+                }
+            },
             "event_ts": _iso(0, 16),
         }
     )
@@ -563,6 +576,12 @@ def test_unrelated_source_account_rows_remain_mismatches_not_proof() -> None:
             "start_offset": 9999,
             "end_offset": 10000,
             "status": "complete",
+            "raw_event": {
+                "_torghut_account_label_alias": {
+                    "logical_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                    "source_account_label": "PA3SX7FYNUTF",
+                }
+            },
         }
     )
 
@@ -577,6 +596,177 @@ def test_unrelated_source_account_rows_remain_mismatches_not_proof() -> None:
     )
     assert census.CANDIDATE_CONFIG_MISMATCH_BLOCKER in report["blockers"]
     assert report["verdict"]["classification"] == census.SOURCE_REFS_MISSING
+
+
+def test_source_account_scope_requires_matching_refs_before_alias_fallback() -> None:
+    identity = census.CensusIdentity(
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        observed_stage="paper",
+        source_account_label="PA3SX7FYNUTF",
+    )
+    common = {
+        "identity": identity,
+        "source_account_label": "PA3SX7FYNUTF",
+        "target_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        "canonical_decision_ids": {"decision-0"},
+        "canonical_execution_ids": {"execution-0"},
+        "canonical_order_ids": {"order-0"},
+        "canonical_client_order_ids": {"client-order-0"},
+    }
+
+    assert (
+        census._source_event_row_matches_identity(
+            {"alpaca_account_label": "other-account"}, **common
+        )
+        is False
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {"alpaca_account_label": "PA3SX7FYNUTF", "trade_decision_id": "decision-0"},
+            **common,
+        )
+        is True
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {"alpaca_account_label": "PA3SX7FYNUTF", "decision_id": "decision-0"},
+            **common,
+        )
+        is True
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {"alpaca_account_label": "PA3SX7FYNUTF", "execution_id": "execution-0"},
+            **common,
+        )
+        is True
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {"alpaca_account_label": "PA3SX7FYNUTF", "alpaca_order_id": "order-0"},
+            **common,
+        )
+        is True
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {
+                "alpaca_account_label": "PA3SX7FYNUTF",
+                "client_order_id": "client-order-0",
+            },
+            **common,
+        )
+        is True
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {
+                "alpaca_account_label": "PA3SX7FYNUTF",
+                "trade_decision_id": "decision-other",
+                "raw_event": {
+                    "_torghut_account_label_alias": {
+                        "logical_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL
+                    }
+                },
+            },
+            **common,
+        )
+        is False
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {
+                "alpaca_account_label": "PA3SX7FYNUTF",
+                "alpaca_order_id": "order-other",
+                "raw_event": {
+                    "_torghut_account_label_alias": {
+                        "logical_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL
+                    }
+                },
+            },
+            **common,
+        )
+        is False
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {
+                "alpaca_account_label": "PA3SX7FYNUTF",
+                "raw_event": {
+                    "nested": {
+                        "canonical": {"account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL}
+                    }
+                },
+            },
+            **common,
+        )
+        is True
+    )
+
+    window_common = {
+        "identity": identity,
+        "source_account_label": "PA3SX7FYNUTF",
+        "target_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        "canonical_source_window_ids": {"window-0"},
+    }
+    assert (
+        census._source_window_row_matches_identity(
+            {"alpaca_account_label": "other-account"}, **window_common
+        )
+        is False
+    )
+    assert (
+        census._source_window_row_matches_identity(
+            {"alpaca_account_label": "PA3SX7FYNUTF", "id": "window-0"},
+            **window_common,
+        )
+        is True
+    )
+    assert (
+        census._source_window_row_matches_identity(
+            {"alpaca_account_label": "PA3SX7FYNUTF", "source_window_id": "window-0"},
+            **window_common,
+        )
+        is True
+    )
+    assert (
+        census._source_window_row_matches_identity(
+            {
+                "alpaca_account_label": "PA3SX7FYNUTF",
+                "id": "window-other",
+                "raw_event": {
+                    "_torghut_account_label_alias": {
+                        "logical_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL
+                    }
+                },
+            },
+            **window_common,
+        )
+        is False
+    )
+    assert (
+        census._source_window_row_matches_identity(
+            {
+                "alpaca_account_label": "PA3SX7FYNUTF",
+                "raw_event": {
+                    "aliases": [{"logical_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL}]
+                },
+            },
+            **window_common,
+        )
+        is True
+    )
+    assert census._text_values("decision-0") == {"decision-0"}
+    assert (
+        census._row_aliases_target_account(
+            {"items": [{"materialized": {"account": DEFAULT_HPAIRS_ACCOUNT_LABEL}}]},
+            DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        )
+        is True
+    )
 
 
 def test_missing_submitted_orders_and_fills_are_machine_readable_blockers() -> None:
@@ -846,7 +1036,7 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
         source_topic="alpaca.trade_updates",
         source_partition=0,
         source_offset=11,
-        alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        alpaca_account_label="PA3SX7FYNUTF",
         event_ts=start + timedelta(minutes=3),
         created_at=start + timedelta(minutes=3),
         symbol="AAA",
@@ -858,8 +1048,14 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
         filled_qty_delta="10",
         avg_fill_price="100",
         filled_notional_delta="1000",
-        execution_id="execution-0",
-        trade_decision_id="decision-0",
+        raw_event={
+            "_torghut_account_label_alias": {
+                "logical_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL,
+                "source_account_label": "PA3SX7FYNUTF",
+            }
+        },
+        execution_id=None,
+        trade_decision_id=None,
         source_window_id="window-0",
     )
     tca = SimpleNamespace(
@@ -880,7 +1076,7 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
         consumer_group="torghut-order-feed",
         source_topic="alpaca.trade_updates",
         source_partition=0,
-        alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        alpaca_account_label="PA3SX7FYNUTF",
         window_started_at=start,
         window_ended_at=end,
         start_offset=10,
@@ -958,6 +1154,7 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
             runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
             account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
             observed_stage="paper",
+            source_account_label="PA3SX7FYNUTF",
         ),
         started_at=start,
         ended_at=end,
@@ -965,8 +1162,12 @@ def test_session_loader_normalizes_bounded_sqlalchemy_rows(monkeypatch) -> None:
 
     assert rows.trade_decisions[0]["id"] == "decision-0"
     assert rows.executions[0]["id"] == "execution-0"
+    assert rows.execution_order_events[0]["alpaca_account_label"] == "PA3SX7FYNUTF"
+    assert rows.execution_order_events[0]["execution_id"] is None
+    assert rows.execution_order_events[0]["trade_decision_id"] is None
     assert rows.execution_order_events[0]["source_offset"] == 11
     assert rows.execution_tca_metrics[0]["id"] == "tca-0"
+    assert rows.order_feed_source_windows[0]["alpaca_account_label"] == "PA3SX7FYNUTF"
     assert rows.order_feed_source_windows[0]["id"] == "window-0"
     assert rows.runtime_ledger_buckets[0]["id"] == "ledger-0"
 

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from app.trading.runtime_authority_verifier import (
     AUTHORITY_EXPLICIT_COSTS_BLOCKER,
@@ -176,7 +178,11 @@ def _fixture(*, days: int = 20, source_backed: bool = True) -> dict[str, object]
     }
 
 
-def _report(payload: dict[str, object]) -> dict[str, object]:
+def _report(
+    payload: dict[str, object],
+    *,
+    source_account_label: str | None = None,
+) -> dict[str, object]:
     rows = census.CensusSourceRows(
         trade_decisions=census._row_list(payload.get("trade_decisions")),
         executions=census._row_list(payload.get("executions")),
@@ -195,6 +201,7 @@ def _report(payload: dict[str, object]) -> dict[str, object]:
             runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
             account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
             observed_stage="paper",
+            source_account_label=source_account_label,
         ),
     )
 
@@ -207,6 +214,217 @@ def _ladder_step(report: dict[str, object], step: str) -> dict[str, object]:
         if item["step"] == step:
             return item
     raise AssertionError(f"missing ladder step {step}")
+
+
+class _FakeResult:
+    def __init__(self, rows: list[object]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[object]:
+        return self._rows
+
+
+class _FakeReadSession:
+    def __init__(
+        self,
+        *,
+        decision_pairs: list[object],
+        scalar_results: list[list[object]],
+    ) -> None:
+        self._decision_pairs = decision_pairs
+        self._scalar_results = scalar_results
+
+    def execute(self, _stmt: object) -> _FakeResult:
+        return _FakeResult(self._decision_pairs)
+
+    def scalars(self, _stmt: object) -> _FakeResult:
+        return _FakeResult(self._scalar_results.pop(0))
+
+
+def test_load_session_rows_keeps_target_only_when_no_canonical_refs() -> None:
+    identity = census.CensusIdentity(
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        observed_stage="paper",
+        source_account_label="PA3SX7FYNUTF",
+    )
+    session = _FakeReadSession(
+        decision_pairs=[],
+        scalar_results=[[], [], [], []],
+    )
+
+    with patch(
+        "scripts.audit_hpairs_source_proof_census.load_runtime_authority_rows",
+        return_value=[],
+    ):
+        rows = census._load_session_rows(
+            session, identity=identity, started_at=None, ended_at=None
+        )
+
+    assert rows.execution_order_events == []
+    assert rows.order_feed_source_windows == []
+
+
+def test_load_session_rows_adds_linked_source_account_windows() -> None:
+    identity = census.CensusIdentity(
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        observed_stage="paper",
+        source_account_label="PA3SX7FYNUTF",
+    )
+    decision = SimpleNamespace(
+        id="decision-1",
+        strategy_id="strategy-1",
+        alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        symbol="AAPL",
+        status="executed",
+        decision_hash="decision-1",
+        created_at=datetime(2026, 5, 1, 14, tzinfo=timezone.utc),
+        executed_at=None,
+    )
+    execution = SimpleNamespace(
+        id="execution-1",
+        trade_decision_id="decision-1",
+        alpaca_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        alpaca_order_id="alpaca-order-1",
+        client_order_id="client-order-1",
+        symbol="AAPL",
+        side="buy",
+        status="filled",
+        filled_qty="1",
+        avg_fill_price="100",
+        created_at=datetime(2026, 5, 1, 15, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 5, 1, 15, tzinfo=timezone.utc),
+        order_feed_last_event_ts=datetime(2026, 5, 1, 15, tzinfo=timezone.utc),
+    )
+    event = SimpleNamespace(
+        id="event-1",
+        source_topic="alpaca.trade_updates",
+        source_partition=0,
+        source_offset=42,
+        alpaca_account_label="PA3SX7FYNUTF",
+        symbol="AAPL",
+        event_type="fill",
+        event_ts=datetime(2026, 5, 1, 15, tzinfo=timezone.utc),
+        status="filled",
+        trade_decision_id="decision-1",
+        execution_id="execution-1",
+        alpaca_order_id="alpaca-order-1",
+        client_order_id="client-order-1",
+        source_window_id="window-1",
+        filled_qty="1",
+        filled_qty_delta="1",
+        avg_fill_price="100",
+        filled_notional_delta="100",
+        created_at=datetime(2026, 5, 1, 15, tzinfo=timezone.utc),
+    )
+    session = _FakeReadSession(
+        decision_pairs=[(decision, DEFAULT_HPAIRS_RUNTIME_STRATEGY)],
+        scalar_results=[[execution], [event], [], []],
+    )
+
+    with patch(
+        "scripts.audit_hpairs_source_proof_census.load_runtime_authority_rows",
+        return_value=[],
+    ):
+        rows = census._load_session_rows(
+            session, identity=identity, started_at=None, ended_at=None
+        )
+
+    assert rows.execution_order_events[0]["alpaca_account_label"] == "PA3SX7FYNUTF"
+
+
+def test_source_account_matching_helpers_cover_alias_and_mismatch_paths() -> None:
+    identity = census.CensusIdentity(
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        observed_stage="paper",
+        source_account_label="PA3SX7FYNUTF",
+    )
+
+    assert (
+        census._source_event_row_matches_identity(
+            {"alpaca_account_label": "OTHER"},
+            identity=identity,
+            source_account_label="PA3SX7FYNUTF",
+            target_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            canonical_decision_ids={"decision-1"},
+            canonical_execution_ids={"execution-1"},
+        )
+        is False
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {"alpaca_account_label": "PA3SX7FYNUTF", "decision_id": "decision-1"},
+            identity=identity,
+            source_account_label="PA3SX7FYNUTF",
+            target_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            canonical_decision_ids={"decision-1"},
+            canonical_execution_ids=set(),
+        )
+        is True
+    )
+    assert (
+        census._source_event_row_matches_identity(
+            {"alpaca_account_label": "PA3SX7FYNUTF", "execution_id": "execution-1"},
+            identity=identity,
+            source_account_label="PA3SX7FYNUTF",
+            target_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            canonical_decision_ids=set(),
+            canonical_execution_ids={"execution-1"},
+        )
+        is True
+    )
+    assert (
+        census._source_window_row_matches_identity(
+            {"alpaca_account_label": "OTHER"},
+            identity=identity,
+            source_account_label="PA3SX7FYNUTF",
+            target_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            canonical_source_window_ids={"window-1"},
+        )
+        is False
+    )
+    assert (
+        census._source_window_row_matches_identity(
+            {"alpaca_account_label": "PA3SX7FYNUTF", "source_window_id": "window-1"},
+            identity=identity,
+            source_account_label="PA3SX7FYNUTF",
+            target_account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+            canonical_source_window_ids={"window-1"},
+        )
+        is True
+    )
+    assert census._text_values("decision-1") == {"decision-1"}
+    assert census._row_aliases_target_account(
+        {"canonical_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL},
+        DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    )
+    assert census._row_aliases_target_account(
+        {"payload": {"logical_account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL}},
+        DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    )
+    assert census._row_aliases_target_account(
+        {"aliases": [{"account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL}]},
+        DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    )
+    assert census._value_mentions_text(
+        DEFAULT_HPAIRS_ACCOUNT_LABEL, DEFAULT_HPAIRS_ACCOUNT_LABEL
+    )
+    assert census._value_mentions_text(
+        [DEFAULT_HPAIRS_ACCOUNT_LABEL], DEFAULT_HPAIRS_ACCOUNT_LABEL
+    )
+    assert census._value_mentions_text(
+        {"account_label": DEFAULT_HPAIRS_ACCOUNT_LABEL},
+        DEFAULT_HPAIRS_ACCOUNT_LABEL,
+    )
+    assert not census._value_mentions_text("OTHER", DEFAULT_HPAIRS_ACCOUNT_LABEL)
 
 
 def test_full_source_backed_census_is_authority_candidate_ready() -> None:
@@ -281,6 +499,84 @@ def test_full_source_backed_census_is_authority_candidate_ready() -> None:
         "flat_no_open_positions_after_grace",
         "twenty_authority_grade_trading_days_daily_post_cost_distribution",
     ]
+
+
+def test_source_account_rows_linked_to_logical_account_count_as_source_proof() -> None:
+    payload = _fixture()
+    for row in payload["execution_order_events"]:
+        assert isinstance(row, dict)
+        row["alpaca_account_label"] = "PA3SX7FYNUTF"
+    for row in payload["order_feed_source_windows"]:
+        assert isinstance(row, dict)
+        row["alpaca_account_label"] = "PA3SX7FYNUTF"
+
+    report = _report(payload, source_account_label="PA3SX7FYNUTF")
+
+    assert report["identity"]["account_label"] == DEFAULT_HPAIRS_ACCOUNT_LABEL
+    assert report["identity"]["source_account_label"] == "PA3SX7FYNUTF"
+    assert report["candidate_config_match"]["matches"] is True
+    assert report["candidate_config_match"]["mismatch_count"] == 0
+    assert report["totals"]["execution_order_event_count"] == 20
+    assert report["totals"]["source_window_count"] == 20
+    assert report["totals"]["execution_order_events_with_source_window_count"] == 20
+    assert report["verdict"]["classification"] == census.AUTHORITY_CANDIDATE_READY
+
+
+def test_unrelated_source_account_rows_remain_mismatches_not_proof() -> None:
+    payload = _fixture()
+    for row in payload["execution_order_events"]:
+        assert isinstance(row, dict)
+        row["alpaca_account_label"] = "PA3SX7FYNUTF"
+    for row in payload["order_feed_source_windows"]:
+        assert isinstance(row, dict)
+        row["alpaca_account_label"] = "PA3SX7FYNUTF"
+    events = payload["execution_order_events"]
+    windows = payload["order_feed_source_windows"]
+    assert isinstance(events, list)
+    assert isinstance(windows, list)
+    events.append(
+        {
+            "id": "event-unrelated-pa",
+            "execution_id": "execution-unrelated-pa",
+            "trade_decision_id": "decision-unrelated-pa",
+            "source_window_id": "window-unrelated-pa",
+            "source_topic": "alpaca.trade_updates",
+            "source_partition": 0,
+            "source_offset": 9999,
+            "alpaca_account_label": "PA3SX7FYNUTF",
+            "event_type": "fill",
+            "status": "filled",
+            "filled_qty_delta": "10",
+            "avg_fill_price": "100",
+            "filled_notional_delta": "1000",
+            "event_ts": _iso(0, 16),
+        }
+    )
+    windows.append(
+        {
+            "id": "window-unrelated-pa",
+            "alpaca_account_label": "PA3SX7FYNUTF",
+            "source_topic": "alpaca.trade_updates",
+            "source_partition": 0,
+            "window_started_at": _iso(0, 16),
+            "window_ended_at": _iso(0, 17),
+            "start_offset": 9999,
+            "end_offset": 10000,
+            "status": "complete",
+        }
+    )
+
+    report = _report(payload, source_account_label="PA3SX7FYNUTF")
+
+    assert report["totals"]["execution_order_event_count"] == 20
+    assert report["totals"]["source_window_count"] == 20
+    assert report["candidate_config_match"]["matches"] is False
+    assert report["candidate_config_match"]["execution_order_event_mismatch_count"] == 1
+    assert (
+        report["candidate_config_match"]["order_feed_source_window_mismatch_count"] == 1
+    )
+    assert census.CANDIDATE_CONFIG_MISMATCH_BLOCKER in report["blockers"]
+    assert report["verdict"]["classification"] == census.SOURCE_REFS_MISSING
 
 
 def test_missing_submitted_orders_and_fills_are_machine_readable_blockers() -> None:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -7397,18 +7397,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             _source_activity_diagnostics_blockers(diagnostics),
         )
 
-    def test_query_timestamps_uses_source_account_but_materializes_target_account(
+    def test_query_timestamps_uses_source_events_but_materializes_target_account(
         self,
     ) -> None:
         cursor = _FakeCursor()
-        cursor._results = [
-            [
-                tuple(
-                    "TORGHUT_REPLAY" if item == "TORGHUT_SIM" else item for item in row
-                )
-                for row in rows
-            ]
-            for rows in cursor._results
+        cursor._results[2] = [
+            tuple("PA3SX7FYNUTF" if item == "TORGHUT_SIM" else item for item in row)
+            for row in cursor._results[2]
         ]
         connection = _FakeConnection(cursor)
         window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
@@ -7422,21 +7417,39 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             _, _, tca_rows = _query_timestamps(
                 dsn="postgresql://example",
                 strategy_names=["intraday_tsmom_v1@paper"],
-                account_label="TORGHUT_REPLAY",
+                account_label="PA3SX7FYNUTF",
                 target_account_label="TORGHUT_SIM",
                 window_start=window_start,
                 window_end=window_end,
                 source_activity_diagnostics=diagnostics,
             )
 
-        for _, params in cursor.executed:
-            self.assertIn("TORGHUT_REPLAY", params)
-            self.assertNotIn("TORGHUT_SIM", params)
+        decision_params = cursor.executed[0][1]
+        execution_params = cursor.executed[1][1]
+        order_event_query, order_event_params = cursor.executed[2]
+        tca_params = cursor.executed[3][1]
+        self.assertEqual(decision_params[1], "TORGHUT_SIM")
+        self.assertEqual(execution_params[1], "TORGHUT_SIM")
+        self.assertEqual(execution_params[2], "TORGHUT_SIM")
+        self.assertIn("e_match.alpaca_account_label = %s", order_event_query)
+        self.assertIn("d_match.alpaca_account_label = %s", order_event_query)
+        self.assertEqual(
+            order_event_params[:5],
+            (
+                "TORGHUT_SIM",
+                "TORGHUT_SIM",
+                ["intraday_tsmom_v1@paper"],
+                "TORGHUT_SIM",
+                "PA3SX7FYNUTF",
+            ),
+        )
+        self.assertEqual(tca_params[1], "TORGHUT_SIM")
+        self.assertEqual(tca_params[2], "TORGHUT_SIM")
         self.assertEqual(diagnostics["account_label"], "TORGHUT_SIM")
-        self.assertEqual(diagnostics["source_account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(diagnostics["source_account_label"], "PA3SX7FYNUTF")
         runtime_bucket = tca_rows[1]["runtime_ledger_bucket"]
         self.assertEqual(runtime_bucket["account_label"], "TORGHUT_SIM")
-        self.assertEqual(runtime_bucket["source_account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(runtime_bucket["source_account_label"], "PA3SX7FYNUTF")
         self.assertEqual(
             diagnostics["order_feed_fill_lifecycle_blockers"],
             ["order_feed_fill_lifecycle_missing"],
@@ -7676,7 +7689,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             datetime(2026, 3, 1, 14, 40, tzinfo=timezone.utc),
         )
         self.assertEqual(
-            carry_order_params[3],
+            carry_order_params[5],
             datetime(2026, 3, 1, 14, 40, tzinfo=timezone.utc),
         )
         self.assertEqual(diagnostics["carry_in_decision_rows_before_lineage_filter"], 1)


### PR DESCRIPTION
## Summary

- Added explicit logical/source account reconciliation to the H-PAIRS source-proof census so TORGHUT_SIM authority readback can count PA3SX7FYNUTF source rows only when durable refs or alias payloads tie them to the canonical logical account.
- Scoped census totals to authority-eligible rows while preserving unrelated source-account rows as candidate-config mismatches/blockers.
- Repaired runtime-window import readback SQL to query canonical TORGHUT_SIM decisions/executions/TCA while accepting linked PA3SX7FYNUTF order lifecycle events and preserving source-account metadata in materialized payloads.
- Added regression coverage for linked source-account proof, unrelated PA-row blocking, and target/source account query parameter contracts.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_audit_hpairs_source_proof_census.py -q`
- PASS: `cd services/torghut && uv run --frozen ruff check scripts/audit_hpairs_source_proof_census.py scripts/import_hypothesis_runtime_windows.py tests/test_audit_hpairs_source_proof_census.py tests/test_import_hypothesis_runtime_windows.py`
- PASS: `cd services/torghut && uv run --frozen ruff format --check scripts/audit_hpairs_source_proof_census.py scripts/import_hypothesis_runtime_windows.py tests/test_audit_hpairs_source_proof_census.py tests/test_import_hypothesis_runtime_windows.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
