### PR TITLE
fix(synthesis): simplify autotrader live scans

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -33,6 +33,7 @@ spec:
     - In scorecard-readback mode, never mutate Alpaca state; prove the next AgentRun reads Synthesis scorecards before any candidate grading.
     - Reconcile every order by id or client order id and write Synthesis runtime state plus a final report.
     - Run the production protective-order preflight and validate live candidates before non-smoke strategy entries.
+    - Use the checked-in live scan-cycle helper for scanner input assembly so market-open loops stay simple and repeatable.
     - In market-open mode, do not terminally finish for preflight success, paper-order smoke success, no-trade decisions, rejected candidates, rejected orders, quiet market state, active monitoring, or protected open positions.
     - "Keep GPT-5.5 execution outcome-first: concise preambles, bounded research, exact safety-critical tool sequences, and detailed evidence in Synthesis autotrader state."
   text: |-
@@ -58,6 +59,7 @@ spec:
     6. Verify paper account routing, Alpaca account/config/clock/calendar/tools/positions/orders, stock protective fields (`order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, `stop_loss_limit_price`), and helper self-tests:
        - `python3 /workspace/lab/scripts/autotrader/protective_preflight.py --self-test`
        - `python3 /workspace/lab/scripts/autotrader/synthesis_autotrader_client.py --self-test`
+       - `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py --self-test`
     7. Verify Synthesis exposes `autotrader_start_session`, `autotrader_upsert_status`, `autotrader_append_event`, `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, `autotrader_record_order`, `autotrader_record_fill`, `autotrader_record_position_snapshot`, `autotrader_finalize_session`, and `autotrader_get_scorecard`.
     8. Call `autotrader_start_session` before scanning and use the returned `sessionId` for every Synthesis write.
 
@@ -71,7 +73,7 @@ spec:
     1. Re-read clock, account, orders, positions, portfolio state, and relevant market data.
     2. Reconcile open orders and absorb external account or position changes as current state.
     3. Call `autotrader_get_scorecard` before ranking candidates and include scorecard influence in Synthesis ticket/risk/status payloads.
-    4. Use `/workspace/.agentrun/autonomous-trader/stock_analysis` plus current Alpaca state, `ANALYSIS_CONTEXT_PATH`, scorecards, and bounded catalyst/liquidity checks to pick exactly the next action: protected entry, managed exit/reduce/hedge/flatten, or no-trade.
+    4. Run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py` for scanner input assembly, Alpaca readback, scorecard readback, and daytrading scan output. Use its printed summary and `cycleDir` for the next action: protected entry, managed exit/reduce/hedge/flatten, or no-trade. Do not hand-build scanner JSON unless this helper fails and the failure is recorded.
     5. Record every selected or blocked candidate with `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, and `autotrader_append_event`.
     6. Submit only when the ticket records setup type, setup grade, expected R, fat-pitch flag, thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
     7. Before every Alpaca mutation, write the planned order with `autotrader_record_order`, use an AgentRun-prefixed deterministic `client_order_id` when supported, and then reconcile by broker order id plus client order id before any next action.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -26,11 +26,11 @@ data:
     - If `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE` is non-empty, pass exactly that value to `autotrader_start_session.mode`.
 
     Execution loop:
-    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate the local analysis context at `ANALYSIS_CONTEXT_PATH`, and self-test the Synthesis and protective-order helper scripts.
+    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate the local analysis context at `ANALYSIS_CONTEXT_PATH`, and self-test the Synthesis, live-scan, and protective-order helper scripts.
     2. Preflight Alpaca account/config/clock/calendar/tools/positions/orders and Synthesis autotrader tool availability.
     3. Call `autotrader_start_session` before scanning and keep its `sessionId` for every Synthesis write.
     4. Before grading candidates, call `autotrader_get_scorecard` and include scorecard influence in the ticket/risk/status payloads.
-    5. Pick the next best action: protected entry, managed exit/reduce/hedge/flatten, or no-trade.
+    5. Run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py`, use its summary plus Synthesis scorecards to pick the next best action: protected entry, managed exit/reduce/hedge/flatten, or no-trade.
     6. Before any Alpaca mutation, record the planned order/risk in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when the broker tool supports it.
     7. After any Alpaca mutation, reconcile by broker order id and client order id, refresh account/positions/orders, then update Synthesis before taking more risk.
     8. Continue market-open cycles until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state.
@@ -54,6 +54,7 @@ data:
 
     Performance and communication:
     - Keep research bounded to information that can change the immediate order, no-order, risk-reduction, or exit decision.
+    - Prefer the live scan-cycle helper over manual scanner JSON assembly; only inspect its `cycleDir` when needed for ticket/risk details or failure diagnosis.
     - Prefer liquid instruments and serial clean cycles over broad watchlist churn.
     - Record useful rejected setups and no-trade decisions so the scorecard compounds instead of adding local files.
     - Do not create feed posts during trading; record runtime truth in Synthesis autotrader tables.

--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from protective_preflight import assert_paper_base_url, normalize_alpaca_base_url
+from synthesis_autotrader_client import SynthesisClient
+
+
+DEFAULT_DATA_BASE_URL = "https://data.alpaca.markets/v2"
+DEFAULT_WATCHLIST = ("SPY", "QQQ", "NVDA", "AVGO", "TSLA", "AAPL", "MSFT", "AMD", "PLTR", "GOOGL")
+MARKET_TIMEZONE = ZoneInfo("America/New_York")
+
+
+class AlpacaRestClient:
+    def __init__(
+        self,
+        *,
+        trading_base_url: str | None = None,
+        data_base_url: str | None = None,
+        timeout_seconds: float = 10.0,
+    ):
+        self.trading_base_url = normalize_alpaca_base_url(
+            trading_base_url or os.environ.get("APCA_API_BASE_URL") or "https://paper-api.alpaca.markets"
+        )
+        assert_paper_base_url(self.trading_base_url)
+        self.data_base_url = normalize_alpaca_data_base_url(
+            data_base_url or os.environ.get("ALPACA_DATA_BASE_URL") or DEFAULT_DATA_BASE_URL
+        )
+        self.key_id = (
+            os.environ.get("APCA_API_KEY_ID")
+            or os.environ.get("ALPACA_API_KEY_ID")
+            or os.environ.get("ALPACA_API_KEY")
+        )
+        self.secret_key = os.environ.get("APCA_API_SECRET_KEY") or os.environ.get("ALPACA_SECRET_KEY")
+        self.timeout_seconds = timeout_seconds
+        if not self.key_id or not self.secret_key:
+            raise RuntimeError("Alpaca credentials are required for live scan cycle")
+
+    def trading_get(self, path: str, query: dict[str, str] | None = None) -> Any:
+        return self._request(self.trading_base_url, path, query)
+
+    def data_get(self, path: str, query: dict[str, str]) -> Any:
+        return self._request(self.data_base_url, path, query)
+
+    def _request(self, base_url: str, path: str, query: dict[str, str] | None = None) -> Any:
+        url = f"{base_url}{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "accept": "application/json",
+                "APCA-API-KEY-ID": self.key_id,
+                "APCA-API-SECRET-KEY": self.secret_key,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+                return json.loads(body) if body else {"ok": True, "status": response.status}
+        except urllib.error.HTTPError as error:
+            body = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Alpaca HTTP {error.code} for GET {url}: {body}") from error
+
+
+def normalize_alpaca_data_base_url(base_url: str) -> str:
+    trimmed = base_url.rstrip("/")
+    parsed = urllib.parse.urlparse(trimmed)
+    path = parsed.path.rstrip("/")
+    if path.endswith("/v2"):
+        next_path = path
+    else:
+        next_path = f"{path}/v2" if path else "/v2"
+    if not parsed.scheme or not parsed.netloc:
+        return trimmed
+    return urllib.parse.urlunparse(parsed._replace(path=next_path, params="", query="", fragment="")).rstrip("/")
+
+
+def normalize_watchlist(values: list[str]) -> list[str]:
+    symbols = values or list(DEFAULT_WATCHLIST)
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in symbols:
+        symbol = value.strip().upper()
+        if not symbol or symbol in seen:
+            continue
+        seen.add(symbol)
+        normalized.append(symbol)
+    if not normalized:
+        raise ValueError("watchlist cannot be empty")
+    return normalized
+
+
+def next_cycle_number(work_dir: Path) -> int:
+    max_cycle = 0
+    pattern = re.compile(r"^cycle-(\d+)$")
+    for path in work_dir.glob("cycle-*"):
+        match = pattern.match(path.name)
+        if match:
+            max_cycle = max(max_cycle, int(match.group(1)))
+    return max_cycle + 1
+
+
+def format_account(account: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "account": {
+            "id": account.get("id"),
+            "equity": account.get("equity"),
+            "cash": account.get("cash"),
+            "buying_power": account.get("buying_power"),
+            "daytrading_buying_power": account.get("daytrading_buying_power") or account.get("daytrade_buying_power"),
+            "trading_blocked": bool(account.get("trading_blocked", False)),
+            "account_blocked": bool(account.get("account_blocked", False)),
+        }
+    }
+
+
+def format_latest_quotes(payload: dict[str, Any], symbols: list[str]) -> dict[str, Any]:
+    raw_quotes = payload.get("quotes") if isinstance(payload, dict) else None
+    if not isinstance(raw_quotes, dict):
+        raw_quotes = {}
+    quotes: dict[str, dict[str, Any]] = {}
+    for symbol in symbols:
+        quote = raw_quotes.get(symbol) or raw_quotes.get(symbol.upper()) or {}
+        if not isinstance(quote, dict):
+            quote = {}
+        bid = quote.get("bid") if "bid" in quote else quote.get("bp")
+        ask = quote.get("ask") if "ask" in quote else quote.get("ap")
+        quotes[symbol] = {"symbol": symbol, "bid": bid, "ask": ask}
+    return {"quotes": quotes}
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{json.dumps(payload, separators=(',', ':'), sort_keys=True)}\n", encoding="utf-8")
+
+
+def market_open_start(now: datetime) -> str:
+    market_day = now.astimezone(MARKET_TIMEZONE).date()
+    market_open = datetime(market_day.year, market_day.month, market_day.day, 9, 30, tzinfo=MARKET_TIMEZONE)
+    return market_open.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def stock_analysis_cli_path(value: str | None) -> str:
+    if value:
+        return value
+    artifact_dir = os.environ.get("AUTONOMOUS_TRADER_ARTIFACT_DIR", "/workspace/.agentrun/autonomous-trader")
+    return str(Path(artifact_dir) / "stock_analysis")
+
+
+def run_stock_analysis_scan(
+    *,
+    stock_analysis_cli: str,
+    cycle_dir: Path,
+    analysis_context_path: Path,
+    watchlist: list[str],
+) -> dict[str, Any]:
+    live_scan_input = cycle_dir / "live-scan-input.json"
+    live_scan = cycle_dir / "live-scan.json"
+    build_command = [
+        stock_analysis_cli,
+        "build-live-scan-input",
+        "--bars",
+        str(cycle_dir / "bars.json"),
+        "--quotes",
+        str(cycle_dir / "quotes.json"),
+        "--account",
+        str(cycle_dir / "account.json"),
+        "--positions",
+        str(cycle_dir / "positions.json"),
+        "--open-orders",
+        str(cycle_dir / "open-orders.json"),
+        "--scorecards",
+        str(cycle_dir / "scorecards.json"),
+        "--analysis-context",
+        str(analysis_context_path),
+        "--require-live-state",
+        "--max-input-age-seconds",
+        "1800",
+        "--output",
+        str(live_scan_input),
+    ]
+    for symbol in watchlist:
+        build_command.extend(["--watchlist", symbol])
+    subprocess.run(build_command, check=True)
+    subprocess.run(
+        [stock_analysis_cli, "daytrading-scan", "--input", str(live_scan_input), "--output", str(live_scan)],
+        check=True,
+    )
+    payload = json.loads(live_scan.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("scanner output must be a JSON object")
+    return payload
+
+
+def fetch_scan_inputs(
+    *,
+    alpaca: AlpacaRestClient,
+    synthesis: SynthesisClient,
+    symbols: list[str],
+    start: str,
+    end: str,
+    feed: str,
+    scorecard_limit: int,
+) -> dict[str, Any]:
+    account = format_account(alpaca.trading_get("/v2/account"))
+    positions = alpaca.trading_get("/v2/positions")
+    orders = alpaca.trading_get("/v2/orders", {"status": "open", "nested": "true"})
+    bars = alpaca.data_get(
+        "/stocks/bars",
+        {
+            "symbols": ",".join(symbols),
+            "timeframe": "1Min",
+            "start": start,
+            "end": end,
+            "limit": "1000",
+            "feed": feed,
+            "sort": "asc",
+        },
+    )
+    quotes = format_latest_quotes(
+        alpaca.data_get("/stocks/quotes/latest", {"symbols": ",".join(symbols), "feed": feed}),
+        symbols,
+    )
+    scorecards = synthesis.get("/api/autotrader/scorecards", {"limit": str(scorecard_limit)})
+    return {
+        "account.json": account,
+        "positions.json": {"positions": positions if isinstance(positions, list) else []},
+        "open-orders.json": {"orders": orders if isinstance(orders, list) else []},
+        "bars.json": bars,
+        "quotes.json": quotes,
+        "scorecards.json": scorecards,
+        "watchlist.json": {"watchlist": symbols},
+    }
+
+
+def summarize_scan(cycle: int, cycle_dir: Path, scan: dict[str, Any], symbols: list[str]) -> dict[str, Any]:
+    results = scan.get("results")
+    if not isinstance(results, list):
+        results = []
+    top_results = []
+    for result in results[:10]:
+        if not isinstance(result, dict):
+            continue
+        top_results.append(
+            {
+                key: result.get(key)
+                for key in (
+                    "symbol",
+                    "bars",
+                    "setup_type",
+                    "setup_grade",
+                    "fat_pitch",
+                    "expected_r",
+                    "no_trade_reason",
+                    "last",
+                    "vwap",
+                    "spread_pct",
+                    "liquidity_score",
+                    "momentum_score",
+                    "risk_notes",
+                )
+            }
+        )
+    return {
+        "ok": True,
+        "cycle": cycle,
+        "cycleDir": str(cycle_dir),
+        "watchlist": symbols,
+        "resultCount": len(results),
+        "topResults": top_results,
+    }
+
+
+def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
+    symbols = normalize_watchlist(args.watchlist)
+    work_dir = Path(args.work_dir or os.environ.get("AUTONOMOUS_TRADER_WORK_DIR", "/tmp/autonomous-trader-work"))
+    cycle = args.cycle if args.cycle is not None else next_cycle_number(work_dir)
+    cycle_dir = work_dir / f"cycle-{cycle}"
+    cycle_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    end = args.end or now.isoformat().replace("+00:00", "Z")
+    start = args.start or market_open_start(now)
+    alpaca = AlpacaRestClient(timeout_seconds=args.timeout_seconds)
+    synthesis = SynthesisClient(base_url=args.synthesis_base_url, timeout_seconds=args.timeout_seconds)
+    inputs = fetch_scan_inputs(
+        alpaca=alpaca,
+        synthesis=synthesis,
+        symbols=symbols,
+        start=start,
+        end=end,
+        feed=args.feed,
+        scorecard_limit=args.scorecard_limit,
+    )
+    for name, payload in inputs.items():
+        write_json(cycle_dir / name, payload)
+    analysis_context = Path(
+        args.analysis_context or os.environ.get("ANALYSIS_CONTEXT_PATH") or work_dir / "analysis-context.json"
+    )
+    scan = run_stock_analysis_scan(
+        stock_analysis_cli=stock_analysis_cli_path(args.stock_analysis_cli),
+        cycle_dir=cycle_dir,
+        analysis_context_path=analysis_context,
+        watchlist=symbols,
+    )
+    return summarize_scan(cycle, cycle_dir, scan, symbols)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run one autonomous-trader live scan cycle.")
+    parser.add_argument("--work-dir")
+    parser.add_argument("--cycle", type=int)
+    parser.add_argument("--watchlist", action="append", default=[])
+    parser.add_argument("--start")
+    parser.add_argument("--end")
+    parser.add_argument("--feed", default="iex")
+    parser.add_argument("--scorecard-limit", type=int, default=20)
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    parser.add_argument("--synthesis-base-url")
+    parser.add_argument("--analysis-context")
+    parser.add_argument("--stock-analysis-cli")
+    parser.add_argument("--self-test", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.self_test:
+        payload = {
+            "ok": True,
+            "defaultWatchlist": list(DEFAULT_WATCHLIST),
+            "stockAnalysisCli": stock_analysis_cli_path(args.stock_analysis_cli),
+        }
+        print(json.dumps(payload, sort_keys=True, indent=2))
+        return 0
+    print(json.dumps(run_cycle(args), sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import live_scan_cycle
+
+
+class LiveScanCycleTest(unittest.TestCase):
+    def test_normalizes_watchlist(self) -> None:
+        self.assertEqual(live_scan_cycle.normalize_watchlist([" spy ", "SPY", "nvda"]), ["SPY", "NVDA"])
+
+    def test_picks_next_cycle_number(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "cycle-1").mkdir()
+            (root / "cycle-3").mkdir()
+            (root / "cycle-other").mkdir()
+
+            self.assertEqual(live_scan_cycle.next_cycle_number(root), 4)
+
+    def test_normalizes_alpaca_data_base_url(self) -> None:
+        self.assertEqual(
+            live_scan_cycle.normalize_alpaca_data_base_url("https://data.alpaca.markets"),
+            "https://data.alpaca.markets/v2",
+        )
+        self.assertEqual(
+            live_scan_cycle.normalize_alpaca_data_base_url("https://data.alpaca.markets/v2/"),
+            "https://data.alpaca.markets/v2",
+        )
+
+    def test_formats_latest_quotes_for_scanner(self) -> None:
+        payload = {
+            "quotes": {
+                "SPY": {"bp": 100.1, "ap": 100.2},
+                "NVDA": {"bid": 200.1, "ask": 200.3},
+            }
+        }
+
+        self.assertEqual(
+            live_scan_cycle.format_latest_quotes(payload, ["SPY", "NVDA", "QQQ"]),
+            {
+                "quotes": {
+                    "SPY": {"symbol": "SPY", "bid": 100.1, "ask": 100.2},
+                    "NVDA": {"symbol": "NVDA", "bid": 200.1, "ask": 200.3},
+                    "QQQ": {"symbol": "QQQ", "bid": None, "ask": None},
+                }
+            },
+        )
+
+    def test_market_open_start_uses_new_york_timezone(self) -> None:
+        self.assertEqual(
+            live_scan_cycle.market_open_start(datetime(2026, 6, 2, 13, 45, tzinfo=UTC)),
+            "2026-06-02T13:30:00Z",
+        )
+        self.assertEqual(
+            live_scan_cycle.market_open_start(datetime(2026, 1, 5, 15, 0, tzinfo=UTC)),
+            "2026-01-05T14:30:00Z",
+        )
+
+    def test_summarizes_scan_without_runtime_ledger(self) -> None:
+        summary = live_scan_cycle.summarize_scan(
+            2,
+            Path("/tmp/autonomous-trader-work/cycle-2"),
+            {
+                "results": [
+                    {
+                        "symbol": "NVDA",
+                        "bars": 10,
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A",
+                        "fat_pitch": False,
+                        "expected_r": 2.0,
+                        "no_trade_reason": None,
+                        "last": 123.45,
+                        "vwap": 122.0,
+                        "spread_pct": 0.02,
+                        "liquidity_score": 2.0,
+                        "momentum_score": 3.0,
+                        "risk_notes": ["limited_bar_history"],
+                    }
+                ]
+            },
+            ["NVDA"],
+        )
+
+        self.assertEqual(summary["cycle"], 2)
+        self.assertEqual(summary["resultCount"], 1)
+        self.assertEqual(summary["topResults"][0]["symbol"], "NVDA")
+
+    def test_run_cycle_returns_summary_without_summary_file(self) -> None:
+        case = self
+
+        class FakeAlpaca:
+            def __init__(self, *, timeout_seconds: float) -> None:
+                self.timeout_seconds = timeout_seconds
+
+            def trading_get(self, path: str, query: dict[str, str] | None = None) -> object:
+                if path == "/v2/account":
+                    return {
+                        "id": "paper-account",
+                        "equity": "30000",
+                        "cash": "30000",
+                        "buying_power": "60000",
+                    }
+                if path == "/v2/positions":
+                    return []
+                if path == "/v2/orders":
+                    case.assertEqual(query, {"status": "open", "nested": "true"})
+                    return []
+                raise AssertionError(f"unexpected trading path {path}")
+
+            def data_get(self, path: str, query: dict[str, str]) -> object:
+                case.assertIn(path, {"/stocks/bars", "/stocks/quotes/latest"})
+                if path.endswith("quotes/latest"):
+                    return {"quotes": {"NVDA": {"bp": 100.0, "ap": 100.1}}}
+                return {"bars": {}}
+
+        class FakeSynthesis:
+            def __init__(self, *, base_url: str | None, timeout_seconds: float) -> None:
+                self.base_url = base_url
+                self.timeout_seconds = timeout_seconds
+
+            def get(self, path: str, query: dict[str, str]) -> object:
+                case.assertEqual(path, "/api/autotrader/scorecards")
+                case.assertEqual(query, {"limit": "20"})
+                return {"scorecards": []}
+
+        def fake_scan(**kwargs: object) -> dict[str, object]:
+            return {"results": [{"symbol": "NVDA", "bars": 9, "no_trade_reason": "limited_live_bars"}]}
+
+        with tempfile.TemporaryDirectory() as directory:
+            args = live_scan_cycle.build_parser().parse_args(["--work-dir", directory, "--watchlist", "NVDA"])
+            with (
+                patch.object(live_scan_cycle, "AlpacaRestClient", FakeAlpaca),
+                patch.object(live_scan_cycle, "SynthesisClient", FakeSynthesis),
+                patch.object(live_scan_cycle, "run_stock_analysis_scan", fake_scan),
+            ):
+                summary = live_scan_cycle.run_cycle(args)
+
+            cycle_dir = Path(directory) / "cycle-1"
+            self.assertEqual(summary["cycle"], 1)
+            self.assertEqual(summary["resultCount"], 1)
+            self.assertTrue((cycle_dir / "account.json").exists())
+            self.assertTrue((cycle_dir / "watchlist.json").exists())
+            self.assertFalse((cycle_dir / "summary.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `scripts/autotrader/live_scan_cycle.py`, a checked-in helper that performs one live scan cycle: broker readback, scorecard readback, scanner input assembly, daytrading scan execution, and concise summary output.
- Keeps scanner files under `AUTONOMOUS_TRADER_WORK_DIR` and avoids creating another runtime ledger or redundant `summary.json` artifact.
- Updates the autonomous-trader ImplementationSpec and system prompt so market-open loops prefer the helper over manual scanner JSON assembly.
- Hardens scan defaults for paper-only Alpaca trading reads, Alpaca data URL normalization, and seasonal New York market-open timing.

## Related Issues

None

## Testing

- `PYTHONPATH=scripts/autotrader python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/test_live_scan_cycle.py scripts/autotrader/protective_preflight.py scripts/autotrader/test_protective_preflight.py scripts/autotrader/synthesis_autotrader_client.py`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/protective_preflight.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
