### PR TITLE
fix(torghut): remove proxy profit evidence paths

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1523,8 +1523,7 @@ def _target_identity(
     *,
     probe: Mapping[str, object],
 ) -> dict[str, object]:
-    source_promotion_allowed = bool(target.get("promotion_allowed"))
-    source_final_promotion_allowed = bool(
+    stripped_source_promotion_authority = bool(target.get("promotion_allowed")) or bool(
         target.get("final_promotion_allowed")
         or target.get("final_promotion_authorized")
     )
@@ -1601,8 +1600,7 @@ def _target_identity(
         ),
         "capital_promotion_allowed": False,
         "final_authority_ok": False,
-        "source_promotion_allowed": source_promotion_allowed,
-        "source_final_promotion_allowed": source_final_promotion_allowed,
+        "stripped_source_promotion_authority": stripped_source_promotion_authority,
         "promotion_allowed": False,
         "final_promotion_allowed": False,
         "max_notional": _safe_text(target.get("max_notional")) or "0",
@@ -5428,9 +5426,7 @@ def _readiness_blockers(
     }
     if not bool(target.get("promotion_allowed")):
         blockers.add("paper_probation_evidence_collection_only")
-    if bool(target.get("source_promotion_allowed")) or bool(
-        target.get("source_final_promotion_allowed")
-    ):
+    if bool(target.get("stripped_source_promotion_authority")):
         blockers.add("paper_route_evidence_audit_stripped_promotion_authority")
     if not bool(probe.get("configured_enabled")):
         blockers.add("paper_route_probe_disabled")
@@ -6403,11 +6399,8 @@ def _target_audit(
                 "allowed": False,
                 "final_authority_ok": False,
                 "reason": "paper_route_evidence_audit_observability_only",
-                "source_promotion_allowed": bool(
-                    target.get("source_promotion_allowed")
-                ),
-                "source_final_promotion_allowed": bool(
-                    target.get("source_final_promotion_allowed")
+                "stripped_source_promotion_authority": bool(
+                    target.get("stripped_source_promotion_authority")
                 ),
                 "blockers": blockers,
             },
@@ -6645,11 +6638,8 @@ def _database_unavailable_target_audit(
                 "allowed": False,
                 "final_authority_ok": False,
                 "reason": "paper_route_evidence_audit_observability_only",
-                "source_promotion_allowed": bool(
-                    target.get("source_promotion_allowed")
-                ),
-                "source_final_promotion_allowed": bool(
-                    target.get("source_final_promotion_allowed")
+                "stripped_source_promotion_authority": bool(
+                    target.get("stripped_source_promotion_authority")
                 ),
                 "blockers": blockers,
             },
@@ -7929,9 +7919,9 @@ def build_paper_route_target_plan_payload(
                 "schema_version": _safe_text(plan.get("schema_version")),
                 "target_count": _safe_int(plan.get("target_count") or len(targets)),
                 "skipped_target_count": _safe_int(plan.get("skipped_target_count")),
-                "source_promotion_allowed": bool(plan.get("promotion_allowed")),
-                "source_final_promotion_allowed": bool(
-                    plan.get("final_promotion_allowed")
+                "stripped_source_promotion_authority": bool(
+                    plan.get("promotion_allowed")
+                    or plan.get("final_promotion_allowed")
                     or plan.get("final_promotion_authorized")
                 ),
                 "promotion_allowed": False,
@@ -8230,9 +8220,9 @@ def build_paper_route_evidence_audit(
                 "schema_version": _safe_text(plan.get("schema_version")),
                 "target_count": _safe_int(plan.get("target_count") or len(targets)),
                 "skipped_target_count": _safe_int(plan.get("skipped_target_count")),
-                "source_promotion_allowed": bool(plan.get("promotion_allowed")),
-                "source_final_promotion_allowed": bool(
-                    plan.get("final_promotion_allowed")
+                "stripped_source_promotion_authority": bool(
+                    plan.get("promotion_allowed")
+                    or plan.get("final_promotion_allowed")
                     or plan.get("final_promotion_authorized")
                 ),
                 "promotion_allowed": False,
@@ -8371,21 +8361,11 @@ def build_paper_route_evidence_audit(
                 )
                 for audit in target_audits
             ),
-            "source_promotion_allowed_count": sum(
+            "stripped_source_promotion_authority_count": sum(
                 int(
                     bool(
                         _as_mapping(_as_mapping(audit.get("target"))).get(
-                            "source_promotion_allowed"
-                        )
-                    )
-                )
-                for audit in target_audits
-            ),
-            "source_final_promotion_allowed_count": sum(
-                int(
-                    bool(
-                        _as_mapping(_as_mapping(audit.get("target"))).get(
-                            "source_final_promotion_allowed"
+                            "stripped_source_promotion_authority"
                         )
                     )
                 )

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -57,7 +57,6 @@ POST_COST_BASIS_RUNTIME_LEDGER = POST_COST_PNL_BASIS
 POST_COST_BASIS_EXECUTION_RECONSTRUCTION = (
     "execution_reconstructed_pnl_after_explicit_costs"
 )
-POST_COST_BASIS_SIMULATION_REPORT = "simulation_report_net_pnl"
 POST_COST_BASIS_TCA_PROXY = "tca_shortfall_proxy"
 RUNTIME_LEDGER_ARTIFACT_SCHEMAS = frozenset(
     {
@@ -4259,33 +4258,6 @@ def _build_realized_strategy_pnl_rows(
     return realized_rows
 
 
-def _load_report_post_cost_expectancy_bps(artifact_refs: list[str]) -> Decimal | None:
-    for ref in artifact_refs:
-        path = Path(ref)
-        if (
-            path.name not in {"simulation-report.json", "evaluation-report.json"}
-            or not path.exists()
-        ):
-            continue
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            continue
-        pnl_payload = _as_mapping(payload.get("pnl"))
-        metrics_payload = _as_mapping(payload.get("metrics"))
-        net_pnl = _decimal_or_none(
-            pnl_payload.get("net_pnl_estimated") or metrics_payload.get("net_pnl")
-        )
-        execution_notional = _decimal_or_none(
-            pnl_payload.get("execution_notional_total")
-            or metrics_payload.get("turnover_notional")
-        )
-        if net_pnl is None or execution_notional is None or execution_notional <= 0:
-            continue
-        return (net_pnl / execution_notional) * Decimal("10000")
-    return None
-
-
 def _load_json_artifact(ref: str) -> dict[str, Any]:
     text = ref.strip()
     if not text:
@@ -6353,22 +6325,6 @@ def main() -> int:
     delay_depth_report = _load_json_artifact(delay_depth_report_ref)
     if delay_depth_report_ref:
         artifact_refs.append(delay_depth_report_ref)
-    report_post_cost_expectancy_bps = _load_report_post_cost_expectancy_bps(
-        artifact_refs
-    )
-    if (
-        report_post_cost_expectancy_bps is not None
-        and args.source_kind.strip().startswith("simulation_")
-    ):
-        tca_rows.append(
-            {
-                "computed_at": executions[-1] if executions else window_end,
-                "post_cost_expectancy_bps": report_post_cost_expectancy_bps,
-                "post_cost_expectancy_basis": POST_COST_BASIS_SIMULATION_REPORT,
-                "post_cost_promotion_eligible": False,
-                "promotion_blocker": "simulation_report_not_runtime_ledger_proof",
-            }
-        )
     if not bucket_ranges:
         bucket_ranges = build_regular_session_buckets(
             window_start=window_start,
@@ -6428,17 +6384,6 @@ def main() -> int:
         **runtime_ledger_artifact_metadata,
         **runtime_ledger_durable_metadata,
         **runtime_ledger_source_metadata,
-        "report_post_cost_expectancy_bps": (
-            str(report_post_cost_expectancy_bps)
-            if report_post_cost_expectancy_bps is not None
-            else None
-        ),
-        "report_post_cost_expectancy_basis": (
-            POST_COST_BASIS_SIMULATION_REPORT
-            if report_post_cost_expectancy_bps is not None
-            and source_kind.startswith("simulation_")
-            else None
-        ),
     }
     if delay_depth_report_ref:
         runtime_observation_payload.update(

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -20,7 +20,6 @@ from scripts.import_hypothesis_runtime_windows import (
     EXECUTION_ELIGIBLE_DECISION_STATUSES,
     POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
     POST_COST_BASIS_RUNTIME_LEDGER,
-    POST_COST_BASIS_SIMULATION_REPORT,
     POST_COST_BASIS_TCA_PROXY,
     _alpaca_2026_equity_fee_schedule_hash,
     _build_realized_strategy_pnl_rows,
@@ -29,7 +28,6 @@ from scripts.import_hypothesis_runtime_windows import (
     _first_bool,
     _first_lineage_digest,
     _load_json_artifact,
-    _load_report_post_cost_expectancy_bps,
     _order_feed_fill_delta_blockers,
     _nonnegative_int,
     _order_lifecycle_query_row,
@@ -804,7 +802,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self,
     ) -> None:
         invalid_cases = {
-            "invalid_pnl_basis": {"pnl_basis": POST_COST_BASIS_SIMULATION_REPORT},
+            "invalid_pnl_basis": {"pnl_basis": "simulation_report_net_pnl"},
             "invalid_schema": {"ledger_schema_version": "torghut.loose_ledger.v0"},
             "explicit_blocker": {"blockers": ["runtime_ledger_incomplete"]},
             "missing_fills": {"fill_count": 0},
@@ -2701,32 +2699,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         ):
             with self.assertRaisesRegex(RuntimeError, "source_dsn_not_configured"):
                 main()
-
-    def test_load_report_post_cost_expectancy_bps_uses_simulation_report(self) -> None:
-        with TemporaryDirectory() as temp_dir:
-            report_path = Path(temp_dir) / "simulation-report.json"
-            report_path.write_text(
-                '{"pnl":{"net_pnl_estimated":"66.16","execution_notional_total":"200061.4"}}',
-                encoding="utf-8",
-            )
-
-            value = _load_report_post_cost_expectancy_bps([str(report_path)])
-
-        self.assertEqual(value, Decimal("3.306984755680006238084907933"))
-
-    def test_load_report_post_cost_expectancy_bps_rejects_gross_only_report(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temp_dir:
-            report_path = Path(temp_dir) / "simulation-report.json"
-            report_path.write_text(
-                '{"pnl":{"gross_pnl":"66.16","execution_notional_total":"200061.4"}}',
-                encoding="utf-8",
-            )
-
-            value = _load_report_post_cost_expectancy_bps([str(report_path)])
-
-        self.assertEqual(value, None)
 
     def test_json_artifact_and_nonnegative_int_helpers_fail_closed(self) -> None:
         with TemporaryDirectory() as temp_dir:
@@ -9543,7 +9515,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(runtime_payload["promotion_authority"], "blocked")
         self.assertEqual(runtime_payload["runtime_ledger_profit_proof_present"], False)
 
-    def test_main_quarantines_report_runtime_pnl_when_tca_rows_are_empty(self) -> None:
+    def test_main_ignores_report_runtime_pnl_when_tca_rows_are_empty(self) -> None:
         with TemporaryDirectory() as temp_dir:
             report_path = Path(temp_dir) / "simulation-report.json"
             report_path.write_text(
@@ -9625,25 +9597,12 @@ class TestImportHypothesisRuntimeWindows(TestCase):
 
         self.assertEqual(exit_code, 0)
         tca_rows = build_buckets.call_args.kwargs["tca_rows"]
-        self.assertEqual(
-            tca_rows,
-            [
-                {
-                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
-                    "post_cost_expectancy_bps": Decimal("50.000"),
-                    "post_cost_expectancy_basis": POST_COST_BASIS_SIMULATION_REPORT,
-                    "post_cost_promotion_eligible": False,
-                    "promotion_blocker": "simulation_report_not_runtime_ledger_proof",
-                }
-            ],
-        )
+        self.assertEqual(tca_rows, [])
         runtime_payload = persist_windows.call_args.kwargs[
             "runtime_observation_payload"
         ]
-        self.assertEqual(
-            runtime_payload["report_post_cost_expectancy_basis"],
-            POST_COST_BASIS_SIMULATION_REPORT,
-        )
+        self.assertNotIn("report_post_cost_expectancy_basis", runtime_payload)
+        self.assertNotIn("report_post_cost_expectancy_bps", runtime_payload)
         self.assertEqual(runtime_payload["authoritative"], False)
         self.assertEqual(
             runtime_payload["authority_reason"],

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -7259,11 +7259,13 @@ class TestPaperRouteEvidenceAudit(TestCase):
         ]
         self.assertFalse(gate_plan["promotion_allowed"])
         self.assertFalse(gate_plan["final_promotion_allowed"])
+        self.assertFalse(gate_plan["stripped_source_promotion_authority"])
         audit = payload["targets"][0]
         self.assertFalse(audit["target"]["promotion_allowed"])
         self.assertFalse(audit["target"]["final_promotion_allowed"])
-        self.assertTrue(audit["target"]["source_promotion_allowed"])
-        self.assertTrue(audit["target"]["source_final_promotion_allowed"])
+        self.assertTrue(audit["target"]["stripped_source_promotion_authority"])
+        self.assertNotIn("source_promotion_allowed", audit["target"])
+        self.assertNotIn("source_final_promotion_allowed", audit["target"])
         self.assertEqual(audit["target"]["strategy_name"], target_strategy_name)
         self.assertIn(strategy_name, audit["target"]["strategy_lookup_names"])
         self.assertFalse(audit["source_activity"]["missing"])
@@ -7329,8 +7331,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "allowed": False,
                 "final_authority_ok": False,
                 "reason": "paper_route_evidence_audit_observability_only",
-                "source_promotion_allowed": True,
-                "source_final_promotion_allowed": True,
+                "stripped_source_promotion_authority": True,
                 "blockers": [
                     "paper_probation_evidence_collection_only",
                     "paper_route_evidence_audit_stripped_promotion_authority",
@@ -7352,8 +7353,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(payload["summary"]["target_with_promotion_decision_count"], 1)
         self.assertEqual(payload["summary"]["promotion_allowed_count"], 0)
         self.assertEqual(payload["summary"]["final_promotion_allowed_count"], 0)
-        self.assertEqual(payload["summary"]["source_promotion_allowed_count"], 1)
-        self.assertEqual(payload["summary"]["source_final_promotion_allowed_count"], 1)
+        self.assertEqual(
+            payload["summary"]["stripped_source_promotion_authority_count"], 1
+        )
         self.assertEqual(
             payload["summary"]["promotion_authority"]["reason"],
             "paper_route_evidence_audit_observability_only",


### PR DESCRIPTION
## Summary

- Removed the `simulation-report.json` / `evaluation-report.json` post-cost PnL importer fallback from runtime-window imports.
- Stopped adding synthetic report-derived TCA rows and report PnL basis metadata to runtime observation payloads.
- Replaced misleading paper-route `source_*promotion_allowed` readback fields with a single stripped-authority diagnostic while keeping all promotion authority false.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py app/trading/paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py app/trading/paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
