### PR TITLE
fix(torghut): preserve bounded signed runtime refs

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -541,12 +541,46 @@ def _runtime_ledger_ref_coverage(
         .all()
     )
     if not full_ref_scan:
+        runtime_refs = sample_refs
+        exact_ref_coverage = runtime_ref_count <= len(runtime_refs)
+        current_runtime_refs: list[TigerBeetleTransferRef] = []
+        signed_refs: list[TigerBeetleTransferRef] = []
+        signed_bucket_ids: set[str] = set()
+        if exact_ref_coverage:
+            current_bucket_ids = {
+                str(bucket_id)
+                for bucket_id in session.execute(
+                    select(StrategyRuntimeLedgerBucket.id).where(
+                        (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
+                        | (StrategyRuntimeLedgerBucket.cost_amount != 0)
+                    )
+                ).scalars()
+            }
+            current_runtime_refs = [
+                ref
+                for ref in runtime_refs
+                if (
+                    ref.runtime_ledger_bucket_id is not None
+                    and str(ref.runtime_ledger_bucket_id) in current_bucket_ids
+                )
+                or (ref.source_id is not None and ref.source_id in current_bucket_ids)
+            ]
+            signed_refs = [
+                ref
+                for ref in current_runtime_refs
+                if _runtime_ledger_ref_is_signed(ref)
+            ]
+            signed_bucket_ids = {
+                str(ref.runtime_ledger_bucket_id or ref.source_id)
+                for ref in signed_refs
+                if ref.runtime_ledger_bucket_id is not None or ref.source_id
+            }
         runtime_source_ids = [
-            str(ref.source_id) for ref in sample_refs if ref.source_id is not None
+            str(ref.source_id) for ref in runtime_refs if ref.source_id is not None
         ]
-        runtime_transfer_ids = [str(ref.transfer_id) for ref in sample_refs]
+        runtime_transfer_ids = [str(ref.transfer_id) for ref in runtime_refs]
         runtime_account_ids: list[str] = []
-        for ref in sample_refs:
+        for ref in current_runtime_refs if exact_ref_coverage else runtime_refs:
             for account_id in _runtime_ledger_payload_account_ids(ref):
                 if account_id not in runtime_account_ids:
                     runtime_account_ids.append(account_id)
@@ -568,24 +602,35 @@ def _runtime_ledger_ref_coverage(
             for account_id in runtime_account_ids
             if account_id not in account_ref_ids
         ]
-        return {
-            "runtime_ledger_required_bucket_count": required_runtime_bucket_count,
-            "runtime_ledger_ref_count": runtime_ref_count,
-            "runtime_ledger_signed_ref_count": 0,
-            "runtime_ledger_missing_signed_ref_count": max(
+        missing_signed_ref_count = (
+            max(
+                required_runtime_bucket_count - len(signed_bucket_ids),
+                len(current_runtime_refs) - len(signed_refs),
+                0,
+            )
+            if exact_ref_coverage
+            else max(
                 required_runtime_bucket_count,
                 runtime_ref_count,
                 0,
-            ),
+            )
+        )
+        return {
+            "runtime_ledger_required_bucket_count": required_runtime_bucket_count,
+            "runtime_ledger_ref_count": runtime_ref_count,
+            "runtime_ledger_signed_ref_count": len(signed_refs),
+            "runtime_ledger_missing_signed_ref_count": missing_signed_ref_count,
             "runtime_ledger_account_ref_count": len(runtime_account_ids)
             - len(missing_account_ids),
             "runtime_ledger_missing_account_ref_count": len(missing_account_ids),
             "runtime_ledger_missing_account_ids": missing_account_ids[:sample_limit],
             "runtime_ledger_source_ids": runtime_source_ids,
             "runtime_ledger_transfer_ids": runtime_transfer_ids,
-            "runtime_ledger_signed_bucket_ids": [],
-            "runtime_ledger_ref_coverage_bounded": True,
-            "runtime_ledger_ref_sample_size": len(sample_refs),
+            "runtime_ledger_signed_bucket_ids": sorted(signed_bucket_ids)[
+                :sample_limit
+            ],
+            "runtime_ledger_ref_coverage_bounded": not exact_ref_coverage,
+            "runtime_ledger_ref_sample_size": len(runtime_refs),
         }
 
     runtime_refs = sample_refs

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -958,6 +958,54 @@ class TestTigerBeetleReconcile(TestCase):
             "strategy_runtime_ledger_buckets",
         )
 
+    def test_bounded_ref_counts_preserve_signed_runtime_refs_when_sample_exact(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket(net_pnl=Decimal("2.50"))
+            session.add(bucket)
+            session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            _add_account_refs_for_plan(session, plan)
+            transfer = plan.transfer_spec
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(transfer.transfer_id),
+                    transfer_kind=transfer.transfer_kind,
+                    ledger=transfer.ledger,
+                    code=transfer.code,
+                    amount=Decimal(transfer.amount),
+                    status="created",
+                    runtime_ledger_bucket_id=bucket.id,
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id=str(bucket.id),
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "signed_amount_micros": plan.signed_amount_micros,
+                        "pnl_direction": plan.pnl_direction,
+                        "debit_account_id": str(transfer.debit_account_id),
+                        "credit_account_id": str(transfer.credit_account_id),
+                    },
+                )
+            )
+            session.flush()
+
+            payload = tigerbeetle_ref_counts(
+                session,
+                cluster_id=2001,
+                full_ref_scan=False,
+            )
+
+        self.assertEqual(payload["runtime_ledger_ref_count"], 1)
+        self.assertEqual(payload["runtime_ledger_signed_ref_count"], 1)
+        self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 0)
+        self.assertEqual(payload["runtime_ledger_missing_account_ref_count"], 0)
+        self.assertEqual(payload["runtime_ledger_signed_bucket_ids"], [str(bucket.id)])
+        self.assertFalse(payload["runtime_ledger_ref_coverage_bounded"])
+
     def test_reconciliation_blocks_runtime_ledger_signed_direction_mismatch(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Preserve signed runtime-ledger ref counts in the bounded TigerBeetle status path when the bounded sample covers every runtime-ledger ref.
- Keep the existing fail-closed missing-signed-ref behavior when bounded status only has a partial runtime-ledger sample.
- Add a regression test for bounded ref counts with signed runtime-ledger bucket refs.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_status.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -k "tigerbeetle or live_submission_gate_matches_status_health_and_readyz" -q`
- `uv run --frozen ruff check app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_reconcile.py`
- `uv run --frozen ruff format --check app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_reconcile.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
