### PR TITLE
feat(torghut): harden hpairs fast replay frontier queue

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -340,6 +340,7 @@ class FastReplayPreviewResult:
     )
 
     def to_manifest_payload(self) -> dict[str, Any]:
+        selected_candidate_ids_by_bucket = _selected_candidate_ids_by_bucket(self.rows)
         return {
             "schema_version": FAST_REPLAY_PREVIEW_SCHEMA_VERSION,
             "status": "preview_only",
@@ -409,6 +410,7 @@ class FastReplayPreviewResult:
             "exploration_candidate_count": self.exploration_candidate_count,
             "input_candidate_count": self.input_candidate_count,
             "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
+            "selected_candidate_ids_by_bucket": selected_candidate_ids_by_bucket,
             "selected_candidate_spec_count": len(self.selected_candidate_spec_ids),
             "selected_row_count": self.selected_row_count,
             "discovery_stage_semantics": _discovery_stage_semantics(),
@@ -452,6 +454,44 @@ class FastReplayPreviewResult:
                 "cluster_fanout_allowed": False,
                 "promotion_allowed": False,
             },
+            "bounded_exact_replay_queue": {
+                "schema_version": "torghut.fast-replay-bounded-exact-replay-queue.v1",
+                "status": "metadata_only_not_dispatched",
+                "queue_scope": "offline_preview_to_exact_replay_handoff",
+                "discovery_stage_semantics": _discovery_stage_semantics(),
+                "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
+                "selected_candidate_ids_by_bucket": selected_candidate_ids_by_bucket,
+                "exact_replay_candidate_cap": self.exact_replay_candidate_cap,
+                "target_candidate_cap": self.exact_replay_candidate_cap,
+                "enqueue_candidate_count": len(self.selected_candidate_spec_ids),
+                "exploitation_candidate_count": self.exploitation_candidate_count,
+                "exploration_candidate_count": self.exploration_candidate_count,
+                "handoff_contract": (
+                    "selected candidate specs are bounded inputs for a later exact "
+                    "replay worker; this preview path does not dispatch workers"
+                ),
+                "candidate_command_contract": {
+                    "source": "selected_candidate_spec_ids",
+                    "command_materialization": "downstream_exact_replay_runner_only",
+                    "command_execution_allowed_here": False,
+                },
+                "command_execution_allowed_here": False,
+                "broad_cluster_fanout_allowed": False,
+                "kubernetes_fanout_allowed": False,
+                "db_writes_allowed": False,
+                "proof_packet_upload_allowed": False,
+                "exact_replay_required": True,
+                "runtime_ledger_required": True,
+                "source_backed_runtime_ledger_required": True,
+                "preview_only": True,
+                "research_ranking_only": True,
+                "promotion_proof": False,
+                "proof_authority": False,
+                "promotion_authority": False,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "final_authority_ok": False,
+            },
             "replay_tape": {
                 "dataset_snapshot_ref": self.replay_tape_manifest.dataset_snapshot_ref,
                 "content_sha256": self.replay_tape_manifest.content_sha256,
@@ -479,6 +519,7 @@ class FastReplayPreviewResult:
                 "queue_scope": "offline_preview_to_exact_replay_or_bounded_sim_handoff",
                 "discovery_stage_semantics": _discovery_stage_semantics(),
                 "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
+                "selected_candidate_ids_by_bucket": selected_candidate_ids_by_bucket,
                 "target_candidate_cap": self.exact_replay_candidate_cap,
                 "enqueue_candidate_count": len(self.selected_candidate_spec_ids),
                 "exploitation_candidate_count": self.exploitation_candidate_count,
@@ -1445,6 +1486,32 @@ def _frontier_selection_blockers_for_row(
     if row.selection_reason == "fast_replay_frontier_lineage_blocked":
         return tuple(exact_replay_selection_blockers)
     return ()
+
+
+def _selected_candidate_ids_by_bucket(
+    rows: Sequence[FastReplayPreviewRow],
+) -> dict[str, list[str]]:
+    bucket_order = (
+        "exploitation",
+        "exploration",
+        "exploitation_backfill",
+    )
+    selected_by_bucket = {
+        bucket: [
+            row.candidate_spec_id
+            for row in rows
+            if row.selected and row.frontier_bucket == bucket
+        ]
+        for bucket in bucket_order
+    }
+    return {
+        **selected_by_bucket,
+        "all": [
+            row.candidate_spec_id
+            for row in rows
+            if row.selected and row.frontier_bucket in bucket_order
+        ],
+    }
 
 
 def _discovery_stage_semantics() -> dict[str, Any]:

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -603,6 +604,40 @@ class TestFastReplayPreview(TestCase):
         self.assertEqual(preview.exploitation_candidate_count, 4)
         self.assertEqual(preview.exploration_candidate_count, 2)
         self.assertEqual(preview.exact_replay_candidate_cap, 6)
+        payload = preview.to_manifest_payload()
+        exact_queue = payload["bounded_exact_replay_queue"]
+        self.assertEqual(exact_queue["exact_replay_candidate_cap"], 6)
+        self.assertEqual(exact_queue["enqueue_candidate_count"], 6)
+        self.assertEqual(
+            exact_queue["selected_candidate_spec_ids"],
+            list(preview.selected_candidate_spec_ids),
+        )
+        self.assertEqual(
+            exact_queue["selected_candidate_ids_by_bucket"]["all"],
+            list(preview.selected_candidate_spec_ids),
+        )
+        self.assertEqual(
+            len(exact_queue["selected_candidate_ids_by_bucket"]["exploitation"]),
+            4,
+        )
+        self.assertEqual(
+            len(exact_queue["selected_candidate_ids_by_bucket"]["exploration"]),
+            2,
+        )
+        self.assertEqual(
+            exact_queue["status"],
+            "metadata_only_not_dispatched",
+        )
+        self.assertFalse(exact_queue["command_execution_allowed_here"])
+        self.assertFalse(exact_queue["kubernetes_fanout_allowed"])
+        self.assertFalse(exact_queue["db_writes_allowed"])
+        self.assertFalse(exact_queue["proof_packet_upload_allowed"])
+        self.assertFalse(exact_queue["promotion_allowed"])
+        self.assertFalse(exact_queue["final_authority_ok"])
+        self.assertEqual(
+            payload["selected_candidate_ids_by_bucket"]["all"],
+            list(preview.selected_candidate_spec_ids),
+        )
         self.assertEqual(
             [row.frontier_bucket for row in preview.rows if row.selected],
             [
@@ -839,6 +874,42 @@ class TestFastReplayPreview(TestCase):
         self.assertFalse(
             manifest_payload["throughput_limits"]["kubernetes_fanout_allowed"]
         )
+        exact_queue = manifest_payload["bounded_exact_replay_queue"]
+        self.assertEqual(
+            exact_queue["candidate_command_contract"]["source"],
+            "selected_candidate_spec_ids",
+        )
+        self.assertFalse(
+            exact_queue["candidate_command_contract"]["command_execution_allowed_here"]
+        )
+        self.assertTrue(exact_queue["preview_only"])
+        self.assertTrue(exact_queue["research_ranking_only"])
+        self.assertFalse(exact_queue["promotion_authority"])
+        self.assertFalse(exact_queue["final_authority_ok"])
+
+    def test_frontier_path_has_no_kubernetes_or_database_execution_imports(
+        self,
+    ) -> None:
+        module_path = Path(fast_replay.__file__)
+        parsed = ast.parse(module_path.read_text(encoding="utf-8"))
+        disallowed_import_roots = {
+            "asyncpg",
+            "kubernetes",
+            "psycopg",
+            "psycopg2",
+            "sqlalchemy",
+            "subprocess",
+        }
+        imported_roots: set[str] = set()
+        for node in ast.walk(parsed):
+            if isinstance(node, ast.Import):
+                imported_roots.update(
+                    alias.name.split(".", maxsplit=1)[0] for alias in node.names
+                )
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported_roots.add(node.module.split(".", maxsplit=1)[0])
+
+        self.assertTrue(disallowed_import_roots.isdisjoint(imported_roots))
 
     def test_robust_lower_percentile_utility_ranks_ahead_of_mean_only_score(
         self,

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -496,6 +496,14 @@ class TestReplayTape(TestCase):
             source_query_digest=first_digest,
             source_table_versions={"signals": "v1"},
         )
+        changed_symbol_universe_key = build_replay_tape_cache_key(
+            dataset_snapshot_ref="snapshot-a",
+            symbols=("AAPL", "NVDA", "TSM"),
+            start_date=date(2026, 3, 27),
+            end_date=date(2026, 3, 27),
+            source_query_digest=first_digest,
+            source_table_versions={"signals": "v1"},
+        )
         changed_key = build_replay_tape_cache_key(
             dataset_snapshot_ref="snapshot-a",
             symbols=("AAPL", "NVDA"),
@@ -558,6 +566,7 @@ class TestReplayTape(TestCase):
         )
 
         self.assertEqual(first_key, reordered_key)
+        self.assertNotEqual(first_key, changed_symbol_universe_key)
         self.assertNotEqual(first_key, changed_key)
         self.assertNotEqual(first_key, changed_source_digest_key)
         self.assertNotEqual(first_key, changed_dataset_key)


### PR DESCRIPTION
## Summary

- Added proof-neutral bounded exact-replay queue metadata to the Torghut H-PAIRS fast-replay preview manifest.
- Exposed selected candidate ids by exploitation, exploration, backfill, and aggregate buckets for deterministic handoff auditing.
- Hardened tests for six-candidate frontier caps, no local exact-replay dispatch side effects, and replay cache invalidation when the symbol universe changes.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` (pass after installing missing local build toolchain for crosshair-tool)
- `cd services/torghut && uv run --frozen pytest tests/test_replay_tape.py tests/test_microstructure_prefilter.py tests/test_fast_replay.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py -q` (pass: 289 passed, 1 warning)
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/replay_tape.py app/trading/discovery/microstructure_prefilter.py app/trading/discovery/fast_replay.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_replay_tape.py tests/test_microstructure_prefilter.py tests/test_fast_replay.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py` (pass)
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/replay_tape.py app/trading/discovery/microstructure_prefilter.py app/trading/discovery/fast_replay.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_replay_tape.py tests/test_microstructure_prefilter.py tests/test_fast_replay.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` (pass)
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` (pass)
- `git diff --check` (pass)

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
