### PR TITLE
fix(torghut): normalize materializer postgres dsn

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -400,13 +400,24 @@ def _safety_blockers(
 
 
 def _session_factory(dsn: str) -> sessionmaker[Session]:
-    engine = create_engine(dsn, pool_pre_ping=True, future=True)
+    engine = create_engine(_sqlalchemy_dsn(dsn), pool_pre_ping=True, future=True)
     return sessionmaker(
         bind=engine,
         autoflush=False,
         expire_on_commit=False,
         future=True,
     )
+
+
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
 
 
 def _strategy_names_from_summaries(

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -459,6 +459,24 @@ def test_paper_route_target_plan_json_and_scalar_helpers_preserve_report_encodin
     assert cli._truthy(0) is False
 
 
+def test_paper_route_target_plan_sqlalchemy_dsn_uses_installed_psycopg_driver() -> None:
+    assert (
+        cli._sqlalchemy_dsn("postgres://user:pass@postgres/torghut")
+        == "postgresql+psycopg://user:pass@postgres/torghut"
+    )
+    assert (
+        cli._sqlalchemy_dsn("postgresql://user:pass@postgres/torghut")
+        == "postgresql+psycopg://user:pass@postgres/torghut"
+    )
+    assert (
+        cli._sqlalchemy_dsn("postgresql+psycopg://user:pass@postgres/torghut")
+        == "postgresql+psycopg://user:pass@postgres/torghut"
+    )
+    assert cli._sqlalchemy_dsn("sqlite+pysqlite:///:memory:") == (
+        "sqlite+pysqlite:///:memory:"
+    )
+
+
 def test_paper_route_target_plan_target_summary_accepts_explicit_quantity_and_symbol_fallbacks() -> (
     None
 ):


### PR DESCRIPTION
## Summary

- Normalize the bounded paper-route materializer SQLAlchemy DSN so raw `postgres://` and `postgresql://` URLs use the installed `psycopg` v3 driver.
- Keep sqlite and already-normalized `postgresql+psycopg://` URLs unchanged.
- Add regression coverage for the DSN normalization path that blocked the promoted-image dry-run.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
