### PR TITLE
fix(torghut): avoid readiness pg indexes view

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -2450,10 +2450,15 @@ def _check_account_scope_invariants_bounded(session: Session) -> dict[str, objec
     all_index_rows = _execute_readiness_account_scope_query(
         session,
         """
-        SELECT tablename AS table_name, indexname AS index_name
-        FROM pg_catalog.pg_indexes
-        WHERE schemaname = current_schema()
-          AND tablename IN :table_names
+        SELECT tbl.relname AS table_name, idx.relname AS index_name
+        FROM pg_catalog.pg_index ix
+        JOIN pg_catalog.pg_class idx ON idx.oid = ix.indexrelid
+        JOIN pg_catalog.pg_class tbl ON tbl.oid = ix.indrelid
+        JOIN pg_catalog.pg_namespace ns ON ns.oid = tbl.relnamespace
+        WHERE ns.nspname = current_schema()
+          AND tbl.relname IN :table_names
+          AND tbl.relkind IN ('r', 'p')
+          AND idx.relkind IN ('i', 'I')
         """,
         table_names=table_names,
     )

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1763,7 +1763,7 @@ class TestTradingApi(TestCase):
                             },
                         ]
                     )
-                if "FROM pg_catalog.pg_index" in sql:
+                if "FROM pg_catalog.pg_index" in sql and "array_agg" in sql:
                     return FakeResult(
                         [
                             {
@@ -1797,7 +1797,7 @@ class TestTradingApi(TestCase):
                             },
                         ]
                     )
-                if "FROM pg_catalog.pg_indexes" in sql:
+                if "FROM pg_catalog.pg_index" in sql:
                     return FakeResult(
                         [
                             {
@@ -1828,6 +1828,7 @@ class TestTradingApi(TestCase):
         self.assertIn("SET LOCAL statement_timeout", joined_sql)
         self.assertNotIn("pg_type", joined_sql)
         self.assertNotIn("information_schema.columns", joined_sql)
+        self.assertNotIn("pg_catalog.pg_indexes", joined_sql)
 
     def test_bounded_account_scope_invariants_reports_legacy_indexes(self) -> None:
         class FakeResult:
@@ -1866,7 +1867,7 @@ class TestTradingApi(TestCase):
                             },
                         ]
                     )
-                if "FROM pg_catalog.pg_index" in sql:
+                if "FROM pg_catalog.pg_index" in sql and "array_agg" in sql:
                     return FakeResult(
                         [
                             {
@@ -1886,7 +1887,7 @@ class TestTradingApi(TestCase):
                             },
                         ]
                     )
-                if "FROM pg_catalog.pg_indexes" in sql:
+                if "FROM pg_catalog.pg_index" in sql:
                     return FakeResult(
                         [
                             {


### PR DESCRIPTION
## Summary

- Replaces the remaining account-scope readiness index-name query against `pg_catalog.pg_indexes` with direct `pg_catalog.pg_index`/`pg_class`/`pg_namespace` joins under the existing bounded readiness statement timeout.
- Preserves the account-scope invariant truth table and legacy-index diagnostics while avoiding the expensive PostgreSQL view observed in production `/readyz` payloads.
- Updates focused trading API readiness tests to verify the bounded catalog path does not use `pg_catalog.pg_indexes`.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q -k 'bounded_account_scope_invariants or database_contract_fails_closed_on_account_scope_timeout or readyz_evaluation_timeout or readyz_timeout_uses_cached_dependency_contract_shape'`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_trading_api.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
