### PR TITLE
fix(torghut): repair hpairs collection blockers

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -137,6 +137,12 @@ HPAIRS_ZERO_ACTIVITY_DIAGNOSTICS_SCHEMA_VERSION = (
 SOURCE_LINEAGE_OBSERVATION_SCHEMA_VERSION = (
     "torghut.paper-route-source-lineage-observation.v1"
 )
+HPAIRS_CURRENT_COLLECTION_PREREQUISITE_BLOCKERS = frozenset(
+    {
+        "drift_checks_missing",
+        "signal_lag_exceeded",
+    }
+)
 PAPER_ROUTE_ACCOUNT_STATE_DISCARD_BLOCKERS = frozenset(
     {
         "paper_route_account_window_start_not_flat",
@@ -1773,6 +1779,106 @@ def _runtime_window_import_health_gate_summary(
     }
 
 
+def _health_gate_ready_bool(
+    health_gate: Mapping[str, object],
+    *,
+    ok_key: str,
+    source_key: str,
+) -> bool:
+    return str(health_gate.get(ok_key) or "").strip().lower() == "true" and _safe_text(
+        health_gate.get(source_key)
+    ) not in {None, "missing"}
+
+
+def _hpairs_current_collection_prerequisite_blockers(
+    *,
+    target: Mapping[str, object],
+    health_gate: Mapping[str, object],
+) -> list[str]:
+    """Return current H-PAIRS source/TA health blockers for collection."""
+
+    if not _target_is_hpairs(target):
+        return []
+
+    raw_blockers = (
+        set(
+            _unique_text_items(
+                [
+                    *_unique_text_items(target.get("candidate_blockers")),
+                    *_unique_text_items(
+                        target.get("runtime_ledger_target_metadata_blockers")
+                    ),
+                ]
+            )
+        )
+        & HPAIRS_CURRENT_COLLECTION_PREREQUISITE_BLOCKERS
+    )
+    current_blockers: set[str] = set()
+    continuity_reason = _safe_text(health_gate.get("continuity_reason"))
+    drift_reason = _safe_text(health_gate.get("drift_reason"))
+
+    signal_currently_stale = not _health_gate_ready_bool(
+        health_gate,
+        ok_key="continuity_ok",
+        source_key="continuity_source",
+    )
+    if (
+        "signal_lag_exceeded" in raw_blockers
+        or continuity_reason == "signal_lag_exceeded"
+    ) and signal_currently_stale:
+        current_blockers.add("signal_lag_exceeded")
+
+    drift_currently_missing = not _health_gate_ready_bool(
+        health_gate,
+        ok_key="drift_ok",
+        source_key="drift_source",
+    )
+    if (
+        "drift_checks_missing" in raw_blockers
+        or (drift_reason is not None and "missing" in drift_reason)
+    ) and drift_currently_missing:
+        current_blockers.add("drift_checks_missing")
+
+    return sorted(current_blockers)
+
+
+def _hpairs_stale_collection_blockers_cleared_by_current_inputs(
+    *,
+    target: Mapping[str, object],
+    health_gate: Mapping[str, object],
+) -> list[str]:
+    if not _target_is_hpairs(target):
+        return []
+
+    raw_blockers = (
+        set(
+            _unique_text_items(
+                [
+                    *_unique_text_items(target.get("candidate_blockers")),
+                    *_unique_text_items(
+                        target.get("runtime_ledger_target_metadata_blockers")
+                    ),
+                ]
+            )
+        )
+        & HPAIRS_CURRENT_COLLECTION_PREREQUISITE_BLOCKERS
+    )
+    cleared: list[str] = []
+    if "drift_checks_missing" in raw_blockers and _health_gate_ready_bool(
+        health_gate,
+        ok_key="drift_ok",
+        source_key="drift_source",
+    ):
+        cleared.append("drift_checks_missing")
+    if "signal_lag_exceeded" in raw_blockers and _health_gate_ready_bool(
+        health_gate,
+        ok_key="continuity_ok",
+        source_key="continuity_source",
+    ):
+        cleared.append("signal_lag_exceeded")
+    return sorted(cleared)
+
+
 def _execution_source_strategy_key(
     *,
     strategy_id: str | None,
@@ -2220,6 +2326,18 @@ def _next_paper_route_runtime_window_targets(
                 and target.get("bounded_live_paper_collection_authorized")
             )
         )
+        current_collection_prerequisite_blockers = (
+            _hpairs_current_collection_prerequisite_blockers(
+                target=pair_balance_target,
+                health_gate=health_gate,
+            )
+        )
+        stale_collection_blockers_cleared_by_current_inputs = (
+            _hpairs_stale_collection_blockers_cleared_by_current_inputs(
+                target=pair_balance_target,
+                health_gate=health_gate,
+            )
+        )
         evidence_collection_blockers = _unique_text_items(
             [
                 *collection_session_blockers,
@@ -2231,6 +2349,7 @@ def _next_paper_route_runtime_window_targets(
                     ]
                 ),
                 *_unique_text_items(source_decision_readiness.get("blockers")),
+                *current_collection_prerequisite_blockers,
                 *target_account_audit_blockers,
                 *account_pre_session_blockers,
                 *clean_window_baseline_blockers,
@@ -2409,6 +2528,12 @@ def _next_paper_route_runtime_window_targets(
             ),
             "bounded_evidence_collection_max_notional": next_notional,
             "bounded_evidence_collection_blockers": evidence_collection_blockers,
+            "current_collection_prerequisite_blockers": (
+                current_collection_prerequisite_blockers
+            ),
+            "stale_collection_blockers_cleared_by_current_inputs": (
+                stale_collection_blockers_cleared_by_current_inputs
+            ),
             "evidence_collection_stage": "paper",
             "probation_allowed": True,
             "probation_reason": "paper_route_probe_next_session_runtime_window",
@@ -2428,7 +2553,14 @@ def _next_paper_route_runtime_window_targets(
             "candidate_blockers": _unique_text_items(
                 [
                     "paper_route_runtime_ledger_import_pending",
-                    *_unique_text_items(target.get("candidate_blockers")),
+                    *[
+                        blocker
+                        for blocker in _unique_text_items(
+                            target.get("candidate_blockers")
+                        )
+                        if blocker
+                        not in stale_collection_blockers_cleared_by_current_inputs
+                    ],
                     *evidence_collection_blockers,
                     *health_gate_blockers,
                     *health_gate_promotion_blockers,
@@ -2438,6 +2570,14 @@ def _next_paper_route_runtime_window_targets(
                 [
                     "paper_route_runtime_ledger_import_pending",
                     "live_runtime_ledger_required",
+                    *[
+                        blocker
+                        for blocker in _unique_text_items(
+                            target.get("runtime_ledger_target_metadata_blockers")
+                        )
+                        if blocker
+                        not in stale_collection_blockers_cleared_by_current_inputs
+                    ],
                     *health_gate_blockers,
                     *health_gate_promotion_blockers,
                 ]

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -257,7 +257,42 @@ def _load_profit_promotion_bounded_row_count(
     return min(len(rows), _PROMOTION_TABLE_COUNT_SCAN_LIMIT)
 
 
-def _runtime_window_import_continuity_signal(state: object) -> tuple[str, str, str]:
+def _fresh_clickhouse_signal_continuity(
+    clickhouse_ta_status: Mapping[str, Any] | None,
+) -> tuple[str, str, str] | None:
+    if not isinstance(clickhouse_ta_status, Mapping):
+        return None
+    state = _safe_text(clickhouse_ta_status.get("state"))
+    latest_signal_at = _coerce_aware_datetime(
+        clickhouse_ta_status.get("latest_signal_at")
+        or clickhouse_ta_status.get("readiness_window_end")
+        or clickhouse_ta_status.get("as_of")
+    )
+    if state != "current" or latest_signal_at is None:
+        return None
+
+    max_age_seconds = max(
+        1,
+        int(settings.trading_feature_max_staleness_ms) // 1000,
+    )
+    lag_seconds = max(
+        0,
+        int((datetime.now(timezone.utc) - latest_signal_at).total_seconds()),
+    )
+    if lag_seconds <= max_age_seconds:
+        return "true", "clickhouse_ta_status", "signals_present"
+    return "false", "clickhouse_ta_status", "signal_lag_exceeded"
+
+
+def _runtime_window_import_continuity_signal(
+    state: object,
+    *,
+    clickhouse_ta_status: Mapping[str, Any] | None = None,
+) -> tuple[str, str, str]:
+    persisted_signal = _fresh_clickhouse_signal_continuity(clickhouse_ta_status)
+    if persisted_signal is not None and persisted_signal[0] == "true":
+        return persisted_signal
+
     state_text = _safe_attr_text(state, "last_signal_continuity_state")
     reason = _safe_attr_text(state, "last_signal_continuity_reason")
     actionable = _safe_bool(getattr(state, "last_signal_continuity_actionable", None))
@@ -279,6 +314,8 @@ def _runtime_window_import_continuity_signal(state: object) -> tuple[str, str, s
         return "true", "signal_continuity", state_text
     if actionable is False and state_text:
         return "true", "signal_continuity", state_text
+    if persisted_signal is not None:
+        return persisted_signal
     return "false", "missing", "signal_continuity_missing"
 
 
@@ -299,9 +336,13 @@ def _runtime_window_import_health_gate_inputs(
     state: object,
     *,
     dependency_quorum_decision: str,
+    clickhouse_ta_status: Mapping[str, Any] | None = None,
 ) -> dict[str, object]:
     continuity_ok, continuity_source, continuity_reason = (
-        _runtime_window_import_continuity_signal(state)
+        _runtime_window_import_continuity_signal(
+            state,
+            clickhouse_ta_status=clickhouse_ta_status,
+        )
     )
     drift_ok, drift_source, drift_reason = _runtime_window_import_drift_signal(state)
     blockers: list[str] = []
@@ -3972,6 +4013,7 @@ def build_live_submission_gate_payload(
     runtime_window_import_health_gate = _runtime_window_import_health_gate_inputs(
         state,
         dependency_quorum_decision=dependency_decision,
+        clickhouse_ta_status=clickhouse_ta_status,
     )
     empirical_ready = (
         bool(empirical_jobs_status.get("ready"))

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -62,6 +62,239 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         Base.metadata.create_all(self.engine)
 
+    def _seed_hpairs_strategy_and_flat_snapshot(
+        self,
+        session: Session,
+        *,
+        window_start: datetime,
+    ) -> None:
+        session.add(
+            Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1m",
+                universe_type="microbar_cross_sectional_pairs_v1",
+                universe_symbols=["AAPL", "AMZN"],
+                max_notional_per_trade=Decimal("25"),
+            )
+        )
+        session.add(
+            PositionSnapshot(
+                alpaca_account_label="TORGHUT_SIM",
+                as_of=window_start,
+                equity=Decimal("100000"),
+                cash=Decimal("100000"),
+                buying_power=Decimal("100000"),
+                positions=[],
+            )
+        )
+        session.commit()
+
+    def _hpairs_live_submission_gate(
+        self,
+        *,
+        candidate_blockers: list[str],
+        continuity_ok: bool,
+        continuity_reason: str,
+        drift_ok: bool,
+        drift_reason: str,
+    ) -> dict[str, object]:
+        return {
+            "allowed": False,
+            "reason": "paper_route_probe_only",
+            "blocked_reasons": [],
+            "promotion_eligible_total": 0,
+            "dependency_quorum_decision": "allow",
+            "continuity_ok": continuity_ok,
+            "continuity_reason": continuity_reason,
+            "drift_ok": drift_ok,
+            "drift_reason": drift_reason,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "observed_stage": "paper",
+                        "strategy_family": "microbar_cross_sectional_pairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "strategy_lookup_names": [
+                            "microbar-cross-sectional-pairs-v1",
+                        ],
+                        "account_label": "TORGHUT_SIM",
+                        "source_account_label": "TORGHUT_SIM",
+                        "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                        "source_kind": "paper_route_probe_runtime_observed",
+                        "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+                        "evidence_collection_ok": True,
+                        "promotion_allowed": False,
+                        "final_promotion_authorized": False,
+                        "final_promotion_allowed": False,
+                        "candidate_blockers": candidate_blockers,
+                        "runtime_ledger_target_metadata_blockers": candidate_blockers,
+                    }
+                ],
+            },
+        }
+
+    def _hpairs_route_reacquisition_book(
+        self,
+        *,
+        blocking_reasons: list[str] | None = None,
+    ) -> dict[str, object]:
+        return {
+            "schema_version": "torghut.route-reacquisition-book.v1",
+            "state": "repair_only",
+            "summary": {
+                "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                "paper_route_probe_active_symbols": ["AAPL", "AMZN"],
+            },
+            "paper_route_probe": {
+                "configured_enabled": True,
+                "active": True,
+                "effective_max_notional": "25",
+                "next_session_max_notional": "25",
+                "eligible_symbol_count": 2,
+                "blocking_reasons": blocking_reasons or [],
+            },
+        }
+
+    def test_hpairs_fresh_collection_clears_stale_drift_and_signal_blockers(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 6, 2, 15, tzinfo=timezone.utc)
+        window_start, _window_end = _next_regular_equities_session_window(generated_at)
+        with Session(self.engine) as session:
+            self._seed_hpairs_strategy_and_flat_snapshot(
+                session,
+                window_start=window_start,
+            )
+
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate=self._hpairs_live_submission_gate(
+                    candidate_blockers=[
+                        "drift_checks_missing",
+                        "signal_lag_exceeded",
+                        "paper_route_runtime_ledger_import_pending",
+                    ],
+                    continuity_ok=True,
+                    continuity_reason="signals_present",
+                    drift_ok=True,
+                    drift_reason="drift_checks_recent",
+                ),
+                route_reacquisition_book=self._hpairs_route_reacquisition_book(),
+                generated_at=generated_at,
+                include_runtime_window_import_audit=False,
+            )
+
+        target = payload["targets"][0]
+        self.assertTrue(target["evidence_collection_ok"])
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+        self.assertNotIn("drift_checks_missing", target["candidate_blockers"])
+        self.assertNotIn("signal_lag_exceeded", target["candidate_blockers"])
+        self.assertIn(
+            "paper_route_runtime_ledger_import_pending",
+            target["candidate_blockers"],
+        )
+        self.assertEqual(
+            target["stale_collection_blockers_cleared_by_current_inputs"],
+            ["drift_checks_missing", "signal_lag_exceeded"],
+        )
+
+    def test_hpairs_stale_signal_and_missing_drift_block_collection_when_current(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 6, 2, 15, tzinfo=timezone.utc)
+        window_start, _window_end = _next_regular_equities_session_window(generated_at)
+        with Session(self.engine) as session:
+            self._seed_hpairs_strategy_and_flat_snapshot(
+                session,
+                window_start=window_start,
+            )
+
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate=self._hpairs_live_submission_gate(
+                    candidate_blockers=[
+                        "drift_checks_missing",
+                        "signal_lag_exceeded",
+                    ],
+                    continuity_ok=False,
+                    continuity_reason="signal_lag_exceeded",
+                    drift_ok=False,
+                    drift_reason="drift_live_promotion_eligible_missing",
+                ),
+                route_reacquisition_book=self._hpairs_route_reacquisition_book(),
+                generated_at=generated_at,
+                include_runtime_window_import_audit=False,
+            )
+
+        target = payload["targets"][0]
+        self.assertFalse(target["evidence_collection_ok"])
+        self.assertFalse(target["bounded_evidence_collection_authorized"])
+        self.assertIn("signal_lag_exceeded", target["candidate_blockers"])
+        self.assertIn("drift_checks_missing", target["candidate_blockers"])
+        self.assertIn(
+            "signal_lag_exceeded",
+            target["bounded_evidence_collection_blockers"],
+        )
+        self.assertIn(
+            "drift_checks_missing",
+            target["bounded_evidence_collection_blockers"],
+        )
+        self.assertIn(
+            "drift_checks_missing",
+            target["runtime_ledger_target_metadata_blockers"],
+        )
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+
+    def test_hpairs_after_hours_market_session_closed_is_not_bypassed(self) -> None:
+        generated_at = datetime(2026, 6, 2, 21, tzinfo=timezone.utc)
+        window_start, _window_end = _next_regular_equities_session_window(generated_at)
+        with Session(self.engine) as session:
+            self._seed_hpairs_strategy_and_flat_snapshot(
+                session,
+                window_start=window_start,
+            )
+
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate=self._hpairs_live_submission_gate(
+                    candidate_blockers=["signal_lag_exceeded"],
+                    continuity_ok=True,
+                    continuity_reason="signals_present",
+                    drift_ok=True,
+                    drift_reason="drift_checks_recent",
+                ),
+                route_reacquisition_book=self._hpairs_route_reacquisition_book(
+                    blocking_reasons=["market_session_closed"],
+                ),
+                generated_at=generated_at,
+                include_runtime_window_import_audit=False,
+            )
+
+        target = payload["targets"][0]
+        self.assertIn(
+            "market_session_closed",
+            payload["paper_route_probe"]["blocking_reasons"],
+        )
+        self.assertFalse(target["evidence_collection_ok"])
+        self.assertFalse(target["bounded_evidence_collection_authorized"])
+        self.assertIn(
+            "paper_route_session_window_closed",
+            target["bounded_evidence_collection_blockers"],
+        )
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+
     def test_balanced_pair_probe_infers_missing_leg_opposite_existing_action(
         self,
     ) -> None:

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -5438,6 +5438,53 @@ class TestSubmissionCouncil(TestCase):
             ["evidence_continuity_not_ok"],
         )
 
+    def test_build_live_submission_gate_payload_clears_signal_lag_with_fresh_clickhouse_status(
+        self,
+    ) -> None:
+        result = build_live_submission_gate_payload(
+            SimpleNamespace(
+                last_autonomy_promotion_eligible=False,
+                last_autonomy_promotion_action=None,
+                drift_live_promotion_eligible=True,
+                last_signal_continuity_state="signal_lag_exceeded",
+                last_signal_continuity_reason="signal_lag_exceeded",
+                last_signal_continuity_actionable=True,
+                signal_continuity_alert_active=True,
+                signal_continuity_alert_reason="signal_lag_exceeded",
+                last_market_context_freshness_seconds=45,
+                metrics=SimpleNamespace(
+                    feature_batch_rows_total=9,
+                    feature_null_rate={"price": 0.0},
+                    feature_staleness_ms_p95=250,
+                    feature_duplicate_ratio=0.0,
+                    decision_state_total={},
+                ),
+            ),
+            hypothesis_summary={
+                "promotion_eligible_total": 0,
+                "capital_stage_totals": {"shadow": 1},
+                "dependency_quorum": {
+                    "decision": "allow",
+                    "reasons": [],
+                    "message": "ready",
+                },
+            },
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+            clickhouse_ta_status={
+                "state": "current",
+                "latest_signal_at": datetime.now(timezone.utc).isoformat(),
+                "equity_ta_rows": 12,
+                "equity_ta_symbols": 2,
+                "source_ref": "clickhouse:ta_signals",
+            },
+        )
+
+        self.assertEqual(result["continuity_ok"], "true")
+        self.assertEqual(result["continuity_source"], "clickhouse_ta_status")
+        self.assertEqual(result["continuity_reason"], "signals_present")
+        self.assertEqual(result["runtime_window_import_health_gate"]["blockers"], [])
+
     def test_build_live_submission_gate_payload_fails_closed_on_empty_quant_evidence(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Repair H-PAIRS target-plan collection blockers so stale upstream `drift_checks_missing` and `signal_lag_exceeded` metadata are cleared only when the current runtime-window health gate proves drift and signal inputs are fresh.
- Surface current H-PAIRS collection prerequisite blockers (`drift_checks_missing`, `signal_lag_exceeded`) as bounded collection blockers when drift checks are missing or signals are stale, while preserving promotion/final/live authority as false.
- Let fresh ClickHouse TA signal status clear stale signal-lag continuity state for runtime-window health gates.
- Add focused regressions for fresh H-PAIRS clearing, stale/missing prerequisite blocking, after-hours session blocking, and fresh ClickHouse signal health.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_simple_pipeline.py tests/test_submission_council.py tests/test_completion_trace.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/scheduler/simple_pipeline.py app/trading/submission_council.py app/trading/completion.py tests/test_paper_route_evidence.py tests/test_simple_pipeline.py tests/test_submission_council.py tests/test_completion_trace.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py app/trading/scheduler/simple_pipeline.py app/trading/submission_council.py app/trading/completion.py tests/test_paper_route_evidence.py tests/test_simple_pipeline.py tests/test_submission_council.py tests/test_completion_trace.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A; backend target-plan/readiness logic only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
