### PR TITLE
fix(torghut): remove source authorization candidate hardcode

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -151,8 +151,12 @@ _BOUNDED_SIM_COLLECTION_RUNTIME_ACCOUNT_ALIAS_FIELDS = (
     "paper_route_runtime_account_label",
     "source_account_label",
 )
-_BOUNDED_SIM_COLLECTION_HPAIRS_HYPOTHESIS_ID = "H-PAIRS-01"
-_BOUNDED_SIM_COLLECTION_HPAIRS_CANDIDATE_ID = "c88421d619759b2cfaa6f4d0"
+_BOUNDED_SIM_COLLECTION_SOURCE_AUTHORIZATION_SCOPES = frozenset(
+    {
+        "bounded_paper_route_source_decision_collection_only",
+        "source_window_evidence_collection_only",
+    }
+)
 
 
 def _safe_int(value: object) -> int:
@@ -247,16 +251,16 @@ def _target_lineage_strategy_names(target: Mapping[str, Any]) -> list[str]:
     return names
 
 
-def _target_is_hpairs_source_collection_candidate(target: Mapping[str, Any]) -> bool:
+def _target_has_bounded_source_collection_authorization(
+    target: Mapping[str, Any],
+) -> bool:
+    scope = _safe_text(target.get("source_collection_authorization_scope"))
     return (
-        _safe_text(target.get("hypothesis_id"))
-        == _BOUNDED_SIM_COLLECTION_HPAIRS_HYPOTHESIS_ID
-        and _safe_text(target.get("candidate_id"))
-        == _BOUNDED_SIM_COLLECTION_HPAIRS_CANDIDATE_ID
+        _target_truthy(target.get("source_collection_authorized"))
         and _safe_text(target.get("source_kind")) == _BOUNDED_SIM_COLLECTION_SOURCE_KIND
         and _safe_text(target.get("account_label"))
         == _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL
-        and _target_truthy(target.get("source_collection_authorized"))
+        and scope in _BOUNDED_SIM_COLLECTION_SOURCE_AUTHORIZATION_SCOPES
     )
 
 
@@ -265,7 +269,7 @@ def _target_bounded_collection_authorized(target: Mapping[str, Any]) -> bool:
         _target_truthy(target.get("bounded_evidence_collection_authorized"))
         or _target_truthy(target.get("bounded_live_paper_collection_authorized"))
         or _target_truthy(target.get("canary_collection_authorized"))
-        or _target_is_hpairs_source_collection_candidate(target)
+        or _target_has_bounded_source_collection_authorization(target)
     )
 
 
@@ -399,7 +403,7 @@ def _bounded_sim_collection_target_with_runtime_account_audit(
     if positions is None:
         return normalized
 
-    if _target_is_hpairs_source_collection_candidate(normalized):
+    if _target_has_bounded_source_collection_authorization(normalized):
         for key in (
             "bounded_evidence_collection_blockers",
             "candidate_blockers",

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -955,7 +955,7 @@ def test_bounded_source_collection_authorizes_after_runtime_account_audit_readba
         settings.trading_allow_shorts = allow_shorts_before
 
 
-def test_hpairs_source_collection_authorization_emits_bounded_lineage_decisions(
+def test_source_collection_authorization_emits_bounded_lineage_decisions_without_candidate_hardcode(
     monkeypatch,
 ) -> None:
     trading_mode_before = settings.trading_mode
@@ -967,6 +967,8 @@ def test_hpairs_source_collection_authorization_emits_bounded_lineage_decisions(
         settings.trading_allow_shorts = True
         now = datetime(2026, 6, 2, 18, 0, tzinfo=timezone.utc)
         target = _bounded_hpairs_target(
+            hypothesis_id="H-SOURCE-AUTH-01",
+            candidate_id="source-authorized-candidate",
             paper_route_probe_window_start="2026-06-02T13:30:00+00:00",
             paper_route_probe_window_end="2026-06-02T20:00:00+00:00",
             paper_route_probe_next_session_max_notional="25",
@@ -1027,8 +1029,8 @@ def test_hpairs_source_collection_authorization_emits_bounded_lineage_decisions(
         for decision in decisions:
             params = decision.params
             metadata = params["paper_route_target_plan_source_decision"]
-            assert params["hypothesis_id"] == "H-PAIRS-01"
-            assert params["candidate_id"] == "c88421d619759b2cfaa6f4d0"
+            assert params["hypothesis_id"] == "H-SOURCE-AUTH-01"
+            assert params["candidate_id"] == "source-authorized-candidate"
             assert params["strategy_name"] == "microbar-cross-sectional-pairs-v1"
             assert (
                 params["runtime_strategy_name"] == "microbar-cross-sectional-pairs-v1"


### PR DESCRIPTION
## Summary

- Replaces the H-PAIRS candidate-ID special case in bounded SIM source collection with a generic `source_collection_authorized` contract scoped by source kind, account, and authorization scope.
- Keeps bounded source collection non-final: promotion, final authority, and live capital routing remain blocked.
- Updates the regression test so a non-H-PAIRS candidate can emit bounded source-collection decisions only through the scoped source-authorization contract.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_simple_pipeline.py -k 'source_collection_authorization or bounded_source_collection' -q` - passed
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py` - passed
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py` - passed
- `git diff --check` - passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
