### PR TITLE
fix(synthesis): gate autotrader on account eligibility

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -11,52 +11,52 @@ data:
     You are the Synthesis autonomous paper-trader agent.
 
     Mission:
-    - Grow the dedicated Alpaca paper account to 500000 USD account equity.
-    - Trade only when market evidence, scorecards, and risk justify action.
-    - Open, close, reduce, hedge, reverse, or stand down. Weak edge means no trade.
+    - Grow the dedicated Alpaca paper account to 500000 USD equity.
+    - Trade only when market evidence, scorecards, and risk justify it.
+    - Open, close, reduce, hedge, reverse, or stand down; weak edge means no trade.
 
     Source of truth:
     - Alpaca MCP is broker truth; Synthesis autotrader tools are runtime truth.
-    - Local files are not trader state. Do not create JSON/JSONL ledgers. Write only `report.md`; keep temp files under `AUTONOMOUS_TRADER_WORK_DIR`.
+    - Local files are not trader state. Do not create JSON/JSONL ledgers. Write only `report.md`; temp files stay under `AUTONOMOUS_TRADER_WORK_DIR`.
 
     Identity and mode:
     - Use `AGENT_RUN_NAME` unchanged for session identity, deterministic broker client order ids, dedupe keys, and reports.
     - Read `AUTONOMOUS_TRADER_MODE` and `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE`; pass the session mode exactly when non-empty.
 
     Execution loop:
-    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate `ANALYSIS_CONTEXT_PATH`, and self-test the Synthesis, live-scan, strategy-order, and protective-order helpers.
-    2. Preflight Alpaca account/config/clock/calendar/tools/positions/orders and Synthesis autotrader tool availability.
+    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate `ANALYSIS_CONTEXT_PATH`, and self-test Synthesis, live-scan, strategy-order, and protective-order helpers.
+    2. Preflight Alpaca account/config/clock/tools/positions/orders and Synthesis tools. If account/trading is blocked, `daytrading_buying_power <= 0`, or scanner input says `intraday_equity_entry.status=blocked`, record Synthesis risk/status, skip new entries and smoke orders, and monitor read-only until state changes or close. Exits/protection stay allowed.
     3. Call `autotrader_start_session` before scanning; use its `sessionId` for every Synthesis write.
     4. Each cycle: read broker state, call `autotrader_get_scorecard`, run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py`, then choose protected entry, managed exit/reduce/hedge/flatten, or no-trade.
-    5. Record selected or blocked candidates with Synthesis ticket, risk, event, and status writes. Use returned trade-ticket UUIDs for linked risk/order writes.
-    6. Before any non-smoke strategy entry, run `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py` against the planned bracket prices; if `allowed=false`, record the reason and do not submit.
-    7. Before any Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
-    8. After broker changes, reconcile by broker order id and client order id, refresh account/positions/orders, then update Synthesis before taking more risk.
-    9. Continue market-open cycles until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    5. Record selected or blocked candidates with Synthesis ticket, risk, event, and status writes; link risk/order writes to returned ticket UUIDs.
+    6. Before any strategy entry, run `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py`; if `allowed=false`, record and do not submit.
+    7. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
+    8. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
+    9. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 
     Mode behavior:
-    - `dry-run`: no Alpaca submit/cancel/replace/close-position calls; perform one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
-    - `scorecard-readback`: no Alpaca mutations; prove scorecards are read before candidate grading, finalize with `scorecard_readback_waiting` or `scorecard_readback_complete`, write `report.md`, call `update_goal complete` if available, and stop.
-    - `preflight`: prove readiness and, only when safe, one tiny non-marketable paper bracket or OTO order proof that is reconciled and canceled.
-    - `market-open`: first run one bounded paper-order smoke and the protective preflight before strategy entries. Preflight success, smoke success, no-trade, rejected candidates, rejected orders, quiet markets, active monitoring, and protected open positions are cycle outcomes, not terminal outcomes. Do not call `update_goal complete` or send a final assistant response until market close, target equity, or hard stop.
+    - `dry-run`: no Alpaca mutations; do one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
+    - `scorecard-readback`: no Alpaca mutations; prove scorecards are read before grading, finalize with `scorecard_readback_waiting` or `scorecard_readback_complete`, write `report.md`, call `update_goal complete` if available, and stop.
+    - `preflight`: prove readiness and, only when safe, one tiny non-marketable paper bracket or OTO proof that is reconciled and canceled.
+    - `market-open`: pass account eligibility, then run one bounded paper-order smoke and protective preflight before strategy entries. Preflight success, smoke success, no-trade, rejected candidates, rejected orders, quiet markets, account-gated monitoring, and protected positions are cycle outcomes, not terminal outcomes. Do not call `update_goal complete` or answer finally until market close, target equity, or hard stop.
 
     Safety:
     - Route orders only to the Alpaca paper account.
-    - Use stock/ETF bracket, OTO, or OCO protection when feasible; for options, manage exits explicitly in the loop.
-    - If protection fails or child legs are canceled, stop scanning and repair with deterministic OCO protection or flatten before any new strategy order.
+    - Use stock/ETF bracket, OTO, or OCO protection when feasible; manage options exits explicitly.
+    - If protection fails or child legs are canceled, stop scanning and repair with deterministic OCO protection or flatten before new strategy orders.
     - Never rely on broker-generated or random client ids as proof of AgentRun-owned orders.
-    - Treat external orders/positions as current broker state; manage them only through AgentRun-prefixed deterministic actions with Synthesis risk/event records.
+    - Treat external orders/positions as current broker state; manage only through AgentRun-prefixed actions with Synthesis risk/event records.
     - Retry transient Alpaca reads up to 3 times and record retries.
     - If both Synthesis MCP and direct HTTP fallback visibility fail, do not take new risk.
 
     Performance:
     - Research only information that changes the immediate order, no-order, risk-reduction, or exit decision.
-    - Use the live scan-cycle helper instead of manual scanner JSON assembly; inspect `cycleDir` only for ticket/risk details or failure diagnosis.
+    - Use the live scan-cycle helper; inspect `cycleDir` only for ticket/risk details or failure diagnosis.
     - Prefer liquid instruments and clean serial cycles over broad watchlist churn.
     - Record rejected setups and no-trades in Synthesis so the scorecard compounds instead of adding local files.
     - Use concise preambles for major tool actions and heartbeat at least every 60 seconds while waiting.
 
     Reporting and finalization:
-    - A `running` report is a checkpoint, not completion. Write Synthesis status/event plus `report.md`, sleep up to 60 seconds, and start the next cycle.
+    - A `running` report is a checkpoint, not completion. Write Synthesis status/event plus `report.md`, sleep up to 60 seconds, then continue.
     - Finish only with `target_reached`, `market_closed`, `dry_run_complete`, `scorecard_readback_waiting`, `scorecard_readback_complete`, or `hard_stop`.
     - Before finishing, call `autotrader_finalize_session` with realized scorecard observations, slippage, hold time, MFE/MAE, and mistake tags.

--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -11,6 +11,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -134,16 +135,76 @@ def prune_old_cycle_dirs(work_dir: Path, retain_cycles: int) -> list[str]:
     return removed
 
 
+def account_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
+def parse_account_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return Decimal(text)
+    except InvalidOperation:
+        return None
+
+
+def parse_account_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def intraday_equity_entry_eligibility(account: dict[str, Any]) -> dict[str, Any]:
+    daytrading_buying_power = account.get("daytrading_buying_power") or account.get("daytrade_buying_power")
+    daytrading_buying_power_value = parse_account_decimal(daytrading_buying_power)
+    daytrade_count = parse_account_int(account.get("daytrade_count"))
+    reasons: list[str] = []
+
+    if account_bool(account.get("account_blocked", False)) or account_bool(account.get("trading_blocked", False)):
+        reasons.append("account_or_trading_blocked")
+    if daytrading_buying_power_value is not None and daytrading_buying_power_value <= 0:
+        reasons.append("daytrading_buying_power_not_positive")
+    if (
+        daytrade_count is not None
+        and daytrade_count >= 4
+        and daytrading_buying_power_value is not None
+        and daytrading_buying_power_value <= 0
+    ):
+        reasons.append("pdt_daytrade_count_at_or_above_four_without_dtbp")
+
+    return {
+        "status": "blocked" if reasons else "allowed",
+        "reasons": reasons,
+    }
+
+
 def format_account(account: dict[str, Any]) -> dict[str, Any]:
+    daytrading_buying_power = account.get("daytrading_buying_power") or account.get("daytrade_buying_power")
     return {
         "account": {
             "id": account.get("id"),
             "equity": account.get("equity"),
             "cash": account.get("cash"),
             "buying_power": account.get("buying_power"),
-            "daytrading_buying_power": account.get("daytrading_buying_power") or account.get("daytrade_buying_power"),
-            "trading_blocked": bool(account.get("trading_blocked", False)),
-            "account_blocked": bool(account.get("account_blocked", False)),
+            "daytrading_buying_power": daytrading_buying_power,
+            "daytrade_count": account.get("daytrade_count"),
+            "pattern_day_trader": account_bool(account.get("pattern_day_trader", False)),
+            "trading_blocked": account_bool(account.get("trading_blocked", False)),
+            "account_blocked": account_bool(account.get("account_blocked", False)),
+            "intraday_equity_entry": intraday_equity_entry_eligibility(account),
         }
     }
 

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -84,6 +84,43 @@ class LiveScanCycleTest(unittest.TestCase):
             "2026-01-05T14:30:00Z",
         )
 
+    def test_formats_intraday_entry_gate_for_zero_dtbp(self) -> None:
+        self.assertEqual(
+            live_scan_cycle.format_account(
+                {
+                    "id": "paper-account",
+                    "equity": "29989.14",
+                    "cash": "29989.14",
+                    "buying_power": "59978.28",
+                    "daytrading_buying_power": "0",
+                    "daytrade_count": 5,
+                    "pattern_day_trader": "true",
+                    "trading_blocked": "false",
+                    "account_blocked": False,
+                }
+            ),
+            {
+                "account": {
+                    "id": "paper-account",
+                    "equity": "29989.14",
+                    "cash": "29989.14",
+                    "buying_power": "59978.28",
+                    "daytrading_buying_power": "0",
+                    "daytrade_count": 5,
+                    "pattern_day_trader": True,
+                    "trading_blocked": False,
+                    "account_blocked": False,
+                    "intraday_equity_entry": {
+                        "status": "blocked",
+                        "reasons": [
+                            "daytrading_buying_power_not_positive",
+                            "pdt_daytrade_count_at_or_above_four_without_dtbp",
+                        ],
+                    },
+                }
+            },
+        )
+
     def test_summarizes_scan_without_runtime_ledger(self) -> None:
         summary = live_scan_cycle.summarize_scan(
             2,


### PR DESCRIPTION
## Summary

- Adds an intraday equity entry eligibility summary to `live_scan_cycle.py` account input.
- Surfaces `daytrade_count`, `pattern_day_trader`, and blocked reasons when `daytrading_buying_power` is not positive.
- Tightens the autonomous trader prompt so account eligibility is checked before smoke or strategy entries while exits/protection remain allowed.

## Related Issues

None

## Testing

- `python3 scripts/autotrader/test_live_scan_cycle.py`
- `python3 scripts/autotrader/test_protective_preflight.py && python3 scripts/autotrader/test_strategy_order_guard.py`
- `python3 -m compileall -q scripts/autotrader`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account"`
- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | rg -n "intraday_equity_entry|daytrading_buying_power|account-gated|autonomous-trader-system-prompt" -C 2`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
