### PR TITLE
ci(synthesis): guard custom image pins

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -89,6 +89,8 @@ jobs:
           PR_AUTHOR="$(jq -r '.user.login // ""' <<< "$pr_json")"
           PR_HEAD_REF="$(jq -r '.head.ref // ""' <<< "$pr_json")"
           PR_BASE_REF="$(jq -r '.base.ref // ""' <<< "$pr_json")"
+          PR_BASE_SHA="$(jq -r '.base.sha // ""' <<< "$pr_json")"
+          PR_HEAD_SHA="$(jq -r '.head.sha // ""' <<< "$pr_json")"
           PR_HEAD_REPO="$(jq -r '.head.repo.full_name // ""' <<< "$pr_json")"
           PR_IS_DRAFT="$(jq -r '.draft // false' <<< "$pr_json")"
 
@@ -144,7 +146,9 @@ jobs:
               break
             fi
 
-            sleep 2
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep 2
+            fi
           done
 
           if [[ "${#changed_files[@]}" -eq 0 ]]; then
@@ -158,6 +162,46 @@ jobs:
               exit 0
             fi
           done
+
+          is_release_image_tag() {
+            [[ "$1" =~ ^[0-9]+(\.[0-9]+){1,3}([-.][A-Za-z0-9_.-]+)?$ ]]
+          }
+
+          extract_synthesis_image_tag() {
+            awk '
+              $0 ~ /name:[[:space:]]*registry\.ide-newton\.ts\.net\/lab\/synthesis/ { in_image = 1; next }
+              in_image && $1 == "newTag:" {
+                tag = $2
+                gsub(/^"|"$/, "", tag)
+                print tag
+                exit
+              }
+            '
+          }
+
+          read_repo_file_at_ref() {
+            local path="$1"
+            local ref="$2"
+            gh api "repos/$GH_REPO/contents/$path?ref=$ref" --jq '.content' | tr -d '\n' | base64 -d
+          }
+
+          if contains "argocd/applications/synthesis/kustomization.yaml" "${changed_files[@]}"; then
+            base_tag="$(
+              read_repo_file_at_ref "argocd/applications/synthesis/kustomization.yaml" "$PR_BASE_SHA" |
+                extract_synthesis_image_tag
+            )"
+            head_tag="$(
+              read_repo_file_at_ref "argocd/applications/synthesis/kustomization.yaml" "$PR_HEAD_SHA" |
+                extract_synthesis_image_tag
+            )"
+
+            if [[ -n "$base_tag" ]] && [[ -n "$head_tag" ]] &&
+              ! is_release_image_tag "$base_tag" &&
+              is_release_image_tag "$head_tag"; then
+              echo "reason=synthesis-custom-pin-overwrite:${base_tag}-to-${head_tag}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
 
           echo "eligible=true" >> "$GITHUB_OUTPUT"
           echo "reason=eligible" >> "$GITHUB_OUTPUT"

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.588.0
+    newTag: autotrader-detail-d0c7a66e
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Restores the Synthesis image pin to `autotrader-detail-d0c7a66e` after release PR #9757 regressed it to `0.588.0`.
- Adds a release automerge guard that blocks release branches from replacing a custom Synthesis image pin with a numeric release tag.
- Keeps normal numeric release-to-release Synthesis promotions eligible for automerge.

## Related Issues

None

## Testing

- `actionlint .github/workflows/release-pr-automerge.yml`
- `bun run lint:argocd`
- `git diff --check -- .github/workflows/release-pr-automerge.yml argocd/applications/synthesis/kustomization.yaml`
- Local guard simulation against the #9756 to #9757 transition: blocked `autotrader-detail-d0c7a66e` to `0.588.0` and allowed normal numeric release tags.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
