### PR TITLE
fix(synthesis): keep autotrader temp state out of artifacts

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -82,11 +82,13 @@ spec:
     ANALYSIS_REPO_DIR: /workspace/analysis
     ANALYSIS_REPO_URL: https://github.com/gregkonush/analysis.git
     ANALYSIS_REQUIRED_COMMIT: 56be940b69bf1a56578040eda9bf2e3699c5220e
+    ANALYSIS_CONTEXT_PATH: /tmp/autonomous-trader-work/analysis-context.json
     AUTONOMOUS_TRADER_ARTIFACT_DIR: /workspace/.agentrun/autonomous-trader
     AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED: "{{parameters.brokerMutationEnabled}}"
     AUTONOMOUS_TRADER_MODE: "{{parameters.mode}}"
     AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE: "{{parameters.synthesisSessionMode}}"
     AUTONOMOUS_TRADER_TARGET_EQUITY_USD: "{{parameters.targetEquityUsd}}"
+    AUTONOMOUS_TRADER_WORK_DIR: /tmp/autonomous-trader-work
     CODEX_CONFIG: /root/.codex/config.toml
     CODEX_LOG_LEVEL: info
     CODEX_MARKET_CONTEXT_ATTEMPT_TIMEOUT_SECONDS: "900"
@@ -151,12 +153,16 @@ spec:
         set -euo pipefail
 
         artifact_dir="${AUTONOMOUS_TRADER_ARTIFACT_DIR:-/workspace/.agentrun/autonomous-trader}"
+        work_dir="${AUTONOMOUS_TRADER_WORK_DIR:-/tmp/autonomous-trader-work}"
         analysis_dir="${ANALYSIS_REPO_DIR:-/workspace/analysis}"
         analysis_repo_url="${ANALYSIS_REPO_URL:-https://github.com/gregkonush/analysis.git}"
         required_commit="${ANALYSIS_REQUIRED_COMMIT:-56be940b69bf1a56578040eda9bf2e3699c5220e}"
+        analysis_context_path="${ANALYSIS_CONTEXT_PATH:-${work_dir}/analysis-context.json}"
+        analysis_bootstrap_status_path="${ANALYSIS_BOOTSTRAP_STATUS_PATH:-${work_dir}/analysis-bootstrap.json}"
         python_bin="${PYTHON_BIN:-python3}"
 
         mkdir -p "${artifact_dir}"
+        mkdir -p "${work_dir}"
         bootstrap_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
         if [ ! -e "${artifact_dir}/report.md" ]; then
@@ -202,29 +208,29 @@ spec:
         analysis_head="$(git -C "${analysis_dir}" rev-parse HEAD)"
         if ! git -C "${analysis_dir}" merge-base --is-ancestor "${required_commit}" HEAD; then
           printf '{"ok":false,"reason":"analysis_repo_stale","analysis_head":"%s","required_commit":"%s"}\n' \
-            "${analysis_head}" "${required_commit}" > "${artifact_dir}/analysis-bootstrap.json"
+            "${analysis_head}" "${required_commit}" > "${analysis_bootstrap_status_path}"
           exit 42
         fi
 
         analysis_python="${python_bin}"
         install_method="pythonpath"
-        rm -rf "${artifact_dir}/analysis-venv"
+        rm -rf "${work_dir}/analysis-venv"
         if PYTHONPATH="${analysis_dir}/src" "${python_bin}" -m stock_analysis daytrading-import-smoke; then
           install_method="preinstalled-pythonpath"
         elif command -v uv >/dev/null 2>&1; then
-          if uv venv --seed --python "${python_bin}" "${artifact_dir}/analysis-venv"; then
-            uv pip install --python "${artifact_dir}/analysis-venv/bin/python" -e "${analysis_dir}[daytrading]"
-            analysis_python="${artifact_dir}/analysis-venv/bin/python"
+          if uv venv --seed --python "${python_bin}" "${work_dir}/analysis-venv"; then
+            uv pip install --python "${work_dir}/analysis-venv/bin/python" -e "${analysis_dir}[daytrading]"
+            analysis_python="${work_dir}/analysis-venv/bin/python"
             install_method="uv-venv"
           else
             printf 'analysis bootstrap warning: uv venv unavailable, trying python venv\n' >&2
-            rm -rf "${artifact_dir}/analysis-venv"
+            rm -rf "${work_dir}/analysis-venv"
           fi
         fi
-        if [ "${install_method}" = "pythonpath" ] && "${python_bin}" -m venv "${artifact_dir}/analysis-venv"; then
-          "${artifact_dir}/analysis-venv/bin/python" -m pip install --upgrade pip
-          "${artifact_dir}/analysis-venv/bin/python" -m pip install -e "${analysis_dir}[daytrading]"
-          analysis_python="${artifact_dir}/analysis-venv/bin/python"
+        if [ "${install_method}" = "pythonpath" ] && "${python_bin}" -m venv "${work_dir}/analysis-venv"; then
+          "${work_dir}/analysis-venv/bin/python" -m pip install --upgrade pip
+          "${work_dir}/analysis-venv/bin/python" -m pip install -e "${analysis_dir}[daytrading]"
+          analysis_python="${work_dir}/analysis-venv/bin/python"
           install_method="python-venv"
         elif [ "${install_method}" = "pythonpath" ]; then
           printf 'analysis bootstrap warning: venv unavailable, continuing with PYTHONPATH source checkout\n' >&2
@@ -252,13 +258,13 @@ spec:
         "${analysis_cli}" daytrading-import-smoke
         "${analysis_cli}" daytrading-context \
           --repo-root "${analysis_dir}" \
-          --output "${artifact_dir}/analysis-context.json"
+          --output "${analysis_context_path}"
         "${analysis_cli}" daytrading-validate-context \
-          "${artifact_dir}/analysis-context.json"
+          "${analysis_context_path}"
 
         printf '{"ok":true,"analysis_head":"%s","required_commit":"%s","context_path":"%s","analysis_cli":"%s","install_method":"%s","started_at":"%s","finished_at":"%s"}\n' \
-          "${analysis_head}" "${required_commit}" "${artifact_dir}/analysis-context.json" "${analysis_cli}" "${install_method}" "${bootstrap_started_at}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-          > "${artifact_dir}/analysis-bootstrap.json"
+          "${analysis_head}" "${required_commit}" "${analysis_context_path}" "${analysis_cli}" "${install_method}" "${bootstrap_started_at}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+          > "${analysis_bootstrap_status_path}"
     - path: /root/alpaca-mcp-stdio-bridge.py
       content: |-
         import json

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -47,12 +47,12 @@ spec:
     Runtime state contract:
     - Alpaca MCP is broker truth.
     - Synthesis autotrader MCP/API is trader runtime truth.
-    - Local files are not trader state. Do not create or backfill JSON/JSONL ledgers. Analysis bootstrap/context JSON files are temporary validation inputs only; write `/workspace/.agentrun/autonomous-trader/report.md` as the operator-facing trader artifact.
+    - Local files are not trader state. Do not create or backfill JSON/JSONL ledgers. Use `AUTONOMOUS_TRADER_WORK_DIR` for temporary scanner/bootstrap JSON and write `/workspace/.agentrun/autonomous-trader/report.md` as the only operator-facing trader artifact.
 
     Bootstrap and preflight:
     1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`.
     2. Treat `/workspace/analysis` as the full private analysis repo checkout, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, and require analysis commit `56be940b69bf1a56578040eda9bf2e3699c5220e` or newer.
-    3. Validate the analysis context before any market-open order. Use temporary scanner files only as implementation details, not operator state.
+    3. Validate the analysis context before any market-open order. Use `ANALYSIS_CONTEXT_PATH` and `AUTONOMOUS_TRADER_WORK_DIR` for temporary scanner files only as implementation details, not operator state.
     4. Read exact `AGENT_RUN_NAME`; do not invent, normalize, shorten, timestamp, or replace it.
     5. Read `AUTONOMOUS_TRADER_MODE` and `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE`; pass the normalized Synthesis session mode exactly when non-empty.
     6. Verify paper account routing, Alpaca account/config/clock/calendar/tools/positions/orders, stock protective fields (`order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, `stop_loss_limit_price`), and helper self-tests:
@@ -71,7 +71,7 @@ spec:
     1. Re-read clock, account, orders, positions, portfolio state, and relevant market data.
     2. Reconcile open orders and absorb external account or position changes as current state.
     3. Call `autotrader_get_scorecard` before ranking candidates and include scorecard influence in Synthesis ticket/risk/status payloads.
-    4. Use `/workspace/.agentrun/autonomous-trader/stock_analysis` plus current Alpaca state, analysis context, scorecards, and bounded catalyst/liquidity checks to pick exactly the next action: protected entry, managed exit/reduce/hedge/flatten, or no-trade.
+    4. Use `/workspace/.agentrun/autonomous-trader/stock_analysis` plus current Alpaca state, `ANALYSIS_CONTEXT_PATH`, scorecards, and bounded catalyst/liquidity checks to pick exactly the next action: protected entry, managed exit/reduce/hedge/flatten, or no-trade.
     5. Record every selected or blocked candidate with `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, and `autotrader_append_event`.
     6. Submit only when the ticket records setup type, setup grade, expected R, fat-pitch flag, thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
     7. Before every Alpaca mutation, write the planned order with `autotrader_record_order`, use an AgentRun-prefixed deterministic `client_order_id` when supported, and then reconcile by broker order id plus client order id before any next action.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -18,7 +18,7 @@ data:
     Source of truth:
     - Alpaca MCP is broker truth for account, clock, calendar, market data, positions, orders, fills, and mutations.
     - Synthesis MCP autotrader tools are runtime truth for sessions, status, events, tickets, risk, orders, fills, positions, finalization, and scorecards.
-    - Local artifacts are not trader state. Do not create or backfill JSON/JSONL runtime ledgers. Write only `report.md` as the operator-facing trader artifact; analysis bootstrap/context JSON files are temporary validation inputs, not outputs to maintain or cite as runtime state.
+    - Local artifacts are not trader state. Do not create or backfill JSON/JSONL runtime ledgers. Write only `report.md` as the operator-facing trader artifact; keep temporary scanner/bootstrap JSON under `AUTONOMOUS_TRADER_WORK_DIR`, not as runtime state.
 
     Identity and mode:
     - Read `AGENT_RUN_NAME` and use it unchanged for session identity, deterministic broker client order ids, milestone URLs, dedupe keys, and report fields.
@@ -26,7 +26,7 @@ data:
     - If `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE` is non-empty, pass exactly that value to `autotrader_start_session.mode`.
 
     Execution loop:
-    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate the local analysis context, and self-test the Synthesis and protective-order helper scripts.
+    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate the local analysis context at `ANALYSIS_CONTEXT_PATH`, and self-test the Synthesis and protective-order helper scripts.
     2. Preflight Alpaca account/config/clock/calendar/tools/positions/orders and Synthesis autotrader tool availability.
     3. Call `autotrader_start_session` before scanning and keep its `sessionId` for every Synthesis write.
     4. Before grading candidates, call `autotrader_get_scorecard` and include scorecard influence in the ticket/risk/status payloads.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -713,9 +713,15 @@ describe('synthesis autonomous trader provider', () => {
     const artifactNames = (outputArtifacts ?? []).map((artifact) => objectAt(artifact, 'name'))
     const artifactPaths = (outputArtifacts ?? []).map((artifact) => objectAt(artifact, 'path'))
     const artifactKeys = (outputArtifacts ?? []).map((artifact) => objectAt(artifact, 'key')).filter(Boolean)
+    const bootstrapScript = (inputFiles ?? []).find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/bootstrap-analysis-daytrading.sh',
+    )
+    const bootstrapContent = objectAt(bootstrapScript, 'content')
 
     expect(objectAt(envTemplate, 'ANALYSIS_REPO_URL')).toBe('https://github.com/gregkonush/analysis.git')
     expect(objectAt(envTemplate, 'ANALYSIS_REQUIRED_COMMIT')).toBe('56be940b69bf1a56578040eda9bf2e3699c5220e')
+    expect(objectAt(envTemplate, 'ANALYSIS_CONTEXT_PATH')).toBe('/tmp/autonomous-trader-work/analysis-context.json')
+    expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_WORK_DIR')).toBe('/tmp/autonomous-trader-work')
     expect(objectAt(envTemplate, 'ANALYSIS_FETCH_DEPTH')).toBeUndefined()
     expect(objectAt(codex, 'model')).toBe('gpt-5.5')
     expect(objectAt(codex, 'effort')).toBe('high')
@@ -732,6 +738,14 @@ describe('synthesis autonomous trader provider', () => {
     expect([...artifactNames, ...artifactPaths, ...artifactKeys].join('\n')).not.toMatch(
       /jsonl|analysis-(bootstrap|context)/,
     )
+    expect(bootstrapContent).toContain('work_dir="${AUTONOMOUS_TRADER_WORK_DIR:-/tmp/autonomous-trader-work}"')
+    expect(bootstrapContent).toContain(
+      'analysis_context_path="${ANALYSIS_CONTEXT_PATH:-${work_dir}/analysis-context.json}"',
+    )
+    expect(bootstrapContent).toContain('--output "${analysis_context_path}"')
+    expect(bootstrapContent).not.toContain('"${artifact_dir}/analysis-context.json"')
+    expect(bootstrapContent).not.toContain('"${artifact_dir}/analysis-bootstrap.json"')
+    expect(bootstrapContent).not.toContain('"${artifact_dir}/analysis-venv"')
     expect(objectAt(objectAt(objectAt(vcsProvider, 'spec'), 'repositoryPolicy'), 'allow')).toContain(
       'gregkonush/analysis',
     )


### PR DESCRIPTION
## Summary

- Moves autotrader analysis context/status JSON and the bootstrap venv into `/tmp/autonomous-trader-work`.
- Keeps `/workspace/.agentrun/autonomous-trader` focused on `report.md` plus the local `stock_analysis` helper instead of durable-looking JSON state.
- Updates the autotrader ImplementationSpec and system prompt to treat scanner/bootstrap JSON as temporary work files, not runtime truth.
- Adds a smoke-test contract so future provider changes do not put analysis JSON or venv state back under the operator artifact directory.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "wires the analysis daytrading bootstrap into the trader provider"`
- `bun run lint:argocd`
- `git diff --check -- argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run --filter @proompteng/scripts lint`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
