### PR TITLE
fix(synthesis): resolve autotrader fills by broker order

### DIFF
--- a/apps/synthesis/src/server/__tests__/mcp.test.ts
+++ b/apps/synthesis/src/server/__tests__/mcp.test.ts
@@ -521,6 +521,28 @@ describe('synthesis MCP', () => {
         ),
       ),
     )
+    const stopFillPayload = await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_record_fill',
+          {
+            sessionId,
+            clientOrderId: 'wrong-child-client-id',
+            brokerOrderId: 'alpaca-order-1',
+            brokerFillId: 'fill-1-stop',
+            symbol: 'NVDA',
+            side: 'sell',
+            quantity: '200',
+            price: '123.80',
+            filledAt: '2026-05-29T14:02:00Z',
+            brokerPayload: { source: 'alpaca', order_id: 'alpaca-order-1' },
+          },
+          headers,
+        ),
+      ),
+    )
+
+    expect(stopFillPayload.fill.clientOrderId).toBe('atr-test-nvda-1')
     await parseToolJson(
       await handleMcpRequest(
         callTool(

--- a/apps/synthesis/src/server/autotrader-schema.ts
+++ b/apps/synthesis/src/server/autotrader-schema.ts
@@ -182,6 +182,7 @@ export const AutotraderRecordFillInputSchema = z
   .object({
     sessionId: z.string().trim().min(1),
     clientOrderId: z.string().trim().min(1).max(128),
+    brokerOrderId: z.string().trim().min(1).max(240).optional(),
     brokerFillId: z.string().trim().min(1).max(240),
     symbol: z.string().trim().min(1).max(32),
     side: AutotraderSideSchema,

--- a/apps/synthesis/src/server/autotrader-store.ts
+++ b/apps/synthesis/src/server/autotrader-store.ts
@@ -76,6 +76,27 @@ const brokerReplacesOrderId = (payload: Record<string, unknown>) => {
   const replaces = payload.replaces
   return typeof replaces === 'string' && replaces.trim() ? replaces.trim() : null
 }
+const textFromPayload = (payload: Record<string, unknown>, keys: string[]) => {
+  for (const key of keys) {
+    const value = payload[key]
+    if (typeof value !== 'string' && typeof value !== 'number') continue
+    const normalized = String(value).trim()
+    if (normalized) return normalized
+  }
+  return null
+}
+const brokerOrderIdFromFill = (input: AutotraderRecordFillInput) => {
+  const explicit = input.brokerOrderId?.trim()
+  if (explicit) return explicit
+  const direct = textFromPayload(input.brokerPayload, ['brokerOrderId', 'broker_order_id', 'orderId', 'order_id'])
+  if (direct) return direct
+  const alpacaOrderId = textFromPayload(input.brokerPayload, ['id'])
+  const payloadLooksLikeOrder =
+    textFromPayload(input.brokerPayload, ['client_order_id', 'clientOrderId']) ||
+    textFromPayload(input.brokerPayload, ['order_class', 'orderClass']) ||
+    textFromPayload(input.brokerPayload, ['submitted_at', 'submittedAt'])
+  return alpacaOrderId && payloadLooksLikeOrder ? alpacaOrderId : null
+}
 const numericFromPayload = (payload: Record<string, unknown>, keys: string[]) => {
   for (const key of keys) {
     const value = payload[key]
@@ -478,9 +499,17 @@ class InMemoryAutotraderStore implements AutotraderStore {
 
   async recordFill(input: AutotraderRecordFillInput): Promise<AutotraderFill> {
     this.requireSession(input.sessionId)
+    const brokerOrderId = brokerOrderIdFromFill(input)
+    const existingClientOrder = this.orders.get(input.clientOrderId)
+    const resolvedClientOrderId =
+      existingClientOrder?.sessionId === input.sessionId
+        ? input.clientOrderId
+        : ([...this.orders.values()].find(
+            (order) => order.sessionId === input.sessionId && order.brokerOrderId === brokerOrderId,
+          )?.clientOrderId ?? input.clientOrderId)
     const fill: AutotraderFill = {
       sessionId: input.sessionId,
-      clientOrderId: input.clientOrderId,
+      clientOrderId: resolvedClientOrderId,
       brokerFillId: input.brokerFillId,
       symbol: normalizedSymbol(input.symbol) ?? input.symbol,
       side: input.side,
@@ -1278,6 +1307,26 @@ class PostgresAutotraderStore implements AutotraderStore {
 
   async recordFill(input: AutotraderRecordFillInput): Promise<AutotraderFill> {
     await this.ensureSchema()
+    const brokerOrderId = brokerOrderIdFromFill(input)
+    let clientOrderId = input.clientOrderId
+    if (brokerOrderId) {
+      const orderResult = await this.pool.query<{ client_order_id: string }>(
+        `SELECT client_order_id
+         FROM (
+           SELECT client_order_id, 0 AS rank
+           FROM autotrader.orders
+           WHERE session_id = $1 AND client_order_id = $2
+           UNION ALL
+           SELECT client_order_id, 1 AS rank
+           FROM autotrader.orders
+           WHERE session_id = $1 AND broker_order_id = $3
+         ) candidates
+         ORDER BY rank
+         LIMIT 1`,
+        [input.sessionId, input.clientOrderId, brokerOrderId],
+      )
+      clientOrderId = orderResult.rows[0]?.client_order_id ?? clientOrderId
+    }
     const result = await this.pool.query<FillRow>(
       `INSERT INTO autotrader.fills (
         session_id, client_order_id, broker_fill_id, symbol, side, quantity, price, filled_at, broker_payload
@@ -1295,7 +1344,7 @@ class PostgresAutotraderStore implements AutotraderStore {
       RETURNING *`,
       [
         input.sessionId,
-        input.clientOrderId,
+        clientOrderId,
         input.brokerFillId,
         normalizedSymbol(input.symbol) ?? input.symbol,
         input.side,

--- a/apps/synthesis/src/server/mcp.ts
+++ b/apps/synthesis/src/server/mcp.ts
@@ -490,12 +490,14 @@ const toolsListResult = {
     },
     {
       name: 'autotrader_record_fill',
-      description: 'Record or reconcile an Alpaca fill by broker fill id.',
+      description:
+        'Record or reconcile an Alpaca fill by broker fill id, resolving the stored order by broker order id.',
       inputSchema: {
         type: 'object',
         properties: {
           sessionId: { type: 'string' },
           clientOrderId: { type: 'string', maxLength: 128 },
+          brokerOrderId: { type: 'string', maxLength: 240 },
           brokerFillId: { type: 'string' },
           symbol: { type: 'string' },
           side: sideSchema,


### PR DESCRIPTION
## Summary

- Allows `autotrader_record_fill` to accept an optional `brokerOrderId` for Alpaca fill reconciliation.
- Resolves the canonical stored `clientOrderId` from the matching same-session broker order before inserting a fill.
- Adds MCP regression coverage for the live stop-fill case where the supplied child client id is stale or mismatched.

## Related Issues

None

## Testing

- `bun test apps/synthesis/src/server/__tests__/mcp.test.ts -t "records an autotrader session and returns compounded scorecards through MCP"`
- `bun test apps/synthesis/src/server/__tests__/mcp.test.ts`
- `bunx oxfmt --check apps/synthesis/src/server/autotrader-schema.ts apps/synthesis/src/server/autotrader-store.ts apps/synthesis/src/server/mcp.ts apps/synthesis/src/server/__tests__/mcp.test.ts`
- `bun run lint:synthesis`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
