### PR TITLE
feat(torghut): harden hpairs replay tape frontier cache

### DIFF
--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -597,6 +597,15 @@ def validate_tape_freshness(
     end_date: date,
     symbols: Sequence[str] = (),
     allow_stale_tape: bool = False,
+    require_exact_cache_identity: bool = False,
+    expected_dataset_snapshot_ref: str | None = None,
+    expected_source_query_digest: str | None = None,
+    expected_feature_schema_hash: str | None = None,
+    expected_cost_model_hash: str | None = None,
+    expected_strategy_family: str | None = None,
+    expected_replay_cache_key: str | None = None,
+    expected_feature_versions: Mapping[str, str] | None = None,
+    expected_source_table_versions: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     reasons: list[str] = []
     if manifest.start_date > start_date or manifest.end_date < end_date:
@@ -658,6 +667,26 @@ def validate_tape_freshness(
             "symbol_trading_days_missing:" + ",".join(missing_symbol_trading_days)
         )
 
+    cache_identity_reasons = _replay_tape_cache_identity_mismatch_reasons(
+        manifest,
+        start_date=start_date,
+        end_date=end_date,
+        symbols=tuple(sorted(requested_symbols)),
+        require_exact_cache_identity=require_exact_cache_identity,
+        expected_dataset_snapshot_ref=expected_dataset_snapshot_ref,
+        expected_source_query_digest=expected_source_query_digest,
+        expected_feature_schema_hash=expected_feature_schema_hash,
+        expected_cost_model_hash=expected_cost_model_hash,
+        expected_strategy_family=expected_strategy_family,
+        expected_replay_cache_key=expected_replay_cache_key,
+        expected_feature_versions=expected_feature_versions,
+        expected_source_table_versions=expected_source_table_versions,
+    )
+    if cache_identity_reasons:
+        raise ValueError(
+            "replay_tape_cache_identity_mismatch:" + ";".join(cache_identity_reasons)
+        )
+
     if reasons and not allow_stale_tape:
         raise ValueError(f"replay_tape_stale:{';'.join(reasons)}")
     return {
@@ -696,6 +725,125 @@ def validate_tape_freshness(
             missing_symbol_trading_days=missing_symbol_trading_days,
         ),
     }
+
+
+def _replay_tape_cache_identity_mismatch_reasons(
+    manifest: ReplayTapeManifest,
+    *,
+    start_date: date,
+    end_date: date,
+    symbols: Sequence[str],
+    require_exact_cache_identity: bool,
+    expected_dataset_snapshot_ref: str | None,
+    expected_source_query_digest: str | None,
+    expected_feature_schema_hash: str | None,
+    expected_cost_model_hash: str | None,
+    expected_strategy_family: str | None,
+    expected_replay_cache_key: str | None,
+    expected_feature_versions: Mapping[str, str] | None,
+    expected_source_table_versions: Mapping[str, str] | None,
+) -> list[str]:
+    reasons: list[str] = []
+    requested_symbols = _normalize_symbols(symbols)
+
+    if require_exact_cache_identity:
+        diagnostics = manifest.cache_identity_diagnostics()
+        raw_missing_components = diagnostics.get("missing_components", ())
+        missing_component_values: Sequence[Any] = ()
+        if isinstance(raw_missing_components, Sequence) and not isinstance(
+            raw_missing_components, (str, bytes, bytearray)
+        ):
+            missing_component_values = cast(Sequence[Any], raw_missing_components)
+        missing_components = tuple(
+            str(component) for component in missing_component_values if str(component)
+        )
+        if missing_components:
+            reasons.append("missing_components:" + ",".join(sorted(missing_components)))
+        if manifest.start_date != start_date or manifest.end_date != end_date:
+            reasons.append(
+                "date_range:"
+                f"{manifest.start_date.isoformat()}..{manifest.end_date.isoformat()}"
+                f"!={start_date.isoformat()}..{end_date.isoformat()}"
+            )
+        if requested_symbols and tuple(manifest.symbols) != requested_symbols:
+            reasons.append(
+                "symbol_universe:"
+                f"{','.join(manifest.symbols)}!={','.join(requested_symbols)}"
+            )
+        recomputed_cache_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref=manifest.dataset_snapshot_ref,
+            symbols=manifest.symbols,
+            start_date=manifest.start_date,
+            end_date=manifest.end_date,
+            source_query_digest=manifest.source_query_digest,
+            feature_schema_hash=manifest.feature_schema_hash,
+            cost_model_hash=manifest.cost_model_hash,
+            strategy_family=manifest.strategy_family,
+            feature_versions=manifest.feature_versions,
+            source_table_versions=manifest.source_table_versions,
+        )
+        if manifest.replay_cache_key != recomputed_cache_key:
+            reasons.append(
+                f"replay_cache_key:{manifest.replay_cache_key}!={recomputed_cache_key}"
+            )
+
+    def append_string_mismatch(
+        component: str,
+        observed: str,
+        expected: str | None,
+    ) -> None:
+        if expected is None:
+            return
+        expected_value = str(expected or "")
+        if str(observed or "") != expected_value:
+            reasons.append(f"{component}:{observed}!={expected_value}")
+
+    append_string_mismatch(
+        "dataset_snapshot_ref",
+        manifest.dataset_snapshot_ref,
+        expected_dataset_snapshot_ref,
+    )
+    append_string_mismatch(
+        "source_query_digest",
+        manifest.source_query_digest,
+        expected_source_query_digest,
+    )
+    append_string_mismatch(
+        "feature_schema_hash",
+        manifest.feature_schema_hash,
+        expected_feature_schema_hash,
+    )
+    append_string_mismatch(
+        "cost_model_hash",
+        manifest.cost_model_hash,
+        expected_cost_model_hash,
+    )
+    append_string_mismatch(
+        "strategy_family",
+        manifest.strategy_family,
+        expected_strategy_family,
+    )
+    append_string_mismatch(
+        "replay_cache_key",
+        manifest.replay_cache_key,
+        expected_replay_cache_key,
+    )
+
+    if expected_feature_versions is not None:
+        expected_versions = _string_mapping(expected_feature_versions)
+        if dict(manifest.feature_versions) != expected_versions:
+            reasons.append(
+                "feature_versions:"
+                f"{dict(manifest.feature_versions)}!={expected_versions}"
+            )
+    if expected_source_table_versions is not None:
+        expected_table_versions = dict(expected_source_table_versions)
+        if dict(manifest.source_table_versions) != expected_table_versions:
+            reasons.append(
+                "source_table_versions:"
+                f"{dict(manifest.source_table_versions)}!={expected_table_versions}"
+            )
+    return reasons
 
 
 def slice_tape_by_window(

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -94,8 +94,8 @@ from app.trading.runtime_ledger import (
 from app.trading.discovery.replay_tape import (
     ReplayTapeManifest,
     build_source_query_digest,
-    materialize_signal_tape,
     load_replay_tape,
+    materialize_signal_tape,
     slice_tape_by_symbols,
     slice_tape_by_window,
     validate_tape_freshness,
@@ -633,6 +633,14 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         default=None,
         help="Optional manifest path for --replay-tape-path.",
+    )
+    parser.add_argument(
+        "--replay-tape-dataset-snapshot-ref",
+        default="",
+        help=(
+            "Expected replay-tape dataset snapshot when reusing a tape. "
+            "If set, fast-preview reuse fails closed when the manifest identity differs."
+        ),
     )
     parser.add_argument(
         "--replay-tape-preview-top-k",
@@ -6561,6 +6569,7 @@ def _apply_fast_replay_preview_narrowing(
 
     start_date = _fast_replay_preview_date_arg(args, "full_window_start_date")
     end_date = _fast_replay_preview_date_arg(args, "full_window_end_date")
+    requested_symbols = _candidate_universe_symbols_from_args(args)
     tape = load_replay_tape(
         Path(tape_path).resolve(),
         manifest_path=(
@@ -6573,8 +6582,24 @@ def _apply_fast_replay_preview_narrowing(
         tape.manifest,
         start_date=start_date,
         end_date=end_date,
-        symbols=_candidate_universe_symbols_from_args(args),
+        symbols=requested_symbols,
         allow_stale_tape=bool(getattr(args, "allow_stale_tape", False)),
+        require_exact_cache_identity=True,
+        expected_dataset_snapshot_ref=(
+            str(getattr(args, "replay_tape_dataset_snapshot_ref", "") or "").strip()
+            or None
+        ),
+        expected_source_query_digest=_materialized_replay_tape_source_query_digest(
+            args=args,
+            symbols=requested_symbols,
+            start_date=start_date,
+            end_date=end_date,
+        ),
+        expected_feature_schema_hash=_materialized_replay_tape_feature_schema_hash(
+            args
+        ),
+        expected_cost_model_hash=_materialized_replay_tape_cost_model_hash(args),
+        expected_strategy_family=_materialized_replay_tape_strategy_family(args),
     )
     selected_rows = slice_tape_by_symbols(
         slice_tape_by_window(
@@ -6582,7 +6607,7 @@ def _apply_fast_replay_preview_narrowing(
             start_date=start_date,
             end_date=end_date,
         ),
-        symbols=_candidate_universe_symbols_from_args(args),
+        symbols=requested_symbols,
     )
     preview = build_fast_replay_preview(
         specs=specs,
@@ -7325,6 +7350,7 @@ def _maybe_materialize_epoch_replay_tape(
             **vars(args),
             "replay_tape_path": tape_path,
             "replay_tape_manifest": manifest_path,
+            "replay_tape_dataset_snapshot_ref": manifest.dataset_snapshot_ref,
         }
     )
     return updated_args, receipt

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -629,6 +629,136 @@ class TestReplayTape(TestCase):
             {"start_date": "2026-03-27", "end_date": "2026-03-27"},
         )
 
+    def test_replay_tape_cache_identity_mismatch_fails_closed(self) -> None:
+        source_query_digest = build_source_query_digest(
+            {"window": "a", "symbols": ["NVDA", "AAPL"]}
+        )
+        with TemporaryDirectory() as tmpdir:
+            manifest = materialize_signal_tape(
+                rows=[
+                    self._signal(day=27, seq=1, symbol="NVDA"),
+                    self._signal(day=27, seq=2, symbol="AAPL"),
+                ],
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-a",
+                symbols=("NVDA", "AAPL"),
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=source_query_digest,
+                feature_schema_hash="feature-schema-v1",
+                cost_model_hash="cost-model-v1",
+                strategy_family="hpairs-v1",
+                feature_versions=hpairs_replay_tape_feature_versions(),
+            )
+
+        validation = validate_tape_freshness(
+            manifest,
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            symbols=("AAPL", "NVDA"),
+            require_exact_cache_identity=True,
+            expected_dataset_snapshot_ref="snapshot-a",
+            expected_source_query_digest=source_query_digest,
+            expected_feature_schema_hash="feature-schema-v1",
+            expected_cost_model_hash="cost-model-v1",
+            expected_strategy_family="hpairs-v1",
+            expected_replay_cache_key=manifest.replay_cache_key,
+            expected_feature_versions=hpairs_replay_tape_feature_versions(),
+        )
+        self.assertEqual(validation["status"], "valid")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "replay_tape_cache_identity_mismatch:.*feature_schema_hash",
+        ):
+            validate_tape_freshness(
+                manifest,
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                symbols=("AAPL", "NVDA"),
+                allow_stale_tape=True,
+                require_exact_cache_identity=True,
+                expected_dataset_snapshot_ref="snapshot-a",
+                expected_source_query_digest=source_query_digest,
+                expected_feature_schema_hash="feature-schema-v2",
+                expected_cost_model_hash="cost-model-v1",
+                expected_strategy_family="hpairs-v1",
+            )
+
+        stale_key_payload = manifest.to_payload()
+        stale_key_payload["replay_cache_key"] = "stale-cache-key"
+        stale_key_manifest = ReplayTapeManifest.from_payload(stale_key_payload)
+        with self.assertRaisesRegex(
+            ValueError,
+            "replay_tape_cache_identity_mismatch:.*replay_cache_key",
+        ):
+            validate_tape_freshness(
+                stale_key_manifest,
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                symbols=("AAPL", "NVDA"),
+                require_exact_cache_identity=True,
+            )
+
+    def test_replay_tape_exact_cache_identity_blocks_incomplete_or_version_mismatch(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            incomplete_manifest = materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, symbol="NVDA")],
+                tape_path=Path(tmpdir) / "incomplete-tape.jsonl",
+                dataset_snapshot_ref="snapshot-incomplete",
+                symbols=(),
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "incomplete"}),
+            )
+            complete_manifest = materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, symbol="NVDA")],
+                tape_path=Path(tmpdir) / "complete-tape.jsonl",
+                dataset_snapshot_ref="snapshot-complete",
+                symbols=("NVDA",),
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "complete"}),
+                feature_schema_hash="feature-schema-v1",
+                cost_model_hash="cost-model-v1",
+                strategy_family="hpairs-v1",
+                feature_versions=hpairs_replay_tape_feature_versions(),
+                source_table_versions={"signals": "v1"},
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "replay_tape_cache_identity_mismatch:"
+            ".*missing_components.*date_range.*symbol_universe",
+        ):
+            validate_tape_freshness(
+                incomplete_manifest,
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                symbols=("AAPL",),
+                allow_stale_tape=True,
+                require_exact_cache_identity=True,
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "replay_tape_cache_identity_mismatch:"
+            ".*feature_versions.*source_table_versions",
+        ):
+            validate_tape_freshness(
+                complete_manifest,
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                symbols=("NVDA",),
+                require_exact_cache_identity=True,
+                expected_feature_versions={
+                    "hpairs": "torghut.hpairs-replay-tape-features.v2"
+                },
+                expected_source_table_versions={"signals": "v2"},
+            )
+
     def test_replay_tape_cache_identity_reports_missing_components(self) -> None:
         with TemporaryDirectory() as tmpdir:
             manifest = materialize_signal_tape(

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -36,7 +36,6 @@ from app.trading.discovery import fast_replay
 from app.trading.discovery.replay_tape import (
     REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
     ReplayTapeManifest,
-    build_source_query_digest,
     materialize_signal_tape,
 )
 from app.trading.discovery.evidence_bundles import evidence_bundle_blockers
@@ -4582,6 +4581,16 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 + "\n",
                 encoding="utf-8",
             )
+            args = self._args(output_dir)
+            args.candidate_specs = [specs_path]
+            args.seed_recent_whitepapers = False
+            args.replay_mode = "real"
+            args.selection_only = True
+            args.replay_tape_path = tape_path
+            args.replay_tape_preview_top_k = 1
+            args.symbols = "NVDA"
+            args.replay_tape_dataset_snapshot_ref = "preview-snapshot"
+            requested_symbols = runner._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
@@ -4611,19 +4620,21 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 ],
                 tape_path=tape_path,
                 dataset_snapshot_ref="preview-snapshot",
-                symbols=("NVDA",),
+                symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 27),
-                source_query_digest=build_source_query_digest({"query": "preview"}),
+                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                    args=args,
+                    symbols=requested_symbols,
+                    start_date=date(2026, 2, 23),
+                    end_date=date(2026, 2, 27),
+                ),
+                feature_schema_hash=runner._materialized_replay_tape_feature_schema_hash(
+                    args
+                ),
+                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
+                strategy_family=runner._materialized_replay_tape_strategy_family(args),
             )
-            args = self._args(output_dir)
-            args.candidate_specs = [specs_path]
-            args.seed_recent_whitepapers = False
-            args.replay_mode = "real"
-            args.selection_only = True
-            args.replay_tape_path = tape_path
-            args.replay_tape_preview_top_k = 1
-            args.symbols = "NVDA"
 
             payload = runner.run_whitepaper_autoresearch_profit_target(args)
 
@@ -4712,7 +4723,28 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 )
                 for index, symbol in enumerate(["NVDA", "AAPL", "INTC"] * 3)
             ]
-            source_query_digest = build_source_query_digest({"window": "frontier"})
+            args = self._args(output_dir)
+            args.replay_mode = "real"
+            args.full_window_start_date = "2026-02-23"
+            args.full_window_end_date = "2026-02-23"
+            args.symbols = "NVDA,AAPL,INTC"
+            args.replay_tape_path = tape_path
+            args.replay_tape_preview_top_k = 8
+            args.replay_tape_exact_candidate_cap = 99
+            args.replay_tape_dataset_snapshot_ref = "frontier-preview"
+            args.allow_unsafe_replay_tape_exact_cap_override = True
+            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            source_query_digest = runner._materialized_replay_tape_source_query_digest(
+                args=args,
+                symbols=requested_symbols,
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+            )
+            feature_schema_hash = runner._materialized_replay_tape_feature_schema_hash(
+                args
+            )
+            cost_model_hash = runner._materialized_replay_tape_cost_model_hash(args)
+            strategy_family = runner._materialized_replay_tape_strategy_family(args)
             materialize_signal_tape(
                 rows=rows,
                 tape_path=tape_path,
@@ -4721,9 +4753,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
                 source_query_digest=source_query_digest,
-                feature_schema_hash="feature-schema-frontier",
-                cost_model_hash="cost-model-frontier",
-                strategy_family="hpairs-frontier-family",
+                feature_schema_hash=feature_schema_hash,
+                cost_model_hash=cost_model_hash,
+                strategy_family=strategy_family,
                 source_table_versions={"signals": "v1"},
             )
             specs = [
@@ -4733,15 +4765,6 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 )
                 for index in range(8)
             ]
-            args = self._args(output_dir)
-            args.replay_mode = "real"
-            args.full_window_start_date = "2026-02-23"
-            args.full_window_end_date = "2026-02-23"
-            args.symbols = "NVDA,AAPL,INTC"
-            args.replay_tape_path = tape_path
-            args.replay_tape_preview_top_k = 8
-            args.replay_tape_exact_candidate_cap = 99
-            args.allow_unsafe_replay_tape_exact_cap_override = True
             candidate_selection = {
                 "schema_version": "torghut.whitepaper-autoresearch-selection.v1",
                 "budget": {"selected_count": len(specs)},
@@ -4773,13 +4796,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         preview_validation = updated_selection["replay_tape_preview"]["validation"]
         self.assertEqual(preview_validation["source_query_digest"], source_query_digest)
-        self.assertEqual(
-            preview_validation["feature_schema_hash"], "feature-schema-frontier"
-        )
-        self.assertEqual(preview_validation["cost_model_hash"], "cost-model-frontier")
-        self.assertEqual(
-            preview_validation["strategy_family"], "hpairs-frontier-family"
-        )
+        self.assertEqual(preview_validation["feature_schema_hash"], feature_schema_hash)
+        self.assertEqual(preview_validation["cost_model_hash"], cost_model_hash)
+        self.assertEqual(preview_validation["strategy_family"], strategy_family)
         self.assertEqual(preview_validation["cache_identity"]["status"], "complete")
         queue_payload = updated_selection["bounded_sim_target_queue"]
         self.assertEqual(queue_payload["exact_replay_candidate_count"], 6)
@@ -4849,13 +4868,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertEqual(
             queue_payload["replay_tape"]["feature_schema_hash"],
-            "feature-schema-frontier",
+            feature_schema_hash,
         )
         self.assertEqual(
-            queue_payload["replay_tape"]["cost_model_hash"], "cost-model-frontier"
+            queue_payload["replay_tape"]["cost_model_hash"], cost_model_hash
         )
         self.assertEqual(
-            queue_payload["replay_tape"]["strategy_family"], "hpairs-frontier-family"
+            queue_payload["replay_tape"]["strategy_family"], strategy_family
         )
         self.assertEqual(
             queue_payload["replay_tape"]["source_query_digest"], source_query_digest
@@ -4903,7 +4922,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertEqual(
             first_entry["reproducibility_metadata"]["feature_schema_hash"],
-            "feature-schema-frontier",
+            feature_schema_hash,
         )
         self.assertEqual(
             first_entry["reproducibility_metadata"]["source_query_digest"],
@@ -4956,7 +4975,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             first_entry["exact_replay_handoff_lineage"]["replay_tape"][
                 "cost_model_hash"
             ],
-            "cost-model-frontier",
+            cost_model_hash,
         )
         self.assertFalse(
             first_entry["exact_replay_handoff_lineage"]["promotion_allowed"]
@@ -4995,6 +5014,91 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             first_entry["hpairs_microstructure_prefilter"],
         )
 
+    def test_fast_replay_preview_rejects_replay_tape_cache_identity_mismatch(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            output_dir.mkdir()
+            tape_path = Path(tmpdir) / "tape.jsonl"
+            args = self._args(output_dir)
+            args.replay_mode = "real"
+            args.full_window_start_date = "2026-02-23"
+            args.full_window_end_date = "2026-02-23"
+            args.symbols = "NVDA,AAPL"
+            args.replay_tape_path = tape_path
+            args.replay_tape_preview_top_k = 2
+            args.replay_tape_dataset_snapshot_ref = "frontier-preview"
+            requested_symbols = runner._candidate_universe_symbols_from_args(args)
+            materialize_signal_tape(
+                rows=[
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc),
+                        symbol="NVDA",
+                        timeframe="1Min",
+                        seq=1,
+                        source="ta",
+                        payload={
+                            "price": Decimal("100"),
+                            "spread_bps": Decimal("2"),
+                            "ofi": Decimal("0.20"),
+                            "microbar_volume": Decimal("100000"),
+                        },
+                    ),
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
+                        symbol="AAPL",
+                        timeframe="1Min",
+                        seq=2,
+                        source="ta",
+                        payload={
+                            "price": Decimal("101"),
+                            "spread_bps": Decimal("2"),
+                            "ofi": Decimal("0.20"),
+                            "microbar_volume": Decimal("100000"),
+                        },
+                    ),
+                ],
+                tape_path=tape_path,
+                dataset_snapshot_ref="frontier-preview",
+                symbols=requested_symbols,
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 23),
+                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                    args=args,
+                    symbols=requested_symbols,
+                    start_date=date(2026, 2, 23),
+                    end_date=date(2026, 2, 23),
+                ),
+                feature_schema_hash="stale-feature-schema",
+                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
+                strategy_family=runner._materialized_replay_tape_strategy_family(args),
+            )
+            spec = self._candidate_spec("spec-frontier-0")
+            candidate_selection = {
+                "schema_version": "torghut.whitepaper-autoresearch-selection.v1",
+                "budget": {"selected_count": 1},
+                "selected_candidate_spec_ids": [spec.candidate_spec_id],
+                "rows": [
+                    {
+                        "candidate_spec_id": spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                        "selection_reason": "test",
+                    }
+                ],
+            }
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "replay_tape_cache_identity_mismatch:.*feature_schema_hash",
+            ):
+                runner._apply_fast_replay_preview_narrowing(
+                    args=args,
+                    output_dir=output_dir,
+                    specs=[spec],
+                    candidate_selection=candidate_selection,
+                )
+
     def test_fast_replay_preview_does_not_backfill_lineage_blocked_candidates(
         self,
     ) -> None:
@@ -5013,14 +5117,33 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 )
                 for index in range(3)
             ]
+            args = self._args(output_dir)
+            args.replay_mode = "real"
+            args.full_window_start_date = "2026-02-23"
+            args.full_window_end_date = "2026-02-23"
+            args.symbols = "NVDA"
+            args.replay_tape_path = tape_path
+            args.replay_tape_preview_top_k = 1
+            args.replay_tape_dataset_snapshot_ref = "blocked-preview"
+            requested_symbols = runner._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=rows,
                 tape_path=tape_path,
                 dataset_snapshot_ref="blocked-preview",
-                symbols=("NVDA",),
+                symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 23),
-                source_query_digest=build_source_query_digest({"window": "blocked"}),
+                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                    args=args,
+                    symbols=requested_symbols,
+                    start_date=date(2026, 2, 23),
+                    end_date=date(2026, 2, 23),
+                ),
+                feature_schema_hash=runner._materialized_replay_tape_feature_schema_hash(
+                    args
+                ),
+                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
+                strategy_family=runner._materialized_replay_tape_strategy_family(args),
             )
             base_spec = self._candidate_spec("spec-lineage-blocked")
             spec = replace(
@@ -5031,13 +5154,6 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     "universe_symbols": ["NVDA"],
                 },
             )
-            args = self._args(output_dir)
-            args.replay_mode = "real"
-            args.full_window_start_date = "2026-02-23"
-            args.full_window_end_date = "2026-02-23"
-            args.symbols = "NVDA"
-            args.replay_tape_path = tape_path
-            args.replay_tape_preview_top_k = 1
             candidate_selection = {
                 "schema_version": "torghut.whitepaper-autoresearch-selection.v1",
                 "budget": {"selected_count": 1},
@@ -5616,6 +5732,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             root = Path(tmpdir)
             output_dir = root / "epoch"
             tape_path = root / "preview-tape.jsonl"
+            args = self._args(output_dir)
+            args.replay_tape_preview_top_k = 1
+            args.full_window_start_date = "2026-02-23"
+            args.full_window_end_date = "2026-02-27"
+            args.symbols = "NVDA"
+            args.replay_tape_dataset_snapshot_ref = "preview-snapshot"
+            requested_symbols = runner._candidate_universe_symbols_from_args(args)
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
@@ -5630,10 +5753,20 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 ],
                 tape_path=tape_path,
                 dataset_snapshot_ref="preview-snapshot",
-                symbols=("NVDA",),
+                symbols=requested_symbols,
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 27),
-                source_query_digest=build_source_query_digest({"query": "preview"}),
+                source_query_digest=runner._materialized_replay_tape_source_query_digest(
+                    args=args,
+                    symbols=requested_symbols,
+                    start_date=date(2026, 2, 23),
+                    end_date=date(2026, 2, 27),
+                ),
+                feature_schema_hash=runner._materialized_replay_tape_feature_schema_hash(
+                    args
+                ),
+                cost_model_hash=runner._materialized_replay_tape_cost_model_hash(args),
+                strategy_family=runner._materialized_replay_tape_strategy_family(args),
             )
             spec = self._candidate_spec("spec-preview-fallback")
             selection = {
@@ -5646,8 +5779,6 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 ],
                 "budget": {"selected_count": 1},
             }
-            args = self._args(output_dir)
-            args.replay_tape_preview_top_k = 1
             with self.assertRaisesRegex(
                 ValueError, "fast_replay_preview_requires_real_replay"
             ):


### PR DESCRIPTION
## Summary

- Hardened replay tape freshness validation with exact cache-identity checks for dataset snapshot, symbol universe, date range, feature schema hash, cost model hash, strategy family, source digest, feature/source versions, and recomputed replay cache keys.
- Wired H-PAIRS fast-preview replay-tape reuse through fail-closed identity validation while keeping the bounded local exact-replay frontier and non-authority handoff semantics intact.
- Added regression coverage for stale cache-key rejection, runner cache-identity mismatch rejection, and exact cache-identity blocker reporting.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_fast_replay.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` (232 passed, 1 warning)
- PASS: `cd services/torghut && uv run --frozen ruff check app/trading/discovery/replay_tape.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- PASS: `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/replay_tape.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_replay_tape.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `cd services/torghut && git diff --check`
- NOTE: the unprefixed `uv run --frozen pyright --project pyrightconfig.json` hit the local Node heap limit; reran successfully with the Node heap limit raised above.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
