### PR TITLE
fix(torghut): lock live journal order-event slice

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -24,6 +24,10 @@ from app.trading.tigerbeetle_journal import (  # noqa: E402
 )
 from scripts import journal_tigerbeetle_order_events as journal_script  # noqa: E402
 
+LIVE_ORDER_EVENT_BATCH_SIZE = 5
+LIVE_ORDER_EVENT_MAX_BATCHES = 2
+LIVE_ORDER_EVENT_SCAN_LIMIT = 250
+
 
 @dataclass(frozen=True)
 class JournalCronCommand:
@@ -74,10 +78,10 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
             dsn_env="DB_DSN",
-            batch_size=5,
-            max_batches=2,
+            batch_size=LIVE_ORDER_EVENT_BATCH_SIZE,
+            max_batches=LIVE_ORDER_EVENT_MAX_BATCHES,
             reconcile_limit=1000,
-            event_scan_limit=250,
+            event_scan_limit=LIVE_ORDER_EVENT_SCAN_LIMIT,
             skip_reconcile=True,
             allow_data_quality_degraded=True,
         ),

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -11,6 +11,8 @@ from yaml import safe_load, safe_load_all
 
 from app.config import Settings
 from app.trading.llm.dspy_programs.runtime import DSPyReviewRuntime
+from app.trading.tigerbeetle_journal import SOURCE_TYPE_EXECUTION_ORDER_EVENT
+from scripts import run_tigerbeetle_journal_cron as tigerbeetle_journal_runner
 
 
 _RESEARCHED_CHIP_TECH_UNIVERSE = (
@@ -1530,11 +1532,40 @@ class TestLiveConfigManifestContract(TestCase):
         live_args = "\n".join(str(item) for item in live_container.get("args", []))
         self.assertIn("--preset live", live_args)
         self.assertIn("--execution-batch-size 5", live_args)
+        self.assertIn("--supervise-timeout-seconds 45", live_args)
         self.assertNotIn("--dsn-env DB_DSN", live_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)
         self.assertNotIn("--account-label TORGHUT_SIM", live_args)
         self.assertNotIn("--batch-size", live_args)
         self.assertNotIn("--max-batches", live_args)
+        live_order_event_commands = [
+            command
+            for command in tigerbeetle_journal_runner._live_commands(
+                execution_batch_size=5
+            )
+            if command.source == SOURCE_TYPE_EXECUTION_ORDER_EVENT
+        ]
+        self.assertEqual(len(live_order_event_commands), 1)
+        live_order_event_command = live_order_event_commands[0]
+        self.assertEqual(
+            live_order_event_command.batch_size,
+            tigerbeetle_journal_runner.LIVE_ORDER_EVENT_BATCH_SIZE,
+        )
+        self.assertEqual(
+            live_order_event_command.event_scan_limit,
+            tigerbeetle_journal_runner.LIVE_ORDER_EVENT_SCAN_LIMIT,
+        )
+        self.assertEqual(
+            live_order_event_command.max_batches,
+            tigerbeetle_journal_runner.LIVE_ORDER_EVENT_MAX_BATCHES,
+        )
+        self.assertLessEqual(
+            live_order_event_command.max_batches,
+            2,
+            "live order-event slices must not run PR #9799's unsafe 3-batch shape under the 45s watchdog",
+        )
+        self.assertTrue(live_order_event_command.skip_reconcile)
+        self.assertTrue(live_order_event_command.allow_data_quality_degraded)
 
         sim_env = {
             item.get("name"): item

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION,
+    SOURCE_TYPE_EXECUTION_ORDER_EVENT,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
 )
 from scripts import run_tigerbeetle_journal_cron as runner
@@ -53,10 +54,48 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertTrue(commands[0].skip_reconcile)
         self.assertTrue(commands[0].allow_data_quality_degraded)
         self.assertEqual(commands[1].batch_size, 5)
-        self.assertEqual(commands[2].batch_size, 5)
-        self.assertEqual(commands[2].max_batches, 2)
+        self.assertEqual(commands[2].source, SOURCE_TYPE_EXECUTION_ORDER_EVENT)
+        self.assertEqual(commands[2].batch_size, runner.LIVE_ORDER_EVENT_BATCH_SIZE)
+        self.assertEqual(commands[2].max_batches, runner.LIVE_ORDER_EVENT_MAX_BATCHES)
+        self.assertLessEqual(commands[2].max_batches, 2)
+        self.assertEqual(
+            commands[2].event_scan_limit,
+            runner.LIVE_ORDER_EVENT_SCAN_LIMIT,
+        )
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertFalse(commands[3].skip_reconcile)
+
+    def test_live_order_event_argv_keeps_slice_bounded_under_watchdog(self) -> None:
+        [command] = [
+            item
+            for item in runner._live_commands(execution_batch_size=5)
+            if item.source == SOURCE_TYPE_EXECUTION_ORDER_EVENT
+        ]
+
+        argv = runner._argv_for_command(
+            command,
+            json_output=True,
+            supervise_timeout_seconds=45.0,
+        )
+
+        self.assertEqual(argv[argv.index("--sources") + 1], "execution_order_event")
+        self.assertEqual(
+            argv[argv.index("--batch-size") + 1],
+            str(runner.LIVE_ORDER_EVENT_BATCH_SIZE),
+        )
+        self.assertEqual(
+            argv[argv.index("--max-batches") + 1],
+            str(runner.LIVE_ORDER_EVENT_MAX_BATCHES),
+        )
+        self.assertLessEqual(int(argv[argv.index("--max-batches") + 1]), 2)
+        self.assertEqual(
+            argv[argv.index("--event-scan-limit") + 1],
+            str(runner.LIVE_ORDER_EVENT_SCAN_LIMIT),
+        )
+        self.assertEqual(argv[argv.index("--supervise-timeout-seconds") + 1], "45.0")
+        self.assertIn("--fail-on-degraded", argv)
+        self.assertIn("--allow-data-quality-degraded", argv)
+        self.assertIn("--json", argv)
 
     def test_safe_non_authority_payload_normalizes_nonzero_command_exit(self) -> None:
         safe_payload = {


### PR DESCRIPTION
## Summary

- Extracts the live TigerBeetle order-event journal slice bounds into named runner constants: batch size 5, max batches 2, and event scan limit 250.
- Adds a focused runner regression proving `execution_order_event` emits a bounded 2-batch argv under the 45s supervised live watchdog with hard-failure flags intact.
- Extends the live CronJob manifest contract test so `--preset live` and `--supervise-timeout-seconds 45` are tied back to the runner's bounded live order-event slice.
- Preserves promotion truth: journal telemetry remains non-authoritative and the change does not touch runtime-ledger proof authority or promotion gates.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen`
- BLOCKED: `cd services/torghut && uv sync --frozen --extra dev` fails building `crosshair-tool==0.0.102` because this aarch64 workspace has no `cc` compiler. Per task constraints, I did not install apt packages or build-essential.
- PASS: `cd services/torghut && uv pip install 'pytest>=8.4.0,<9.0' 'pytest-cov>=7.0.0,<8.0' 'pytest-xdist>=3.8.0,<4.0' 'hypothesis>=6.151.0,<7.0' pyright==1.1.408 ruff==0.15.2` to install locked dev-check tooling except the blocked native CrossHair package.
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q` -> 84 passed, 1 warning.
- PASS: `cd services/torghut && uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- PASS: `cd services/torghut && uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`
- NOT RUN: `bun run lint:argocd` because no Argo manifest files changed.
- BLOCKED: read-only live cluster readback with `kubectl` because `kubectl` is not installed in this workspace; no direct cluster mutation was attempted.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
