### PR TITLE
chore(agents): promote images 92de19aa

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: f9f03b98
-  digest: sha256:2f4488f385ee4968dd7b4796421eba16db112c9f621d0d6864ae46b8a8ec1c22
+  tag: 92de19aa
+  digest: sha256:00bdea26e4af9618bc9487902b8f52d5c66c4b289fcf5c1c4807a41eb9db2f10
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: f9f03b98
-    digest: sha256:49261cce5b99fbd4223dafc55cc108182c6bfb9f975275269ae3fd1c08230921
+    tag: 92de19aa
+    digest: sha256:be1423ead62209d11b658132ab4b8fda4d5e5d6e5012914acfc9744ece3b0192
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: f9f03b98b26008bb9606a3576fb8dba5d1a2dc30
-      AGENTS_GITOPS_REVISION: f9f03b98b26008bb9606a3576fb8dba5d1a2dc30
-      AGENTS_SOURCE_CI_RUN_ID: "26774294589"
+      AGENTS_SOURCE_HEAD_SHA: 92de19aad5ed88b6784eeb0235e49e072970d9d5
+      AGENTS_GITOPS_REVISION: 92de19aad5ed88b6784eeb0235e49e072970d9d5
+      AGENTS_SOURCE_CI_RUN_ID: "26828283034"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:49261cce5b99fbd4223dafc55cc108182c6bfb9f975275269ae3fd1c08230921
-      AGENTS_SERVING_BUILD_COMMIT: f9f03b98b26008bb9606a3576fb8dba5d1a2dc30
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:49261cce5b99fbd4223dafc55cc108182c6bfb9f975275269ae3fd1c08230921
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:be1423ead62209d11b658132ab4b8fda4d5e5d6e5012914acfc9744ece3b0192
+      AGENTS_SERVING_BUILD_COMMIT: 92de19aad5ed88b6784eeb0235e49e072970d9d5
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:be1423ead62209d11b658132ab4b8fda4d5e5d6e5012914acfc9744ece3b0192
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: f9f03b98
-    digest: sha256:ad1e4aa2263118117543f6f7869d54b510ead5e7ea511d46fdd718753af6a66b
+    tag: 92de19aa
+    digest: sha256:b9707d98cf0d6a7401d133c2527c14564c3db57c74968d52468951e2186b3bcd
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: f9f03b98
-    digest: sha256:2f4488f385ee4968dd7b4796421eba16db112c9f621d0d6864ae46b8a8ec1c22
+    tag: 92de19aa
+    digest: sha256:00bdea26e4af9618bc9487902b8f52d5c66c4b289fcf5c1c4807a41eb9db2f10
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `92de19aad5ed88b6784eeb0235e49e072970d9d5`
- Image tag: `92de19aa`
- Agents build run: `26828283034`
- Promotion source: `workflow_run`