### PR TITLE
fix(torghut): skip empty runtime journal reconcile

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -94,7 +94,6 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             batch_size=5,
             max_batches=1,
             reconcile_limit=1000,
-            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
         ),
     ]
@@ -129,7 +128,6 @@ def _sim_commands() -> list[JournalCronCommand]:
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
             **common,
         ),

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -763,7 +763,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 runtime_argv[runtime_argv.index("--sources") + 1],
                 script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             )
-            self.assertIn("--reconcile-empty-selection", runtime_argv)
+            self.assertNotIn("--reconcile-empty-selection", runtime_argv)
             self.assertIn("--fail-on-degraded", runtime_argv)
             self.assertIn("--allow-data-quality-degraded", runtime_argv)
 

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -72,9 +72,9 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertFalse(commands[3].skip_reconcile)
-        self.assertTrue(commands[3].reconcile_empty_selection)
+        self.assertFalse(commands[3].reconcile_empty_selection)
 
-    def test_runtime_ledger_command_reconciles_empty_selection(self) -> None:
+    def test_live_runtime_ledger_command_skips_empty_selection_reconcile(self) -> None:
         command = runner._live_commands(execution_batch_size=5)[-1]
 
         argv = runner._argv_for_command(
@@ -83,7 +83,19 @@ class RunTigerBeetleJournalCronTest(TestCase):
             supervise_timeout_seconds=45.0,
         )
 
-        self.assertIn("--reconcile-empty-selection", argv)
+        self.assertNotIn("--reconcile-empty-selection", argv)
+        self.assertNotIn("--skip-reconcile", argv)
+
+    def test_sim_runtime_ledger_command_skips_empty_selection_reconcile(self) -> None:
+        command = runner._sim_commands()[-1]
+
+        argv = runner._argv_for_command(
+            command,
+            json_output=True,
+            supervise_timeout_seconds=45.0,
+        )
+
+        self.assertNotIn("--reconcile-empty-selection", argv)
         self.assertNotIn("--skip-reconcile", argv)
 
     def test_live_order_event_argv_keeps_slice_bounded_under_watchdog(self) -> None:


### PR DESCRIPTION
## Summary

- Stops scheduled live and sim runtime-ledger TigerBeetle journal slices from running empty-selection reconciliation probes.
- Keeps runtime-ledger reconciliation enabled when rows are actually selected, preserving accounting-only fail-closed behavior.
- Updates cron and rendered-manifest tests so scheduled runtime-ledger slices omit `--reconcile-empty-selection`.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
