### PR TITLE
fix(torghut): preserve readyz dependencies on timeouts

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -972,6 +972,20 @@ def _cached_trading_health_surface_payload(
     return payload, checked_at
 
 
+def _cached_readiness_dependencies_for_health_surface(
+    *,
+    include_database_contract: bool,
+) -> tuple[dict[str, object], datetime] | None:
+    cache_key = _readiness_dependency_cache_key(include_database_contract)
+    with _TRADING_DEPENDENCY_HEALTH_CACHE_LOCK:
+        cache_entry = _TRADING_DEPENDENCY_HEALTH_CACHE.get(cache_key)
+        if cache_entry is None:
+            return None
+        dependencies = deepcopy(cast(dict[str, object], cache_entry["dependencies"]))
+        checked_at = cast(datetime, cache_entry["checked_at"])
+    return dependencies, checked_at
+
+
 def _fail_closed_health_evaluation_gate(
     *,
     reason_code: str,
@@ -991,30 +1005,167 @@ def _fail_closed_health_evaluation_gate(
     }
 
 
+def _health_surface_timeout_dependency_placeholder(
+    *,
+    reason_code: str,
+    detail: str,
+) -> dict[str, object]:
+    return {
+        "ok": False,
+        "detail": detail,
+        "reason": reason_code,
+        "reason_codes": [reason_code],
+    }
+
+
+def _minimal_health_surface_timeout_live_submission_gate(
+    *,
+    reason_code: str,
+    detail: str,
+) -> dict[str, object]:
+    blocked_reasons: list[str] = []
+    if settings.trading_mode == "live":
+        if not settings.trading_enabled:
+            blocked_reasons.append("trading_disabled")
+        if settings.trading_kill_switch_enabled:
+            blocked_reasons.append("kill_switch_enabled")
+        if (
+            settings.trading_pipeline_mode == "simple"
+            and not settings.trading_simple_submit_enabled
+        ):
+            blocked_reasons.append("simple_submit_disabled")
+
+    reason = blocked_reasons[0] if blocked_reasons else reason_code
+
+    return {
+        "allowed": False,
+        "promotion_authority": False,
+        "promotion_authority_ok": False,
+        "final_authority_ok": False,
+        "final_promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "reason": reason,
+        "reason_codes": blocked_reasons or [reason_code],
+        "blocked_reasons": blocked_reasons or [reason_code],
+        "detail": detail if reason == reason_code else reason,
+        "capital_stage": "shadow",
+        "capital_state": "observe",
+        "health_evaluation_timeout": {
+            "ok": False,
+            "reason": reason_code,
+            "reason_codes": [reason_code],
+            "detail": detail,
+        },
+    }
+
+
+def _minimal_health_surface_timeout_proof_floor() -> dict[str, object]:
+    return {
+        "route_state": "repair_only",
+        "capital_state": "zero_notional",
+        "promotion_authority": False,
+        "final_authority_ok": False,
+        "final_promotion_allowed": False,
+        "final_promotion_authorized": False,
+    }
+
+
+def _minimal_health_surface_timeout_payload(
+    *,
+    include_database_contract: bool,
+    reason_code: str,
+    detail: str,
+) -> dict[str, object]:
+    cached_dependencies = _cached_readiness_dependencies_for_health_surface(
+        include_database_contract=include_database_contract,
+    )
+    if cached_dependencies is None:
+        dependencies: dict[str, object] = {}
+        unavailable_detail = f"not evaluated before {reason_code}"
+        for dependency_name in ("postgres", "clickhouse", "alpaca", "tigerbeetle"):
+            dependencies[dependency_name] = (
+                _health_surface_timeout_dependency_placeholder(
+                    reason_code=reason_code,
+                    detail=unavailable_detail,
+                )
+            )
+        if include_database_contract:
+            dependencies["database"] = _health_surface_timeout_dependency_placeholder(
+                reason_code=reason_code,
+                detail=unavailable_detail,
+            )
+    else:
+        dependencies, checked_at = cached_dependencies
+        now = datetime.now(timezone.utc)
+        cache_age_seconds = round(max(0.0, (now - checked_at).total_seconds()), 3)
+        cache_ttl_seconds = settings.trading_readiness_dependency_cache_ttl_seconds
+        dependencies["readiness_cache"] = {
+            "checked_at": checked_at.isoformat(),
+            "cache_ttl_seconds": cache_ttl_seconds,
+            "cache_stale_tolerance_seconds": settings.trading_readiness_dependency_cache_stale_tolerance_seconds,
+            "cache_used": True,
+            "cache_age_seconds": cache_age_seconds,
+            "cache_stale": cache_age_seconds > cache_ttl_seconds,
+            "health_surface_timeout_fallback": True,
+        }
+
+    dependencies["health_evaluation"] = {
+        "ok": False,
+        "detail": detail,
+        "reason_codes": [reason_code],
+    }
+    scheduler: TradingScheduler | None = getattr(app.state, "trading_scheduler", None)
+    if scheduler is None:
+        scheduler = TradingScheduler()
+        app.state.trading_scheduler = scheduler
+    _scheduler_ok, scheduler_payload = _evaluate_scheduler_status(scheduler)
+    live_submission_gate = _minimal_health_surface_timeout_live_submission_gate(
+        reason_code=reason_code,
+        detail=detail,
+    )
+    proof_floor = _minimal_health_surface_timeout_proof_floor()
+    live_mode = settings.trading_mode == "live"
+    dependencies["live_submission_gate"] = {
+        "ok": bool(live_submission_gate.get("allowed", False)),
+        "detail": str(live_submission_gate.get("reason") or reason_code),
+        "capital_stage": live_submission_gate.get("capital_stage"),
+    }
+    dependencies["profitability_proof_floor"] = {
+        "ok": False if live_mode else True,
+        "detail": str(proof_floor.get("route_state") or "repair_only"),
+        "capital_state": proof_floor.get("capital_state"),
+        "required": live_mode,
+    }
+    return cast(
+        dict[str, object],
+        _strip_promotion_authority_claims_for_readiness(
+            {
+                "status": "degraded",
+                "reason": reason_code,
+                "reason_codes": [reason_code],
+                "scheduler": scheduler_payload,
+                "dependencies": dependencies,
+                "live_submission_gate": live_submission_gate,
+                "proof_floor": proof_floor,
+            }
+        ),
+    )
+
+
 def _health_surface_timeout_fallback_payload(
     *,
     cache_key: str,
+    include_database_contract: bool,
     reason_code: str,
     detail: str,
 ) -> dict[str, object]:
     cached = _cached_trading_health_surface_payload(cache_key)
     if cached is None:
-        return {
-            "status": "degraded",
-            "reason": reason_code,
-            "reason_codes": [reason_code],
-            "dependencies": {
-                "health_evaluation": {
-                    "ok": False,
-                    "detail": detail,
-                    "reason_codes": [reason_code],
-                }
-            },
-            "live_submission_gate": _fail_closed_health_evaluation_gate(
-                reason_code=reason_code,
-                detail=detail,
-            ),
-        }
+        return _minimal_health_surface_timeout_payload(
+            include_database_contract=include_database_contract,
+            reason_code=reason_code,
+            detail=detail,
+        )
 
     payload, checked_at = cached
     payload["status"] = "degraded"
@@ -1096,6 +1247,7 @@ def _evaluate_trading_health_payload_bounded(
         return (
             _health_surface_timeout_fallback_payload(
                 cache_key=cache_key,
+                include_database_contract=include_database_contract,
                 reason_code=reason_code,
                 detail=detail,
             ),
@@ -1107,6 +1259,7 @@ def _evaluate_trading_health_payload_bounded(
         return (
             _health_surface_timeout_fallback_payload(
                 cache_key=cache_key,
+                include_database_contract=include_database_contract,
                 reason_code=reason_code,
                 detail=str(exc),
             ),
@@ -3466,9 +3619,11 @@ def trading_status() -> dict[str, object]:
         live_submission_gate=live_submission_gate,
     )
     route_claim_symbols = _route_claim_symbols(profit_signal_quorum)
-    options_catalog_freshness_skip_reason = status_read_budget.skip_reason_if_unavailable(
-        "options_catalog_freshness",
-        min_remaining_seconds=2.0,
+    options_catalog_freshness_skip_reason = (
+        status_read_budget.skip_reason_if_unavailable(
+            "options_catalog_freshness",
+            min_remaining_seconds=2.0,
+        )
     )
     if options_catalog_freshness_skip_reason is not None:
         options_catalog_freshness = _budget_exhausted_options_catalog_freshness_payload(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -4992,9 +4992,129 @@ class TestTradingApi(TestCase):
             "readyz_evaluation_timeout",
             payload["dependencies"]["health_evaluation"]["reason_codes"],
         )
+        self.assertIsInstance(payload["dependencies"]["postgres"], dict)
+        self.assertFalse(payload["dependencies"]["postgres"]["ok"])
+        self.assertIsInstance(payload["dependencies"]["database"], dict)
+        self.assertFalse(payload["dependencies"]["database"]["ok"])
+        self.assertIsInstance(payload["scheduler"], dict)
         self.assertFalse(payload["live_submission_gate"]["allowed"])
         self.assertFalse(payload["live_submission_gate"]["promotion_authority"])
         self.assertFalse(payload["live_submission_gate"]["final_authority_ok"])
+
+    def test_readyz_timeout_uses_cached_dependency_contract_shape(self) -> None:
+        original_timeout = main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS
+        main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = 0.01
+        health_cache_key = main_module._trading_health_surface_cache_key(
+            include_database_contract=True,
+            allow_stale_dependency_cache=True,
+        )
+        dependency_cache_key = _readiness_dependency_cache_key(True)
+        checked_at = datetime.now(timezone.utc)
+        _TRADING_DEPENDENCY_HEALTH_CACHE[dependency_cache_key] = {
+            "checked_at": checked_at,
+            "dependencies": {
+                "postgres": {"ok": True, "detail": "ok"},
+                "clickhouse": {"ok": True, "detail": "ok"},
+                "alpaca": {"ok": True, "detail": "ok"},
+                "tigerbeetle": {
+                    "ok": True,
+                    "blockers": ["tigerbeetle_runtime_ledger_signed_refs_missing"],
+                },
+                "database": {
+                    "ok": True,
+                    "detail": "ok",
+                    "account_scope_errors": [],
+                },
+            },
+        }
+        with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.pop(
+                health_cache_key,
+                None,
+            )
+
+        def _slow_health_payload(**_kwargs: object) -> tuple[dict[str, object], int]:
+            time.sleep(0.2)
+            return ({"status": "ok", "live_submission_gate": {"allowed": True}}, 200)
+
+        try:
+            with patch(
+                "app.main._evaluate_trading_health_payload",
+                side_effect=_slow_health_payload,
+            ):
+                response = self.client.get("/readyz")
+            time.sleep(0.25)
+        finally:
+            main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = original_timeout
+            with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+                main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+                main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        dependencies = payload["dependencies"]
+        self.assertEqual(payload["reason"], "readyz_evaluation_timeout")
+        self.assertTrue(dependencies["postgres"]["ok"])
+        self.assertTrue(dependencies["clickhouse"]["ok"])
+        self.assertTrue(dependencies["database"]["ok"])
+        self.assertEqual(dependencies["database"]["account_scope_errors"], [])
+        self.assertEqual(
+            dependencies["tigerbeetle"]["blockers"],
+            ["tigerbeetle_runtime_ledger_signed_refs_missing"],
+        )
+        self.assertTrue(dependencies["readiness_cache"]["cache_used"])
+        self.assertTrue(
+            dependencies["readiness_cache"]["health_surface_timeout_fallback"]
+        )
+        self.assertIsInstance(payload["scheduler"], dict)
+        self.assertFalse(payload["live_submission_gate"]["promotion_authority"])
+        self.assertFalse(payload["live_submission_gate"]["final_authority_ok"])
+        self.assertFalse(payload["live_submission_gate"]["final_promotion_allowed"])
+
+    def test_timeout_live_gate_records_live_mode_blockers(self) -> None:
+        original = {
+            "trading_mode": settings.trading_mode,
+            "trading_enabled": settings.trading_enabled,
+            "trading_kill_switch_enabled": settings.trading_kill_switch_enabled,
+            "trading_pipeline_mode": settings.trading_pipeline_mode,
+            "trading_simple_submit_enabled": settings.trading_simple_submit_enabled,
+        }
+        try:
+            settings.trading_mode = "live"
+            settings.trading_enabled = False
+            settings.trading_kill_switch_enabled = True
+            settings.trading_pipeline_mode = "simple"
+            settings.trading_simple_submit_enabled = False
+
+            gate = main_module._minimal_health_surface_timeout_live_submission_gate(
+                reason_code="readyz_evaluation_timeout",
+                detail="readyz evaluation exceeded 3.0s",
+            )
+        finally:
+            settings.trading_mode = original["trading_mode"]
+            settings.trading_enabled = original["trading_enabled"]
+            settings.trading_kill_switch_enabled = original[
+                "trading_kill_switch_enabled"
+            ]
+            settings.trading_pipeline_mode = original["trading_pipeline_mode"]
+            settings.trading_simple_submit_enabled = original[
+                "trading_simple_submit_enabled"
+            ]
+
+        self.assertFalse(gate["allowed"])
+        self.assertEqual(gate["reason"], "trading_disabled")
+        self.assertEqual(
+            gate["blocked_reasons"],
+            [
+                "trading_disabled",
+                "kill_switch_enabled",
+                "simple_submit_disabled",
+            ],
+        )
+        self.assertFalse(gate["promotion_authority"])
+        self.assertFalse(gate["final_authority_ok"])
+        self.assertFalse(gate["final_promotion_allowed"])
 
     def test_trading_health_timeout_uses_cached_blockers_fail_closed(self) -> None:
         original_timeout = main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS


### PR DESCRIPTION
## Summary

- Preserves object-shaped readiness dependency payloads during cold `/readyz` health-surface timeouts by reusing the readiness dependency cache when the full diagnostic payload has not completed.
- Adds fail-closed minimal timeout payloads that include scheduler, live submission gate, proof-floor, and health-evaluation reason codes without asserting promotion or final authority.
- Keeps TigerBeetle/accounting blockers visible when cached readiness or health payloads exist, while marking unevaluated cold dependencies degraded instead of healthy.
- Adds regression coverage for cold timeout contract shape and cached dependency fallback honesty.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_trading_api.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
