### PR TITLE
fix(torghut): use sim paper route target plan

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -130,7 +130,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
               value: "75000"
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
-              value: http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan
+              value: http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS
               value: "10"
             - name: TRADING_KILL_SWITCH_ENABLED

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -689,7 +689,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_URL"),
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS"),


### PR DESCRIPTION
## Summary

- Point `torghut-sim` at its own `/trading/paper-route-target-plan` endpoint instead of the live service.
- Keep sim H-PAIRS account reservation, target-account audit, and paper evidence collection on the `TORGHUT_SIM` evidence surface.
- Update the manifest contract so future sim target-plan wiring regressions fail in tests.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_sim_manifest_runs_paper_live_signal_profile tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
