### PR TITLE
fix(torghut): require explicit proof mode authority contract

### DIFF
--- a/services/torghut/app/trading/runtime_ledger_proof_policy.py
+++ b/services/torghut/app/trading/runtime_ledger_proof_policy.py
@@ -94,6 +94,27 @@ class RuntimeLedgerProofPolicy:
             )
         return payload
 
+    def mode_contract(
+        self,
+        proof_mode: str | None = None,
+    ) -> dict[str, object]:
+        mode = normalize_runtime_ledger_proof_mode(proof_mode or self.proof_mode)
+        authority_scope = {
+            "smoke": "plumbing_only",
+            "probation": "bounded_evidence_collection_only",
+            "authority": "final_promotion_authority_candidate",
+        }[mode]
+        mode_can_grant_final_authority = mode == "authority"
+        return {
+            "proof_mode": mode,
+            "default_proof_mode": DEFAULT_RUNTIME_LEDGER_PROOF_MODE,
+            "authority_scope": authority_scope,
+            "mode_can_grant_final_authority": mode_can_grant_final_authority,
+            "mode_can_grant_promotion_authority": mode_can_grant_final_authority,
+            "requires_explicit_authority_mode_for_final_promotion": True,
+            "implicit_default_final_authority": False,
+        }
+
     def targets_for_mode(self, proof_mode: str) -> dict[str, object]:
         mode = normalize_runtime_ledger_proof_mode(proof_mode)
         min_days = self.min_trading_days

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -2054,6 +2054,9 @@ def build_runtime_ledger_proof_packet(
     proof_mode_targets = DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.targets_for_mode(
         resolved_proof_mode
     )
+    proof_mode_contract = DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.mode_contract(
+        resolved_proof_mode
+    )
     min_runtime_ledger_net_pnl = max(
         min_runtime_ledger_net_pnl,
         cast(Decimal, proof_mode_targets["min_net_pnl_after_costs"]),
@@ -2108,6 +2111,7 @@ def build_runtime_ledger_proof_packet(
             "canary_collection_authorized": bool(
                 proof_mode_targets["canary_collection_authorized"]
             ),
+            "mode_contract": proof_mode_contract,
             "promotion_allowed": False,
             "capital_promotion_allowed": False,
             "final_promotion_allowed": False,
@@ -3077,6 +3081,7 @@ def build_runtime_ledger_proof_packet(
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated_at,
         "proof_mode": resolved_proof_mode,
+        "proof_mode_contract": proof_mode_contract,
         "verdict": verdict,
         "ok": post_cost_proof_satisfied,
         "final_authority_ok": post_cost_proof_authority_allowed,

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -878,12 +878,23 @@ def _add_runtime_ledger_proof_packet_check(
     packet = _mapping(runtime_ledger_proof_packet)
     authority = _mapping(packet.get("promotion_authority"))
     capital_authority = _mapping(packet.get("capital_promotion_authority"))
+    proof_mode_contract = _mapping(packet.get("proof_mode_contract"))
     schema_version = _text(packet.get("schema_version"))
     proof_mode = _text(packet.get("proof_mode"))
     allowed = authority.get("allowed") is True
+    mode_contract_allows_authority = (
+        proof_mode_contract.get("mode_can_grant_final_authority") is True
+        and proof_mode_contract.get("mode_can_grant_promotion_authority") is True
+        and proof_mode_contract.get(
+            "requires_explicit_authority_mode_for_final_promotion"
+        )
+        is True
+        and proof_mode_contract.get("implicit_default_final_authority") is False
+    )
     packet_ok = (
         packet.get("ok") is True
         and proof_mode == "authority"
+        and mode_contract_allows_authority
         and packet.get("final_authority_ok") is True
         and packet.get("promotion_allowed") is True
         and packet.get("capital_promotion_allowed") is True
@@ -899,6 +910,8 @@ def _add_runtime_ledger_proof_packet_check(
             "present": bool(packet),
             "schema_version": schema_version,
             "proof_mode": proof_mode,
+            "proof_mode_contract": dict(proof_mode_contract),
+            "mode_contract_allows_authority": mode_contract_allows_authority,
             "final_authority_ok": packet.get("final_authority_ok"),
             "promotion_allowed": packet.get("promotion_allowed"),
             "capital_promotion_allowed": packet.get("capital_promotion_allowed"),
@@ -925,6 +938,7 @@ def _add_runtime_ledger_proof_packet_check(
             "schema_version": RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
             "ok": True,
             "proof_mode": "authority",
+            "proof_mode_contract.mode_can_grant_final_authority": True,
             "final_authority_ok": True,
             "promotion_allowed": True,
             "capital_promotion_allowed": True,

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1135,6 +1135,18 @@ class TestRuntimeLedgerProofPacket(TestCase):
         )
 
         self.assertEqual(result["proof_mode"], "smoke")
+        self.assertEqual(
+            result["proof_mode_contract"],
+            {
+                "proof_mode": "smoke",
+                "default_proof_mode": "smoke",
+                "authority_scope": "plumbing_only",
+                "mode_can_grant_final_authority": False,
+                "mode_can_grant_promotion_authority": False,
+                "requires_explicit_authority_mode_for_final_promotion": True,
+                "implicit_default_final_authority": False,
+            },
+        )
         self.assertTrue(result["ok"], result)
         self.assertFalse(result["final_authority_ok"])
         self.assertFalse(result["promotion_allowed"])
@@ -1378,6 +1390,13 @@ class TestRuntimeLedgerProofPacket(TestCase):
 
         self.assertTrue(result["ok"], result)
         self.assertEqual(result["proof_mode"], "probation")
+        self.assertEqual(
+            result["proof_mode_contract"]["authority_scope"],
+            "bounded_evidence_collection_only",
+        )
+        self.assertFalse(
+            result["proof_mode_contract"]["mode_can_grant_final_authority"]
+        )
         self.assertEqual(
             result["verdict"],
             "probation_proof_satisfied_evidence_collection_only",
@@ -3373,6 +3392,12 @@ class TestRuntimeLedgerProofPacket(TestCase):
             self.assertEqual(exit_code, 0)
             payload = json.loads(output_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["proof_mode"], "smoke")
+            self.assertEqual(
+                payload["proof_mode_contract"]["authority_scope"], "plumbing_only"
+            )
+            self.assertFalse(
+                payload["proof_mode_contract"]["implicit_default_final_authority"]
+            )
             self.assertEqual(
                 payload["verdict"],
                 "smoke_proof_satisfied_evidence_collection_only",

--- a/services/torghut/tests/test_runtime_ledger_proof_policy.py
+++ b/services/torghut/tests/test_runtime_ledger_proof_policy.py
@@ -68,6 +68,44 @@ class TestRuntimeLedgerProofPolicy(TestCase):
             },
         )
 
+    def test_mode_contract_makes_non_authority_defaults_explicit(self) -> None:
+        self.assertEqual(
+            DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.mode_contract(),
+            {
+                "proof_mode": "smoke",
+                "default_proof_mode": "smoke",
+                "authority_scope": "plumbing_only",
+                "mode_can_grant_final_authority": False,
+                "mode_can_grant_promotion_authority": False,
+                "requires_explicit_authority_mode_for_final_promotion": True,
+                "implicit_default_final_authority": False,
+            },
+        )
+        self.assertEqual(
+            DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.mode_contract("probation"),
+            {
+                "proof_mode": "probation",
+                "default_proof_mode": "smoke",
+                "authority_scope": "bounded_evidence_collection_only",
+                "mode_can_grant_final_authority": False,
+                "mode_can_grant_promotion_authority": False,
+                "requires_explicit_authority_mode_for_final_promotion": True,
+                "implicit_default_final_authority": False,
+            },
+        )
+        self.assertEqual(
+            DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.mode_contract("authority"),
+            {
+                "proof_mode": "authority",
+                "default_proof_mode": "smoke",
+                "authority_scope": "final_promotion_authority_candidate",
+                "mode_can_grant_final_authority": True,
+                "mode_can_grant_promotion_authority": True,
+                "requires_explicit_authority_mode_for_final_promotion": True,
+                "implicit_default_final_authority": False,
+            },
+        )
+
     def test_policy_can_be_overridden_without_touching_call_sites(self) -> None:
         policy = runtime_ledger_proof_policy_from_env(
             {

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -290,6 +290,15 @@ def _runtime_ledger_proof_packet(
     return {
         "schema_version": verifier.RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
         "proof_mode": "authority",
+        "proof_mode_contract": {
+            "proof_mode": "authority",
+            "default_proof_mode": "smoke",
+            "authority_scope": "final_promotion_authority_candidate",
+            "mode_can_grant_final_authority": True,
+            "mode_can_grant_promotion_authority": True,
+            "requires_explicit_authority_mode_for_final_promotion": True,
+            "implicit_default_final_authority": False,
+        },
         "ok": allowed,
         "final_authority_ok": allowed,
         "promotion_allowed": allowed,
@@ -632,6 +641,15 @@ class TestVerifyTradingReadiness(TestCase):
     ) -> None:
         packet = _runtime_ledger_proof_packet()
         packet["proof_mode"] = "smoke"
+        packet["proof_mode_contract"] = {
+            "proof_mode": "smoke",
+            "default_proof_mode": "smoke",
+            "authority_scope": "plumbing_only",
+            "mode_can_grant_final_authority": False,
+            "mode_can_grant_promotion_authority": False,
+            "requires_explicit_authority_mode_for_final_promotion": True,
+            "implicit_default_final_authority": False,
+        }
         packet["final_authority_ok"] = False
         packet["capital_promotion_allowed"] = False
         packet["evidence_collection_ok"] = True
@@ -653,7 +671,30 @@ class TestVerifyTradingReadiness(TestCase):
         observed = result["checks"]["runtime_ledger_proof_packet_authority"]["observed"]
         self.assertEqual(observed["proof_mode"], "smoke")
         self.assertFalse(observed["authority_allowed"])
+        self.assertFalse(observed["mode_contract_allows_authority"])
         self.assertEqual(result["next_action"], "rerun_proof_packet_in_authority_mode")
+
+    def test_runtime_ledger_proof_packet_requires_explicit_authority_mode_contract(
+        self,
+    ) -> None:
+        packet = _runtime_ledger_proof_packet(allowed=True)
+        packet.pop("proof_mode_contract")
+
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            runtime_ledger_proof_packet=packet,
+            require_runtime_ledger_proof_packet=True,
+        )
+
+        self.assertFalse(result["ok"])
+        observed = result["checks"]["runtime_ledger_proof_packet_authority"]["observed"]
+        self.assertEqual(observed["proof_mode"], "authority")
+        self.assertEqual(observed["proof_mode_contract"], {})
+        self.assertFalse(observed["mode_contract_allows_authority"])
+        self.assertIn(
+            "runtime_ledger_proof_packet_authority",
+            result["failed_checks"],
+        )
 
     def test_runtime_ledger_proof_packet_rejects_mislabeled_smoke_authority(
         self,


### PR DESCRIPTION
## Summary

- Adds an explicit `proof_mode_contract` for Torghut runtime-ledger proof packets so smoke/probation/authority semantics are carried in packet output.
- Requires readiness to see an explicit authority-mode contract before treating a proof packet as final promotion authority.
- Extends regressions for smoke defaults, probation evidence collection, authority contracts, and missing-contract fail-closed behavior.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- PASS: `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py`
- PASS: `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Readiness now fails closed for runtime-ledger proof packets that claim final authority without the explicit authority-mode proof contract. No migration is required for newly assembled packets because this PR emits that contract.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no separate documentation update is required for this proof-packet output hardening.
