### PR TITLE
fix(torghut): extend live journal timeouts

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: tigerbeetle-journal-order-events-live
 spec:
-  schedule: "*/2 * * * *"
+  schedule: "*/3 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -28,6 +28,8 @@ LIVE_ORDER_EVENT_BATCH_SIZE = 1
 LIVE_ORDER_EVENT_MAX_BATCHES = 1
 LIVE_ORDER_EVENT_SCAN_LIMIT = 250
 LIVE_EXECUTION_BATCH_SIZE = 25
+LIVE_EXECUTION_TIMEOUT_SECONDS = 120.0
+LIVE_RUNTIME_LEDGER_TIMEOUT_SECONDS = 180.0
 LIVE_TCA_METRIC_BATCH_SIZE = 5
 LIVE_TCA_METRIC_MAX_BATCHES = 1
 
@@ -44,6 +46,7 @@ class JournalCronCommand:
     skip_reconcile: bool = False
     reconcile_empty_selection: bool = False
     allow_data_quality_degraded: bool = False
+    supervise_timeout_seconds: float | None = None
 
 
 def _parse_args() -> argparse.Namespace:
@@ -72,6 +75,7 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             reconcile_limit=1000,
             skip_reconcile=True,
             allow_data_quality_degraded=True,
+            supervise_timeout_seconds=LIVE_EXECUTION_TIMEOUT_SECONDS,
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_TCA_METRIC,
@@ -98,6 +102,7 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             max_batches=1,
             reconcile_limit=1000,
             allow_data_quality_degraded=True,
+            supervise_timeout_seconds=LIVE_RUNTIME_LEDGER_TIMEOUT_SECONDS,
         ),
     ]
 
@@ -183,7 +188,10 @@ def _argv_for_command(
     argv.append("--fail-on-degraded")
     if command.allow_data_quality_degraded:
         argv.append("--allow-data-quality-degraded")
-    argv.extend(["--supervise-timeout-seconds", str(supervise_timeout_seconds)])
+    command_timeout_seconds = command.supervise_timeout_seconds
+    if command_timeout_seconds is None:
+        command_timeout_seconds = supervise_timeout_seconds
+    argv.extend(["--supervise-timeout-seconds", str(command_timeout_seconds)])
     if json_output:
         argv.append("--json")
     return argv

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1445,7 +1445,7 @@ class TestLiveConfigManifestContract(TestCase):
             "torghut-tigerbeetle-journal-order-events-sim"
         )
 
-        self.assertEqual(live_spec.get("schedule"), "*/2 * * * *")
+        self.assertEqual(live_spec.get("schedule"), "*/3 * * * *")
         self.assertEqual(sim_spec.get("schedule"), "21,51 * * * *")
         for spec, job_spec, container in (
             (live_spec, live_job_spec, live_container),

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -70,6 +70,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(command.max_batches, 1)
         self.assertTrue(command.skip_reconcile)
         self.assertTrue(command.allow_data_quality_degraded)
+        self.assertEqual(command.supervise_timeout_seconds, 120.0)
 
     def test_live_preset_raises_only_execution_batch_size(self) -> None:
         commands = runner._live_commands(execution_batch_size=10)
@@ -79,6 +80,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(commands[0].max_batches, 1)
         self.assertTrue(commands[0].skip_reconcile)
         self.assertTrue(commands[0].allow_data_quality_degraded)
+        self.assertEqual(commands[0].supervise_timeout_seconds, 120.0)
         self.assertEqual(commands[1].source, SOURCE_TYPE_EXECUTION_TCA_METRIC)
         self.assertEqual(commands[1].batch_size, runner.LIVE_TCA_METRIC_BATCH_SIZE)
         self.assertEqual(commands[1].batch_size, 5)
@@ -98,6 +100,44 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertFalse(commands[3].skip_reconcile)
         self.assertFalse(commands[3].reconcile_empty_selection)
+        self.assertEqual(commands[3].supervise_timeout_seconds, 180.0)
+
+    def test_live_execution_and_runtime_ledger_extend_timeout_under_watchdog(
+        self,
+    ) -> None:
+        commands = runner._live_commands(execution_batch_size=25)
+        execution = commands[0]
+        runtime_ledger = commands[3]
+
+        execution_argv = runner._argv_for_command(
+            execution,
+            json_output=True,
+            supervise_timeout_seconds=45.0,
+        )
+        runtime_ledger_argv = runner._argv_for_command(
+            runtime_ledger,
+            json_output=True,
+            supervise_timeout_seconds=45.0,
+        )
+
+        self.assertEqual(
+            execution_argv[execution_argv.index("--sources") + 1],
+            "execution",
+        )
+        self.assertEqual(
+            execution_argv[execution_argv.index("--supervise-timeout-seconds") + 1],
+            str(runner.LIVE_EXECUTION_TIMEOUT_SECONDS),
+        )
+        self.assertEqual(
+            runtime_ledger_argv[runtime_ledger_argv.index("--sources") + 1],
+            "strategy_runtime_ledger_bucket",
+        )
+        self.assertEqual(
+            runtime_ledger_argv[
+                runtime_ledger_argv.index("--supervise-timeout-seconds") + 1
+            ],
+            str(runner.LIVE_RUNTIME_LEDGER_TIMEOUT_SECONDS),
+        )
 
     def test_live_runtime_ledger_command_skips_empty_selection_reconcile(self) -> None:
         command = runner._live_commands(execution_batch_size=5)[-1]
@@ -360,9 +400,21 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(exit_code, 1)
         self.assertEqual(len(observed), 4)
         first_argv = observed[0][0]
+        second_argv = observed[1][0]
+        runtime_ledger_argv = observed[3][0]
         self.assertEqual(first_argv[first_argv.index("--batch-size") + 1], "5000")
         self.assertEqual(
             first_argv[first_argv.index("--supervise-timeout-seconds") + 1],
+            str(runner.LIVE_EXECUTION_TIMEOUT_SECONDS),
+        )
+        self.assertEqual(
+            second_argv[second_argv.index("--supervise-timeout-seconds") + 1],
             "0.001",
+        )
+        self.assertEqual(
+            runtime_ledger_argv[
+                runtime_ledger_argv.index("--supervise-timeout-seconds") + 1
+            ],
+            str(runner.LIVE_RUNTIME_LEDGER_TIMEOUT_SECONDS),
         )
         self.assertTrue(all(json_output for _, _, json_output in observed))


### PR DESCRIPTION
## Summary

- Extends the supervised timeout for the live execution journal stage from the shared 45 second budget to 120 seconds.
- Extends the supervised timeout for the live runtime-ledger bucket journal stage to 180 seconds.
- Moves the live journal cron cadence from every 2 minutes to every 3 minutes and adds regression coverage for the per-source timeout contract.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check HEAD~1..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
