### PR TITLE
chore(synthesis): promote image 0.589.1

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: autotrader-detail-d0c7a66e
+    newTag: 0.589.1
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promotes Synthesis from `autotrader-detail-d0c7a66e` to release image `0.589.1`.
- Uses the image built from merged commit `af81ff6491962c0ff34e9df212e6bdcf8bcf4b94`.
- Verified the published image tag exists at digest `sha256:9a4ee404c1762b29368c3b5e630cea2df1ee3d1a9bf347ac5477d702a2f027c2`.

## Related Issues

None

## Testing

- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/synthesis:0.589.1`
- `bun run lint:argocd`
- `git diff --check`
- GitHub Actions `Docker Build and Push` run `26812252412`: `success`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
