### PR TITLE
fix(torghut): reuse reconciled tigerbeetle ref counts

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6789,6 +6789,39 @@ def _empty_tigerbeetle_ref_counts(
     }
 
 
+def _latest_reconciliation_ref_counts(
+    latest_reconciliation: Mapping[str, object] | None,
+) -> dict[str, object] | None:
+    if latest_reconciliation is None:
+        return None
+    raw_ref_counts = latest_reconciliation.get("ref_counts")
+    if not isinstance(raw_ref_counts, Mapping):
+        return None
+    ref_counts = dict(cast(Mapping[str, object], raw_ref_counts))
+    required_keys = (
+        "account_ref_count",
+        "transfer_ref_count",
+        "runtime_ledger_ref_count",
+        "runtime_ledger_signed_ref_count",
+        "runtime_ledger_missing_signed_ref_count",
+        "runtime_ledger_missing_account_ref_count",
+    )
+    if not all(key in ref_counts for key in required_keys):
+        return None
+    ref_counts.setdefault("schema_version", "torghut.tigerbeetle-ref-counts.v1")
+    ref_counts["source"] = "latest_tigerbeetle_reconciliation"
+    ref_counts["source_reconciliation_status"] = latest_reconciliation.get("status")
+    ref_counts["source_reconciliation_ok"] = bool(latest_reconciliation.get("ok"))
+    ref_counts["source_reconciliation_age_seconds"] = latest_reconciliation.get(
+        "age_seconds"
+    )
+    ref_counts["source_reconciliation_stale"] = bool(
+        latest_reconciliation.get("reconciliation_stale")
+    )
+    ref_counts["bounded_status_live_query_skipped"] = True
+    return ref_counts
+
+
 def _unavailable_tigerbeetle_reconciliation_payload(
     *,
     reason_codes: Sequence[str],
@@ -6845,25 +6878,29 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
 
     ref_counts: dict[str, object]
     ref_counts_available = True
-    try:
-        _apply_status_read_statement_timeout(session, milliseconds=750)
-        ref_counts = tigerbeetle_ref_counts(
-            session,
-            cluster_id=settings.tigerbeetle_cluster_id,
-            full_ref_scan=False,
-        )
-    except SQLAlchemyError as exc:
-        logger.warning("TigerBeetle ref-count status unavailable: %s", exc)
-        session.rollback()
-        ref_counts_available = False
-        reason_codes = ["tigerbeetle_ref_counts_unavailable"]
-        if _sqlalchemy_error_indicates_statement_timeout(exc):
-            reason_codes.append("tigerbeetle_ref_counts_query_timeout")
-        blockers.extend(reason_codes)
-        ref_counts = _empty_tigerbeetle_ref_counts(
-            reason_codes=reason_codes,
-            last_error=str(exc),
-        )
+    latest_ref_counts = _latest_reconciliation_ref_counts(latest_reconciliation)
+    if latest_ref_counts is not None:
+        ref_counts = latest_ref_counts
+    else:
+        try:
+            _apply_status_read_statement_timeout(session, milliseconds=750)
+            ref_counts = tigerbeetle_ref_counts(
+                session,
+                cluster_id=settings.tigerbeetle_cluster_id,
+                full_ref_scan=False,
+            )
+        except SQLAlchemyError as exc:
+            logger.warning("TigerBeetle ref-count status unavailable: %s", exc)
+            session.rollback()
+            ref_counts_available = False
+            reason_codes = ["tigerbeetle_ref_counts_unavailable"]
+            if _sqlalchemy_error_indicates_statement_timeout(exc):
+                reason_codes.append("tigerbeetle_ref_counts_query_timeout")
+            blockers.extend(reason_codes)
+            ref_counts = _empty_tigerbeetle_ref_counts(
+                reason_codes=reason_codes,
+                last_error=str(exc),
+            )
     runtime_ledger_ref_count = _tigerbeetle_status_int(
         ref_counts.get("runtime_ledger_ref_count")
     )

--- a/services/torghut/tests/test_tigerbeetle_status.py
+++ b/services/torghut/tests/test_tigerbeetle_status.py
@@ -93,6 +93,48 @@ class TestTigerBeetleStatus(TestCase):
         self.assertTrue(payload["ok"])
         self.assertEqual(ref_counts_mock.call_args.kwargs["full_ref_scan"], False)
 
+    def test_status_reuses_latest_reconciliation_ref_counts(self) -> None:
+        latest_reconciliation = {
+            "ok": True,
+            "status": "ok",
+            "age_seconds": 12,
+            "reconciliation_stale": False,
+            "blockers": [],
+            "ref_counts": {
+                "schema_version": "torghut.tigerbeetle-ref-counts.v1",
+                "cluster_id": 2001,
+                "account_ref_count": 54_129,
+                "transfer_ref_count": 28_993,
+                "by_source_type": {"strategy_runtime_ledger_bucket": 26},
+                "runtime_ledger_ref_count": 26,
+                "runtime_ledger_signed_ref_count": 26,
+                "runtime_ledger_missing_signed_ref_count": 0,
+                "runtime_ledger_missing_account_ref_count": 0,
+                "source_materialization": {},
+            },
+        }
+
+        with Session(self.engine) as session:
+            with (
+                patch(
+                    "app.main.latest_tigerbeetle_reconciliation_payload",
+                    return_value=latest_reconciliation,
+                ),
+                patch("app.main.tigerbeetle_ref_counts") as ref_counts_mock,
+            ):
+                payload = _build_tigerbeetle_ledger_status(session)
+
+        ref_counts_mock.assert_not_called()
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["claimed_by_runtime_evidence"])
+        self.assertEqual(payload["runtime_ledger_ref_count"], 26)
+        ref_counts = payload["ref_counts"]
+        self.assertIsInstance(ref_counts, dict)
+        assert isinstance(ref_counts, dict)
+        self.assertEqual(ref_counts["source"], "latest_tigerbeetle_reconciliation")
+        self.assertTrue(ref_counts["bounded_status_live_query_skipped"])
+        self.assertNotIn("tigerbeetle_ref_counts_unavailable", payload["blockers"])
+
     def test_ref_count_failure_degrades_without_status_exception(self) -> None:
         with Session(self.engine) as session:
             with patch(


### PR DESCRIPTION
## Summary

- Reuses complete TigerBeetle ref-count snapshots from the latest reconciliation run in `/trading/status` instead of recounting large ref tables on every status read.
- Falls back to the existing bounded live ref-count query when the reconciliation payload is missing or incomplete, preserving fail-closed timeout behavior.
- Adds regression coverage proving complete persisted counts skip the live scan without hiding runtime-ledger ref authority fields.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_tigerbeetle_status.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -q -k 'tigerbeetle_ledger_status_fails_closed_on_ref_count_timeout or tigerbeetle_ledger_status_fails_closed_on_reconciliation_timeout or trading_status_skips_expensive_reads_when_budget_remaining_is_low or trading_status_fails_closed_late_reads_after_budget_exhausted or trading_status_skips_early_expensive_reads_when_budget_remaining_is_low'`
- `uv run --frozen ruff check app/main.py tests/test_tigerbeetle_status.py tests/test_trading_api.py`
- `uv run --frozen ruff format --check app/main.py tests/test_tigerbeetle_status.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend status/read-model change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
