### PR TITLE
fix(torghut): persist order-feed source classifications

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -312,6 +312,7 @@ class OrderFeedSourceWindow(Base, TimestampMixin):
     status_reason: Mapped[Optional[str]] = mapped_column(
         String(length=128), nullable=True
     )
+    classification_counts: Mapped[Any] = mapped_column(JSONType, nullable=True)
     payload_json: Mapped[Any] = mapped_column(JSONType, nullable=True)
 
     events: Mapped[list["ExecutionOrderEvent"]] = relationship(

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -689,9 +689,11 @@ def _classify_source_window_drop(
     source_window.status = "dropped"
     source_window.status_reason = drop_reason or "unknown_drop"
     source_window.dropped_count = 1
+    classification_counts = {drop_reason or "unknown_drop": 1}
+    source_window.classification_counts = classification_counts
     source_window.payload_json = {
         "classification": drop_reason or "unknown_drop",
-        "classification_counts": {drop_reason or "unknown_drop": 1},
+        "classification_counts": classification_counts,
         "source_coverage_complete": False,
         "promotion_authority_eligible": False,
         "authority_class": "invalid_order_feed_message",
@@ -718,9 +720,11 @@ def _classify_source_window_unhandled_failure(
     source_window.status = "failed_unhandled"
     source_window.status_reason = _source_window_failure_reason(exc)
     source_window.failed_unhandled_count = 1
+    classification_counts = {"failed_unhandled": 1}
+    source_window.classification_counts = classification_counts
     source_window.payload_json = {
         "classification": "failed_unhandled",
-        "classification_counts": {"failed_unhandled": 1},
+        "classification_counts": classification_counts,
         "source_coverage_complete": False,
         "promotion_authority_eligible": False,
         "authority_class": "failed_unhandled_order_feed_message",
@@ -757,9 +761,11 @@ def _classify_source_window_event(
         source_window.status = "duplicate"
         source_window.status_reason = "duplicate_event_fingerprint"
         source_window.duplicate_count = 1
+        classification_counts = {"duplicate": 1}
+        source_window.classification_counts = classification_counts
         payload: dict[str, Any] = {
             "classification": "duplicate",
-            "classification_counts": {"duplicate": 1},
+            "classification_counts": classification_counts,
             **_source_window_source_identity_payload(source_window),
             **_order_event_evidence_payload(persisted),
             "source_coverage_complete": False,
@@ -780,6 +786,7 @@ def _classify_source_window_event(
     if persisted.trade_decision_id is None:
         source_window.unlinked_decision_count = 1
         classification_counts["unlinked_decision"] = 1
+    source_window.classification_counts = classification_counts
     payload = {
         "classification": "inserted",
         "classification_counts": classification_counts,
@@ -2894,6 +2901,7 @@ def _refresh_source_window_linkage_counts(
     else:
         classification_counts.pop("unlinked_decision", None)
     payload_dict["classification_counts"] = classification_counts
+    source_window.classification_counts = classification_counts
     source_window_complete = bool(
         event_count
         and source_window.unlinked_execution_count == 0
@@ -2971,6 +2979,15 @@ def _retry_failed_duplicate_order_event_application(
             event.source_window_id
         )
         source_window.status_reason = "duplicate_after_failed_unhandled_reprocessed"
+        raw_classification_counts = payload_dict.get("classification_counts")
+        if isinstance(raw_classification_counts, Mapping):
+            source_window.classification_counts = {
+                str(key): value
+                for key, value in cast(
+                    Mapping[object, Any],
+                    raw_classification_counts,
+                ).items()
+            }
         source_window.payload_json = coerce_json_payload(payload_dict)
 
 

--- a/services/torghut/migrations/versions/0047_order_feed_source_window_classification_counts.py
+++ b/services/torghut/migrations/versions/0047_order_feed_source_window_classification_counts.py
@@ -1,0 +1,45 @@
+"""Add first-class source-window classification counts.
+
+Revision ID: 0047_order_feed_source_window_classification_counts
+Revises: 0046_autoresearch_portfolio_latest_index
+Create Date: 2026-06-02 12:05:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0047_order_feed_source_window_classification_counts"
+down_revision = "0046_autoresearch_portfolio_latest_index"
+branch_labels = None
+depends_on = None
+
+_TABLE_NAME = "order_feed_source_windows"
+_COLUMN_NAME = "classification_counts"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(_TABLE_NAME):
+        return
+    existing_columns = {column["name"] for column in inspector.get_columns(_TABLE_NAME)}
+    if _COLUMN_NAME not in existing_columns:
+        op.add_column(
+            _TABLE_NAME,
+            sa.Column(_COLUMN_NAME, postgresql.JSONB(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(_TABLE_NAME):
+        return
+    existing_columns = {column["name"] for column in inspector.get_columns(_TABLE_NAME)}
+    if _COLUMN_NAME in existing_columns:
+        op.drop_column(_TABLE_NAME, _COLUMN_NAME)

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -3203,6 +3203,11 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.status_reason, "malformed_json")
         self.assertEqual(source_window.malformed_count, 1)
         self.assertEqual(source_window.dropped_count, 1)
+        self.assertEqual(source_window.classification_counts, {"malformed_json": 1})
+        self.assertEqual(
+            source_window.payload_json["classification_counts"],
+            source_window.classification_counts,
+        )
         self.assertFalse(source_window.payload_json["source_coverage_complete"])
         self.assertFalse(source_window.payload_json["promotion_authority_eligible"])
         self.assertEqual(
@@ -3237,6 +3242,14 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.status_reason, "missing_trade_update_payload")
         self.assertEqual(source_window.missing_payload_count, 1)
         self.assertEqual(source_window.dropped_count, 1)
+        self.assertEqual(
+            source_window.classification_counts,
+            {"missing_trade_update_payload": 1},
+        )
+        self.assertEqual(
+            source_window.payload_json["classification_counts"],
+            source_window.classification_counts,
+        )
 
     def test_out_of_scope_account_is_durably_classified(self) -> None:
         record = FakeRecord(
@@ -3270,6 +3283,14 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.status, "dropped")
         self.assertEqual(source_window.status_reason, "out_of_scope_account")
         self.assertEqual(source_window.out_of_scope_account_count, 1)
+        self.assertEqual(
+            source_window.classification_counts,
+            {"out_of_scope_account": 1},
+        )
+        self.assertEqual(
+            source_window.payload_json["classification_counts"],
+            source_window.classification_counts,
+        )
 
     def test_out_of_scope_account_without_source_position_is_not_committed(
         self,
@@ -3698,6 +3719,18 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.inserted_count, 1)
         self.assertEqual(source_window.unlinked_execution_count, 1)
         self.assertEqual(source_window.unlinked_decision_count, 1)
+        self.assertEqual(
+            source_window.classification_counts,
+            {
+                "inserted": 1,
+                "unlinked_execution": 1,
+                "unlinked_decision": 1,
+            },
+        )
+        self.assertEqual(
+            source_window.payload_json["classification_counts"],
+            source_window.classification_counts,
+        )
         self.assertEqual(
             source_window.payload_json["linked_refs"],
             {


### PR DESCRIPTION
## Summary

- Add first-class `classification_counts` storage to the append-only order-feed source-window ledger.
- Persist durable classification summaries for inserted, duplicate, malformed, missing-payload, missing-identity, out-of-scope, unlinked, and failed-unhandled Kafka source windows.
- Add a source-window migration and focused regression assertions that the ledger column matches payload evidence for dropped and unlinked lifecycle classifications.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_simple_pipeline.py -q`
- `cd services/torghut && uv run --frozen ruff check app/models/entities.py app/trading/order_feed.py scripts/import_hypothesis_runtime_windows.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_simple_pipeline.py migrations/versions/0047_order_feed_source_window_classification_counts.py`
- `cd services/torghut && uv run --frozen ruff format --check app/models/entities.py app/trading/order_feed.py scripts/import_hypothesis_runtime_windows.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_simple_pipeline.py migrations/versions/0047_order_feed_source_window_classification_counts.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds nullable `order_feed_source_windows.classification_counts` JSONB column via migration `0047_order_feed_source_window_classification_counts`; no runtime flag, threshold, or direct cluster mutation required.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
