### PR TITLE
fix(agents): wait for app-server continuations

### DIFF
--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -31,6 +31,8 @@ import type {
   ThreadResumeResponse,
   ThreadStartParams,
   ThreadStartResponse,
+  ThreadStatus,
+  ThreadStatusChangedNotification,
   ThreadTokenUsageUpdatedNotification,
   Turn,
   TurnCompletedNotification,
@@ -151,6 +153,17 @@ export type CodexAppServerTurnOptions = {
   developerInstructions?: string | null
   personality?: ThreadStartParams['personality']
   goal?: CodexAppServerGoalOptions | null
+}
+
+export type ThreadIdleWaitOptions = {
+  quietMs?: number
+  timeoutMs?: number
+  signal?: AbortSignal
+}
+
+export type ThreadIdleWaitResult = {
+  status: ThreadStatus | null
+  lastTurn: Turn | null
 }
 
 const normalizeTurnGoalOptions = (goal: CodexAppServerGoalOptions): CodexAppServerGoalOptions => {
@@ -417,6 +430,9 @@ export class CodexAppServerClient {
   private pendingTurnStreams = new Map<string, TurnStream>()
   private turnItems = new Map<string, Set<string>>()
   private itemTurnMap = new Map<string, string>()
+  private threadStatuses = new Map<string, ThreadStatus>()
+  private threadLastTurns = new Map<string, Turn>()
+  private threadStatusWaiters = new Set<() => void>()
   private lastActiveTurnId: string | null = null
   private readyPromise: Promise<void>
   private resolveReady: (() => void) | null = null
@@ -730,6 +746,76 @@ export class CodexAppServerClient {
       params,
     )) as ThreadGoalClearResponse
     return response.cleared
+  }
+
+  async waitForThreadIdle(
+    threadId: string,
+    { quietMs = 1000, timeoutMs = 0, signal }: ThreadIdleWaitOptions = {},
+  ): Promise<ThreadIdleWaitResult> {
+    await this.ensureReady()
+    if (!this.threadStatuses.has(threadId)) {
+      return {
+        status: null,
+        lastTurn: this.threadLastTurns.get(threadId) ?? null,
+      }
+    }
+
+    let idleSince: number | null = null
+    const startedAt = Date.now()
+
+    return new Promise<ThreadIdleWaitResult>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null
+      const cleanup = () => {
+        if (timer) clearTimeout(timer)
+        this.threadStatusWaiters.delete(check)
+        signal?.removeEventListener('abort', onAbort)
+      }
+      const onAbort = () => {
+        cleanup()
+        reject(signal?.reason ?? new Error(`wait for thread ${threadId} idle cancelled`))
+      }
+      const finish = () => {
+        cleanup()
+        resolve({
+          status: this.threadStatuses.get(threadId) ?? null,
+          lastTurn: this.threadLastTurns.get(threadId) ?? null,
+        })
+      }
+      const schedule = (delayMs: number) => {
+        if (timer) clearTimeout(timer)
+        timer = setTimeout(check, Math.max(0, delayMs))
+      }
+      const check = () => {
+        if (signal?.aborted) {
+          onAbort()
+          return
+        }
+        if (timeoutMs > 0 && Date.now() - startedAt >= timeoutMs) {
+          cleanup()
+          reject(new Error(`timed out waiting for thread ${threadId} to become idle`))
+          return
+        }
+
+        const status = this.threadStatuses.get(threadId)
+        if (status?.type === 'idle') {
+          idleSince ??= Date.now()
+          const remainingQuietMs = quietMs - (Date.now() - idleSince)
+          if (remainingQuietMs <= 0) {
+            finish()
+            return
+          }
+          schedule(remainingQuietMs)
+          return
+        }
+
+        idleSince = null
+        schedule(250)
+      }
+
+      signal?.addEventListener('abort', onAbort, { once: true })
+      this.threadStatusWaiters.add(check)
+      check()
+    })
   }
 
   async interruptTurn(turnId: string, threadId: string): Promise<void> {
@@ -1254,6 +1340,8 @@ export class CodexAppServerClient {
       }
       case 'turn/completed': {
         const params = notification.params as TurnCompletedNotification
+        this.threadLastTurns.set(params.threadId, params.turn)
+        this.notifyThreadStatusWaiters()
         const turnId = this.findTurnId(params) ?? params.turn.id
         this.reconcileActiveTurnId(turnId)
         const resolved = this.resolveTurnStream(params) ?? { stream: this.turnStreams.get(turnId), turnId }
@@ -1269,6 +1357,13 @@ export class CodexAppServerClient {
           turnId,
           status: params.turn.status,
         })
+        break
+      }
+      case 'thread/status/changed': {
+        const params = notification.params as ThreadStatusChangedNotification
+        this.threadStatuses.set(params.threadId, params.status)
+        this.notifyThreadStatusWaiters()
+        this.log('info', 'thread status changed', { threadId: params.threadId, status: params.status })
         break
       }
       case 'turn/started': {
@@ -1618,6 +1713,10 @@ export class CodexAppServerClient {
       const remaining = Array.from(this.turnStreams.keys())
       this.lastActiveTurnId = remaining.length ? (remaining.at(-1) ?? null) : null
     }
+  }
+
+  private notifyThreadStatusWaiters(): void {
+    for (const waiter of this.threadStatusWaiters) waiter()
   }
 
   private failTurnStream(turnId: string, error: unknown): void {

--- a/services/agents/src/runner/codex-app-server.test.ts
+++ b/services/agents/src/runner/codex-app-server.test.ts
@@ -200,6 +200,120 @@ describe('codex app-server runner adapter', () => {
     expect(await readFile(logPath, 'utf8')).toContain('"delta":"done"')
   })
 
+  it('waits for the app-server thread to settle before reporting success', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agents-codex-runner-'))
+    const runPath = join(dir, 'run.json')
+    const statusPath = join(dir, 'status.json')
+    await writeFile(
+      runPath,
+      `${JSON.stringify({
+        implementation: { text: 'continue until the session is actually done' },
+        agentRun: { name: 'run-continuation' },
+      })}\n`,
+      'utf8',
+    )
+
+    let waitedForThreadId: string | null = null
+    const fakeClient: CodexAppServerRunnerClient = {
+      runTurnStream: async () => ({
+        stream: makeStream(),
+        turnId: 'turn-initial',
+        threadId: 'thread-continuation',
+      }),
+      waitForThreadIdle: async (threadId) => {
+        waitedForThreadId = threadId
+        return { lastTurn: makeTurn('completed') }
+      },
+      stop: () => undefined,
+    }
+
+    const exitCode = await runCodexAppServerAdapter(
+      {
+        provider: 'codex-runner',
+        payloads: {
+          eventFilePath: runPath,
+        },
+        artifacts: {
+          statusPath,
+        },
+      },
+      {
+        prompt: 'continue until the session is actually done',
+      },
+      {
+        createClient: () => fakeClient,
+        uploadArtifacts: async (artifacts) => artifacts,
+      },
+    )
+
+    expect(exitCode).toBe(0)
+    expect(waitedForThreadId).toBe('thread-continuation')
+    const status = JSON.parse(await readFile(statusPath, 'utf8')) as Record<string, unknown>
+    expect(status).toMatchObject({
+      status: 'succeeded',
+      threadId: 'thread-continuation',
+      turnStatus: 'completed',
+    })
+  })
+
+  it('fails when an automatic app-server continuation fails before the thread settles', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agents-codex-runner-'))
+    const runPath = join(dir, 'run.json')
+    const statusPath = join(dir, 'status.json')
+    await writeFile(
+      runPath,
+      `${JSON.stringify({
+        implementation: { text: 'continue until failure is visible' },
+        agentRun: { name: 'run-continuation-failure' },
+      })}\n`,
+      'utf8',
+    )
+
+    const fakeClient: CodexAppServerRunnerClient = {
+      runTurnStream: async () => ({
+        stream: makeStream(),
+        turnId: 'turn-initial',
+        threadId: 'thread-continuation-failure',
+      }),
+      waitForThreadIdle: async () => ({
+        lastTurn: makeTurn('failed', {
+          message: 'automatic continuation failed',
+          codexErrorInfo: null,
+          additionalDetails: null,
+        }),
+      }),
+      stop: () => undefined,
+    }
+
+    await expect(
+      runCodexAppServerAdapter(
+        {
+          provider: 'codex-runner',
+          payloads: {
+            eventFilePath: runPath,
+          },
+          artifacts: {
+            statusPath,
+          },
+        },
+        {
+          prompt: 'continue until failure is visible',
+        },
+        {
+          createClient: () => fakeClient,
+          uploadArtifacts: async (artifacts) => artifacts,
+        },
+      ),
+    ).rejects.toBeInstanceOf(CodexRunnerTurnError)
+
+    const status = JSON.parse(await readFile(statusPath, 'utf8')) as Record<string, unknown>
+    expect(status).toMatchObject({
+      status: 'failed',
+      turnStatus: 'failed',
+    })
+    expect(String(status.error)).toContain('automatic continuation failed')
+  })
+
   it('renders threadConfig string templates from runtime environment before creating the Codex client', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'agents-codex-runner-'))
     const runPath = join(dir, 'run.json')

--- a/services/agents/src/runner/codex-app-server.ts
+++ b/services/agents/src/runner/codex-app-server.ts
@@ -60,6 +60,10 @@ export type CodexAppServerRunnerClient = {
     prompt: string,
     options?: CodexAppServerTurnOptions,
   ) => Promise<{ stream: AsyncGenerator<StreamDelta, Turn | null, void>; turnId: string; threadId: string }>
+  waitForThreadIdle?: (
+    threadId: string,
+    options?: { quietMs?: number; timeoutMs?: number; signal?: AbortSignal },
+  ) => Promise<{ lastTurn: Turn | null }>
   interruptTurn?: (turnId: string, threadId: string) => Promise<void>
   stop?: () => void
 }
@@ -962,6 +966,29 @@ const consumeTurnStreamEffect = ({
         : new CodexRunnerTurnError({ operation: 'stream-turn', threadId, turnId, cause }),
   })
 
+const parseNonNegativeInteger = (value: string | undefined, fallback: number): number => {
+  if (value === undefined) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+
+const waitForThreadIdleEffect = (
+  client: CodexAppServerRunnerClient,
+  threadId: string,
+  signal: AbortSignal | undefined,
+) =>
+  Effect.tryPromise({
+    try: () => {
+      if (!client.waitForThreadIdle) return Promise.resolve(null)
+      return client.waitForThreadIdle(threadId, {
+        quietMs: parseNonNegativeInteger(process.env.CODEX_APP_SERVER_THREAD_IDLE_QUIET_MS, 1000),
+        timeoutMs: parseNonNegativeInteger(process.env.CODEX_APP_SERVER_THREAD_IDLE_TIMEOUT_MS, 0),
+        signal,
+      })
+    },
+    catch: (cause) => new CodexRunnerTurnError({ operation: 'stream-turn', threadId, cause }),
+  })
+
 const uploadOutputArtifactsEffect = (
   artifacts: AgentProviderOutputArtifact[],
   uploadArtifacts: typeof uploadOutputArtifacts,
@@ -1061,6 +1088,10 @@ export const runCodexAppServerAdapterEffect = ({
       turnId: response.turnId,
       logStream: state.logStream,
     })
+    const idleResult = yield* waitForThreadIdleEffect(state.client, response.threadId, options.abortSignal)
+    if (idleResult?.lastTurn) {
+      state.finalTurn = idleResult.lastTurn
+    }
 
     const terminalError = terminalErrorForTurn(state.finalTurn, state.threadId, state.turnId)
     if (terminalError) {


### PR DESCRIPTION
## Summary

- Keeps the Codex app-server runner connected after a streamed turn completes until the app-server thread is idle for a quiet window.
- Tracks thread status and last completed turn notifications so automatic continuation failures fail the AgentRun instead of being hidden.
- Adds runner regressions for successful continuation quiescence and failed automatic continuation handling.

## Related Issues

None

## Testing

- `bun test services/agents/src/runner/codex-app-server.test.ts`
- `bun test packages/codex/src/app-server-client.test.ts packages/codex/src/app-server-client.events.test.ts packages/codex/src/codex.test.ts`
- `bun run --cwd services/agents test -- src/runner/codex-app-server.test.ts`
- `bun run --cwd packages/codex test -- src/app-server-client.test.ts src/app-server-client.events.test.ts src/codex.test.ts`
- `bun run --cwd packages/codex build`
- `bun run --cwd packages/codex lint:oxlint`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents lint:oxlint`
- `bun run --cwd services/agents tsc`
- `bunx oxfmt --check packages/codex/src/app-server-client.ts services/agents/src/runner/codex-app-server.ts services/agents/src/runner/codex-app-server.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A - runner behavior change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
