### PR TITLE
fix(torghut): relax proof read timeout

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
@@ -107,7 +108,12 @@ _AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
 )
 _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT = 256
 _RUNTIME_LEDGER_REPAIR_CANDIDATE_LIMIT = 8
-_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS = 500
+_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_DEFAULT_MS = 2500
+_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MIN_MS = 500
+_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MAX_MS = 10000
+_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_ENV = (
+    "TORGHUT_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS"
+)
 _RUNTIME_LEDGER_SUMMARY_PER_HYPOTHESIS_LIMIT = 16
 _PROMOTION_TABLE_COUNT_SCAN_LIMIT = 1000
 _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT = 256
@@ -135,7 +141,23 @@ def _maybe_set_runtime_ledger_status_statement_timeout(session: Session) -> None
         except Exception:
             pass
     session.execute(
-        text(f"SET LOCAL statement_timeout = {_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS}")
+        text(
+            f"SET LOCAL statement_timeout = {_runtime_ledger_status_query_timeout_ms()}"
+        )
+    )
+
+
+def _runtime_ledger_status_query_timeout_ms() -> int:
+    raw_timeout = os.getenv(_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_ENV)
+    if raw_timeout is None:
+        return _RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_DEFAULT_MS
+    try:
+        timeout_ms = int(raw_timeout)
+    except ValueError:
+        return _RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_DEFAULT_MS
+    return min(
+        _RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MAX_MS,
+        max(_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MIN_MS, timeout_ms),
     )
 
 

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
@@ -55,6 +56,7 @@ from app.trading.submission_council import (
     _metric_window_activity_reason_codes,
     _rollback_runtime_ledger_status_session,
     _runtime_ledger_repair_reason_codes,
+    _runtime_ledger_status_query_timeout_ms,
     _refresh_runtime_summary_totals,
     _runtime_ledger_paper_probation_blockers,
     _runtime_ledger_paper_probation_import_plan,
@@ -1083,8 +1085,47 @@ class TestSubmissionCouncil(TestCase):
 
         self.assertEqual(
             fake_session.calls,
-            ["SET LOCAL statement_timeout = 500"],
+            ["SET LOCAL statement_timeout = 2500"],
         )
+
+    def test_runtime_ledger_status_timeout_helper_uses_configured_timeout(
+        self,
+    ) -> None:
+        fake_session = _RaisingBindRuntimeLedgerStatusSession()
+
+        with patch.dict(
+            os.environ,
+            {"TORGHUT_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS": "3250"},
+        ):
+            _maybe_set_runtime_ledger_status_statement_timeout(
+                fake_session,  # type: ignore[arg-type]
+            )
+
+        self.assertEqual(
+            fake_session.calls,
+            ["SET LOCAL statement_timeout = 3250"],
+        )
+
+    def test_runtime_ledger_status_timeout_helper_bounds_configured_timeout(
+        self,
+    ) -> None:
+        with patch.dict(
+            os.environ,
+            {"TORGHUT_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS": "25"},
+        ):
+            self.assertEqual(_runtime_ledger_status_query_timeout_ms(), 500)
+
+        with patch.dict(
+            os.environ,
+            {"TORGHUT_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS": "25000"},
+        ):
+            self.assertEqual(_runtime_ledger_status_query_timeout_ms(), 10000)
+
+        with patch.dict(
+            os.environ,
+            {"TORGHUT_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS": "not-an-int"},
+        ):
+            self.assertEqual(_runtime_ledger_status_query_timeout_ms(), 2500)
 
     def test_runtime_ledger_status_rollback_helper_ignores_missing_rollback(
         self,


### PR DESCRIPTION
## Summary

- Raises the bounded runtime-ledger/proof status read timeout from 500ms to a 2500ms default after live sim readback showed H-PAIRS proof queries completing around 1.1s and self-canceling at 500ms.
- Adds `TORGHUT_RUNTIME_LEDGER_STATUS_QUERY_TIMEOUT_MS` with 500ms-10000ms bounds so production can tune read latency without code changes.
- Preserves fail-closed behavior when proof read-model queries still time out.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py::TestSubmissionCouncil::test_runtime_ledger_status_timeout_helper_applies_timeout_when_bind_lookup_fails tests/test_submission_council.py::TestSubmissionCouncil::test_runtime_ledger_status_timeout_helper_uses_configured_timeout tests/test_submission_council.py::TestSubmissionCouncil::test_runtime_ledger_status_timeout_helper_bounds_configured_timeout tests/test_submission_council.py::TestSubmissionCouncil::test_load_latest_certificate_evidence_fails_closed_on_window_timeout tests/test_submission_council.py::TestSubmissionCouncil::test_load_runtime_ledger_repair_candidates_fails_closed_on_query_timeout -q`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
