### PR TITLE
fix(torghut): admit source-backed sim runtime proof

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2055,19 +2055,19 @@ def _runtime_observation_authority_payload(
         or row.get("authority_reason") == "exact_replay_artifact_not_runtime_proof"
         for row in tca_rows
     )
-    if source_kind.startswith("simulation_"):
-        return {
-            "authoritative": False,
-            "authority_reason": "simulation_source_replay_only",
-            "promotion_authority": "blocked",
-            "runtime_ledger_profit_proof_present": has_runtime_ledger_profit_proof,
-        }
     if has_runtime_ledger_profit_proof:
         return {
             "authoritative": True,
             "authority_reason": "runtime_ledger_profit_proof",
             "promotion_authority": "runtime_ledger",
             "runtime_ledger_profit_proof_present": True,
+        }
+    if source_kind.startswith("simulation_"):
+        return {
+            "authoritative": False,
+            "authority_reason": "simulation_source_replay_only",
+            "promotion_authority": "blocked",
+            "runtime_ledger_profit_proof_present": has_runtime_ledger_profit_proof,
         }
     if exact_replay_artifact_only:
         return {

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -610,7 +610,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(payload["promotion_authority"], "runtime_ledger")
         self.assertEqual(payload["runtime_ledger_profit_proof_present"], True)
 
-    def test_runtime_observation_authority_keeps_simulation_replay_only(
+    def test_runtime_observation_authority_accepts_source_backed_torghut_sim_proof(
         self,
     ) -> None:
         payload = _runtime_observation_authority_payload(
@@ -626,10 +626,43 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
         )
 
+        self.assertEqual(payload["authoritative"], True)
+        self.assertEqual(payload["authority_reason"], "runtime_ledger_profit_proof")
+        self.assertEqual(payload["promotion_authority"], "runtime_ledger")
+        self.assertEqual(payload["runtime_ledger_profit_proof_present"], True)
+
+    def test_runtime_observation_authority_keeps_simulation_replay_only_without_source_proof(
+        self,
+    ) -> None:
+        payload = _runtime_observation_authority_payload(
+            source_kind="simulation_paper_runtime",
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "post_cost_expectancy_bps": Decimal("40"),
+                    "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+                    "post_cost_promotion_eligible": True,
+                    "runtime_ledger_bucket": _complete_runtime_ledger_bucket(
+                        source_window_ids=[],
+                        trade_decision_ids=[],
+                        execution_ids=[],
+                        execution_order_event_ids=[],
+                        source_offsets=[],
+                        source_materialization="exact_replay_artifact",
+                        authority_class="exact_replay_artifact_only_not_live",
+                        authority_reason="exact_replay_artifact_not_runtime_proof",
+                        pnl_derivation="exact_replay_artifact_only_not_live",
+                        promotion_authority="blocked",
+                        blockers=[],
+                    ),
+                }
+            ],
+        )
+
         self.assertEqual(payload["authoritative"], False)
         self.assertEqual(payload["authority_reason"], "simulation_source_replay_only")
         self.assertEqual(payload["promotion_authority"], "blocked")
-        self.assertEqual(payload["runtime_ledger_profit_proof_present"], True)
+        self.assertEqual(payload["runtime_ledger_profit_proof_present"], False)
 
     def test_parse_args_accepts_dataset_snapshot_ref(self) -> None:
         with patch(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1897,6 +1897,48 @@ class TestRuntimeWindowImport(TestCase):
                     "source_kind": "runtime_ledger_source_collection_candidate",
                 },
             )
+            ledger_row = session.execute(
+                select(StrategyRuntimeLedgerBucket).where(
+                    StrategyRuntimeLedgerBucket.run_id
+                    == "import-hpairs-source-backed-readback"
+                )
+            ).scalar_one()
+            ledger_payload = ledger_row.payload_json
+            self.assertEqual(ledger_row.hypothesis_id, "H-PAIRS-01")
+            self.assertEqual(ledger_row.candidate_id, "cand-hpairs-source-backed")
+            self.assertEqual(ledger_row.observed_stage, "paper")
+            self.assertEqual(ledger_row.account_label, "TORGHUT_SIM")
+            self.assertEqual(
+                ledger_row.runtime_strategy_name,
+                "microbar-cross-sectional-pairs-v1",
+            )
+            self.assertEqual(
+                ledger_payload["trade_decision_ids"],
+                ["decision-buy", "decision-sell"],
+            )
+            self.assertEqual(
+                ledger_payload["execution_ids"],
+                ["execution-buy", "execution-sell"],
+            )
+            self.assertEqual(
+                ledger_payload["execution_order_event_ids"],
+                ["event-fill-buy", "event-fill-sell"],
+            )
+            self.assertEqual(
+                ledger_payload["source_window_ids"],
+                ["source-window-buy", "source-window-sell"],
+            )
+            self.assertEqual(
+                ledger_payload["source_offsets"],
+                [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100},
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 101},
+                ],
+            )
+            self.assertEqual(
+                ledger_payload["source_materialization"], "execution_order_events"
+            )
+            self.assertEqual(ledger_payload["blockers"], [])
             session.commit()
 
         readback = summary["runtime_window_import_readback"]
@@ -2460,6 +2502,32 @@ class TestRuntimeWindowImport(TestCase):
         self.assertIn(
             "runtime_ledger_source_window_ids_missing",
             _runtime_ledger_bucket_blockers(missing_source_window_ids),
+        )
+
+        missing_trade_decision_ids = _runtime_ledger_bucket(trade_decision_ids=[])
+        self.assertIn(
+            "runtime_ledger_trade_decision_refs_missing",
+            _runtime_ledger_bucket_blockers(missing_trade_decision_ids),
+        )
+
+        missing_execution_ids = _runtime_ledger_bucket(execution_ids=[])
+        self.assertIn(
+            "runtime_ledger_execution_refs_missing",
+            _runtime_ledger_bucket_blockers(missing_execution_ids),
+        )
+
+        missing_execution_order_event_ids = _runtime_ledger_bucket(
+            execution_order_event_ids=[]
+        )
+        self.assertIn(
+            "runtime_ledger_execution_order_event_refs_missing",
+            _runtime_ledger_bucket_blockers(missing_execution_order_event_ids),
+        )
+
+        missing_source_offsets = _runtime_ledger_bucket(source_offsets=[])
+        self.assertIn(
+            "runtime_ledger_source_offsets_missing",
+            _runtime_ledger_bucket_blockers(missing_source_offsets),
         )
 
     def test_runtime_ledger_bucket_requires_structured_source_offsets(self) -> None:


### PR DESCRIPTION
## Summary

- Allows strict source-backed runtime-ledger proof to take authority before simulation-source labeling so real TORGHUT_SIM H-PAIRS buckets are not misclassified as replay-only.
- Keeps simulation/replay/artifact-only evidence blocked unless the runtime-ledger bucket satisfies the existing source-window, source-ref, source-offset, explicit-cost, closed-position, and authority-marker checks.
- Adds regression coverage for source-backed TORGHUT_SIM authority, replay-only simulation blocking, persisted lineage fields, and explicit missing-ref blockers.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
