### PR TITLE
fix(torghut): keep live journal slices within watchdog

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -36,6 +36,10 @@ The `torghut-paper-account-flatten` CronJob runs both before the regular session
 The post-close run is part of the paper-route proof lane: it persists the flat account snapshot required before the
 21:23 UTC renewal/import conductor can turn a closed paper-route window into authority-checkable runtime-ledger evidence.
 
+The live TigerBeetle journal CronJob uses small supervised source slices. Keep the execution batch and order-event
+max-batch settings conservative enough to finish under the watchdog; failed slices do not grant accounting authority and
+slow the backlog drain that feeds runtime-ledger proof.
+
 Trigger a simulation run via Argo:
 
 The proof packet separates post-cost proof authority from live capital promotion

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -57,7 +57,7 @@ spec:
                   cd /app
                   exec /opt/venv/bin/python scripts/run_tigerbeetle_journal_cron.py \
                     --preset live \
-                    --execution-batch-size 10 \
+                    --execution-batch-size 5 \
                     --supervise-timeout-seconds 45 \
                     --json
               env:

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -75,7 +75,7 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
             dsn_env="DB_DSN",
             batch_size=5,
-            max_batches=3,
+            max_batches=2,
             reconcile_limit=1000,
             event_scan_limit=250,
             skip_reconcile=True,

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -748,6 +748,12 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             source_args = [argv[argv.index("--sources") + 1] for argv in command_argvs]
             self.assertEqual(source_args, [command.source for command in commands])
             self.assertTrue(all("," not in source for source in source_args))
+            if cronjob_name == "torghut-tigerbeetle-journal-order-events-live":
+                order_event_argv = command_argvs[2]
+                self.assertEqual(
+                    order_event_argv[order_event_argv.index("--max-batches") + 1],
+                    "2",
+                )
             runtime_argv = command_argvs[-1]
             self.assertEqual(
                 runtime_argv[runtime_argv.index("--sources") + 1],

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1529,7 +1529,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("SIM_DB_DSN", live_env)
         live_args = "\n".join(str(item) for item in live_container.get("args", []))
         self.assertIn("--preset live", live_args)
-        self.assertIn("--execution-batch-size 10", live_args)
+        self.assertIn("--execution-batch-size 5", live_args)
         self.assertNotIn("--dsn-env DB_DSN", live_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)
         self.assertNotIn("--account-label TORGHUT_SIM", live_args)

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -54,6 +54,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertTrue(commands[0].allow_data_quality_degraded)
         self.assertEqual(commands[1].batch_size, 5)
         self.assertEqual(commands[2].batch_size, 5)
+        self.assertEqual(commands[2].max_batches, 2)
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertFalse(commands[3].skip_reconcile)
 


### PR DESCRIPTION
## Summary

- Reduced the live TigerBeetle execution journal batch from 10 to 5 so the supervised worker is less likely to exceed the 45s watchdog.
- Capped the live execution-order-event slice at 2 batches while leaving source-specific commands split and fail-closed.
- Documented the live journal watchdog/backlog-drain constraint in the Torghut GitOps README.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py -k 'cronjob or live_preset or main_runs_all_commands' -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'tigerbeetle_journal_order_events or paper_account_flatten' -q`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
