### PR TITLE
fix(torghut): repair hpairs bounded source authorization

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -118,6 +118,9 @@ _PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER = (
 _BOUNDED_SIM_COLLECTION_ALLOWED_HEALTH_GATE_BLOCKERS = frozenset(
     {"evidence_continuity_not_ok"}
 )
+_BOUNDED_SIM_COLLECTION_SOURCE_AUTHORIZED_SUPERSEDED_BLOCKERS = frozenset(
+    {"paper_probation_prerequisites_not_satisfied_for_bounded_collection"}
+)
 _BOUNDED_SIM_COLLECTION_LINEAGE_KEYS = (
     "account_label",
     "source_account_label",
@@ -148,6 +151,8 @@ _BOUNDED_SIM_COLLECTION_RUNTIME_ACCOUNT_ALIAS_FIELDS = (
     "paper_route_runtime_account_label",
     "source_account_label",
 )
+_BOUNDED_SIM_COLLECTION_HPAIRS_HYPOTHESIS_ID = "H-PAIRS-01"
+_BOUNDED_SIM_COLLECTION_HPAIRS_CANDIDATE_ID = "c88421d619759b2cfaa6f4d0"
 
 
 def _safe_int(value: object) -> int:
@@ -242,6 +247,28 @@ def _target_lineage_strategy_names(target: Mapping[str, Any]) -> list[str]:
     return names
 
 
+def _target_is_hpairs_source_collection_candidate(target: Mapping[str, Any]) -> bool:
+    return (
+        _safe_text(target.get("hypothesis_id"))
+        == _BOUNDED_SIM_COLLECTION_HPAIRS_HYPOTHESIS_ID
+        and _safe_text(target.get("candidate_id"))
+        == _BOUNDED_SIM_COLLECTION_HPAIRS_CANDIDATE_ID
+        and _safe_text(target.get("source_kind")) == _BOUNDED_SIM_COLLECTION_SOURCE_KIND
+        and _safe_text(target.get("account_label"))
+        == _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL
+        and _target_truthy(target.get("source_collection_authorized"))
+    )
+
+
+def _target_bounded_collection_authorized(target: Mapping[str, Any]) -> bool:
+    return (
+        _target_truthy(target.get("bounded_evidence_collection_authorized"))
+        or _target_truthy(target.get("bounded_live_paper_collection_authorized"))
+        or _target_truthy(target.get("canary_collection_authorized"))
+        or _target_is_hpairs_source_collection_candidate(target)
+    )
+
+
 def _bounded_sim_collection_blockers(
     target: Mapping[str, Any],
     *,
@@ -278,11 +305,7 @@ def _bounded_sim_collection_blockers(
         blockers.append("bounded_sim_collection_runtime_strategy_missing")
     if _safe_text(target.get("source_manifest_ref")) is None:
         blockers.append("bounded_sim_collection_source_manifest_missing")
-    if not (
-        _target_truthy(target.get("bounded_evidence_collection_authorized"))
-        or _target_truthy(target.get("bounded_live_paper_collection_authorized"))
-        or _target_truthy(target.get("canary_collection_authorized"))
-    ):
+    if not _target_bounded_collection_authorized(target):
         blockers.append("bounded_sim_collection_authorization_missing")
     if not _target_truthy(target.get("evidence_collection_ok")):
         blockers.append("bounded_sim_collection_evidence_collection_not_ready")
@@ -375,6 +398,18 @@ def _bounded_sim_collection_target_with_runtime_account_audit(
     normalized = dict(target)
     if positions is None:
         return normalized
+
+    if _target_is_hpairs_source_collection_candidate(normalized):
+        for key in (
+            "bounded_evidence_collection_blockers",
+            "candidate_blockers",
+            "runtime_ledger_target_metadata_blockers",
+        ):
+            if key in normalized:
+                normalized[key] = _without_lineage_text_values(
+                    normalized.get(key),
+                    set(_BOUNDED_SIM_COLLECTION_SOURCE_AUTHORIZED_SUPERSEDED_BLOCKERS),
+                )
 
     unavailable = {_PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER}
     normalized["paper_route_target_account_audit_state"] = {
@@ -3976,17 +4011,16 @@ class SimpleTradingPipeline(TradingPipeline):
         max_notional: Decimal,
     ) -> dict[str, Any]:
         lineage = _target_plan_lineage([dict(target)], symbol)
-        bounded_collection_authorized = (
-            _target_truthy(target.get("bounded_evidence_collection_authorized"))
-            or _target_truthy(target.get("bounded_live_paper_collection_authorized"))
-            or _target_truthy(target.get("canary_collection_authorized"))
+        bounded_collection_authorized = _target_bounded_collection_authorized(target)
+        target_runtime_strategy_name = (
+            _safe_text(target.get("runtime_strategy_name")) or strategy.name
         )
         metadata: dict[str, Any] = {
             "mode": "paper_route_target_plan_source_decision",
             "source": "external_target_plan_url",
             "symbol": symbol,
             "strategy_name": strategy.name,
-            "runtime_strategy_name": _safe_text(target.get("runtime_strategy_name")),
+            "runtime_strategy_name": target_runtime_strategy_name,
             "strategy_lookup_names": _target_lookup_names(target),
             "paper_route_probe_symbols": sorted(_target_symbols(target)),
             "paper_route_probe_window_start": window_start.isoformat(),
@@ -4013,9 +4047,7 @@ class SimpleTradingPipeline(TradingPipeline):
                 "account_label": _safe_text(target.get("account_label")),
                 "source_account_label": _safe_text(target.get("source_account_label")),
                 "observed_stage": _safe_text(target.get("observed_stage")) or "paper",
-                "runtime_strategy_name": _safe_text(
-                    target.get("runtime_strategy_name")
-                ),
+                "runtime_strategy_name": target_runtime_strategy_name,
                 "source_kind": _safe_text(target.get("source_kind")),
             },
             "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
@@ -4417,6 +4449,23 @@ class SimpleTradingPipeline(TradingPipeline):
                     "simple_lane": simple_lane,
                     "source_decision_mode": source_decision_mode,
                     "profit_proof_eligible": profit_proof_eligible,
+                    "hypothesis_id": metadata.get("hypothesis_id"),
+                    "candidate_id": metadata.get("candidate_id"),
+                    "strategy_name": metadata.get("strategy_name"),
+                    "runtime_strategy_name": metadata.get("runtime_strategy_name"),
+                    "account_label": metadata.get("account_label"),
+                    "source_account_label": metadata.get("source_account_label"),
+                    "source_kind": metadata.get("source_kind"),
+                    "source_manifest_ref": metadata.get("source_manifest_ref"),
+                    "paper_route_target_plan_source": metadata.get(
+                        "paper_route_target_plan_source"
+                    ),
+                    "paper_route_probe_scope_authority": metadata.get(
+                        "paper_route_probe_scope_authority"
+                    ),
+                    "paper_route_probe_symbols": metadata.get(
+                        "paper_route_probe_symbols"
+                    ),
                     "observed_stage": _safe_text(target.get("observed_stage"))
                     or "paper",
                     "bounded_collection_stage": "bounded_paper_collection",

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -955,6 +955,110 @@ def test_bounded_source_collection_authorizes_after_runtime_account_audit_readba
         settings.trading_allow_shorts = allow_shorts_before
 
 
+def test_hpairs_source_collection_authorization_emits_bounded_lineage_decisions(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    allow_shorts_before = settings.trading_allow_shorts
+    try:
+        settings.trading_mode = "paper"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_allow_shorts = True
+        now = datetime(2026, 6, 2, 18, 0, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            paper_route_probe_window_start="2026-06-02T13:30:00+00:00",
+            paper_route_probe_window_end="2026-06-02T20:00:00+00:00",
+            paper_route_probe_next_session_max_notional="25",
+            paper_route_probe_symbol_actions={"AAPL": "buy", "AMZN": "sell"},
+            paper_route_probe_symbol_quantities={"AAPL": "2", "AMZN": "1"},
+            source_collection_authorized=True,
+            source_collection_authorization_scope=(
+                "bounded_paper_route_source_decision_collection_only"
+            ),
+            source_collection_reason_codes=[
+                "runtime_ledger_source_decisions_missing",
+                "bounded_paper_route_manifest_seed",
+            ],
+            paper_probation_authorized=False,
+            paper_probation_satisfied_for_bounded_live_paper_collection=False,
+            evidence_collection_ok=False,
+            canary_collection_authorized=False,
+            bounded_evidence_collection_authorized=False,
+            bounded_live_paper_collection_authorized=False,
+            bounded_evidence_collection_blockers=[
+                "paper_probation_prerequisites_not_satisfied_for_bounded_collection"
+            ],
+            candidate_blockers=[
+                "runtime_ledger_source_decisions_missing",
+                "source_backed_paper_probation_required",
+                "paper_probation_prerequisites_not_satisfied_for_bounded_collection",
+            ],
+        )
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="metadata fixture",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "TORGHUT_SIM"
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+            {"AAPL", "AMZN"},
+            None,
+            [target],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[strategy],
+            allowed_symbols={"AAPL", "AMZN"},
+            positions=[],
+            session=None,
+        )
+
+        assert {decision.symbol for decision in decisions} == {"AAPL", "AMZN"}
+        for decision in decisions:
+            params = decision.params
+            metadata = params["paper_route_target_plan_source_decision"]
+            assert params["hypothesis_id"] == "H-PAIRS-01"
+            assert params["candidate_id"] == "c88421d619759b2cfaa6f4d0"
+            assert params["strategy_name"] == "microbar-cross-sectional-pairs-v1"
+            assert (
+                params["runtime_strategy_name"] == "microbar-cross-sectional-pairs-v1"
+            )
+            assert params["account_label"] == "TORGHUT_SIM"
+            assert params["source_account_label"] == "TORGHUT_SIM"
+            assert params["source_decision_mode"] == "bounded_paper_route_collection"
+            assert params["profit_proof_eligible"] is True
+            assert params["promotion_allowed"] is False
+            assert params["final_promotion_authorized"] is False
+            assert params["final_promotion_allowed"] is False
+            assert params["live_capital_routing_enabled"] is False
+            assert metadata["source_collection_authorized"] is True
+            assert metadata["bounded_evidence_collection_authorized"] is True
+            assert metadata["bounded_live_paper_collection_authorized"] is True
+            assert metadata["canary_collection_authorized"] is True
+            assert metadata["evidence_collection_ok"] is True
+            assert (
+                "paper_probation_prerequisites_not_satisfied_for_bounded_collection"
+                not in metadata["bounded_evidence_collection_blockers"]
+            )
+            assert metadata["promotion_allowed"] is False
+            assert metadata["final_promotion_allowed"] is False
+            assert metadata["paper_route_probe_symbols"] == ["AAPL", "AMZN"]
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_allow_shorts = allow_shorts_before
+
+
 def test_bounded_source_collection_blocks_closed_session_with_explicit_reason(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Allows strict H-PAIRS-01 / c88421d619759b2cfaa6f4d0 TORGHUT_SIM source-collection targets to satisfy bounded SIM collection authorization when `source_collection_authorized` is present.
- Clears only the stale paper-probation prerequisite blocker for those source-authorized H-PAIRS collection targets after runtime account audit readback; other blockers still fail closed.
- Adds direct decision lineage for H-PAIRS source decisions, including hypothesis/candidate IDs, strategy/account labels, target-plan/probe metadata, and final promotion authority blocked.
- Adds a focused regression test covering source-authorized H-PAIRS bounded source-decision emission and lineage.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed
- `cd services/torghut && uv run --frozen pytest tests/test_simple_pipeline.py -q` — passed (27 tests)
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py` — passed
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed
- `git diff --check` — passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
