### PR TITLE
fix(torghut): accelerate live journal backlog drain

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: tigerbeetle-journal-order-events-live
 spec:
-  schedule: "*/6 * * * *"
+  schedule: "*/2 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
@@ -57,7 +57,7 @@ spec:
                   cd /app
                   exec /opt/venv/bin/python scripts/run_tigerbeetle_journal_cron.py \
                     --preset live \
-                    --execution-batch-size 5 \
+                    --execution-batch-size 25 \
                     --supervise-timeout-seconds 45 \
                     --json
               env:

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -27,6 +27,7 @@ from scripts import journal_tigerbeetle_order_events as journal_script  # noqa: 
 LIVE_ORDER_EVENT_BATCH_SIZE = 1
 LIVE_ORDER_EVENT_MAX_BATCHES = 1
 LIVE_ORDER_EVENT_SCAN_LIMIT = 250
+LIVE_EXECUTION_BATCH_SIZE = 25
 LIVE_TCA_METRIC_BATCH_SIZE = 5
 LIVE_TCA_METRIC_MAX_BATCHES = 1
 
@@ -53,7 +54,9 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument("--preset", choices=("live", "sim"), required=True)
-    parser.add_argument("--execution-batch-size", type=int, default=5)
+    parser.add_argument(
+        "--execution-batch-size", type=int, default=LIVE_EXECUTION_BATCH_SIZE
+    )
     parser.add_argument("--supervise-timeout-seconds", type=float, default=45.0)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1445,7 +1445,7 @@ class TestLiveConfigManifestContract(TestCase):
             "torghut-tigerbeetle-journal-order-events-sim"
         )
 
-        self.assertEqual(live_spec.get("schedule"), "*/6 * * * *")
+        self.assertEqual(live_spec.get("schedule"), "*/2 * * * *")
         self.assertEqual(sim_spec.get("schedule"), "21,51 * * * *")
         for spec, job_spec, container in (
             (live_spec, live_job_spec, live_container),
@@ -1514,6 +1514,10 @@ class TestLiveConfigManifestContract(TestCase):
                 security_context.get("seccompProfile", {}),
             )
             self.assertEqual(seccomp_profile.get("type"), "Unconfined")
+        live_args = "\n".join(str(item) for item in live_container.get("args", []))
+        self.assertIn("--execution-batch-size 25", live_args)
+        sim_args = "\n".join(str(item) for item in sim_container.get("args", []))
+        self.assertNotIn("--execution-batch-size", sim_args)
 
         live_env = {
             item.get("name"): item
@@ -1531,7 +1535,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("SIM_DB_DSN", live_env)
         live_args = "\n".join(str(item) for item in live_container.get("args", []))
         self.assertIn("--preset live", live_args)
-        self.assertIn("--execution-batch-size 5", live_args)
+        self.assertIn("--execution-batch-size 25", live_args)
         self.assertIn("--supervise-timeout-seconds 45", live_args)
         self.assertNotIn("--dsn-env DB_DSN", live_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -46,6 +46,31 @@ class RunTigerBeetleJournalCronTest(TestCase):
             "SIM_DB_DSN",
         )
 
+    def test_default_live_execution_batch_size_drains_backlog_under_cron_cadence(
+        self,
+    ) -> None:
+        with patch(
+            "scripts.run_tigerbeetle_journal_cron.sys.argv",
+            [
+                "run_tigerbeetle_journal_cron.py",
+                "--preset",
+                "live",
+            ],
+        ):
+            args = runner._parse_args()
+
+        [command] = [
+            item
+            for item in runner._commands_for_preset(args)
+            if item.source == SOURCE_TYPE_EXECUTION
+        ]
+
+        self.assertEqual(runner.LIVE_EXECUTION_BATCH_SIZE, 25)
+        self.assertEqual(command.batch_size, runner.LIVE_EXECUTION_BATCH_SIZE)
+        self.assertEqual(command.max_batches, 1)
+        self.assertTrue(command.skip_reconcile)
+        self.assertTrue(command.allow_data_quality_degraded)
+
     def test_live_preset_raises_only_execution_batch_size(self) -> None:
         commands = runner._live_commands(execution_batch_size=10)
 


### PR DESCRIPTION
## Summary

- Speeds the live TigerBeetle journal CronJob from every 6 minutes to every 2 minutes so recent reconciliation blockers drain faster.
- Raises the live execution-fill slice from 5 to 25 per run while keeping TCA and order-event slices bounded under the 45 second watchdog.
- Adds contract tests for the live schedule, execution batch, and default runner batch so future changes do not silently regress backlog velocity.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py -q -k 'tigerbeetle_journal_order_events_cronjob or default_live_execution_batch_size or live_preset_raises_only_execution_batch_size or live_tca_metric_argv'`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
