### PR TITLE
revert(torghut): restore bounded journal cadence

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: tigerbeetle-journal-order-events-live
 spec:
-  schedule: "*/2 * * * *"
+  schedule: "*/6 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
@@ -57,7 +57,7 @@ spec:
                   cd /app
                   exec /opt/venv/bin/python scripts/run_tigerbeetle_journal_cron.py \
                     --preset live \
-                    --execution-batch-size 25 \
+                    --execution-batch-size 5 \
                     --supervise-timeout-seconds 45 \
                     --json
               env:

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -27,7 +27,6 @@ from scripts import journal_tigerbeetle_order_events as journal_script  # noqa: 
 LIVE_ORDER_EVENT_BATCH_SIZE = 1
 LIVE_ORDER_EVENT_MAX_BATCHES = 1
 LIVE_ORDER_EVENT_SCAN_LIMIT = 250
-LIVE_EXECUTION_BATCH_SIZE = 25
 LIVE_TCA_METRIC_BATCH_SIZE = 5
 LIVE_TCA_METRIC_MAX_BATCHES = 1
 
@@ -54,9 +53,7 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument("--preset", choices=("live", "sim"), required=True)
-    parser.add_argument(
-        "--execution-batch-size", type=int, default=LIVE_EXECUTION_BATCH_SIZE
-    )
+    parser.add_argument("--execution-batch-size", type=int, default=5)
     parser.add_argument("--supervise-timeout-seconds", type=float, default=45.0)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1445,7 +1445,7 @@ class TestLiveConfigManifestContract(TestCase):
             "torghut-tigerbeetle-journal-order-events-sim"
         )
 
-        self.assertEqual(live_spec.get("schedule"), "*/2 * * * *")
+        self.assertEqual(live_spec.get("schedule"), "*/6 * * * *")
         self.assertEqual(sim_spec.get("schedule"), "21,51 * * * *")
         for spec, job_spec, container in (
             (live_spec, live_job_spec, live_container),
@@ -1514,10 +1514,6 @@ class TestLiveConfigManifestContract(TestCase):
                 security_context.get("seccompProfile", {}),
             )
             self.assertEqual(seccomp_profile.get("type"), "Unconfined")
-        live_args = "\n".join(str(item) for item in live_container.get("args", []))
-        self.assertIn("--execution-batch-size 25", live_args)
-        sim_args = "\n".join(str(item) for item in sim_container.get("args", []))
-        self.assertNotIn("--execution-batch-size", sim_args)
 
         live_env = {
             item.get("name"): item
@@ -1535,7 +1531,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("SIM_DB_DSN", live_env)
         live_args = "\n".join(str(item) for item in live_container.get("args", []))
         self.assertIn("--preset live", live_args)
-        self.assertIn("--execution-batch-size 25", live_args)
+        self.assertIn("--execution-batch-size 5", live_args)
         self.assertIn("--supervise-timeout-seconds 45", live_args)
         self.assertNotIn("--dsn-env DB_DSN", live_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -46,31 +46,6 @@ class RunTigerBeetleJournalCronTest(TestCase):
             "SIM_DB_DSN",
         )
 
-    def test_default_live_execution_batch_size_drains_backlog_under_cron_cadence(
-        self,
-    ) -> None:
-        with patch(
-            "scripts.run_tigerbeetle_journal_cron.sys.argv",
-            [
-                "run_tigerbeetle_journal_cron.py",
-                "--preset",
-                "live",
-            ],
-        ):
-            args = runner._parse_args()
-
-        [command] = [
-            item
-            for item in runner._commands_for_preset(args)
-            if item.source == SOURCE_TYPE_EXECUTION
-        ]
-
-        self.assertEqual(runner.LIVE_EXECUTION_BATCH_SIZE, 25)
-        self.assertEqual(command.batch_size, runner.LIVE_EXECUTION_BATCH_SIZE)
-        self.assertEqual(command.max_batches, 1)
-        self.assertTrue(command.skip_reconcile)
-        self.assertTrue(command.allow_data_quality_degraded)
-
     def test_live_preset_raises_only_execution_batch_size(self) -> None:
         commands = runner._live_commands(execution_batch_size=10)
 


### PR DESCRIPTION
## Summary

- Reverts PR #9835's live TigerBeetle journal acceleration before it rolls out broadly.
- Restores the live journal CronJob cadence to every 6 minutes and the explicit live execution batch size to 5.
- Keeps the current #9831 empty-selection timeout fix path available for verification without increasing live CronJob pressure.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` - passed
- `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py -q -k 'tigerbeetle_journal_order_events_cronjob or default_live_execution_batch_size or live_preset_raises_only_execution_batch_size or live_tca_metric_argv'` - passed
- `cd services/torghut && uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py` - passed
- `cd services/torghut && uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py` - passed
- `git diff --check` - passed

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
