### PR TITLE
chore(torghut): promote bounded journal image

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:26b9b09187ca8b15bab6938538e6b1717ef8645a421181b63c636903b9c33cc4
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:903cc59f97eabcaab6cb15073ea315b96292e9b194069dc8af4aea1ba348e947
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -83,7 +83,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:26b9b09187ca8b15bab6938538e6b1717ef8645a421181b63c636903b9c33cc4
+                  value: sha256:903cc59f97eabcaab6cb15073ea315b96292e9b194069dc8af4aea1ba348e947
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -119,7 +119,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:26b9b09187ca8b15bab6938538e6b1717ef8645a421181b63c636903b9c33cc4
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:903cc59f97eabcaab6cb15073ea315b96292e9b194069dc8af4aea1ba348e947
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -188,6 +188,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:26b9b09187ca8b15bab6938538e6b1717ef8645a421181b63c636903b9c33cc4
+                  value: sha256:903cc59f97eabcaab6cb15073ea315b96292e9b194069dc8af4aea1ba348e947
                 - name: PYTHONUNBUFFERED
                   value: "1"


### PR DESCRIPTION
## Summary

- Promotes the Torghut TigerBeetle journal CronJobs to the `b09bad38` image digest built after PR #9816.
- Updates both live and sim CronJob image refs plus `TORGHUT_IMAGE_DIGEST` to `sha256:903cc59f97eabcaab6cb15073ea315b96292e9b194069dc8af4aea1ba348e947`.
- This puts the one-row live `execution_order_event` slice into the GitOps manifest; no runtime-ledger proof or promotion authority files are touched.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -q` -> 33 passed, 1 warning.
- PASS: `git diff --check`
- BLOCKED: `bun run lint:argocd` -> `kubeconform is required but not installed`. Per task constraints, I did not install apt packages or add system tooling.
- PASS: image source evidence from `gh run download 26822224694 -R proompteng/lab --dir /tmp/torghut-build-artifacts`: `torghut-release-contract.json` maps source `b09bad381b6c5e0741727c7b9d5ba2c1b1bc1030` to digest `sha256:903cc59f97eabcaab6cb15073ea315b96292e9b194069dc8af4aea1ba348e947`.
- PASS: prior code PR #9816 CI was green before merge, including Pyright, pytest shards, quality signals, and integration.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
