### PR TITLE
fix(synthesis): gate autotrader broker mutations by mode

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -83,7 +83,7 @@ spec:
     ANALYSIS_REPO_URL: https://github.com/gregkonush/analysis.git
     ANALYSIS_REQUIRED_COMMIT: 56be940b69bf1a56578040eda9bf2e3699c5220e
     AUTONOMOUS_TRADER_ARTIFACT_DIR: /workspace/.agentrun/autonomous-trader
-    AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED: "true"
+    AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED: "{{parameters.brokerMutationEnabled}}"
     AUTONOMOUS_TRADER_MODE: "{{parameters.mode}}"
     AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE: "{{parameters.synthesisSessionMode}}"
     AUTONOMOUS_TRADER_TARGET_EQUITY_USD: "{{parameters.targetEquityUsd}}"
@@ -139,7 +139,7 @@ spec:
         command = "/usr/bin/python3"
         args = ["-u", "/root/alpaca-mcp-stdio-bridge.py"]
         startup_timeout_sec = 60.0
-        env = { FASTMCP_SHOW_SERVER_BANNER = "false", FASTMCP_LOG_LEVEL = "ERROR", AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED = "true" }
+        env = { FASTMCP_SHOW_SERVER_BANNER = "false", FASTMCP_LOG_LEVEL = "ERROR", AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED = "{{ env.AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED }}" }
 
         [mcp_servers.synthesis]
         command = "node"

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
@@ -33,6 +33,7 @@ spec:
     head: codex/synthesis-autonomous-trader-session
     mode: market-open
     synthesisSessionMode: market_open
+    brokerMutationEnabled: "true"
     accountType: paper
     targetEquityUsd: "500000"
     marketOpenTimezone: America/New_York

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-scorecard-readback-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-scorecard-readback-template.yaml
@@ -33,6 +33,7 @@ spec:
     head: codex/synthesis-autonomous-trader-scorecard-readback
     mode: scorecard-readback
     synthesisSessionMode: scorecard_readback
+    brokerMutationEnabled: "false"
     accountType: paper
     targetEquityUsd: "500000"
     marketOpenTimezone: America/New_York

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -634,6 +634,7 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(objectAt(templateSpec, 'goal'), 'objective')).toContain('dedicated Synthesis Alpaca paper account')
     expect(objectAt(parameters, 'mode')).toBe('market-open')
     expect(objectAt(parameters, 'synthesisSessionMode')).toBe('market_open')
+    expect(objectAt(parameters, 'brokerMutationEnabled')).toBe('true')
     expect(objectAt(parameters, 'accountType')).toBe('paper')
     expect(objectAt(parameters, 'targetEquityUsd')).toBe('500000')
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_MODE')).toBe('{{parameters.mode}}')
@@ -642,7 +643,9 @@ describe('synthesis autonomous trader provider', () => {
     )
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_TARGET_EQUITY_USD')).toBe('{{parameters.targetEquityUsd}}')
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_ACCOUNT_TYPE')).toBe('{{parameters.accountType}}')
-    expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED')).toBe('true')
+    expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED')).toBe(
+      '{{parameters.brokerMutationEnabled}}',
+    )
     expect(
       (secretEnv ?? [])
         .filter(
@@ -680,6 +683,7 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(objectAt(scheduleSpec, 'targetRef'), 'name')).toBe('autonomous-trader-scorecard-readback-template')
     expect(objectAt(parameters, 'mode')).toBe('scorecard-readback')
     expect(objectAt(parameters, 'synthesisSessionMode')).toBe('scorecard_readback')
+    expect(objectAt(parameters, 'brokerMutationEnabled')).toBe('false')
     expect(objectAt(goal, 'objective')).toContain('reads finalized Synthesis scorecards before candidate grading')
     expect(Object.hasOwn(goal, 'tokenBudget')).toBe(false)
     expect(secrets).toContain('synthesis-env')
@@ -866,7 +870,9 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(codexConfig, 'content')).toContain('command = "/usr/bin/python3"')
     expect(objectAt(codexConfig, 'content')).toContain('args = ["-u", "/root/alpaca-mcp-stdio-bridge.py"]')
     expect(objectAt(codexConfig, 'content')).toContain('startup_timeout_sec = 60.0')
-    expect(objectAt(codexConfig, 'content')).toContain('AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED = "true"')
+    expect(objectAt(codexConfig, 'content')).toContain(
+      'AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED = "{{ env.AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED }}"',
+    )
     expect(objectAt(bridge, 'content')).toContain('Content-Length:')
     expect(objectAt(bridge, 'content')).toContain('/usr/local/bin/alpaca-mcp-server')
     expect(objectAt(bridge, 'content')).toContain('--transport')


### PR DESCRIPTION
## Summary

- Makes `AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED` render from an AgentRun parameter instead of being hard-coded on.
- Keeps the market-open template explicitly mutation-enabled while making scorecard-readback explicitly broker read-only.
- Updates the smoke tests to cover the mode-specific broker gate and rendered Codex Alpaca MCP config.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`
- `git diff --check -- argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-scorecard-readback-template.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
