### PR TITLE
fix(torghut): collect live runtime-window blockers

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -32,6 +32,11 @@ source-activity blockers such as `paper_route_source_activity_missing`, `source_
 `source_executions_missing`, and `source_tca_missing` into the final verdict. Treat those as the next repair target
 before rerunning import; do not collapse them into a generic runtime-ledger-missing diagnosis.
 
+The renewal conductor also carries an explicit live H-PAIRS runtime-window target for account `PA3SX7FYNUTF`. That target
+uses `DB_DSN` for source and target reads/writes and is a separate scope from the sim paper-route target. It is expected
+to remain blocked until live execution-eligible decisions, executions, order events, TCA rows, and durable runtime-ledger
+buckets exist; the target makes those blockers visible in the scheduled proof packet without granting promotion.
+
 The `torghut-paper-account-flatten` CronJob runs both before the regular session and after the regular session close.
 The post-close run is part of the paper-route proof lane: it persists the flat account snapshot required before the
 21:23 UTC renewal/import conductor can turn a closed paper-route window into authority-checkable runtime-ledger evidence.

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -61,6 +61,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
+                    --runtime-window-target hypothesis_id=H-PAIRS-01,candidate_id=c88421d619759b2cfaa6f4d0,observed_stage=live,strategy_family=microbar_cross_sectional_pairs,strategy_name=microbar-cross-sectional-pairs-v1,account_label=PA3SX7FYNUTF,source_account_label=PA3SX7FYNUTF,source_dsn_env=DB_DSN,target_dsn_env=DB_DSN,source_kind=live_runtime_observed,source_manifest_ref=config/trading/hypotheses/h-pairs-01.json \
                     --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan \
                     --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/status \
                     --runtime-window-target-plan-url-timeout-seconds 45 \

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -166,8 +166,8 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Import runtime windows for every hypothesis manifest that can be "
             "mapped to a runtime strategy. Explicit --runtime-window-target "
-            "entries remain supported and take precedence on duplicate "
-            "hypothesis_id values."
+            "entries remain supported and take precedence on duplicate target "
+            "scopes."
         ),
     )
     parser.add_argument(
@@ -205,7 +205,7 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Repeatable path to a candidate-board/runtime-window-import-plan JSON "
             "artifact. Explicit --runtime-window-target entries take precedence "
-            "over duplicate hypothesis_id values."
+            "over duplicate target scopes."
         ),
     )
     parser.add_argument(
@@ -1538,13 +1538,19 @@ def _runtime_window_target_metadata(payload: Mapping[str, Any]) -> dict[str, Any
 
 def _runtime_window_target_identity(
     target: RuntimeWindowImportTarget,
-) -> tuple[str, str, str, str, str, str, str]:
+) -> tuple[str, str, str, str, str, str, str, str, str, str, str, str, str]:
     return (
         target.hypothesis_id,
-        target.candidate_id,
+        target.observed_stage,
+        target.strategy_family,
+        target.source_dsn_env,
         target.strategy_name,
+        target.account_label,
         target.target_dsn_env,
         target.source_account_label,
+        target.dataset_snapshot_ref,
+        target.source_manifest_ref,
+        target.source_kind,
         target.window_start,
         target.window_end,
     )
@@ -1692,17 +1698,15 @@ def _runtime_window_targets(
                 ),
             )
         )
-    explicit_hypothesis_ids = {target.hypothesis_id for target in targets}
-    seen_hypothesis_ids = set(explicit_hypothesis_ids)
-    seen_target_keys = {_runtime_window_target_identity(target) for target in targets}
+    seen_hypothesis_ids = {target.hypothesis_id for target in targets}
+    explicit_target_keys = {
+        _runtime_window_target_identity(target) for target in targets
+    }
     for target in (*plan_targets, *autoresearch_targets):
-        if target.hypothesis_id in explicit_hypothesis_ids:
-            continue
         target_key = _runtime_window_target_identity(target)
-        if target_key in seen_target_keys:
+        if target_key in explicit_target_keys:
             continue
         targets.append(target)
-        seen_target_keys.add(target_key)
         seen_hypothesis_ids.add(target.hypothesis_id)
     for target in registry_targets:
         if target.hypothesis_id in seen_hypothesis_ids:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1718,12 +1718,21 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertNotIn("--runtime-window-hypothesis-id H-TSMOM-01", args)
-        self.assertNotIn("--runtime-window-target hypothesis_id=", args)
+        self.assertIn("--runtime-window-target hypothesis_id=H-PAIRS-01", args)
         self.assertIn("--runtime-window-account-label TORGHUT_SIM", args)
         self.assertIn("--runtime-window-observed-stage paper", args)
         self.assertIn("--runtime-window-source-dsn-env SIM_DB_DSN", args)
         self.assertIn("--runtime-window-target-dsn-env SIM_DB_DSN", args)
-        self.assertNotIn("--runtime-window-source-dsn-env DB_DSN", args)
+        self.assertIn(
+            "--runtime-window-target "
+            "hypothesis_id=H-PAIRS-01,candidate_id=c88421d619759b2cfaa6f4d0,"
+            "observed_stage=live,strategy_family=microbar_cross_sectional_pairs,"
+            "strategy_name=microbar-cross-sectional-pairs-v1,account_label=PA3SX7FYNUTF,"
+            "source_account_label=PA3SX7FYNUTF,source_dsn_env=DB_DSN,target_dsn_env=DB_DSN,"
+            "source_kind=live_runtime_observed,"
+            "source_manifest_ref=config/trading/hypotheses/h-pairs-01.json",
+            args,
+        )
         self.assertIn(
             "RENEWAL_OUTPUT=/tmp/torghut-empirical-renewal/runtime-window-renewal.json",
             args,

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import argparse
 from datetime import datetime, timezone
 from decimal import Decimal
 from unittest import TestCase
+from unittest.mock import patch
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
@@ -119,6 +121,54 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
         Base.metadata.create_all(engine)
         self.session_local = sessionmaker(
             bind=engine, expire_on_commit=False, future=True
+        )
+
+    def test_explicit_live_target_does_not_suppress_paper_plan_target(self) -> None:
+        paper_target = renew.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="c88421d619759b2cfaa6f4d0",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            target_dsn_env="SIM_DB_DSN",
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+            source_kind="paper_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+        )
+        args = argparse.Namespace(
+            runtime_window_target=[
+                (
+                    "hypothesis_id=H-PAIRS-01,"
+                    "candidate_id=c88421d619759b2cfaa6f4d0,"
+                    "observed_stage=live,"
+                    "strategy_family=microbar_cross_sectional_pairs,"
+                    "strategy_name=microbar-cross-sectional-pairs-v1,"
+                    "account_label=PA3SX7FYNUTF,"
+                    "source_account_label=PA3SX7FYNUTF,"
+                    "source_dsn_env=DB_DSN,"
+                    "target_dsn_env=DB_DSN,"
+                    "source_kind=live_runtime_observed,"
+                    "source_manifest_ref=config/trading/hypotheses/h-pairs-01.json"
+                )
+            ],
+            runtime_window_target_plan_required=False,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+        )
+
+        with patch.object(
+            renew, "_runtime_window_plan_targets", return_value=[paper_target]
+        ):
+            targets = renew._runtime_window_targets(args)
+
+        self.assertEqual(len(targets), 2)
+        self.assertEqual(
+            {(target.observed_stage, target.account_label) for target in targets},
+            {("live", "PA3SX7FYNUTF"), ("paper", "TORGHUT_SIM")},
         )
 
     def test_hpairs_source_proof_census_status_is_non_authority_renewal_evidence(


### PR DESCRIPTION
## Summary

- Allows explicit runtime-window targets to coexist with plan/autoresearch targets when they are different target scopes, instead of suppressing by hypothesis id alone.
- Adds a live H-PAIRS runtime-window target for `PA3SX7FYNUTF` to the empirical renewal conductor so scheduled proof packets include live source-activity blockers.
- Documents that the live target is blocker collection only and does not grant promotion authority.

## Related Issues

None.

## Testing

- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py -k 'explicit_live_target_does_not_suppress_paper_plan_target or runtime_bucket_materialization_rerun_is_idempotent_for_same_scope'`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal`
- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_renew_latest_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/renew_latest_empirical_promotion_jobs.py tests/test_renew_latest_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
