### PR TITLE
fix(synthesis): order autotrader events chronologically

### DIFF
--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -416,11 +416,26 @@ describe('synthesis REST auth', () => {
         body: JSON.stringify({
           sessionId,
           seq: 3,
+          occurredAt: '2026-05-29T15:00:00Z',
           eventType: 'no_trade_decision',
           symbol: 'AMD',
           setupType: 'vwap_reclaim',
           setupGrade: 'C',
           payload: { reason: 'wide spread' },
+        }),
+      }),
+    )
+    await handleAutotraderAppendEvent(
+      new Request('http://synthesis.test/api/autotrader/events', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId,
+          seq: 100,
+          occurredAt: '2026-05-29T13:30:00Z',
+          eventType: 'protective_preflight_started',
+          severity: 'info',
+          payload: { reason: 'preflight helper reserved high sequence numbers' },
         }),
       }),
     )
@@ -503,7 +518,10 @@ describe('synthesis REST auth', () => {
     expect(detailPayload.session.closingEquity).toBe('38025')
     expect(detailPayload.status.phase).toBe('no_trade')
     expect(detailPayload.status.currentAction).toContain('standing down')
-    expect(detailPayload.events[0].eventType).toBe('no_trade_decision')
+    expect(detailPayload.events.map((event: { eventType: string }) => event.eventType)).toEqual([
+      'protective_preflight_started',
+      'no_trade_decision',
+    ])
     expect(detailPayload.tradeTickets[0].noTradeReason).toBe('C setup blocked')
     expect(detailPayload.setupExamples[0]).toMatchObject({
       ticketId: ticketPayload.ticket.id,

--- a/apps/synthesis/src/server/autotrader-store.ts
+++ b/apps/synthesis/src/server/autotrader-store.ts
@@ -627,7 +627,7 @@ class InMemoryAutotraderStore implements AutotraderStore {
       status: this.statuses.get(sessionId) ?? null,
       events: [...this.events.values()]
         .filter((event) => event.sessionId === sessionId)
-        .sort((left, right) => left.seq - right.seq),
+        .sort((left, right) => Date.parse(left.occurredAt) - Date.parse(right.occurredAt) || left.seq - right.seq),
       tradeTickets: sessionTickets,
       riskChecks: [...this.riskChecks.values()].filter((riskCheck) => riskCheck.sessionId === sessionId),
       orders: [...this.orders.values()].filter((order) => order.sessionId === sessionId),
@@ -1537,7 +1537,10 @@ class PostgresAutotraderStore implements AutotraderStore {
       exampleResult,
     ] = await Promise.all([
       this.pool.query<StatusRow>(`SELECT * FROM autotrader.status WHERE session_id = $1`, [sessionId]),
-      this.pool.query<EventRow>(`SELECT * FROM autotrader.events WHERE session_id = $1 ORDER BY seq ASC`, [sessionId]),
+      this.pool.query<EventRow>(
+        `SELECT * FROM autotrader.events WHERE session_id = $1 ORDER BY occurred_at ASC, seq ASC`,
+        [sessionId],
+      ),
       this.pool.query<TicketRow>(
         `SELECT * FROM autotrader.trade_tickets WHERE session_id = $1 ORDER BY created_at ASC`,
         [sessionId],


### PR DESCRIPTION
## Summary

- Orders autotrader session-detail events by `occurred_at` with `seq` as a tie-breaker.
- Keeps the in-memory test store and Postgres store ordering behavior aligned.
- Adds a regression where an older helper event has a higher sequence number than a newer cycle event.

## Related Issues

None

## Testing

- `bun test apps/synthesis/src/server/__tests__/api.test.ts -t "serves canonical autotrader state and scorecards through REST handlers"`
- `bunx oxfmt --check apps/synthesis/src/server/autotrader-store.ts apps/synthesis/src/server/__tests__/api.test.ts`
- `bun test apps/synthesis/src/server/__tests__/api.test.ts apps/synthesis/src/server/__tests__/mcp.test.ts`
- `bun run lint:synthesis`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
