### PR TITLE
chore(torghut): promote image 077b2559

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.592.0-7-g95298ea5a
+              value: v0.592.0-9-g077b2559d
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 95298ea5a45f2ee39c684f8d974ec61a725e28da
+              value: 077b2559deb3da70636825940405b90671cf3878
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.592.0-7-g95298ea5a
+              value: v0.592.0-9-g077b2559d
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 95298ea5a45f2ee39c684f8d974ec61a725e28da
+              value: 077b2559deb3da70636825940405b90671cf3878
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -127,7 +127,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+                  value: sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-02T17:15:23Z"
+        client.knative.dev/updateTimestamp: "2026-06-02T17:34:38Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           ports:
             - name: http1
               containerPort: 8181
@@ -531,11 +531,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.592.0-7-g95298ea5a
+              value: v0.592.0-9-g077b2559d
             - name: TORGHUT_COMMIT
-              value: 95298ea5a45f2ee39c684f8d974ec61a725e28da
+              value: 077b2559deb3da70636825940405b90671cf3878
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+              value: sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-02T17:15:23Z"
+        client.knative.dev/updateTimestamp: "2026-06-02T17:34:38Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           ports:
             - name: http1
               containerPort: 8181
@@ -373,11 +373,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.592.0-7-g95298ea5a
+              value: v0.592.0-9-g077b2559d
             - name: TORGHUT_COMMIT
-              value: 95298ea5a45f2ee39c684f8d974ec61a725e28da
+              value: 077b2559deb3da70636825940405b90671cf3878
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+              value: sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -83,7 +83,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+                  value: sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -119,7 +119,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -188,6 +188,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+                  value: sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: 95298ea5a45f2ee39c684f8d974ec61a725e28da
+            value: 077b2559deb3da70636825940405b90671cf3878
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+            value: sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c0842a53e5049f48b5810e1615ff2efe89068967c524e178585e946c3262307d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `077b2559deb3da70636825940405b90671cf3878`
- Image tag: `077b2559`
- Image digest: `sha256:8a7184738957795e253401458059df210ab63b014c50f4acf164883b5a148f03`