### PR TITLE
fix(synthesis): harden autotrader protective preflight

### DIFF
--- a/scripts/autotrader/protective_preflight.py
+++ b/scripts/autotrader/protective_preflight.py
@@ -30,9 +30,20 @@ OPEN_ORDER_STATUSES = {
 PAPER_ALPACA_HOST = "paper-api.alpaca.markets"
 
 
+def normalize_alpaca_base_url(base_url: str) -> str:
+    trimmed = base_url.rstrip("/")
+    parsed = urllib.parse.urlparse(trimmed)
+    path = parsed.path.rstrip("/")
+    if path.endswith("/v2"):
+        path = path[:-3]
+    if not parsed.scheme or not parsed.netloc:
+        return trimmed
+    return urllib.parse.urlunparse(parsed._replace(path=path, params="", query="", fragment="")).rstrip("/")
+
+
 class AlpacaClient:
     def __init__(self, *, base_url: str | None = None, timeout_seconds: float = 10.0):
-        self.base_url = (base_url or os.environ.get("APCA_API_BASE_URL") or DEFAULT_ALPACA_BASE_URL).rstrip("/")
+        self.base_url = normalize_alpaca_base_url(base_url or os.environ.get("APCA_API_BASE_URL") or DEFAULT_ALPACA_BASE_URL)
         self.key_id = os.environ.get("APCA_API_KEY_ID") or os.environ.get("ALPACA_API_KEY_ID") or os.environ.get("ALPACA_API_KEY")
         self.secret_key = os.environ.get("APCA_API_SECRET_KEY") or os.environ.get("ALPACA_SECRET_KEY")
         self.timeout_seconds = timeout_seconds
@@ -320,6 +331,36 @@ def cancel_and_reconcile_order(
     )
 
 
+def read_smoke_exposure(
+    alpaca: AlpacaClient,
+    payload: dict[str, Any],
+    broker_order: dict[str, Any] | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any] | None]:
+    open_orders = alpaca.list_open_orders(payload["symbol"])
+    smoke_open_orders = [
+        order for order in flatten_orders(open_orders) if order_belongs_to_smoke(order, payload, broker_order)
+    ]
+    position = alpaca.get_open_position(payload["symbol"])
+    return open_orders, smoke_open_orders, position
+
+
+def wait_for_smoke_exposure_clear(
+    alpaca: AlpacaClient,
+    payload: dict[str, Any],
+    broker_order: dict[str, Any] | None,
+    *,
+    timeout_seconds: float,
+    poll_seconds: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any] | None]:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    open_orders, smoke_open_orders, position = read_smoke_exposure(alpaca, payload, broker_order)
+    while (smoke_open_orders or position_quantity(position) != 0) and time.monotonic() < deadline:
+        if poll_seconds > 0:
+            time.sleep(min(poll_seconds, max(0.0, deadline - time.monotonic())))
+        open_orders, smoke_open_orders, position = read_smoke_exposure(alpaca, payload, broker_order)
+    return open_orders, smoke_open_orders, position
+
+
 def append_event(
     synthesis: SynthesisClient | None,
     *,
@@ -346,7 +387,9 @@ def append_event(
 def run_preflight(args: argparse.Namespace) -> dict[str, Any]:
     payload = build_bracket_payload(args)
     validate_bracket_payload(payload)
-    base_url = (args.alpaca_base_url or os.environ.get("APCA_API_BASE_URL") or DEFAULT_ALPACA_BASE_URL).rstrip("/")
+    base_url = normalize_alpaca_base_url(
+        args.alpaca_base_url or os.environ.get("APCA_API_BASE_URL") or DEFAULT_ALPACA_BASE_URL
+    )
     if args.submit_smoke:
         assert_paper_base_url(base_url)
     report: dict[str, Any] = {
@@ -407,11 +450,13 @@ def run_preflight(args: argparse.Namespace) -> dict[str, Any]:
         final_status = alpaca_order_status(final_order)
         report["filledQty"] = order_filled_quantity(final_order)
         report["protectiveLegCount"] = max(protective_leg_count(reconciled_order), protective_leg_count(final_order))
-        open_orders = alpaca.list_open_orders(payload["symbol"])
-        smoke_open_orders = [
-            order for order in flatten_orders(open_orders) if order_belongs_to_smoke(order, payload, final_order or broker_order)
-        ]
-        position = alpaca.get_open_position(payload["symbol"])
+        open_orders, smoke_open_orders, position = wait_for_smoke_exposure_clear(
+            alpaca,
+            payload,
+            final_order or broker_order,
+            timeout_seconds=args.cancel_reconcile_timeout_seconds,
+            poll_seconds=args.cancel_reconcile_poll_seconds,
+        )
         report["openOrdersAfterCancel"] = len(open_orders)
         report["smokeOpenOrdersAfterCancel"] = len(smoke_open_orders)
         report["positionAfterCancel"] = position
@@ -490,13 +535,13 @@ def run_preflight(args: argparse.Namespace) -> dict[str, Any]:
                     protective_leg_count(reconciled_after_error),
                     protective_leg_count(final_order),
                 )
-                open_orders = alpaca.list_open_orders(payload["symbol"])
-                smoke_open_orders = [
-                    order
-                    for order in flatten_orders(open_orders)
-                    if order_belongs_to_smoke(order, payload, final_order or reconciled_after_error)
-                ]
-                position = alpaca.get_open_position(payload["symbol"])
+                open_orders, smoke_open_orders, position = wait_for_smoke_exposure_clear(
+                    alpaca,
+                    payload,
+                    final_order or reconciled_after_error,
+                    timeout_seconds=args.cancel_reconcile_timeout_seconds,
+                    poll_seconds=args.cancel_reconcile_poll_seconds,
+                )
                 report["openOrdersAfterCancel"] = len(open_orders)
                 report["smokeOpenOrdersAfterCancel"] = len(smoke_open_orders)
                 report["positionAfterCancel"] = position

--- a/scripts/autotrader/test_protective_preflight.py
+++ b/scripts/autotrader/test_protective_preflight.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+import protective_preflight
+
+
+class AlpacaBaseUrlTest(unittest.TestCase):
+    def test_normalizes_provider_v2_base_url(self) -> None:
+        self.assertEqual(
+            protective_preflight.normalize_alpaca_base_url("https://paper-api.alpaca.markets/v2"),
+            "https://paper-api.alpaca.markets",
+        )
+
+    def test_normalizes_v2_base_url_with_trailing_slash(self) -> None:
+        self.assertEqual(
+            protective_preflight.normalize_alpaca_base_url("https://paper-api.alpaca.markets/v2/"),
+            "https://paper-api.alpaca.markets",
+        )
+
+    def test_alpaca_client_uses_normalized_env_base_url(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "APCA_API_BASE_URL": "https://paper-api.alpaca.markets/v2",
+                "APCA_API_KEY_ID": "key",
+                "APCA_API_SECRET_KEY": "secret",
+            },
+            clear=True,
+        ):
+            client = protective_preflight.AlpacaClient()
+
+        self.assertEqual(client.base_url, "https://paper-api.alpaca.markets")
+
+
+class SmokeExposureReadbackTest(unittest.TestCase):
+    def test_waits_for_stale_open_order_readback_to_clear(self) -> None:
+        payload = {
+            "symbol": "SPY",
+            "client_order_id": "smoke-1",
+        }
+        broker_order = {
+            "id": "parent-1",
+            "client_order_id": "smoke-1",
+            "legs": [
+                {"id": "take-profit-1", "client_order_id": "take-profit-1"},
+                {"id": "stop-loss-1", "client_order_id": "stop-loss-1"},
+            ],
+        }
+
+        class FakeAlpaca:
+            def __init__(self) -> None:
+                self.open_order_reads = 0
+
+            def list_open_orders(self, symbol: str) -> list[dict[str, object]]:
+                self.open_order_reads += 1
+                if self.open_order_reads == 1:
+                    return [broker_order]
+                return []
+
+            def get_open_position(self, symbol: str) -> None:
+                return None
+
+        fake_alpaca = FakeAlpaca()
+
+        open_orders, smoke_open_orders, position = protective_preflight.wait_for_smoke_exposure_clear(
+            fake_alpaca,  # type: ignore[arg-type]
+            payload,
+            broker_order,
+            timeout_seconds=0.1,
+            poll_seconds=0,
+        )
+
+        self.assertEqual(open_orders, [])
+        self.assertEqual(smoke_open_orders, [])
+        self.assertIsNone(position)
+        self.assertEqual(fake_alpaca.open_order_reads, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Normalizes Alpaca base URLs in `protective_preflight.py` so the live provider value ending in `/v2` does not produce `/v2/v2/...` requests.
- Polls the post-cancel smoke-order exposure readback until Alpaca open-order state settles, preserving the parent/child cancellation, zero-fill, and no-position safety checks.
- Adds focused Python regression coverage for the live `/v2` base URL shape and stale open-order readback after cancel.

## Related Issues

None

## Testing

- `PYTHONPATH=scripts/autotrader python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 -m py_compile scripts/autotrader/protective_preflight.py scripts/autotrader/test_protective_preflight.py`
- `python3 scripts/autotrader/protective_preflight.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
