### PR TITLE
fix(torghut): expose proof packet mode readiness readback

### DIFF
--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -1826,11 +1826,20 @@ def evaluate_trading_readiness(
             "required": require_runtime_ledger_proof_packet,
             "schema_version": _text(packet_summary.get("schema_version")),
             "proof_mode": _text(packet_summary.get("proof_mode")),
+            "proof_mode_contract": dict(
+                _mapping(packet_summary.get("proof_mode_contract"))
+            ),
             "final_authority_ok": packet_summary.get("final_authority_ok"),
+            "evidence_collection_only": packet_summary.get("evidence_collection_only"),
+            "evidence_collection_ok": packet_summary.get("evidence_collection_ok"),
+            "canary_collection_authorized": packet_summary.get(
+                "canary_collection_authorized"
+            ),
+            "promotion_allowed": packet_summary.get("promotion_allowed"),
             "capital_promotion_allowed": packet_summary.get(
                 "capital_promotion_allowed"
             ),
-            "evidence_collection_ok": packet_summary.get("evidence_collection_ok"),
+            "final_promotion_allowed": packet_summary.get("final_promotion_allowed"),
             "next_action": _text(packet_summary.get("next_action")),
         },
         "tigerbeetle_parity": {

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -552,6 +552,17 @@ class TestVerifyTradingReadiness(TestCase):
             result["runtime_ledger_proof_packet"]["schema_version"],
             verifier.RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
         )
+        self.assertEqual(
+            result["runtime_ledger_proof_packet"]["proof_mode"], "authority"
+        )
+        self.assertTrue(result["runtime_ledger_proof_packet"]["final_authority_ok"])
+        self.assertFalse(
+            result["runtime_ledger_proof_packet"]["evidence_collection_ok"]
+        )
+        self.assertTrue(result["runtime_ledger_proof_packet"]["promotion_allowed"])
+        self.assertTrue(
+            result["runtime_ledger_proof_packet"]["final_promotion_allowed"]
+        )
 
     def test_tigerbeetle_parity_can_be_required_as_accounting_only_gate(
         self,
@@ -651,7 +662,10 @@ class TestVerifyTradingReadiness(TestCase):
             "implicit_default_final_authority": False,
         }
         packet["final_authority_ok"] = False
+        packet["evidence_collection_only"] = True
         packet["capital_promotion_allowed"] = False
+        packet["promotion_allowed"] = False
+        packet["final_promotion_allowed"] = False
         packet["evidence_collection_ok"] = True
         packet["next_action"] = "rerun_proof_packet_in_authority_mode"
         packet["promotion_authority"] = {
@@ -672,7 +686,67 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertEqual(observed["proof_mode"], "smoke")
         self.assertFalse(observed["authority_allowed"])
         self.assertFalse(observed["mode_contract_allows_authority"])
+        packet_summary = result["runtime_ledger_proof_packet"]
+        self.assertEqual(packet_summary["proof_mode"], "smoke")
+        self.assertEqual(
+            packet_summary["proof_mode_contract"]["authority_scope"],
+            "plumbing_only",
+        )
+        self.assertFalse(packet_summary["final_authority_ok"])
+        self.assertTrue(packet_summary["evidence_collection_ok"])
+        self.assertFalse(packet_summary["promotion_allowed"])
+        self.assertFalse(packet_summary["final_promotion_allowed"])
         self.assertEqual(result["next_action"], "rerun_proof_packet_in_authority_mode")
+
+    def test_runtime_ledger_proof_packet_readback_separates_probation_collection(
+        self,
+    ) -> None:
+        proof_packet = _runtime_ledger_proof_packet()
+        proof_packet["proof_mode"] = "probation"
+        proof_packet["proof_mode_contract"] = {
+            "proof_mode": "probation",
+            "default_proof_mode": "smoke",
+            "authority_scope": "bounded_evidence_collection_only",
+            "mode_can_grant_final_authority": False,
+            "mode_can_grant_promotion_authority": False,
+            "requires_explicit_authority_mode_for_final_promotion": True,
+            "implicit_default_final_authority": False,
+        }
+        proof_packet["final_authority_ok"] = False
+        proof_packet["evidence_collection_only"] = True
+        proof_packet["evidence_collection_ok"] = True
+        proof_packet["canary_collection_authorized"] = True
+        proof_packet["promotion_allowed"] = False
+        proof_packet["capital_promotion_allowed"] = False
+        proof_packet["final_promotion_allowed"] = False
+        proof_packet["next_action"] = "rerun_proof_packet_in_authority_mode"
+        proof_packet["promotion_authority"] = {
+            "allowed": False,
+            "reason": "runtime_ledger_proof_mode_not_authority",
+            "blocking_reasons": ["runtime_ledger_proof_mode_not_authority"],
+            "failed_checks": ["runtime_ledger_proof_mode_authority_required"],
+        }
+
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            runtime_ledger_proof_packet=proof_packet,
+            require_runtime_ledger_proof_packet=True,
+        )
+
+        self.assertFalse(result["ok"])
+        packet_summary = result["runtime_ledger_proof_packet"]
+        self.assertEqual(packet_summary["proof_mode"], "probation")
+        self.assertEqual(
+            packet_summary["proof_mode_contract"]["authority_scope"],
+            "bounded_evidence_collection_only",
+        )
+        self.assertFalse(packet_summary["final_authority_ok"])
+        self.assertTrue(packet_summary["evidence_collection_only"])
+        self.assertTrue(packet_summary["evidence_collection_ok"])
+        self.assertTrue(packet_summary["canary_collection_authorized"])
+        self.assertFalse(packet_summary["promotion_allowed"])
+        self.assertFalse(packet_summary["capital_promotion_allowed"])
+        self.assertFalse(packet_summary["final_promotion_allowed"])
 
     def test_runtime_ledger_proof_packet_requires_explicit_authority_mode_contract(
         self,


### PR DESCRIPTION
## Summary

- Extends Torghut trading-readiness runtime-ledger proof-packet readback with the explicit proof-mode contract and promotion/final-authority booleans.
- Keeps smoke/probation proof packets visibly evidence-collection-only by surfacing evidence_collection_only/ok and canary_collection_authorized separately from final_authority_ok.
- Adds regression coverage for authority, smoke, and probation proof-packet readiness summaries so one-day evidence packets cannot be mistaken for final promotion proof.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass)
- `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py tests/test_runtime_window_import.py -q` (pass: 170 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check scripts/verify_trading_readiness.py tests/test_verify_trading_readiness.py` (pass)
- `cd services/torghut && uv run --frozen ruff format --check scripts/verify_trading_readiness.py tests/test_verify_trading_readiness.py` (pass)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` (pass)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` (pass)
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` (pass)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
