### PR TITLE
fix(torghut): drain live TigerBeetle execution refs

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -57,7 +57,7 @@ spec:
                   cd /app
                   exec /opt/venv/bin/python scripts/run_tigerbeetle_journal_cron.py \
                     --preset live \
-                    --execution-batch-size 5 \
+                    --execution-batch-size 25 \
                     --supervise-timeout-seconds 45 \
                     --json
               env:

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -27,6 +27,7 @@ from scripts import journal_tigerbeetle_order_events as journal_script  # noqa: 
 LIVE_ORDER_EVENT_BATCH_SIZE = 1
 LIVE_ORDER_EVENT_MAX_BATCHES = 1
 LIVE_ORDER_EVENT_SCAN_LIMIT = 250
+LIVE_EXECUTION_BATCH_SIZE = 25
 LIVE_TCA_METRIC_BATCH_SIZE = 5
 LIVE_TCA_METRIC_MAX_BATCHES = 1
 
@@ -53,7 +54,9 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument("--preset", choices=("live", "sim"), required=True)
-    parser.add_argument("--execution-batch-size", type=int, default=5)
+    parser.add_argument(
+        "--execution-batch-size", type=int, default=LIVE_EXECUTION_BATCH_SIZE
+    )
     parser.add_argument("--supervise-timeout-seconds", type=float, default=45.0)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1531,7 +1531,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("SIM_DB_DSN", live_env)
         live_args = "\n".join(str(item) for item in live_container.get("args", []))
         self.assertIn("--preset live", live_args)
-        self.assertIn("--execution-batch-size 5", live_args)
+        self.assertIn("--execution-batch-size 25", live_args)
         self.assertIn("--supervise-timeout-seconds 45", live_args)
         self.assertNotIn("--dsn-env DB_DSN", live_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -46,6 +46,29 @@ class RunTigerBeetleJournalCronTest(TestCase):
             "SIM_DB_DSN",
         )
 
+    def test_default_live_execution_batch_size_drains_source_ref_backlog(self) -> None:
+        with patch(
+            "scripts.run_tigerbeetle_journal_cron.sys.argv",
+            [
+                "run_tigerbeetle_journal_cron.py",
+                "--preset",
+                "live",
+            ],
+        ):
+            args = runner._parse_args()
+
+        [command] = [
+            item
+            for item in runner._commands_for_preset(args)
+            if item.source == SOURCE_TYPE_EXECUTION
+        ]
+
+        self.assertEqual(runner.LIVE_EXECUTION_BATCH_SIZE, 25)
+        self.assertEqual(command.batch_size, runner.LIVE_EXECUTION_BATCH_SIZE)
+        self.assertEqual(command.max_batches, 1)
+        self.assertTrue(command.skip_reconcile)
+        self.assertTrue(command.allow_data_quality_degraded)
+
     def test_live_preset_raises_only_execution_batch_size(self) -> None:
         commands = runner._live_commands(execution_batch_size=10)
 


### PR DESCRIPTION
## Summary

- Restores the live TigerBeetle execution-fill journal batch to 25 rows while keeping the six-minute cadence, one-batch limit, 45s watchdog, and order-event slice at one selected row.
- Adds a named runner default constant so the live source-ref backlog drains at the same bounded rate as the manifest.
- Extends runner and manifest contract tests so execution catch-up can increase without reopening the unsafe multi-batch or order-event timeout shape.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py`
- `bun run lint:argocd`
- `git diff --check`
- Live read-only evidence before fix: current 25-row execution slice completed in about 11 seconds under the 45s watchdog; DB probe showed 3165 filled executions missing execution-fill refs.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
