### PR TITLE
fix(synthesis): skip autotrader scans when account gated

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -27,8 +27,8 @@ data:
     1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate `ANALYSIS_CONTEXT_PATH`, and self-test Synthesis, live-scan, strategy-order, and protective-order helpers.
     2. Preflight Alpaca account/config/clock/tools/positions/orders and Synthesis tools. If account/trading is blocked, `daytrading_buying_power <= 0`, or scanner input says `intraday_equity_entry.status=blocked`, record Synthesis risk/status, skip new entries and smoke orders, and monitor read-only until state changes or close. Exits/protection stay allowed.
     3. Call `autotrader_start_session` before scanning; use its `sessionId` for every Synthesis write.
-    4. Each cycle: read broker state, call `autotrader_get_scorecard`, run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py`, then choose protected entry, managed exit/reduce/hedge/flatten, or no-trade.
-    5. Record selected or blocked candidates with Synthesis ticket, risk, event, and status writes; link risk/order writes to returned ticket UUIDs.
+    4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py --account-gate-only`. If `skipFullScan=true`, record monitor status and skip candidate tickets. Otherwise call `autotrader_get_scorecard`, run full scan, then choose entry, exit/reduce/hedge/flatten, or no-trade.
+    5. Record selected or blocked scanned candidates with Synthesis ticket, risk, event, and status writes; link risk/order writes to returned ticket UUIDs.
     6. Before any strategy entry, run `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py`; if `allowed=false`, record and do not submit.
     7. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
     8. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.

--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -209,6 +209,42 @@ def format_account(account: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def list_payload(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def account_gate_action(account: dict[str, Any], positions: list[Any], orders: list[Any]) -> str:
+    eligibility = account.get("intraday_equity_entry")
+    entry_allowed = isinstance(eligibility, dict) and eligibility.get("status") == "allowed"
+    if entry_allowed:
+        return "scan"
+    if positions or orders:
+        return "manage_existing_broker_state"
+    return "monitor_only"
+
+
+def summarize_account_gate(
+    *,
+    raw_account: dict[str, Any],
+    raw_positions: Any,
+    raw_orders: Any,
+) -> dict[str, Any]:
+    account = format_account(raw_account)["account"]
+    positions = list_payload(raw_positions)
+    orders = list_payload(raw_orders)
+    action = account_gate_action(account, positions, orders)
+    return {
+        "ok": True,
+        "mode": "account_gate",
+        "account": account,
+        "openPositionCount": len(positions),
+        "openOrderCount": len(orders),
+        "hasOpenBrokerState": bool(positions or orders),
+        "action": action,
+        "skipFullScan": action == "monitor_only",
+    }
+
+
 def format_latest_quotes(payload: dict[str, Any], symbols: list[str]) -> dict[str, Any]:
     raw_quotes = payload.get("quotes") if isinstance(payload, dict) else None
     if not isinstance(raw_quotes, dict):
@@ -418,6 +454,15 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
     )
 
 
+def run_account_gate(args: argparse.Namespace) -> dict[str, Any]:
+    alpaca = AlpacaRestClient(timeout_seconds=args.timeout_seconds)
+    return summarize_account_gate(
+        raw_account=alpaca.trading_get("/v2/account"),
+        raw_positions=alpaca.trading_get("/v2/positions"),
+        raw_orders=alpaca.trading_get("/v2/orders", {"status": "open", "nested": "true"}),
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run one autonomous-trader live scan cycle.")
     parser.add_argument("--work-dir")
@@ -433,6 +478,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--stock-analysis-cli")
     parser.add_argument("--retain-cycles", type=int, default=5)
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--account-gate-only", action="store_true")
     return parser
 
 
@@ -441,10 +487,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.self_test:
         payload = {
             "ok": True,
+            "accountGateOnly": True,
             "defaultWatchlist": list(DEFAULT_WATCHLIST),
             "stockAnalysisCli": stock_analysis_cli_path(args.stock_analysis_cli),
         }
         print(json.dumps(payload, sort_keys=True, indent=2))
+        return 0
+    if args.account_gate_only:
+        print(json.dumps(run_account_gate(args), sort_keys=True, indent=2))
         return 0
     print(json.dumps(run_cycle(args), sort_keys=True, indent=2))
     return 0

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -121,6 +121,76 @@ class LiveScanCycleTest(unittest.TestCase):
             },
         )
 
+    def test_summarizes_account_gate_as_monitor_only_when_entry_blocked_and_flat(self) -> None:
+        summary = live_scan_cycle.summarize_account_gate(
+            raw_account={
+                "id": "paper-account",
+                "equity": "29989.14",
+                "buying_power": "59978.28",
+                "daytrading_buying_power": "0",
+                "daytrade_count": 5,
+            },
+            raw_positions=[],
+            raw_orders=[],
+        )
+
+        self.assertEqual(summary["mode"], "account_gate")
+        self.assertEqual(summary["action"], "monitor_only")
+        self.assertTrue(summary["skipFullScan"])
+        self.assertFalse(summary["hasOpenBrokerState"])
+        self.assertEqual(summary["openPositionCount"], 0)
+        self.assertEqual(summary["openOrderCount"], 0)
+        self.assertEqual(summary["account"]["intraday_equity_entry"]["status"], "blocked")
+
+    def test_summarizes_account_gate_as_manage_state_when_entry_blocked_with_position(self) -> None:
+        summary = live_scan_cycle.summarize_account_gate(
+            raw_account={
+                "id": "paper-account",
+                "equity": "29989.14",
+                "buying_power": "59978.28",
+                "daytrading_buying_power": "0",
+                "daytrade_count": 5,
+            },
+            raw_positions=[{"symbol": "AAPL", "qty": "1"}],
+            raw_orders=[],
+        )
+
+        self.assertEqual(summary["action"], "manage_existing_broker_state")
+        self.assertFalse(summary["skipFullScan"])
+        self.assertTrue(summary["hasOpenBrokerState"])
+        self.assertEqual(summary["openPositionCount"], 1)
+
+    def test_run_account_gate_fetches_only_broker_state(self) -> None:
+        case = self
+
+        class FakeAlpaca:
+            def __init__(self, *, timeout_seconds: float) -> None:
+                self.timeout_seconds = timeout_seconds
+
+            def trading_get(self, path: str, query: dict[str, str] | None = None) -> object:
+                if path == "/v2/account":
+                    return {
+                        "id": "paper-account",
+                        "equity": "30000",
+                        "buying_power": "60000",
+                        "daytrading_buying_power": "0",
+                        "daytrade_count": "5",
+                    }
+                if path == "/v2/positions":
+                    case.assertIsNone(query)
+                    return []
+                if path == "/v2/orders":
+                    case.assertEqual(query, {"status": "open", "nested": "true"})
+                    return []
+                raise AssertionError(f"unexpected trading path {path}")
+
+        args = live_scan_cycle.build_parser().parse_args(["--account-gate-only", "--timeout-seconds", "3"])
+        with patch.object(live_scan_cycle, "AlpacaRestClient", FakeAlpaca):
+            summary = live_scan_cycle.run_account_gate(args)
+
+        self.assertEqual(summary["action"], "monitor_only")
+        self.assertTrue(summary["skipFullScan"])
+
     def test_summarizes_scan_without_runtime_ledger(self) -> None:
         summary = live_scan_cycle.summarize_scan(
             2,


### PR DESCRIPTION
## Summary

- Adds `--account-gate-only` to the existing autotrader live scan helper.
- Returns a lightweight broker-state summary with `skipFullScan=true` when the account cannot take fresh entries and has no open positions or orders.
- Updates the autotrader prompt to run the account gate before full scans and skip candidate tickets while flat and account-gated.

## Related Issues

None

## Testing

- `python3 scripts/autotrader/test_live_scan_cycle.py`
- `python3 scripts/autotrader/test_protective_preflight.py`
- `python3 scripts/autotrader/test_strategy_order_guard.py`
- `python3 -m compileall -q scripts/autotrader`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test | jq '{ok, accountGateOnly, defaultWatchlistCount: (.defaultWatchlist|length)}'`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account"`
- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | rg -n 'account-gate-only|skipFullScan|skip candidate tickets|autonomous-trader-system-prompt' -C 2`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
