### PR TITLE
fix(torghut): retry readyz database timeouts

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -271,22 +271,41 @@ jobs:
             local output_path="$2"
             local label="$3"
             local status
+            local decision
 
-            for attempt in $(seq 1 18); do
+            for attempt in $(seq 1 48); do
               status="$(
                 curl -sS --connect-timeout 10 --max-time 90 \
                   -o "${output_path}" -w '%{http_code}' "${url}" || true
               )"
-              if [[ "${status}" =~ ^2[0-9][0-9]$ ]] &&
+              if [[ "${status}" =~ ^[0-9]{3}$ ]] &&
+                [ "${status}" != '000' ] &&
                 python3 -m json.tool "${output_path}" >/dev/null 2>&1; then
-                printf '%s' "${status}"
-                return 0
-              fi
-              if [ "${status}" = '503' ] &&
-                python3 -m json.tool "${output_path}" >/dev/null 2>&1 &&
-                python3 -c 'import json, sys; payload = json.load(open(sys.argv[1], encoding="utf-8")); sys.exit(0 if payload.get("status") == "degraded" else 1)' "${output_path}"; then
-                printf '%s' "${status}"
-                return 0
+                decision="$(
+                  bun run packages/scripts/src/torghut/readyz-contract.ts \
+                    --status "${status}" \
+                    --readyz-json "${output_path}"
+                )"
+                case "${decision}" in
+                  acceptable)
+                    printf '%s' "${status}"
+                    return 0
+                    ;;
+                  retryable_database_timeout)
+                    if [ "${attempt}" -eq 48 ]; then
+                      echo "${label} still reports a retryable database-readiness timeout after ${attempt} attempts" >&2
+                      printf '%s' "${status}"
+                      return 0
+                    fi
+                    echo "Attempt ${attempt}: ${label} database readiness timed out; retrying until repair-only readyz contract is acceptable" >&2
+                    sleep 5
+                    continue
+                    ;;
+                  *)
+                    printf '%s' "${status}"
+                    return 0
+                    ;;
+                esac
               fi
 
               if [ "${attempt}" -eq 18 ]; then

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -53,10 +53,12 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).not.toContain('Torghut /readyz returned HTTP')
   })
 
-  it('retries transient readyz 503 payloads until they match the repair-only contract', () => {
+  it('retries database-timeout readyz 503 payloads until they match the repair-only contract', () => {
     expect(workflow).toContain('fetch_readyz_json()')
-    expect(workflow).toContain('payload.get("status") == "degraded"')
-    expect(workflow).toContain('without an acceptable readyz contract; retrying')
+    expect(workflow).toContain('packages/scripts/src/torghut/readyz-contract.ts')
+    expect(workflow).toContain('retryable_database_timeout')
+    expect(workflow).toContain('database readiness timed out; retrying')
+    expect(workflow).toContain('without an acceptable readyz contract')
     expect(workflow).toContain('fetch_readyz_json \\')
   })
 

--- a/packages/scripts/src/torghut/__tests__/readyz-contract.test.ts
+++ b/packages/scripts/src/torghut/__tests__/readyz-contract.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'bun:test'
+
+import { classifyReadyzForPostDeployRetry } from '../readyz-contract'
+
+const repairOnlyReadyz = {
+  status: 'degraded',
+  scheduler: { ok: true, running: true },
+  dependencies: {
+    postgres: { ok: true, detail: 'ok' },
+    clickhouse: { ok: true, detail: 'ok' },
+    database: { ok: true, detail: 'ok' },
+    live_submission_gate: { ok: false, detail: 'simple_submit_disabled' },
+    profitability_proof_floor: { ok: false, detail: 'repair_only', capital_state: 'zero_notional' },
+  },
+}
+
+describe('classifyReadyzForPostDeployRetry', () => {
+  it('accepts healthy 2xx readyz payloads immediately', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '200',
+        readyz: { status: 'ok' },
+      }),
+    ).toBe('acceptable')
+  })
+
+  it('accepts repair-only 503 only when runtime database dependencies are healthy', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: repairOnlyReadyz,
+      }),
+    ).toBe('acceptable')
+  })
+
+  it('retries a degraded 503 when the database contract only shows a statement timeout', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: {
+          ...repairOnlyReadyz,
+          reason: 'readyz_evaluation_timeout',
+          dependencies: {
+            ...repairOnlyReadyz.dependencies,
+            database: {
+              ok: false,
+              detail: 'database contract failed',
+              schema_current: false,
+              account_scope_ready: false,
+              account_scope_errors: [
+                '(psycopg.errors.QueryCanceled) canceling statement due to statement timeout\n' +
+                  '[SQL: SELECT alembic_version.version_num FROM alembic_version]',
+              ],
+            },
+          },
+        },
+      }),
+    ).toBe('retryable_database_timeout')
+  })
+
+  it('does not retry real database reachability failures', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: {
+          ...repairOnlyReadyz,
+          dependencies: {
+            ...repairOnlyReadyz.dependencies,
+            database: {
+              ok: false,
+              detail: 'database unavailable',
+              error: 'connection refused',
+              schema_current: false,
+            },
+          },
+        },
+      }),
+    ).toBe('unacceptable')
+  })
+
+  it('does not retry schema drift because migrations remain fail-closed', () => {
+    expect(
+      classifyReadyzForPostDeployRetry({
+        httpStatus: '503',
+        readyz: {
+          ...repairOnlyReadyz,
+          dependencies: {
+            ...repairOnlyReadyz.dependencies,
+            database: {
+              ok: false,
+              detail: 'database contract failed',
+              schema_current: false,
+              schema_missing_heads: ['0048_required_head'],
+              schema_unexpected_heads: ['0047_old_head'],
+            },
+          },
+        },
+      }),
+    ).toBe('unacceptable')
+  })
+})

--- a/packages/scripts/src/torghut/readyz-contract.ts
+++ b/packages/scripts/src/torghut/readyz-contract.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from 'node:fs'
+import process from 'node:process'
+
+type JsonObject = Record<string, unknown>
+
+export type ReadyzPostDeployDecision = 'acceptable' | 'retryable_database_timeout' | 'unacceptable'
+
+type ClassifyReadyzInput = {
+  httpStatus: string
+  readyz: unknown
+}
+
+const isObject = (value: unknown): value is JsonObject =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const objectAt = (value: unknown, key: string): JsonObject | undefined => {
+  if (!isObject(value)) return undefined
+  const nested = value[key]
+  return isObject(nested) ? nested : undefined
+}
+
+const stringAt = (value: unknown, key: string): string => {
+  if (!isObject(value)) return ''
+  const nested = value[key]
+  if (typeof nested === 'string') return nested
+  if (typeof nested === 'number' || typeof nested === 'boolean') return String(nested)
+  return ''
+}
+
+const parseHttpStatus = (value: string): number | undefined => {
+  if (!/^[0-9]{3}$/.test(value)) return undefined
+  return Number(value)
+}
+
+const dependencyOk = (dependencies: JsonObject, name: string): boolean => objectAt(dependencies, name)?.ok === true
+
+const containsDatabaseTimeoutSignal = (value: unknown): boolean => {
+  if (typeof value === 'string') {
+    const normalized = value.toLowerCase()
+    return (
+      normalized.includes('statement timeout') ||
+      normalized.includes('querycanceled') ||
+      normalized.includes('canceling statement due to statement timeout') ||
+      normalized.includes('readyz_evaluation_timeout')
+    )
+  }
+  if (Array.isArray(value)) return value.some(containsDatabaseTimeoutSignal)
+  if (!isObject(value)) return false
+  return Object.values(value).some(containsDatabaseTimeoutSignal)
+}
+
+const hasRepairOnlyReadyzContract = (readyz: JsonObject): boolean => {
+  if (readyz.status !== 'degraded') return false
+
+  const dependencies = objectAt(readyz, 'dependencies')
+  if (!dependencies) return false
+  if (!dependencyOk(dependencies, 'postgres')) return false
+  if (!dependencyOk(dependencies, 'clickhouse')) return false
+  if (!dependencyOk(dependencies, 'database')) return false
+
+  const scheduler = objectAt(readyz, 'scheduler')
+  if (!scheduler || scheduler.ok !== true || scheduler.running !== true) return false
+
+  const liveSubmissionGate = objectAt(dependencies, 'live_submission_gate')
+  if (!liveSubmissionGate || stringAt(liveSubmissionGate, 'detail') !== 'simple_submit_disabled') return false
+
+  const proofFloor = objectAt(dependencies, 'profitability_proof_floor')
+  if (
+    !proofFloor ||
+    stringAt(proofFloor, 'detail') !== 'repair_only' ||
+    stringAt(proofFloor, 'capital_state') !== 'zero_notional'
+  ) {
+    return false
+  }
+
+  return true
+}
+
+export const classifyReadyzForPostDeployRetry = ({
+  httpStatus,
+  readyz,
+}: ClassifyReadyzInput): ReadyzPostDeployDecision => {
+  const statusCode = parseHttpStatus(httpStatus)
+  if (statusCode === undefined || !isObject(readyz)) return 'unacceptable'
+  if (statusCode >= 200 && statusCode < 300) return 'acceptable'
+  if (statusCode !== 503 || readyz.status !== 'degraded') return 'unacceptable'
+  if (hasRepairOnlyReadyzContract(readyz)) return 'acceptable'
+
+  const database = objectAt(objectAt(readyz, 'dependencies'), 'database')
+  if (database && database.ok !== true && containsDatabaseTimeoutSignal(database)) {
+    return 'retryable_database_timeout'
+  }
+
+  return 'unacceptable'
+}
+
+const usage = () => {
+  console.error('usage: readyz-contract.ts --status <http-status> --readyz-json <path>')
+}
+
+const parseArgs = (argv: string[]): { status: string; readyzPath: string } => {
+  let status = ''
+  let readyzPath = ''
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--status') {
+      status = argv[index + 1] ?? ''
+      index += 1
+    } else if (arg === '--readyz-json') {
+      readyzPath = argv[index + 1] ?? ''
+      index += 1
+    }
+  }
+
+  return { status, readyzPath }
+}
+
+if (import.meta.main) {
+  const { status, readyzPath } = parseArgs(process.argv.slice(2))
+  if (!status || !readyzPath) {
+    usage()
+    process.exit(2)
+  }
+
+  try {
+    const readyz = JSON.parse(readFileSync(readyzPath, 'utf8')) as unknown
+    console.log(classifyReadyzForPostDeployRetry({ httpStatus: status, readyz }))
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(2)
+  }
+}


### PR DESCRIPTION
## Summary

- Added a Torghut readyz post-deploy classifier that accepts healthy 2xx responses and repair-only 503 responses only when runtime database dependencies are healthy.
- Updated the post-deploy verifier to retry retryable database statement-timeout 503s for longer instead of accepting any degraded 503 immediately.
- Kept real database reachability failures and schema drift fail-closed by returning them to the existing evidence validator without retry masking.
- Added regression coverage for statement-timeout retries versus real database failures and schema drift.

## Related Issues

Related: held rollback PR #9798 and failed workflow run 26817609385.

## Testing

- PASS: `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/readyz-contract.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- PASS: `bunx oxfmt --check packages/scripts/src/torghut/readyz-contract.ts packages/scripts/src/torghut/__tests__/readyz-contract.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- PASS: `bun run --cwd packages/scripts lint:oxlint` exited 0 with existing unrelated warnings in packages/scripts.
- PASS: `git diff --check`
- PASS: `bun run packages/scripts/src/torghut/readyz-contract.ts --status 503 --readyz-json /tmp/run26817609385-artifacts/torghut-revenue-repair-26817609385-1/torghut-readyz.json` returned `retryable_database_timeout` for the failed-run artifact.
- NOTE: `bun install --frozen-lockfile` could not complete in this workspace because node-pty attempted a native rebuild and `make` is unavailable; the partial install made the package oxlint binary available for the lint command above.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
