### PR TITLE
revert(torghut): rollback failed promotion 1bd42f0e4ba0e4444c3bee72e594cc13368a870a

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -32,10 +32,6 @@ source-activity blockers such as `paper_route_source_activity_missing`, `source_
 `source_executions_missing`, and `source_tca_missing` into the final verdict. Treat those as the next repair target
 before rerunning import; do not collapse them into a generic runtime-ledger-missing diagnosis.
 
-The `torghut-paper-account-flatten` CronJob runs both before the regular session and after the regular session close.
-The post-close run is part of the paper-route proof lane: it persists the flat account snapshot required before the
-21:23 UTC renewal/import conductor can turn a closed paper-route window into authority-checkable runtime-ledger evidence.
-
 Trigger a simulation run via Argo:
 
 The proof packet separates post-cost proof authority from live capital promotion

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: paper-account-flatten
 spec:
-  schedule: "5,20,25 9,16 * * 1-5"
+  schedule: "5,20,25 9 * * 1-5"
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `1bd42f0e4ba0e4444c3bee72e594cc13368a870a`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/26817609385`
- Rollback source: `HEAD^` manifests from the failed run checkout