### PR TITLE
fix(torghut): clean hpairs runtime proof import debt

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -403,6 +403,14 @@ def _build_bucket(
     usable_fills = [row for row in rows if row.is_usable_fill]
     carry_in_usable_fills = [row for row in carry_in_rows if row.is_usable_fill]
     all_usable_fills = [*carry_in_usable_fills, *usable_fills]
+    current_bucket_filled_notional = sum(
+        (
+            row.filled_notional
+            for row in usable_fills
+            if row.filled_notional is not None
+        ),
+        Decimal("0"),
+    )
     if not usable_fills:
         blockers.append("runtime_fills_missing")
 
@@ -469,7 +477,11 @@ def _build_bucket(
         blockers.append("closed_round_trip_missing")
     if open_position_count > 0:
         blockers.append("unclosed_position")
-    if accumulator.filled_notional <= 0:
+    reported_filled_notional = max(
+        accumulator.filled_notional,
+        current_bucket_filled_notional,
+    )
+    if reported_filled_notional <= 0:
         blockers.append("filled_notional_missing")
     if require_order_lifecycle or source_authority_claimed:
         source_lifecycle_present = any(
@@ -532,7 +544,7 @@ def _build_bucket(
         unfilled_order_count=unfilled_order_count,
         closed_trade_count=accumulator.closed_trade_count,
         open_position_count=open_position_count,
-        filled_notional=accumulator.filled_notional,
+        filled_notional=reported_filled_notional,
         gross_strategy_pnl=accumulator.gross_strategy_pnl,
         cost_amount=accumulator.cost_amount,
         net_strategy_pnl_after_costs=accumulator.net_strategy_pnl_after_costs,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -472,18 +472,21 @@ def _source_decision_priority_payloads(
     decision_json = _as_mapping(row.get("decision_json"))
     if decision_json:
         payloads.append(decision_json)
+        params = _as_mapping(decision_json.get("params"))
+        if params:
+            payloads.append(params)
         for key in (
             "strategy_signal_paper",
+            "paper_route_target_plan_source_decision",
             "paper_route_target_plan",
             "paper_route_target",
         ):
             if nested := _as_mapping(decision_json.get(key)):
                 payloads.append(nested)
-        params = _as_mapping(decision_json.get("params"))
         if params:
-            payloads.append(params)
             for key in (
                 "strategy_signal_paper",
+                "paper_route_target_plan_source_decision",
                 "paper_route_target_plan",
                 "paper_route_target",
             ):
@@ -4822,12 +4825,19 @@ def _source_runtime_ledger_payload_from_row(
     row: Sequence[object],
 ) -> dict[str, object]:
     payload = dict(zip(_SOURCE_RUNTIME_LEDGER_COLUMNS, row, strict=True))
-    payload_json = _as_mapping(payload.get("payload_json"))
+    payload_json = {
+        key: value
+        for key, value in _as_mapping(payload.get("payload_json")).items()
+        if key != "payload_json"
+    }
+    row_payload = {
+        key: value for key, value in payload.items() if key != "payload_json"
+    }
     started_at = _parse_dt_or_none(payload.get("bucket_started_at"))
     ended_at = _parse_dt_or_none(payload.get("bucket_ended_at"))
     return {
         **payload_json,
-        **payload,
+        **row_payload,
         "bucket_started_at": started_at.isoformat()
         if started_at is not None
         else payload.get("bucket_started_at"),

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -64,6 +64,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _source_decision_mode,
     _source_decision_mode_counts,
     _source_decision_rows_profit_proof_eligible,
+    _source_runtime_ledger_payload_from_row,
     _source_order_feed_payload_delta_fill,
     _required_order_lifecycle_source_row_count,
     _source_window_classification_counts,
@@ -1795,6 +1796,43 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             )
         )
 
+    def test_source_decision_helpers_prefer_current_target_source_over_legacy_probe(
+        self,
+    ) -> None:
+        row = {
+            "decision_json": {
+                "paper_route_target_plan": {
+                    "source_decision_mode": "route_acquisition_probe",
+                    "profit_proof_eligible": False,
+                },
+                "params": {
+                    "source_decision_mode": "bounded_paper_route_collection",
+                    "profit_proof_eligible": True,
+                    "source_candidate_ids": ["c88421d619759b2cfaa6f4d0"],
+                    "source_hypothesis_ids": ["H-PAIRS-01"],
+                    "paper_route_target_plan_source_decision": {
+                        "source_decision_mode": "bounded_paper_route_collection",
+                        "profit_proof_eligible": True,
+                    },
+                },
+            }
+        }
+
+        self.assertEqual(_source_decision_mode(row), "bounded_paper_route_collection")
+        self.assertEqual(
+            _source_decision_mode_counts([row]),
+            {"bounded_paper_route_collection": 1},
+        )
+        self.assertTrue(_source_decision_rows_profit_proof_eligible([row]))
+        self.assertTrue(
+            _source_row_matches_lineage(
+                row,
+                candidate_id="c88421d619759b2cfaa6f4d0",
+                hypothesis_id="H-PAIRS-01",
+                require_source_lineage=True,
+            )
+        )
+
     def test_runtime_ledger_tca_rows_from_durable_buckets_queries_matching_proof(
         self,
     ) -> None:
@@ -2109,6 +2147,23 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 ["intraday-tsmom-profit-v3"],
             ),
         )
+
+    def test_source_runtime_ledger_payload_drops_recursive_payload_json(self) -> None:
+        cursor = _SourceLedgerCursor()
+        row = list(cursor._results[0][0])
+        payload_json = dict(cast(Mapping[str, object], row[-1]))
+        payload_json["payload_json"] = {"stale_nested_payload": True}
+        row[-1] = payload_json
+
+        payload = _source_runtime_ledger_payload_from_row(tuple(row))
+
+        self.assertNotIn("payload_json", payload)
+        self.assertEqual(payload["run_id"], "runtime-proof-source")
+        self.assertEqual(
+            payload["source_decision_mode_counts"],
+            {"strategy_signal_paper": 2},
+        )
+        self.assertEqual(payload["bucket_started_at"], "2026-03-06T14:30:00+00:00")
 
     def test_runtime_ledger_tca_rows_from_source_dsn_block_aggregate_only_proof(
         self,

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -271,6 +271,7 @@ def test_partial_unclosed_positions_report_realized_pnl_but_block_expectancy() -
     assert bucket.closed_trade_count == 1
     assert bucket.open_position_count == 1
     assert "unclosed_position" in bucket.blockers
+    assert bucket.filled_notional == Decimal("1440")
     assert bucket.gross_strategy_pnl == Decimal("40")
     assert bucket.net_strategy_pnl_after_costs == Decimal("38.60")
     assert bucket.post_cost_expectancy_bps is None
@@ -1415,8 +1416,11 @@ def test_linked_order_feed_fill_accepts_structured_source_offsets_mapping() -> N
     )
 
     assert bucket.fill_count == 1
+    assert bucket.filled_notional == Decimal("100")
     assert "runtime_fills_missing" not in bucket.blockers
-    assert "filled_notional_missing" in bucket.blockers
+    assert "filled_notional_missing" not in bucket.blockers
+    assert "closed_round_trip_missing" in bucket.blockers
+    assert "unclosed_position" in bucket.blockers
 
 
 def test_linked_order_feed_fill_without_explicit_costs_stays_non_authority() -> None:
@@ -1621,10 +1625,11 @@ def test_source_authority_open_position_blocks_final_expectancy() -> None:
     assert bucket.fill_count == 1
     assert bucket.closed_trade_count == 0
     assert bucket.open_position_count == 1
+    assert bucket.filled_notional == Decimal("100")
     assert bucket.post_cost_expectancy_bps is None
     assert "unclosed_position" in bucket.blockers
     assert "closed_round_trip_missing" in bucket.blockers
-    assert "filled_notional_missing" in bucket.blockers
+    assert "filled_notional_missing" not in bucket.blockers
     assert "runtime_ledger_expectancy_missing" in bucket.blockers
 
 


### PR DESCRIPTION
## Summary

- Fix H-PAIRS runtime-ledger buckets so real source fill notional remains visible even when final authority still blocks on open positions or missing closed round trips.
- Prefer current bounded paper-route collection source-decision metadata over stale nested probe metadata during runtime-window imports.
- Drop recursive `payload_json` wrappers when importing source runtime-ledger buckets so old payload blobs do not keep poisoning evidence classification.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend runtime-ledger and importer change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
