### PR TITLE
fix(synthesis): link related autotrader scorecards

### DIFF
--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -741,6 +741,130 @@ describe('synthesis REST auth', () => {
     })
   })
 
+  test('links related prior scorecards to active autotrader session detail', async () => {
+    const authedHeaders = {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    }
+    const priorSessionResponse = await handleAutotraderStartSession(
+      new Request('http://synthesis.test/api/autotrader/sessions', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          agentRunName: 'autonomous-trader-related-scorecard-source',
+          mode: 'market_open',
+          tradingDate: '2026-05-29',
+          accountId: 'paper-account',
+          goalEquity: '500000',
+          marketOpenAt: '2026-05-29T13:30:00Z',
+          marketCloseAt: '2026-05-29T20:00:00Z',
+        }),
+      }),
+    )
+    const priorSessionId = (await priorSessionResponse.json()).session.id
+    const priorTicketResponse = await handleAutotraderCreateTradeTicket(
+      new Request('http://synthesis.test/api/autotrader/trade-tickets', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId: priorSessionId,
+          idempotencyKey: 'googl-vwap-prior-afternoon',
+          symbol: 'GOOGL',
+          instrument: 'stock',
+          side: 'buy',
+          setupType: 'vwap_reclaim',
+          setupGrade: 'A',
+          regime: 'regular_session',
+          timeBucket: 'afternoon',
+          thesis: 'Older GOOGL reclaim was invalid.',
+          entryTrigger: 'VWAP reclaim.',
+          invalidation: 'Lose VWAP.',
+          protectionType: 'none',
+          status: 'blocked',
+        }),
+      }),
+    )
+    const priorTicketId = (await priorTicketResponse.json()).ticket.id
+    await handleAutotraderFinalizeSession(
+      new Request('http://synthesis.test/api/autotrader/finalize', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId: priorSessionId,
+          terminalReason: 'market_closed',
+          summary: { accountEquity: '30000' },
+          scorecardObservations: [
+            {
+              ticketId: priorTicketId,
+              symbol: 'GOOGL',
+              setupType: 'vwap_reclaim',
+              setupGrade: 'A',
+              regime: 'regular_session',
+              timeBucket: 'afternoon',
+              outcome: 'rejected_invalid',
+              realizedR: '0',
+              notes: 'older GOOGL A reclaim was blocked correctly',
+            },
+          ],
+        }),
+      }),
+    )
+
+    const currentSessionResponse = await handleAutotraderStartSession(
+      new Request('http://synthesis.test/api/autotrader/sessions', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          agentRunName: 'autonomous-trader-related-scorecard-consumer',
+          mode: 'market_open',
+          tradingDate: '2026-06-02',
+          accountId: 'paper-account',
+          goalEquity: '500000',
+          marketOpenAt: '2026-06-02T13:30:00Z',
+          marketCloseAt: '2026-06-02T20:00:00Z',
+        }),
+      }),
+    )
+    const currentSessionId = (await currentSessionResponse.json()).session.id
+    await handleAutotraderCreateTradeTicket(
+      new Request('http://synthesis.test/api/autotrader/trade-tickets', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId: currentSessionId,
+          idempotencyKey: 'googl-vwap-current-aplus',
+          symbol: 'GOOGL',
+          instrument: 'stock',
+          side: 'buy',
+          setupType: 'vwap_reclaim',
+          setupGrade: 'A+',
+          regime: 'regular_session',
+          timeBucket: 'mid_session',
+          thesis: 'Current A+ setup should show related prior GOOGL reclaim context.',
+          entryTrigger: 'VWAP reclaim.',
+          invalidation: 'Lose VWAP.',
+          protectionType: 'bracket',
+          status: 'validated',
+        }),
+      }),
+    )
+
+    const detailResponse = await handleAutotraderGetSession(
+      new Request(`http://synthesis.test/api/autotrader/sessions/${currentSessionId}`),
+      currentSessionId,
+    )
+    const detailPayload = await detailResponse.json()
+
+    expect(detailPayload.setupExamples).toHaveLength(0)
+    expect(detailPayload.scorecards[0]).toMatchObject({
+      symbol: 'GOOGL',
+      setupType: 'vwap_reclaim',
+      setupGrade: 'A',
+      timeBucket: 'afternoon',
+      rejectedInvalid: 1,
+    })
+  })
+
   test('finalizes idempotently and detaches cross-session ticket references', async () => {
     const authedHeaders = {
       authorization: `Bearer ${token}`,

--- a/apps/synthesis/src/server/autotrader-store.ts
+++ b/apps/synthesis/src/server/autotrader-store.ts
@@ -129,6 +129,32 @@ const scorecardKeyFor = (value: {
     .digest('base64url')
     .slice(0, 32)
 
+const scorecardRelationKeyFor = (value: { symbol?: string | null; setupType: string }) => {
+  const symbol = normalizedSymbol(value.symbol)
+  const setupType = value.setupType.trim().toLowerCase()
+  return symbol && setupType ? `${symbol}|${setupType}` : null
+}
+
+const scorecardRelationsForTickets = (tickets: AutotraderTradeTicket[]) => {
+  const relationByKey = new Map<string, { symbol: string; setupType: string }>()
+  for (const ticket of tickets) {
+    const relationKey = scorecardRelationKeyFor(ticket)
+    const symbol = normalizedSymbol(ticket.symbol)
+    const setupType = ticket.setupType.trim()
+    if (!relationKey || !symbol || !setupType) continue
+    relationByKey.set(relationKey, { symbol, setupType })
+  }
+  return [...relationByKey.values()]
+}
+
+const scorecardMatchesTicketRelation = (scorecard: AutotraderScorecard, relationKeys: ReadonlySet<string>) => {
+  const relationKey = scorecardRelationKeyFor(scorecard)
+  return Boolean(relationKey && relationKeys.has(relationKey))
+}
+
+const scorecardRelationKeySet = (relations: { symbol: string; setupType: string }[]) =>
+  new Set(relations.map((relation) => scorecardRelationKeyFor(relation)).filter((key): key is string => Boolean(key)))
+
 type FinalizationWarning = {
   type: 'detached_unknown_ticket_id' | 'detached_cross_session_ticket_id'
   ticketId: string
@@ -622,6 +648,7 @@ class InMemoryAutotraderStore implements AutotraderStore {
         }),
       ),
     ])
+    const sessionScorecardRelationKeys = scorecardRelationKeySet(scorecardRelationsForTickets(sessionTickets))
     return {
       session,
       status: this.statuses.get(sessionId) ?? null,
@@ -635,7 +662,13 @@ class InMemoryAutotraderStore implements AutotraderStore {
       positionSnapshots: latestPositionSnapshots(
         [...this.positions.values()].filter((snapshot) => snapshot.sessionId === sessionId),
       ),
-      scorecards: [...this.scorecards.values()].filter((scorecard) => sessionScorecardKeys.has(scorecard.key)),
+      scorecards: [...this.scorecards.values()]
+        .filter(
+          (scorecard) =>
+            sessionScorecardKeys.has(scorecard.key) ||
+            scorecardMatchesTicketRelation(scorecard, sessionScorecardRelationKeys),
+        )
+        .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt)),
       setupExamples: sessionExamples,
     }
   }
@@ -1583,14 +1616,26 @@ class PostgresAutotraderStore implements AutotraderStore {
         ),
       ]),
     ]
-    const scorecards = sessionScorecardKeys.length
+    const scorecardWhere: string[] = []
+    const scorecardValues: unknown[] = []
+    if (sessionScorecardKeys.length) {
+      scorecardValues.push(sessionScorecardKeys)
+      scorecardWhere.push(`key = ANY($${scorecardValues.length}::text[])`)
+    }
+    for (const relation of scorecardRelationsForTickets(tickets)) {
+      scorecardValues.push(relation.symbol)
+      const symbolParameter = scorecardValues.length
+      scorecardValues.push(relation.setupType)
+      scorecardWhere.push(`(symbol = $${symbolParameter} AND setup_type = $${scorecardValues.length})`)
+    }
+    const scorecards = scorecardWhere.length
       ? (
           await this.pool.query<ScorecardRow>(
             `SELECT *
              FROM autotrader.scorecards
-             WHERE key = ANY($1::text[])
+             WHERE ${scorecardWhere.join(' OR ')}
              ORDER BY updated_at DESC`,
-            [sessionScorecardKeys],
+            scorecardValues,
           )
         ).rows.map(mapScorecard)
       : []


### PR DESCRIPTION
## Summary

- Link autotrader session detail to related prior scorecards by normalized symbol and setup type, even when grade, regime, or time bucket differ.
- Keep exact same-session setup examples unchanged while exposing prior learning that the trader can already read through the scorecard endpoint.
- Add a regression for an active GOOGL A+ ticket surfacing an older GOOGL vwap_reclaim scorecard.

## Related Issues

None

## Testing

- `bun test apps/synthesis/src/server/__tests__/api.test.ts -t "links related prior scorecards to active autotrader session detail"`
- `bun test apps/synthesis/src/server/__tests__/api.test.ts apps/synthesis/src/server/__tests__/mcp.test.ts`
- `bunx oxfmt --check apps/synthesis/src/server/autotrader-store.ts apps/synthesis/src/server/__tests__/api.test.ts`
- `bun run lint:synthesis`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
