### PR TITLE
fix(torghut): reconcile empty journal slices

### DIFF
--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -110,6 +110,15 @@ def _parse_args() -> argparse.Namespace:
         help="Persist journal refs without running reconciliation in this invocation.",
     )
     parser.add_argument(
+        "--reconcile-empty-selection",
+        action="store_true",
+        help=(
+            "Run bounded reconciliation even when this invocation selects no new "
+            "source rows. This is intended for scheduled freshness probes; by "
+            "default empty source slices remain a no-op."
+        ),
+    )
+    parser.add_argument(
         "--fail-on-degraded",
         action="store_true",
         help="Exit non-zero when journaling/reconciliation is degraded.",
@@ -649,6 +658,9 @@ def _payload(
         "event_scan_limit": getattr(args, "event_scan_limit", None),
         "sources": list(_parse_sources(getattr(args, "sources", "all"))),
         "skip_reconcile": bool(getattr(args, "skip_reconcile", False)),
+        "reconcile_empty_selection": bool(
+            getattr(args, "reconcile_empty_selection", False)
+        ),
         "supervised_worker": bool(getattr(args, "supervised_worker", False)),
         "supervise_timeout_seconds": float(
             getattr(args, "supervise_timeout_seconds", 0.0) or 0.0
@@ -1137,7 +1149,10 @@ def main() -> int:
             not args.dry_run
             and not args.skip_reconcile
             and not stop_journaling
-            and selected_source_rows > 0
+            and (
+                selected_source_rows > 0
+                or bool(getattr(args, "reconcile_empty_selection", False))
+            )
         ):
             reconciliation = reconcile_tigerbeetle_transfers(
                 session,
@@ -1152,6 +1167,7 @@ def main() -> int:
                 "ok": True,
                 "status": "skipped",
                 "reason": "no_source_rows_selected",
+                "reconcile_empty_selection": False,
             }
 
     payload = _payload(

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -35,6 +35,7 @@ class JournalCronCommand:
     account_label: str | None = None
     event_scan_limit: int | None = None
     skip_reconcile: bool = False
+    reconcile_empty_selection: bool = False
     allow_data_quality_degraded: bool = False
 
 
@@ -87,6 +88,7 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             batch_size=5,
             max_batches=1,
             reconcile_limit=1000,
+            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
         ),
     ]
@@ -121,6 +123,7 @@ def _sim_commands() -> list[JournalCronCommand]:
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
             **common,
         ),
@@ -168,6 +171,8 @@ def _argv_for_command(
     argv.extend(["--reconcile-limit", str(command.reconcile_limit)])
     if command.skip_reconcile:
         argv.append("--skip-reconcile")
+    if command.reconcile_empty_selection:
+        argv.append("--reconcile-empty-selection")
     argv.append("--fail-on-degraded")
     if command.allow_data_quality_degraded:
         argv.append("--allow-data-quality-degraded")

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -759,6 +759,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 runtime_argv[runtime_argv.index("--sources") + 1],
                 script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             )
+            self.assertIn("--reconcile-empty-selection", runtime_argv)
             self.assertIn("--fail-on-degraded", runtime_argv)
             self.assertIn("--allow-data-quality-degraded", runtime_argv)
 
@@ -1777,9 +1778,63 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertEqual(payload["failed"], 0)
         self.assertEqual(payload["reconciliation"]["status"], "skipped")
         self.assertEqual(payload["reconciliation"]["reason"], "no_source_rows_selected")
+        self.assertFalse(payload["reconcile_empty_selection"])
         self.assertEqual(FakeJournal.instances[0].runtime_buckets, [])
         self.assertEqual(FakeJournal.instances[0].stable_ref_backfills, 0)
         reconcile.assert_not_called()
+
+    def test_main_can_reconcile_when_source_selects_no_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--sources",
+                        "strategy_runtime_ledger_bucket",
+                        "--batch-size",
+                        "5",
+                        "--reconcile-limit",
+                        "12",
+                        "--reconcile-empty-selection",
+                        "--fail-on-degraded",
+                        "--allow-data-quality-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={"ok": True, "status": "ok"},
+                ) as reconcile,
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["selected"], 0)
+        self.assertTrue(payload["reconcile_empty_selection"])
+        self.assertEqual(payload["reconciliation"]["status"], "ok")
+        self.assertEqual(FakeJournal.instances[0].stable_ref_backfills, 0)
+        reconcile.assert_called_once()
+        self.assertEqual(reconcile.call_args.kwargs["limit"], 12)
+        self.assertIs(
+            reconcile.call_args.kwargs["client"],
+            FakeJournal.instances[0].reconciliation_client,
+        )
 
     def test_main_dry_run_rolls_back_without_reconcile(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -57,6 +57,19 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(commands[2].max_batches, 2)
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertFalse(commands[3].skip_reconcile)
+        self.assertTrue(commands[3].reconcile_empty_selection)
+
+    def test_runtime_ledger_command_reconciles_empty_selection(self) -> None:
+        command = runner._live_commands(execution_batch_size=5)[-1]
+
+        argv = runner._argv_for_command(
+            command,
+            json_output=True,
+            supervise_timeout_seconds=45.0,
+        )
+
+        self.assertIn("--reconcile-empty-selection", argv)
+        self.assertNotIn("--skip-reconcile", argv)
 
     def test_safe_non_authority_payload_normalizes_nonzero_command_exit(self) -> None:
         safe_payload = {


### PR DESCRIPTION
## Summary
- Added explicit `--reconcile-empty-selection` support for TigerBeetle journal runs so empty scheduled slices can still refresh bounded reconciliation freshness.
- Wired live and sim runtime-ledger journal slices to use the new flag while preserving default no-op behavior for other empty slices.
- Added regression tests for empty-selection reconciliation and cron command generation.

## Related Issues
None

## Testing
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q -k tigerbeetle_journal_order_events_cronjob`
- `uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py scripts/run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py`
- `uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py scripts/run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)
N/A

## Breaking Changes
None

## Checklist
- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
