### PR TITLE
fix(torghut): bypass optional account scope timeouts

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -2342,7 +2342,7 @@ def _resolve_universe_resolver_for_readiness(scheduler: TradingScheduler) -> Any
     return None
 
 
-_ACCOUNT_SCOPE_STATEMENT_TIMEOUT_MS = 750
+_ACCOUNT_SCOPE_STATEMENT_TIMEOUT_MS = 150
 
 
 def _execute_readiness_account_scope_query(
@@ -2613,7 +2613,6 @@ def _evaluate_database_contract(session: Session) -> dict[str, object]:
 
     try:
         schema_status = check_schema_current(session)
-        account_scope_status = _check_account_scope_invariants_bounded(session)
     except SQLAlchemyError as exc:
         return {
             "ok": False,
@@ -2639,14 +2638,38 @@ def _evaluate_database_contract(session: Session) -> dict[str, object]:
             "account_scope_errors": [str(exc)],
         }
 
+    try:
+        account_scope_status = _check_account_scope_invariants_bounded(session)
+    except (SQLAlchemyError, RuntimeError) as exc:
+        account_scope_status = {
+            "account_scope_ready": False,
+            "account_scope_errors": [str(exc)],
+            "account_scope_check_mode": "bounded_catalog",
+            "account_scope_check_failed": True,
+        }
+
     account_scope_checks = dict(account_scope_status)
     account_scope_warnings: list[str] = []
     if not settings.trading_multi_account_enabled:
+        raw_account_scope_errors = [
+            str(error)
+            for error in cast(
+                list[object],
+                account_scope_checks.get("account_scope_errors", []),
+            )
+        ]
         account_scope_checks["account_scope_ready"] = True
         account_scope_checks["account_scope_errors"] = []
         account_scope_warnings.append(
             "account scope checks are bypassed when trading_multi_account_enabled is false"
         )
+        if account_scope_checks.get("account_scope_check_failed"):
+            account_scope_checks["account_scope_bypassed_errors"] = (
+                raw_account_scope_errors
+            )
+            account_scope_warnings.append(
+                "account scope catalog check failed but is non-blocking while trading_multi_account_enabled is false"
+            )
 
     schema_current = bool(schema_status.get("schema_current"))
     account_scope_ready = bool(account_scope_checks.get("account_scope_ready"))

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -1959,16 +1959,62 @@ class TestTradingApi(TestCase):
         self,
         _mock_check: object,
     ) -> None:
-        with patch(
-            "app.main._check_account_scope_invariants_bounded",
-            side_effect=SQLAlchemyError("canceling statement due to statement timeout"),
-        ):
-            payload = main_module._evaluate_database_contract(object())  # type: ignore[arg-type]
+        original_multi = settings.trading_multi_account_enabled
+        settings.trading_multi_account_enabled = True
+        try:
+            with patch(
+                "app.main._check_account_scope_invariants_bounded",
+                side_effect=SQLAlchemyError(
+                    "canceling statement due to statement timeout"
+                ),
+            ):
+                payload = main_module._evaluate_database_contract(object())  # type: ignore[arg-type]
+        finally:
+            settings.trading_multi_account_enabled = original_multi
 
         self.assertFalse(payload["ok"])
         self.assertFalse(payload["account_scope_ready"])
         self.assertIn("statement timeout", payload["account_scope_errors"][0])
-        self.assertEqual(payload["schema_current"], False)
+        self.assertEqual(payload["schema_current"], True)
+
+    @patch(
+        "app.main.check_schema_current",
+        return_value={
+            "schema_current": True,
+            "current_heads": ["0011_execution_tca_simulator_divergence"],
+            "expected_heads": ["0011_execution_tca_simulator_divergence"],
+            "schema_head_signature": "7f8e4d0",
+            "schema_missing_heads": [],
+            "schema_unexpected_heads": [],
+            "schema_head_count_expected": 1,
+            "schema_head_count_current": 1,
+            "schema_head_delta_count": 0,
+        },
+    )
+    def test_database_contract_bypasses_account_scope_timeout_when_disabled(
+        self,
+        _mock_check: object,
+    ) -> None:
+        original_multi = settings.trading_multi_account_enabled
+        settings.trading_multi_account_enabled = False
+        try:
+            with patch(
+                "app.main._check_account_scope_invariants_bounded",
+                side_effect=SQLAlchemyError(
+                    "canceling statement due to statement timeout"
+                ),
+            ):
+                payload = main_module._evaluate_database_contract(object())  # type: ignore[arg-type]
+        finally:
+            settings.trading_multi_account_enabled = original_multi
+
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["account_scope_ready"])
+        self.assertEqual(payload["account_scope_errors"], [])
+        self.assertIn(
+            "account scope catalog check failed but is non-blocking",
+            " ".join(payload["account_scope_warnings"]),
+        )
 
     @patch(
         "app.main.check_schema_current",


### PR DESCRIPTION
## Summary

- Splits Torghut schema readiness from optional account-scope catalog diagnostics so schema health stays honest when the non-required account-scope query times out.
- Lowers the bounded account-scope catalog statement timeout to 150ms and preserves fail-closed behavior when multi-account trading is enabled.
- Keeps repair-only/single-account deployments from failing database readiness on non-blocking account-scope catalog timeouts while preserving the timed-out diagnostic as a machine-readable warning.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q -k 'account_scope_timeout or bounded_account_scope_invariants or db_check_allows_account_scope_issues_when_multi_account_disabled'`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_trading_api.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
