### PR TITLE
fix(torghut): cache bounded health refreshes safely

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -1501,24 +1501,47 @@ def _evaluate_trading_health_payload_bounded(
         include_database_contract=include_database_contract,
         allow_stale_dependency_cache=allow_stale_dependency_cache,
     )
+    callback_future: Future[tuple[dict[str, object], int]] | None = None
+    cached_result: tuple[dict[str, object], int] | None = None
     with _TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
         future = _TRADING_HEALTH_SURFACE_EVALUATIONS.get(cache_key)
-        if future is None or future.done():
+        if future is not None and future.done():
+            cache_entry = _TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.get(cache_key)
+            _TRADING_HEALTH_SURFACE_EVALUATIONS.pop(cache_key, None)
+            if cache_entry is not None:
+                payload = deepcopy(cast(dict[str, object], cache_entry["payload"]))
+                status_value = cache_entry.get("status_code")
+                status_code = status_value if isinstance(status_value, int) else 503
+                refresh_future = _TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR.submit(
+                    _evaluate_trading_health_payload,
+                    include_database_contract=include_database_contract,
+                    allow_stale_dependency_cache=allow_stale_dependency_cache,
+                )
+                _TRADING_HEALTH_SURFACE_EVALUATIONS[cache_key] = refresh_future
+                callback_future = refresh_future
+                cached_result = (payload, status_code)
+            else:
+                future = None
+        if future is None and cached_result is None:
             future = _TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR.submit(
                 _evaluate_trading_health_payload,
                 include_database_contract=include_database_contract,
                 allow_stale_dependency_cache=allow_stale_dependency_cache,
             )
             _TRADING_HEALTH_SURFACE_EVALUATIONS[cache_key] = future
-            future.add_done_callback(
-                lambda completed, key=cache_key: (
-                    _record_trading_health_surface_completion(
-                        key,
-                        completed,
-                    )
-                )
-            )
+            callback_future = future
 
+    if callback_future is not None:
+        callback_future.add_done_callback(
+            lambda completed, key=cache_key: _record_trading_health_surface_completion(
+                key,
+                completed,
+            )
+        )
+    if cached_result is not None:
+        return cached_result
+
+    assert future is not None
     timeout_seconds = max(0.1, _TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS)
     try:
         payload, status_code = future.result(timeout=timeout_seconds)
@@ -6384,6 +6407,8 @@ def _fetch_paper_route_target_plan_url(
             }
         if not parsed.hostname:
             return {"load_error": "paper_route_target_plan_invalid_host"}
+        if _paper_route_target_plan_url_points_to_self(parsed):
+            return {"load_error": "paper_route_target_plan_self_reference"}
 
         path = parsed.path or "/"
         if parsed.query:
@@ -6458,6 +6483,42 @@ def _fetch_paper_route_target_plan_url(
         result = dict(result)
         result["fetch_attempts"] = max_attempts
     return result
+
+
+def _paper_route_target_plan_url_points_to_self(parsed: Any) -> bool:
+    path = str(getattr(parsed, "path", "") or "").rstrip("/")
+    if path != "/trading/paper-route-target-plan":
+        return False
+    hostname = str(getattr(parsed, "hostname", "") or "").strip().lower()
+    if not hostname:
+        return False
+
+    self_hosts = {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "torghut",
+        "torghut.torghut",
+        "torghut.torghut.svc",
+        "torghut.torghut.svc.cluster.local",
+        "torghut-sim",
+        "torghut-sim.torghut",
+        "torghut-sim.torghut.svc",
+        "torghut-sim.torghut.svc.cluster.local",
+    }
+    service_name = os.getenv("K_SERVICE", "").strip().lower()
+    namespace = os.getenv("POD_NAMESPACE", os.getenv("NAMESPACE", "")).strip().lower()
+    if service_name:
+        self_hosts.add(service_name)
+        if namespace:
+            self_hosts.update(
+                {
+                    f"{service_name}.{namespace}",
+                    f"{service_name}.{namespace}.svc",
+                    f"{service_name}.{namespace}.svc.cluster.local",
+                }
+            )
+    return hostname in self_hosts
 
 
 def _load_external_paper_route_target_plan() -> dict[str, Any]:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 import json
 import inspect
+import os
 import time
 from collections.abc import Iterator
+from concurrent.futures import Future
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from threading import Event
 from types import SimpleNamespace
 from typing import Any
+from urllib.parse import urlsplit
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -5397,6 +5401,116 @@ class TestTradingApi(TestCase):
         self.assertFalse(payload["live_submission_gate"]["promotion_authority"])
         self.assertFalse(payload["live_submission_gate"]["final_authority_ok"])
         self.assertFalse(payload["live_submission_gate"]["final_promotion_allowed"])
+
+    def test_readyz_serves_completed_health_cache_while_refreshing(self) -> None:
+        cache_key = main_module._trading_health_surface_cache_key(
+            include_database_contract=True,
+            allow_stale_dependency_cache=True,
+        )
+        cached_payload: dict[str, object] = {
+            "status": "degraded",
+            "reason": "cached_health_payload",
+            "reason_codes": ["cached_health_payload"],
+            "dependencies": {"postgres": {"ok": True, "detail": "ok"}},
+            "live_submission_gate": {
+                "allowed": False,
+                "promotion_authority": False,
+                "final_authority_ok": False,
+                "final_promotion_allowed": False,
+            },
+        }
+        completed_future: Future[tuple[dict[str, object], int]] = Future()
+        completed_future.set_result((cached_payload, 503))
+        refresh_called = Event()
+        refresh_calls: list[object] = []
+
+        def _refresh_health_payload(
+            **_kwargs: object,
+        ) -> tuple[dict[str, object], int]:
+            refresh_calls.append(_kwargs)
+            refresh_called.set()
+            return (
+                {
+                    **cached_payload,
+                    "reason": "refreshed_health_payload",
+                    "reason_codes": ["refreshed_health_payload"],
+                },
+                503,
+            )
+
+        with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS[cache_key] = (
+                completed_future
+            )
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE[cache_key] = {
+                "payload": cached_payload,
+                "status_code": 503,
+                "checked_at": datetime.now(timezone.utc),
+            }
+
+        try:
+            with patch(
+                "app.main._evaluate_trading_health_payload",
+                side_effect=_refresh_health_payload,
+            ):
+                response = self.client.get("/readyz")
+                self.assertTrue(refresh_called.wait(1.0))
+                self.assertEqual(len(refresh_calls), 1)
+        finally:
+            with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+                main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+                main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["reason"], "cached_health_payload")
+        self.assertNotEqual(payload["reason"], "readyz_evaluation_timeout")
+
+    def test_readyz_starts_fresh_eval_when_completed_future_has_no_cache(self) -> None:
+        cache_key = main_module._trading_health_surface_cache_key(
+            include_database_contract=True,
+            allow_stale_dependency_cache=True,
+        )
+        completed_future: Future[tuple[dict[str, object], int]] = Future()
+        completed_future.set_result(({"reason": "orphaned_health_payload"}, 503))
+        refresh_calls: list[object] = []
+
+        def _refresh_health_payload(
+            **_kwargs: object,
+        ) -> tuple[dict[str, object], int]:
+            refresh_calls.append(_kwargs)
+            return (
+                {
+                    "status": "degraded",
+                    "reason": "fresh_health_payload",
+                    "reason_codes": ["fresh_health_payload"],
+                },
+                503,
+            )
+
+        with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS[cache_key] = (
+                completed_future
+            )
+
+        try:
+            with patch(
+                "app.main._evaluate_trading_health_payload",
+                side_effect=_refresh_health_payload,
+            ):
+                response = self.client.get("/readyz")
+        finally:
+            with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+                main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+                main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["reason"], "fresh_health_payload")
+        self.assertEqual(len(refresh_calls), 1)
 
     def test_timeout_live_gate_records_live_mode_blockers(self) -> None:
         original = {
@@ -11059,6 +11173,46 @@ class TestTradingApi(TestCase):
         finally:
             settings.trading_paper_route_target_plan_url = original_target_plan_url
             settings.trading_paper_route_target_plan_timeout_seconds = original_timeout
+
+    def test_load_external_paper_route_target_plan_rejects_self_reference(self) -> None:
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        original_cache = main_module._paper_route_target_plan_success_cache
+        main_module._paper_route_target_plan_success_cache = None
+        try:
+            settings.trading_paper_route_target_plan_url = "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan"
+            with patch("app.main.HTTPConnection") as connection:
+                plan = _load_external_paper_route_target_plan()
+            connection.assert_not_called()
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            main_module._paper_route_target_plan_success_cache = original_cache
+
+        self.assertEqual(plan["load_error"], "paper_route_target_plan_self_reference")
+
+    def test_paper_route_target_plan_self_reference_requires_host(self) -> None:
+        parsed = urlsplit("/trading/paper-route-target-plan")
+
+        self.assertFalse(
+            main_module._paper_route_target_plan_url_points_to_self(parsed)
+        )
+
+    def test_paper_route_target_plan_self_reference_matches_current_service(
+        self,
+    ) -> None:
+        parsed = urlsplit(
+            "http://route-sim.proof-ns.svc.cluster.local/trading/paper-route-target-plan"
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "K_SERVICE": "route-sim",
+                "POD_NAMESPACE": "proof-ns",
+            },
+        ):
+            self.assertTrue(
+                main_module._paper_route_target_plan_url_points_to_self(parsed)
+            )
 
     def test_load_external_paper_route_target_plan_uses_recent_success_after_timeout(
         self,


### PR DESCRIPTION
## Summary

- Serve a completed bounded trading health payload from cache immediately while starting one background refresh.
- Attach trading health refresh callbacks outside the shared evaluation lock so fast completions cannot deadlock readiness.
- Reject paper-route target-plan URLs that point back at the same Torghut target-plan route before making an HTTP request.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen python -m py_compile app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_readyz_serves_completed_health_cache_while_refreshing tests/test_trading_api.py::TestTradingApi::test_readyz_starts_fresh_eval_when_completed_future_has_no_cache tests/test_trading_api.py::TestTradingApi::test_load_external_paper_route_target_plan_rejects_self_reference tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_self_reference_requires_host tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_self_reference_matches_current_service -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k "readyz or paper_route_target_plan" -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not needed for this internal Torghut readiness/proof plumbing fix.
