### PR TITLE
fix(synthesis): simplify autotrader artifacts

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -576,12 +576,6 @@ spec:
     - name: autonomous-trader-report
       path: /workspace/.agentrun/autonomous-trader/report.md
       key: synthesis/autonomous-trader/{{ agentRun.name }}/report.md
-    - name: autonomous-trader-analysis-bootstrap
-      path: /workspace/.agentrun/autonomous-trader/analysis-bootstrap.json
-      key: synthesis/autonomous-trader/{{ agentRun.name }}/analysis-bootstrap.json
-    - name: autonomous-trader-analysis-context
-      path: /workspace/.agentrun/autonomous-trader/analysis-context.json
-      key: synthesis/autonomous-trader/{{ agentRun.name }}/analysis-context.json
     - name: runner-log
       path: /workspace/.agent/runner.log
     - name: runner-status

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -47,7 +47,7 @@ spec:
     Runtime state contract:
     - Alpaca MCP is broker truth.
     - Synthesis autotrader MCP/API is trader runtime truth.
-    - Local files are not trader state. Do not create or backfill JSON/JSONL ledgers. The runner collects analysis bootstrap/context metadata separately; write only `/workspace/.agentrun/autonomous-trader/report.md` as the final human summary.
+    - Local files are not trader state. Do not create or backfill JSON/JSONL ledgers. Analysis bootstrap/context JSON files are temporary validation inputs only; write `/workspace/.agentrun/autonomous-trader/report.md` as the operator-facing trader artifact.
 
     Bootstrap and preflight:
     1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -18,7 +18,7 @@ data:
     Source of truth:
     - Alpaca MCP is broker truth for account, clock, calendar, market data, positions, orders, fills, and mutations.
     - Synthesis MCP autotrader tools are runtime truth for sessions, status, events, tickets, risk, orders, fills, positions, finalization, and scorecards.
-    - Local artifacts are not trader state. Do not create or backfill JSON/JSONL runtime ledgers. Write only the final `report.md`; analysis bootstrap/context metadata is setup evidence collected separately.
+    - Local artifacts are not trader state. Do not create or backfill JSON/JSONL runtime ledgers. Write only `report.md` as the operator-facing trader artifact; analysis bootstrap/context JSON files are temporary validation inputs, not outputs to maintain or cite as runtime state.
 
     Identity and mode:
     - Read `AGENT_RUN_NAME` and use it unchanged for session identity, deterministic broker client order ids, milestone URLs, dedupe keys, and report fields.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -757,13 +757,9 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(bootstrap, 'content')).toContain('daytrading-context')
     expect(objectAt(bootstrap, 'content')).toContain('daytrading-validate-context')
     expect(objectAt(bootstrap, 'content')).toContain('analysis-bootstrap.json')
-    expect(artifactNames).toEqual([
-      'autonomous-trader-report',
-      'autonomous-trader-analysis-bootstrap',
-      'autonomous-trader-analysis-context',
-      'runner-log',
-      'runner-status',
-    ])
+    expect(artifactNames).toEqual(['autonomous-trader-report', 'runner-log', 'runner-status'])
+    expect(artifactNames).not.toContain('autonomous-trader-analysis-bootstrap')
+    expect(artifactNames).not.toContain('autonomous-trader-analysis-context')
     expect(objectAt(objectAt(objectAt(vcsProvider, 'spec'), 'repositoryPolicy'), 'allow')).toContain(
       'gregkonush/analysis',
     )


### PR DESCRIPTION
## Summary

- Removes the uploaded `analysis-bootstrap.json` and `analysis-context.json` artifacts from the autonomous-trader AgentProvider.
- Keeps analysis JSON generation as temporary bootstrap validation input, while making `report.md` the only operator-facing trader artifact.
- Updates the autonomous-trader prompt/spec wording and smoke test to enforce the simpler artifact contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "wires the analysis daytrading bootstrap into the trader provider"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
