### PR TITLE
fix(torghut): expose proof packet authority target gates

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -3131,6 +3131,9 @@ def build_runtime_ledger_proof_packet(
             "promotion_allowed": False,
             "capital_promotion_allowed": False,
             "final_promotion_allowed": False,
+            "source_backed_runtime_ledger_proof_required": final_authority_mode,
+            "non_empty_runtime_ledger_source_refs_required": final_authority_mode,
+            "runtime_ledger_import_readback_required": final_authority_mode,
             "min_runtime_ledger_net_pnl_after_costs": _decimal_text(
                 min_runtime_ledger_net_pnl
             ),

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -878,9 +878,30 @@ def _add_runtime_ledger_proof_packet_check(
     packet = _mapping(runtime_ledger_proof_packet)
     authority = _mapping(packet.get("promotion_authority"))
     capital_authority = _mapping(packet.get("capital_promotion_authority"))
+    target = _mapping(packet.get("target"))
     proof_mode_contract = _mapping(packet.get("proof_mode_contract"))
     schema_version = _text(packet.get("schema_version"))
     proof_mode = _text(packet.get("proof_mode"))
+    target_min_trading_days = _int(target.get("min_runtime_ledger_trading_days"))
+    target_min_net_pnl = _decimal(target.get("min_runtime_ledger_net_pnl_after_costs"))
+    target_min_daily_net_pnl = _decimal(
+        target.get("min_runtime_ledger_daily_net_pnl_after_costs")
+    )
+    target_source_proof_required = (
+        target.get("source_backed_runtime_ledger_proof_required") is True
+    )
+    target_non_empty_source_refs_required = (
+        target.get("non_empty_runtime_ledger_source_refs_required") is True
+    )
+    authority_target_contract_ok = (
+        target_min_trading_days >= 20
+        and target_min_net_pnl is not None
+        and target_min_net_pnl >= Decimal("10000")
+        and target_min_daily_net_pnl is not None
+        and target_min_daily_net_pnl >= Decimal("500")
+        and target_source_proof_required
+        and target_non_empty_source_refs_required
+    )
     allowed = authority.get("allowed") is True
     mode_contract_allows_authority = (
         proof_mode_contract.get("mode_can_grant_final_authority") is True
@@ -895,6 +916,7 @@ def _add_runtime_ledger_proof_packet_check(
         packet.get("ok") is True
         and proof_mode == "authority"
         and mode_contract_allows_authority
+        and authority_target_contract_ok
         and packet.get("final_authority_ok") is True
         and packet.get("promotion_allowed") is True
         and packet.get("capital_promotion_allowed") is True
@@ -912,6 +934,7 @@ def _add_runtime_ledger_proof_packet_check(
             "proof_mode": proof_mode,
             "proof_mode_contract": dict(proof_mode_contract),
             "mode_contract_allows_authority": mode_contract_allows_authority,
+            "authority_target_contract_ok": authority_target_contract_ok,
             "final_authority_ok": packet.get("final_authority_ok"),
             "promotion_allowed": packet.get("promotion_allowed"),
             "capital_promotion_allowed": packet.get("capital_promotion_allowed"),
@@ -933,17 +956,36 @@ def _add_runtime_ledger_proof_packet_check(
                 for check in _sequence(authority.get("failed_checks"))
                 if _text(check)
             ],
+            "target": dict(target),
+            "min_runtime_ledger_trading_days": target_min_trading_days,
+            "min_runtime_ledger_net_pnl_after_costs": _text(
+                target.get("min_runtime_ledger_net_pnl_after_costs")
+            ),
+            "min_runtime_ledger_daily_net_pnl_after_costs": _text(
+                target.get("min_runtime_ledger_daily_net_pnl_after_costs")
+            ),
+            "source_backed_runtime_ledger_proof_required": (
+                target_source_proof_required
+            ),
+            "non_empty_runtime_ledger_source_refs_required": (
+                target_non_empty_source_refs_required
+            ),
         },
         expected={
             "schema_version": RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
             "ok": True,
             "proof_mode": "authority",
             "proof_mode_contract.mode_can_grant_final_authority": True,
+            "authority_target_contract_ok": True,
             "final_authority_ok": True,
             "promotion_allowed": True,
             "capital_promotion_allowed": True,
             "final_promotion_allowed": True,
             "promotion_authority.allowed": True,
+            "target.min_runtime_ledger_trading_days": 20,
+            "target.min_runtime_ledger_daily_net_pnl_after_costs": "500",
+            "target.source_backed_runtime_ledger_proof_required": True,
+            "target.non_empty_runtime_ledger_source_refs_required": True,
         },
     )
 
@@ -1829,6 +1871,32 @@ def evaluate_trading_readiness(
             "proof_mode_contract": dict(
                 _mapping(packet_summary.get("proof_mode_contract"))
             ),
+            "target": dict(_mapping(packet_summary.get("target"))),
+            "min_runtime_ledger_trading_days": _mapping(
+                packet_summary.get("target")
+            ).get("min_runtime_ledger_trading_days"),
+            "min_runtime_ledger_net_pnl_after_costs": _mapping(
+                packet_summary.get("target")
+            ).get("min_runtime_ledger_net_pnl_after_costs"),
+            "min_runtime_ledger_daily_net_pnl_after_costs": _mapping(
+                packet_summary.get("target")
+            ).get("min_runtime_ledger_daily_net_pnl_after_costs"),
+            "source_backed_runtime_ledger_proof_required": _mapping(
+                packet_summary.get("target")
+            ).get("source_backed_runtime_ledger_proof_required"),
+            "non_empty_runtime_ledger_source_refs_required": _mapping(
+                packet_summary.get("target")
+            ).get("non_empty_runtime_ledger_source_refs_required"),
+            "blockers": [
+                _text(blocker)
+                for blocker in _sequence(packet_summary.get("blockers"))
+                if _text(blocker)
+            ],
+            "authority_blockers": [
+                _text(blocker)
+                for blocker in _sequence(packet_summary.get("authority_blockers"))
+                if _text(blocker)
+            ],
             "final_authority_ok": packet_summary.get("final_authority_ok"),
             "evidence_collection_only": packet_summary.get("evidence_collection_only"),
             "evidence_collection_ok": packet_summary.get("evidence_collection_ok"),

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -742,6 +742,19 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(result["schema_version"], packet.SCHEMA_VERSION)
         self.assertEqual(result["verdict"], "promotion_authority_allowed")
         self.assertEqual(result["promotion_authority"]["blocking_reasons"], [])
+        self.assertEqual(result["blockers"], [])
+        self.assertEqual(result["target"]["proof_mode"], "authority")
+        self.assertEqual(result["target"]["min_runtime_ledger_trading_days"], 20)
+        self.assertEqual(
+            result["target"]["min_runtime_ledger_daily_net_pnl_after_costs"], "500"
+        )
+        self.assertEqual(
+            result["target"]["min_runtime_ledger_net_pnl_after_costs"], "10000"
+        )
+        self.assertTrue(result["target"]["source_backed_runtime_ledger_proof_required"])
+        self.assertTrue(
+            result["target"]["non_empty_runtime_ledger_source_refs_required"]
+        )
         self.assertEqual(result["candidate"]["hypothesis_id"], "H-PAIRS-01")
         self.assertEqual(
             result["checks"]["runtime_ledger_post_cost_profit_target"]["observed"][
@@ -1157,6 +1170,13 @@ class TestRuntimeLedgerProofPacket(TestCase):
             ["runtime_ledger_proof_mode_not_authority"],
         )
         self.assertFalse(result["target"]["promotion_allowed"])
+        self.assertFalse(
+            result["target"]["source_backed_runtime_ledger_proof_required"]
+        )
+        self.assertFalse(
+            result["target"]["non_empty_runtime_ledger_source_refs_required"]
+        )
+        self.assertEqual(result["target"]["min_runtime_ledger_trading_days"], 1)
         self.assertEqual(
             result["post_cost_proof_authority"]["blocking_reasons"],
             ["runtime_ledger_proof_mode_not_authority"],

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -305,6 +305,17 @@ def _runtime_ledger_proof_packet(
         "capital_promotion_allowed": allowed,
         "final_promotion_allowed": allowed,
         "evidence_collection_ok": False,
+        "authority_blockers": blocking_reasons,
+        "blockers": blocking_reasons,
+        "target": {
+            "proof_mode": "authority",
+            "final_authority": True,
+            "source_backed_runtime_ledger_proof_required": True,
+            "non_empty_runtime_ledger_source_refs_required": True,
+            "min_runtime_ledger_trading_days": 20,
+            "min_runtime_ledger_net_pnl_after_costs": "10000",
+            "min_runtime_ledger_daily_net_pnl_after_costs": "500",
+        },
         "next_action": "none"
         if allowed
         else "collect_or_improve_post_cost_runtime_profit_evidence",
@@ -559,10 +570,20 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertFalse(
             result["runtime_ledger_proof_packet"]["evidence_collection_ok"]
         )
-        self.assertTrue(result["runtime_ledger_proof_packet"]["promotion_allowed"])
-        self.assertTrue(
-            result["runtime_ledger_proof_packet"]["final_promotion_allowed"]
+        packet_summary = result["runtime_ledger_proof_packet"]
+        self.assertTrue(packet_summary["promotion_allowed"])
+        self.assertTrue(packet_summary["final_promotion_allowed"])
+        self.assertEqual(packet_summary["min_runtime_ledger_trading_days"], 20)
+        self.assertEqual(
+            packet_summary["min_runtime_ledger_daily_net_pnl_after_costs"], "500"
         )
+        self.assertEqual(
+            packet_summary["min_runtime_ledger_net_pnl_after_costs"], "10000"
+        )
+        self.assertTrue(packet_summary["source_backed_runtime_ledger_proof_required"])
+        self.assertTrue(packet_summary["non_empty_runtime_ledger_source_refs_required"])
+        self.assertEqual(packet_summary["blockers"], [])
+        self.assertEqual(packet_summary["authority_blockers"], [])
 
     def test_tigerbeetle_parity_can_be_required_as_accounting_only_gate(
         self,
@@ -765,6 +786,31 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertEqual(observed["proof_mode"], "authority")
         self.assertEqual(observed["proof_mode_contract"], {})
         self.assertFalse(observed["mode_contract_allows_authority"])
+        self.assertIn(
+            "runtime_ledger_proof_packet_authority",
+            result["failed_checks"],
+        )
+
+    def test_runtime_ledger_proof_packet_requires_authority_target_contract(
+        self,
+    ) -> None:
+        packet = _runtime_ledger_proof_packet(allowed=True)
+        target = packet["target"]
+        assert isinstance(target, dict)
+        target["min_runtime_ledger_trading_days"] = 1
+        target["source_backed_runtime_ledger_proof_required"] = False
+
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            runtime_ledger_proof_packet=packet,
+            require_runtime_ledger_proof_packet=True,
+        )
+
+        self.assertFalse(result["ok"])
+        observed = result["checks"]["runtime_ledger_proof_packet_authority"]["observed"]
+        self.assertFalse(observed["authority_target_contract_ok"])
+        self.assertEqual(observed["min_runtime_ledger_trading_days"], 1)
+        self.assertFalse(observed["source_backed_runtime_ledger_proof_required"])
         self.assertIn(
             "runtime_ledger_proof_packet_authority",
             result["failed_checks"],


### PR DESCRIPTION
## Summary

- Adds explicit proof-packet target fields for authority source-backed runtime-ledger proof requirements, non-empty source refs, and runtime-import readback requirements.
- Makes trading-readiness authority checks fail closed unless authority packets carry 20 trading days, at least $10,000 total post-cost / $500 daily post-cost targets, and source-backed proof requirements.
- Extends proof-packet and readiness regressions so smoke/default packets remain non-authoritative and readiness surfaces target requirements plus blockers.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
