### PR TITLE
fix(torghut): bound live TCA journal slice

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -27,6 +27,8 @@ from scripts import journal_tigerbeetle_order_events as journal_script  # noqa: 
 LIVE_ORDER_EVENT_BATCH_SIZE = 1
 LIVE_ORDER_EVENT_MAX_BATCHES = 1
 LIVE_ORDER_EVENT_SCAN_LIMIT = 250
+LIVE_TCA_METRIC_BATCH_SIZE = 5
+LIVE_TCA_METRIC_MAX_BATCHES = 1
 
 
 @dataclass(frozen=True)
@@ -71,8 +73,8 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_TCA_METRIC,
             dsn_env="DB_DSN",
-            batch_size=5,
-            max_batches=3,
+            batch_size=LIVE_TCA_METRIC_BATCH_SIZE,
+            max_batches=LIVE_TCA_METRIC_MAX_BATCHES,
             reconcile_limit=1000,
             skip_reconcile=True,
         ),

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from app.trading.tigerbeetle_journal import (
     SOURCE_TYPE_EXECUTION,
     SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+    SOURCE_TYPE_EXECUTION_TCA_METRIC,
     SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
 )
 from scripts import run_tigerbeetle_journal_cron as runner
@@ -53,7 +54,12 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(commands[0].max_batches, 1)
         self.assertTrue(commands[0].skip_reconcile)
         self.assertTrue(commands[0].allow_data_quality_degraded)
+        self.assertEqual(commands[1].source, SOURCE_TYPE_EXECUTION_TCA_METRIC)
+        self.assertEqual(commands[1].batch_size, runner.LIVE_TCA_METRIC_BATCH_SIZE)
         self.assertEqual(commands[1].batch_size, 5)
+        self.assertEqual(commands[1].max_batches, runner.LIVE_TCA_METRIC_MAX_BATCHES)
+        self.assertEqual(commands[1].max_batches, 1)
+        self.assertTrue(commands[1].skip_reconcile)
         self.assertEqual(commands[2].source, SOURCE_TYPE_EXECUTION_ORDER_EVENT)
         self.assertEqual(commands[2].batch_size, runner.LIVE_ORDER_EVENT_BATCH_SIZE)
         self.assertEqual(commands[2].batch_size, 1)
@@ -112,6 +118,34 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(argv[argv.index("--supervise-timeout-seconds") + 1], "45.0")
         self.assertIn("--fail-on-degraded", argv)
         self.assertIn("--allow-data-quality-degraded", argv)
+        self.assertIn("--json", argv)
+
+    def test_live_tca_metric_argv_keeps_slice_bounded_under_watchdog(self) -> None:
+        [command] = [
+            item
+            for item in runner._live_commands(execution_batch_size=5)
+            if item.source == SOURCE_TYPE_EXECUTION_TCA_METRIC
+        ]
+
+        argv = runner._argv_for_command(
+            command,
+            json_output=True,
+            supervise_timeout_seconds=45.0,
+        )
+
+        self.assertEqual(argv[argv.index("--sources") + 1], "execution_tca_metric")
+        self.assertEqual(
+            argv[argv.index("--batch-size") + 1],
+            str(runner.LIVE_TCA_METRIC_BATCH_SIZE),
+        )
+        self.assertEqual(
+            argv[argv.index("--max-batches") + 1],
+            str(runner.LIVE_TCA_METRIC_MAX_BATCHES),
+        )
+        self.assertEqual(int(argv[argv.index("--max-batches") + 1]), 1)
+        self.assertEqual(argv[argv.index("--supervise-timeout-seconds") + 1], "45.0")
+        self.assertIn("--skip-reconcile", argv)
+        self.assertIn("--fail-on-degraded", argv)
         self.assertIn("--json", argv)
 
     def test_safe_non_authority_payload_normalizes_nonzero_command_exit(self) -> None:


### PR DESCRIPTION
## Summary

- Bounds the live TigerBeetle `execution_tca_metric` journal slice to one 5-row batch per cron tick.
- Keeps the runtime-ledger reconciliation slice unchanged so live cron runs can still refresh reconciliation freshness.
- Adds regression coverage for the live TCA watchdog budget.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q -k tigerbeetle_journal_order_events_cronjob`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py`
- `uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
