### PR TITLE
ci(torghut): skip flaky remote build cache export

### DIFF
--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -84,8 +84,10 @@ jobs:
         env:
           TORGHUT_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
           TORGHUT_IMAGE_PLATFORMS: linux/arm64
-          TORGHUT_IMAGE_CACHE_REF: registry.ide-newton.ts.net/lab/torghut:buildcache
-          DOCKER_BUILD_CACHE_MODE: max
+          # Remote cache export has intermittently canceled after the image push,
+          # before the release contract can be written. Keep the image contract
+          # path authoritative and skip the cache until the exporter is stable.
+          TORGHUT_IMAGE_CACHE_REF: none
         run: bun run packages/scripts/src/torghut/build-image.ts
 
       - name: Resolve pushed image digest


### PR DESCRIPTION
## Summary

- Disable Torghut registry cache export in `torghut-build-push` by setting `TORGHUT_IMAGE_CACHE_REF=none`.
- Preserve the normal buildx image push, digest resolution, release contract artifact, and latest-tag steps.
- Document the observed failure mode where remote cache export completed but the job was canceled before the release contract step.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/torghut-build-push.yaml`
- `git diff --check`
- `actionlint .github/workflows/torghut-build-push.yaml` reports the existing custom `arc-arm64` runner label only.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
