### PR TITLE
fix(torghut): shrink live journal order-event slice

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -24,8 +24,8 @@ from app.trading.tigerbeetle_journal import (  # noqa: E402
 )
 from scripts import journal_tigerbeetle_order_events as journal_script  # noqa: E402
 
-LIVE_ORDER_EVENT_BATCH_SIZE = 5
-LIVE_ORDER_EVENT_MAX_BATCHES = 2
+LIVE_ORDER_EVENT_BATCH_SIZE = 1
+LIVE_ORDER_EVENT_MAX_BATCHES = 1
 LIVE_ORDER_EVENT_SCAN_LIMIT = 250
 
 

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -751,8 +751,12 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             if cronjob_name == "torghut-tigerbeetle-journal-order-events-live":
                 order_event_argv = command_argvs[2]
                 self.assertEqual(
+                    order_event_argv[order_event_argv.index("--batch-size") + 1],
+                    "1",
+                )
+                self.assertEqual(
                     order_event_argv[order_event_argv.index("--max-batches") + 1],
-                    "2",
+                    "1",
                 )
             runtime_argv = command_argvs[-1]
             self.assertEqual(

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1551,6 +1551,7 @@ class TestLiveConfigManifestContract(TestCase):
             live_order_event_command.batch_size,
             tigerbeetle_journal_runner.LIVE_ORDER_EVENT_BATCH_SIZE,
         )
+        self.assertEqual(live_order_event_command.batch_size, 1)
         self.assertEqual(
             live_order_event_command.event_scan_limit,
             tigerbeetle_journal_runner.LIVE_ORDER_EVENT_SCAN_LIMIT,
@@ -1559,10 +1560,16 @@ class TestLiveConfigManifestContract(TestCase):
             live_order_event_command.max_batches,
             tigerbeetle_journal_runner.LIVE_ORDER_EVENT_MAX_BATCHES,
         )
+        self.assertEqual(live_order_event_command.max_batches, 1)
         self.assertLessEqual(
             live_order_event_command.max_batches,
             2,
             "live order-event slices must not run PR #9799's unsafe 3-batch shape under the 45s watchdog",
+        )
+        self.assertLessEqual(
+            live_order_event_command.batch_size * live_order_event_command.max_batches,
+            1,
+            "live order-event slices must stay to one selected row after the 2-batch image still timed out",
         )
         self.assertTrue(live_order_event_command.skip_reconcile)
         self.assertTrue(live_order_event_command.allow_data_quality_degraded)

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -56,7 +56,9 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(commands[1].batch_size, 5)
         self.assertEqual(commands[2].source, SOURCE_TYPE_EXECUTION_ORDER_EVENT)
         self.assertEqual(commands[2].batch_size, runner.LIVE_ORDER_EVENT_BATCH_SIZE)
+        self.assertEqual(commands[2].batch_size, 1)
         self.assertEqual(commands[2].max_batches, runner.LIVE_ORDER_EVENT_MAX_BATCHES)
+        self.assertEqual(commands[2].max_batches, 1)
         self.assertLessEqual(commands[2].max_batches, 2)
         self.assertEqual(
             commands[2].event_scan_limit,
@@ -88,6 +90,8 @@ class RunTigerBeetleJournalCronTest(TestCase):
             str(runner.LIVE_ORDER_EVENT_MAX_BATCHES),
         )
         self.assertLessEqual(int(argv[argv.index("--max-batches") + 1]), 2)
+        self.assertEqual(int(argv[argv.index("--batch-size") + 1]), 1)
+        self.assertEqual(int(argv[argv.index("--max-batches") + 1]), 1)
         self.assertEqual(
             argv[argv.index("--event-scan-limit") + 1],
             str(runner.LIVE_ORDER_EVENT_SCAN_LIMIT),


### PR DESCRIPTION
## Summary

- Shrinks the live TigerBeetle `execution_order_event` supervised slice to one selected row: batch size 1, max batches 1, event scan limit 250.
- Keeps hard-failure semantics intact: true worker timeouts still exit non-zero and are not normalized away.
- Adds focused runner, journal-script, and live manifest contract regressions proving the live CronJob's 45s watchdog maps to a one-row order-event slice.
- Preserves promotion truth: TigerBeetle journal telemetry remains non-authoritative and does not override runtime-ledger proof or promotion authority.

## Related Issues

None

## Testing

- PASS: read-only Kubernetes API after image PR #9809 showed live job `torghut-tigerbeetle-journal-order-events-live-29673414` failed with `tigerbeetle_journal_worker_timeout` even at `batch_size:5`, `max_batches:2`, confirming the 2-batch source image was still unsafe.
- BLOCKED: Argo Application and Knative Service readback via the in-cluster service account returned 403, so only CronJob, Job, Pod, and Pod log readback were available. No direct cluster mutation was attempted.
- BLOCKED: `cd services/torghut && uv sync --frozen --extra dev` fails building `crosshair-tool==0.0.102` because this aarch64 workspace has no `cc` compiler. Per task constraints, I did not install apt packages or build-essential.
- PASS: `cd services/torghut && uv sync --frozen`
- PASS: `cd services/torghut && uv pip install 'pytest>=8.4.0,<9.0' 'pytest-cov>=7.0.0,<8.0' 'pytest-xdist>=3.8.0,<4.0' 'hypothesis>=6.151.0,<7.0' pyright==1.1.408 ruff==0.15.2` to install locked dev-check tooling except the blocked native CrossHair package.
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q` -> 84 passed, 1 warning.
- PASS: `cd services/torghut && uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- PASS: `cd services/torghut && uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`
- NOT RUN: `bun run lint:argocd` because no Argo manifest files changed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
