### PR TITLE
fix(torghut): slice live execution journaling

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -57,7 +57,7 @@ spec:
                   cd /app
                   exec /opt/venv/bin/python scripts/run_tigerbeetle_journal_cron.py \
                     --preset live \
-                    --execution-batch-size 25 \
+                    --execution-batch-size 5 \
                     --supervise-timeout-seconds 45 \
                     --json
               env:

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -140,6 +140,15 @@ def _parse_args() -> argparse.Namespace:
         help="Emit stderr progress every N processed source rows; set 0 to disable.",
     )
     parser.add_argument(
+        "--commit-each-row",
+        action="store_true",
+        help=(
+            "Commit each successfully journaled source row before moving to the "
+            "next row. This keeps scheduled catch-up progress durable when a "
+            "later native TigerBeetle call has to be killed by the supervisor."
+        ),
+    )
+    parser.add_argument(
         "--supervise-timeout-seconds",
         type=float,
         default=0.0,
@@ -449,6 +458,12 @@ def _journal_source_batch(
         selected=len(rows),
     )
     for row in rows:
+        if progress_interval == 1:
+            _emit_progress(
+                "source_row_start",
+                source=source,
+                row_id=str(getattr(row, "id", "unknown")),
+            )
         try:
             if args.dry_run:
                 batch["journaled"] = int(batch["journaled"]) + 1
@@ -463,6 +478,9 @@ def _journal_source_batch(
                 ):
                     _attach_runtime_bucket_journal_payload(row, ref)
                 batch["journaled"] = int(batch["journaled"]) + 1
+                if bool(getattr(args, "commit_each_row", False)):
+                    session.commit()
+                    _reset_session_identity_map(session)
         except Exception as exc:
             batch["failed"] = int(batch["failed"]) + 1
             error_counts = batch["error_counts"]
@@ -661,6 +679,7 @@ def _payload(
         "reconcile_empty_selection": bool(
             getattr(args, "reconcile_empty_selection", False)
         ),
+        "commit_each_row": bool(getattr(args, "commit_each_row", False)),
         "supervised_worker": bool(getattr(args, "supervised_worker", False)),
         "supervise_timeout_seconds": float(
             getattr(args, "supervise_timeout_seconds", 0.0) or 0.0

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -27,7 +27,8 @@ from scripts import journal_tigerbeetle_order_events as journal_script  # noqa: 
 LIVE_ORDER_EVENT_BATCH_SIZE = 1
 LIVE_ORDER_EVENT_MAX_BATCHES = 1
 LIVE_ORDER_EVENT_SCAN_LIMIT = 250
-LIVE_EXECUTION_BATCH_SIZE = 25
+LIVE_EXECUTION_BATCH_SIZE = 5
+LIVE_EXECUTION_SLICE_COUNT = 5
 LIVE_TCA_METRIC_BATCH_SIZE = 5
 LIVE_TCA_METRIC_MAX_BATCHES = 1
 
@@ -44,6 +45,9 @@ class JournalCronCommand:
     skip_reconcile: bool = False
     reconcile_empty_selection: bool = False
     allow_data_quality_degraded: bool = False
+    commit_each_row: bool = False
+    progress_interval: int | None = None
+    repeat_count: int = 1
 
 
 def _parse_args() -> argparse.Namespace:
@@ -72,6 +76,9 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             reconcile_limit=1000,
             skip_reconcile=True,
             allow_data_quality_degraded=True,
+            commit_each_row=True,
+            progress_interval=1,
+            repeat_count=LIVE_EXECUTION_SLICE_COUNT,
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_TCA_METRIC,
@@ -183,6 +190,10 @@ def _argv_for_command(
     argv.append("--fail-on-degraded")
     if command.allow_data_quality_degraded:
         argv.append("--allow-data-quality-degraded")
+    if command.commit_each_row:
+        argv.append("--commit-each-row")
+    if command.progress_interval is not None:
+        argv.extend(["--progress-interval", str(max(0, command.progress_interval))])
     argv.extend(["--supervise-timeout-seconds", str(supervise_timeout_seconds)])
     if json_output:
         argv.append("--json")
@@ -280,19 +291,21 @@ def main() -> int:
     args = _parse_args()
     exit_code = 0
     for command in _commands_for_preset(args):
-        command_exit_code = _run_command(
-            _argv_for_command(
-                command,
-                json_output=bool(args.json),
-                supervise_timeout_seconds=max(
-                    float(args.supervise_timeout_seconds), 0.001
+        for _ in range(max(1, int(command.repeat_count))):
+            command_exit_code = _run_command(
+                _argv_for_command(
+                    command,
+                    json_output=bool(args.json),
+                    supervise_timeout_seconds=max(
+                        float(args.supervise_timeout_seconds), 0.001
+                    ),
                 ),
-            ),
-            source=command.source,
-            json_output=bool(args.json),
-        )
-        if command_exit_code:
-            exit_code = 1
+                source=command.source,
+                json_output=bool(args.json),
+            )
+            if command_exit_code:
+                exit_code = 1
+                break
     return exit_code
 
 

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -998,6 +998,60 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             },
         )
 
+    def test_source_batch_can_commit_successful_rows_individually(self) -> None:
+        class FakeNested:
+            def __enter__(self) -> None:
+                return None
+
+            def __exit__(self, *args: object) -> bool:
+                del args
+                return False
+
+        class FakeSession:
+            commits = 0
+            expunges = 0
+
+            def begin_nested(self) -> FakeNested:
+                return FakeNested()
+
+            def commit(self) -> None:
+                self.commits += 1
+
+            def expunge_all(self) -> None:
+                self.expunges += 1
+
+        session = FakeSession()
+        rows = [SimpleNamespace(id="first"), SimpleNamespace(id="second")]
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr):
+            batch = script._journal_source_batch(
+                session,
+                args=argparse.Namespace(
+                    dry_run=False,
+                    progress_interval=1,
+                    commit_each_row=True,
+                ),
+                source=script.SOURCE_TYPE_EXECUTION,
+                rows=rows,
+                journal_one=lambda row: object(),
+            )
+
+        self.assertEqual(batch["journaled"], 2)
+        self.assertEqual(batch["failed"], 0)
+        self.assertEqual(session.commits, 2)
+        self.assertEqual(session.expunges, 2)
+        events = [
+            json.loads(line) for line in stderr.getvalue().splitlines() if line.strip()
+        ]
+        row_start_events = [
+            event for event in events if event["event"] == "source_row_start"
+        ]
+        self.assertEqual(
+            [event["row_id"] for event in row_start_events],
+            ["first", "second"],
+        )
+
     def test_select_unlinked_events_filters_to_journalable_account_rows(self) -> None:
         settings_obj = Settings(TORGHUT_TIGERBEETLE_ENABLED=True)
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1531,13 +1531,29 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("SIM_DB_DSN", live_env)
         live_args = "\n".join(str(item) for item in live_container.get("args", []))
         self.assertIn("--preset live", live_args)
-        self.assertIn("--execution-batch-size 25", live_args)
+        self.assertIn("--execution-batch-size 5", live_args)
         self.assertIn("--supervise-timeout-seconds 45", live_args)
         self.assertNotIn("--dsn-env DB_DSN", live_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)
         self.assertNotIn("--account-label TORGHUT_SIM", live_args)
         self.assertNotIn("--batch-size", live_args)
         self.assertNotIn("--max-batches", live_args)
+        live_execution_commands = [
+            command
+            for command in tigerbeetle_journal_runner._live_commands(
+                execution_batch_size=5
+            )
+            if command.source == tigerbeetle_journal_runner.SOURCE_TYPE_EXECUTION
+        ]
+        self.assertEqual(len(live_execution_commands), 1)
+        live_execution_command = live_execution_commands[0]
+        self.assertEqual(live_execution_command.batch_size, 5)
+        self.assertEqual(
+            live_execution_command.repeat_count,
+            tigerbeetle_journal_runner.LIVE_EXECUTION_SLICE_COUNT,
+        )
+        self.assertTrue(live_execution_command.commit_each_row)
+        self.assertEqual(live_execution_command.progress_interval, 1)
         live_order_event_commands = [
             command
             for command in tigerbeetle_journal_runner._live_commands(

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -46,7 +46,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
             "SIM_DB_DSN",
         )
 
-    def test_default_live_execution_batch_size_drains_source_ref_backlog(self) -> None:
+    def test_default_live_execution_slices_drain_source_ref_backlog(self) -> None:
         with patch(
             "scripts.run_tigerbeetle_journal_cron.sys.argv",
             [
@@ -63,9 +63,13 @@ class RunTigerBeetleJournalCronTest(TestCase):
             if item.source == SOURCE_TYPE_EXECUTION
         ]
 
-        self.assertEqual(runner.LIVE_EXECUTION_BATCH_SIZE, 25)
+        self.assertEqual(runner.LIVE_EXECUTION_BATCH_SIZE, 5)
+        self.assertEqual(runner.LIVE_EXECUTION_SLICE_COUNT, 5)
         self.assertEqual(command.batch_size, runner.LIVE_EXECUTION_BATCH_SIZE)
         self.assertEqual(command.max_batches, 1)
+        self.assertEqual(command.repeat_count, runner.LIVE_EXECUTION_SLICE_COUNT)
+        self.assertTrue(command.commit_each_row)
+        self.assertEqual(command.progress_interval, 1)
         self.assertTrue(command.skip_reconcile)
         self.assertTrue(command.allow_data_quality_degraded)
 
@@ -75,6 +79,9 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(commands[0].source, SOURCE_TYPE_EXECUTION)
         self.assertEqual(commands[0].batch_size, 10)
         self.assertEqual(commands[0].max_batches, 1)
+        self.assertEqual(commands[0].repeat_count, runner.LIVE_EXECUTION_SLICE_COUNT)
+        self.assertTrue(commands[0].commit_each_row)
+        self.assertEqual(commands[0].progress_interval, 1)
         self.assertTrue(commands[0].skip_reconcile)
         self.assertTrue(commands[0].allow_data_quality_degraded)
         self.assertEqual(commands[1].source, SOURCE_TYPE_EXECUTION_TCA_METRIC)
@@ -356,11 +363,53 @@ class RunTigerBeetleJournalCronTest(TestCase):
             exit_code = runner.main()
 
         self.assertEqual(exit_code, 1)
-        self.assertEqual(len(observed), 4)
+        self.assertEqual(len(observed), 8)
         first_argv = observed[0][0]
         self.assertEqual(first_argv[first_argv.index("--batch-size") + 1], "5000")
+        self.assertIn("--commit-each-row", first_argv)
+        self.assertEqual(first_argv[first_argv.index("--progress-interval") + 1], "1")
         self.assertEqual(
             first_argv[first_argv.index("--supervise-timeout-seconds") + 1],
             "0.001",
         )
+        self.assertEqual(
+            [source for _, source, _ in observed[: runner.LIVE_EXECUTION_SLICE_COUNT]],
+            [SOURCE_TYPE_EXECUTION] * runner.LIVE_EXECUTION_SLICE_COUNT,
+        )
         self.assertTrue(all(json_output for _, _, json_output in observed))
+
+    def test_main_stops_repeated_execution_slices_after_failure(self) -> None:
+        observed: list[str] = []
+
+        def fake_run(argv: list[str], *, source: str, json_output: bool) -> int:
+            del argv, json_output
+            observed.append(source)
+            return 1 if source == SOURCE_TYPE_EXECUTION else 0
+
+        with (
+            patch(
+                "scripts.run_tigerbeetle_journal_cron._parse_args",
+                return_value=argparse.Namespace(
+                    preset="live",
+                    execution_batch_size=runner.LIVE_EXECUTION_BATCH_SIZE,
+                    supervise_timeout_seconds=45,
+                    json=True,
+                ),
+            ),
+            patch(
+                "scripts.run_tigerbeetle_journal_cron._run_command",
+                side_effect=fake_run,
+            ),
+        ):
+            exit_code = runner.main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(
+            observed,
+            [
+                SOURCE_TYPE_EXECUTION,
+                SOURCE_TYPE_EXECUTION_TCA_METRIC,
+                SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            ],
+        )


### PR DESCRIPTION
## Summary

- Splits live execution TigerBeetle journaling into five supervised 5-row slices instead of one 25-row child process.
- Commits each successfully journaled execution row before continuing so a later native TigerBeetle timeout cannot discard earlier progress.
- Adds row-start progress logging plus regression and manifest-contract coverage for the live sliced execution journal contract.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py scripts/journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
