### PR TITLE
chore(synthesis): run autotrader market recovery

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-market-open-recovery-20260602.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-market-open-recovery-20260602.yaml
@@ -1,0 +1,69 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: autonomous-trader-market-open-recovery-20260602
+  namespace: synthesis
+  annotations:
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: recovery
+    autonomous-trader.proompteng.ai/recovery-for: autonomous-trader-market-open-lxhgb
+    autonomous-trader.proompteng.ai/recovery-session-date: "2026-06-02"
+  labels:
+    app.kubernetes.io/part-of: synthesis
+    app.kubernetes.io/component: autonomous-trader
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: recovery
+spec:
+  agentRef:
+    name: autonomous-trader-agent
+  implementationSpecRef:
+    name: autonomous-trader-v1
+  goal:
+    objective: >-
+      Continue the 2026-06-02 market-open autotrader recovery run in the dedicated Synthesis Alpaca paper
+      account after the earlier AgentRun exited early; read current broker state, manage open positions and
+      orders, keep cycling until market close or a real terminal condition, and record every decision, risk
+      check, broker action, reconciliation result, and scorecard update in Synthesis.
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-only
+  runtime:
+    type: job
+    config:
+      serviceAccountName: agents-sa
+      backoffLimit: 0
+      logRetentionSeconds: 604800
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/synthesis-autonomous-trader-session
+    mode: market-open
+    synthesisSessionMode: market_open
+    brokerMutationEnabled: "true"
+    accountType: paper
+    targetEquityUsd: "500000"
+    marketOpenTimezone: America/New_York
+    premarketBootstrapMinutes: "15"
+  secrets:
+    - autonomous-trader-alpaca-mcp
+    - agents-artifacts
+    - codex-auth
+    - github-token
+    - synthesis-env
+  workload:
+    volumes:
+      - type: secret
+        name: synthesis-env
+        secretName: synthesis-env
+        mountPath: /var/run/synthesis
+        readOnly: true
+    resources:
+      requests:
+        cpu: "2"
+        memory: 4Gi
+        ephemeral-storage: 2Gi
+      limits:
+        memory: 16Gi
+        ephemeral-storage: 16Gi

--- a/argocd/applications/synthesis/agents-domain/kustomization.yaml
+++ b/argocd/applications/synthesis/agents-domain/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - autonomous-trader-implspec.yaml
   - autonomous-trader-agentrun-template.yaml
   - autonomous-trader-schedule.yaml
+  - autonomous-trader-market-open-recovery-20260602.yaml
   - autonomous-trader-green-agentrun-template.yaml
   - autonomous-trader-green-schedule.yaml
   - autonomous-trader-scorecard-readback-template.yaml


### PR DESCRIPTION
## Summary

- Adds a one-off `autonomous-trader-market-open-recovery-20260602` AgentRun through the Synthesis GitOps app.
- Uses the active blue autotrader production path: same agent, implementation spec, secrets, resources, broker mutation setting, and analysis branch as the market-open template.
- Leaves the scheduled blue/green templates unchanged while allowing Argo CD to create a recovery market-open run for today's session.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account"`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | rg -n "autonomous-trader-market-open-recovery-20260602|objective:|brokerMutationEnabled|ttlSecondsAfterFinished" -C 2`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
