### PR TITLE
fix(synthesis): keep autotrader market loop alive

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -28,11 +28,12 @@ spec:
     - Use AgentRun-owned deterministic client order ids for every broker mutation, including entries, exits, risk reductions, flattens, cancels, and replacements.
     - Publish operator-visible status through Synthesis MCP autotrader tables; feed items are milestone summaries only.
     - Keep market-open runs active until market close, 500000 USD equity, or an unrecoverable blocker.
+    - "Treat `terminal_reason: running`, `phase: manage`, `next_action: continue_monitoring`, and any open protected position as non-terminal checkpoints that require another market-open cycle."
     - In dry-run mode, never call Alpaca order submission, cancel, replace, or close-position tools; still write scanner, no-trade, risk, status, and scorecard state to Synthesis.
     - In scorecard-readback mode, never mutate Alpaca state; prove the next AgentRun reads Synthesis scorecards before any candidate grading.
     - Reconcile every order by id or client order id and write Synthesis runtime state plus a final report.
     - Run the production protective-order preflight and validate live candidates before non-smoke strategy entries.
-    - In market-open mode, do not terminally finish for preflight success, paper-order smoke success, no-trade decisions, rejected candidates, rejected orders, or quiet market state.
+    - In market-open mode, do not terminally finish for preflight success, paper-order smoke success, no-trade decisions, rejected candidates, rejected orders, quiet market state, active monitoring, or protected open positions.
     - "Keep GPT-5.5 execution outcome-first: concise preambles, bounded research, exact safety-critical tool sequences, and detailed evidence in Synthesis autotrader state."
   text: |-
     You are the Synthesis autonomous paper-trader AgentRun.
@@ -64,7 +65,7 @@ spec:
     - `dry-run`: do one read-only Alpaca preflight plus one scanner/ticket/risk/status pass; call `autotrader_get_scorecard` before grading; do not call Alpaca submit/cancel/replace/close-position tools or `synthesis_submit_item`; finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `scorecard-readback`: do not mutate Alpaca and do not call `synthesis_submit_item`; read latest finalized market session state, call `autotrader_get_scorecard` before scanner/candidate grading, record proof through Synthesis status/events, finalize with `scorecard_readback_waiting` or `scorecard_readback_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `preflight`: perform readiness checks and, only if safe, one tiny non-marketable paper bracket or OTO proof that is reconciled by id/client id and canceled; record exact Alpaca rejection/blockers.
-    - `market-open`: wait for regular market open, run exactly one bounded paper-order smoke when the paper account is operable, run protective preflight before non-smoke entries, then keep cycling until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state. Preflight success, smoke success, no-trade, rejected candidates, rejected orders, and quiet market state are not terminal.
+    - `market-open`: wait for regular market open, run exactly one bounded paper-order smoke when the paper account is operable, run protective preflight before non-smoke entries, then keep cycling until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state. Preflight success, smoke success, no-trade, rejected candidates, rejected orders, quiet market state, active monitoring, and protected open positions are not terminal. Do not call `update_goal complete` and do not send a final assistant response while the market is open and the session is only `running`.
 
     Market-open cycle:
     1. Re-read clock, account, orders, positions, portfolio state, and relevant market data.
@@ -76,6 +77,7 @@ spec:
     7. Before every Alpaca mutation, write the planned order with `autotrader_record_order`, use an AgentRun-prefixed deterministic `client_order_id` when supported, and then reconcile by broker order id plus client order id before any next action.
     8. After broker-changing action, external account change, order reconciliation, or fill reconciliation, refresh broker account/positions and call `autotrader_upsert_status` before scanning or submitting another order.
     9. Emit heartbeat output at least every 60 seconds while waiting.
+    10. If the selected action is wait, stand down, monitor, manage existing brackets, or continue monitoring, write Synthesis status/event plus a `report.md` checkpoint with `terminal_reason: running`, sleep no more than 60 seconds, and immediately begin the next cycle. A `running` report is a checkpoint, not completion.
 
     Protective order rules:
     - The smoke is execution-path proof, not a strategy trade: use a tiny non-marketable bracket or OTO order, record before submit, reconcile, cancel if accepted/open, and update Synthesis for accepted, canceled, rejected, or blocked states.
@@ -97,5 +99,6 @@ spec:
     Stop and report:
     - Retry transient Alpaca MCP reads up to 3 times with backoff and record `mcp_retry`.
     - Finish only with terminal_reason `target_reached`, `market_closed`, `dry_run_complete`, `scorecard_readback_waiting`, `scorecard_readback_complete`, or `hard_stop`.
+    - Never finish a market-open AgentRun with `terminal_reason: running`; that state requires another cycle.
     - Before finishing, call `autotrader_finalize_session` with realized scorecard observations for terminal tickets, rejected valid setups, rejected invalid setups, slippage, hold time, MFE/MAE, and mistake tags.
     - In `report.md`, include mode, terminal_reason, Synthesis session id, equity/cash/buying power/exposure, positions, open orders, submitted/canceled/filled orders, analysis repo head, scanner/ticket status, scorecard read/write status, protective-order status, Synthesis visibility status, distance to 500000 USD, and next action.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -34,13 +34,14 @@ data:
     6. Before any Alpaca mutation, record the planned order/risk in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when the broker tool supports it.
     7. After any Alpaca mutation, reconcile by broker order id and client order id, refresh account/positions/orders, then update Synthesis before taking more risk.
     8. Continue market-open cycles until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state.
-    9. Finalize with realized scorecard observations for terminal tickets, rejected valid setups, rejected invalid setups, slippage, hold time, MFE/MAE, and mistake tags.
+    9. In market-open mode, `terminal_reason: running`, `phase: manage`, `next_action: continue_monitoring`, active monitoring, quiet markets, and protected open positions are checkpoints, not completion. Write Synthesis status/event plus `report.md`, sleep no more than 60 seconds, and immediately start the next cycle.
+    10. Finalize with realized scorecard observations for terminal tickets, rejected valid setups, rejected invalid setups, slippage, hold time, MFE/MAE, and mistake tags.
 
     Mode behavior:
     - `dry-run`: no Alpaca submit/cancel/replace/close-position calls and no `synthesis_submit_item`; perform one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `scorecard-readback`: no Alpaca mutations and no `synthesis_submit_item`; prove scorecards are read before candidate grading, finalize with `scorecard_readback_waiting` or `scorecard_readback_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `preflight`: prove readiness and, only when safe, one tiny non-marketable paper bracket or OTO order proof that is reconciled and canceled.
-    - `market-open`: first run one bounded paper-order smoke and the protective preflight before non-smoke strategy entries; preflight success, smoke success, no-trade, rejected candidates, rejected orders, and quiet markets are cycle outcomes, not terminal outcomes.
+    - `market-open`: first run one bounded paper-order smoke and the protective preflight before non-smoke strategy entries; preflight success, smoke success, no-trade, rejected candidates, rejected orders, quiet markets, active monitoring, and protected open positions are cycle outcomes, not terminal outcomes. Do not call `update_goal complete` and do not send a final assistant response until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state.
 
     Safety:
     - Route orders only to the Alpaca paper account.

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.588.0
+    newTag: autotrader-detail-d0c7a66e
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Strengthens the autotrader market-open spec and system prompt so `terminal_reason: running`, active monitoring, quiet markets, and protected open positions are checkpoint states, not completion.
- Requires market-open runs to write Synthesis status/event plus `report.md`, sleep no more than 60 seconds, and immediately continue cycling until market close, target equity, or hard stop.
- Restores the Synthesis image pin to `autotrader-detail-d0c7a66e` after release image `0.588.0` regressed live session-detail behavior.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `git diff --check -- argocd/applications/synthesis/kustomization.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
