### PR TITLE
fix(torghut): bound hpairs offline frontier selection

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -111,6 +111,9 @@ class FastReplayPreviewRow:
     candidate_lineage: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
+    replay_tape_cache_identity: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
 
     def to_payload(self) -> dict[str, Any]:
         observed_post_cost_expectancy_bps = _observed_post_cost_expectancy_bps(self)
@@ -178,6 +181,7 @@ class FastReplayPreviewRow:
             "duplicate_of_candidate_spec_id": self.duplicate_of_candidate_spec_id,
             "duplicate_candidate_spec_ids": list(self.duplicate_candidate_spec_ids),
             "candidate_lineage": dict(self.candidate_lineage),
+            "replay_tape_cache_identity": dict(self.replay_tape_cache_identity),
             "frontier_selection": {
                 "schema_version": "torghut.fast-replay-frontier-selection.v1",
                 "selected": self.selected,
@@ -322,7 +326,10 @@ class FastReplayPreviewResult:
                 "exploitation_slots": FAST_REPLAY_DEFAULT_EXPLOITATION_COUNT,
                 "exploration_slots": FAST_REPLAY_DEFAULT_EXPLORATION_COUNT,
                 "broad_cluster_fanout_allowed": False,
-                "lineage_filter": "block_exact_replay_selection_when_local_cost_or_capacity_inputs_are_missing",
+                "lineage_filter": (
+                    "block_exact_replay_selection_when_local_cost_capacity_or_"
+                    "replay_tape_identity_inputs_are_missing"
+                ),
                 "lineage_filter_blockers": sorted(
                     FAST_REPLAY_EXACT_SELECTION_SOURCE_INPUT_BLOCKERS
                     | FAST_REPLAY_EXACT_SELECTION_IMPACT_CAPACITY_BLOCKERS
@@ -920,6 +927,7 @@ def _score_candidate_spec(
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
+            replay_tape_cache_identity=replay_tape_manifest.cache_identity_diagnostics(),
         )
 
     return_vectors = [stat.returns_bps for stat in matched if stat.returns_bps.size]
@@ -1055,6 +1063,7 @@ def _score_candidate_spec(
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
+        replay_tape_cache_identity=replay_tape_manifest.cache_identity_diagnostics(),
     )
 
 
@@ -1264,6 +1273,7 @@ def _row_with_rank_and_selection(
         duplicate_of_candidate_spec_id=row.duplicate_of_candidate_spec_id,
         duplicate_candidate_spec_ids=row.duplicate_candidate_spec_ids,
         candidate_lineage=dict(row.candidate_lineage),
+        replay_tape_cache_identity=dict(row.replay_tape_cache_identity),
     )
 
 
@@ -1314,6 +1324,7 @@ def _row_with_frontier_dedupe(
         duplicate_of_candidate_spec_id=duplicate_of_candidate_spec_id,
         duplicate_candidate_spec_ids=duplicate_candidate_spec_ids,
         candidate_lineage=dict(row.candidate_lineage),
+        replay_tape_cache_identity=dict(row.replay_tape_cache_identity),
     )
 
 
@@ -1990,6 +2001,13 @@ def _lineage_blockers_for_row(row: FastReplayPreviewRow) -> tuple[str, ...]:
         "live_paper_runtime_ledger_required",
     ]
     blockers.extend(_exact_replay_selection_blockers_for_row(row))
+    cache_identity = _mapping(row.replay_tape_cache_identity)
+    if cache_identity:
+        blockers.extend(
+            str(blocker)
+            for blocker in _string_tuple(cache_identity.get("blockers"))
+            if str(blocker).strip()
+        )
     if _observed_post_cost_expectancy_bps(row) <= 0:
         blockers.append("positive_post_cost_expectancy_missing")
         blockers.append("target_implied_notional_blocked_non_positive_expectancy")

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -433,8 +433,9 @@ def _staged_search_budget_payload(
             "exploitation_slots": exploitation_slots,
             "exploration_slots": exploration_slots,
             "ranking_basis": (
-                "top economic train-screen survivors first, then deterministic "
-                "diversity/exploration picks within the same capped shortlist"
+                "top four economic train-screen survivors by post-cost consistency "
+                "score first, then up to two deterministic exploration picks with "
+                "distinct parameter/symbol/regime keys when available"
             ),
         },
         "train_screen_candidates_started": max(0, int(train_screen_candidates_started)),
@@ -1373,16 +1374,7 @@ def _candidate_evaluation_key_payload(
         ),
         "dataset_snapshot_id": str(replay_lineage.get("dataset_snapshot_id") or ""),
         "replay_lineage_hash": str(replay_lineage.get("lineage_hash") or ""),
-        "replay_tape": {
-            "content_sha256": str(validation.get("content_sha256") or ""),
-            "dataset_snapshot_ref": str(validation.get("dataset_snapshot_ref") or ""),
-            "source_query_digest": str(validation.get("source_query_digest") or ""),
-            "selected_symbols": list(
-                cast(Sequence[Any], validation.get("selected_symbols") or ())
-            ),
-            "selected_row_count": int(validation.get("selected_row_count") or 0),
-            "validation_status": str(validation.get("status") or ""),
-        },
+        "replay_tape": _replay_tape_selection_metadata(validation),
         "replay_window_spec": {
             "train_start": window.train_start.isoformat(),
             "train_end": window.train_end.isoformat(),
@@ -1422,6 +1414,37 @@ def _candidate_evaluation_key_payload(
     }
     payload["candidate_evaluation_key"] = _stable_payload_hash(payload)
     return payload
+
+
+def _replay_tape_selection_metadata(
+    validation: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    payload = dict(validation or {})
+    return {
+        "content_sha256": str(payload.get("content_sha256") or ""),
+        "dataset_snapshot_ref": str(payload.get("dataset_snapshot_ref") or ""),
+        "source_query_digest": str(payload.get("source_query_digest") or ""),
+        "source_table_versions": dict(
+            cast(Mapping[str, Any], payload.get("source_table_versions") or {})
+        ),
+        "feature_schema_hash": str(payload.get("feature_schema_hash") or ""),
+        "cost_model_hash": str(payload.get("cost_model_hash") or ""),
+        "strategy_family": str(payload.get("strategy_family") or ""),
+        "feature_versions": dict(
+            cast(Mapping[str, Any], payload.get("feature_versions") or {})
+        ),
+        "replay_cache_key": str(payload.get("replay_cache_key") or ""),
+        "cache_identity": dict(
+            cast(Mapping[str, Any], payload.get("cache_identity") or {})
+        ),
+        "selected_symbols": list(
+            cast(Sequence[Any], payload.get("selected_symbols") or ())
+        ),
+        "selected_row_count": int(payload.get("selected_row_count") or 0),
+        "validation_status": str(payload.get("status") or ""),
+        "manifest_start_date": str(payload.get("manifest_start_date") or ""),
+        "manifest_end_date": str(payload.get("manifest_end_date") or ""),
+    }
 
 
 def _resolve_prefetch_symbols(
@@ -2258,26 +2281,10 @@ def _exact_replay_ledger_artifact_update(
         )
     if replay_tape_validation:
         artifact_payload["replay_tape"] = {
+            **_replay_tape_selection_metadata(replay_tape_validation),
             "status": str(replay_tape_validation.get("status") or ""),
             "tape_path": str(replay_tape_validation.get("tape_path") or ""),
             "manifest_path": str(replay_tape_validation.get("manifest_path") or ""),
-            "selected_row_count": int(
-                replay_tape_validation.get("selected_row_count") or 0
-            ),
-            "selected_symbols": list(
-                cast(
-                    Sequence[Any], replay_tape_validation.get("selected_symbols") or ()
-                )
-            ),
-            "source_query_digest": str(
-                replay_tape_validation.get("source_query_digest") or ""
-            ),
-            "source_table_versions": dict(
-                cast(
-                    Mapping[str, Any],
-                    replay_tape_validation.get("source_table_versions") or {},
-                )
-            ),
             "artifact_refs": dict(
                 cast(
                     Mapping[str, Any], replay_tape_validation.get("artifact_refs") or {}
@@ -2312,6 +2319,10 @@ def _exact_replay_ledger_artifact_update(
         ),
         "runtime_ledger_post_cost_expectancy_bps": str(
             runtime_bucket.post_cost_expectancy_bps
+        ),
+        "runtime_ledger_cost_basis_counts": dict(runtime_bucket.cost_basis_counts),
+        "runtime_ledger_cost_basis_count": sum(
+            runtime_bucket.cost_basis_counts.values()
         ),
         "runtime_ledger_pnl_basis": POST_COST_PNL_BASIS,
         "runtime_ledger_pnl_source": "exact_replay_runtime_ledger",
@@ -3409,6 +3420,60 @@ def _exploration_distance(
     return min(distances, default=0)
 
 
+def _exploration_diversity_key(item: _WorklistItem) -> tuple[str, str, str]:
+    symbols = item.strategy_overrides.get("universe_symbols")
+    if isinstance(symbols, Sequence) and not isinstance(
+        symbols, (str, bytes, bytearray)
+    ):
+        symbol_key = ",".join(
+            sorted(str(symbol).upper() for symbol in symbols if str(symbol).strip())
+        )
+    else:
+        symbol_key = str(symbols or "")
+    params_payload = {
+        key: value
+        for key, value in item.params_candidate.items()
+        if key
+        in {
+            "entry_threshold_bps",
+            "exit_threshold_bps",
+            "long_stop_loss_bps",
+            "max_entries_per_session",
+            "min_cross_section_continuation_rank",
+            "min_cross_section_reversal_rank",
+            "selection_mode",
+            "short_stop_loss_bps",
+            "signal_motif",
+            "top_n",
+        }
+    }
+    if not params_payload:
+        params_payload = dict(item.params_candidate)
+    params_key = _stable_payload_hash(params_payload)
+    regime_payload = {
+        key: item.strategy_overrides.get(key)
+        for key in (
+            "normalization_regime",
+            "market_regime",
+            "regime",
+            "runtime_family",
+            "strategy_family",
+        )
+        if key in item.strategy_overrides
+    }
+    nested_params = item.strategy_overrides.get("params")
+    if isinstance(nested_params, Mapping):
+        regime_payload.update(
+            {
+                key: nested_params.get(key)
+                for key in ("selection_mode", "signal_motif", "rank_feature")
+                if key in nested_params
+            }
+        )
+    regime_key = _stable_payload_hash(regime_payload)
+    return (params_key, symbol_key, regime_key)
+
+
 def _select_exact_replay_train_survivors(
     ranked_survivors: Sequence[_WorklistItem],
     *,
@@ -3432,11 +3497,23 @@ def _select_exact_replay_train_survivors(
         for survivor in ranked_survivors[exploitation_slots:]
         if _exploration_payload_signature(survivor) not in reasons
     ]
+    explored_diversity_keys: set[tuple[str, str, str]] = {
+        _exploration_diversity_key(item) for item in selected
+    }
+    deferred_exploration: list[_WorklistItem] = []
     for _ in range(exploration_slots):
         if not remaining:
             break
+        distinct_remaining = [
+            (index, survivor)
+            for index, survivor in enumerate(remaining)
+            if _exploration_diversity_key(survivor) not in explored_diversity_keys
+        ]
+        if not distinct_remaining:
+            deferred_exploration.extend(remaining)
+            break
         best_index, best_survivor = max(
-            enumerate(remaining),
+            distinct_remaining,
             key=lambda indexed: (
                 _exploration_distance(indexed[1], selected),
                 -indexed[0],
@@ -3446,7 +3523,18 @@ def _select_exact_replay_train_survivors(
         reasons[_exploration_payload_signature(best_survivor)] = (
             "exploration_diversity_pick"
         )
+        explored_diversity_keys.add(_exploration_diversity_key(best_survivor))
         del remaining[best_index]
+    for survivor in deferred_exploration + remaining:
+        exploration_selected_count = sum(
+            1 for reason in reasons.values() if reason == "exploration_diversity_pick"
+        )
+        if exploration_selected_count >= exploration_slots:
+            break
+        if _exploration_payload_signature(survivor) in reasons:
+            continue
+        selected.append(survivor)
+        reasons[_exploration_payload_signature(survivor)] = "exploration_diversity_pick"
     return reasons
 
 
@@ -4624,6 +4712,75 @@ def _candidate_source_lineage_ok(item: Mapping[str, Any]) -> bool:
     )
 
 
+def _candidate_replay_tape_metadata_blockers(item: Mapping[str, Any]) -> list[str]:
+    candidate_key = _mapping(item.get("candidate_evaluation_key_payload"))
+    replay_tape = _mapping(candidate_key.get("replay_tape"))
+    if not replay_tape:
+        replay_tape = _mapping(item.get("replay_tape"))
+    if not replay_tape:
+        return []
+
+    required_fields = (
+        "content_sha256",
+        "dataset_snapshot_ref",
+        "source_query_digest",
+        "feature_schema_hash",
+        "cost_model_hash",
+        "strategy_family",
+        "replay_cache_key",
+    )
+    blockers = [
+        f"missing_replay_tape_{field}"
+        for field in required_fields
+        if not str(replay_tape.get(field) or "").strip()
+    ]
+    if int(replay_tape.get("selected_row_count") or 0) <= 0:
+        blockers.append("missing_replay_tape_selected_rows")
+    cache_identity = _mapping(replay_tape.get("cache_identity"))
+    blockers.extend(
+        str(blocker)
+        for blocker in cast(Sequence[Any], cache_identity.get("blockers") or ())
+        if str(blocker).strip()
+    )
+    return list(dict.fromkeys(blockers))
+
+
+def _candidate_post_cost_proof_blockers(item: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    pnl_basis = str(item.get("runtime_ledger_pnl_basis") or "").strip()
+    if pnl_basis != POST_COST_PNL_BASIS:
+        blockers.append("missing_post_cost_pnl_basis")
+
+    cost_basis_counts = item.get("runtime_ledger_cost_basis_counts")
+    cost_basis_count = _candidate_runtime_ledger_count(
+        item,
+        "runtime_ledger_cost_basis_count",
+        "exact_replay_ledger_cost_basis_count",
+    )
+    if isinstance(cost_basis_counts, Mapping):
+        parsed_cost_basis_count = 0
+        for value in cost_basis_counts.values():
+            try:
+                parsed_cost_basis_count += int(value or 0)
+            except (TypeError, ValueError):
+                continue
+        cost_basis_count = max(
+            cost_basis_count,
+            parsed_cost_basis_count,
+        )
+    if cost_basis_count <= 0 and not str(item.get("cost_basis") or "").strip():
+        blockers.append("missing_cost_basis")
+
+    expectancy_value = item.get("runtime_ledger_post_cost_expectancy_bps")
+    if expectancy_value in (None, ""):
+        blockers.append("missing_post_cost_expectancy_bps")
+    else:
+        expectancy = _safe_decimal(expectancy_value)
+        if expectancy <= Decimal("0"):
+            blockers.append("non_positive_post_cost_expectancy_bps")
+    return blockers
+
+
 def _candidate_exact_replay_parity_ok(
     item: Mapping[str, Any],
     *,
@@ -4783,6 +4940,25 @@ def _candidate_handoff_diagnostics(
             }
         )
 
+    if artifact_refs and runtime_ledger_row_count > 0 and runtime_ledger_fill_count > 0:
+        replay_tape_blockers = _candidate_replay_tape_metadata_blockers(item)
+        if replay_tape_blockers:
+            diagnostics.append(
+                {
+                    "category": "missing_replay_tape_metadata",
+                    "blockers": replay_tape_blockers,
+                }
+            )
+
+        post_cost_blockers = _candidate_post_cost_proof_blockers(item)
+        if post_cost_blockers:
+            diagnostics.append(
+                {
+                    "category": "missing_post_cost_basis",
+                    "blockers": post_cost_blockers,
+                }
+            )
+
     return diagnostics
 
 
@@ -4909,6 +5085,13 @@ def _build_paper_probation_shortlist(
             blockers.append("missing_source_lineage")
         if not exact_replay_parity_ok:
             blockers.append("failed_exact_replay_parity")
+        if (
+            artifact_refs
+            and runtime_ledger_row_count > 0
+            and runtime_ledger_fill_count > 0
+        ):
+            blockers.extend(_candidate_replay_tape_metadata_blockers(item))
+            blockers.extend(_candidate_post_cost_proof_blockers(item))
         open_position_count = _candidate_runtime_ledger_count(
             item,
             "runtime_ledger_open_position_count",

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -120,12 +120,15 @@ class TestFastReplayPreview(TestCase):
                 end_date=date(2026, 2, 23),
                 source_query_digest=source_query_digest,
                 source_table_versions={"signals": "v1"},
+                feature_schema_hash="feature-fast",
+                cost_model_hash="cost-fast",
+                strategy_family="hpairs-fast",
             )
 
         preview = build_fast_replay_preview(
             specs=(
                 self._spec("spec-good", symbols=["AAA"]),
-                self._spec("spec-stress", symbols=["BBB"]),
+                self._spec("spec-stress", symbols=["BBB"], selection_mode="reversal"),
             ),
             rows=rows,
             replay_tape_manifest=manifest,
@@ -216,13 +219,10 @@ class TestFastReplayPreview(TestCase):
         self.assertIn("feature_schema_hash", payload["replay_tape"])
         self.assertIn("cost_model_hash", payload["replay_tape"])
         self.assertIn("strategy_family", payload["replay_tape"])
-        self.assertEqual(
-            payload["replay_tape"]["cache_identity"]["status"], "incomplete"
-        )
-        self.assertIn(
-            "replay_tape_cache_identity_missing_feature_schema_hash",
-            payload["replay_tape"]["cache_identity"]["blockers"],
-        )
+        self.assertEqual(payload["replay_tape"]["cache_identity"]["status"], "complete")
+        self.assertEqual(payload["replay_tape"]["feature_schema_hash"], "feature-fast")
+        self.assertEqual(payload["replay_tape"]["cost_model_hash"], "cost-fast")
+        self.assertEqual(payload["replay_tape"]["strategy_family"], "hpairs-fast")
         self.assertFalse(payload["proof_authority"])
         self.assertEqual(
             row_payload["candidate_lineage"]["hypothesis_id"], "hyp-spec-good"
@@ -324,6 +324,9 @@ class TestFastReplayPreview(TestCase):
                 source_query_digest=build_source_query_digest(
                     {"window": "hpairs-features"}
                 ),
+                feature_schema_hash="feature-hpairs",
+                cost_model_hash="cost-hpairs",
+                strategy_family="hpairs-feature-ranking",
             )
             tape = load_replay_tape(tape_path)
 
@@ -423,6 +426,9 @@ class TestFastReplayPreview(TestCase):
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
                 source_query_digest=build_source_query_digest({"window": "notional"}),
+                feature_schema_hash="feature-notional",
+                cost_model_hash="cost-notional",
+                strategy_family="hpairs-notional",
             )
 
         preview = build_fast_replay_preview(
@@ -475,6 +481,10 @@ class TestFastReplayPreview(TestCase):
             "target_implied_notional_blocked_non_positive_expectancy",
             negative["lineage_blockers"],
         )
+        self.assertIn(
+            "positive_post_cost_expectancy_missing",
+            negative["lineage_blockers"],
+        )
 
     def test_fast_preview_ranking_uses_combined_preview_score_before_raw_prefilter(
         self,
@@ -497,7 +507,7 @@ class TestFastReplayPreview(TestCase):
                 matched_symbol_count=1,
                 requested_symbol_count=1,
                 trading_day_count=1,
-                signed_return_bps=Decimal("0"),
+                signed_return_bps=Decimal("1"),
                 avg_abs_return_bps=Decimal("0"),
                 median_spread_bps=Decimal("0"),
                 activity_score=Decimal("0"),
@@ -565,6 +575,9 @@ class TestFastReplayPreview(TestCase):
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
                 source_query_digest=build_source_query_digest({"window": "cap"}),
+                feature_schema_hash="feature-cap",
+                cost_model_hash="cost-cap",
+                strategy_family="hpairs-cap",
             )
         specs = tuple(
             self._spec(
@@ -622,7 +635,7 @@ class TestFastReplayPreview(TestCase):
                 matched_symbol_count=1,
                 requested_symbol_count=1,
                 trading_day_count=1,
-                signed_return_bps=Decimal("1"),
+                signed_return_bps=Decimal("3"),
                 avg_abs_return_bps=Decimal("1"),
                 median_spread_bps=Decimal("1"),
                 activity_score=Decimal("1"),
@@ -790,6 +803,9 @@ class TestFastReplayPreview(TestCase):
                 source_query_digest=build_source_query_digest(
                     {"window": "lineage-blocked"}
                 ),
+                feature_schema_hash="feature-lineage-blocked",
+                cost_model_hash="cost-lineage-blocked",
+                strategy_family="hpairs-lineage-blocked",
             )
 
         preview = build_fast_replay_preview(
@@ -835,6 +851,62 @@ class TestFastReplayPreview(TestCase):
         self.assertFalse(payload["promotion_authority"])
         self.assertFalse(payload["promotion_allowed"])
         self.assertFalse(payload["final_promotion_allowed"])
+        self.assertFalse(payload["final_authority_ok"])
+
+    def test_missing_replay_tape_identity_reports_lineage_blockers(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            rows = [
+                self._signal(
+                    symbol="AAA", offset=index, price=str(100 + index), ofi="0.50"
+                )
+                for index in range(1, 4)
+            ]
+            manifest = materialize_signal_tape(
+                rows=rows,
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-missing-identity",
+                symbols=("AAA",),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest(
+                    {"window": "missing-identity"}
+                ),
+            )
+
+        preview = build_fast_replay_preview(
+            specs=(self._spec("spec-missing-identity", symbols=["AAA"]),),
+            rows=rows,
+            replay_tape_manifest=manifest,
+            top_k=1,
+            min_rows_per_candidate=2,
+            exploitation_count=1,
+            exploration_count=0,
+            exact_replay_candidate_cap=1,
+        )
+
+        self.assertEqual(
+            preview.selected_candidate_spec_ids, ("spec-missing-identity",)
+        )
+        payload = preview.rows[0].to_payload()
+        self.assertEqual(
+            payload["selection_reason"], "fast_replay_frontier_exploitation_selected"
+        )
+        self.assertIn(
+            "replay_tape_cache_identity_missing_feature_schema_hash",
+            payload["lineage_blockers"],
+        )
+        self.assertIn(
+            "replay_tape_cache_identity_missing_cost_model_hash",
+            payload["lineage_blockers"],
+        )
+        self.assertIn(
+            "replay_tape_cache_identity_missing_strategy_family",
+            payload["lineage_blockers"],
+        )
+        self.assertTrue(payload["frontier_selection"]["exact_replay_enqueue_allowed"])
+        self.assertFalse(payload["promotion_allowed"])
         self.assertFalse(payload["final_authority_ok"])
 
     def test_frontier_selection_dedupes_equivalent_exact_replay_targets(

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -722,6 +722,12 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 "content_sha256": "tape-sha",
                 "dataset_snapshot_ref": "snapshot-lineage",
                 "source_query_digest": "query-sha",
+                "source_table_versions": {"signals": "v1"},
+                "feature_schema_hash": "feature-sha",
+                "cost_model_hash": "cost-sha",
+                "strategy_family": "hpairs",
+                "feature_versions": {"hpairs": "v1"},
+                "replay_cache_key": "cache-key",
                 "selected_symbols": ["NVDA"],
                 "selected_row_count": 10,
                 "status": "valid",
@@ -749,6 +755,12 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 "content_sha256": "different-tape-sha",
                 "dataset_snapshot_ref": "snapshot-lineage",
                 "source_query_digest": "query-sha",
+                "source_table_versions": {"signals": "v1"},
+                "feature_schema_hash": "feature-sha",
+                "cost_model_hash": "cost-sha",
+                "strategy_family": "hpairs",
+                "feature_versions": {"hpairs": "v1"},
+                "replay_cache_key": "cache-key",
                 "selected_symbols": ["NVDA"],
                 "selected_row_count": 10,
                 "status": "valid",
@@ -776,6 +788,12 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 "content_sha256": "tape-sha",
                 "dataset_snapshot_ref": "snapshot-lineage",
                 "source_query_digest": "query-sha",
+                "source_table_versions": {"signals": "v1"},
+                "feature_schema_hash": "feature-sha",
+                "cost_model_hash": "cost-sha",
+                "strategy_family": "hpairs",
+                "feature_versions": {"hpairs": "v1"},
+                "replay_cache_key": "cache-key",
                 "selected_symbols": ["NVDA"],
                 "selected_row_count": 10,
                 "status": "valid",
@@ -791,9 +809,45 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 "implementation_uncertainty_model": "interval-v1",
             },
         )
+        changed_feature_schema = frontier._candidate_evaluation_key_payload(
+            candidate_search_key="candidate-key",
+            params_candidate={"long_stop_loss_bps": "12"},
+            strategy_overrides={
+                "normalization_regime": "price_scaled",
+                "universe_symbols": ["NVDA"],
+            },
+            replay_lineage=lineage,
+            replay_tape_validation={
+                "content_sha256": "tape-sha",
+                "dataset_snapshot_ref": "snapshot-lineage",
+                "source_query_digest": "query-sha",
+                "source_table_versions": {"signals": "v1"},
+                "feature_schema_hash": "feature-sha-v2",
+                "cost_model_hash": "cost-sha",
+                "strategy_family": "hpairs",
+                "feature_versions": {"hpairs": "v2"},
+                "replay_cache_key": "cache-key-v2",
+                "selected_symbols": ["NVDA"],
+                "selected_row_count": 10,
+                "status": "valid",
+            },
+            window=window,
+            full_window_start=date(2026, 3, 18),
+            full_window_end=date(2026, 3, 19),
+            full_window_summary={
+                "market_impact_stress_model": "impact-v1",
+                "market_impact_stress_cost_bps": "8",
+                "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+                "delay_adjusted_depth_stress_ms": "50",
+                "implementation_uncertainty_model": "interval-v1",
+            },
+        )
 
         self.assertEqual(base["schema_version"], "torghut.candidate-evaluation-key.v1")
         self.assertEqual(base["replay_tape"]["source_query_digest"], "query-sha")
+        self.assertEqual(base["replay_tape"]["feature_schema_hash"], "feature-sha")
+        self.assertEqual(base["replay_tape"]["cost_model_hash"], "cost-sha")
+        self.assertEqual(base["replay_tape"]["strategy_family"], "hpairs")
         self.assertEqual(
             base["effective_strategy_config_sha256"],
             lineage["candidate_configmap_sha256"],
@@ -805,6 +859,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertNotEqual(
             base["candidate_evaluation_key"],
             changed_cost["candidate_evaluation_key"],
+        )
+        self.assertNotEqual(
+            base["candidate_evaluation_key"],
+            changed_feature_schema["candidate_evaluation_key"],
         )
 
     def test_rank_scored_candidates_uses_deployable_lower_bound_for_ordering(
@@ -2636,6 +2694,9 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 ),
                 "runtime_ledger_artifact_row_count": 12,
                 "runtime_ledger_artifact_fill_count": 4,
+                "runtime_ledger_cost_basis_count": 4,
+                "runtime_ledger_post_cost_expectancy_bps": "25",
+                "runtime_ledger_pnl_basis": "realized_strategy_pnl_after_explicit_costs",
                 "runtime_ledger_open_position_count": 0,
                 "replay_artifact_refs": ["/tmp/microbar-exact-replay-ledger.json"],
                 "dataset_snapshot_id": "snapshot-microbar",
@@ -2724,6 +2785,122 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 diagnostic["category"]
                 for diagnostic in shortlist[0]["handoff_diagnostics"]
             },
+        )
+
+    def test_paper_probation_shortlist_blocks_missing_post_cost_basis(self) -> None:
+        shortlist = frontier._build_paper_probation_shortlist(
+            [
+                {
+                    "candidate_id": "missing-post-cost-proof",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "125",
+                        "net_pnl": "250",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "100",
+                    },
+                    "full_window": {"net_per_day": "125", "net_pnl": "250"},
+                    "runtime_ledger_artifact_ref": "/tmp/exact-replay-ledger.json",
+                    "exact_replay_ledger_artifact_ref": "/tmp/exact-replay-ledger.json",
+                    "runtime_ledger_artifact_row_count": 6,
+                    "runtime_ledger_artifact_fill_count": 2,
+                    "runtime_ledger_open_position_count": 0,
+                    "dataset_snapshot_id": "snapshot-post-cost",
+                    "replay_lineage": {"lineage_hash": "lineage-post-cost"},
+                    "candidate_evaluation_key": "eval-post-cost",
+                    "candidate_evaluation_key_payload": {
+                        "candidate_evaluation_key": "eval-post-cost",
+                        "replay_tape": {
+                            "content_sha256": "tape-sha",
+                            "dataset_snapshot_ref": "snapshot-post-cost",
+                            "source_query_digest": "query-sha",
+                            "feature_schema_hash": "feature-sha",
+                            "cost_model_hash": "cost-sha",
+                            "strategy_family": "hpairs",
+                            "replay_cache_key": "cache-key",
+                            "selected_symbols": ["NVDA"],
+                            "selected_row_count": 10,
+                            "validation_status": "valid",
+                        },
+                    },
+                    "hard_vetoes": [],
+                }
+            ],
+            top_n=1,
+            objective_veto_policy=frontier.ObjectiveVetoPolicy(
+                required_max_gross_exposure_pct_equity=Decimal("1"),
+                required_min_cash=Decimal("0"),
+            ),
+        )
+
+        item = shortlist[0]
+        self.assertFalse(item["paper_probation_allowed"])
+        self.assertIn("missing_post_cost_pnl_basis", item["probation_blockers"])
+        self.assertIn("missing_cost_basis", item["probation_blockers"])
+        self.assertIn("missing_post_cost_expectancy_bps", item["probation_blockers"])
+        self.assertFalse(item["bounded_sim_handoff"]["promotion_allowed"])
+        self.assertFalse(item["bounded_sim_handoff"]["final_promotion_allowed"])
+        self.assertIn(
+            "missing_post_cost_basis",
+            {diagnostic["category"] for diagnostic in item["handoff_diagnostics"]},
+        )
+
+    def test_paper_probation_shortlist_blocks_missing_replay_tape_metadata(
+        self,
+    ) -> None:
+        shortlist = frontier._build_paper_probation_shortlist(
+            [
+                {
+                    "candidate_id": "missing-tape-metadata",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "125",
+                        "net_pnl": "250",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "100",
+                    },
+                    "full_window": {"net_per_day": "125", "net_pnl": "250"},
+                    "runtime_ledger_artifact_ref": "/tmp/exact-replay-ledger.json",
+                    "exact_replay_ledger_artifact_ref": "/tmp/exact-replay-ledger.json",
+                    "runtime_ledger_artifact_row_count": 6,
+                    "runtime_ledger_artifact_fill_count": 2,
+                    "runtime_ledger_cost_basis_count": 2,
+                    "runtime_ledger_post_cost_expectancy_bps": "25",
+                    "runtime_ledger_pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+                    "runtime_ledger_open_position_count": 0,
+                    "dataset_snapshot_id": "snapshot-tape-missing",
+                    "replay_lineage": {"lineage_hash": "lineage-tape-missing"},
+                    "candidate_evaluation_key": "eval-tape-missing",
+                    "candidate_evaluation_key_payload": {
+                        "candidate_evaluation_key": "eval-tape-missing",
+                        "replay_tape": {
+                            "content_sha256": "tape-sha",
+                            "dataset_snapshot_ref": "snapshot-tape-missing",
+                            "source_query_digest": "query-sha",
+                            "selected_symbols": ["NVDA"],
+                            "selected_row_count": 10,
+                            "validation_status": "valid",
+                        },
+                    },
+                    "hard_vetoes": [],
+                }
+            ],
+            top_n=1,
+            objective_veto_policy=frontier.ObjectiveVetoPolicy(
+                required_max_gross_exposure_pct_equity=Decimal("1"),
+                required_min_cash=Decimal("0"),
+            ),
+        )
+
+        item = shortlist[0]
+        self.assertFalse(item["paper_probation_allowed"])
+        self.assertIn(
+            "missing_replay_tape_feature_schema_hash", item["probation_blockers"]
+        )
+        self.assertIn("missing_replay_tape_cost_model_hash", item["probation_blockers"])
+        self.assertIn("missing_replay_tape_strategy_family", item["probation_blockers"])
+        self.assertFalse(item["bounded_sim_handoff"]["evidence_collection_ok"])
+        self.assertIn(
+            "missing_replay_tape_metadata",
+            {diagnostic["category"] for diagnostic in item["handoff_diagnostics"]},
         )
 
     def test_paper_probation_shortlist_blocks_generic_replay_artifact(self) -> None:
@@ -2844,6 +3021,58 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(
             frontier._safe_exact_replay_candidate_budget(12),
             6,
+        )
+
+    def test_exact_replay_shortlist_exploration_falls_back_when_diversity_exhausted(
+        self,
+    ) -> None:
+        survivors: list[frontier._WorklistItem] = []
+        for index, net_per_day in enumerate(
+            ["120", "110", "100", "90", "80", "70"],
+            start=1,
+        ):
+            survivors.append(
+                frontier._WorklistItem(
+                    params_candidate={"long_stop_loss_bps": "12"},
+                    strategy_overrides={
+                        "universe_symbols": ["NVDA"],
+                        "normalization_regime": "matched_filter",
+                        "max_notional_per_trade": str(1000 + index),
+                    },
+                    deferred_candidate_index=index,
+                    deferred_candidate_key=f"candidate-{index}",
+                    deferred_train_payload=self._payload(
+                        start_date="2026-03-18",
+                        end_date="2026-03-20",
+                        daily_net={
+                            "2026-03-18": net_per_day,
+                            "2026-03-19": net_per_day,
+                            "2026-03-20": net_per_day,
+                        },
+                        decision_count=3,
+                        filled_count=3,
+                        wins=3,
+                        losses=0,
+                    ),
+                )
+            )
+
+        worklist: deque[frontier._WorklistItem] = deque()
+        frontier._enqueue_ranked_train_screen_survivors(
+            worklist=worklist,
+            survivors=survivors,
+            full_replay_candidate_budget=6,
+        )
+
+        selected = [item for item in worklist if item.deferred_full_replay_selected]
+        self.assertEqual(len(selected), 6)
+        self.assertEqual(
+            [item.deferred_full_replay_selection_reason for item in selected[:4]],
+            ["exploitation_top_economic_rank"] * 4,
+        )
+        self.assertEqual(
+            [item.deferred_full_replay_selection_reason for item in selected[4:]],
+            ["exploration_diversity_pick"] * 2,
         )
 
     def test_frontier_workflow_states_separate_preview_exact_handoff_and_authority(


### PR DESCRIPTION
## Summary

- Adds deterministic H-PAIRS offline frontier narrowing that caps exact replay handoff to six candidates: four exploitation survivors plus two diversity/exploration picks when available.
- Binds replay-tape/cache lineage metadata into candidate evaluation and exact-replay ledger selection payloads, including snapshot, universe/date range, feature/cost hashes, strategy family, and cache identity.
- Fails closed for promotion-like paper/SIM handoff when replay tape metadata, post-cost basis, cost basis, or positive post-cost expectancy evidence is missing.
- Extends fast replay preview selection blockers so rank-only H-PAIRS output cannot enqueue non-positive expectancy or incomplete tape-identity candidates as exact-replay ready.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (passed after installing local build-essential because the dev dependency crosshair-tool requires `cc` in this workspace)
- `cd services/torghut && uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -q` (110 passed, 1 warning)
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py -q` (11 passed, 1 warning)
- `cd services/torghut && uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_fast_replay_preview_builds_bounded_sim_target_queue_and_caps_exact_replay tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_replay_tape_preview_narrows_direct_specs_without_promotion_proof -q` (2 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py tests/test_search_consistent_profitability_frontier.py tests/test_fast_replay.py tests/test_replay_tape.py` (passed)
- `cd services/torghut && uv run --frozen ruff format --check scripts/search_consistent_profitability_frontier.py app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py tests/test_search_consistent_profitability_frontier.py tests/test_fast_replay.py tests/test_replay_tape.py` (passed)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (0 errors)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (0 errors)
- `git diff --check` (passed)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
