### PR TITLE
chore(synthesis): restore autotrader detail image

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.588.0
+    newTag: autotrader-detail-d0c7a66e
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Restores the Synthesis deployment image to `autotrader-detail-d0c7a66e`.
- Keeps the merged autotrader session-detail fix live after release image `0.588.0` regressed the served API behavior.
- Preserves the existing GitOps deployment path; no direct manifest apply.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check -- argocd/applications/synthesis/kustomization.yaml`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/synthesis:autotrader-detail-d0c7a66e`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
