### PR TITLE
fix(torghut): materialize signed runtime ledger refs

### DIFF
--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -11,9 +11,10 @@ import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Any, cast
 
-from sqlalchemy import String, create_engine, select
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from app.config import Settings
@@ -31,6 +32,7 @@ from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
     TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
     TigerBeetleLedgerJournal,
+    build_runtime_ledger_bucket_transfer_plan,
     build_order_event_transfer_plan,
     tigerbeetle_runtime_ledger_journal_payload,
 )
@@ -305,23 +307,9 @@ def _select_unlinked_runtime_buckets(
     account_label: str | None,
     limit: int,
 ) -> list[StrategyRuntimeLedgerBucket]:
-    complete_ref = (
-        select(TigerBeetleTransferRef.id)
-        .where(
-            TigerBeetleTransferRef.cluster_id == settings_obj.tigerbeetle_cluster_id,
-            TigerBeetleTransferRef.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-            TigerBeetleTransferRef.source_id
-            == StrategyRuntimeLedgerBucket.id.cast(String),
-            TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL,
-            TigerBeetleTransferRef.runtime_ledger_bucket_id
-            == StrategyRuntimeLedgerBucket.id,
-        )
-        .exists()
-    )
     stmt = (
         select(StrategyRuntimeLedgerBucket)
         .where(
-            ~complete_ref,
             (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
             | (StrategyRuntimeLedgerBucket.cost_amount != 0),
         )
@@ -329,7 +317,101 @@ def _select_unlinked_runtime_buckets(
     )
     if account_label:
         stmt = stmt.where(StrategyRuntimeLedgerBucket.account_label == account_label)
-    return list(session.execute(stmt.limit(limit)).scalars().all())
+    scan_limit = max(limit, min(limit * 20, 10000))
+    candidates = session.execute(stmt.limit(scan_limit)).scalars().all()
+    buckets: list[StrategyRuntimeLedgerBucket] = []
+    for bucket in candidates:
+        if _runtime_bucket_has_signed_ref(
+            session,
+            bucket,
+            settings_obj=settings_obj,
+        ):
+            continue
+        buckets.append(bucket)
+        if len(buckets) >= limit:
+            break
+    return buckets
+
+
+def _runtime_bucket_has_signed_ref(
+    session: Any,
+    bucket: StrategyRuntimeLedgerBucket,
+    *,
+    settings_obj: Settings,
+) -> bool:
+    refs = (
+        session.execute(
+            select(TigerBeetleTransferRef).where(
+                TigerBeetleTransferRef.cluster_id
+                == settings_obj.tigerbeetle_cluster_id,
+                TigerBeetleTransferRef.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                TigerBeetleTransferRef.source_id == str(bucket.id),
+                TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL,
+                TigerBeetleTransferRef.runtime_ledger_bucket_id == bucket.id,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return any(_runtime_ref_matches_signed_bucket(ref, bucket) for ref in refs)
+
+
+def _payload_mapping(row: TigerBeetleTransferRef) -> Mapping[str, object]:
+    raw_payload = cast(object, row.payload_json)
+    if isinstance(raw_payload, Mapping):
+        return cast(Mapping[str, object], raw_payload)
+    return {}
+
+
+def _payload_int_matches(
+    payload: Mapping[str, object],
+    key: str,
+    expected: int,
+) -> bool:
+    value = payload.get(key)
+    if value is None:
+        return False
+    try:
+        return int(str(value)) == expected
+    except (TypeError, ValueError):
+        return False
+
+
+def _runtime_ref_matches_signed_bucket(
+    ref: TigerBeetleTransferRef,
+    bucket: StrategyRuntimeLedgerBucket,
+) -> bool:
+    plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+    if plan is None:
+        return False
+    transfer_spec = plan.transfer_spec
+    payload = _payload_mapping(ref)
+    return (
+        ref.transfer_id == str(transfer_spec.transfer_id)
+        and ref.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL
+        and ref.amount == Decimal(transfer_spec.amount)
+        and ref.ledger == transfer_spec.ledger
+        and ref.code == transfer_spec.code
+        and ref.runtime_ledger_bucket_id == bucket.id
+        and ref.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET
+        and ref.source_id == str(bucket.id)
+        and _payload_int_matches(
+            payload,
+            "debit_account_id",
+            transfer_spec.debit_account_id,
+        )
+        and _payload_int_matches(
+            payload,
+            "credit_account_id",
+            transfer_spec.credit_account_id,
+        )
+        and _payload_int_matches(
+            payload,
+            "signed_amount_micros",
+            plan.signed_amount_micros,
+        )
+        and str(payload.get("pnl_direction") or "") == plan.pnl_direction
+    )
 
 
 def _journal_source_batch(

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
 from app.config import Settings
@@ -26,7 +26,12 @@ from app.models import (
     ExecutionOrderEvent,
     ExecutionTCAMetric,
     StrategyRuntimeLedgerBucket,
+    TigerBeetleAccountRef,
     TigerBeetleTransferRef,
+)
+from app.trading.tigerbeetle_journal import (
+    TigerBeetleLedgerJournal,
+    build_runtime_ledger_bucket_transfer_plan,
 )
 from app.trading.tigerbeetle_ledger_model import (
     LEDGER_USD_MICRO,
@@ -36,7 +41,10 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_FILL_POST,
     TRANSFER_KIND_RUNTIME_NET_PNL,
 )
-from app.trading.tigerbeetle_client import TigerBeetleClientTimeoutError
+from app.trading.tigerbeetle_client import (
+    FakeTigerBeetleClient,
+    TigerBeetleClientTimeoutError,
+)
 from scripts import journal_tigerbeetle_order_events as script
 
 
@@ -727,7 +735,10 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             self.assertIn("--allow-data-quality-degraded", runtime_section)
 
     def test_process_rows_attaches_runtime_bucket_journal_payload(self) -> None:
-        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        settings_obj = Settings(
+            TORGHUT_TIGERBEETLE_ENABLED=True,
+            TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
+        )
         observed_at = datetime.now(timezone.utc)
         with Session(self.engine) as session:
             bucket = StrategyRuntimeLedgerBucket(
@@ -818,6 +829,111 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertFalse(
             payload["tigerbeetle_journal_parity"]["promotion_authority"],
         )
+
+    def test_runtime_bucket_journal_materializes_signed_ref_and_is_idempotent(
+        self,
+    ) -> None:
+        settings_obj = Settings(
+            TORGHUT_TIGERBEETLE_ENABLED=True,
+            TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
+        )
+        client = FakeTigerBeetleClient()
+        observed_at = datetime.now(timezone.utc)
+        with Session(self.engine) as session:
+            bucket = StrategyRuntimeLedgerBucket(
+                run_id="runtime-run-signed-ref",
+                candidate_id="candidate",
+                hypothesis_id="hypothesis",
+                observed_stage="paper",
+                bucket_started_at=observed_at,
+                bucket_ended_at=observed_at,
+                account_label="paper",
+                runtime_strategy_name="demo-runtime",
+                strategy_family="demo",
+                fill_count=1,
+                decision_count=1,
+                submitted_order_count=1,
+                cancelled_order_count=0,
+                rejected_order_count=0,
+                unfilled_order_count=0,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("190.25"),
+                gross_strategy_pnl=Decimal("3.00"),
+                cost_amount=Decimal("0.50"),
+                net_strategy_pnl_after_costs=Decimal("2.50"),
+                post_cost_expectancy_bps=Decimal("12.50"),
+                ledger_schema_version="torghut.runtime-ledger.v1",
+                pnl_basis="post_cost",
+                payload_json={
+                    "source_refs": ["postgres:execution_order_events:event-1"],
+                    "source_row_counts": {"execution_order_events": 1},
+                    "source_window_refs": ["kafka:torghut.trade-updates.v1:0:1-2"],
+                },
+            )
+            session.add(bucket)
+            session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+
+            with TigerBeetleLedgerJournal(
+                settings_obj=settings_obj,
+                client=client,
+            ) as journal:
+                ref = journal.journal_runtime_ledger_bucket(session, bucket)
+                self.assertIsNotNone(ref)
+                assert ref is not None
+                script._attach_runtime_bucket_journal_payload(bucket, ref)
+                ref_again = journal.journal_runtime_ledger_bucket(session, bucket)
+
+            session.flush()
+            payload = ref.payload_json
+            self.assertIsInstance(payload, dict)
+            transfer = plan.transfer_spec
+            self.assertEqual(ref_again, ref)
+            self.assertEqual(ref.runtime_ledger_bucket_id, bucket.id)
+            self.assertEqual(ref.source_type, script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
+            self.assertEqual(ref.source_id, str(bucket.id))
+            self.assertEqual(ref.transfer_id, str(transfer.transfer_id))
+            self.assertEqual(payload["signed_amount_micros"], plan.signed_amount_micros)
+            self.assertEqual(payload["pnl_direction"], plan.pnl_direction)
+            self.assertEqual(
+                payload["debit_account_id"], str(transfer.debit_account_id)
+            )
+            self.assertEqual(
+                payload["credit_account_id"],
+                str(transfer.credit_account_id),
+            )
+            self.assertEqual(len(client.transfers), 1)
+            self.assertEqual(len(client.accounts), 4)
+            self.assertEqual(
+                len(
+                    session.execute(
+                        select(TigerBeetleTransferRef).where(
+                            TigerBeetleTransferRef.source_type
+                            == script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                            TigerBeetleTransferRef.source_id == str(bucket.id),
+                        )
+                    )
+                    .scalars()
+                    .all()
+                ),
+                1,
+            )
+            self.assertEqual(
+                len(session.execute(select(TigerBeetleAccountRef)).scalars().all()),
+                4,
+            )
+            self.assertEqual(
+                script._select_unlinked_runtime_buckets(
+                    session,
+                    settings_obj=settings_obj,
+                    account_label="paper",
+                    limit=10,
+                ),
+                [],
+            )
 
     def test_source_batch_stops_on_tigerbeetle_timeout(self) -> None:
         rows = [SimpleNamespace(id="first"), SimpleNamespace(id="second")]
@@ -1275,7 +1391,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
 
         self.assertEqual([row.id for row in metrics], [newer.id])
 
-    def test_select_runtime_buckets_repairs_legacy_ref_missing_bucket_fk(
+    def test_select_runtime_buckets_repairs_unsigned_legacy_ref_materialization(
         self,
     ) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
@@ -1310,18 +1426,26 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             )
             session.add(bucket)
             session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            transfer = plan.transfer_spec
             legacy_ref = TigerBeetleTransferRef(
                 cluster_id=settings_obj.tigerbeetle_cluster_id,
-                transfer_id="1234",
-                transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
-                ledger=LEDGER_USD_MICRO,
-                code=TRANSFER_CODE_FILL_POST,
-                amount=Decimal("2500000"),
+                transfer_id=str(transfer.transfer_id),
+                transfer_kind=transfer.transfer_kind,
+                ledger=transfer.ledger,
+                code=transfer.code,
+                amount=Decimal(transfer.amount),
                 status="created",
                 source_type=script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
                 source_id=str(bucket.id),
                 payload_json={
                     "source": script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    "account_ids": [
+                        str(transfer.debit_account_id),
+                        str(transfer.credit_account_id),
+                    ],
                 },
             )
             session.add(legacy_ref)
@@ -1331,22 +1455,58 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 session,
                 settings_obj=settings_obj,
                 account_label="paper",
-                limit=10,
+                limit=1,
             )
 
             self.assertEqual([row.id for row in selected], [bucket.id])
+            self.assertEqual(
+                script._payload_mapping(legacy_ref), legacy_ref.payload_json
+            )
+            self.assertFalse(
+                script._payload_int_matches(
+                    {"signed_amount_micros": "not-an-int"},
+                    "signed_amount_micros",
+                    plan.signed_amount_micros,
+                )
+            )
 
             legacy_ref.runtime_ledger_bucket_id = bucket.id
             session.add(legacy_ref)
             session.flush()
-            selected_after_repair = script._select_unlinked_runtime_buckets(
+            selected_after_fk_repair = script._select_unlinked_runtime_buckets(
                 session,
                 settings_obj=settings_obj,
                 account_label="paper",
-                limit=10,
+                limit=1,
             )
 
-        self.assertEqual(selected_after_repair, [])
+            legacy_ref.payload_json = {
+                **legacy_ref.payload_json,
+                "signed_amount_micros": plan.signed_amount_micros,
+                "pnl_direction": plan.pnl_direction,
+                "debit_account_id": str(transfer.debit_account_id),
+                "credit_account_id": str(transfer.credit_account_id),
+            }
+            session.add(legacy_ref)
+            session.flush()
+            selected_after_signed_materialization = (
+                script._select_unlinked_runtime_buckets(
+                    session,
+                    settings_obj=settings_obj,
+                    account_label="paper",
+                    limit=10,
+                )
+            )
+            legacy_ref.payload_json = None
+            bucket.net_strategy_pnl_after_costs = Decimal("0")
+            bucket.cost_amount = Decimal("0")
+            self.assertEqual(script._payload_mapping(legacy_ref), {})
+            self.assertFalse(
+                script._runtime_ref_matches_signed_bucket(legacy_ref, bucket)
+            )
+
+        self.assertEqual([row.id for row in selected_after_fk_repair], [bucket.id])
+        self.assertEqual(selected_after_signed_materialization, [])
 
     def test_main_journals_selected_events_and_reconciles(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -1508,6 +1508,93 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual([row.id for row in selected_after_fk_repair], [bucket.id])
         self.assertEqual(selected_after_signed_materialization, [])
 
+    def test_runtime_signed_ref_helpers_fail_closed_on_unusable_payloads(
+        self,
+    ) -> None:
+        observed_at = datetime.now(timezone.utc)
+        bucket = StrategyRuntimeLedgerBucket(
+            run_id="runtime-run-unjournalable",
+            candidate_id="candidate",
+            hypothesis_id="hypothesis",
+            observed_stage="paper",
+            bucket_started_at=observed_at,
+            bucket_ended_at=observed_at,
+            account_label="paper",
+            runtime_strategy_name="demo-runtime",
+            strategy_family="demo",
+            fill_count=1,
+            decision_count=1,
+            submitted_order_count=1,
+            cancelled_order_count=0,
+            rejected_order_count=0,
+            unfilled_order_count=0,
+            closed_trade_count=1,
+            open_position_count=0,
+            filled_notional=Decimal("190.25"),
+            gross_strategy_pnl=Decimal("0"),
+            cost_amount=Decimal("0"),
+            net_strategy_pnl_after_costs=Decimal("0"),
+            post_cost_expectancy_bps=Decimal("0"),
+            ledger_schema_version="torghut.runtime-ledger.v1",
+            pnl_basis="post_cost",
+            payload_json={"source": "test"},
+        )
+        ref = TigerBeetleTransferRef(
+            transfer_id="0",
+            transfer_kind=script.TRANSFER_KIND_RUNTIME_NET_PNL,
+            amount=Decimal("0"),
+            payload_json="not-a-mapping",
+        )
+
+        self.assertEqual(script._payload_mapping(ref), {})
+        self.assertFalse(script._payload_int_matches({"value": object()}, "value", 1))
+        self.assertFalse(script._runtime_ref_matches_signed_bucket(ref, bucket))
+
+    def test_select_runtime_buckets_stops_at_limit(
+        self,
+    ) -> None:
+        settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
+        observed_at = datetime.now(timezone.utc)
+        with Session(self.engine) as session:
+            bucket = StrategyRuntimeLedgerBucket(
+                run_id="runtime-run-limit",
+                candidate_id="candidate",
+                hypothesis_id="hypothesis",
+                observed_stage="paper",
+                bucket_started_at=observed_at,
+                bucket_ended_at=observed_at,
+                account_label="paper",
+                runtime_strategy_name="demo-runtime",
+                strategy_family="demo",
+                fill_count=1,
+                decision_count=1,
+                submitted_order_count=1,
+                cancelled_order_count=0,
+                rejected_order_count=0,
+                unfilled_order_count=0,
+                closed_trade_count=1,
+                open_position_count=0,
+                filled_notional=Decimal("190.25"),
+                gross_strategy_pnl=Decimal("3.00"),
+                cost_amount=Decimal("0.50"),
+                net_strategy_pnl_after_costs=Decimal("2.50"),
+                post_cost_expectancy_bps=Decimal("12.50"),
+                ledger_schema_version="torghut.runtime-ledger.v1",
+                pnl_basis="post_cost",
+                payload_json={"source": "test"},
+            )
+            session.add(bucket)
+            session.flush()
+
+            selected = script._select_unlinked_runtime_buckets(
+                session,
+                settings_obj=settings_obj,
+                account_label="paper",
+                limit=1,
+            )
+
+        self.assertEqual([row.id for row in selected], [bucket.id])
+
     def test_main_journals_selected_events_and_reconciles(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "torghut.db")

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -777,6 +777,62 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 1)
             self.assertEqual(payload["runtime_ledger_missing_account_ref_count"], 2)
 
+    def test_reconciliation_keeps_unsigned_runtime_placeholder_blocked_with_accounts(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket(net_pnl=Decimal("2.50"))
+            session.add(bucket)
+            session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            _add_account_refs_for_plan(session, plan)
+            transfer = plan.transfer_spec
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(transfer.transfer_id),
+                    transfer_kind=transfer.transfer_kind,
+                    ledger=transfer.ledger,
+                    code=transfer.code,
+                    amount=Decimal(transfer.amount),
+                    status="created",
+                    runtime_ledger_bucket_id=bucket.id,
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id=str(bucket.id),
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "account_ids": [
+                            str(transfer.debit_account_id),
+                            str(transfer.credit_account_id),
+                        ],
+                    },
+                )
+            )
+            session.flush()
+            client = FakeTigerBeetleClient()
+            client.transfers[transfer.transfer_id] = transfer
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            self.assertFalse(payload["ok"], payload)
+            self.assertIn(
+                BLOCKER_RUNTIME_LEDGER_SIGNED_REFS_MISSING,
+                payload["blockers"],
+            )
+            self.assertNotIn(
+                BLOCKER_RUNTIME_LEDGER_ACCOUNT_REFS_MISSING,
+                payload["blockers"],
+            )
+            self.assertEqual(payload["runtime_ledger_signed_ref_count"], 0)
+            self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 1)
+            self.assertEqual(payload["runtime_ledger_missing_account_ref_count"], 0)
+
     def test_reconciliation_blocks_stable_ref_payload_mismatch(self) -> None:
         with Session(self.engine) as session:
             bucket = _runtime_bucket(net_pnl=Decimal("2.50"))


### PR DESCRIPTION
## Summary

- Re-selects runtime-ledger buckets for TigerBeetle journaling until the persisted transfer ref is a real signed match for the bucket transfer plan.
- Treats source/account-only runtime refs as unsigned placeholders, so scheduled journaling can backfill signed amount, PnL direction, debit/credit accounts, and bucket identity without duplicating transfers.
- Adds regression coverage for signed runtime ref materialization, idempotent duplicate journaling, unsigned placeholder readiness blocking, and existing supervised safe-exit behavior.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py app/trading/tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py app/trading/tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
