### PR TITLE
fix(torghut): keep completion trace out of promotion authority

### DIFF
--- a/services/torghut/app/trading/completion.py
+++ b/services/torghut/app/trading/completion.py
@@ -1590,6 +1590,9 @@ def build_doc29_completion_status(
         for gate in gates
         if str(gate['status']) != TRACE_STATUS_SATISFIED
     ]
+    final_promotion_blockers = list(blocked_gate_ids)
+    if all_satisfied:
+        final_promotion_blockers.append('completion_trace_not_runtime_ledger_authority')
     promotion_authority = {
         'evidence_collection_ok': (
             str(gate_status_map.get(DOC29_LIVE_CANARY_GATE, {}).get('status'))
@@ -1605,13 +1608,12 @@ def build_doc29_completion_status(
         ),
         'capital_promotion_allowed': False,
         'promotion_allowed': False,
-        'final_authority_ok': all_satisfied,
-        'final_promotion_allowed': all_satisfied,
-        'final_promotion_blockers': blocked_gate_ids,
+        'final_authority_ok': False,
+        'final_promotion_allowed': False,
+        'final_promotion_blockers': final_promotion_blockers,
+        'completion_trace_all_satisfied': all_satisfied,
+        'authority_source': 'completion_trace_status_only',
     }
-    if all_satisfied:
-        promotion_authority['capital_promotion_allowed'] = True
-        promotion_authority['promotion_allowed'] = True
     return {
         'doc_id': matrix['doc_id'],
         'design_doc_path': matrix['design_doc_path'],

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -343,7 +343,7 @@ class TestCompletionTrace(TestCase):
         self.assertEqual(gate['status'], 'satisfied')
         self.assertEqual(gate['latest_run'], 'sim-2026-03-06-full-day')
 
-    def test_doc29_completion_status_all_satisfied_sets_final_authority(self) -> None:
+    def test_doc29_completion_status_all_satisfied_stays_status_only(self) -> None:
         with self.session_local() as session:
             with patch(
                 'app.trading.completion.load_doc29_completion_matrix',
@@ -362,11 +362,19 @@ class TestCompletionTrace(TestCase):
                 )
 
         self.assertTrue(status['summary']['all_satisfied'])
-        self.assertTrue(status['promotion_authority']['capital_promotion_allowed'])
-        self.assertTrue(status['promotion_authority']['promotion_allowed'])
-        self.assertTrue(status['promotion_authority']['final_authority_ok'])
-        self.assertTrue(status['promotion_authority']['final_promotion_allowed'])
-        self.assertEqual(status['promotion_authority']['final_promotion_blockers'], [])
+        self.assertTrue(status['promotion_authority']['completion_trace_all_satisfied'])
+        self.assertEqual(
+            status['promotion_authority']['authority_source'],
+            'completion_trace_status_only',
+        )
+        self.assertFalse(status['promotion_authority']['capital_promotion_allowed'])
+        self.assertFalse(status['promotion_authority']['promotion_allowed'])
+        self.assertFalse(status['promotion_authority']['final_authority_ok'])
+        self.assertFalse(status['promotion_authority']['final_promotion_allowed'])
+        self.assertEqual(
+            status['promotion_authority']['final_promotion_blockers'],
+            ['completion_trace_not_runtime_ledger_authority'],
+        )
 
     def test_doc29_completion_status_derives_empirical_jobs_gate(self) -> None:
         with self.session_local() as session:
@@ -797,11 +805,19 @@ class TestCompletionTrace(TestCase):
             '24',
         )
         self.assertTrue(status['summary']['all_satisfied'])
-        self.assertTrue(status['promotion_authority']['final_authority_ok'])
-        self.assertTrue(status['promotion_authority']['capital_promotion_allowed'])
-        self.assertTrue(status['promotion_authority']['promotion_allowed'])
-        self.assertTrue(status['promotion_authority']['final_promotion_allowed'])
-        self.assertEqual(status['promotion_authority']['final_promotion_blockers'], [])
+        self.assertTrue(status['promotion_authority']['completion_trace_all_satisfied'])
+        self.assertEqual(
+            status['promotion_authority']['authority_source'],
+            'completion_trace_status_only',
+        )
+        self.assertFalse(status['promotion_authority']['final_authority_ok'])
+        self.assertFalse(status['promotion_authority']['capital_promotion_allowed'])
+        self.assertFalse(status['promotion_authority']['promotion_allowed'])
+        self.assertFalse(status['promotion_authority']['final_promotion_allowed'])
+        self.assertEqual(
+            status['promotion_authority']['final_promotion_blockers'],
+            ['completion_trace_not_runtime_ledger_authority'],
+        )
 
     def test_runtime_ledger_daily_summary_falls_back_to_bucket_rows(self) -> None:
         first = _runtime_ledger_bucket(


### PR DESCRIPTION
## Summary

- Keeps Doc 29 completion trace output status-only instead of granting capital or final promotion authority.
- Adds an explicit `completion_trace_not_runtime_ledger_authority` blocker when completion gates are all satisfied.
- Updates completion trace tests to assert runtime-ledger proof remains the only final promotion authority path.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_completion_trace.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q -k "completion or final_promotion_allowed or promotion_authority"`
- `cd services/torghut && uv run --frozen ruff check app/trading/completion.py tests/test_completion_trace.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/completion.py tests/test_completion_trace.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
