### PR TITLE
fix(torghut): require source authority markers in runtime ledger

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -105,6 +105,19 @@ _SOURCE_REF_BLOCKER_EXECUTION_ORDER_EVENT_MISSING = (
     "runtime_ledger_execution_order_event_refs_missing"
 )
 _SOURCE_REF_BLOCKER_SOURCE_OFFSETS_MISSING = "runtime_ledger_source_offsets_missing"
+_SOURCE_REF_BLOCKER_SOURCE_MATERIALIZATION_MISSING = (
+    "runtime_ledger_source_materialization_missing"
+)
+_SOURCE_REF_BLOCKER_AUTHORITY_CLASS_MISSING = "runtime_ledger_authority_class_missing"
+_PROMOTION_GRADE_AUTHORITY_CLASSES = frozenset(
+    {
+        "runtime_order_feed_execution_source",
+        "event_sourced_runtime_ledger_profit_proof",
+        "source_execution_runtime_ledger_materialized",
+        "execution_order_events_runtime_ledger",
+        "source_execution_lifecycle_materialized_runtime_ledger",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -197,6 +210,7 @@ class _NormalizedFill:
     source_window_id: str | None = None
     source_offset_present: bool = False
     source_materialization: str | None = None
+    authority_class: str | None = None
 
     @property
     def is_usable_fill(self) -> bool:
@@ -601,10 +615,14 @@ def _source_materialization_blockers(
 
     blockers: list[str] = []
     for row in lifecycle_rows:
-        if row.source_materialization not in _PROMOTION_GRADE_SOURCE_MATERIALIZATIONS:
+        if not _row_requires_promotion_source_authority(row):
             continue
         if row.event_type not in _SUBMITTED_ORDER_EVENTS | _FILL_EVENTS:
             continue
+        if row.source_materialization not in _PROMOTION_GRADE_SOURCE_MATERIALIZATIONS:
+            blockers.append(_SOURCE_REF_BLOCKER_SOURCE_MATERIALIZATION_MISSING)
+        if row.authority_class not in _PROMOTION_GRADE_AUTHORITY_CLASSES:
+            blockers.append(_SOURCE_REF_BLOCKER_AUTHORITY_CLASS_MISSING)
         if row.execution_order_event_id is None:
             blockers.append(_SOURCE_REF_BLOCKER_EXECUTION_ORDER_EVENT_MISSING)
         if row.decision_id is None:
@@ -616,6 +634,21 @@ def _source_materialization_blockers(
         if not row.source_offset_present:
             blockers.append(_SOURCE_REF_BLOCKER_SOURCE_OFFSETS_MISSING)
     return _dedupe(blockers)
+
+
+def _row_requires_promotion_source_authority(row: _NormalizedFill) -> bool:
+    """Return true for source rows that claim promotion-grade runtime authority.
+
+    Lifecycle-only ``order_feed_lifecycle`` rows can prove order state without
+    economics or promotion authority. Rows that claim a promotion source
+    materialization or authority marker must carry both the marker and all
+    source refs before a bucket can become authority.
+    """
+
+    return (
+        row.source_materialization in _PROMOTION_GRADE_SOURCE_MATERIALIZATIONS
+        or row.authority_class in _PROMOTION_GRADE_AUTHORITY_CLASSES
+    )
 
 
 def _apply_fill_to_position(
@@ -816,8 +849,9 @@ def _normalize_fill_row(
     )
     source_offset_present = _source_offset_present(row)
     source_materialization = _coerce_text(
-        _row_value(row, "source_materialization", "authority_class", "source")
+        _row_value(row, "source_materialization", "source")
     )
+    authority_class = _coerce_text(_row_value(row, "authority_class"))
     order_id = _coerce_text(
         _row_value(
             row,
@@ -916,6 +950,7 @@ def _normalize_fill_row(
         source_window_id=source_window_id,
         source_offset_present=source_offset_present,
         source_materialization=source_materialization,
+        authority_class=authority_class,
         execution_policy_hash=execution_policy_hash,
         cost_model_hash=cost_model_hash,
         lineage_hash=lineage_hash,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2464,6 +2464,7 @@ def _runtime_lifecycle_ledger_row(
     if _source_authority_order_event_row(row):
         ledger_row["source"] = "execution_order_event"
         ledger_row["source_materialization"] = "execution_order_events"
+        ledger_row["authority_class"] = "runtime_order_feed_execution_source"
         for key in (
             "execution_order_event_id",
             "execution_id",

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -1518,6 +1518,121 @@ def test_promotion_authority_class_requires_source_refs_without_lifecycle_gate()
     assert "runtime_ledger_source_offsets_missing" in bucket.blockers
 
 
+def test_aggregate_only_source_bucket_remains_blocked_from_authority() -> None:
+    bucket = _bucket(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(1),
+                "source_materialization": "aggregate_only",
+                "authority_class": "aggregate_only",
+                "execution_order_event_id": "event-buy",
+                "execution_id": "execution-buy",
+                "trade_decision_id": "decision-buy",
+                "source_window_id": "window-buy",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 7,
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "1",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(2),
+                "source_materialization": "aggregate_only",
+                "authority_class": "aggregate_only",
+                "execution_order_event_id": "event-sell",
+                "execution_id": "execution-sell",
+                "trade_decision_id": "decision-sell",
+                "source_window_id": "window-sell",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 8,
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "1",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "101",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+        ]
+    )
+
+    assert bucket.fill_count == 0
+    assert bucket.post_cost_expectancy_bps is None
+    assert "runtime_source_not_promotion_authority" in bucket.blockers
+    assert "runtime_fills_missing" in bucket.blockers
+
+
+def test_promotion_authority_class_also_requires_source_materialization() -> None:
+    bucket = _bucket(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(1),
+                "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+                "execution_order_event_id": "event-buy",
+                "execution_id": "execution-buy",
+                "trade_decision_id": "decision-buy",
+                "source_window_id": "window-buy",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 7,
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "1",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+            {
+                "event_type": "fill",
+                "executed_at": _ts(2),
+                "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+                "execution_order_event_id": "event-sell",
+                "execution_id": "execution-sell",
+                "trade_decision_id": "decision-sell",
+                "source_window_id": "window-sell",
+                "source_topic": "alpaca.trade_updates",
+                "source_partition": 0,
+                "source_offset": 8,
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "1",
+                "filled_qty_delta": "1",
+                "fill_quantity_basis": "cumulative_to_delta",
+                "avg_fill_price": "101",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+        ]
+    )
+
+    assert bucket.fill_count == 2
+    assert bucket.closed_trade_count == 1
+    assert bucket.post_cost_expectancy_bps is None
+    assert "runtime_ledger_source_materialization_missing" in bucket.blockers
+    assert "runtime_ledger_authority_class_missing" not in bucket.blockers
+
+
 def test_fill_quantity_basis_aliases_are_normalized() -> None:
     assert _coerce_fill_quantity_basis("fill-delta") == "delta"
     assert _coerce_fill_quantity_basis("cum") == "cumulative"


### PR DESCRIPTION
## Summary

- Requires promotion-grade runtime ledger source rows to carry both a source materialization marker and an authority-class marker before source refs can make a bucket authoritative.
- Keeps order-feed lifecycle rows separate from execution economics while preserving imported source-backed runtime rows by stamping `runtime_order_feed_execution_source` authority on materialized order-event ledger rows.
- Adds regression coverage for aggregate-only source rows staying blocked and authority-class-only rows failing closed on missing source materialization.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_simple_pipeline.py -q`
- `cd services/torghut && uv run --frozen ruff check app/models/entities.py app/trading/order_feed.py app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_simple_pipeline.py`
- `cd services/torghut && uv run --frozen ruff format --check app/models/entities.py app/trading/order_feed.py app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_simple_pipeline.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable because this is runtime proof plumbing; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this scoped proof-plumbing change.
