### PR TITLE
feat(torghut): add bounded paper-route materialization cli

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""Safely materialize bounded H-PAIRS paper-route targets into TORGHUT_SIM."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, cast
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, Strategy
+from app.trading.paper_route_target_plan import (
+    PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+    fetch_paper_route_target_plan_url,
+    materialize_bounded_paper_route_target_plan,
+    paper_route_target_plan_from_payload,
+    paper_route_target_plan_targets,
+)
+
+SCHEMA_VERSION = "torghut.bounded-paper-route-target-materialization-cli.v1"
+OPERATOR_CONFIRMATION = "MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS"
+PROMOTION_FLAG_FIELDS = (
+    "promotion_allowed",
+    "promotion_authorized",
+    "final_authority_ok",
+    "final_promotion_allowed",
+    "final_promotion_authorized",
+    "capital_promotion_allowed",
+    "capital_promotion_authorized",
+    "live_capital_routing_enabled",
+)
+LIVE_LABEL_MARKERS = ("LIVE", "PROD", "REAL")
+
+
+def _json_default(value: object) -> str:
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _safe_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _safe_decimal(value: object) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    try:
+        return Decimal(str(value).strip())
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def _decimal_text(value: Decimal) -> str:
+    return format(value, "f")
+
+
+def _truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float | Decimal):
+        return bool(value)
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _to_str_map(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[object, Any], value).items()}
+
+
+def _target_symbol_actions(target: Mapping[str, Any]) -> dict[str, str]:
+    raw_actions = _to_str_map(target.get("paper_route_probe_symbol_actions"))
+    actions: dict[str, str] = {}
+    for raw_symbol, raw_action in raw_actions.items():
+        symbol = str(raw_symbol).strip().upper()
+        action = str(raw_action).strip().lower()
+        if symbol and action in {"buy", "sell"}:
+            actions[symbol] = action
+    return actions
+
+
+def _target_symbol_quantities(target: Mapping[str, Any]) -> dict[str, Decimal]:
+    quantities: dict[str, Decimal] = {}
+    for field in (
+        "paper_route_probe_symbol_quantities",
+        "target_symbol_quantities",
+        "symbol_quantities",
+    ):
+        raw_quantities = _to_str_map(target.get(field))
+        for raw_symbol, raw_quantity in raw_quantities.items():
+            symbol = str(raw_symbol).strip().upper()
+            quantity = _safe_decimal(raw_quantity)
+            if symbol and quantity > 0:
+                quantities[symbol] = quantity
+    fallback_quantity = _first_positive_decimal(
+        target,
+        ("target_quantity", "paper_route_probe_target_quantity", "qty", "quantity"),
+    )
+    if fallback_quantity > 0:
+        for symbol in _target_symbol_actions(target):
+            quantities.setdefault(symbol, fallback_quantity)
+    return quantities
+
+
+def _first_positive_decimal(
+    payload: Mapping[str, Any],
+    fields: Sequence[str],
+) -> Decimal:
+    for field in fields:
+        value = _safe_decimal(payload.get(field))
+        if value > 0:
+            return value
+    return Decimal("0")
+
+
+def _target_notional(target: Mapping[str, Any]) -> Decimal:
+    return _first_positive_decimal(
+        target,
+        (
+            "target_notional",
+            "paper_route_probe_target_notional",
+            "paper_route_probe_effective_max_notional",
+            "bounded_evidence_collection_max_notional",
+            "paper_route_probe_next_session_max_notional",
+            "max_notional",
+        ),
+    )
+
+
+def _target_quantity(target: Mapping[str, Any]) -> Decimal:
+    explicit_quantity = _first_positive_decimal(
+        target,
+        ("target_quantity", "paper_route_probe_target_quantity", "qty", "quantity"),
+    )
+    if explicit_quantity > 0:
+        return explicit_quantity
+    return sum(_target_symbol_quantities(target).values(), Decimal("0"))
+
+
+def _target_plan_ref(target: Mapping[str, Any]) -> str | None:
+    return (
+        _safe_text(target.get("source_plan_ref"))
+        or _safe_text(target.get("source_plan_id"))
+        or _safe_text(target.get("source_manifest_ref"))
+        or _safe_text(target.get("paper_route_target_plan_source"))
+    )
+
+
+def _load_json_file(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, Mapping):
+        raise ValueError("paper_route_target_plan_json_must_be_object")
+    return dict(cast(Mapping[str, Any], payload))
+
+
+def _load_plan(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
+    plan_file = cast(Path | None, args.plan_json)
+    plan_url = _safe_text(args.plan_url)
+    if plan_file is None and plan_url is None:
+        raise ValueError("paper_route_target_plan_source_required")
+    if plan_file is not None and plan_url is not None:
+        raise ValueError("paper_route_target_plan_single_source_required")
+
+    if plan_file is not None:
+        payload = _load_json_file(plan_file)
+        plan = paper_route_target_plan_from_payload(payload) or payload
+        return (
+            dict(plan),
+            {
+                "kind": "file",
+                "path": str(plan_file),
+            },
+        )
+
+    assert plan_url is not None
+    plan = fetch_paper_route_target_plan_url(
+        plan_url,
+        timeout_seconds=float(args.plan_url_timeout_seconds),
+        attempts=max(int(args.plan_url_attempts), 1),
+    )
+    load_error = _safe_text(plan.get("load_error"))
+    if load_error:
+        raise ValueError(load_error)
+    return (
+        dict(plan),
+        {
+            "kind": "url",
+            "url": plan_url,
+        },
+    )
+
+
+def _target_summaries(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
+    summaries: list[dict[str, Any]] = []
+    for index, target in enumerate(paper_route_target_plan_targets(plan)):
+        actions = _target_symbol_actions(target)
+        quantities = _target_symbol_quantities(target)
+        target_notional = _target_notional(target)
+        summaries.append(
+            {
+                "target_index": index,
+                "hypothesis_id": _safe_text(target.get("hypothesis_id")),
+                "candidate_id": _safe_text(target.get("candidate_id")),
+                "runtime_strategy_name": _safe_text(target.get("runtime_strategy_name"))
+                or _safe_text(target.get("strategy_name")),
+                "strategy_name": _safe_text(target.get("strategy_name")),
+                "account_label": _safe_text(target.get("account_label")),
+                "target_plan_ref": _target_plan_ref(target),
+                "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
+                "bounded_collection_stage": _safe_text(
+                    target.get("bounded_collection_stage")
+                )
+                or _safe_text(target.get("evidence_collection_stage"))
+                or _safe_text(target.get("observed_stage")),
+                "target_notional": _decimal_text(target_notional),
+                "target_quantity": _decimal_text(_target_quantity(target)),
+                "symbols": sorted(actions),
+                "symbol_actions": actions,
+                "symbol_quantities": {
+                    symbol: _decimal_text(quantity)
+                    for symbol, quantity in sorted(quantities.items())
+                },
+            }
+        )
+    return summaries
+
+
+def _unique_texts(values: Sequence[object]) -> list[str]:
+    return sorted({text for value in values if (text := _safe_text(value))})
+
+
+def _plan_flag_blockers(plan: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    for field in PROMOTION_FLAG_FIELDS:
+        if _truthy(plan.get(field)):
+            blockers.append(f"paper_route_materialization_plan_{field}_must_be_false")
+    for index, target in enumerate(paper_route_target_plan_targets(plan)):
+        for field in PROMOTION_FLAG_FIELDS:
+            if _truthy(target.get(field)):
+                blockers.append(
+                    f"paper_route_materialization_target_{index}_{field}_must_be_false"
+                )
+    return blockers
+
+
+def _confirmation_blockers(
+    *,
+    args: argparse.Namespace,
+    summaries: Sequence[Mapping[str, Any]],
+    dsn_env: str,
+) -> list[str]:
+    if not bool(args.commit):
+        return []
+
+    blockers: list[str] = []
+    confirmations = {
+        "account_label": (
+            _safe_text(args.confirm_account_label),
+            PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+        ),
+        "dsn_env": (_safe_text(args.confirm_dsn_env), dsn_env),
+        "hypothesis_id": (
+            _safe_text(args.confirm_hypothesis_id),
+            ",".join(_unique_texts([item.get("hypothesis_id") for item in summaries])),
+        ),
+        "candidate_id": (
+            _safe_text(args.confirm_candidate_id),
+            ",".join(_unique_texts([item.get("candidate_id") for item in summaries])),
+        ),
+        "runtime_strategy_name": (
+            _safe_text(args.confirm_runtime_strategy_name),
+            ",".join(
+                _unique_texts([item.get("runtime_strategy_name") for item in summaries])
+            ),
+        ),
+        "target_plan_ref": (
+            _safe_text(args.confirm_target_plan_ref),
+            ",".join(
+                _unique_texts([item.get("target_plan_ref") for item in summaries])
+            ),
+        ),
+        "max_notional": (
+            _safe_text(args.confirm_max_notional),
+            _safe_text(args.max_notional),
+        ),
+    }
+    for name, (observed, expected) in confirmations.items():
+        if expected is None or not observed or observed != expected:
+            blockers.append(
+                f"paper_route_materialization_commit_confirm_{name}_missing"
+            )
+
+    if _safe_text(args.operator_confirmation) != OPERATOR_CONFIRMATION:
+        blockers.append("paper_route_materialization_operator_confirmation_missing")
+    return blockers
+
+
+def _safety_blockers(
+    *,
+    args: argparse.Namespace,
+    plan: Mapping[str, Any],
+    summaries: Sequence[Mapping[str, Any]],
+    dsn: str | None,
+    dsn_env: str,
+) -> list[str]:
+    blockers: list[str] = []
+    account_label = _safe_text(args.account_label)
+    if account_label != PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL:
+        blockers.append("paper_route_materialization_account_label_must_be_torghut_sim")
+    if account_label and any(
+        marker in account_label.upper() for marker in LIVE_LABEL_MARKERS
+    ):
+        blockers.append("paper_route_materialization_live_account_label_rejected")
+    if not dsn:
+        blockers.append("paper_route_materialization_database_dsn_env_missing")
+
+    max_notional = _safe_decimal(args.max_notional)
+    if max_notional <= 0:
+        blockers.append("paper_route_materialization_bounded_max_notional_required")
+
+    capital_mode = _safe_text(args.capital_mode) or ""
+    if capital_mode.lower() in {"live", "prod", "production", "real"}:
+        blockers.append("paper_route_materialization_non_live_capital_mode_required")
+    for flag_name in (
+        "promotion_allowed",
+        "final_promotion_allowed",
+        "final_authority_ok",
+        "capital_promotion_allowed",
+    ):
+        if bool(getattr(args, flag_name)):
+            blockers.append(
+                f"paper_route_materialization_request_{flag_name}_must_be_false"
+            )
+
+    blockers.extend(_plan_flag_blockers(plan))
+    if not summaries:
+        blockers.append("paper_route_materialization_target_plan_targets_missing")
+
+    for summary in summaries:
+        index = int(summary.get("target_index", 0))
+        target_account_label = _safe_text(summary.get("account_label"))
+        if target_account_label != PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL:
+            blockers.append(
+                f"paper_route_materialization_target_{index}_account_label_must_be_torghut_sim"
+            )
+        if target_account_label and any(
+            marker in target_account_label.upper() for marker in LIVE_LABEL_MARKERS
+        ):
+            blockers.append(
+                f"paper_route_materialization_target_{index}_live_account_label_rejected"
+            )
+        for field in (
+            "hypothesis_id",
+            "candidate_id",
+            "runtime_strategy_name",
+            "target_plan_ref",
+            "bounded_collection_stage",
+        ):
+            if not _safe_text(summary.get(field)):
+                blockers.append(
+                    f"paper_route_materialization_target_{index}_{field}_missing"
+                )
+        target_notional = _safe_decimal(summary.get("target_notional"))
+        if target_notional <= 0:
+            blockers.append(
+                f"paper_route_materialization_target_{index}_target_notional_missing"
+            )
+        elif max_notional > 0 and target_notional > max_notional:
+            blockers.append(
+                f"paper_route_materialization_target_{index}_target_notional_exceeds_max"
+            )
+        if _safe_decimal(summary.get("target_quantity")) <= 0:
+            blockers.append(
+                f"paper_route_materialization_target_{index}_target_quantity_missing"
+            )
+        if not cast(Sequence[object], summary.get("symbols", [])):
+            blockers.append(
+                f"paper_route_materialization_target_{index}_symbol_actions_missing"
+            )
+
+    blockers.extend(
+        _confirmation_blockers(args=args, summaries=summaries, dsn_env=dsn_env)
+    )
+    return sorted(dict.fromkeys(blockers))
+
+
+def _session_factory(dsn: str) -> sessionmaker[Session]:
+    engine = create_engine(dsn, pool_pre_ping=True, future=True)
+    return sessionmaker(
+        bind=engine,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+
+
+def _strategy_names_from_summaries(
+    summaries: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    return _unique_texts([item.get("runtime_strategy_name") for item in summaries])
+
+
+def _copy_preview_strategies(
+    *,
+    source_session: Session,
+    preview_session: Session,
+    strategy_names: Sequence[str],
+) -> None:
+    if not strategy_names:
+        return
+    strategies = list(
+        source_session.execute(
+            select(Strategy).where(Strategy.name.in_(list(strategy_names)))
+        )
+        .scalars()
+        .all()
+    )
+    for strategy in strategies:
+        preview_session.add(
+            Strategy(
+                name=strategy.name,
+                description=strategy.description,
+                enabled=strategy.enabled,
+                base_timeframe=strategy.base_timeframe,
+                universe_type=strategy.universe_type,
+                universe_symbols=strategy.universe_symbols,
+                max_position_pct_equity=strategy.max_position_pct_equity,
+                max_notional_per_trade=strategy.max_notional_per_trade,
+            )
+        )
+    preview_session.commit()
+
+
+def _run_dry_run_materialization(
+    *,
+    source_session: Session,
+    plan: Mapping[str, Any],
+    max_notional: Decimal,
+    summaries: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    preview_engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    try:
+        Base.metadata.create_all(preview_engine)
+        preview_session_factory = sessionmaker(
+            bind=preview_engine,
+            autoflush=False,
+            expire_on_commit=False,
+            future=True,
+        )
+        with preview_session_factory() as preview_session:
+            _copy_preview_strategies(
+                source_session=source_session,
+                preview_session=preview_session,
+                strategy_names=_strategy_names_from_summaries(summaries),
+            )
+            return _run_materialization(
+                session=preview_session,
+                plan=plan,
+                max_notional=max_notional,
+                commit=False,
+            )
+    finally:
+        preview_engine.dispose()
+
+
+def _run_materialization(
+    *,
+    session: Session,
+    plan: Mapping[str, Any],
+    max_notional: Decimal,
+    commit: bool,
+) -> dict[str, Any]:
+    result = materialize_bounded_paper_route_target_plan(
+        session,
+        plan,
+        generated_at=datetime.now(timezone.utc),
+        bounded_notional_limit=max_notional,
+    )
+    if commit and not result.get("blockers"):
+        session.commit()
+    else:
+        session.rollback()
+    return result
+
+
+def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    dsn_env = _safe_text(args.database_dsn_env) or "DB_DSN"
+    dsn = _safe_text(os.environ.get(dsn_env))
+    max_notional = _safe_decimal(args.max_notional)
+    commit = bool(args.commit)
+    dry_run = not commit
+
+    try:
+        plan, plan_source = _load_plan(args)
+        load_blockers: list[str] = []
+    except Exception as exc:
+        plan = {}
+        plan_source = {"kind": "unavailable"}
+        load_blockers = [f"paper_route_materialization_plan_load_failed:{exc}"]
+
+    summaries = _target_summaries(plan)
+    blockers = load_blockers + _safety_blockers(
+        args=args,
+        plan=plan,
+        summaries=summaries,
+        dsn=dsn,
+        dsn_env=dsn_env,
+    )
+
+    materialization: dict[str, Any] = {}
+    if not blockers and dsn is not None:
+        try:
+            factory = _session_factory(dsn)
+            with factory() as session:
+                if commit:
+                    materialization = _run_materialization(
+                        session=session,
+                        plan=plan,
+                        max_notional=max_notional,
+                        commit=True,
+                    )
+                else:
+                    materialization = _run_dry_run_materialization(
+                        source_session=session,
+                        plan=plan,
+                        max_notional=max_notional,
+                        summaries=summaries,
+                    )
+            blockers.extend(str(item) for item in materialization.get("blockers", []))
+        except Exception as exc:
+            blockers.append(f"paper_route_materialization_database_failed:{exc}")
+
+    blockers = sorted(dict.fromkeys(blockers))
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "mode": "commit" if commit else "dry_run",
+        "dry_run": dry_run,
+        "commit": commit,
+        "materialized": commit and not blockers,
+        "account_label": _safe_text(args.account_label),
+        "required_account_label": PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+        "database_dsn_env": dsn_env,
+        "database_dsn_configured": bool(dsn),
+        "plan_source": plan_source,
+        "max_notional": _decimal_text(max_notional),
+        "capital_mode": _safe_text(args.capital_mode),
+        "promotion_allowed": False,
+        "final_authority_ok": False,
+        "final_promotion_allowed": False,
+        "capital_promotion_allowed": False,
+        "operator_confirmation_required": OPERATOR_CONFIRMATION if commit else None,
+        "target_count": len(summaries),
+        "hypothesis_ids": _unique_texts(
+            [item.get("hypothesis_id") for item in summaries]
+        ),
+        "candidate_ids": _unique_texts(
+            [item.get("candidate_id") for item in summaries]
+        ),
+        "runtime_strategy_names": _unique_texts(
+            [item.get("runtime_strategy_name") for item in summaries]
+        ),
+        "target_plan_refs": _unique_texts(
+            [item.get("target_plan_ref") for item in summaries]
+        ),
+        "targets": summaries,
+        "materialization": materialization,
+        "materialized_decision_count": int(
+            materialization.get("materialized_decision_count", 0)
+        ),
+        "route_submission_count": int(materialization.get("route_submission_count", 0)),
+        "blockers": blockers,
+        "blocked": bool(blockers),
+    }
+    return (2 if blockers else 0), report
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Materialize bounded H-PAIRS paper-route target-plan rows for "
+            "TORGHUT_SIM evidence collection. Defaults to dry-run and rolls back all "
+            "database writes unless --commit and every confirmation are supplied."
+        )
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--plan-json", type=Path, default=None)
+    source.add_argument("--plan-url", default=None)
+    parser.add_argument("--plan-url-timeout-seconds", type=float, default=5.0)
+    parser.add_argument("--plan-url-attempts", type=int, default=1)
+    parser.add_argument("--database-dsn-env", default="DB_DSN")
+    parser.add_argument(
+        "--account-label", default=PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL
+    )
+    parser.add_argument("--max-notional", default=None)
+    parser.add_argument("--capital-mode", default="paper")
+    parser.add_argument("--dry-run", action="store_true", default=True)
+    parser.add_argument("--commit", action="store_true")
+    parser.add_argument("--promotion-allowed", action="store_true")
+    parser.add_argument("--final-promotion-allowed", action="store_true")
+    parser.add_argument("--final-authority-ok", action="store_true")
+    parser.add_argument("--capital-promotion-allowed", action="store_true")
+    parser.add_argument("--confirm-account-label", default=None)
+    parser.add_argument("--confirm-dsn-env", default=None)
+    parser.add_argument("--confirm-hypothesis-id", default=None)
+    parser.add_argument("--confirm-candidate-id", default=None)
+    parser.add_argument("--confirm-runtime-strategy-name", default=None)
+    parser.add_argument("--confirm-target-plan-ref", default=None)
+    parser.add_argument("--confirm-max-notional", default=None)
+    parser.add_argument("--operator-confirmation", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    exit_code, report = build_report(args)
+    payload = json.dumps(report, indent=2, sort_keys=True, default=_json_default)
+    output_path = cast(Path | None, args.output)
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload + "\n", encoding="utf-8")
+    print(payload)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -1,0 +1,641 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, Strategy, TradeDecision
+from app.trading.paper_route_target_plan import (
+    materialize_bounded_paper_route_target_plan,
+)
+from scripts import materialize_bounded_paper_route_targets as cli
+
+
+def _hpairs_target(**overrides: object) -> dict[str, Any]:
+    target: dict[str, Any] = {
+        "hypothesis_id": "H-PAIRS-01",
+        "candidate_id": "c88421d619759b2cfaa6f4d0",
+        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+        "strategy_name": "microbar-cross-sectional-pairs-v1",
+        "account_label": "TORGHUT_SIM",
+        "source_plan_ref": "paper-route-plan:c88421d619759b2cfaa6f4d0",
+        "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+        "target_notional": "20",
+        "bounded_collection_stage": "paper",
+        "evidence_collection_stage": "paper",
+        "window_start": "2026-06-01T13:30:00+00:00",
+        "window_end": "2026-06-01T20:00:00+00:00",
+        "paper_route_probe_symbol_actions": {
+            "AAPL": "buy",
+            "AMZN": "sell",
+        },
+        "paper_route_probe_symbol_quantities": {
+            "AAPL": "1",
+            "AMZN": "1",
+        },
+        "paper_route_clean_window_state": "clean_window_collection_ready",
+        "paper_route_clean_window_baseline_state": {
+            "state": "clean",
+            "blockers": [],
+        },
+        "paper_route_clean_window_baseline_blockers": [],
+        "source_decision_readiness": {
+            "schema_version": "torghut.paper-route-source-decision-readiness.v1",
+            "ready": True,
+            "blockers": [],
+            "strategy_lookup_names": ["microbar-cross-sectional-pairs-v1"],
+            "matched_strategy": {
+                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                "enabled": True,
+                "base_timeframe": "1Min",
+                "universe_symbols": ["AAPL", "AMZN"],
+                "max_notional_per_trade": "25",
+            },
+            "raw_probe_symbols": ["AAPL", "AMZN"],
+            "scoped_probe_symbols": ["AAPL", "AMZN"],
+        },
+        "evidence_collection_ok": True,
+        "bounded_evidence_collection_authorized": True,
+        "capital_promotion_allowed": False,
+        "promotion_allowed": False,
+        "final_authority_ok": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "live_capital_routing_enabled": False,
+    }
+    target.update(overrides)
+    return target
+
+
+def _plan(*targets: dict[str, Any], **overrides: object) -> dict[str, Any]:
+    plan: dict[str, Any] = {
+        "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+        "source": "paper_route_evidence_audit",
+        "purpose": "next_session_paper_route_runtime_window_evidence_collection",
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "capital_promotion_allowed": False,
+        "targets": list(targets),
+    }
+    plan.update(overrides)
+    return plan
+
+
+@pytest.fixture()
+def sqlite_dsn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    dsn = f"sqlite+pysqlite:///{tmp_path / 'torghut.sqlite3'}"
+    engine = create_engine(dsn, future=True)
+    Base.metadata.create_all(engine)
+    session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    with session_local() as session:
+        session.add(
+            Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                description="H-PAIRS bounded target plan fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+                max_notional_per_trade=Decimal("25"),
+            )
+        )
+        session.commit()
+    monkeypatch.setenv("DB_DSN", dsn)
+    yield dsn
+    engine.dispose()
+
+
+@pytest.fixture()
+def in_memory_session() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    with session_local() as session:
+        session.add(
+            Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                description="H-PAIRS bounded target plan fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+                max_notional_per_trade=Decimal("25"),
+            )
+        )
+        session.commit()
+        yield session
+    engine.dispose()
+
+
+def _write_plan(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    plan_path = tmp_path / "target-plan.json"
+    plan_path.write_text(json.dumps(payload), encoding="utf-8")
+    return plan_path
+
+
+def _count_decisions(dsn: str) -> int:
+    engine = create_engine(dsn, future=True)
+    try:
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            return int(
+                session.execute(
+                    select(func.count()).select_from(TradeDecision)
+                ).scalar_one()
+            )
+    finally:
+        engine.dispose()
+
+
+def _run_cli(
+    argv: list[str], capsys: pytest.CaptureFixture[str]
+) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert isinstance(payload, dict)
+    return exit_code, payload
+
+
+def _safe_commit_args(plan_path: Path) -> list[str]:
+    return [
+        "--plan-json",
+        str(plan_path),
+        "--max-notional",
+        "25",
+        "--commit",
+        "--confirm-account-label",
+        "TORGHUT_SIM",
+        "--confirm-dsn-env",
+        "DB_DSN",
+        "--confirm-hypothesis-id",
+        "H-PAIRS-01",
+        "--confirm-candidate-id",
+        "c88421d619759b2cfaa6f4d0",
+        "--confirm-runtime-strategy-name",
+        "microbar-cross-sectional-pairs-v1",
+        "--confirm-target-plan-ref",
+        "paper-route-plan:c88421d619759b2cfaa6f4d0",
+        "--confirm-max-notional",
+        "25",
+        "--operator-confirmation",
+        cli.OPERATOR_CONFIRMATION,
+    ]
+
+
+def test_dry_run_is_default_and_rolls_back_materialization(
+    tmp_path: Path,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = _write_plan(tmp_path, _plan(_hpairs_target()))
+
+    exit_code, payload = _run_cli(
+        ["--plan-json", str(plan_path), "--max-notional", "25"],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert payload["mode"] == "dry_run"
+    assert payload["dry_run"] is True
+    assert payload["commit"] is False
+    assert payload["materialized"] is False
+    assert payload["account_label"] == "TORGHUT_SIM"
+    assert payload["max_notional"] == "25"
+    assert payload["promotion_allowed"] is False
+    assert payload["final_promotion_allowed"] is False
+    assert payload["capital_promotion_allowed"] is False
+    assert payload["materialized_decision_count"] == 2
+    assert payload["route_submission_count"] == 2
+    assert payload["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_commit_writes_only_for_torghut_sim_with_explicit_confirmations(
+    tmp_path: Path,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = _write_plan(tmp_path, _plan(_hpairs_target()))
+
+    exit_code, payload = _run_cli(_safe_commit_args(plan_path), capsys)
+
+    assert exit_code == 0
+    assert payload["mode"] == "commit"
+    assert payload["dry_run"] is False
+    assert payload["materialized"] is True
+    assert payload["materialized_decision_count"] == 2
+    assert payload["route_submission_count"] == 2
+    assert payload["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 2
+
+
+def test_commit_rejects_missing_account_and_dsn_confirmation(
+    tmp_path: Path,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = _write_plan(tmp_path, _plan(_hpairs_target()))
+
+    exit_code, payload = _run_cli(
+        [
+            "--plan-json",
+            str(plan_path),
+            "--max-notional",
+            "25",
+            "--commit",
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert (
+        "paper_route_materialization_commit_confirm_account_label_missing"
+        in payload["blockers"]
+    )
+    assert (
+        "paper_route_materialization_commit_confirm_dsn_env_missing"
+        in payload["blockers"]
+    )
+    assert (
+        "paper_route_materialization_operator_confirmation_missing"
+        in payload["blockers"]
+    )
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_rejects_live_account_labels(
+    tmp_path: Path,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = _write_plan(
+        tmp_path, _plan(_hpairs_target(account_label="TORGHUT_LIVE"))
+    )
+
+    exit_code, payload = _run_cli(
+        [
+            "--plan-json",
+            str(plan_path),
+            "--account-label",
+            "TORGHUT_LIVE",
+            "--max-notional",
+            "25",
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert (
+        "paper_route_materialization_account_label_must_be_torghut_sim"
+        in payload["blockers"]
+    )
+    assert (
+        "paper_route_materialization_live_account_label_rejected" in payload["blockers"]
+    )
+    assert (
+        "paper_route_materialization_target_0_account_label_must_be_torghut_sim"
+        in payload["blockers"]
+    )
+    assert (
+        "paper_route_materialization_target_0_live_account_label_rejected"
+        in payload["blockers"]
+    )
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_rejects_unbounded_or_missing_target_identity(
+    tmp_path: Path,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = _write_plan(
+        tmp_path,
+        _plan(
+            _hpairs_target(
+                candidate_id="",
+                source_plan_ref="",
+                source_manifest_ref="",
+                target_notional="0",
+            )
+        ),
+    )
+
+    exit_code, payload = _run_cli(["--plan-json", str(plan_path)], capsys)
+
+    assert exit_code == 2
+    assert (
+        "paper_route_materialization_bounded_max_notional_required"
+        in payload["blockers"]
+    )
+    assert (
+        "paper_route_materialization_target_0_candidate_id_missing"
+        in payload["blockers"]
+    )
+    assert (
+        "paper_route_materialization_target_0_target_plan_ref_missing"
+        in payload["blockers"]
+    )
+    assert (
+        "paper_route_materialization_target_0_target_notional_missing"
+        in payload["blockers"]
+    )
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_rejects_promotion_capital_and_final_authority_flags(
+    tmp_path: Path,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = _write_plan(
+        tmp_path,
+        _plan(
+            _hpairs_target(capital_promotion_allowed=True, final_authority_ok=True),
+            promotion_allowed=True,
+        ),
+    )
+
+    exit_code, payload = _run_cli(
+        [
+            "--plan-json",
+            str(plan_path),
+            "--max-notional",
+            "25",
+            "--promotion-allowed",
+            "--final-promotion-allowed",
+            "--capital-promotion-allowed",
+        ],
+        capsys,
+    )
+
+    blockers = set(payload["blockers"])
+    assert exit_code == 2
+    assert (
+        "paper_route_materialization_request_promotion_allowed_must_be_false"
+        in blockers
+    )
+    assert (
+        "paper_route_materialization_request_final_promotion_allowed_must_be_false"
+        in blockers
+    )
+    assert (
+        "paper_route_materialization_request_capital_promotion_allowed_must_be_false"
+        in blockers
+    )
+    assert (
+        "paper_route_materialization_plan_promotion_allowed_must_be_false" in blockers
+    )
+    assert (
+        "paper_route_materialization_target_0_capital_promotion_allowed_must_be_false"
+        in blockers
+    )
+    assert (
+        "paper_route_materialization_target_0_final_authority_ok_must_be_false"
+        in blockers
+    )
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_cli_preserves_existing_paper_route_target_plan_materialization_semantics(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    in_memory_session: Session,
+    sqlite_dsn: str,
+) -> None:
+    plan = _plan(_hpairs_target())
+    direct = materialize_bounded_paper_route_target_plan(
+        in_memory_session,
+        plan,
+        generated_at=datetime(2026, 6, 1, 13, 35, tzinfo=timezone.utc),
+        bounded_notional_limit=Decimal("25"),
+    )
+    plan_path = _write_plan(tmp_path, plan)
+
+    exit_code, payload = _run_cli(_safe_commit_args(plan_path), capsys)
+
+    assert exit_code == 0
+    assert payload["materialization"]["schema_version"] == direct["schema_version"]
+    assert (
+        payload["materialization"]["source_decision_mode"]
+        == direct["source_decision_mode"]
+    )
+    assert (
+        payload["materialized_decision_count"] == direct["materialized_decision_count"]
+    )
+    assert payload["route_submission_count"] == direct["route_submission_count"]
+    assert payload["candidate_ids"] == ["c88421d619759b2cfaa6f4d0"]
+    assert payload["runtime_strategy_names"] == ["microbar-cross-sectional-pairs-v1"]
+    assert payload["target_plan_refs"] == ["paper-route-plan:c88421d619759b2cfaa6f4d0"]
+    assert payload["materialization"]["promotion_allowed"] is False
+    assert payload["materialization"]["final_promotion_allowed"] is False
+    assert payload["materialization"]["live_capital_routing_enabled"] is False
+
+
+def test_paper_route_target_plan_json_and_scalar_helpers_preserve_report_encoding_edges() -> (
+    None
+):
+    generated_at = datetime(2026, 6, 2, 12, 0, tzinfo=timezone.utc)
+
+    assert cli._json_default(Decimal("12.500")) == "12.500"
+    assert cli._json_default(generated_at) == generated_at.isoformat()
+    assert cli._json_default(Path("target-plan.json")) == "target-plan.json"
+    assert cli._safe_decimal("not-a-number") == Decimal("0")
+    assert cli._truthy(1) is True
+    assert cli._truthy(0) is False
+
+
+def test_paper_route_target_plan_target_summary_accepts_explicit_quantity_and_symbol_fallbacks() -> (
+    None
+):
+    target = _hpairs_target(
+        paper_route_probe_symbol_quantities={},
+        target_quantity="3",
+    )
+
+    summaries = cli._target_summaries(_plan(target))
+
+    assert summaries == [
+        {
+            "target_index": 0,
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "account_label": "TORGHUT_SIM",
+            "target_plan_ref": "paper-route-plan:c88421d619759b2cfaa6f4d0",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+            "bounded_collection_stage": "paper",
+            "target_notional": "20",
+            "target_quantity": "3",
+            "symbols": ["AAPL", "AMZN"],
+            "symbol_actions": {"AAPL": "buy", "AMZN": "sell"},
+            "symbol_quantities": {"AAPL": "3", "AMZN": "3"},
+        }
+    ]
+
+
+def test_paper_route_target_plan_invalid_payload_reports_load_blockers(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = tmp_path / "invalid-plan.json"
+    plan_path.write_text("[]", encoding="utf-8")
+
+    exit_code, payload = _run_cli(
+        ["--plan-json", str(plan_path), "--max-notional", "25"],
+        capsys,
+    )
+
+    assert exit_code == 2
+    blockers = set(payload["blockers"])
+    assert (
+        "paper_route_materialization_plan_load_failed:paper_route_target_plan_json_must_be_object"
+        in blockers
+    )
+    assert "paper_route_materialization_target_plan_targets_missing" in blockers
+
+
+def test_paper_route_target_plan_missing_dsn_live_capital_mode_and_empty_plan_are_blockers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("DB_DSN", raising=False)
+    plan_path = _write_plan(tmp_path, _plan())
+
+    exit_code, payload = _run_cli(
+        [
+            "--plan-json",
+            str(plan_path),
+            "--max-notional",
+            "25",
+            "--capital-mode",
+            "live",
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    blockers = set(payload["blockers"])
+    assert "paper_route_materialization_database_dsn_env_missing" in blockers
+    assert "paper_route_materialization_non_live_capital_mode_required" in blockers
+    assert "paper_route_materialization_target_plan_targets_missing" in blockers
+
+
+def test_paper_route_target_plan_rejects_exceeded_notional_missing_quantity_and_missing_actions(
+    tmp_path: Path,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = _write_plan(
+        tmp_path,
+        _plan(
+            _hpairs_target(
+                paper_route_probe_symbol_actions={},
+                paper_route_probe_symbol_quantities={},
+                target_quantity="",
+                target_notional="50",
+            )
+        ),
+    )
+
+    exit_code, payload = _run_cli(
+        ["--plan-json", str(plan_path), "--max-notional", "25"],
+        capsys,
+    )
+
+    assert exit_code == 2
+    blockers = set(payload["blockers"])
+    assert (
+        "paper_route_materialization_target_0_target_notional_exceeds_max" in blockers
+    )
+    assert "paper_route_materialization_target_0_target_quantity_missing" in blockers
+    assert "paper_route_materialization_target_0_symbol_actions_missing" in blockers
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_paper_route_target_plan_writes_json_output_file_for_safe_dry_run(
+    tmp_path: Path,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = _write_plan(tmp_path, _plan(_hpairs_target()))
+    output_path = tmp_path / "reports" / "materialization.json"
+
+    exit_code, payload = _run_cli(
+        [
+            "--plan-json",
+            str(plan_path),
+            "--max-notional",
+            "25",
+            "--output",
+            str(output_path),
+        ],
+        capsys,
+    )
+
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert written["schema_version"] == cli.SCHEMA_VERSION
+    assert written["dry_run"] is True
+    assert written == payload
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_paper_route_target_plan_url_load_failure_is_reported_without_materialization(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code, payload = _run_cli(
+        [
+            "--plan-url",
+            "file:///tmp/target-plan.json",
+            "--max-notional",
+            "25",
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert (
+        "paper_route_materialization_plan_load_failed:paper_route_target_plan_invalid_scheme:file"
+        in payload["blockers"]
+    )
+    assert payload["plan_source"] == {"kind": "unavailable"}
+
+
+def test_paper_route_target_plan_database_open_failure_is_reported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    plan_path = _write_plan(tmp_path, _plan(_hpairs_target()))
+    monkeypatch.setenv(
+        "DB_DSN",
+        f"sqlite+pysqlite:///{tmp_path / 'missing' / 'torghut.sqlite3'}",
+    )
+
+    exit_code, payload = _run_cli(
+        ["--plan-json", str(plan_path), "--max-notional", "25"],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert any(
+        blocker.startswith("paper_route_materialization_database_failed:")
+        for blocker in payload["blockers"]
+    )


### PR DESCRIPTION
## Summary

- Added `scripts/materialize_bounded_paper_route_targets.py`, a JSON-emitting CLI that loads H-PAIRS paper-route target plans from a file or URL and defaults to dry-run preview mode.
- Enforced fail-closed safety checks for TORGHUT_SIM-only account labels, explicit bounded max notional, target identity, non-live capital mode, false promotion/final/capital flags, DSN confirmation, and operator confirmation before any commit.
- Kept dry-run previews isolated from the configured database by copying matching strategy rows into an in-memory preview database before invoking existing materialization semantics.
- Added regression coverage for dry-run no writes, guarded commits, live-label rejection, unbounded or missing identity rejection, promotion/capital/final flag rejection, and parity with the existing paper-route target-plan materializer.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py tests/test_verify_trading_readiness.py -k paper_route_target_plan -q`
- `cd services/torghut && uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py app/trading/paper_route_target_plan.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py app/trading/paper_route_target_plan.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
