### PR TITLE
fix(synthesis): suppress protective order false alerts

### DIFF
--- a/apps/synthesis/src/routes/-autotrader-alerts.test.ts
+++ b/apps/synthesis/src/routes/-autotrader-alerts.test.ts
@@ -247,6 +247,51 @@ describe('getAutotraderRuntimeAlerts', () => {
     )
   })
 
+  test('does not flag broker-attached protective OCO orders as unreconciled', () => {
+    const detail = detailFor({
+      orders: [
+        {
+          sessionId: 'session-1',
+          ticketId: null,
+          clientOrderId: 'atr-20260529-test-1-AVGO-oco-repair-01',
+          brokerOrderId: 'alpaca-oco-1',
+          symbol: 'AVGO',
+          instrument: 'stock',
+          side: 'sell',
+          quantity: '5',
+          orderType: 'limit',
+          orderClass: 'oco',
+          limitPrice: '488.40',
+          stopPrice: null,
+          takeProfitLimitPrice: null,
+          stopLossStopPrice: '481.40',
+          stopLossLimitPrice: '481.10',
+          status: 'accepted',
+          rejectReason: null,
+          brokerPayload: {},
+          updatedAt: '2026-05-29T13:59:20Z',
+        },
+      ],
+      positionSnapshots: [
+        {
+          id: 'pos-avgo',
+          sessionId: 'session-1',
+          symbol: 'AVGO',
+          quantity: '5',
+          marketValue: '2417.25',
+          averageEntryPrice: '483.194',
+          unrealizedPnl: '1.28',
+          capturedAt: '2026-05-29T13:59:30Z',
+          brokerPayload: {},
+        },
+      ],
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, now).map((alert) => alert.key)).not.toContain(
+      'unreconciled-order:atr-20260529-test-1-AVGO-oco-repair-01',
+    )
+  })
+
   test('flags positions with no confirmed protection or managed-loop fallback', () => {
     const detail = detailFor({
       positionSnapshots: [

--- a/apps/synthesis/src/routes/-autotrader-alerts.ts
+++ b/apps/synthesis/src/routes/-autotrader-alerts.ts
@@ -23,6 +23,7 @@ const terminalOrderStatuses = new Set<AutotraderOrder['status']>([
 ])
 
 const protectiveOrderClasses = new Set(['bracket', 'oco', 'oto'])
+const protectiveExitOrderClasses = new Set(['oco'])
 
 const ageMs = (value: string | null | undefined, now: Date) => {
   if (!value) return null
@@ -131,16 +132,31 @@ export const didMarketSessionEndEarly = (detail: AutotraderSessionDetail) => {
   return finalizedAt != null && marketClose != null && finalizedAt < marketClose
 }
 
-export const isAutotraderOrderUnreconciled = (order: AutotraderOrder, now = new Date()) => {
-  if (terminalOrderStatuses.has(order.status)) return false
-  const orderAgeMs = ageMs(order.updatedAt, now)
-  return orderAgeMs == null || orderAgeMs > unreconciledOrderMs
-}
-
 export const hasBrokerAttachedProtection = (order: AutotraderOrder) => {
   if (order.status === 'rejected' || order.status === 'canceled' || order.status === 'expired') return false
   if (order.orderClass && protectiveOrderClasses.has(order.orderClass.toLowerCase())) return true
   return Boolean(order.stopPrice || order.takeProfitLimitPrice || order.stopLossStopPrice || order.stopLossLimitPrice)
+}
+
+const isBrokerAttachedProtectiveExitOrder = (order: AutotraderOrder) => {
+  if (!order.brokerOrderId) return false
+  const orderClass = order.orderClass?.toLowerCase() ?? ''
+  const orderType = order.orderType.toLowerCase()
+  return (
+    protectiveExitOrderClasses.has(orderClass) ||
+    orderClass.includes('take_profit') ||
+    orderClass.includes('stop_loss') ||
+    orderType === 'stop' ||
+    orderType === 'stop_limit' ||
+    Boolean(order.stopPrice || order.stopLossStopPrice || order.stopLossLimitPrice)
+  )
+}
+
+export const isAutotraderOrderUnreconciled = (order: AutotraderOrder, now = new Date()) => {
+  if (terminalOrderStatuses.has(order.status)) return false
+  if (isBrokerAttachedProtectiveExitOrder(order)) return false
+  const orderAgeMs = ageMs(order.updatedAt, now)
+  return orderAgeMs == null || orderAgeMs > unreconciledOrderMs
 }
 
 const ticketHasManagedLoopFallback = (ticket: AutotraderTradeTicket) =>


### PR DESCRIPTION
## Summary

- Prevent live broker-attached protective exit orders from being reported as stale unreconciled orders.
- Keep stale nonterminal entry/order alerts intact for orders that still need reconciliation.
- Add a regression test using the live AVGO repaired OCO shape.

## Related Issues

None

## Testing

- `bun test apps/synthesis/src/routes/-autotrader-alerts.test.ts`
- `bunx oxfmt --check apps/synthesis/src/routes/-autotrader-alerts.ts apps/synthesis/src/routes/-autotrader-alerts.test.ts`
- `bun run lint:synthesis`
- `git diff --check -- apps/synthesis/src/routes/-autotrader-alerts.ts apps/synthesis/src/routes/-autotrader-alerts.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
