### PR TITLE
fix(torghut): flatten paper proof account after close

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -32,6 +32,10 @@ source-activity blockers such as `paper_route_source_activity_missing`, `source_
 `source_executions_missing`, and `source_tca_missing` into the final verdict. Treat those as the next repair target
 before rerunning import; do not collapse them into a generic runtime-ledger-missing diagnosis.
 
+The `torghut-paper-account-flatten` CronJob runs both before the regular session and after the regular session close.
+The post-close run is part of the paper-route proof lane: it persists the flat account snapshot required before the
+21:23 UTC renewal/import conductor can turn a closed paper-route window into authority-checkable runtime-ledger evidence.
+
 Trigger a simulation run via Argo:
 
 The proof packet separates post-cost proof authority from live capital promotion

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: paper-account-flatten
 spec:
-  schedule: "5,20,25 9 * * 1-5"
+  schedule: "5,20,25 9,16 * * 1-5"
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1210,7 +1210,7 @@ class TestLiveConfigManifestContract(TestCase):
             "argocd/applications/torghut/paper-account-flatten-cronjob.yaml"
         )
 
-        self.assertEqual(spec.get("schedule"), "5,20,25 9 * * 1-5")
+        self.assertEqual(spec.get("schedule"), "5,20,25 9,16 * * 1-5")
         self.assertEqual(spec.get("timeZone"), "America/New_York")
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
         job_spec = cast(


### PR DESCRIPTION
## Summary

- Added post-close weekday runs to `torghut-paper-account-flatten` while keeping the existing pre-open cleanup runs.
- Preserves the paper-only account guards, lineage persistence, and snapshot persistence used by the proof lane.
- Documented that the post-close flatten snapshot is required before the 21:23 UTC runtime-window import/proof-packet conductor.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
