### PR TITLE
chore(torghut): promote image 9fa6747c

### DIFF
--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -126,7 +126,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+                  value: sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
           ports:
             - name: http1
               containerPort: 8181
@@ -531,11 +531,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.586.0-479-g3ebefe407
+              value: v0.589.0-8-g9fa6747c5
             - name: TORGHUT_COMMIT
-              value: 3ebefe407cdab08b51491b7fe8355a39715f7182
+              value: 9fa6747c5c483a1c20b10da7a81b449d6258579d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+              value: sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
           ports:
             - name: http1
               containerPort: 8181
@@ -373,11 +373,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.586.0-479-g3ebefe407
+              value: v0.589.0-8-g9fa6747c5
             - name: TORGHUT_COMMIT
-              value: 3ebefe407cdab08b51491b7fe8355a39715f7182
+              value: 9fa6747c5c483a1c20b10da7a81b449d6258579d
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+              value: sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -123,7 +123,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+                  value: sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -159,7 +159,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -273,6 +273,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+                  value: sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: 3ebefe407cdab08b51491b7fe8355a39715f7182
+            value: 9fa6747c5c483a1c20b10da7a81b449d6258579d
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+            value: sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- Promotes the Torghut service image built from `9fa6747c5c483a1c20b10da7a81b449d6258579d` to digest `sha256:8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22`.
- Updates all Torghut GitOps workloads that reference the Torghut Python service image, including live/sim KServices, proof jobs, journal jobs, and workflow templates.
- Aligns `TORGHUT_COMMIT`, `TORGHUT_VERSION`, and `TORGHUT_IMAGE_DIGEST` lineage fields where those env vars are present.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize-9fa6747c.yaml`
- `rg -n "077ac0298322afabc4c196fee66b0808b27c270f16ebb6d6fe26caf8080fda5a|3ebefe407cdab08b51491b7fe8355a39715f7182|v0\\.586\\.0-479-g3ebefe407" argocd/applications/torghut /tmp/torghut-kustomize-9fa6747c.yaml || true`
- `rg -n "8cfc8eacda9878f844f6d0977c9e39623999f150a98bc37f7020a788f9127a22" /tmp/torghut-kustomize-9fa6747c.yaml | wc -l`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
