### PR TITLE
fix(torghut): preserve collection fill diagnostics

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -222,6 +222,7 @@ class _NormalizedFill:
     lineage_hash: str | None
     replay_data_hash: str | None
     blockers: tuple[str, ...]
+    bucket_blockers: tuple[str, ...] = ()
     filled_qty_delta: Decimal | None = None
     filled_notional_delta: Decimal | None = None
     fill_quantity_basis: str | None = None
@@ -380,6 +381,7 @@ def _build_bucket(
     blockers: list[str] = []
     for row in [*carry_in_rows, *rows]:
         blockers.extend(row.blockers)
+        blockers.extend(row.bucket_blockers)
 
     lifecycle_rows = [
         row for row in [*carry_in_rows, *rows] if row.event_type in _LIFECYCLE_EVENTS
@@ -938,7 +940,8 @@ def _normalize_fill_row(
     blockers: list[str] = []
     if _has_tca_pnl_shortcut(row):
         blockers.append("tca_shortfall_not_runtime_pnl")
-    blockers.extend(_runtime_source_mode_blockers(row))
+    bucket_blockers = _runtime_source_collection_mode_blockers(row)
+    blockers.extend(_runtime_source_hard_mode_blockers(row))
     if _is_non_promotion_runtime_source_row(row):
         blockers.append("runtime_source_not_promotion_authority")
     blockers.extend(_tigerbeetle_journal_blockers(row))
@@ -1000,6 +1003,7 @@ def _normalize_fill_row(
         lineage_hash=lineage_hash,
         replay_data_hash=replay_data_hash,
         blockers=tuple(_dedupe(blockers)),
+        bucket_blockers=tuple(_dedupe(bucket_blockers)),
         lifecycle_only=lifecycle_only,
         order_feed_lifecycle_source=order_feed_lifecycle_source,
     )
@@ -1181,7 +1185,7 @@ def _is_non_promotion_runtime_source_row(
     )
     if promotion_authority is False:
         return True
-    if _runtime_source_mode_blockers(row):
+    if _runtime_source_hard_mode_blockers(row):
         return True
     for key in (
         "authority_class",
@@ -1204,7 +1208,7 @@ def _is_non_promotion_runtime_source_row(
     return False
 
 
-def _runtime_source_mode_blockers(
+def _runtime_source_collection_mode_blockers(
     row: RuntimeLedgerFill | Mapping[str, object],
 ) -> list[str]:
     blockers: list[str] = []
@@ -1228,6 +1232,31 @@ def _runtime_source_mode_blockers(
         normalized = text.lower().replace("-", "_").replace(" ", "_")
         if any(marker in normalized for marker in _SOURCE_DECISION_COLLECTION_MARKERS):
             blockers.append("source_decision_mode_not_profit_proof_eligible")
+    return _dedupe(blockers)
+
+
+def _runtime_source_hard_mode_blockers(
+    row: RuntimeLedgerFill | Mapping[str, object],
+) -> list[str]:
+    blockers: list[str] = []
+    for key in (
+        "authority_class",
+        "authority_mode",
+        "authority_reason",
+        "decision_mode",
+        "materialization_mode",
+        "pnl_derivation",
+        "proof_mode",
+        "route_mode",
+        "source",
+        "source_kind",
+        "source_materialization",
+        "source_mode",
+    ):
+        text = _coerce_text(_row_value(row, key))
+        if text is None:
+            continue
+        normalized = text.lower().replace("-", "_").replace(" ", "_")
         if any(marker in normalized for marker in _EXECUTION_RECONSTRUCTION_MARKERS):
             blockers.append("execution_reconstruction_not_runtime_ledger_proof")
     return _dedupe(blockers)

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -1738,10 +1738,13 @@ def test_source_decision_collection_mode_is_not_profit_proof_eligible() -> None:
             bucket_ranges=[(_ts(), _ts(60))],
         )[0]
 
-        assert bucket.fill_count == 0
+        assert bucket.fill_count == 2
+        assert bucket.closed_trade_count == 1
+        assert bucket.filled_notional == Decimal("201")
         assert bucket.post_cost_expectancy_bps is None
+        assert bucket.diagnostic_closed_trade_expectancy_bps is not None
         assert "source_decision_mode_not_profit_proof_eligible" in bucket.blockers
-        assert "runtime_source_not_promotion_authority" in bucket.blockers
+        assert "runtime_source_not_promotion_authority" not in bucket.blockers
 
 
 def test_execution_reconstruction_rows_do_not_become_runtime_authority() -> None:


### PR DESCRIPTION
## Summary

- Split collection-mode source decision blockers from hard per-fill runtime blockers in the runtime ledger.
- Keeps `source_decision_mode_not_profit_proof_eligible` as a bucket-level promotion blocker while preserving real fill count, closed-trip diagnostics, and filled notional for collection evidence.
- Leaves execution reconstruction and other non-runtime proof derivations fail-closed as unusable promotion evidence.
- Updates the regression test so collection-mode evidence remains non-promotable but no longer collapses real fills to zero-notional diagnostics.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q -k "route_acquisition or partitions_mixed_source_decision_modes or authorizes_event_sourced_lifecycle"`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_submission_council.py -q -k "runtime_ledger or source_decision_mode or route_acquisition or filled_notional"`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger.py tests/test_runtime_ledger.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger.py tests/test_runtime_ledger.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
