### PR TITLE
feat(torghut): add hpairs microstructure frontier risk ranking

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -26,8 +26,8 @@ from app.trading.discovery.microstructure_prefilter import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v7"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v8"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v8"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v9"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -43,6 +43,8 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
     "conformal_tail_risk_prefilter",
+    "bootstrap_lower_percentile_utility_prefilter",
+    "implementation_risk_preview_exact_runtime_parity_reporting",
 )
 FAST_REPLAY_FRONTIER_IDENTITY_SCHEMA_VERSION = (
     "torghut.fast-replay-frontier-identity.v1"
@@ -114,6 +116,8 @@ class FastReplayPreviewRow:
     replay_tape_cache_identity: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
+    robust_lower_percentile_post_cost_utility_bps: Decimal = Decimal("0")
+    bootstrap_lower_percentile_post_cost_utility_bps: Decimal = Decimal("0")
 
     def to_payload(self) -> dict[str, Any]:
         observed_post_cost_expectancy_bps = _observed_post_cost_expectancy_bps(self)
@@ -135,6 +139,12 @@ class FastReplayPreviewRow:
         )
         lineage_blockers = _lineage_blockers_for_row(self)
         risk_flags = _risk_flags_for_row(self, lineage_blockers=lineage_blockers)
+        ranking_only_reasons = _ranking_only_reasons_for_row(
+            self, lineage_blockers=lineage_blockers
+        )
+        risk_veto_reasons = _risk_veto_reasons_for_row(
+            self, risk_flags=risk_flags, lineage_blockers=lineage_blockers
+        )
         prefilter_capacity_lineage = _mapping(
             self.microstructure_prefilter.get("impact_capacity_lineage")
         )
@@ -146,6 +156,13 @@ class FastReplayPreviewRow:
             "candidate_spec_id": self.candidate_spec_id,
             "rank": self.rank,
             "preview_score": str(self.preview_score),
+            "preview_rank_score": str(self.preview_score),
+            "robust_lower_percentile_post_cost_utility_bps": str(
+                self.robust_lower_percentile_post_cost_utility_bps
+            ),
+            "bootstrap_lower_percentile_post_cost_utility_bps": str(
+                self.bootstrap_lower_percentile_post_cost_utility_bps
+            ),
             "selected": self.selected,
             "selection_reason": self.selection_reason,
             "matched_row_count": self.matched_row_count,
@@ -174,6 +191,11 @@ class FastReplayPreviewRow:
             ),
             "exploration_score": str(self.exploration_score),
             "frontier_bucket": self.frontier_bucket,
+            "ranking_only_reasons": list(ranking_only_reasons),
+            "risk_veto_reasons": list(risk_veto_reasons),
+            "exact_replay_required": True,
+            "runtime_ledger_required": True,
+            "source_backed_runtime_ledger_required": True,
             "discovery_stage_metadata": discovery_stage_metadata,
             "candidate_frontier_hash": self.candidate_frontier_hash,
             "exact_replay_frontier_key": self.exact_replay_frontier_key,
@@ -189,6 +211,14 @@ class FastReplayPreviewRow:
                 "reason_code": self.selection_reason,
                 "blockers": list(frontier_selection_blockers),
                 "rank": self.rank,
+                "preview_rank_score": str(self.preview_score),
+                "robust_lower_percentile_post_cost_utility_bps": str(
+                    self.robust_lower_percentile_post_cost_utility_bps
+                ),
+                "ranking_only_reasons": list(ranking_only_reasons),
+                "risk_veto_reasons": list(risk_veto_reasons),
+                "exact_replay_required": True,
+                "runtime_ledger_required": True,
                 "exact_replay_enqueue_allowed": exact_replay_qualified,
                 "bounded_sim_evidence_enqueue_allowed": exact_replay_qualified,
                 "discovery_stage_metadata": discovery_stage_metadata,
@@ -344,6 +374,19 @@ class FastReplayPreviewResult:
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
                 "square_root_impact_capacity": "sqrt(notional / tape dollar-volume proxy) capacity prefilter",
                 "conformal_tail_risk": "distribution-free lower-tail signed-return penalty used only for ranking",
+                "bootstrap_robust_optimization": "deterministic lower-percentile bootstrap post-cost utility used only for ranking",
+                "implementation_risk_backtesting": "preview/exact/runtime parity fields are reported as required downstream evidence, not proof",
+            },
+            "ranking_authority_boundary": {
+                "schema_version": "torghut.fast-replay-ranking-authority-boundary.v1",
+                "preview_rank_score_field": "preview_rank_score",
+                "ranking_only_reasons_field": "ranking_only_reasons",
+                "risk_veto_reasons_field": "risk_veto_reasons",
+                "exact_replay_required": True,
+                "runtime_ledger_required": True,
+                "promotion_allowed": False,
+                "ranking_output_can_authorize_promotion": False,
+                "prefilter_only": True,
             },
             "blockers": [
                 "preview_only_not_promotion_proof",
@@ -399,6 +442,15 @@ class FastReplayPreviewResult:
                 "promotion_allowed": False,
                 "final_promotion_allowed": False,
                 "final_authority_ok": False,
+            },
+            "throughput_limits": {
+                "schema_version": "torghut.fast-replay-throughput-limits.v1",
+                "exact_replay_candidate_cap": self.exact_replay_candidate_cap,
+                "max_exact_replay_candidates": FAST_REPLAY_EXACT_REPLAY_CANDIDATE_CAP,
+                "max_local_workers": 2,
+                "kubernetes_fanout_allowed": False,
+                "cluster_fanout_allowed": False,
+                "promotion_allowed": False,
             },
             "replay_tape": {
                 "dataset_snapshot_ref": self.replay_tape_manifest.dataset_snapshot_ref,
@@ -981,8 +1033,25 @@ def _score_candidate_spec(
         median_spread_bps=median_spread_bps,
     )
     conformal_tail_risk_penalty_bps = _conformal_tail_risk_penalty_bps(signed_returns)
+    post_cost_utilities_bps = _post_cost_utility_distribution_bps(
+        signed_returns_bps=signed_returns,
+        median_spread_bps=median_spread_bps,
+        impact_liquidity_penalty_bps=impact_liquidity_penalty_bps,
+        square_root_impact_capacity_penalty_bps=square_root_impact_capacity_penalty_bps,
+    )
+    lower_percentile_post_cost_utility_bps = _lower_percentile_post_cost_utility_bps(
+        post_cost_utilities_bps
+    )
+    bootstrap_lower_percentile_post_cost_utility_bps = (
+        _bootstrap_lower_percentile_post_cost_utility_bps(post_cost_utilities_bps)
+    )
+    robust_lower_percentile_post_cost_utility_bps = min(
+        lower_percentile_post_cost_utility_bps,
+        bootstrap_lower_percentile_post_cost_utility_bps,
+    )
     preview_score = (
-        signed_return_bps
+        robust_lower_percentile_post_cost_utility_bps * 0.65
+        + signed_return_bps * 0.35
         + avg_abs_return_bps * 0.12
         + direction * ofi_pressure_score * 6.0
         + ofi_decay_alignment_score * 8.0
@@ -1064,19 +1133,37 @@ def _score_candidate_spec(
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
         replay_tape_cache_identity=replay_tape_manifest.cache_identity_diagnostics(),
+        robust_lower_percentile_post_cost_utility_bps=_decimal_from_float(
+            robust_lower_percentile_post_cost_utility_bps
+        ),
+        bootstrap_lower_percentile_post_cost_utility_bps=_decimal_from_float(
+            bootstrap_lower_percentile_post_cost_utility_bps
+        ),
     )
 
 
-def _preview_rank_key(row: FastReplayPreviewRow) -> tuple[bool, float, float, str]:
+def _preview_rank_key(
+    row: FastReplayPreviewRow,
+) -> tuple[bool, float, float, float, str]:
     prefilter_score = _float_or_none(
         row.microstructure_prefilter.get("prefilter_score")
     )
     return (
         row.selection_reason == "insufficient_replay_tape_rows"
         or _row_explicitly_non_hpairs(row),
+        -_risk_adjusted_robust_rank_score(row),
         -float(row.preview_score),
         -(prefilter_score if prefilter_score is not None else float(row.preview_score)),
         row.candidate_spec_id,
+    )
+
+
+def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
+    return (
+        float(row.robust_lower_percentile_post_cost_utility_bps)
+        - float(row.macro_stress_veto_score) * 25.0
+        - float(row.square_root_impact_capacity_penalty_bps) * 0.15
+        - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
 
@@ -1274,6 +1361,12 @@ def _row_with_rank_and_selection(
         duplicate_candidate_spec_ids=row.duplicate_candidate_spec_ids,
         candidate_lineage=dict(row.candidate_lineage),
         replay_tape_cache_identity=dict(row.replay_tape_cache_identity),
+        robust_lower_percentile_post_cost_utility_bps=(
+            row.robust_lower_percentile_post_cost_utility_bps
+        ),
+        bootstrap_lower_percentile_post_cost_utility_bps=(
+            row.bootstrap_lower_percentile_post_cost_utility_bps
+        ),
     )
 
 
@@ -1325,6 +1418,12 @@ def _row_with_frontier_dedupe(
         duplicate_candidate_spec_ids=duplicate_candidate_spec_ids,
         candidate_lineage=dict(row.candidate_lineage),
         replay_tape_cache_identity=dict(row.replay_tape_cache_identity),
+        robust_lower_percentile_post_cost_utility_bps=(
+            row.robust_lower_percentile_post_cost_utility_bps
+        ),
+        bootstrap_lower_percentile_post_cost_utility_bps=(
+            row.bootstrap_lower_percentile_post_cost_utility_bps
+        ),
     )
 
 
@@ -1455,6 +1554,48 @@ def _exact_replay_selection_blockers_for_row(
     if "candidate_notional_missing" in impact_blockers:
         blockers.add("candidate_notional_lineage_missing")
     return tuple(sorted(blockers))
+
+
+def _post_cost_utility_distribution_bps(
+    *,
+    signed_returns_bps: NDArray[np.float64],
+    median_spread_bps: float,
+    impact_liquidity_penalty_bps: float,
+    square_root_impact_capacity_penalty_bps: float,
+) -> NDArray[np.float64]:
+    if signed_returns_bps.size == 0:
+        return np.asarray([], dtype=np.float64)
+    total_cost_bps = (
+        max(0.0, median_spread_bps)
+        + max(0.0, impact_liquidity_penalty_bps)
+        + max(0.0, square_root_impact_capacity_penalty_bps)
+    )
+    return signed_returns_bps - total_cost_bps
+
+
+def _lower_percentile_post_cost_utility_bps(
+    post_cost_utilities_bps: NDArray[np.float64],
+) -> float:
+    if post_cost_utilities_bps.size == 0:
+        return 0.0
+    percentile = 20.0 if post_cost_utilities_bps.size >= 5 else 10.0
+    return float(np.percentile(post_cost_utilities_bps, percentile))
+
+
+def _bootstrap_lower_percentile_post_cost_utility_bps(
+    post_cost_utilities_bps: NDArray[np.float64],
+) -> float:
+    if post_cost_utilities_bps.size == 0:
+        return 0.0
+    if post_cost_utilities_bps.size == 1:
+        return float(post_cost_utilities_bps[0])
+    sample_count = int(post_cost_utilities_bps.size)
+    replicates: list[float] = []
+    for offset in range(sample_count):
+        indices = (np.arange(sample_count) + offset) % sample_count
+        shifted = post_cost_utilities_bps[indices]
+        replicates.append(float(np.mean(shifted[: max(1, sample_count - 1)])))
+    return float(np.percentile(np.asarray(replicates, dtype=np.float64), 20))
 
 
 def _ofi_decay_score(values: NDArray[np.float64]) -> float:
@@ -2037,6 +2178,51 @@ def _risk_flags_for_row(
     if row.selection_reason == "insufficient_replay_tape_rows":
         flags.add("insufficient_replay_tape_rows")
     return tuple(sorted(flags))
+
+
+def _ranking_only_reasons_for_row(
+    row: FastReplayPreviewRow, *, lineage_blockers: Sequence[str]
+) -> tuple[str, ...]:
+    reasons = {
+        "preview_rank_score_is_prefilter_only",
+        "clusterlob_ofi_regime_news_impact_bootstrap_conformal_features_rank_only",
+        "exact_replay_required_before_any_promotion_claim",
+        "runtime_ledger_required_before_any_profitability_claim",
+    }
+    if row.robust_lower_percentile_post_cost_utility_bps != 0:
+        reasons.add("robust_lower_percentile_post_cost_utility_used_for_ranking")
+    if row.bootstrap_lower_percentile_post_cost_utility_bps != 0:
+        reasons.add("bootstrap_lower_percentile_post_cost_utility_used_for_ranking")
+    if row.macro_stress_veto_score > 0:
+        reasons.add("macro_news_ofi_stress_slice_downranks_only")
+    if row.conformal_tail_risk_penalty_bps > 0:
+        reasons.add("conformal_tail_risk_buffer_downranks_only")
+    if row.square_root_impact_capacity_penalty_bps > 0:
+        reasons.add("square_root_impact_capacity_cap_downranks_only")
+    if row.selection_reason == "insufficient_replay_tape_rows":
+        reasons.add("missing_replay_tape_source_data_explicit_blocker")
+    if lineage_blockers:
+        reasons.add("lineage_blockers_reported_not_fabricated")
+    return tuple(sorted(reasons))
+
+
+def _risk_veto_reasons_for_row(
+    row: FastReplayPreviewRow,
+    *,
+    risk_flags: Sequence[str],
+    lineage_blockers: Sequence[str],
+) -> tuple[str, ...]:
+    vetoes = {str(flag) for flag in risk_flags if str(flag).strip()}
+    vetoes.update(str(blocker) for blocker in lineage_blockers if str(blocker).strip())
+    if row.macro_stress_veto_score > 0:
+        vetoes.add("macro_news_stress_slice_veto_or_downrank")
+    if row.liquidity_regime_score <= 0 and row.matched_row_count > 0:
+        vetoes.add("liquidity_regime_unobserved_or_weak")
+    if row.square_root_impact_capacity_penalty_bps > 0:
+        vetoes.add("square_root_impact_capacity_penalty")
+    if row.robust_lower_percentile_post_cost_utility_bps <= 0:
+        vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
+    return tuple(sorted(vetoes))
 
 
 def _mapping(value: Any) -> dict[str, Any]:

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6636,6 +6636,23 @@ def _apply_fast_replay_preview_narrowing(
         if preview_row is not None:
             updated["fast_replay_preview_rank"] = preview_row["rank"]
             updated["fast_replay_preview_score"] = preview_row["preview_score"]
+            updated["fast_replay_preview_rank_score"] = preview_row.get(
+                "preview_rank_score", preview_row["preview_score"]
+            )
+            updated["fast_replay_robust_lower_percentile_post_cost_utility_bps"] = (
+                preview_row.get("robust_lower_percentile_post_cost_utility_bps")
+            )
+            updated["fast_replay_bootstrap_lower_percentile_post_cost_utility_bps"] = (
+                preview_row.get("bootstrap_lower_percentile_post_cost_utility_bps")
+            )
+            updated["fast_replay_ranking_only_reasons"] = list(
+                cast(Sequence[Any], preview_row.get("ranking_only_reasons") or ())
+            )
+            updated["fast_replay_risk_veto_reasons"] = list(
+                cast(Sequence[Any], preview_row.get("risk_veto_reasons") or ())
+            )
+            updated["fast_replay_exact_replay_required"] = True
+            updated["fast_replay_runtime_ledger_required"] = True
             updated["fast_replay_preview_selected"] = preview_row["selected"]
             updated["fast_replay_preview_selection_reason"] = preview_row[
                 "selection_reason"
@@ -6846,6 +6863,15 @@ def _fast_replay_preview_proof_semantics() -> dict[str, Any]:
             _DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES
         ),
         "safe_exact_replay_candidate_cap": _DEFAULT_FAST_REPLAY_EXACT_CANDIDATE_CAP,
+        "ranking_authority_boundary": {
+            "preview_rank_score_field": "preview_rank_score",
+            "ranking_only_reasons_field": "ranking_only_reasons",
+            "risk_veto_reasons_field": "risk_veto_reasons",
+            "exact_replay_required": True,
+            "runtime_ledger_required": True,
+            "promotion_allowed": False,
+            "ranking_output_can_authorize_promotion": False,
+        },
         "final_promotion_requires": [
             "exact_replay_evidence",
             "source_backed_runtime_ledger",
@@ -6981,6 +7007,22 @@ def _bounded_sim_target_queue_metadata(
                 "frontier_dedupe_metadata": row.get("frontier_dedupe_metadata"),
                 "preview_rank": row.get("rank"),
                 "preview_score": row.get("preview_score"),
+                "preview_rank_score": row.get("preview_rank_score")
+                or row.get("preview_score"),
+                "ranking_only_reasons": list(
+                    cast(Sequence[Any], row.get("ranking_only_reasons") or ())
+                ),
+                "risk_veto_reasons": list(
+                    cast(Sequence[Any], row.get("risk_veto_reasons") or ())
+                ),
+                "robust_lower_percentile_post_cost_utility_bps": row.get(
+                    "robust_lower_percentile_post_cost_utility_bps"
+                ),
+                "bootstrap_lower_percentile_post_cost_utility_bps": row.get(
+                    "bootstrap_lower_percentile_post_cost_utility_bps"
+                ),
+                "exact_replay_required": True,
+                "runtime_ledger_required": True,
                 "observed_post_cost_expectancy_bps": row.get(
                     "observed_post_cost_expectancy_bps"
                 ),
@@ -7007,6 +7049,11 @@ def _bounded_sim_target_queue_metadata(
                         replay_tape_manifest.cache_identity_diagnostics()
                     ),
                     "preview_score": row.get("preview_score"),
+                    "preview_rank_score": row.get("preview_rank_score")
+                    or row.get("preview_score"),
+                    "robust_lower_percentile_post_cost_utility_bps": row.get(
+                        "robust_lower_percentile_post_cost_utility_bps"
+                    ),
                     "frontier_bucket": row.get("frontier_bucket"),
                     "handoff_lineage_hash": handoff_lineage_hash,
                 },
@@ -7051,6 +7098,16 @@ def _bounded_sim_target_queue_metadata(
         "proof_semantics": _fast_replay_preview_proof_semantics(),
         "whitepaper_mechanisms": list(FAST_REPLAY_WHITEPAPER_MECHANISMS),
         "queue_policy": "top_exploitation_plus_exploration_exact_replay_cap",
+        "ranking_authority_boundary": {
+            "schema_version": "torghut.fast-replay-queue-ranking-authority-boundary.v1",
+            "preview_rank_score_field": "preview_rank_score",
+            "ranking_only_reasons_field": "ranking_only_reasons",
+            "risk_veto_reasons_field": "risk_veto_reasons",
+            "exact_replay_required": True,
+            "runtime_ledger_required": True,
+            "promotion_allowed": False,
+            "ranking_output_can_authorize_promotion": False,
+        },
         "dedupe_policy": {
             "schema_version": "torghut.fast-replay-sim-target-queue-dedupe.v1",
             "status": "enabled",
@@ -7156,6 +7213,18 @@ def _fast_replay_exact_handoff_lineage(
         "frontier_dedupe_metadata": row.get("frontier_dedupe_metadata"),
         "preview_rank": row.get("rank"),
         "preview_score": row.get("preview_score"),
+        "preview_rank_score": row.get("preview_rank_score") or row.get("preview_score"),
+        "ranking_only_reasons": list(
+            cast(Sequence[Any], row.get("ranking_only_reasons") or ())
+        ),
+        "risk_veto_reasons": list(
+            cast(Sequence[Any], row.get("risk_veto_reasons") or ())
+        ),
+        "robust_lower_percentile_post_cost_utility_bps": row.get(
+            "robust_lower_percentile_post_cost_utility_bps"
+        ),
+        "exact_replay_required": True,
+        "runtime_ledger_required": True,
         "proof_semantics_label": row.get("proof_semantics_label"),
         "replay_tape": {
             "dataset_snapshot_ref": replay_tape_manifest.dataset_snapshot_ref,

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -776,6 +776,194 @@ class TestFastReplayPreview(TestCase):
             payloads["budget-exhausted"]["frontier_selection"]["final_authority_ok"]
         )
 
+    def test_preview_boundary_fields_are_ranking_only_and_never_authorize_promotion(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            rows = [
+                self._signal(symbol="AAA", offset=1, price="100", ofi="0.40"),
+                self._signal(symbol="AAA", offset=2, price="101", ofi="0.50"),
+                self._signal(symbol="AAA", offset=3, price="102", ofi="0.60"),
+            ]
+            manifest = materialize_signal_tape(
+                rows=rows,
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-boundary-fields",
+                symbols=("AAA",),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest({"window": "boundary"}),
+                feature_schema_hash="feature-boundary",
+                cost_model_hash="cost-boundary",
+                strategy_family="hpairs-boundary",
+            )
+
+        preview = build_fast_replay_preview(
+            specs=(self._spec("spec-boundary", symbols=["AAA"]),),
+            rows=rows,
+            replay_tape_manifest=manifest,
+            top_k=1,
+            min_rows_per_candidate=2,
+        )
+        payload = preview.rows[0].to_payload()
+        manifest_payload = preview.to_manifest_payload()
+
+        self.assertEqual(payload["preview_rank_score"], payload["preview_score"])
+        self.assertTrue(payload["exact_replay_required"])
+        self.assertTrue(payload["runtime_ledger_required"])
+        self.assertIn("ranking_only_reasons", payload)
+        self.assertIn("risk_veto_reasons", payload)
+        self.assertIn(
+            "exact_replay_required_before_any_promotion_claim",
+            payload["ranking_only_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_required_before_any_profitability_claim",
+            payload["ranking_only_reasons"],
+        )
+        self.assertFalse(payload["promotion_allowed"])
+        self.assertFalse(payload["frontier_selection"]["promotion_allowed"])
+        self.assertFalse(payload["frontier_selection"]["final_authority_ok"])
+        boundary = manifest_payload["ranking_authority_boundary"]
+        self.assertEqual(boundary["preview_rank_score_field"], "preview_rank_score")
+        self.assertTrue(boundary["exact_replay_required"])
+        self.assertTrue(boundary["runtime_ledger_required"])
+        self.assertFalse(boundary["ranking_output_can_authorize_promotion"])
+        self.assertEqual(
+            manifest_payload["throughput_limits"]["max_exact_replay_candidates"], 6
+        )
+        self.assertLessEqual(
+            manifest_payload["throughput_limits"]["exact_replay_candidate_cap"], 6
+        )
+        self.assertEqual(manifest_payload["throughput_limits"]["max_local_workers"], 2)
+        self.assertFalse(
+            manifest_payload["throughput_limits"]["kubernetes_fanout_allowed"]
+        )
+
+    def test_robust_lower_percentile_utility_ranks_ahead_of_mean_only_score(
+        self,
+    ) -> None:
+        def row(
+            candidate_spec_id: str,
+            *,
+            preview_score: str,
+            robust_utility: str,
+        ) -> fast_replay.FastReplayPreviewRow:
+            return fast_replay.FastReplayPreviewRow(
+                candidate_spec_id=candidate_spec_id,
+                rank=0,
+                preview_score=Decimal(preview_score),
+                selected=False,
+                selection_reason="fast_replay_preview_ranked",
+                matched_row_count=10,
+                matched_symbol_count=1,
+                requested_symbol_count=1,
+                trading_day_count=1,
+                signed_return_bps=Decimal("1"),
+                avg_abs_return_bps=Decimal("0"),
+                median_spread_bps=Decimal("0"),
+                activity_score=Decimal("0"),
+                coverage_score=Decimal("1"),
+                ofi_pressure_score=Decimal("0"),
+                microprice_bias_bps=Decimal("0"),
+                spread_tail_bps=Decimal("0"),
+                return_tail_abs_bps=Decimal("0"),
+                impact_liquidity_penalty_bps=Decimal("0"),
+                cluster_lob_activity_score=Decimal("0"),
+                ofi_decay_alignment_score=Decimal("0"),
+                liquidity_regime_score=Decimal("1"),
+                macro_stress_veto_score=Decimal("0"),
+                conformal_tail_risk_penalty_bps=Decimal("0"),
+                square_root_impact_capacity_penalty_bps=Decimal("0"),
+                exploration_score=Decimal("0"),
+                frontier_bucket="not_selected",
+                microstructure_prefilter={
+                    "is_hpairs_candidate": True,
+                    "proof_source": "prefilter_only",
+                    "promotion_allowed": False,
+                    "final_promotion_allowed": False,
+                },
+                robust_lower_percentile_post_cost_utility_bps=Decimal(robust_utility),
+                bootstrap_lower_percentile_post_cost_utility_bps=Decimal(
+                    robust_utility
+                ),
+            )
+
+        ranked = sorted(
+            (
+                row("mean-only-tail-risk", preview_score="100", robust_utility="-5"),
+                row("robust-frontier", preview_score="50", robust_utility="12"),
+            ),
+            key=fast_replay._preview_rank_key,
+        )
+
+        self.assertEqual(ranked[0].candidate_spec_id, "robust-frontier")
+        payload = ranked[0].to_payload()
+        self.assertEqual(payload["robust_lower_percentile_post_cost_utility_bps"], "12")
+        self.assertIn(
+            "robust_lower_percentile_post_cost_utility_used_for_ranking",
+            payload["ranking_only_reasons"],
+        )
+        self.assertFalse(payload["promotion_allowed"])
+
+    def test_macro_regime_impact_veto_fields_downrank_without_promotion_authority(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            rows = [
+                self._signal(
+                    symbol="AAA", offset=1, price="100", ofi="0.50", stress=True
+                ),
+                self._signal(
+                    symbol="AAA", offset=2, price="101", ofi="0.60", stress=True
+                ),
+                self._signal(
+                    symbol="AAA", offset=3, price="102", ofi="0.70", stress=True
+                ),
+            ]
+            manifest = materialize_signal_tape(
+                rows=rows,
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-stress-boundary",
+                symbols=("AAA",),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=build_source_query_digest({"window": "stress"}),
+                feature_schema_hash="feature-stress",
+                cost_model_hash="cost-stress",
+                strategy_family="hpairs-stress",
+            )
+
+        preview = build_fast_replay_preview(
+            specs=(
+                self._spec(
+                    "spec-stress-boundary",
+                    symbols=["AAA"],
+                    max_notional_per_trade="2500000",
+                ),
+            ),
+            rows=rows,
+            replay_tape_manifest=manifest,
+            top_k=1,
+            min_rows_per_candidate=2,
+        )
+        payload = preview.rows[0].to_payload()
+
+        self.assertGreater(Decimal(payload["macro_stress_veto_score"]), Decimal("0"))
+        self.assertIn(
+            "macro_news_stress_slice_veto_or_downrank", payload["risk_veto_reasons"]
+        )
+        self.assertIn(
+            "macro_news_ofi_stress_slice_downranks_only",
+            payload["ranking_only_reasons"],
+        )
+        self.assertIn(
+            "square_root_impact_capacity_penalty", payload["risk_veto_reasons"]
+        )
+        self.assertFalse(payload["promotion_allowed"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["final_authority_ok"])
+
     def test_missing_cost_capacity_lineage_blocks_exact_replay_selection(
         self,
     ) -> None:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4818,6 +4818,16 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             queue_payload["runner_policy"]["default_parallel_frontier_candidate_cap"],
             6,
         )
+        ranking_boundary = queue_payload["ranking_authority_boundary"]
+        self.assertTrue(ranking_boundary["exact_replay_required"])
+        self.assertTrue(ranking_boundary["runtime_ledger_required"])
+        self.assertFalse(ranking_boundary["ranking_output_can_authorize_promotion"])
+        first_entry = queue_payload["entries"][0]
+        self.assertIn("preview_rank_score", first_entry)
+        self.assertIn("ranking_only_reasons", first_entry)
+        self.assertIn("risk_veto_reasons", first_entry)
+        self.assertTrue(first_entry["exact_replay_required"])
+        self.assertTrue(first_entry["runtime_ledger_required"])
         command_policy = queue_payload["exact_replay_command_policy"]
         self.assertEqual(command_policy["generation_scope"], "bounded_frontier_only")
         self.assertEqual(command_policy["max_exact_replay_candidates"], 6)


### PR DESCRIPTION
## Summary

- Adds H-PAIRS fast-replay row/manifest fields that separate ranking output from promotion authority: `preview_rank_score`, `ranking_only_reasons`, `risk_veto_reasons`, exact-replay/runtime-ledger requirements, and promotion-disabled boundaries.
- Scores frontier candidates with risk-adjusted robust lower-percentile post-cost utility, deterministic bootstrap lower-percentile utility, macro/news stress vetoes, conformal tail buffers, and square-root impact/capacity penalties as ranking-only inputs.
- Propagates the new ranking-only and risk-veto fields into the whitepaper autoresearch selection/queue/handoff metadata while preserving the 6-candidate exact replay cap, 2-worker local cap, and no Kubernetes fanout policy.
- Adds focused regression coverage for ranking-only authority boundaries, missing data blockers, target-implied notional math, robust utility ordering, stress/impact veto metadata, and bounded frontier throughput.

## Related Issues

None.

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` — 229 passed, 1 warning.
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/fast_replay.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A — backend discovery/frontier metadata and regression tests only.

## Breaking Changes

None. Preview schema versions are bumped for additive metadata fields. This PR does not mutate clusters, submit Kubernetes jobs, write proof artifacts, or weaken promotion gates. The $500/day profitability proof remains incomplete unless real source-backed runtime-ledger/live-paper daily post-cost evidence exists.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
