### PR TITLE
chore(symphony): promote image 824b75c8

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-01T03:49:03Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-02T18:20:14Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "84300aed"
-    digest: sha256:b3d2fad832cdaa24bf1fbeee9d555b32c4714127ad20b96ca4d3caa27605f037
+    newTag: "824b75c8"
+    digest: sha256:a315f78d9dee8a1f5852fc4b721bae964b02e55f0c4c776d4d82d56f5e70c43d

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-01T03:49:03Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-02T18:20:14Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "84300aed"
-    digest: sha256:b3d2fad832cdaa24bf1fbeee9d555b32c4714127ad20b96ca4d3caa27605f037
+    newTag: "824b75c8"
+    digest: sha256:a315f78d9dee8a1f5852fc4b721bae964b02e55f0c4c776d4d82d56f5e70c43d

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-01T03:49:03Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-02T18:20:14Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "84300aed"
-    digest: sha256:b3d2fad832cdaa24bf1fbeee9d555b32c4714127ad20b96ca4d3caa27605f037
+    newTag: "824b75c8"
+    digest: sha256:a315f78d9dee8a1f5852fc4b721bae964b02e55f0c4c776d4d82d56f5e70c43d


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `824b75c8356c40274528506560499aac97b79cfe`
- Image tag: `824b75c8`
- Image digest: `sha256:a315f78d9dee8a1f5852fc4b721bae964b02e55f0c4c776d4d82d56f5e70c43d`