### PR TITLE
fix(torghut): materialize hpairs source evidence refs

### DIFF
--- a/services/torghut/app/trading/execution.py
+++ b/services/torghut/app/trading/execution.py
@@ -96,6 +96,96 @@ _RUNTIME_COST_BASIS_KEYS = (
     "commission_basis",
     "broker_fee_basis",
 )
+_BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE = "bounded_paper_route_collection"
+_TARGET_PLAN_SOURCE_DECISION_MODE = "paper_route_target_plan_source_decision"
+_TARGET_PLAN_SOURCE_DECISION_REQUIRED_REFS = (
+    "hypothesis_id",
+    "candidate_id",
+    "runtime_strategy_name",
+    "account_label",
+    "observed_stage",
+)
+
+
+def _mapping_payload(value: object) -> dict[str, Any]:
+    coerced = coerce_json_payload(value)
+    if not isinstance(coerced, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[object, Any], coerced).items()}
+
+
+def _target_plan_source_metadata(payload: object) -> dict[str, Any]:
+    payload_mapping = _mapping_payload(payload)
+    params = _mapping_payload(payload_mapping.get("params"))
+    metadata = _mapping_payload(params.get("paper_route_target_plan_source_decision"))
+    if metadata:
+        return metadata
+    return _mapping_payload(params.get("paper_route_target_plan"))
+
+
+def _target_plan_source_decision_mode(payload: object) -> str | None:
+    payload_mapping = _mapping_payload(payload)
+    params = _mapping_payload(payload_mapping.get("params"))
+    metadata = _target_plan_source_metadata(payload_mapping)
+    for item in (
+        params.get("source_decision_mode"),
+        metadata.get("source_decision_mode"),
+        payload_mapping.get("source_decision_mode"),
+    ):
+        text = str(item or "").strip()
+        if text:
+            return text
+    return None
+
+
+def _target_plan_ref_value(payload: object, key: str) -> str | None:
+    payload_mapping = _mapping_payload(payload)
+    params = _mapping_payload(payload_mapping.get("params"))
+    metadata = _target_plan_source_metadata(payload_mapping)
+    for item in (params.get(key), metadata.get(key), payload_mapping.get(key)):
+        text = str(item or "").strip()
+        if text:
+            return text
+    return None
+
+
+def _has_target_plan_source_decision(payload: object) -> bool:
+    metadata = _target_plan_source_metadata(payload)
+    return str(metadata.get("mode") or "").strip() == _TARGET_PLAN_SOURCE_DECISION_MODE
+
+
+def _target_plan_source_decision_needs_refresh(
+    existing_payload: object,
+    new_payload: object,
+) -> bool:
+    """Return true when an idempotent target-plan decision row lacks source refs.
+
+    ``decision_hash`` intentionally ignores telemetry, so a pre-existing planned
+    row can otherwise shadow a newer bounded H-PAIRS target-plan decision that
+    carries the durable hypothesis/candidate/runtime/account/stage refs needed
+    for downstream source evidence.
+    """
+
+    if not _has_target_plan_source_decision(new_payload):
+        return False
+    if (
+        _target_plan_source_decision_mode(new_payload)
+        != _BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+    ):
+        return False
+    if not _has_target_plan_source_decision(existing_payload):
+        return True
+    if (
+        _target_plan_source_decision_mode(existing_payload)
+        != _BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+    ):
+        return True
+    for key in _TARGET_PLAN_SOURCE_DECISION_REQUIRED_REFS:
+        new_value = _target_plan_ref_value(new_payload, key)
+        existing_value = _target_plan_ref_value(existing_payload, key)
+        if new_value and existing_value != new_value:
+            return True
+    return False
 
 
 class OrderExecutor:
@@ -131,6 +221,19 @@ class OrderExecutor:
         )
         existing = session.execute(stmt).scalar_one_or_none()
         if existing:
+            decision_payload = coerce_json_payload(decision.model_dump(mode="json"))
+            if _target_plan_source_decision_needs_refresh(
+                existing.decision_json,
+                decision_payload,
+            ):
+                existing.decision_json = decision_payload
+                existing.rationale = decision.rationale
+                existing.strategy_id = strategy.id
+                existing.symbol = decision.symbol
+                existing.timeframe = decision.timeframe
+                session.add(existing)
+                session.commit()
+                session.refresh(existing)
             return existing
 
         decision_payload = coerce_json_payload(decision.model_dump(mode="json"))

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -23,6 +23,7 @@ from ..models import (
     Execution,
     ExecutionOrderEvent,
     ExecutionTCAMetric,
+    OrderFeedSourceWindow,
     PositionSnapshot,
     RejectedSignalOutcomeEvent,
     Strategy,
@@ -2970,28 +2971,40 @@ def _unavailable_source_activity(
         "execution_refs": [],
         "order_lifecycle_refs": [],
         "tca_metric_refs": [],
+        "source_window_refs": [],
+        "source_offset_refs": [],
         "source_reference_blockers": [
             "source_execution_refs_missing",
             "source_order_lifecycle_refs_missing",
             "source_explicit_costs_missing",
         ],
+        "source_window_blockers": [],
         "submitted_order_blockers": [
             "source_submitted_orders_missing",
             "source_execution_refs_missing",
         ],
         "decision_count": lineage_matched_decision_count,
+        "source_decision_count": lineage_matched_decision_count,
+        "target_plan_source_decision_count": 0,
+        "source_decision_mode_counts": {},
         "execution_count": 0,
+        "linked_execution_count": 0,
         "filled_execution_count": 0,
         "order_event_count": 0,
+        "linked_order_lifecycle_count": 0,
         "fill_order_event_count": 0,
         "complete_fill_order_event_count": 0,
         "tca_sample_count": 0,
+        "explicit_cost_tca_count": 0,
+        "source_window_count": 0,
+        "linked_source_window_count": 0,
         "readback_state": "query_unavailable",
         "stage_presence": {
             "source_decisions_present": raw_decision_count > 0,
             "submitted_lifecycle_present": False,
             "fills_present": False,
             "source_refs_present": False,
+            "source_windows_present": False,
             "runtime_execution_economics_present": False,
         },
         "query_limits": {
@@ -3096,6 +3109,38 @@ def _source_decision_rejection_summary(
         ],
         "blockers": blockers,
     }
+
+
+def _trade_decision_source_decision_mode(row: TradeDecision) -> str:
+    payload = _as_mapping(row.decision_json)
+    params = _as_mapping(payload.get("params"))
+    metadata = _as_mapping(params.get("paper_route_target_plan_source_decision"))
+    if not metadata:
+        metadata = _as_mapping(params.get("paper_route_target_plan"))
+    mode = (
+        _safe_text(payload.get("source_decision_mode"))
+        or _safe_text(params.get("source_decision_mode"))
+        or _safe_text(metadata.get("source_decision_mode"))
+    )
+    return normalize_source_decision_mode(mode) or "missing"
+
+
+def _trade_decision_is_target_plan_source_decision(row: TradeDecision) -> bool:
+    payload = _as_mapping(row.decision_json)
+    params = _as_mapping(payload.get("params"))
+    metadata = _as_mapping(params.get("paper_route_target_plan_source_decision"))
+    if not metadata:
+        metadata = _as_mapping(params.get("paper_route_target_plan"))
+    return _safe_text(metadata.get("mode")) == "paper_route_target_plan_source_decision"
+
+
+def _source_decision_mode_counts(
+    decision_rows: Sequence[TradeDecision],
+) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for row in decision_rows:
+        counts[_trade_decision_source_decision_mode(row)] += 1
+    return dict(sorted(counts.items()))
 
 
 def _source_activity_lifecycle_summary(
@@ -3204,6 +3249,38 @@ def _source_activity_lifecycle_summary(
     }
 
 
+def _order_event_source_offset_refs(
+    order_event_rows: Sequence[ExecutionOrderEvent],
+) -> list[dict[str, object]]:
+    refs: list[dict[str, object]] = []
+    seen: set[tuple[str, int, int]] = set()
+    for row in order_event_rows:
+        topic = _safe_text(row.source_topic)
+        partition = row.source_partition
+        offset = row.source_offset
+        if topic is None or partition is None or offset is None:
+            continue
+        key = (topic, int(partition), int(offset))
+        if key in seen:
+            continue
+        seen.add(key)
+        refs.append(
+            {"topic": topic, "partition": int(partition), "offset": int(offset)}
+        )
+        if len(refs) >= PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT:
+            break
+    return refs
+
+
+def _source_window_refs(
+    source_window_rows: Sequence[OrderFeedSourceWindow],
+) -> list[str]:
+    return [
+        str(row.id)
+        for row in source_window_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
+    ]
+
+
 def _source_activity_readback_state(
     *,
     decision_count: int,
@@ -3261,26 +3338,38 @@ def _strategy_source_activity(
             "execution_refs": [],
             "order_lifecycle_refs": [],
             "tca_metric_refs": [],
+            "source_window_refs": [],
+            "source_offset_refs": [],
             "source_reference_blockers": [
                 "source_decision_refs_missing",
                 "source_execution_refs_missing",
                 "source_order_lifecycle_refs_missing",
                 "source_explicit_costs_missing",
             ],
+            "source_window_blockers": [],
             "submitted_order_blockers": ["source_submitted_orders_missing"],
             "decision_count": 0,
+            "source_decision_count": 0,
+            "target_plan_source_decision_count": 0,
+            "source_decision_mode_counts": {},
             "execution_count": 0,
+            "linked_execution_count": 0,
             "filled_execution_count": 0,
             "order_event_count": 0,
+            "linked_order_lifecycle_count": 0,
             "fill_order_event_count": 0,
             "complete_fill_order_event_count": 0,
             "tca_sample_count": 0,
+            "explicit_cost_tca_count": 0,
+            "source_window_count": 0,
+            "linked_source_window_count": 0,
             "readback_state": "no_source_activity",
             "stage_presence": {
                 "source_decisions_present": False,
                 "submitted_lifecycle_present": False,
                 "fills_present": False,
                 "source_refs_present": False,
+                "source_windows_present": False,
                 "runtime_execution_economics_present": False,
             },
             "query_limits": {
@@ -3495,6 +3584,45 @@ def _strategy_source_activity(
             )
     else:
         order_event_truncated = False
+    source_window_rows: list[OrderFeedSourceWindow] = []
+    if order_event_rows:
+        source_window_ids = sorted(
+            {
+                row.source_window_id
+                for row in order_event_rows
+                if row.source_window_id is not None
+            }
+        )
+        if source_window_ids:
+            try:
+                _maybe_set_paper_route_audit_statement_timeout(session)
+                source_window_rows = list(
+                    session.execute(
+                        select(OrderFeedSourceWindow)
+                        .where(OrderFeedSourceWindow.id.in_(source_window_ids))
+                        .order_by(OrderFeedSourceWindow.window_ended_at.desc())
+                        .limit(PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT)
+                    ).scalars()
+                )
+            except SQLAlchemyError as exc:
+                _rollback_after_source_activity_error(
+                    session,
+                    source="order_feed_source_windows",
+                    exc=exc,
+                )
+                return _unavailable_source_activity(
+                    strategy_name=strategy_name,
+                    strategy_lookup_names=strategy_filters,
+                    account_label=account_label,
+                    symbols=symbol_filters,
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                    require_source_lineage=require_source_lineage,
+                    source="order_feed_source_windows",
+                    missing_reason="source_windows_unavailable",
+                    raw_decision_count=raw_decision_count,
+                    lineage_matched_decision_count=len(decision_rows),
+                )
     tca_rows: list[ExecutionTCAMetric] = []
     if decision_ids:
         tca_stmt = (
@@ -3608,6 +3736,19 @@ def _strategy_source_activity(
     complete_fill_order_event_count = sum(
         int(_order_event_has_complete_fill_lifecycle(row)) for row in order_event_rows
     )
+    source_window_count = len(source_window_rows)
+    source_offset_refs = _order_event_source_offset_refs(order_event_rows)
+    source_window_reference_count = len(
+        {
+            row.source_window_id
+            for row in order_event_rows
+            if row.source_window_id is not None
+        }
+    )
+    target_plan_source_decision_count = sum(
+        int(_trade_decision_is_target_plan_source_decision(row))
+        for row in decision_rows
+    )
     decision_rejection_summary = _source_decision_rejection_summary(decision_rows)
     decision_reject_blockers = _unique_text_items(
         decision_rejection_summary.get("blockers")
@@ -3649,6 +3790,7 @@ def _strategy_source_activity(
     tca_metric_refs = [
         str(row.id) for row in tca_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT]
     ]
+    source_window_refs = _source_window_refs(source_window_rows)
     source_reference_blockers = _unique_text_items(
         [
             *(["source_decision_refs_missing"] if not decision_refs else []),
@@ -3659,6 +3801,20 @@ def _strategy_source_activity(
                 else []
             ),
             *(["source_explicit_costs_missing"] if not tca_metric_refs else []),
+        ]
+    )
+    source_window_blockers = _unique_text_items(
+        [
+            *(
+                ["source_window_refs_missing"]
+                if order_lifecycle_refs and not source_window_refs
+                else []
+            ),
+            *(
+                ["source_offsets_missing"]
+                if order_lifecycle_refs and not source_offset_refs
+                else []
+            ),
         ]
     )
     submitted_order_blockers = _unique_text_items(
@@ -3727,15 +3883,26 @@ def _strategy_source_activity(
         "execution_refs": execution_refs,
         "order_lifecycle_refs": order_lifecycle_refs,
         "tca_metric_refs": tca_metric_refs,
+        "source_window_refs": source_window_refs,
+        "source_offset_refs": source_offset_refs,
         "source_reference_blockers": source_reference_blockers,
+        "source_window_blockers": source_window_blockers,
         "submitted_order_blockers": submitted_order_blockers,
         "decision_count": decision_count,
+        "source_decision_count": decision_count,
+        "target_plan_source_decision_count": target_plan_source_decision_count,
+        "source_decision_mode_counts": _source_decision_mode_counts(decision_rows),
         "execution_count": execution_count,
+        "linked_execution_count": execution_count,
         "filled_execution_count": filled_execution_count,
         "order_event_count": order_event_count,
+        "linked_order_lifecycle_count": order_event_count,
         "fill_order_event_count": fill_order_event_count,
         "complete_fill_order_event_count": complete_fill_order_event_count,
         "tca_sample_count": tca_sample_count,
+        "explicit_cost_tca_count": tca_sample_count,
+        "source_window_count": source_window_count,
+        "linked_source_window_count": source_window_reference_count,
         "submitted_order_count": execution_count,
         "readback_state": readback_state,
         "stage_presence": {
@@ -3749,7 +3916,10 @@ def _strategy_source_activity(
                 or execution_refs
                 or order_lifecycle_refs
                 or tca_metric_refs
+                or source_window_refs
+                or source_offset_refs
             ),
+            "source_windows_present": source_window_count > 0,
             "runtime_execution_economics_present": tca_sample_count > 0
             or complete_fill_order_event_count > 0,
         },
@@ -5413,11 +5583,15 @@ def _source_activity_stage_diagnostics(
 ) -> dict[str, object]:
     stage_presence = _as_mapping(source_activity.get("stage_presence"))
     decision_count = _safe_int(source_activity.get("decision_count"))
+    target_plan_source_decision_count = _safe_int(
+        source_activity.get("target_plan_source_decision_count")
+    )
     execution_count = _safe_int(
         source_activity.get("submitted_order_count")
         or source_activity.get("execution_count")
     )
     tca_sample_count = _safe_int(source_activity.get("tca_sample_count"))
+    source_window_count = _safe_int(source_activity.get("source_window_count"))
     complete_fill_order_event_count = _safe_int(
         source_activity.get("complete_fill_order_event_count")
     )
@@ -5431,6 +5605,9 @@ def _source_activity_stage_diagnostics(
     source_tca_present = bool(
         stage_presence.get("runtime_execution_economics_present")
     ) or (tca_sample_count > 0 or complete_fill_order_event_count > 0)
+    source_windows_present = bool(stage_presence.get("source_windows_present")) or (
+        source_window_count > 0
+    )
     runtime_ledger_buckets_present = runtime_bucket_count > 0
     blockers = _unique_text_items(
         [
@@ -5447,12 +5624,16 @@ def _source_activity_stage_diagnostics(
     return {
         "schema_version": "torghut.paper-route-source-activity-stage-diagnostics.v1",
         "source_decisions_present": source_decisions_present,
+        "target_plan_source_decisions_present": target_plan_source_decision_count > 0,
         "source_executions_present": source_executions_present,
         "source_tca_present": source_tca_present,
+        "source_windows_present": source_windows_present,
         "runtime_ledger_buckets_present": runtime_ledger_buckets_present,
         "decision_count": decision_count,
+        "target_plan_source_decision_count": target_plan_source_decision_count,
         "execution_count": execution_count,
         "tca_sample_count": tca_sample_count,
+        "source_window_count": source_window_count,
         "runtime_ledger_bucket_count": runtime_bucket_count,
         "blockers": blockers,
     }

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -495,6 +495,67 @@ def _paper_route_decision_hash(payload: Mapping[str, Any]) -> str:
     return sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _paper_route_source_materialization_blockers(
+    payload: object,
+    *,
+    identity: Mapping[str, Any],
+) -> list[str]:
+    payload_mapping = _to_str_map(payload)
+    params = _to_str_map(payload_mapping.get("params"))
+    source_metadata = _to_str_map(params.get("paper_route_target_plan_source_decision"))
+    if not source_metadata:
+        source_metadata = _to_str_map(payload_mapping.get("paper_route_target_plan"))
+    required_values = {
+        "hypothesis_id": identity.get("hypothesis_id"),
+        "candidate_id": identity.get("candidate_id"),
+        "runtime_strategy_name": identity.get("runtime_strategy_name"),
+        "account_label": PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+        "bounded_collection_stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
+        "source_plan_ref": identity.get("source_plan_ref"),
+    }
+    blockers: list[str] = []
+    for key, expected in required_values.items():
+        expected_text = _safe_text(expected)
+        observed_text = (
+            _safe_text(payload_mapping.get(key))
+            or _safe_text(params.get(key))
+            or _safe_text(source_metadata.get(key))
+        )
+        if expected_text is None:
+            blockers.append(f"paper_route_target_plan_expected_{key}_missing")
+        elif observed_text != expected_text:
+            blockers.append(f"paper_route_source_decision_{key}_missing")
+    mode = (
+        _safe_text(payload_mapping.get("source_decision_mode"))
+        or _safe_text(params.get("source_decision_mode"))
+        or _safe_text(source_metadata.get("source_decision_mode"))
+    )
+    if mode != BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE:
+        blockers.append("paper_route_source_decision_mode_missing")
+    if not bool(payload_mapping.get("final_promotion_allowed") is False) or not bool(
+        params.get("final_promotion_allowed") is False
+    ):
+        blockers.append("paper_route_source_decision_final_promotion_not_blocked")
+    return sorted(dict.fromkeys(blockers))
+
+
+def _paper_route_source_decision_needs_refresh(
+    existing: TradeDecision,
+    *,
+    identity: Mapping[str, Any],
+) -> bool:
+    if existing.alpaca_account_label != PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL:
+        return True
+    if _safe_text(existing.status) != "planned":
+        return False
+    return bool(
+        _paper_route_source_materialization_blockers(
+            existing.decision_json,
+            identity=identity,
+        )
+    )
+
+
 def _paper_route_decision_payload(
     *,
     target: Mapping[str, Any],
@@ -514,6 +575,8 @@ def _paper_route_decision_payload(
             source_decision_mode
         ),
         "profit_proof_eligible_scope": "bounded_paper_collection_only",
+        "stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
+        "observed_stage": "paper",
         "hypothesis_id": identity.get("hypothesis_id"),
         "candidate_id": identity.get("candidate_id"),
         "runtime_strategy_name": identity.get("runtime_strategy_name"),
@@ -575,6 +638,8 @@ def _paper_route_decision_payload(
             source_decision_mode_is_profit_proof_eligible(source_decision_mode)
         ),
         "profit_proof_eligible_scope": "bounded_paper_collection_only",
+        "stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
+        "observed_stage": "paper",
         "hypothesis_id": identity.get("hypothesis_id"),
         "candidate_id": identity.get("candidate_id"),
         "runtime_strategy_name": identity.get("runtime_strategy_name"),
@@ -672,6 +737,8 @@ def materialize_bounded_paper_route_target_plan(
     materialized_decisions: list[dict[str, Any]] = []
     route_submissions: list[dict[str, Any]] = []
     blocked_targets: list[dict[str, Any]] = []
+    repaired_decision_count = 0
+    existing_decision_count = 0
     for target_index, target in enumerate(paper_route_target_plan_targets(plan)):
         identity = _target_identity(target, target_index=target_index)
         blockers = _target_materialization_blockers(
@@ -762,6 +829,41 @@ def materialize_bounded_paper_route_target_plan(
                 )
                 session.add(existing)
                 session.flush()
+            else:
+                existing_decision_count += 1
+                if _paper_route_source_decision_needs_refresh(
+                    existing,
+                    identity=identity,
+                ):
+                    existing.strategy_id = strategy.id
+                    existing.symbol = symbol
+                    existing.timeframe = "1Min"
+                    existing.decision_json = coerce_json_payload(payload)
+                    existing.rationale = (
+                        "bounded H-PAIRS paper-route target materialization; "
+                        "live-capital routing disabled"
+                    )
+                    session.add(existing)
+                    session.flush()
+                    repaired_decision_count += 1
+            integrity_blockers = _paper_route_source_materialization_blockers(
+                existing.decision_json,
+                identity=identity,
+            )
+            if integrity_blockers:
+                blocked_targets.append(
+                    {
+                        "target_index": target_index,
+                        "hypothesis_id": identity.get("hypothesis_id"),
+                        "candidate_id": identity.get("candidate_id"),
+                        "symbol": symbol,
+                        "blockers": integrity_blockers,
+                        "readiness": _blocked_target_readiness(integrity_blockers),
+                        "target_identity": identity,
+                        "trade_decision_id": str(existing.id),
+                    }
+                )
+                continue
             route_submission = dict(
                 cast(Mapping[str, Any], payload["paper_route_order_submission"])
             )
@@ -802,6 +904,10 @@ def materialize_bounded_paper_route_target_plan(
         "bounded_notional_limit": _decimal_text(limit),
         "target_count": len(paper_route_target_plan_targets(plan)),
         "materialized_decision_count": len(materialized_decisions),
+        "source_decision_count": len(materialized_decisions),
+        "target_plan_source_decision_count": len(materialized_decisions),
+        "existing_decision_count": existing_decision_count,
+        "repaired_decision_count": repaired_decision_count,
         "route_submission_count": len(route_submissions),
         "blocked_target_count": len(blocked_targets),
         "blocked": bool(blocked_targets),

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -4007,6 +4007,8 @@ class SimpleTradingPipeline(TradingPipeline):
             "source_kind": _safe_text(target.get("source_kind")),
             "account_label": _safe_text(target.get("account_label")),
             "source_account_label": _safe_text(target.get("source_account_label")),
+            "observed_stage": _safe_text(target.get("observed_stage")) or "paper",
+            "bounded_collection_stage": "bounded_paper_collection",
             "account_stage_runtime_identity": {
                 "account_label": _safe_text(target.get("account_label")),
                 "source_account_label": _safe_text(target.get("source_account_label")),
@@ -4415,6 +4417,9 @@ class SimpleTradingPipeline(TradingPipeline):
                     "simple_lane": simple_lane,
                     "source_decision_mode": source_decision_mode,
                     "profit_proof_eligible": profit_proof_eligible,
+                    "observed_stage": _safe_text(target.get("observed_stage"))
+                    or "paper",
+                    "bounded_collection_stage": "bounded_paper_collection",
                     "promotion_allowed": False,
                     "final_promotion_authorized": False,
                     "final_authority_ok": False,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -16,6 +17,7 @@ from app.models import (
     Execution,
     ExecutionOrderEvent,
     ExecutionTCAMetric,
+    OrderFeedSourceWindow,
     PositionSnapshot,
     RejectedSignalOutcomeEvent,
     Strategy,
@@ -36,6 +38,7 @@ from app.trading.paper_route_evidence import (
     _hpairs_zero_activity_reason_flags,
     _next_regular_equities_session_window,
     _normalized_open_positions,
+    _order_event_source_offset_refs,
     _paper_route_probe_summary,
     _paper_route_probe_symbol_quantities,
     _pair_probe_balance_state,
@@ -63,6 +66,125 @@ class TestPaperRouteEvidenceAudit(TestCase):
             poolclass=StaticPool,
         )
         Base.metadata.create_all(self.engine)
+
+    def test_order_event_source_offset_refs_skip_deduplicate_and_limit(self) -> None:
+        rows = [
+            SimpleNamespace(source_topic=None, source_partition=0, source_offset=1),
+            SimpleNamespace(
+                source_topic="trade_updates",
+                source_partition=0,
+                source_offset=1,
+            ),
+            SimpleNamespace(
+                source_topic="trade_updates",
+                source_partition=0,
+                source_offset=1,
+            ),
+        ]
+        rows.extend(
+            SimpleNamespace(
+                source_topic="trade_updates",
+                source_partition=0,
+                source_offset=offset,
+            )
+            for offset in range(2, PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT + 4)
+        )
+
+        refs = _order_event_source_offset_refs(rows)
+
+        self.assertEqual(len(refs), PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT)
+        self.assertEqual(
+            refs[0],
+            {"topic": "trade_updates", "partition": 0, "offset": 1},
+        )
+        self.assertEqual(
+            refs[-1],
+            {
+                "topic": "trade_updates",
+                "partition": 0,
+                "offset": PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT,
+            },
+        )
+
+    def test_source_activity_reports_source_window_query_unavailable(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        event_at = window_start + timedelta(minutes=15)
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="source-window-query-unavailable",
+                enabled=True,
+                base_timeframe="1m",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "candidate_id": "candidate-source-window-unavailable",
+                    "hypothesis_id": "H-ORDER-FEED",
+                },
+                rationale="source window unavailable fixture",
+                status="executed",
+                created_at=event_at,
+                executed_at=event_at,
+            )
+            session.add(decision)
+            session.flush()
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="source-window-unavailable-event",
+                    source_topic="trade_updates",
+                    source_partition=0,
+                    source_offset=42,
+                    alpaca_account_label="TORGHUT_SIM",
+                    event_ts=event_at,
+                    symbol="AAPL",
+                    alpaca_order_id="source-window-unavailable-order",
+                    client_order_id="source-window-unavailable-client",
+                    event_type="fill",
+                    status="filled",
+                    raw_event={},
+                    trade_decision_id=decision.id,
+                    source_window_id="00000000-0000-0000-0000-000000000999",
+                    created_at=event_at,
+                )
+            )
+            session.commit()
+            original_execute = session.execute
+
+            def execute_with_source_window_failure(
+                statement: object, *args: object, **kwargs: object
+            ) -> object:
+                if "order_feed_source_windows" in str(statement):
+                    raise SQLAlchemyError("source window table unavailable")
+                return original_execute(statement, *args, **kwargs)
+
+            with patch.object(session, "execute", execute_with_source_window_failure):
+                source_activity = _strategy_source_activity(
+                    session,
+                    strategy_name="source-window-query-unavailable",
+                    account_label="TORGHUT_SIM",
+                    symbols=["AAPL"],
+                    window_start=window_start,
+                    window_end=window_start + timedelta(hours=1),
+                    candidate_id="candidate-source-window-unavailable",
+                    hypothesis_id="H-ORDER-FEED",
+                    require_source_lineage=True,
+                )
+
+        self.assertTrue(source_activity["missing"])
+        self.assertEqual(
+            source_activity["missing_reasons"],
+            ["source_windows_unavailable"],
+        )
+        self.assertEqual(source_activity["raw_decision_count"], 1)
+        self.assertEqual(source_activity["lineage_matched_decision_count"], 1)
 
     def _seed_hpairs_strategy_and_flat_snapshot(
         self,
@@ -5830,6 +5952,34 @@ class TestPaperRouteEvidenceAudit(TestCase):
             )
             session.add(execution)
             session.flush()
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed",
+                source_topic="trade_updates",
+                source_partition=0,
+                alpaca_account_label="TORGHUT_SIM",
+                assignment_mode="group",
+                collector_identity="test-order-feed",
+                source_revision="alpaca_trade_updates_v1",
+                window_started_at=event_at,
+                window_ended_at=event_at,
+                start_offset=1,
+                end_offset=1,
+                consumed_count=1,
+                inserted_count=1,
+                status="inserted",
+                status_reason="linked_execution_and_decision",
+                payload_json={
+                    "source_ref": {
+                        "topic": "trade_updates",
+                        "partition": 0,
+                        "offset": 1,
+                    },
+                    "source_coverage_complete": True,
+                    "promotion_authority_eligible": False,
+                },
+            )
+            session.add(source_window)
+            session.flush()
             session.add(
                 ExecutionOrderEvent(
                     event_fingerprint="order-feed-fill-event",
@@ -5861,6 +6011,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     },
                     execution_id=execution.id,
                     trade_decision_id=decision.id,
+                    source_window_id=source_window.id,
                     created_at=event_at,
                 )
             )
@@ -5931,6 +6082,13 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(source_activity["order_event_count"], 1)
         self.assertEqual(source_activity["fill_order_event_count"], 1)
         self.assertEqual(source_activity["complete_fill_order_event_count"], 1)
+        self.assertEqual(source_activity["source_window_count"], 1)
+        self.assertEqual(source_activity["linked_source_window_count"], 1)
+        self.assertEqual(len(source_activity["source_window_refs"]), 1)
+        self.assertEqual(
+            source_activity["source_offset_refs"],
+            [{"topic": "trade_updates", "partition": 0, "offset": 1}],
+        )
         self.assertEqual(source_activity["last_order_event_at"], event_at.isoformat())
         self.assertEqual(source_activity["missing_reasons"], [])
         self.assertEqual(source_activity["decision_refs"], [decision_ref])
@@ -5938,6 +6096,14 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(len(source_activity["order_lifecycle_refs"]), 1)
         self.assertIn(
             "source_explicit_costs_missing",
+            source_activity["source_reference_blockers"],
+        )
+        self.assertNotIn(
+            "source_window_refs_missing",
+            source_activity["source_reference_blockers"],
+        )
+        self.assertNotIn(
+            "source_offsets_missing",
             source_activity["source_reference_blockers"],
         )
         import_audit = payload["runtime_window_import_audit"]

--- a/services/torghut/tests/test_paper_route_target_plan.py
+++ b/services/torghut/tests/test_paper_route_target_plan.py
@@ -11,7 +11,17 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.models import Base, Strategy, TradeDecision
+from app.config import settings
+from app.trading.execution import (
+    OrderExecutor,
+    _target_plan_ref_value,
+    _target_plan_source_decision_mode,
+    _target_plan_source_decision_needs_refresh,
+)
+from app.trading.models import StrategyDecision, decision_hash
 from app.trading.paper_route_target_plan import (
+    _paper_route_source_decision_needs_refresh,
+    _paper_route_source_materialization_blockers,
     _truthy,
     materialize_bounded_paper_route_target_plan,
 )
@@ -139,6 +149,8 @@ def test_fresh_hpairs_target_materializes_bounded_collection_source_decisions(
     )
 
     assert result["materialized_decision_count"] == 2
+    assert result["source_decision_count"] == 2
+    assert result["target_plan_source_decision_count"] == 2
     assert result["route_submission_count"] == 2
     assert result["blocked_target_count"] == 0
     assert result["promotion_allowed"] is False
@@ -153,6 +165,12 @@ def test_fresh_hpairs_target_materializes_bounded_collection_source_decisions(
             payload["source_decision_mode"]
             == BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
         )
+        assert payload["hypothesis_id"] == "H-PAIRS-01"
+        assert payload["candidate_id"] == "c88421d619759b2cfaa6f4d0"
+        assert payload["runtime_strategy_name"] == "microbar-cross-sectional-pairs-v1"
+        assert payload["account_label"] == "TORGHUT_SIM"
+        assert payload["observed_stage"] == "paper"
+        assert payload["bounded_collection_stage"] == "bounded_paper_collection"
         assert payload["final_authority_ok"] is False
         assert (
             params["source_decision_mode"]
@@ -171,6 +189,302 @@ def test_fresh_hpairs_target_materializes_bounded_collection_source_decisions(
             _bounded_paper_route_collection_entry_metadata(params)
             == params["paper_route_probe"]
         )
+
+
+def test_existing_hpairs_target_plan_decision_is_repaired_with_source_refs(
+    db_session: Session,
+) -> None:
+    generated_at = datetime(2026, 6, 1, 13, 35, tzinfo=timezone.utc)
+    plan = _plan(_hpairs_target())
+    first = materialize_bounded_paper_route_target_plan(
+        db_session,
+        plan,
+        generated_at=generated_at,
+        bounded_notional_limit=Decimal("25"),
+    )
+    row = db_session.execute(
+        select(TradeDecision).where(TradeDecision.symbol == "AAPL")
+    ).scalar_one()
+    row.decision_json = {
+        "params": {
+            "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+            "paper_route_target_plan_source_decision": {
+                "mode": "paper_route_target_plan_source_decision"
+            },
+        },
+        "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+    }
+    db_session.add(row)
+    db_session.flush()
+
+    repaired = materialize_bounded_paper_route_target_plan(
+        db_session,
+        plan,
+        generated_at=generated_at,
+        bounded_notional_limit=Decimal("25"),
+    )
+    repaired_row = db_session.execute(
+        select(TradeDecision).where(TradeDecision.id == row.id)
+    ).scalar_one()
+    source_metadata = repaired_row.decision_json["params"][
+        "paper_route_target_plan_source_decision"
+    ]
+
+    assert first["materialized_decision_count"] == 2
+    assert repaired["existing_decision_count"] == 2
+    assert repaired["repaired_decision_count"] == 1
+    assert repaired["blocked_target_count"] == 0
+    assert source_metadata["hypothesis_id"] == "H-PAIRS-01"
+    assert source_metadata["candidate_id"] == "c88421d619759b2cfaa6f4d0"
+    assert (
+        source_metadata["runtime_strategy_name"] == "microbar-cross-sectional-pairs-v1"
+    )
+    assert source_metadata["account_label"] == "TORGHUT_SIM"
+    assert source_metadata["observed_stage"] == "paper"
+    assert source_metadata["bounded_collection_stage"] == "bounded_paper_collection"
+    assert source_metadata["final_promotion_allowed"] is False
+
+
+def test_unrepairable_existing_hpairs_target_plan_decision_is_visible_blocker(
+    db_session: Session,
+) -> None:
+    generated_at = datetime(2026, 6, 1, 13, 35, tzinfo=timezone.utc)
+    plan = _plan(_hpairs_target())
+    materialize_bounded_paper_route_target_plan(
+        db_session,
+        plan,
+        generated_at=generated_at,
+        bounded_notional_limit=Decimal("25"),
+    )
+    row = db_session.execute(
+        select(TradeDecision).where(TradeDecision.symbol == "AAPL")
+    ).scalar_one()
+    row.status = "executed"
+    row.decision_json = {
+        "params": {},
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+    }
+    db_session.add(row)
+    db_session.flush()
+
+    result = materialize_bounded_paper_route_target_plan(
+        db_session,
+        plan,
+        generated_at=generated_at,
+        bounded_notional_limit=Decimal("25"),
+    )
+
+    assert result["blocked_target_count"] == 1
+    assert result["materialized_decision_count"] == 1
+    assert result["route_submission_count"] == 1
+    assert "paper_route_source_decision_hypothesis_id_missing" in result["blockers"]
+    assert result["blocked_targets"][0]["trade_decision_id"] == str(row.id)
+
+
+def test_order_executor_refreshes_existing_bounded_target_plan_source_refs(
+    db_session: Session,
+) -> None:
+    strategy = db_session.execute(select(Strategy)).scalar_one()
+    event_ts = datetime(2026, 6, 1, 13, 36, tzinfo=timezone.utc)
+    decision = StrategyDecision(
+        strategy_id=str(strategy.id),
+        symbol="AAPL",
+        event_ts=event_ts,
+        timeframe="1Min",
+        action="buy",
+        qty=Decimal("1"),
+        rationale="external paper-route target plan source decision",
+        params={
+            "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+            "paper_route_target_plan_source_decision": {
+                "mode": "paper_route_target_plan_source_decision",
+                "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "account_label": "TORGHUT_SIM",
+                "observed_stage": "paper",
+                "bounded_collection_stage": "bounded_paper_collection",
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "live_capital_routing_enabled": False,
+            },
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "live_capital_routing_enabled": False,
+        },
+    )
+    digest = decision_hash(
+        decision,
+        account_label="TORGHUT_SIM" if settings.trading_multi_account_enabled else None,
+    )
+    existing_row = TradeDecision(
+        strategy_id=strategy.id,
+        alpaca_account_label="TORGHUT_SIM",
+        symbol="AAPL",
+        timeframe="1Min",
+        decision_json={
+            "params": {
+                "source_decision_mode": (
+                    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+                )
+            }
+        },
+        rationale="stale target-plan decision without source refs",
+        decision_hash=digest,
+        status="planned",
+        created_at=event_ts,
+    )
+    db_session.add(existing_row)
+    db_session.commit()
+    existing_id = existing_row.id
+
+    row = OrderExecutor().ensure_decision(
+        db_session,
+        decision,
+        strategy,
+        "TORGHUT_SIM",
+    )
+
+    metadata = row.decision_json["params"]["paper_route_target_plan_source_decision"]
+    assert row.id == existing_id
+    assert row.rationale == "external paper-route target plan source decision"
+    assert metadata["hypothesis_id"] == "H-PAIRS-01"
+    assert metadata["candidate_id"] == "c88421d619759b2cfaa6f4d0"
+    assert metadata["runtime_strategy_name"] == "microbar-cross-sectional-pairs-v1"
+    assert metadata["account_label"] == "TORGHUT_SIM"
+    assert metadata["observed_stage"] == "paper"
+    assert metadata["bounded_collection_stage"] == "bounded_paper_collection"
+    assert row.status == "planned"
+
+
+def test_order_executor_target_plan_source_refresh_helpers_cover_missing_refs() -> None:
+    new_payload = {
+        "params": {
+            "paper_route_target_plan_source_decision": {
+                "mode": "paper_route_target_plan_source_decision",
+                "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "account_label": "TORGHUT_SIM",
+                "bounded_collection_stage": "bounded_paper_collection",
+            },
+        },
+    }
+
+    assert _target_plan_source_decision_mode({}) is None
+    assert _target_plan_ref_value({}, "hypothesis_id") is None
+    assert _target_plan_source_decision_needs_refresh({}, new_payload) is True
+    assert (
+        _target_plan_source_decision_needs_refresh(
+            {
+                "params": {
+                    "paper_route_target_plan_source_decision": {
+                        "mode": "paper_route_target_plan_source_decision",
+                        "source_decision_mode": "artifact_only",
+                    }
+                }
+            },
+            new_payload,
+        )
+        is True
+    )
+    assert (
+        _target_plan_source_decision_needs_refresh(
+            {
+                "params": {
+                    "paper_route_target_plan_source_decision": {
+                        "mode": "paper_route_target_plan_source_decision",
+                        "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "other-candidate",
+                        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "account_label": "TORGHUT_SIM",
+                        "bounded_collection_stage": "bounded_paper_collection",
+                    }
+                }
+            },
+            new_payload,
+        )
+        is True
+    )
+
+
+def test_target_plan_source_materialization_blockers_are_fail_closed() -> None:
+    identity = {
+        "hypothesis_id": "H-PAIRS-01",
+        "candidate_id": None,
+        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+        "source_plan_ref": "paper-route-plan:c88421d619759b2cfaa6f4d0",
+    }
+    blockers = _paper_route_source_materialization_blockers(
+        {
+            "params": {"final_promotion_allowed": False},
+            "paper_route_target_plan": {
+                "hypothesis_id": "H-PAIRS-01",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "account_label": "TORGHUT_SIM",
+                "bounded_collection_stage": "bounded_paper_collection",
+                "source_plan_ref": "paper-route-plan:c88421d619759b2cfaa6f4d0",
+            },
+            "final_promotion_allowed": False,
+        },
+        identity=identity,
+    )
+
+    assert "paper_route_target_plan_expected_candidate_id_missing" in blockers
+    assert "paper_route_source_decision_mode_missing" in blockers
+
+
+def test_target_plan_source_decision_refresh_guards_status_and_account(
+    db_session: Session,
+) -> None:
+    strategy = db_session.execute(select(Strategy)).scalar_one()
+    identity = {
+        "hypothesis_id": "H-PAIRS-01",
+        "candidate_id": "c88421d619759b2cfaa6f4d0",
+        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+        "source_plan_ref": "paper-route-plan:c88421d619759b2cfaa6f4d0",
+    }
+    wrong_account = TradeDecision(
+        strategy_id=strategy.id,
+        alpaca_account_label="OTHER",
+        symbol="AAPL",
+        timeframe="1Min",
+        decision_json={},
+        rationale="wrong account",
+        decision_hash="wrong-account",
+        status="planned",
+    )
+    executed = TradeDecision(
+        strategy_id=strategy.id,
+        alpaca_account_label="TORGHUT_SIM",
+        symbol="AAPL",
+        timeframe="1Min",
+        decision_json={},
+        rationale="already executed",
+        decision_hash="executed",
+        status="executed",
+    )
+
+    assert (
+        _paper_route_source_decision_needs_refresh(
+            wrong_account,
+            identity=identity,
+        )
+        is True
+    )
+    assert (
+        _paper_route_source_decision_needs_refresh(
+            executed,
+            identity=identity,
+        )
+        is False
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Repaired bounded H-PAIRS paper-route target-plan source materialization so idempotent planned TradeDecision rows are refreshed when they lack hypothesis/candidate/runtime strategy/account/stage refs.
- Added fail-closed materialized-decision integrity checks plus source/target-plan decision counts and repaired/existing diagnostics for bounded TORGHUT_SIM collection.
- Added paper/SIM evidence diagnostics for source decision modes, target-plan source decisions, linked executions, order lifecycle rows, explicit TCA/cost rows, source-window refs, source offsets, and runtime bucket counts as separate readbacks.
- Preserved strict promotion safety: bounded paper collection remains diagnostic/evidence collection only; final promotion and live capital routing stay blocked unless real 20-day source-backed post-cost proof exists.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed after installing local build tooling (`gcc`/`build-essential`) needed to compile `crosshair-tool` in this container.
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_target_plan.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_completion_trace.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py -q` — passed, 470 tests.
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_target_plan.py app/trading/paper_route_evidence.py app/trading/submission_council.py app/trading/completion.py app/trading/order_feed.py app/trading/runtime_ledger.py app/trading/execution.py app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_paper_route_target_plan.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_completion_trace.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py` — passed.
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_target_plan.py app/trading/paper_route_evidence.py app/trading/submission_council.py app/trading/completion.py app/trading/order_feed.py app/trading/runtime_ledger.py app/trading/execution.py app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_paper_route_target_plan.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_completion_trace.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed.
- `cd services/torghut && git diff --check` — passed.

## Screenshots (if applicable)

N/A — backend/source-evidence diagnostics only.

## Breaking Changes

None. No migrations, cluster mutations, live submit flags, or broker capital settings changed. The $500/day profitability proof remains incomplete until real source-backed runtime-ledger/live-paper daily post-cost proof exists and the existing strict final promotion gates pass.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
