### PR TITLE
fix(torghut): require canonical runtime ledger source ids

### DIFF
--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -340,7 +340,7 @@ def _promotion_grade_authority_marker_present(bucket: Mapping[str, object]) -> b
     return _promotion_grade_authority_field_present(
         bucket,
         "authority_class",
-    ) or _promotion_grade_authority_field_present(bucket, "authority_reason")
+    ) and _promotion_grade_authority_field_present(bucket, "authority_reason")
 
 
 def _non_promotion_derivation_present(bucket: Mapping[str, object]) -> bool:
@@ -503,64 +503,36 @@ def runtime_ledger_promotion_source_authority_blockers(
     if not _source_refs_present(
         bucket,
         "source_window_ids",
-        "source_window_id",
-        "source_window_refs",
-        "source_window_ref",
         "runtime_ledger_source_window_ids",
-        "runtime_ledger_source_window_id",
-        "runtime_ledger_source_window_refs",
-        "runtime_ledger_source_window_ref",
     ) or _source_ref_count(
         bucket,
         "source_window_ids",
-        "source_window_id",
-        "source_window_refs",
-        "source_window_ref",
         "runtime_ledger_source_window_ids",
-        "runtime_ledger_source_window_id",
-        "runtime_ledger_source_window_refs",
-        "runtime_ledger_source_window_ref",
     ) < _source_row_count(bucket, "order_feed_source_windows"):
         blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER)
         blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER)
     if not _source_refs_present(
         bucket,
         "trade_decision_ids",
-        "trade_decision_refs",
-        "trade_decision_id",
-        "decision_ids",
-        "decision_id",
     ) or _source_ref_count(
         bucket,
         "trade_decision_ids",
-        "trade_decision_refs",
-        "trade_decision_id",
-        "decision_ids",
-        "decision_id",
     ) < _source_row_count(bucket, "trade_decisions"):
         blockers.append(RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER)
     if not _source_refs_present(
         bucket,
         "execution_ids",
-        "execution_refs",
-        "execution_id",
     ) or _source_ref_count(
         bucket,
         "execution_ids",
-        "execution_refs",
-        "execution_id",
     ) < _source_row_count(bucket, "executions"):
         blockers.append(RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER)
     if not _source_refs_present(
         bucket,
         "execution_order_event_ids",
-        "execution_order_event_refs",
-        "execution_order_event_id",
     ) or _source_ref_count(
         bucket,
         "execution_order_event_ids",
-        "execution_order_event_refs",
-        "execution_order_event_id",
     ) < _source_row_count(bucket, "execution_order_events"):
         blockers.append(RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER)
     if not _source_offsets_present(bucket) or _source_offset_count(

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -59,6 +59,7 @@ def _source_payload(day_index: int) -> dict[str, object]:
         ],
         "source_materialization": "execution_order_events",
         "authority_class": "runtime_order_feed_execution_source",
+        "authority_reason": "event_sourced_runtime_ledger_profit_proof",
         "order_feed_lifecycle_complete": True,
         "execution_economics_complete": True,
         "cost_basis_counts": {"explicit_broker_fee_runtime": 1},

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -126,6 +126,7 @@ def _runtime_ledger_source_authority_payload(
         'source_offsets': source_offsets,
         'source_materialization': 'execution_order_events',
         'authority_class': 'runtime_order_feed_execution_source',
+        'authority_reason': 'event_sourced_runtime_ledger_profit_proof',
     }
     if cost_basis is not None:
         payload['cost_basis'] = cost_basis

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -949,7 +949,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("runtime_ledger_authority_class_missing", blockers)
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(aggregate_only))
 
-    def test_runtime_ledger_profit_proof_accepts_source_window_ref_aliases(
+    def test_runtime_ledger_profit_proof_rejects_source_ref_aliases(
         self,
     ) -> None:
         source_window_ref_bucket = _complete_runtime_ledger_bucket(
@@ -971,7 +971,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
         )
 
-        self.assertTrue(
+        self.assertIn(
+            "runtime_ledger_source_window_ids_missing",
+            _runtime_ledger_bucket_profit_proof_blockers(source_window_ref_bucket),
+        )
+        self.assertFalse(
             _runtime_ledger_bucket_profit_proof_present(source_window_ref_bucket)
         )
         self.assertTrue(

--- a/services/torghut/tests/test_inspect_hpairs_runtime_evidence.py
+++ b/services/torghut/tests/test_inspect_hpairs_runtime_evidence.py
@@ -56,6 +56,7 @@ def _source_payload(day_index: int) -> dict[str, object]:
         ],
         "source_materialization": "execution_order_events",
         "authority_class": "runtime_order_feed_execution_source",
+        "authority_reason": "event_sourced_runtime_ledger_profit_proof",
         "order_feed_lifecycle_complete": True,
         "execution_economics_complete": True,
         "cost_basis_counts": {"explicit_broker_fee_runtime": 1},

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -872,6 +872,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
+            "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             "source_decision_mode_counts": {"strategy_signal_paper": 1},
         }
 

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -39,15 +39,16 @@ def _source_backed_payload(**overrides: object) -> dict[str, object]:
             "order_feed_source_windows": 1,
         },
         **_economics_payload(),
-        "trade_decision_id": "decision-1",
-        "execution_id": "execution-1",
-        "execution_order_event_id": "event-1",
-        "source_window_id": "source-window-1",
+        "trade_decision_ids": ["decision-1"],
+        "execution_ids": ["execution-1"],
+        "execution_order_event_ids": ["event-1"],
+        "source_window_ids": ["source-window-1"],
         "source_offsets": [
             {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
         ],
         "source_materialization": "execution_order_events",
         "authority_class": "runtime_order_feed_execution_source",
+        "authority_reason": "event_sourced_runtime_ledger_profit_proof",
     }
     payload.update(overrides)
     return payload
@@ -201,6 +202,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
+            "authority_reason": "event_sourced_runtime_ledger_profit_proof",
         }
 
         self.assertEqual(
@@ -226,15 +228,16 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "execution_order_events": 1,
                 "order_feed_source_windows": 1,
             },
-            "trade_decision_id": "decision-1",
-            "execution_id": "execution-1",
-            "execution_order_event_id": "event-1",
-            "source_window_id": "source-window-1",
+            "trade_decision_ids": ["decision-1"],
+            "execution_ids": ["execution-1"],
+            "execution_order_event_ids": ["event-1"],
+            "source_window_ids": ["source-window-1"],
             "source_offsets": [
                 {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
+            "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             "filled_notional": "1000",
             "cost_amount": "0",
             "post_cost_basis_counts": {"broker_reported_zero_cost": 1},
@@ -283,7 +286,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
         self.assertIn("runtime_ledger_source_window_ids_missing", blockers)
         self.assertIn("runtime_ledger_source_offsets_missing", blockers)
 
-    def test_promotion_source_authority_counts_mapping_and_scalar_refs(
+    def test_promotion_source_authority_counts_mapping_canonical_refs(
         self,
     ) -> None:
         blockers = runtime_ledger_promotion_source_authority_blockers(
@@ -303,15 +306,16 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                     "order_feed_source_windows": 1,
                 },
                 **_economics_payload(),
-                "trade_decision_id": "decision-1",
-                "execution_id": "execution-1",
-                "execution_order_event_id": "event-1",
+                "trade_decision_ids": {"decision-1": True},
+                "execution_ids": ["execution-1"],
+                "execution_order_event_ids": {"event-1": True},
                 "source_window_ids": {"source-window-1": True},
                 "source_offsets": [
                     {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             }
         )
 
@@ -479,15 +483,16 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                     "execution_order_events": 1,
                     "order_feed_source_windows": 1,
                 },
-                "trade_decision_id": "decision-1",
-                "execution_id": "execution-1",
-                "execution_order_event_id": "event-1",
-                "source_window_id": "source-window-1",
+                "trade_decision_ids": ["decision-1"],
+                "execution_ids": ["execution-1"],
+                "execution_order_event_ids": ["event-1"],
+                "source_window_ids": ["source-window-1"],
                 "source_offsets": [
                     {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
                 "execution_economics_complete": False,
             }
         )
@@ -514,15 +519,16 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                     "order_feed_source_windows": 1,
                 },
                 **_economics_payload(),
-                "trade_decision_id": "decision-1",
-                "execution_id": "execution-1",
-                "execution_order_event_id": "event-1",
-                "source_window_id": "source-window-1",
+                "trade_decision_ids": ["decision-1"],
+                "execution_ids": ["execution-1"],
+                "execution_order_event_ids": ["event-1"],
+                "source_window_ids": ["source-window-1"],
                 "source_offsets": [
                     {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
                 "source_kind": "paper_route_probe_runtime_observed",
                 "promotion_authority": False,
             }
@@ -530,7 +536,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
 
         self.assertIn("runtime_ledger_authority_class_missing", blockers)
 
-    def test_promotion_source_authority_accepts_runtime_authority_reason_only(
+    def test_promotion_source_authority_rejects_runtime_authority_reason_only(
         self,
     ) -> None:
         blockers = runtime_ledger_promotion_source_authority_blockers(
@@ -550,10 +556,10 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                     "order_feed_source_windows": 1,
                 },
                 **_economics_payload(),
-                "trade_decision_id": "decision-1",
-                "execution_id": "execution-1",
-                "execution_order_event_id": "event-1",
-                "source_window_id": "source-window-1",
+                "trade_decision_ids": ["decision-1"],
+                "execution_ids": ["execution-1"],
+                "execution_order_event_ids": ["event-1"],
+                "source_window_ids": ["source-window-1"],
                 "source_offsets": [
                     {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
                 ],
@@ -562,7 +568,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             }
         )
 
-        self.assertEqual(blockers, [])
+        self.assertIn("runtime_ledger_authority_class_missing", blockers)
 
     def test_promotion_source_authority_requires_named_source_ref_tables(
         self,
@@ -591,6 +597,7 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             }
         )
 
@@ -615,15 +622,16 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "order_feed_source_windows": 1,
             },
             **_economics_payload(),
-            "trade_decision_id": "decision-1",
-            "execution_id": "execution-1",
-            "execution_order_event_id": "event-1",
-            "source_window_id": "source-window-1",
+            "trade_decision_ids": ["decision-1"],
+            "execution_ids": ["execution-1"],
+            "execution_order_event_ids": ["event-1"],
+            "source_window_ids": ["source-window-1"],
             "source_offsets": [
                 {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
+            "authority_reason": "event_sourced_runtime_ledger_profit_proof",
         }
 
         blockers = runtime_ledger_promotion_source_authority_blockers(
@@ -660,15 +668,16 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                     "execution_order_events": 1,
                     "order_feed_source_windows": 1,
                 },
-                "trade_decision_id": "decision-1",
-                "execution_id": "execution-1",
-                "execution_order_event_id": "event-1",
-                "source_window_id": "source-window-1",
+                "trade_decision_ids": ["decision-1"],
+                "execution_ids": ["execution-1"],
+                "execution_order_event_ids": ["event-1"],
+                "source_window_ids": ["source-window-1"],
                 "source_offsets": [
                     {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
                 "source_window_gap_count": 1,
             }
         )
@@ -694,15 +703,16 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "order_feed_source_windows": 1,
             },
             **_economics_payload(),
-            "trade_decision_id": "decision-1",
-            "execution_id": "execution-1",
-            "execution_order_event_id": "event-1",
-            "source_window_id": "source-window-1",
+            "trade_decision_ids": ["decision-1"],
+            "execution_ids": ["execution-1"],
+            "execution_order_event_ids": ["event-1"],
+            "source_window_ids": ["source-window-1"],
             "source_offsets": [
                 {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
+            "authority_reason": "event_sourced_runtime_ledger_profit_proof",
         }
 
         range_blockers = runtime_ledger_promotion_source_authority_blockers(
@@ -744,15 +754,16 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "order_feed_source_windows": 1,
             },
             **_economics_payload(),
-            "trade_decision_id": "decision-1",
-            "execution_id": "execution-1",
-            "execution_order_event_id": "event-1",
-            "source_window_id": "source-window-1",
+            "trade_decision_ids": ["decision-1"],
+            "execution_ids": ["execution-1"],
+            "execution_order_event_ids": ["event-1"],
+            "source_window_ids": ["source-window-1"],
             "source_offsets": [
                 {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
             ],
             "source_materialization": "source_execution_lifecycle",
             "authority_class": "source_execution_lifecycle_materialized_runtime_ledger",
+            "authority_reason": "source_execution_lifecycle_materialized_runtime_ledger",
         }
 
         lifecycle_blockers = runtime_ledger_promotion_source_authority_blockers(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -2530,6 +2530,26 @@ class TestRuntimeWindowImport(TestCase):
             _runtime_ledger_bucket_blockers(missing_source_offsets),
         )
 
+        legacy_ref_aliases = _runtime_ledger_bucket(
+            source_window_ids=[],
+            source_window_refs=["postgres:order_feed_source_windows:source-window-buy"],
+            trade_decision_ids=[],
+            trade_decision_refs=["postgres:trade_decisions:decision-buy"],
+            execution_ids=[],
+            execution_refs=["postgres:executions:execution-buy"],
+            execution_order_event_ids=[],
+            execution_order_event_refs=[
+                "postgres:execution_order_events:event-fill-buy"
+            ],
+        )
+        alias_blockers = _runtime_ledger_bucket_blockers(legacy_ref_aliases)
+        self.assertIn("runtime_ledger_source_window_ids_missing", alias_blockers)
+        self.assertIn("runtime_ledger_trade_decision_refs_missing", alias_blockers)
+        self.assertIn("runtime_ledger_execution_refs_missing", alias_blockers)
+        self.assertIn(
+            "runtime_ledger_execution_order_event_refs_missing", alias_blockers
+        )
+
     def test_runtime_ledger_bucket_requires_structured_source_offsets(self) -> None:
         for malformed_offsets in (
             ["alpaca.trade_updates:0:100"],
@@ -2556,6 +2576,12 @@ class TestRuntimeWindowImport(TestCase):
             "runtime_ledger_authority_class_missing",
             _runtime_ledger_bucket_blockers(bucket),
         )
+        for marker_field in ("authority_class", "authority_reason"):
+            marker_only = _runtime_ledger_bucket(**{marker_field: None})
+            self.assertIn(
+                "runtime_ledger_authority_class_missing",
+                _runtime_ledger_bucket_blockers(marker_only),
+            )
 
     def test_runtime_ledger_bucket_requires_explicit_cost_basis_and_amount(
         self,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -314,6 +314,7 @@ class TestSubmissionCouncil(TestCase):
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
+            "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             "blockers": [],
         }
 
@@ -1239,6 +1240,7 @@ class TestSubmissionCouncil(TestCase):
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             }
             reversal_source_payload = {
                 "source_window_start": (now - timedelta(minutes=75)).isoformat(),
@@ -1266,6 +1268,7 @@ class TestSubmissionCouncil(TestCase):
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             }
             session.add_all(
                 [
@@ -1623,6 +1626,7 @@ class TestSubmissionCouncil(TestCase):
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             },
             manifest={"candidate_id": "c88421d619759b2cfaa6f4d0"},
         )
@@ -1762,6 +1766,7 @@ class TestSubmissionCouncil(TestCase):
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
+            "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             "reason_codes": ["runtime_ledger_stage_not_live"],
         }
 
@@ -1836,6 +1841,7 @@ class TestSubmissionCouncil(TestCase):
                     ],
                     "source_materialization": "execution_order_events",
                     "authority_class": "runtime_order_feed_execution_source",
+                    "authority_reason": "event_sourced_runtime_ledger_profit_proof",
                     "reason_codes": ["runtime_ledger_stage_not_live"],
                 },
                 {
@@ -1963,6 +1969,7 @@ class TestSubmissionCouncil(TestCase):
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
+            "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             "reason_codes": ["runtime_ledger_stage_not_live"],
         }
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -8724,6 +8724,7 @@ class TestTradingApi(TestCase):
                     ],
                     "source_materialization": "execution_order_events",
                     "authority_class": "runtime_order_feed_execution_source",
+                    "authority_reason": "event_sourced_runtime_ledger_profit_proof",
                     "source_decision_mode_counts": {"strategy_signal_paper": 5},
                     "cost_basis_counts": {"broker_reported": 4},
                 },

--- a/services/torghut/tests/test_verify_hpairs_runtime_authority.py
+++ b/services/torghut/tests/test_verify_hpairs_runtime_authority.py
@@ -86,6 +86,7 @@ def _source_payload(day_index: int) -> dict[str, object]:
         ],
         "source_materialization": "execution_order_events",
         "authority_class": "runtime_order_feed_execution_source",
+        "authority_reason": "event_sourced_runtime_ledger_profit_proof",
         "order_feed_lifecycle_complete": True,
         "execution_economics_complete": True,
         "cost_basis_counts": {"explicit_broker_fee_runtime": 20},


### PR DESCRIPTION
## Summary

- Require promotion-grade runtime-ledger buckets to carry canonical source ID arrays instead of legacy `*_refs` or scalar alias fields.
- Require both `authority_class` and `authority_reason` to be promotion-grade in the shared runtime-ledger source-authority predicate.
- Align source-backed test fixtures with the stricter authority contract and add regressions proving legacy ref aliases are blocked.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py tests/test_runtime_ledger_source_authority.py tests/test_audit_hpairs_source_proof_census.py tests/test_verify_hpairs_runtime_authority.py tests/test_inspect_hpairs_runtime_evidence.py tests/test_completion_trace.py tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_trading_api.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_source_authority.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_runtime_ledger_source_authority.py tests/test_audit_hpairs_source_proof_census.py tests/test_verify_hpairs_runtime_authority.py tests/test_inspect_hpairs_runtime_evidence.py tests/test_completion_trace.py tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger_source_authority.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_runtime_ledger_source_authority.py tests/test_audit_hpairs_source_proof_census.py tests/test_verify_hpairs_runtime_authority.py tests/test_inspect_hpairs_runtime_evidence.py tests/test_completion_trace.py tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_submission_council.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
