### PR TITLE
fix(torghut): prioritize live gate status budget

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -3824,15 +3824,6 @@ def trading_status() -> dict[str, object]:
         status_read_budget,
         scheduler=scheduler,
     )
-    tigerbeetle_ledger = _load_trading_status_tigerbeetle_ledger(status_read_budget)
-    runtime_ledger_portfolio_summary = (
-        _load_trading_status_runtime_ledger_portfolio_summary(
-            status_read_budget,
-            account_label=settings.trading_account_label,
-            stage_scope=status_stage_scope,
-            observed_at=status_observed_at,
-        )
-    )
     market_context_status = scheduler.market_context_status()
     hypothesis_payload, hypothesis_summary, hypothesis_dependency_quorum = (
         _load_trading_status_hypothesis_runtime(
@@ -3854,26 +3845,6 @@ def trading_status() -> dict[str, object]:
     )
     shorting_metadata_status = scheduler.shorting_metadata_status()
     rejection_alert_status = scheduler.rejection_alert_status()
-    last_decision_at = None
-    last_decision_skip_reason = status_read_budget.skip_reason_if_unavailable(
-        "last_decision",
-        min_remaining_seconds=0.25,
-    )
-    if last_decision_skip_reason is None:
-        with SessionLocal() as session:
-            last_decision_at = _load_last_decision_at(session)
-    persisted_rejected_signal_outcome_learning = None
-    rejected_signal_outcome_learning_skip_reason = (
-        status_read_budget.skip_reason_if_unavailable(
-            "rejected_signal_outcome_learning",
-            min_remaining_seconds=0.5,
-        )
-    )
-    if rejected_signal_outcome_learning_skip_reason is None:
-        with SessionLocal() as session:
-            persisted_rejected_signal_outcome_learning = (
-                _load_rejected_signal_outcome_learning_summary(session)
-            )
     live_submission_gate_skip_reason = status_read_budget.skip_reason_if_unavailable(
         "live_submission_gate",
         min_remaining_seconds=4.0,
@@ -3897,6 +3868,35 @@ def trading_status() -> dict[str, object]:
                 ),
                 quant_health_status=quant_evidence,
                 clickhouse_ta_status=clickhouse_ta_status,
+            )
+    tigerbeetle_ledger = _load_trading_status_tigerbeetle_ledger(status_read_budget)
+    runtime_ledger_portfolio_summary = (
+        _load_trading_status_runtime_ledger_portfolio_summary(
+            status_read_budget,
+            account_label=settings.trading_account_label,
+            stage_scope=status_stage_scope,
+            observed_at=status_observed_at,
+        )
+    )
+    last_decision_at = None
+    last_decision_skip_reason = status_read_budget.skip_reason_if_unavailable(
+        "last_decision",
+        min_remaining_seconds=0.25,
+    )
+    if last_decision_skip_reason is None:
+        with SessionLocal() as session:
+            last_decision_at = _load_last_decision_at(session)
+    persisted_rejected_signal_outcome_learning = None
+    rejected_signal_outcome_learning_skip_reason = (
+        status_read_budget.skip_reason_if_unavailable(
+            "rejected_signal_outcome_learning",
+            min_remaining_seconds=0.5,
+        )
+    )
+    if rejected_signal_outcome_learning_skip_reason is None:
+        with SessionLocal() as session:
+            persisted_rejected_signal_outcome_learning = (
+                _load_rejected_signal_outcome_learning_summary(session)
             )
     simple_lane_reject_reason_totals = _simple_lane_reject_reason_totals(state)
     simple_lane_status = _build_simple_lane_status_payload()

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -3013,7 +3013,90 @@ class TestTradingApi(TestCase):
             payload["status_read_budget"]["skipped_reads"],
         )
 
-    def test_trading_status_skips_expensive_reads_when_budget_remaining_is_low(
+    def test_trading_status_prioritizes_live_gate_before_late_reads_when_budget_is_low(
+        self,
+    ) -> None:
+        class ManualBudget(main_module._TradingStatusReadBudget):
+            def __init__(self) -> None:
+                super().__init__(max_seconds=10.0)
+                self.current_elapsed = 1.0
+
+            def elapsed_seconds(self) -> float:
+                return self.current_elapsed
+
+        budget = ManualBudget()
+        live_submission_gate_payload = {
+            "allowed": False,
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "blocked_reasons": ["alpha_readiness_not_promotion_eligible"],
+            "read_model_unavailable": False,
+            "promotion_authority": False,
+            "final_authority_ok": False,
+            "final_promotion_allowed": False,
+        }
+
+        def _build_live_submission_gate(
+            *args: object,
+            **kwargs: object,
+        ) -> dict[str, object]:
+            budget.current_elapsed = 9.8
+            return live_submission_gate_payload
+
+        with (
+            patch("app.main._TradingStatusReadBudget", return_value=budget),
+            patch(
+                "app.main._load_clickhouse_ta_status",
+                return_value={
+                    "state": "current",
+                    "latest_signal_at": datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    "source_ref": "clickhouse:ta_signals",
+                },
+            ),
+            patch("app.main._build_tigerbeetle_ledger_status") as tigerbeetle_status,
+            patch(
+                "app.main._daily_runtime_ledger_portfolio_summary"
+            ) as portfolio_summary,
+            patch("app.main._load_last_decision_at") as last_decision,
+            patch(
+                "app.main._load_rejected_signal_outcome_learning_summary"
+            ) as rejected_signal_learning,
+            patch(
+                "app.main._build_live_submission_gate_payload",
+                side_effect=_build_live_submission_gate,
+            ) as live_gate,
+        ):
+            response = self.client.get("/trading/status")
+
+        self.assertEqual(response.status_code, 200)
+        live_gate.assert_called_once()
+        tigerbeetle_status.assert_not_called()
+        portfolio_summary.assert_not_called()
+        last_decision.assert_not_called()
+        rejected_signal_learning.assert_not_called()
+        payload = response.json()
+        skipped_reads = payload["status_read_budget"]["skipped_reads"]
+        self.assertNotIn("live_submission_gate", skipped_reads)
+        self.assertIn("tigerbeetle_ledger", skipped_reads)
+        self.assertIn("runtime_ledger_portfolio_summary", skipped_reads)
+        self.assertIn("last_decision", skipped_reads)
+        self.assertIn("rejected_signal_outcome_learning", skipped_reads)
+        self.assertFalse(payload["live_submission_gate"]["allowed"])
+        self.assertEqual(
+            payload["live_submission_gate"]["reason"],
+            "alpha_readiness_not_promotion_eligible",
+        )
+        self.assertFalse(payload["live_submission_gate"]["read_model_unavailable"])
+        self.assertFalse(payload["status_read_budget"]["exhausted"])
+        self.assertEqual(payload["status_read_budget"]["remaining_seconds"], 0.2)
+        self.assertIn(
+            "tigerbeetle_ledger_status_read_budget_insufficient_remaining",
+            payload["tigerbeetle_ledger"]["blockers"],
+        )
+        self.assertTrue(
+            payload["portfolio_runtime_ledger_summary"]["read_model_unavailable"]
+        )
+
+    def test_trading_status_skips_live_gate_when_gate_dependencies_consume_budget(
         self,
     ) -> None:
         class ManualBudget(main_module._TradingStatusReadBudget):
@@ -3026,11 +3109,18 @@ class TestTradingApi(TestCase):
 
         budget = ManualBudget()
 
-        def _load_rejected_signal_outcome_learning_summary(
-            _session: Session,
-        ) -> dict[str, object]:
+        def _load_hypothesis_runtime(
+            *_args: object,
+            **_kwargs: object,
+        ) -> tuple[
+            dict[str, object],
+            dict[str, object],
+            main_module.JangarDependencyQuorumStatus,
+        ]:
             budget.current_elapsed = 8.5
-            return {}
+            return main_module._budget_unavailable_hypothesis_runtime_payload(
+                reason="hypothesis_runtime_test_budget_marker"
+            )
 
         with (
             patch("app.main._TradingStatusReadBudget", return_value=budget),
@@ -3043,8 +3133,8 @@ class TestTradingApi(TestCase):
                 },
             ),
             patch(
-                "app.main._load_rejected_signal_outcome_learning_summary",
-                side_effect=_load_rejected_signal_outcome_learning_summary,
+                "app.main._load_trading_status_hypothesis_runtime",
+                side_effect=_load_hypothesis_runtime,
             ),
             patch("app.main._build_live_submission_gate_payload") as live_gate,
         ):


### PR DESCRIPTION
## Summary

- Reorders `/trading/status` so the live submission gate gets read budget before lower-priority TigerBeetle ledger, runtime portfolio ledger, last-decision, and rejected-signal learning reads.
- Keeps the endpoint fail-closed when required gate dependencies consume the budget before the gate can run.
- Adds budget regressions that prove the live gate is not skipped by late reads, while late reads are skipped once the gate consumes the remaining budget.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_api.py -k 'trading_status_prioritizes_live_gate_before_late_reads_when_budget_is_low or trading_status_skips_live_gate_when_gate_dependencies_consume_budget or trading_status_skips_early_expensive_reads_when_budget_remaining_is_low or trading_status_fails_closed_late_reads_after_budget_exhausted'`
- `uv run --frozen pytest tests/test_trading_api.py -k 'trading_status'`
- `uv run --frozen pytest tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `git diff origin/main --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
