### PR TITLE
fix(torghut): skip empty runtime journal reconcile

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -94,7 +94,6 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             batch_size=5,
             max_batches=1,
             reconcile_limit=1000,
-            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
         ),
     ]

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -763,7 +763,15 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 runtime_argv[runtime_argv.index("--sources") + 1],
                 script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             )
-            self.assertIn("--reconcile-empty-selection", runtime_argv)
+            if cronjob_name == "torghut-tigerbeetle-journal-order-events-live":
+                tca_argv = command_argvs[1]
+                self.assertEqual(
+                    tca_argv[tca_argv.index("--max-batches") + 1],
+                    "1",
+                )
+                self.assertNotIn("--reconcile-empty-selection", runtime_argv)
+            else:
+                self.assertIn("--reconcile-empty-selection", runtime_argv)
             self.assertIn("--fail-on-degraded", runtime_argv)
             self.assertIn("--allow-data-quality-degraded", runtime_argv)
 

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -72,9 +72,9 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertFalse(commands[3].skip_reconcile)
-        self.assertTrue(commands[3].reconcile_empty_selection)
+        self.assertFalse(commands[3].reconcile_empty_selection)
 
-    def test_runtime_ledger_command_reconciles_empty_selection(self) -> None:
+    def test_live_runtime_ledger_command_skips_empty_selection_reconcile(self) -> None:
         command = runner._live_commands(execution_batch_size=5)[-1]
 
         argv = runner._argv_for_command(
@@ -83,7 +83,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
             supervise_timeout_seconds=45.0,
         )
 
-        self.assertIn("--reconcile-empty-selection", argv)
+        self.assertNotIn("--reconcile-empty-selection", argv)
         self.assertNotIn("--skip-reconcile", argv)
 
     def test_live_order_event_argv_keeps_slice_bounded_under_watchdog(self) -> None:


### PR DESCRIPTION
## Summary

- Removes `--reconcile-empty-selection` from the live `strategy_runtime_ledger_bucket` journal slice so the 45s supervised live CronJob no longer spends its single runtime bucket slice reconciling an empty selection.
- Preserves live hard-failure semantics: the runtime bucket slice still reconciles selected rows, still fails on degraded output, and still marks TigerBeetle journal telemetry as non-authoritative.
- Keeps the sim preset behavior unchanged, including empty-selection reconciliation for simulation coverage.
- Updates live CronJob contract regressions to assert the live image command omits empty-selection reconciliation while the live TCA slice remains bounded to one batch.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — failed because `crosshair-tool==0.0.102` requires native `cc`, which is not installed in this workspace and apt/build-essential installation is prohibited for this task.
- `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q` — passed, 87 passed, 1 warning.
- `cd services/torghut && uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py` — passed.
- `cd services/torghut && uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed, 0 errors.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed, 0 errors.
- `git diff --check` — passed.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
