### PR TITLE
fix(torghut): demote non-ledger promotion gates

### DIFF
--- a/services/torghut/app/trading/autonomy/gates.py
+++ b/services/torghut/app/trading/autonomy/gates.py
@@ -363,15 +363,24 @@ class GateEvaluationReport:
     recalibration_run_id: str | None
     evaluated_at: datetime
     code_version: str
+    evidence_collection_allowed: bool = False
+    promotion_blockers: list[str] = field(default_factory=_empty_str_list)
 
     def to_payload(self) -> dict[str, object]:
         return {
             "policy_version": self.policy_version,
             "promotion_target": self.promotion_target,
             "promotion_allowed": self.promotion_allowed,
+            "capital_promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "evidence_collection_allowed": self.evidence_collection_allowed,
+            "bounded_evidence_collection_authorized": self.evidence_collection_allowed,
+            "authority_source": "autonomy_gate_status_only",
             "recommended_mode": self.recommended_mode,
             "gates": [item.to_payload() for item in self.gates],
             "reasons": list(self.reasons),
+            "promotion_blockers": list(self.promotion_blockers),
             "uncertainty_gate_action": self.uncertainty_gate_action,
             "coverage_error": self.coverage_error,
             "conformal_interval_width": self.conformal_interval_width,
@@ -438,31 +447,31 @@ def evaluate_gate_matrix(
 
     reasons = [reason for gate in gates for reason in gate.reasons]
     recommended_mode: PromotionTarget = "shadow"
-    promotion_allowed = False
+    evidence_collection_allowed = False
+    promotion_blockers = ["autonomy_gate_not_runtime_ledger_authority"]
 
     if uncertainty_outcome.action in ("abstain", "fail"):
-        promotion_allowed = False
         recommended_mode = "shadow"
     elif promotion_target == "shadow":
-        promotion_allowed = all_required_pass
+        evidence_collection_allowed = all_required_pass
         recommended_mode = "shadow"
     elif promotion_target == "paper":
-        promotion_allowed = all_required_pass
+        evidence_collection_allowed = all_required_pass
         recommended_mode = "paper" if all_required_pass else "shadow"
     elif promotion_target == "live":
-        promotion_allowed = all_required_pass and gate5_pass
-        if promotion_allowed:
-            recommended_mode = "live"
-        elif all_required_pass:
+        evidence_collection_allowed = all_required_pass and gate5_pass
+        if all_required_pass:
             recommended_mode = "paper"
 
     return GateEvaluationReport(
         policy_version=policy.policy_version,
         promotion_target=promotion_target,
-        promotion_allowed=promotion_allowed,
+        promotion_allowed=False,
+        evidence_collection_allowed=evidence_collection_allowed,
         recommended_mode=recommended_mode,
         gates=gates,
         reasons=reasons,
+        promotion_blockers=promotion_blockers,
         uncertainty_gate_action=uncertainty_outcome.action,
         coverage_error=(
             str(uncertainty_outcome.coverage_error)
@@ -816,8 +825,13 @@ def _gate2_tca_reasons(inputs: GateInputs, policy: GatePolicyMatrix) -> list[str
     if policy.gate2_min_tca_expected_shortfall_coverage > 0:
         if expected_shortfall_sample_count <= 0 or expected_shortfall_coverage is None:
             reasons.append("tca_expected_shortfall_calibration_coverage_missing")
-        elif expected_shortfall_coverage < policy.gate2_min_tca_expected_shortfall_coverage:
-            reasons.append("tca_expected_shortfall_calibration_coverage_below_threshold")
+        elif (
+            expected_shortfall_coverage
+            < policy.gate2_min_tca_expected_shortfall_coverage
+        ):
+            reasons.append(
+                "tca_expected_shortfall_calibration_coverage_below_threshold"
+            )
 
     avg_tca_churn_ratio = _decimal(inputs.tca_metrics.get("avg_churn_ratio"))
     if avg_tca_churn_ratio is None:

--- a/services/torghut/app/trading/reporting.py
+++ b/services/torghut/app/trading/reporting.py
@@ -205,8 +205,10 @@ class EvaluationGateOutcome:
     promotion_requested: bool
     promotion_target: Literal["shadow", "paper", "live"]
     promotion_allowed: bool
+    evidence_collection_allowed: bool
     recommended_mode: Literal["shadow", "paper", "live"]
     reasons: list[str]
+    promotion_blockers: list[str]
 
     def to_payload(self) -> dict[str, object]:
         return {
@@ -214,8 +216,15 @@ class EvaluationGateOutcome:
             "promotion_requested": self.promotion_requested,
             "promotion_target": self.promotion_target,
             "promotion_allowed": self.promotion_allowed,
+            "capital_promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "evidence_collection_allowed": self.evidence_collection_allowed,
+            "bounded_evidence_collection_authorized": self.evidence_collection_allowed,
+            "authority_source": "offline_evaluation_status_only",
             "recommended_mode": self.recommended_mode,
             "reasons": list(self.reasons),
+            "promotion_blockers": list(self.promotion_blockers),
         }
 
 
@@ -508,22 +517,20 @@ def _evaluate_gates(
 
     promotion_requested = promotion_target != "shadow"
     gates_pass = len(reasons) == 0
-    promotion_allowed = False
+    evidence_collection_allowed = False
     recommended_mode: Literal["shadow", "paper", "live"] = "shadow"
+    promotion_blockers = ["offline_evaluation_not_runtime_ledger_authority"]
 
     if promotion_requested and policy.promotion_enabled and gates_pass:
         if promotion_target == "paper":
-            promotion_allowed = True
+            evidence_collection_allowed = True
             recommended_mode = "paper"
         elif promotion_target == "live":
             if policy.allow_live:
-                promotion_allowed = True
-                recommended_mode = "live"
+                evidence_collection_allowed = True
+                recommended_mode = "paper"
             else:
                 reasons.append("live_promotion_disabled")
-        else:
-            promotion_allowed = True
-            recommended_mode = "shadow"
 
     if promotion_requested and not policy.promotion_enabled:
         reasons.append("promotion_disabled")
@@ -532,9 +539,11 @@ def _evaluate_gates(
         policy_version=policy.policy_version,
         promotion_requested=promotion_requested,
         promotion_target=promotion_target,
-        promotion_allowed=promotion_allowed,
+        promotion_allowed=False,
+        evidence_collection_allowed=evidence_collection_allowed,
         recommended_mode=recommended_mode,
         reasons=reasons,
+        promotion_blockers=promotion_blockers,
     )
 
 

--- a/services/torghut/tests/test_autonomy_gates.py
+++ b/services/torghut/tests/test_autonomy_gates.py
@@ -16,47 +16,40 @@ from app.trading.autonomy.gates import (
 class TestAutonomyGates(TestCase):
     def test_gate_matrix_passes_paper_with_safe_metrics(self) -> None:
         policy = GatePolicyMatrix()
-        inputs = GateInputs(
-            feature_schema_version="3.0.0",
-            required_feature_null_rate=Decimal("0.00"),
-            staleness_ms_p95=0,
-            symbol_coverage=3,
-            tca_metrics={
-                "order_count": 12,
-                "avg_slippage_bps": "18",
-                "avg_shortfall_notional": "7",
-                "avg_churn_ratio": "0.45",
-                "avg_realized_shortfall_bps": "7",
-                "avg_divergence_bps": "1",
-                "avg_calibration_error_bps": "0",
-                "expected_shortfall_coverage": "0.50",
-                "expected_shortfall_sample_count": 12,
-            },
-            llm_metrics={"error_ratio": "0.00"},
-            metrics={
-                "decision_count": 20,
-                "trade_count": 10,
-                "net_pnl": "50",
-                "max_drawdown": "100",
-                "turnover_ratio": "1.5",
-                "cost_bps": "5",
-            },
-            robustness={
-                "fold_count": 4,
-                "negative_fold_count": 1,
-                "net_pnl_cv": "0.3",
-            },
-            forecast_metrics=_healthy_forecast_metrics_payload(),
-            profitability_evidence=_profitability_evidence_payload(),
-        )
+        inputs = _healthy_gate_inputs(symbol_coverage=3)
 
         report = evaluate_gate_matrix(
             inputs, policy=policy, promotion_target="paper", code_version="test"
         )
 
-        self.assertTrue(report.promotion_allowed)
+        self.assertFalse(report.promotion_allowed)
+        self.assertTrue(report.evidence_collection_allowed)
         self.assertEqual(report.recommended_mode, "paper")
+        payload = report.to_payload()
+        self.assertFalse(payload["capital_promotion_allowed"])
+        self.assertFalse(payload["final_promotion_allowed"])
+        self.assertFalse(payload["final_authority_ok"])
+        self.assertEqual(
+            payload["promotion_blockers"],
+            ["autonomy_gate_not_runtime_ledger_authority"],
+        )
         self.assertEqual(report.uncertainty_gate_action, "pass")
+
+    def test_gate_matrix_shadow_target_is_evidence_only_when_clean(self) -> None:
+        report = evaluate_gate_matrix(
+            _healthy_gate_inputs(),
+            policy=GatePolicyMatrix(),
+            promotion_target="shadow",
+            code_version="test",
+        )
+
+        self.assertFalse(report.promotion_allowed)
+        self.assertTrue(report.evidence_collection_allowed)
+        self.assertEqual(report.recommended_mode, "shadow")
+        self.assertEqual(
+            report.promotion_blockers,
+            ["autonomy_gate_not_runtime_ledger_authority"],
+        )
 
     def test_live_remains_gated_by_default(self) -> None:
         policy = GatePolicyMatrix(gate5_live_enabled=False)
@@ -325,7 +318,9 @@ class TestAutonomyGates(TestCase):
             report.reasons,
         )
 
-    def test_gate_matrix_treats_invalid_tca_expected_shortfall_sample_count_as_missing(self) -> None:
+    def test_gate_matrix_treats_invalid_tca_expected_shortfall_sample_count_as_missing(
+        self,
+    ) -> None:
         policy = GatePolicyMatrix(
             gate2_min_tca_expected_shortfall_coverage=Decimal("0.50"),
         )
@@ -409,13 +404,16 @@ class TestAutonomyGates(TestCase):
             inputs, policy=policy, promotion_target="paper", code_version="test"
         )
 
-        self.assertTrue(report.promotion_allowed)
+        self.assertFalse(report.promotion_allowed)
+        self.assertTrue(report.evidence_collection_allowed)
         self.assertNotIn(
             "tca_expected_shortfall_calibration_coverage_missing",
             report.reasons,
         )
 
-    def test_gate_matrix_fails_when_tca_realized_shortfall_and_divergence_exceed_threshold(self) -> None:
+    def test_gate_matrix_fails_when_tca_realized_shortfall_and_divergence_exceed_threshold(
+        self,
+    ) -> None:
         policy = GatePolicyMatrix(
             gate2_max_tca_realized_shortfall_bps=Decimal("1"),
             gate2_max_tca_divergence_bps=Decimal("0.5"),
@@ -948,6 +946,42 @@ class TestAutonomyGates(TestCase):
         self.assertFalse(report.promotion_allowed)
         self.assertEqual(report.uncertainty_gate_action, "fail")
         self.assertIn("regime_shift_score_fail_threshold_exceeded", report.reasons)
+
+
+def _healthy_gate_inputs(*, symbol_coverage: int = 2) -> GateInputs:
+    return GateInputs(
+        feature_schema_version="3.0.0",
+        required_feature_null_rate=Decimal("0.00"),
+        staleness_ms_p95=0,
+        symbol_coverage=symbol_coverage,
+        tca_metrics={
+            "order_count": 12,
+            "avg_slippage_bps": "18",
+            "avg_shortfall_notional": "7",
+            "avg_churn_ratio": "0.45",
+            "avg_realized_shortfall_bps": "7",
+            "avg_divergence_bps": "1",
+            "avg_calibration_error_bps": "0",
+            "expected_shortfall_coverage": "0.50",
+            "expected_shortfall_sample_count": 12,
+        },
+        llm_metrics={"error_ratio": "0.00"},
+        metrics={
+            "decision_count": 20,
+            "trade_count": 10,
+            "net_pnl": "50",
+            "max_drawdown": "100",
+            "turnover_ratio": "1.5",
+            "cost_bps": "5",
+        },
+        robustness={
+            "fold_count": 4,
+            "negative_fold_count": 1,
+            "net_pnl_cv": "0.3",
+        },
+        forecast_metrics=_healthy_forecast_metrics_payload(),
+        profitability_evidence=_profitability_evidence_payload(),
+    )
 
 
 def _profitability_evidence_payload(

--- a/services/torghut/tests/test_evaluation_report.py
+++ b/services/torghut/tests/test_evaluation_report.py
@@ -76,6 +76,15 @@ class TestEvaluationReport(TestCase):
         self.assertEqual(report.metrics.max_drawdown, Decimal("0"))
         self.assertEqual(report.gates.recommended_mode, "shadow")
         self.assertFalse(report.gates.promotion_allowed)
+        self.assertFalse(report.gates.evidence_collection_allowed)
+        gate_payload = report.gates.to_payload()
+        self.assertFalse(gate_payload["capital_promotion_allowed"])
+        self.assertFalse(gate_payload["final_promotion_allowed"])
+        self.assertFalse(gate_payload["final_authority_ok"])
+        self.assertEqual(
+            gate_payload["promotion_blockers"],
+            ["offline_evaluation_not_runtime_ledger_authority"],
+        )
         self.assertEqual(report.impact_assumptions.default_execution_seconds, 60)
         self.assertEqual(report.impact_assumptions.decisions_with_adv, 0)
         self.assertIn(
@@ -88,6 +97,33 @@ class TestEvaluationReport(TestCase):
 
         turnover_ratio = report.metrics.turnover_ratio.quantize(Decimal("0.1"))
         self.assertEqual(turnover_ratio, Decimal("4.0"))
+
+        evidence_collection_report = generate_evaluation_report(
+            results,
+            config=config,
+            gate_policy=EvaluationGatePolicy(promotion_enabled=True),
+            promotion_target="paper",
+        )
+        self.assertFalse(evidence_collection_report.gates.promotion_allowed)
+        self.assertTrue(evidence_collection_report.gates.evidence_collection_allowed)
+        self.assertEqual(evidence_collection_report.gates.recommended_mode, "paper")
+
+        live_request_report = generate_evaluation_report(
+            results,
+            config=config,
+            gate_policy=EvaluationGatePolicy(promotion_enabled=True, allow_live=True),
+            promotion_target="live",
+        )
+        self.assertFalse(live_request_report.gates.promotion_allowed)
+        self.assertTrue(live_request_report.gates.evidence_collection_allowed)
+        self.assertEqual(live_request_report.gates.recommended_mode, "paper")
+        live_request_gate_payload = live_request_report.gates.to_payload()
+        self.assertFalse(live_request_gate_payload["final_promotion_allowed"])
+        self.assertFalse(live_request_gate_payload["final_authority_ok"])
+        self.assertEqual(
+            live_request_report.gates.promotion_blockers,
+            ["offline_evaluation_not_runtime_ledger_authority"],
+        )
 
     def test_report_prefers_recorded_impact_inputs_when_present(self) -> None:
         fixture_path = Path(__file__).parent / "fixtures" / "walkforward_signals.json"


### PR DESCRIPTION
## Summary

- Demotes offline walk-forward evaluation gates so they can authorize bounded evidence collection but never capital/final promotion authority.
- Demotes autonomous gate-matrix outputs the same way: gate pass now reports `evidence_collection_allowed` while `promotion_allowed`, `capital_promotion_allowed`, `final_promotion_allowed`, and `final_authority_ok` remain false.
- Adds regression assertions that non-runtime-ledger gates stay status-only and expose promotion blockers instead of pretending to be proof.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_evaluation_report.py tests/test_autonomy_gates.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_autonomous_lane.py tests/test_trading_scheduler_autonomy.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_evaluation_report.py tests/test_autonomy_gates.py tests/test_autonomous_lane.py tests/test_trading_scheduler_autonomy.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_promotion_truthfulness.py tests/test_verify_trading_readiness.py -q -k "promotion or authority or proof_packet"`
- `cd services/torghut && uv run --frozen pytest tests/test_evaluation_report.py tests/test_autonomy_gates.py tests/test_autonomous_lane.py tests/test_trading_scheduler_autonomy.py tests/test_promotion_truthfulness.py tests/test_verify_trading_readiness.py -q -k "not slow"`
- `cd services/torghut && ruff check app/trading/reporting.py app/trading/autonomy/gates.py tests/test_evaluation_report.py tests/test_autonomy_gates.py`
- `cd services/torghut && ruff format --check app/trading/reporting.py app/trading/autonomy/gates.py tests/test_evaluation_report.py tests/test_autonomy_gates.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
