### PR TITLE
test(synthesis): guard autotrader codex config args

### DIFF
--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -825,6 +825,9 @@ describe('synthesis autonomous trader provider', () => {
     const bridge = (inputFiles ?? []).find(
       (inputFile) => objectAt(inputFile, 'path') === '/root/alpaca-mcp-stdio-bridge.py',
     )
+    const alpacaBridgeArgs = objectAt(codexConfig, 'content')
+      .split('\n')
+      .filter((line) => line.trim() === 'args = ["-u", "/root/alpaca-mcp-stdio-bridge.py"]')
 
     expect(objectAt(alpaca, 'command')).toBe('/usr/bin/python3')
     expect(objectAt(alpaca, 'args')).toEqual(['-u', '/root/alpaca-mcp-stdio-bridge.py'])
@@ -837,6 +840,7 @@ describe('synthesis autonomous trader provider', () => {
     )
     expect(objectAt(codexConfig, 'content')).toContain('command = "/usr/bin/python3"')
     expect(objectAt(codexConfig, 'content')).toContain('args = ["-u", "/root/alpaca-mcp-stdio-bridge.py"]')
+    expect(alpacaBridgeArgs).toHaveLength(1)
     expect(objectAt(codexConfig, 'content')).toContain('startup_timeout_sec = 60.0')
     expect(objectAt(codexConfig, 'content')).toContain(
       'AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED = "{{ env.AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED }}"',


### PR DESCRIPTION
## Summary

- Adds a smoke-test guard that the embedded autonomous-trader Codex config contains exactly one Alpaca MCP bridge `args` line.
- Protects the market-open runner from ambiguous TOML caused by duplicate MCP config keys.
- Leaves runtime manifests unchanged because current `origin/main` already contains a single Alpaca bridge args entry.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "bridges Codex framed MCP stdio to Alpaca newline stdio"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `git diff --check -- packages/scripts/src/agents/__tests__/smoke-agents.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
