### PR TITLE
fix(synthesis): guard stale autotrader entries

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -60,6 +60,7 @@ spec:
        - `python3 /workspace/lab/scripts/autotrader/protective_preflight.py --self-test`
        - `python3 /workspace/lab/scripts/autotrader/synthesis_autotrader_client.py --self-test`
        - `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py --self-test`
+       - `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py --self-test`
     7. Verify Synthesis exposes `autotrader_start_session`, `autotrader_upsert_status`, `autotrader_append_event`, `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, `autotrader_record_order`, `autotrader_record_fill`, `autotrader_record_position_snapshot`, `autotrader_finalize_session`, and `autotrader_get_scorecard`.
     8. Call `autotrader_start_session` before scanning and use the returned `sessionId` for every Synthesis write.
 
@@ -74,12 +75,13 @@ spec:
     2. Reconcile open orders and absorb external account or position changes as current state.
     3. Call `autotrader_get_scorecard` before ranking candidates and include scorecard influence in Synthesis ticket/risk/status payloads.
     4. Run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py` for scanner input assembly, Alpaca readback, scorecard readback, and daytrading scan output. Use its printed summary and `cycleDir` for the next action: protected entry, managed exit/reduce/hedge/flatten, or no-trade. Do not hand-build scanner JSON unless this helper fails and the failure is recorded.
-    5. Record every selected or blocked candidate with `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, and `autotrader_append_event`.
+    5. Record every selected or blocked candidate with `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, and `autotrader_append_event`; use the returned trade-ticket UUID for linked risk/order writes, not the ticket idempotency key.
     6. Submit only when the ticket records setup type, setup grade, expected R, fat-pitch flag, thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
-    7. Before every Alpaca mutation, write the planned order with `autotrader_record_order`, use an AgentRun-prefixed deterministic `client_order_id` when supported, and then reconcile by broker order id plus client order id before any next action.
-    8. After broker-changing action, external account change, order reconciliation, or fill reconciliation, refresh broker account/positions and call `autotrader_upsert_status` before scanning or submitting another order.
-    9. Emit heartbeat output at least every 60 seconds while waiting.
-    10. If the selected action is wait, stand down, monitor, manage existing brackets, or continue monitoring, write Synthesis status/event plus a `report.md` checkpoint with `terminal_reason: running`, sleep no more than 60 seconds, and immediately begin the next cycle. A `running` report is a checkpoint, not completion.
+    7. Before any non-smoke strategy entry, run `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py --symbol SYMBOL --side SIDE --entry-limit ENTRY --take-profit-limit TARGET --stop-loss-stop STOP`. If `allowed=false`, record the guard reason through Synthesis ticket/risk/event/status and do not submit the broker order.
+    8. Before every Alpaca mutation, write the planned order with `autotrader_record_order`, use an AgentRun-prefixed deterministic `client_order_id` when supported, and then reconcile by broker order id plus client order id before any next action.
+    9. After broker-changing action, external account change, order reconciliation, or fill reconciliation, refresh broker account/positions and call `autotrader_upsert_status` before scanning or submitting another order.
+    10. Emit heartbeat output at least every 60 seconds while waiting.
+    11. If the selected action is wait, stand down, monitor, manage existing brackets, or continue monitoring, write Synthesis status/event plus a `report.md` checkpoint with `terminal_reason: running`, sleep no more than 60 seconds, and immediately begin the next cycle. A `running` report is a checkpoint, not completion.
 
     Protective order rules:
     - The smoke is execution-path proof, not a strategy trade: use a tiny non-marketable bracket or OTO order, record before submit, reconcile, cancel if accepted/open, and update Synthesis for accepted, canceled, rejected, or blocked states.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -26,16 +26,18 @@ data:
     - If `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE` is non-empty, pass exactly that value to `autotrader_start_session.mode`.
 
     Execution loop:
-    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate the local analysis context at `ANALYSIS_CONTEXT_PATH`, and self-test the Synthesis, live-scan, and protective-order helper scripts.
+    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate the local analysis context at `ANALYSIS_CONTEXT_PATH`, and self-test the Synthesis, live-scan, strategy-order, and protective-order helper scripts.
     2. Preflight Alpaca account/config/clock/calendar/tools/positions/orders and Synthesis autotrader tool availability.
     3. Call `autotrader_start_session` before scanning and keep its `sessionId` for every Synthesis write.
     4. Before grading candidates, call `autotrader_get_scorecard` and include scorecard influence in the ticket/risk/status payloads.
     5. Run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py`, use its summary plus Synthesis scorecards to pick the next best action: protected entry, managed exit/reduce/hedge/flatten, or no-trade.
-    6. Before any Alpaca mutation, record the planned order/risk in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when the broker tool supports it.
-    7. After any Alpaca mutation, reconcile by broker order id and client order id, refresh account/positions/orders, then update Synthesis before taking more risk.
-    8. Continue market-open cycles until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state.
-    9. In market-open mode, `terminal_reason: running`, `phase: manage`, `next_action: continue_monitoring`, active monitoring, quiet markets, and protected open positions are checkpoints, not completion. Write Synthesis status/event plus `report.md`, sleep no more than 60 seconds, and immediately start the next cycle.
-    10. Finalize with realized scorecard observations for terminal tickets, rejected valid setups, rejected invalid setups, slippage, hold time, MFE/MAE, and mistake tags.
+    6. For risk/order writes linked to a trade ticket, use the returned trade-ticket UUID, not the ticket idempotency key.
+    7. Before any non-smoke strategy entry, run `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py` against the planned bracket prices; if `allowed=false`, record the guard reason in Synthesis and do not submit the broker order.
+    8. Before any Alpaca mutation, record the planned order/risk in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when the broker tool supports it.
+    9. After any Alpaca mutation, reconcile by broker order id and client order id, refresh account/positions/orders, then update Synthesis before taking more risk.
+    10. Continue market-open cycles until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state.
+    11. In market-open mode, `terminal_reason: running`, `phase: manage`, `next_action: continue_monitoring`, active monitoring, quiet markets, and protected open positions are checkpoints, not completion. Write Synthesis status/event plus `report.md`, sleep no more than 60 seconds, and immediately start the next cycle.
+    12. Finalize with realized scorecard observations for terminal tickets, rejected valid setups, rejected invalid setups, slippage, hold time, MFE/MAE, and mistake tags.
 
     Mode behavior:
     - `dry-run`: no Alpaca submit/cancel/replace/close-position calls; perform one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.

--- a/scripts/autotrader/strategy_order_guard.py
+++ b/scripts/autotrader/strategy_order_guard.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from live_scan_cycle import AlpacaRestClient
+
+
+def parse_price(value: str | float | int, field: str) -> float:
+    try:
+        price = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{field} must be numeric") from error
+    if price <= 0:
+        raise ValueError(f"{field} must be positive")
+    return price
+
+
+def latest_quote_prices(payload: dict[str, Any], symbol: str) -> tuple[float | None, float | None]:
+    quotes = payload.get("quotes")
+    quote = quotes.get(symbol.upper()) if isinstance(quotes, dict) else None
+    if not isinstance(quote, dict):
+        return None, None
+    return optional_price(quote.get("bp") or quote.get("bid")), optional_price(quote.get("ap") or quote.get("ask"))
+
+
+def latest_trade_price(payload: dict[str, Any], symbol: str) -> float | None:
+    trades = payload.get("trades")
+    trade = trades.get(symbol.upper()) if isinstance(trades, dict) else None
+    if not isinstance(trade, dict):
+        return None
+    return optional_price(trade.get("p") or trade.get("price"))
+
+
+def optional_price(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        price = float(value)
+    except (TypeError, ValueError):
+        return None
+    return price if price > 0 else None
+
+
+def spread_pct(bid: float | None, ask: float | None) -> float | None:
+    if bid is None or ask is None or bid <= 0 or ask <= 0 or ask < bid:
+        return None
+    midpoint = (bid + ask) / 2
+    return ((ask - bid) / midpoint) * 100
+
+
+def decide_strategy_order(
+    *,
+    symbol: str,
+    side: str,
+    entry_limit: float,
+    take_profit_limit: float,
+    stop_loss_stop: float,
+    latest_bid: float | None,
+    latest_ask: float | None,
+    latest_trade: float | None,
+    max_spread_pct: float,
+    min_target_headroom_pct: float,
+) -> dict[str, Any]:
+    side = side.lower()
+    if side not in {"buy", "sell"}:
+        raise ValueError("side must be buy or sell")
+    if side == "buy" and not (take_profit_limit > entry_limit > stop_loss_stop):
+        return block("invalid_buy_bracket_prices")
+    if side == "sell" and not (take_profit_limit < entry_limit < stop_loss_stop):
+        return block("invalid_sell_bracket_prices")
+
+    observed_spread_pct = spread_pct(latest_bid, latest_ask)
+    if observed_spread_pct is None:
+        return block("missing_or_invalid_quote")
+    if observed_spread_pct > max_spread_pct:
+        return block("spread_too_wide", spreadPct=observed_spread_pct)
+    if latest_trade is None:
+        return block("missing_latest_trade", spreadPct=observed_spread_pct)
+
+    if side == "buy":
+        market_entry = latest_ask
+        if market_entry is None:
+            return block("missing_latest_ask", spreadPct=observed_spread_pct)
+        if latest_trade >= take_profit_limit or market_entry >= take_profit_limit:
+            return block("target_already_touched", spreadPct=observed_spread_pct)
+        if latest_trade <= stop_loss_stop:
+            return block("stop_already_touched", spreadPct=observed_spread_pct)
+        target_headroom_pct = ((take_profit_limit - market_entry) / market_entry) * 100
+        if target_headroom_pct < min_target_headroom_pct:
+            return block(
+                "target_headroom_too_small",
+                spreadPct=observed_spread_pct,
+                targetHeadroomPct=target_headroom_pct,
+            )
+    else:
+        market_entry = latest_bid
+        if market_entry is None:
+            return block("missing_latest_bid", spreadPct=observed_spread_pct)
+        if latest_trade <= take_profit_limit or market_entry <= take_profit_limit:
+            return block("target_already_touched", spreadPct=observed_spread_pct)
+        if latest_trade >= stop_loss_stop:
+            return block("stop_already_touched", spreadPct=observed_spread_pct)
+        target_headroom_pct = ((market_entry - take_profit_limit) / market_entry) * 100
+        if target_headroom_pct < min_target_headroom_pct:
+            return block(
+                "target_headroom_too_small",
+                spreadPct=observed_spread_pct,
+                targetHeadroomPct=target_headroom_pct,
+            )
+
+    return {
+        "allowed": True,
+        "reason": "fresh_strategy_order",
+        "spreadPct": observed_spread_pct,
+        "targetHeadroomPct": target_headroom_pct,
+    }
+
+
+def block(reason: str, **extra: Any) -> dict[str, Any]:
+    return {"allowed": False, "reason": reason, **extra}
+
+
+def evaluate_order(args: argparse.Namespace) -> dict[str, Any]:
+    symbol = args.symbol.upper()
+    alpaca = AlpacaRestClient(timeout_seconds=args.timeout_seconds)
+    quote_payload = alpaca.data_get("/stocks/quotes/latest", {"symbols": symbol, "feed": args.feed})
+    trade_payload = alpaca.data_get("/stocks/trades/latest", {"symbols": symbol, "feed": args.feed})
+    latest_bid, latest_ask = latest_quote_prices(quote_payload, symbol)
+    latest_trade = latest_trade_price(trade_payload, symbol)
+    decision = decide_strategy_order(
+        symbol=symbol,
+        side=args.side,
+        entry_limit=parse_price(args.entry_limit, "entry_limit"),
+        take_profit_limit=parse_price(args.take_profit_limit, "take_profit_limit"),
+        stop_loss_stop=parse_price(args.stop_loss_stop, "stop_loss_stop"),
+        latest_bid=latest_bid,
+        latest_ask=latest_ask,
+        latest_trade=latest_trade,
+        max_spread_pct=args.max_spread_pct,
+        min_target_headroom_pct=args.min_target_headroom_pct,
+    )
+    return {
+        "ok": True,
+        "symbol": symbol,
+        "side": args.side,
+        "entryLimit": args.entry_limit,
+        "takeProfitLimit": args.take_profit_limit,
+        "stopLossStop": args.stop_loss_stop,
+        "latestBid": latest_bid,
+        "latestAsk": latest_ask,
+        "latestTrade": latest_trade,
+        **decision,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Guard one planned autotrader strategy order before broker submit.")
+    parser.add_argument("--symbol")
+    parser.add_argument("--side", choices=("buy", "sell"))
+    parser.add_argument("--entry-limit")
+    parser.add_argument("--take-profit-limit")
+    parser.add_argument("--stop-loss-stop")
+    parser.add_argument("--feed", default="iex")
+    parser.add_argument("--max-spread-pct", type=float, default=0.35)
+    parser.add_argument("--min-target-headroom-pct", type=float, default=0.25)
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    parser.add_argument("--self-test", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.self_test:
+        allowed = decide_strategy_order(
+            symbol="NVDA",
+            side="buy",
+            entry_limit=229.20,
+            take_profit_limit=231.80,
+            stop_loss_stop=227.90,
+            latest_bid=229.15,
+            latest_ask=229.20,
+            latest_trade=229.18,
+            max_spread_pct=0.35,
+            min_target_headroom_pct=0.25,
+        )
+        stale = decide_strategy_order(
+            symbol="NVDA",
+            side="buy",
+            entry_limit=229.20,
+            take_profit_limit=231.80,
+            stop_loss_stop=227.90,
+            latest_bid=231.00,
+            latest_ask=231.44,
+            latest_trade=231.04,
+            max_spread_pct=0.35,
+            min_target_headroom_pct=0.25,
+        )
+        payload = {
+            "ok": allowed["allowed"] is True and stale["allowed"] is False,
+            "allowed": allowed,
+            "stale": stale,
+        }
+        print(json.dumps(payload, sort_keys=True, indent=2))
+        return 0
+    required = ("symbol", "side", "entry_limit", "take_profit_limit", "stop_loss_stop")
+    missing = [name.replace("_", "-") for name in required if getattr(args, name) is None]
+    if missing:
+        raise SystemExit(f"missing required arguments: {', '.join(missing)}")
+    print(json.dumps(evaluate_order(args), sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/autotrader/test_strategy_order_guard.py
+++ b/scripts/autotrader/test_strategy_order_guard.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import strategy_order_guard
+
+
+class StrategyOrderGuardTest(unittest.TestCase):
+    def test_allows_fresh_buy_bracket(self) -> None:
+        decision = strategy_order_guard.decide_strategy_order(
+            symbol="NVDA",
+            side="buy",
+            entry_limit=229.20,
+            take_profit_limit=231.80,
+            stop_loss_stop=227.90,
+            latest_bid=229.15,
+            latest_ask=229.20,
+            latest_trade=229.18,
+            max_spread_pct=0.35,
+            min_target_headroom_pct=0.25,
+        )
+
+        self.assertTrue(decision["allowed"])
+        self.assertEqual(decision["reason"], "fresh_strategy_order")
+
+    def test_blocks_live_stale_buy_bracket_when_target_headroom_is_too_small(self) -> None:
+        decision = strategy_order_guard.decide_strategy_order(
+            symbol="NVDA",
+            side="buy",
+            entry_limit=229.20,
+            take_profit_limit=231.80,
+            stop_loss_stop=227.90,
+            latest_bid=231.00,
+            latest_ask=231.44,
+            latest_trade=231.04,
+            max_spread_pct=0.35,
+            min_target_headroom_pct=0.25,
+        )
+
+        self.assertFalse(decision["allowed"])
+        self.assertEqual(decision["reason"], "target_headroom_too_small")
+
+    def test_blocks_buy_bracket_when_target_already_touched(self) -> None:
+        decision = strategy_order_guard.decide_strategy_order(
+            symbol="NVDA",
+            side="buy",
+            entry_limit=229.20,
+            take_profit_limit=231.80,
+            stop_loss_stop=227.90,
+            latest_bid=231.70,
+            latest_ask=231.75,
+            latest_trade=231.85,
+            max_spread_pct=0.35,
+            min_target_headroom_pct=0.25,
+        )
+
+        self.assertFalse(decision["allowed"])
+        self.assertEqual(decision["reason"], "target_already_touched")
+
+    def test_blocks_invalid_buy_bracket_prices(self) -> None:
+        decision = strategy_order_guard.decide_strategy_order(
+            symbol="NVDA",
+            side="buy",
+            entry_limit=229.20,
+            take_profit_limit=228.00,
+            stop_loss_stop=227.90,
+            latest_bid=229.10,
+            latest_ask=229.20,
+            latest_trade=229.18,
+            max_spread_pct=0.35,
+            min_target_headroom_pct=0.25,
+        )
+
+        self.assertFalse(decision["allowed"])
+        self.assertEqual(decision["reason"], "invalid_buy_bracket_prices")
+
+    def test_allows_fresh_sell_bracket(self) -> None:
+        decision = strategy_order_guard.decide_strategy_order(
+            symbol="SPY",
+            side="sell",
+            entry_limit=500.00,
+            take_profit_limit=495.00,
+            stop_loss_stop=502.00,
+            latest_bid=500.00,
+            latest_ask=500.10,
+            latest_trade=500.05,
+            max_spread_pct=0.35,
+            min_target_headroom_pct=0.25,
+        )
+
+        self.assertTrue(decision["allowed"])
+        self.assertEqual(decision["reason"], "fresh_strategy_order")
+
+    def test_evaluate_order_fetches_latest_quote_and_trade(self) -> None:
+        case = self
+
+        class FakeAlpaca:
+            def __init__(self, *, timeout_seconds: float) -> None:
+                self.timeout_seconds = timeout_seconds
+
+            def data_get(self, path: str, query: dict[str, str]) -> object:
+                case.assertEqual(query, {"symbols": "NVDA", "feed": "iex"})
+                if path == "/stocks/quotes/latest":
+                    return {"quotes": {"NVDA": {"bp": 229.15, "ap": 229.20}}}
+                if path == "/stocks/trades/latest":
+                    return {"trades": {"NVDA": {"p": 229.18}}}
+                raise AssertionError(f"unexpected path {path}")
+
+        args = strategy_order_guard.build_parser().parse_args(
+            [
+                "--symbol",
+                "nvda",
+                "--side",
+                "buy",
+                "--entry-limit",
+                "229.20",
+                "--take-profit-limit",
+                "231.80",
+                "--stop-loss-stop",
+                "227.90",
+            ]
+        )
+        with patch.object(strategy_order_guard, "AlpacaRestClient", FakeAlpaca):
+            result = strategy_order_guard.evaluate_order(args)
+
+        self.assertTrue(result["allowed"])
+        self.assertEqual(result["symbol"], "NVDA")
+        self.assertEqual(result["latestAsk"], 229.20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `scripts/autotrader/strategy_order_guard.py`, a read-only pre-submit guard for planned strategy brackets.
- Blocks stale strategy orders before Alpaca submission when latest quote/trade shows target already touched, stop already touched, target headroom too small, invalid bracket prices, missing live data, or too-wide spread.
- Adds unit coverage for the live stale NVDA shape that previously submitted then canceled unfilled after price traded near/through target.
- Updates autotrader prompts to self-test the guard, use returned trade-ticket UUIDs for linked writes, and record guard blocks in Synthesis instead of submitting stale broker orders.

## Related Issues

None

## Testing

- `PYTHONPATH=scripts/autotrader python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 -m py_compile scripts/autotrader/strategy_order_guard.py scripts/autotrader/test_strategy_order_guard.py scripts/autotrader/live_scan_cycle.py scripts/autotrader/test_live_scan_cycle.py scripts/autotrader/protective_preflight.py scripts/autotrader/test_protective_preflight.py scripts/autotrader/synthesis_autotrader_client.py`
- `python3 scripts/autotrader/strategy_order_guard.py --self-test`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/protective_preflight.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`
- `bun run --filter @proompteng/scripts lint`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
