### PR TITLE
chore(jangar): promote image 824b75c8

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-06-01T03:43:14Z
+    deploy.knative.dev/rollout: 2026-06-02T18:37:45Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 84300aed90d32b77ae01a28d9a070d194b72c59a
+              value: 824b75c8356c40274528506560499aac97b79cfe
             - name: JANGAR_GITOPS_REVISION
-              value: 84300aed90d32b77ae01a28d9a070d194b72c59a
+              value: 824b75c8356c40274528506560499aac97b79cfe
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26733690404"
+              value: "26839709515"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:6d80d9481cfb17b6aded045e092fcc8e5cc3ca79c8c60ed1658b431b05d3e15b
+              value: sha256:11bb84db30117d040377169406da60256f64a15fc339063177bf12beb9061d2c
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 84300aed90d32b77ae01a28d9a070d194b72c59a
+              value: 824b75c8356c40274528506560499aac97b79cfe
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:6d80d9481cfb17b6aded045e092fcc8e5cc3ca79c8c60ed1658b431b05d3e15b
+              value: sha256:11bb84db30117d040377169406da60256f64a15fc339063177bf12beb9061d2c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 84300aed
-    digest: sha256:6d80d9481cfb17b6aded045e092fcc8e5cc3ca79c8c60ed1658b431b05d3e15b
+    newTag: 824b75c8
+    digest: sha256:11bb84db30117d040377169406da60256f64a15fc339063177bf12beb9061d2c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `824b75c8356c40274528506560499aac97b79cfe`
- Image tag: `824b75c8`
- Image digest: `sha256:11bb84db30117d040377169406da60256f64a15fc339063177bf12beb9061d2c`
- Source CI run: `26839709515`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates