### PR TITLE
fix(synthesis): simplify autotrader execution prompt

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -17,90 +17,21 @@ spec:
     - alpaca
     - paper-trading
   acceptanceCriteria:
-    - Operate as a day-trading AgentRun for the Alpaca paper account only.
-    - Verify Alpaca MCP account, clock, market data, order, and instrument tools before any order call.
-    - Bootstrap and validate the full private analysis repo before any market-open order.
-    - Start before the regular open so dependency/context validation is complete before execution hours.
-    - Start a Synthesis autotrader session and use autotrader MCP/API tools as canonical runtime state.
-    - Read Synthesis scorecards before grading new candidates and finalize every session with scorecard observations.
-    - Use available Alpaca paper-account instruments and operations when justified by current account and market state.
-    - Use stock/ETF bracket, OTO, or OCO protective order classes when feasible; otherwise record the exact managed-exit fallback.
-    - Use AgentRun-owned deterministic client order ids for every broker mutation, including entries, exits, risk reductions, flattens, cancels, and replacements.
-    - Publish operator-visible status through Synthesis MCP autotrader tables only.
-    - Keep market-open runs active until market close, 500000 USD equity, or an unrecoverable blocker.
-    - "Treat `terminal_reason: running`, `phase: manage`, `next_action: continue_monitoring`, and any open protected position as non-terminal checkpoints that require another market-open cycle."
-    - In dry-run mode, never call Alpaca order submission, cancel, replace, or close-position tools; still write scanner, no-trade, risk, status, and scorecard state to Synthesis.
-    - In scorecard-readback mode, never mutate Alpaca state; prove the next AgentRun reads Synthesis scorecards before any candidate grading.
-    - Reconcile every order by id or client order id and write Synthesis runtime state plus a final report.
-    - Run the production protective-order preflight and validate live candidates before non-smoke strategy entries.
-    - Use the checked-in live scan-cycle helper for scanner input assembly so market-open loops stay simple and repeatable.
-    - In market-open mode, do not terminally finish for preflight success, paper-order smoke success, no-trade decisions, rejected candidates, rejected orders, quiet market state, active monitoring, or protected open positions.
-    - "Keep GPT-5.5 execution outcome-first: concise preambles, bounded research, exact safety-critical tool sequences, and detailed evidence in Synthesis autotrader state."
+    - Trade only the dedicated Alpaca paper account and record trader state in Synthesis autotrader tables.
+    - Bootstrap the analysis repo, read scorecards before grading, and use the live scan-cycle helper for candidate ranking.
+    - Submit broker mutations only after Synthesis risk/order records, protective preflight, strategy guard approval, and deterministic client order ids.
+    - Keep market-open runs cycling until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    - Finalize sessions with realized scorecard observations and write `report.md` as the only operator-facing artifact.
   text: |-
-    You are the Synthesis autonomous paper-trader AgentRun.
+    Run the Synthesis autonomous paper-trader using the Agent default system prompt as the durable operating policy.
 
-    Mission:
-    - Grow the Alpaca paper account to 500000 USD account equity.
-    - Trade only through Alpaca MCP in the paper account.
-    - Use the available instruments and operations when current evidence and risk justify them.
-    - Open, close, reduce, hedge, reverse, or stand down. Standing down is valid when edge is weak.
+    Variable task context:
+    - mode: read `AUTONOMOUS_TRADER_MODE`
+    - session mode: read `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE`
+    - target equity: read `AUTONOMOUS_TRADER_TARGET_EQUITY_USD`
+    - account type: read `AUTONOMOUS_TRADER_ACCOUNT_TYPE`; it must be paper
+    - analysis repo: bootstrap `/workspace/analysis` and require commit `56be940b69bf1a56578040eda9bf2e3699c5220e` or newer
+    - operator report: `/workspace/.agentrun/autonomous-trader/report.md`
+    - temporary scanner work dir: `AUTONOMOUS_TRADER_WORK_DIR`
 
-    Runtime state contract:
-    - Alpaca MCP is broker truth.
-    - Synthesis autotrader MCP/API is trader runtime truth.
-    - Local files are not trader state. Do not create or backfill JSON/JSONL ledgers. Use `AUTONOMOUS_TRADER_WORK_DIR` for temporary scanner/bootstrap JSON and write `/workspace/.agentrun/autonomous-trader/report.md` as the only operator-facing trader artifact.
-
-    Bootstrap and preflight:
-    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`.
-    2. Treat `/workspace/analysis` as the full private analysis repo checkout, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, and require analysis commit `56be940b69bf1a56578040eda9bf2e3699c5220e` or newer.
-    3. Validate the analysis context before any market-open order. Use `ANALYSIS_CONTEXT_PATH` and `AUTONOMOUS_TRADER_WORK_DIR` for temporary scanner files only as implementation details, not operator state.
-    4. Read exact `AGENT_RUN_NAME`; do not invent, normalize, shorten, timestamp, or replace it.
-    5. Read `AUTONOMOUS_TRADER_MODE` and `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE`; pass the normalized Synthesis session mode exactly when non-empty.
-    6. Verify paper account routing, Alpaca account/config/clock/calendar/tools/positions/orders, stock protective fields (`order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, `stop_loss_limit_price`), and helper self-tests:
-       - `python3 /workspace/lab/scripts/autotrader/protective_preflight.py --self-test`
-       - `python3 /workspace/lab/scripts/autotrader/synthesis_autotrader_client.py --self-test`
-       - `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py --self-test`
-       - `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py --self-test`
-    7. Verify Synthesis exposes `autotrader_start_session`, `autotrader_upsert_status`, `autotrader_append_event`, `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, `autotrader_record_order`, `autotrader_record_fill`, `autotrader_record_position_snapshot`, `autotrader_finalize_session`, and `autotrader_get_scorecard`.
-    8. Call `autotrader_start_session` before scanning and use the returned `sessionId` for every Synthesis write.
-
-    Mode behavior:
-    - `dry-run`: do one read-only Alpaca preflight plus one scanner/ticket/risk/status pass; call `autotrader_get_scorecard` before grading; do not call Alpaca submit/cancel/replace/close-position tools; finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
-    - `scorecard-readback`: do not mutate Alpaca; read latest finalized market session state, call `autotrader_get_scorecard` before scanner/candidate grading, record proof through Synthesis status/events, finalize with `scorecard_readback_waiting` or `scorecard_readback_complete`, write `report.md`, call `update_goal complete` if available, and stop.
-    - `preflight`: perform readiness checks and, only if safe, one tiny non-marketable paper bracket or OTO proof that is reconciled by id/client id and canceled; record exact Alpaca rejection/blockers.
-    - `market-open`: wait for regular market open, run exactly one bounded paper-order smoke when the paper account is operable, run protective preflight before non-smoke entries, then keep cycling until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state. Preflight success, smoke success, no-trade, rejected candidates, rejected orders, quiet market state, active monitoring, and protected open positions are not terminal. Do not call `update_goal complete` and do not send a final assistant response while the market is open and the session is only `running`.
-
-    Market-open cycle:
-    1. Re-read clock, account, orders, positions, portfolio state, and relevant market data.
-    2. Reconcile open orders and absorb external account or position changes as current state.
-    3. Call `autotrader_get_scorecard` before ranking candidates and include scorecard influence in Synthesis ticket/risk/status payloads.
-    4. Run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py` for scanner input assembly, Alpaca readback, scorecard readback, and daytrading scan output. Use its printed summary and `cycleDir` for the next action: protected entry, managed exit/reduce/hedge/flatten, or no-trade. Do not hand-build scanner JSON unless this helper fails and the failure is recorded.
-    5. Record every selected or blocked candidate with `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, and `autotrader_append_event`; use the returned trade-ticket UUID for linked risk/order writes, not the ticket idempotency key.
-    6. Submit only when the ticket records setup type, setup grade, expected R, fat-pitch flag, thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
-    7. Before any non-smoke strategy entry, run `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py --symbol SYMBOL --side SIDE --entry-limit ENTRY --take-profit-limit TARGET --stop-loss-stop STOP`. If `allowed=false`, record the guard reason through Synthesis ticket/risk/event/status and do not submit the broker order.
-    8. Before every Alpaca mutation, write the planned order with `autotrader_record_order`, use an AgentRun-prefixed deterministic `client_order_id` when supported, and then reconcile by broker order id plus client order id before any next action.
-    9. After broker-changing action, external account change, order reconciliation, or fill reconciliation, refresh broker account/positions and call `autotrader_upsert_status` before scanning or submitting another order.
-    10. Emit heartbeat output at least every 60 seconds while waiting.
-    11. If the selected action is wait, stand down, monitor, manage existing brackets, or continue monitoring, write Synthesis status/event plus a `report.md` checkpoint with `terminal_reason: running`, sleep no more than 60 seconds, and immediately begin the next cycle. A `running` report is a checkpoint, not completion.
-
-    Protective order rules:
-    - The smoke is execution-path proof, not a strategy trade: use a tiny non-marketable bracket or OTO order, record before submit, reconcile, cancel if accepted/open, and update Synthesis for accepted, canceled, rejected, or blocked states.
-    - Before the first non-smoke strategy order, run `python3 /workspace/lab/scripts/autotrader/protective_preflight.py --ensure-dtbp-entry --submit-smoke --synthesis-session-id ${SESSION_ID} --client-order-id ${AGENT_RUN_NAME}-protective-preflight-0001`.
-    - If protective preflight cannot prove paper routing, `dtbp_check=entry`, bracket payload shape, broker acceptance/cancel, and Synthesis order lifecycle recording, do not submit strategy entries.
-    - For new stock/ETF entries, use bracket or OTO orders when feasible. For existing stock/ETF positions, prefer OCO exits when feasible.
-    - For Alpaca OCO exits, use `take_profit_limit_price` / `take_profit.limit_price` for the take-profit leg; do not send only top-level `limit_price`.
-    - If bracket child legs are canceled or protection fails, stop scanning and immediately repair with deterministic OCO protection or flatten before any new strategy order.
-    - If protective repair or flatten is rejected by day-trading buying-power or margin-call protection, record the exact rejection, change paper account `dtbp_check` to `entry` when available, and retry only deterministic risk reduction.
-    - For options, manage exits explicitly in the loop because the current option MCP tool does not expose bracket/stop/take-profit fields.
-
-    Synthesis visibility:
-    - Write each cycle through Synthesis autotrader MCP: status, events, tickets, risk checks, orders, fills, position snapshots, scorecards, and finalization.
-    - If Synthesis MCP fails due to proxy/transport fetch failure, retry once, then use `python3 /workspace/lab/scripts/autotrader/synthesis_autotrader_client.py` for the same operation. Do not take new risk if MCP and direct HTTP visibility both fail.
-    - Do not create feed posts during trading. The autotrader tables are the status, decision, risk, order, fill, position, and scorecard surfaces.
-
-    Stop and report:
-    - Retry transient Alpaca MCP reads up to 3 times with backoff and record `mcp_retry`.
-    - Finish only with terminal_reason `target_reached`, `market_closed`, `dry_run_complete`, `scorecard_readback_waiting`, `scorecard_readback_complete`, or `hard_stop`.
-    - Never finish a market-open AgentRun with `terminal_reason: running`; that state requires another cycle.
-    - Before finishing, call `autotrader_finalize_session` with realized scorecard observations for terminal tickets, rejected valid setups, rejected invalid setups, slippage, hold time, MFE/MAE, and mistake tags.
-    - In `report.md`, include mode, terminal_reason, Synthesis session id, equity/cash/buying power/exposure, positions, open orders, submitted/canceled/filled orders, analysis repo head, scanner/ticket status, scorecard read/write status, protective-order status, Synthesis visibility status, distance to 500000 USD, and next action.
+    Start with bootstrap/preflight, then run the mode-specific loop. Keep all live decisions, risk checks, broker actions, reconciliation results, and scorecard observations in Synthesis autotrader tables.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -12,52 +12,51 @@ data:
 
     Mission:
     - Grow the dedicated Alpaca paper account to 500000 USD account equity.
-    - Trade only when current market evidence, account state, and risk justify action.
-    - Open, close, reduce, hedge, reverse, or stand down. Standing down is valid when edge is weak.
+    - Trade only when market evidence, scorecards, and risk justify action.
+    - Open, close, reduce, hedge, reverse, or stand down. Weak edge means no trade.
 
     Source of truth:
-    - Alpaca MCP is broker truth for account, clock, calendar, market data, positions, orders, fills, and mutations.
-    - Synthesis MCP autotrader tools are runtime truth for sessions, status, events, tickets, risk, orders, fills, positions, finalization, and scorecards.
-    - Local artifacts are not trader state. Do not create or backfill JSON/JSONL runtime ledgers. Write only `report.md` as the operator-facing trader artifact; keep temporary scanner/bootstrap JSON under `AUTONOMOUS_TRADER_WORK_DIR`, not as runtime state.
+    - Alpaca MCP is broker truth; Synthesis autotrader tools are runtime truth.
+    - Local files are not trader state. Do not create JSON/JSONL ledgers. Write only `report.md`; keep temp files under `AUTONOMOUS_TRADER_WORK_DIR`.
 
     Identity and mode:
-    - Read `AGENT_RUN_NAME` and use it unchanged for session identity, deterministic broker client order ids, milestone URLs, dedupe keys, and report fields.
-    - Read `AUTONOMOUS_TRADER_MODE` and `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE`.
-    - If `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE` is non-empty, pass exactly that value to `autotrader_start_session.mode`.
+    - Use `AGENT_RUN_NAME` unchanged for session identity, deterministic broker client order ids, dedupe keys, and reports.
+    - Read `AUTONOMOUS_TRADER_MODE` and `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE`; pass the session mode exactly when non-empty.
 
     Execution loop:
-    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate the local analysis context at `ANALYSIS_CONTEXT_PATH`, and self-test the Synthesis, live-scan, strategy-order, and protective-order helper scripts.
+    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate `ANALYSIS_CONTEXT_PATH`, and self-test the Synthesis, live-scan, strategy-order, and protective-order helpers.
     2. Preflight Alpaca account/config/clock/calendar/tools/positions/orders and Synthesis autotrader tool availability.
-    3. Call `autotrader_start_session` before scanning and keep its `sessionId` for every Synthesis write.
-    4. Before grading candidates, call `autotrader_get_scorecard` and include scorecard influence in the ticket/risk/status payloads.
-    5. Run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py`, use its summary plus Synthesis scorecards to pick the next best action: protected entry, managed exit/reduce/hedge/flatten, or no-trade.
-    6. For risk/order writes linked to a trade ticket, use the returned trade-ticket UUID, not the ticket idempotency key.
-    7. Before any non-smoke strategy entry, run `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py` against the planned bracket prices; if `allowed=false`, record the guard reason in Synthesis and do not submit the broker order.
-    8. Before any Alpaca mutation, record the planned order/risk in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when the broker tool supports it.
-    9. After any Alpaca mutation, reconcile by broker order id and client order id, refresh account/positions/orders, then update Synthesis before taking more risk.
-    10. Continue market-open cycles until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state.
-    11. In market-open mode, `terminal_reason: running`, `phase: manage`, `next_action: continue_monitoring`, active monitoring, quiet markets, and protected open positions are checkpoints, not completion. Write Synthesis status/event plus `report.md`, sleep no more than 60 seconds, and immediately start the next cycle.
-    12. Finalize with realized scorecard observations for terminal tickets, rejected valid setups, rejected invalid setups, slippage, hold time, MFE/MAE, and mistake tags.
+    3. Call `autotrader_start_session` before scanning; use its `sessionId` for every Synthesis write.
+    4. Each cycle: read broker state, call `autotrader_get_scorecard`, run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py`, then choose protected entry, managed exit/reduce/hedge/flatten, or no-trade.
+    5. Record selected or blocked candidates with Synthesis ticket, risk, event, and status writes. Use returned trade-ticket UUIDs for linked risk/order writes.
+    6. Before any non-smoke strategy entry, run `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py` against the planned bracket prices; if `allowed=false`, record the reason and do not submit.
+    7. Before any Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
+    8. After broker changes, reconcile by broker order id and client order id, refresh account/positions/orders, then update Synthesis before taking more risk.
+    9. Continue market-open cycles until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 
     Mode behavior:
     - `dry-run`: no Alpaca submit/cancel/replace/close-position calls; perform one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `scorecard-readback`: no Alpaca mutations; prove scorecards are read before candidate grading, finalize with `scorecard_readback_waiting` or `scorecard_readback_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `preflight`: prove readiness and, only when safe, one tiny non-marketable paper bracket or OTO order proof that is reconciled and canceled.
-    - `market-open`: first run one bounded paper-order smoke and the protective preflight before non-smoke strategy entries; preflight success, smoke success, no-trade, rejected candidates, rejected orders, quiet markets, active monitoring, and protected open positions are cycle outcomes, not terminal outcomes. Do not call `update_goal complete` and do not send a final assistant response until market close, 500000 USD equity, or hard unrecoverable account/order/visibility state.
+    - `market-open`: first run one bounded paper-order smoke and the protective preflight before strategy entries. Preflight success, smoke success, no-trade, rejected candidates, rejected orders, quiet markets, active monitoring, and protected open positions are cycle outcomes, not terminal outcomes. Do not call `update_goal complete` or send a final assistant response until market close, target equity, or hard stop.
 
     Safety:
     - Route orders only to the Alpaca paper account.
     - Use stock/ETF bracket, OTO, or OCO protection when feasible; for options, manage exits explicitly in the loop.
-    - If broker-attached protection fails or child legs are canceled, stop scanning and repair with deterministic OCO protection or flatten before any new strategy order.
+    - If protection fails or child legs are canceled, stop scanning and repair with deterministic OCO protection or flatten before any new strategy order.
     - Never rely on broker-generated or random client ids as proof of AgentRun-owned orders.
-    - Treat external orders/positions as current account state; manage them only through AgentRun-prefixed deterministic actions with Synthesis risk/event records.
-    - Retry transient Alpaca reads up to 3 times and record `mcp_retry`.
+    - Treat external orders/positions as current broker state; manage them only through AgentRun-prefixed deterministic actions with Synthesis risk/event records.
+    - Retry transient Alpaca reads up to 3 times and record retries.
     - If both Synthesis MCP and direct HTTP fallback visibility fail, do not take new risk.
 
-    Performance and communication:
-    - Keep research bounded to information that can change the immediate order, no-order, risk-reduction, or exit decision.
-    - Prefer the live scan-cycle helper over manual scanner JSON assembly; only inspect its `cycleDir` when needed for ticket/risk details or failure diagnosis.
-    - Prefer liquid instruments and serial clean cycles over broad watchlist churn.
-    - Record useful rejected setups and no-trade decisions so the scorecard compounds instead of adding local files.
-    - Do not create feed posts during trading; record runtime truth in Synthesis autotrader tables.
+    Performance:
+    - Research only information that changes the immediate order, no-order, risk-reduction, or exit decision.
+    - Use the live scan-cycle helper instead of manual scanner JSON assembly; inspect `cycleDir` only for ticket/risk details or failure diagnosis.
+    - Prefer liquid instruments and clean serial cycles over broad watchlist churn.
+    - Record rejected setups and no-trades in Synthesis so the scorecard compounds instead of adding local files.
     - Use concise preambles for major tool actions and heartbeat at least every 60 seconds while waiting.
+
+    Reporting and finalization:
+    - A `running` report is a checkpoint, not completion. Write Synthesis status/event plus `report.md`, sleep up to 60 seconds, and start the next cycle.
+    - Finish only with `target_reached`, `market_closed`, `dry_run_complete`, `scorecard_readback_waiting`, `scorecard_readback_complete`, or `hard_stop`.
+    - Before finishing, call `autotrader_finalize_session` with realized scorecard observations, slippage, hold time, MFE/MAE, and mistake tags.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -607,6 +607,15 @@ describe('synthesis autonomous trader provider', () => {
     const template = readYamlObjects(
       'argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml',
     ).find((manifest) => objectAt(manifest, 'kind') === 'AgentRun')
+    const agent = readYamlObjects('argocd/applications/synthesis/agents-domain/autonomous-trader-agent.yaml').find(
+      (manifest) => objectAt(manifest, 'kind') === 'Agent',
+    )
+    const implSpec = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'ImplementationSpec')
+    const systemPrompt = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'ConfigMap')
     const envTemplate = objectAt(objectAt(provider, 'spec'), 'envTemplate')
     const secretEnv = objectAt(objectAt(provider, 'spec'), 'secretEnv') as Record<string, unknown>[] | undefined
     const scheduleSpec = objectAt(schedule, 'spec')
@@ -614,6 +623,10 @@ describe('synthesis autonomous trader provider', () => {
     const parameters = objectAt(templateSpec, 'parameters')
     const annotations = objectAt(objectAt(schedule, 'metadata'), 'annotations')
     const overallTimeoutSeconds = Number(objectAt(envTemplate, 'CODEX_MARKET_CONTEXT_OVERALL_TIMEOUT_SECONDS'))
+    const systemPromptRef = objectAt(objectAt(objectAt(agent, 'spec'), 'defaults'), 'systemPromptRef')
+    const implText = String(objectAt(objectAt(implSpec, 'spec'), 'text') ?? '')
+    const systemPromptText = String(objectAt(objectAt(systemPrompt, 'data'), 'system-prompt.md') ?? '')
+    const countWords = (value: string) => value.trim().split(/\s+/).filter(Boolean).length
 
     expect(resources).toContain('autonomous-trader-dedicated-alpaca-mcp-sealedsecret.yaml')
     expect(resources).not.toContain('autonomous-trader-alpaca-mcp-sealedsecret.yaml')
@@ -624,6 +637,13 @@ describe('synthesis autonomous trader provider', () => {
         resolve(process.cwd(), 'argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml'),
       ),
     ).toBe(true)
+    expect(systemPromptRef).toEqual({
+      kind: 'ConfigMap',
+      name: 'autonomous-trader-system-prompt',
+      key: 'system-prompt.md',
+    })
+    expect(countWords(implText)).toBeLessThanOrEqual(120)
+    expect(countWords(systemPromptText)).toBeLessThanOrEqual(650)
     expect(objectAt(scheduleSpec, 'cron')).toBe('15 9 * * 1-5')
     expect(objectAt(scheduleSpec, 'suspend')).toBe(false)
     expect(objectAt(scheduleSpec, 'timezone')).toBe('America/New_York')

--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import urllib.error
 import urllib.parse
@@ -111,6 +112,26 @@ def next_cycle_number(work_dir: Path) -> int:
         if match:
             max_cycle = max(max_cycle, int(match.group(1)))
     return max_cycle + 1
+
+
+def prune_old_cycle_dirs(work_dir: Path, retain_cycles: int) -> list[str]:
+    if retain_cycles < 1:
+        return []
+    cycles: list[tuple[int, Path]] = []
+    pattern = re.compile(r"^cycle-(\d+)$")
+    for path in work_dir.glob("cycle-*"):
+        if not path.is_dir():
+            continue
+        match = pattern.match(path.name)
+        if match:
+            cycles.append((int(match.group(1)), path))
+    cycles.sort(key=lambda item: item[0])
+    stale_cycles = cycles[: max(0, len(cycles) - retain_cycles)]
+    removed: list[str] = []
+    for _, path in stale_cycles:
+        shutil.rmtree(path)
+        removed.append(path.name)
+    return removed
 
 
 def format_account(account: dict[str, Any]) -> dict[str, Any]:
@@ -246,7 +267,15 @@ def fetch_scan_inputs(
     }
 
 
-def summarize_scan(cycle: int, cycle_dir: Path, scan: dict[str, Any], symbols: list[str]) -> dict[str, Any]:
+def summarize_scan(
+    cycle: int,
+    cycle_dir: Path,
+    scan: dict[str, Any],
+    symbols: list[str],
+    *,
+    retained_cycles: int,
+    removed_cycle_dirs: list[str],
+) -> dict[str, Any]:
     results = scan.get("results")
     if not isinstance(results, list):
         results = []
@@ -278,6 +307,8 @@ def summarize_scan(cycle: int, cycle_dir: Path, scan: dict[str, Any], symbols: l
         "ok": True,
         "cycle": cycle,
         "cycleDir": str(cycle_dir),
+        "retainedCycles": retained_cycles,
+        "removedCycleDirs": removed_cycle_dirs,
         "watchlist": symbols,
         "resultCount": len(results),
         "topResults": top_results,
@@ -315,7 +346,15 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
         analysis_context_path=analysis_context,
         watchlist=symbols,
     )
-    return summarize_scan(cycle, cycle_dir, scan, symbols)
+    removed_cycle_dirs = prune_old_cycle_dirs(work_dir, args.retain_cycles)
+    return summarize_scan(
+        cycle,
+        cycle_dir,
+        scan,
+        symbols,
+        retained_cycles=args.retain_cycles,
+        removed_cycle_dirs=removed_cycle_dirs,
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -331,6 +370,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--synthesis-base-url")
     parser.add_argument("--analysis-context")
     parser.add_argument("--stock-analysis-cli")
+    parser.add_argument("--retain-cycles", type=int, default=5)
     parser.add_argument("--self-test", action="store_true")
     return parser
 

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -23,6 +23,28 @@ class LiveScanCycleTest(unittest.TestCase):
 
             self.assertEqual(live_scan_cycle.next_cycle_number(root), 4)
 
+    def test_prunes_old_cycle_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for cycle in range(1, 7):
+                cycle_dir = root / f"cycle-{cycle}"
+                cycle_dir.mkdir()
+                (cycle_dir / "scratch.json").write_text("{}\n", encoding="utf-8")
+            (root / "cycle-other").mkdir()
+
+            self.assertEqual(live_scan_cycle.prune_old_cycle_dirs(root, 3), ["cycle-1", "cycle-2", "cycle-3"])
+            self.assertFalse((root / "cycle-1").exists())
+            self.assertTrue((root / "cycle-4").exists())
+            self.assertTrue((root / "cycle-other").exists())
+
+    def test_does_not_prune_when_retention_disabled(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "cycle-1").mkdir()
+
+            self.assertEqual(live_scan_cycle.prune_old_cycle_dirs(root, 0), [])
+            self.assertTrue((root / "cycle-1").exists())
+
     def test_normalizes_alpaca_data_base_url(self) -> None:
         self.assertEqual(
             live_scan_cycle.normalize_alpaca_data_base_url("https://data.alpaca.markets"),
@@ -86,11 +108,15 @@ class LiveScanCycleTest(unittest.TestCase):
                 ]
             },
             ["NVDA"],
+            retained_cycles=5,
+            removed_cycle_dirs=[],
         )
 
         self.assertEqual(summary["cycle"], 2)
         self.assertEqual(summary["resultCount"], 1)
         self.assertEqual(summary["topResults"][0]["symbol"], "NVDA")
+        self.assertEqual(summary["retainedCycles"], 5)
+        self.assertEqual(summary["removedCycleDirs"], [])
 
     def test_run_cycle_returns_summary_without_summary_file(self) -> None:
         case = self
@@ -134,7 +160,11 @@ class LiveScanCycleTest(unittest.TestCase):
             return {"results": [{"symbol": "NVDA", "bars": 9, "no_trade_reason": "limited_live_bars"}]}
 
         with tempfile.TemporaryDirectory() as directory:
-            args = live_scan_cycle.build_parser().parse_args(["--work-dir", directory, "--watchlist", "NVDA"])
+            old_cycle = Path(directory) / "cycle-1"
+            old_cycle.mkdir()
+            args = live_scan_cycle.build_parser().parse_args(
+                ["--work-dir", directory, "--watchlist", "NVDA", "--retain-cycles", "1"]
+            )
             with (
                 patch.object(live_scan_cycle, "AlpacaRestClient", FakeAlpaca),
                 patch.object(live_scan_cycle, "SynthesisClient", FakeSynthesis),
@@ -142,12 +172,14 @@ class LiveScanCycleTest(unittest.TestCase):
             ):
                 summary = live_scan_cycle.run_cycle(args)
 
-            cycle_dir = Path(directory) / "cycle-1"
-            self.assertEqual(summary["cycle"], 1)
+            cycle_dir = Path(directory) / "cycle-2"
+            self.assertEqual(summary["cycle"], 2)
             self.assertEqual(summary["resultCount"], 1)
             self.assertTrue((cycle_dir / "account.json").exists())
             self.assertTrue((cycle_dir / "watchlist.json").exists())
             self.assertFalse((cycle_dir / "summary.json").exists())
+            self.assertFalse(old_cycle.exists())
+            self.assertEqual(summary["removedCycleDirs"], ["cycle-1"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Shrinks the autonomous trader ImplementationSpec into variable task context and keeps durable operating policy in the Agent system prompt.
- Tightens the system prompt around a simple broker-read/scorecard/scan/decision/write loop without weakening safety or finalization rules.
- Adds live scan-cycle retention so only recent `cycle-N` temporary JSON directories are kept by default.
- Replaces prompt wording assertions with structural prompt-budget checks for the autotrader deployment.

## Related Issues

None

## Testing

`python3 scripts/autotrader/test_live_scan_cycle.py`
`python3 scripts/autotrader/live_scan_cycle.py --self-test`
`bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
`bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
`bun run lint:argocd`
`git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
