### PR TITLE
fix(synthesis): harden autotrader analysis checkout

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -188,7 +188,7 @@ spec:
         }
 
         fetch_analysis_main() {
-          git_with_auth -C "${analysis_dir}" fetch --prune origin main:refs/remotes/origin/main
+          git_with_auth -C "${analysis_dir}" fetch --prune origin refs/heads/main:refs/remotes/origin/main
         }
 
         if [ ! -d "${analysis_dir}/.git" ]; then
@@ -201,8 +201,9 @@ spec:
         git -C "${analysis_dir}" remote set-url origin "${analysis_repo_url}"
         git -C "${analysis_dir}" config gc.auto 0
         fetch_analysis_main
-        git -C "${analysis_dir}" checkout --force --detach origin/main
-        git -C "${analysis_dir}" reset --hard origin/main
+        analysis_main_sha="$(git -C "${analysis_dir}" rev-parse refs/remotes/origin/main^{commit})"
+        git -C "${analysis_dir}" checkout --force "${analysis_main_sha}"
+        git -C "${analysis_dir}" reset --hard "${analysis_main_sha}"
         git -C "${analysis_dir}" clean -ffd
 
         analysis_head="$(git -C "${analysis_dir}" rev-parse HEAD)"

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -742,6 +742,14 @@ describe('synthesis autonomous trader provider', () => {
     expect(bootstrapContent).toContain(
       'analysis_context_path="${ANALYSIS_CONTEXT_PATH:-${work_dir}/analysis-context.json}"',
     )
+    expect(bootstrapContent).toContain('fetch --prune origin refs/heads/main:refs/remotes/origin/main')
+    expect(bootstrapContent).toContain(
+      'analysis_main_sha="$(git -C "${analysis_dir}" rev-parse refs/remotes/origin/main^{commit})"',
+    )
+    expect(bootstrapContent).toContain('git -C "${analysis_dir}" checkout --force "${analysis_main_sha}"')
+    expect(bootstrapContent).not.toContain('fetch --prune origin main:refs/remotes/origin/main')
+    expect(bootstrapContent).not.toContain('checkout --force --detach origin/main')
+    expect(bootstrapContent).not.toContain('reset --hard origin/main')
     expect(bootstrapContent).toContain('--output "${analysis_context_path}"')
     expect(bootstrapContent).not.toContain('"${artifact_dir}/analysis-context.json"')
     expect(bootstrapContent).not.toContain('"${artifact_dir}/analysis-bootstrap.json"')


### PR DESCRIPTION
## Summary

- Harden the autonomous-trader analysis bootstrap fetch to use `refs/heads/main:refs/remotes/origin/main`.
- Resolve `refs/remotes/origin/main` to a commit SHA before checkout/reset so Git cannot misclassify `origin/main` as a checkout path.
- Add a smoke-test guard for the exact fetch and checkout contract that failed in the premarket AgentRun.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "wires the analysis daytrading bootstrap into the trader provider"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint`
- `git diff --check -- argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
