### PR TITLE
fix(torghut): skip empty runtime journal reconciliation

### DIFF
--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -992,6 +992,7 @@ def main() -> int:
     batches: list[dict[str, Any]] = []
     reconciliation: dict[str, object] | None = None
     stop_journaling = False
+    selected_source_rows = 0
 
     with (
         session_factory() as session,
@@ -1100,7 +1101,9 @@ def main() -> int:
                 session.rollback()
                 _reset_session_identity_map(session)
                 break
-            if not stop_journaling:
+            iteration_selected_rows = sum(batch_lengths)
+            selected_source_rows += iteration_selected_rows
+            if not stop_journaling and iteration_selected_rows > 0:
                 stable_ref_backfill = journal.backfill_stable_ref_payloads(
                     session,
                     limit=batch_size,
@@ -1130,7 +1133,12 @@ def main() -> int:
             if batch_lengths and all(length < batch_size for length in batch_lengths):
                 break
 
-        if not args.dry_run and not args.skip_reconcile and not stop_journaling:
+        if (
+            not args.dry_run
+            and not args.skip_reconcile
+            and not stop_journaling
+            and selected_source_rows > 0
+        ):
             reconciliation = reconcile_tigerbeetle_transfers(
                 session,
                 settings_obj=settings_obj,
@@ -1139,6 +1147,12 @@ def main() -> int:
                 persist=True,
             )
             session.commit()
+        elif not args.dry_run and not args.skip_reconcile and not stop_journaling:
+            reconciliation = {
+                "ok": True,
+                "status": "skipped",
+                "reason": "no_source_rows_selected",
+            }
 
     payload = _payload(
         args=args,

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -151,6 +151,7 @@ class FakeJournal:
         self.executions: list[str] = []
         self.tca_metrics: list[str] = []
         self.runtime_buckets: list[str] = []
+        self.stable_ref_backfills = 0
         self.reconciliation_client = SimpleNamespace(name="shared-tigerbeetle-client")
         self.closed = False
         FakeJournal.instances.append(self)
@@ -214,6 +215,7 @@ class FakeJournal:
         limit: int = 1000,
     ) -> dict[str, object]:
         del session, limit
+        self.stable_ref_backfills += 1
         return {"selected": 0, "updated": 0, "skipped": 0}
 
 
@@ -1724,6 +1726,53 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(FakeJournal.instances[0].executions, [])
         self.assertEqual(FakeJournal.instances[0].tca_metrics, ["AAPL"])
         self.assertEqual(FakeJournal.instances[0].runtime_buckets, [])
+        reconcile.assert_not_called()
+
+    def test_main_skips_backfill_and_reconcile_when_source_selects_no_rows(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--sources",
+                        "strategy_runtime_ledger_bucket",
+                        "--batch-size",
+                        "5",
+                        "--fail-on-degraded",
+                        "--allow-data-quality-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script, "reconcile_tigerbeetle_transfers") as reconcile,
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["selected"], 0)
+        self.assertEqual(payload["journaled"], 0)
+        self.assertEqual(payload["failed"], 0)
+        self.assertEqual(payload["reconciliation"]["status"], "skipped")
+        self.assertEqual(payload["reconciliation"]["reason"], "no_source_rows_selected")
+        self.assertEqual(FakeJournal.instances[0].runtime_buckets, [])
+        self.assertEqual(FakeJournal.instances[0].stable_ref_backfills, 0)
         reconcile.assert_not_called()
 
     def test_main_dry_run_rolls_back_without_reconcile(self) -> None:


### PR DESCRIPTION
## Summary

- Skip TigerBeetle stable-ref backfill and reconciliation when a journal source slice selects zero source rows.
- Emit an explicit non-authoritative skipped reconciliation payload with reason `no_source_rows_selected`.
- Add regression coverage for the scheduled runtime-ledger bucket source when it selects zero rows.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py::TestJournalTigerBeetleOrderEventsScript::test_main_skips_backfill_and_reconcile_when_source_selects_no_rows -q`
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py -q`
- `uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m coverage run -m pytest tests/test_journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py -q`
- `uv run --frozen python -m coverage xml -o coverage.xml --fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check origin/main..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
