### PR TITLE
fix(torghut): separate tigerbeetle lookup failures

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -877,6 +877,8 @@ def _latest_run_payload(
         "authority": "accounting_parity_only",
         "promotion_authority": False,
         "overrides_runtime_ledger_authority": False,
+        "client_lookup_ok": bool(payload.get("client_lookup_ok", row.status == "ok")),
+        "client_error": payload.get("client_error"),
         "account_ref_count": account_ref_count,
         "transfer_ref_count": transfer_ref_count,
         "checked_transfer_count": row.checked_transfer_count,
@@ -1016,6 +1018,8 @@ def reconcile_tigerbeetle_transfers(
     legacy_source_amount_unverifiable_refs: list[dict[str, object]] = []
 
     transfer_lookup: dict[str, object] = {}
+    client_lookup_ok = True
+    client_error: str | None = None
     owned_client = client is None
     tb_client: TigerBeetleClientProtocol | None = None
     try:
@@ -1029,7 +1033,9 @@ def reconcile_tigerbeetle_transfers(
                 for item in looked_up
                 if (lookup_key := _transfer_lookup_key(item)) is not None
             }
-    except Exception:
+    except Exception as exc:
+        client_lookup_ok = False
+        client_error = f"{type(exc).__name__}: {exc}"
         blockers.append(BLOCKER_CLIENT_UNAVAILABLE)
     finally:
         if owned_client and tb_client is not None:
@@ -1051,85 +1057,90 @@ def reconcile_tigerbeetle_transfers(
                     reason="stable_ref_payload_does_not_match_transfer_ref_identity",
                 ),
             )
-        actual = transfer_lookup.get(ref_transfer_id)
-        if actual is None:
-            missing_transfer_count += 1
-            blockers.append(BLOCKER_TRANSFER_MISSING)
-            _append_sample(
-                missing_transfer_refs,
-                _ref_sample(
-                    ref,
-                    blocker=BLOCKER_TRANSFER_MISSING,
-                    reason="transfer_ref_not_found_in_tigerbeetle_lookup",
-                ),
-            )
-            continue
-        if Decimal(str(_attr(actual, "amount"))) != ref.amount:
-            mismatched_transfer_count += 1
-            blockers.append(BLOCKER_AMOUNT_MISMATCH)
-            _append_sample(
-                mismatched_refs,
-                _ref_sample(
-                    ref,
-                    blocker=BLOCKER_AMOUNT_MISMATCH,
-                    reason="actual_amount_micros_differs_from_transfer_ref",
-                    actual=actual,
-                ),
-            )
-        if int(str(_attr(actual, "code"))) != ref.code:
-            mismatched_transfer_count += 1
-            blockers.append(BLOCKER_CODE_MISMATCH)
-            _append_sample(
-                mismatched_refs,
-                _ref_sample(
-                    ref,
-                    blocker=BLOCKER_CODE_MISMATCH,
-                    reason="actual_code_differs_from_transfer_ref",
-                    actual=actual,
-                ),
-            )
-        if int(str(_attr(actual, "ledger"))) != ref.ledger:
-            mismatched_transfer_count += 1
-            blockers.append(BLOCKER_LEDGER_MISMATCH)
-            _append_sample(
-                mismatched_refs,
-                _ref_sample(
-                    ref,
-                    blocker=BLOCKER_LEDGER_MISMATCH,
-                    reason="actual_ledger_differs_from_transfer_ref",
-                    actual=actual,
-                ),
-            )
-        debit_account_id = _payload_value(ref, "debit_account_id")
-        if debit_account_id is not None and _u128_text(
-            _attr(actual, "debit_account_id")
-        ) != _u128_text(debit_account_id):
-            mismatched_transfer_count += 1
-            blockers.append(BLOCKER_DEBIT_ACCOUNT_MISMATCH)
-            _append_sample(
-                mismatched_refs,
-                _ref_sample(
-                    ref,
-                    blocker=BLOCKER_DEBIT_ACCOUNT_MISMATCH,
-                    reason="actual_debit_account_differs_from_transfer_ref_payload",
-                    actual=actual,
-                ),
-            )
-        credit_account_id = _payload_value(ref, "credit_account_id")
-        if credit_account_id is not None and _u128_text(
-            _attr(actual, "credit_account_id")
-        ) != _u128_text(credit_account_id):
-            mismatched_transfer_count += 1
-            blockers.append(BLOCKER_CREDIT_ACCOUNT_MISMATCH)
-            _append_sample(
-                mismatched_refs,
-                _ref_sample(
-                    ref,
-                    blocker=BLOCKER_CREDIT_ACCOUNT_MISMATCH,
-                    reason="actual_credit_account_differs_from_transfer_ref_payload",
-                    actual=actual,
-                ),
-            )
+        actual = transfer_lookup.get(ref_transfer_id) if client_lookup_ok else None
+        if client_lookup_ok:
+            if actual is None:
+                missing_transfer_count += 1
+                blockers.append(BLOCKER_TRANSFER_MISSING)
+                _append_sample(
+                    missing_transfer_refs,
+                    _ref_sample(
+                        ref,
+                        blocker=BLOCKER_TRANSFER_MISSING,
+                        reason="transfer_ref_not_found_in_tigerbeetle_lookup",
+                    ),
+                )
+                continue
+            if Decimal(str(_attr(actual, "amount"))) != ref.amount:
+                mismatched_transfer_count += 1
+                blockers.append(BLOCKER_AMOUNT_MISMATCH)
+                _append_sample(
+                    mismatched_refs,
+                    _ref_sample(
+                        ref,
+                        blocker=BLOCKER_AMOUNT_MISMATCH,
+                        reason="actual_amount_micros_differs_from_transfer_ref",
+                        actual=actual,
+                    ),
+                )
+            if int(str(_attr(actual, "code"))) != ref.code:
+                mismatched_transfer_count += 1
+                blockers.append(BLOCKER_CODE_MISMATCH)
+                _append_sample(
+                    mismatched_refs,
+                    _ref_sample(
+                        ref,
+                        blocker=BLOCKER_CODE_MISMATCH,
+                        reason="actual_code_differs_from_transfer_ref",
+                        actual=actual,
+                    ),
+                )
+            if int(str(_attr(actual, "ledger"))) != ref.ledger:
+                mismatched_transfer_count += 1
+                blockers.append(BLOCKER_LEDGER_MISMATCH)
+                _append_sample(
+                    mismatched_refs,
+                    _ref_sample(
+                        ref,
+                        blocker=BLOCKER_LEDGER_MISMATCH,
+                        reason="actual_ledger_differs_from_transfer_ref",
+                        actual=actual,
+                    ),
+                )
+            debit_account_id = _payload_value(ref, "debit_account_id")
+            if debit_account_id is not None and _u128_text(
+                _attr(actual, "debit_account_id")
+            ) != _u128_text(debit_account_id):
+                mismatched_transfer_count += 1
+                blockers.append(BLOCKER_DEBIT_ACCOUNT_MISMATCH)
+                _append_sample(
+                    mismatched_refs,
+                    _ref_sample(
+                        ref,
+                        blocker=BLOCKER_DEBIT_ACCOUNT_MISMATCH,
+                        reason=(
+                            "actual_debit_account_differs_from_transfer_ref_payload"
+                        ),
+                        actual=actual,
+                    ),
+                )
+            credit_account_id = _payload_value(ref, "credit_account_id")
+            if credit_account_id is not None and _u128_text(
+                _attr(actual, "credit_account_id")
+            ) != _u128_text(credit_account_id):
+                mismatched_transfer_count += 1
+                blockers.append(BLOCKER_CREDIT_ACCOUNT_MISMATCH)
+                _append_sample(
+                    mismatched_refs,
+                    _ref_sample(
+                        ref,
+                        blocker=BLOCKER_CREDIT_ACCOUNT_MISMATCH,
+                        reason=(
+                            "actual_credit_account_differs_from_transfer_ref_payload"
+                        ),
+                        actual=actual,
+                    ),
+                )
         if not _ref_matches_expected_event(
             session,
             ref,
@@ -1202,7 +1213,7 @@ def reconcile_tigerbeetle_transfers(
                 if source_uuid is not None
                 else None
             )
-            if bucket is not None:
+            if bucket is not None and actual is not None:
                 direction_matches, metadata_matches = (
                     _runtime_ledger_ref_matches_expected_bucket(ref, actual, bucket)
                 )
@@ -1434,6 +1445,8 @@ def reconcile_tigerbeetle_transfers(
         "authority": "accounting_parity_only",
         "promotion_authority": False,
         "overrides_runtime_ledger_authority": False,
+        "client_lookup_ok": client_lookup_ok,
+        "client_error": client_error,
         "account_ref_count": _payload_int(ref_counts, "account_ref_count"),
         "transfer_ref_count": _payload_int(ref_counts, "transfer_ref_count"),
         "checked_transfer_count": checked_transfer_count,

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -1453,6 +1453,11 @@ class TestTigerBeetleReconcile(TestCase):
 
             self.assertFalse(payload["ok"])
             self.assertIn(BLOCKER_CLIENT_UNAVAILABLE, payload["blockers"])
+            self.assertNotIn(BLOCKER_TRANSFER_MISSING, payload["blockers"])
+            self.assertFalse(payload["client_lookup_ok"])
+            self.assertIn("RuntimeError: lookup failed", str(payload["client_error"]))
+            self.assertEqual(payload["missing_transfer_count"], 0)
+            self.assertEqual(payload["missing_transfer_refs"], [])
 
     def test_latest_reconciliation_payload_normalizes_blockers(self) -> None:
         with Session(self.engine) as session:
@@ -1468,6 +1473,8 @@ class TestTigerBeetleReconcile(TestCase):
                     source_missing_count=0,
                     payload_json={
                         "blockers": [BLOCKER_CODE_MISMATCH, 7],
+                        "client_lookup_ok": False,
+                        "client_error": "RuntimeError: lookup failed",
                         "mismatched_ref_count": 1,
                         "missing_source_row_count": 3,
                         "unlinked_order_event_ref_count": 4,
@@ -1511,6 +1518,8 @@ class TestTigerBeetleReconcile(TestCase):
         self.assertEqual(payload["runtime_ledger_signed_ref_count"], 4)
         self.assertFalse(payload["promotion_authority"])
         self.assertFalse(payload["overrides_runtime_ledger_authority"])
+        self.assertFalse(payload["client_lookup_ok"])
+        self.assertEqual(payload["client_error"], "RuntimeError: lookup failed")
         self.assertIn("reconciliation_freshness", payload)
         self.assertEqual(payload["mismatched_ref_count"], 1)
         self.assertEqual(payload["missing_source_row_count"], 3)


### PR DESCRIPTION
## Summary

- Separates TigerBeetle protocol/client lookup failures from true missing-transfer reconciliation blockers.
- Adds reconciliation payload/readback fields for `client_lookup_ok` and `client_error` so status evidence can distinguish connectivity from ledger parity gaps.
- Keeps TigerBeetle evidence accounting-only and non-promotional while preserving source/ref diagnostics during lookup outages.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_runtime_ledger_parity.py tests/test_tigerbeetle_status.py tests/test_verify_tigerbeetle_ledger.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/tigerbeetle_client.py app/trading/tigerbeetle_ids.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_ledger_model.py app/trading/tigerbeetle_reconcile.py app/trading/tigerbeetle_runtime_ledger_parity.py scripts/audit_tigerbeetle_runtime_ledger_parity.py scripts/verify_tigerbeetle_ledger.py tests/test_tigerbeetle_client.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_runtime_ledger_parity.py tests/test_tigerbeetle_status.py tests/test_verify_tigerbeetle_ledger.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tigerbeetle_client.py app/trading/tigerbeetle_ids.py app/trading/tigerbeetle_journal.py app/trading/tigerbeetle_ledger_model.py app/trading/tigerbeetle_reconcile.py app/trading/tigerbeetle_runtime_ledger_parity.py scripts/audit_tigerbeetle_runtime_ledger_parity.py scripts/verify_tigerbeetle_ledger.py tests/test_tigerbeetle_client.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_runtime_ledger_parity.py tests/test_tigerbeetle_status.py tests/test_verify_tigerbeetle_ledger.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no separate docs were needed for this focused diagnostic payload change.
