### PR TITLE
fix(torghut): bound status read pressure

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -543,6 +543,15 @@ class Settings(BaseSettings):
             "bounded reads instead of waiting for large catalog aggregates to time out."
         ),
     )
+    trading_tca_status_lineage_sample_limit: int = Field(
+        default=200,
+        alias="TRADING_TCA_STATUS_LINEAGE_SAMPLE_LIMIT",
+        description=(
+            "Maximum execution audit rows sampled when trading status summarizes "
+            "non-authoritative TCA cost lineage. Truncated samples remain fail-closed "
+            "and never count as promotion authority."
+        ),
+    )
     trading_poll_ms: int = Field(default=5000, alias="TRADING_POLL_MS")
     trading_reconcile_ms: int = Field(default=15000, alias="TRADING_RECONCILE_MS")
     trading_order_feed_enabled: bool = Field(

--- a/services/torghut/app/trading/tca.py
+++ b/services/torghut/app/trading/tca.py
@@ -12,7 +12,7 @@ from decimal import ROUND_CEILING, Decimal
 from typing import Any, Optional, cast
 
 from sqlalchemy import func, or_, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, load_only
 
 from ..config import settings
 from ..models import Execution, ExecutionTCAMetric, TradeDecision
@@ -38,6 +38,11 @@ ADAPTIVE_EXECUTION_SLOWDOWN = Decimal("1.40")
 ADAPTIVE_EXECUTION_SPEEDUP = Decimal("0.85")
 EXECUTION_TCA_COST_LINEAGE_SCHEMA_VERSION = "torghut.execution-tca-cost-lineage.v1"
 POST_COST_PNL_BASIS = "realized_strategy_pnl_after_explicit_costs"
+_TCA_STATUS_LINEAGE_SAMPLE_DEFAULT_LIMIT = 200
+_TCA_STATUS_LINEAGE_SAMPLE_MAX_LIMIT = 1000
+_TCA_STATUS_LINEAGE_SAMPLE_TRUNCATED_BLOCKER = (
+    "runtime_tca_cost_lineage_sample_truncated"
+)
 _CENT = Decimal("0.01")
 _ALPACA_2026_EQUITY_SEC_FEE_RATE = Decimal("20.60") / Decimal("1000000")
 _ALPACA_2026_EQUITY_TAF_RATE_PER_SHARE = Decimal("0.000195")
@@ -896,11 +901,13 @@ def build_tca_gate_inputs(
         account_label=normalized_account_label,
         symbols=normalized_symbols,
     )
+    filled_execution_count = int(execution_count or 0)
     runtime_ledger_lineage = _build_tca_runtime_ledger_lineage_summary(
         session,
         strategy_id=strategy_id,
         account_label=normalized_account_label,
         symbols=normalized_symbols,
+        total_filled_execution_count=filled_execution_count,
     )
     return {
         "account_label": normalized_account_label or None,
@@ -940,7 +947,7 @@ def build_tca_gate_inputs(
         else Decimal("0"),
         "avg_calibration_error_bps": avg_calibration_error_bps,
         "last_computed_at": last_computed_at,
-        "filled_execution_count": int(execution_count or 0),
+        "filled_execution_count": filled_execution_count,
         "latest_execution_created_at": latest_execution_created_at,
         "unsettled_execution_count": unsettled_execution_count,
         "symbol_breakdown": symbol_breakdown,
@@ -988,9 +995,19 @@ def _build_tca_runtime_ledger_lineage_summary(
     strategy_id: str | None,
     account_label: str,
     symbols: tuple[str, ...],
+    total_filled_execution_count: int | None = None,
 ) -> dict[str, object]:
+    sample_limit = _tca_status_lineage_sample_limit()
     stmt = (
         select(Execution)
+        .options(
+            load_only(
+                Execution.id,
+                Execution.alpaca_order_id,
+                Execution.symbol,
+                Execution.execution_audit_json,
+            )
+        )
         .join(ExecutionTCAMetric, ExecutionTCAMetric.execution_id == Execution.id)
         .where(
             Execution.avg_fill_price.is_not(None),
@@ -1003,7 +1020,79 @@ def _build_tca_runtime_ledger_lineage_summary(
         stmt = stmt.where(Execution.alpaca_account_label == account_label)
     if symbols:
         stmt = stmt.where(Execution.symbol.in_(symbols))
-    return _execution_lineage_summary(session.execute(stmt).scalars().all())
+    stmt = stmt.order_by(Execution.created_at.desc(), Execution.id.desc()).limit(
+        sample_limit + 1
+    )
+    sampled_executions = list(session.execute(stmt).scalars())
+    query_truncated = len(sampled_executions) > sample_limit
+    executions = sampled_executions[:sample_limit]
+    summary = _execution_lineage_summary(executions)
+    sampled_count = len(executions)
+    known_total = (
+        max(0, int(total_filled_execution_count))
+        if total_filled_execution_count is not None
+        else None
+    )
+    known_truncated = known_total is not None and known_total > sampled_count
+    truncated = query_truncated or known_truncated
+    summary.update(
+        {
+            "bounded": True,
+            "coverage_exact": not truncated,
+            "query_limit": sample_limit,
+            "sampled_execution_count": sampled_count,
+            "truncated": truncated,
+        }
+    )
+    if known_total is not None:
+        summary["total_filled_execution_count"] = known_total
+    if truncated:
+        _mark_tca_lineage_summary_fail_closed(
+            summary,
+            reason=_TCA_STATUS_LINEAGE_SAMPLE_TRUNCATED_BLOCKER,
+            missing_count=max(1, (known_total or sampled_count + 1) - sampled_count),
+        )
+    return summary
+
+
+def _tca_status_lineage_sample_limit() -> int:
+    configured_limit = getattr(
+        settings,
+        "trading_tca_status_lineage_sample_limit",
+        _TCA_STATUS_LINEAGE_SAMPLE_DEFAULT_LIMIT,
+    )
+    try:
+        parsed_limit = int(configured_limit)
+    except (TypeError, ValueError):
+        parsed_limit = _TCA_STATUS_LINEAGE_SAMPLE_DEFAULT_LIMIT
+    return max(1, min(parsed_limit, _TCA_STATUS_LINEAGE_SAMPLE_MAX_LIMIT))
+
+
+def _mark_tca_lineage_summary_fail_closed(
+    summary: dict[str, object],
+    *,
+    reason: str,
+    missing_count: int,
+) -> None:
+    blockers = [
+        str(blocker)
+        for blocker in cast(Collection[object], summary.get("blockers") or [])
+    ]
+    if reason not in blockers:
+        blockers.append(reason)
+    blocker_counts: dict[str, int] = {}
+    for key, value in cast(
+        Mapping[object, object], summary.get("blocker_counts") or {}
+    ).items():
+        try:
+            blocker_counts[str(key)] = int(cast(Any, value))
+        except (TypeError, ValueError):
+            blocker_counts[str(key)] = 1
+    blocker_counts[reason] = max(1, missing_count)
+    summary["status"] = "blocked"
+    summary["blockers"] = blockers
+    summary["blocker_counts"] = dict(sorted(blocker_counts.items()))
+    summary["promotion_authority"] = False
 
 
 def _execution_lineage_summary(executions: Collection[Execution]) -> dict[str, object]:

--- a/services/torghut/migrations/versions/0048_status_read_timeout_indexes.py
+++ b/services/torghut/migrations/versions/0048_status_read_timeout_indexes.py
@@ -1,0 +1,112 @@
+"""Add status read timeout indexes.
+
+Revision ID: 0048_status_read_timeout_indexes
+Revises: 0047_order_feed_source_window_classification_counts
+Create Date: 2026-06-02 12:45:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0048_status_read_timeout_indexes"
+down_revision = "0047_order_feed_source_window_classification_counts"
+branch_labels = None
+depends_on = None
+
+_INDEXES: tuple[tuple[str, str, str], ...] = (
+    (
+        "ix_strategy_hyp_windows_hyp_ended_desc",
+        "strategy_hypothesis_metric_windows",
+        """
+CREATE INDEX IF NOT EXISTS ix_strategy_hyp_windows_hyp_ended_desc
+ON strategy_hypothesis_metric_windows (
+  hypothesis_id,
+  window_ended_at DESC NULLS LAST,
+  created_at DESC
+)
+""",
+    ),
+    (
+        "ix_strategy_promotion_decisions_status_lookup",
+        "strategy_promotion_decisions",
+        """
+CREATE INDEX IF NOT EXISTS ix_strategy_promotion_decisions_status_lookup
+ON strategy_promotion_decisions (
+  hypothesis_id,
+  run_id,
+  candidate_id,
+  promotion_target,
+  created_at DESC
+)
+""",
+    ),
+    (
+        "ix_executions_account_symbol_filled_created",
+        "executions",
+        """
+CREATE INDEX IF NOT EXISTS ix_executions_account_symbol_filled_created
+ON executions (
+  alpaca_account_label,
+  symbol,
+  created_at DESC
+)
+WHERE avg_fill_price IS NOT NULL
+  AND filled_qty > 0
+""",
+    ),
+    (
+        "ix_execution_tca_metrics_account_symbol_computed",
+        "execution_tca_metrics",
+        """
+CREATE INDEX IF NOT EXISTS ix_execution_tca_metrics_account_symbol_computed
+ON execution_tca_metrics (
+  alpaca_account_label,
+  symbol,
+  computed_at DESC
+)
+""",
+    ),
+    (
+        "ix_options_catalog_active_last_seen_desc",
+        "torghut_options_contract_catalog",
+        """
+CREATE INDEX IF NOT EXISTS ix_options_catalog_active_last_seen_desc
+ON torghut_options_contract_catalog (
+  last_seen_ts DESC NULLS LAST
+)
+INCLUDE (
+  underlying_symbol,
+  provider_updated_ts,
+  close_price,
+  open_interest
+)
+WHERE status = 'active'
+""",
+    ),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    for _index_name, table_name, create_sql in _INDEXES:
+        if not inspector.has_table(table_name):
+            continue
+        op.execute(sa.text(create_sql))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    for index_name, table_name, _create_sql in reversed(_INDEXES):
+        if not inspector.has_table(table_name):
+            continue
+        op.execute(sa.text(f"DROP INDEX IF EXISTS {index_name}"))

--- a/services/torghut/tests/test_execution_tca.py
+++ b/services/torghut/tests/test_execution_tca.py
@@ -8,6 +8,7 @@ from unittest import TestCase
 from sqlalchemy import create_engine, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
+from app.config import settings
 from app.models import Base, Execution, ExecutionTCAMetric, Strategy, TradeDecision
 from app.trading.tca import (
     build_tca_gate_inputs,
@@ -70,6 +71,59 @@ class TestExecutionTcaCostLineage(TestCase):
         self.assertEqual(runtime_lineage["status"], "source_backed")
         self.assertEqual(runtime_lineage["source_backed_count"], 1)
         self.assertEqual(runtime_lineage["explicit_cost_count"], 1)
+        self.assertTrue(runtime_lineage["coverage_exact"])
+
+    def test_build_tca_gate_inputs_bounds_lineage_sample_fail_closed(self) -> None:
+        original_limit = settings.trading_tca_status_lineage_sample_limit
+        settings.trading_tca_status_lineage_sample_limit = 1
+        self.addCleanup(
+            setattr,
+            settings,
+            "trading_tca_status_lineage_sample_limit",
+            original_limit,
+        )
+
+        with self.session_local() as session:
+            strategy = self._insert_strategy(session)
+            for idx in range(3):
+                decision = self._insert_decision(
+                    session,
+                    strategy,
+                    decision_hash=f"source-backed-decision-{idx}",
+                    execution_policy={"version": "adaptive-limit-v1"},
+                )
+                execution = self._insert_execution(
+                    session,
+                    decision,
+                    order_id=f"source-backed-order-{idx}",
+                    raw_order={
+                        "commission": "0.02",
+                        "cost_model": {"source": "broker_reported_commission"},
+                    },
+                )
+                upsert_execution_tca_metric(session, execution)
+            session.flush()
+
+            tca_inputs = build_tca_gate_inputs(
+                session,
+                strategy_id=str(strategy.id),
+                account_label="paper",
+                symbols=["AAPL"],
+            )
+
+        runtime_lineage = tca_inputs["runtime_ledger_lineage"]
+        assert isinstance(runtime_lineage, dict)
+        self.assertEqual(runtime_lineage["status"], "blocked")
+        self.assertFalse(runtime_lineage["coverage_exact"])
+        self.assertTrue(runtime_lineage["truncated"])
+        self.assertEqual(runtime_lineage["query_limit"], 1)
+        self.assertEqual(runtime_lineage["sampled_execution_count"], 1)
+        self.assertEqual(runtime_lineage["total_filled_execution_count"], 3)
+        self.assertFalse(runtime_lineage["promotion_authority"])
+        self.assertIn(
+            "runtime_tca_cost_lineage_sample_truncated",
+            runtime_lineage["blockers"],
+        )
 
     def test_upsert_blocks_missing_explicit_cost_without_inference(self) -> None:
         with self.session_local() as session:

--- a/services/torghut/tests/test_status_read_timeout_indexes_migration.py
+++ b/services/torghut/tests/test_status_read_timeout_indexes_migration.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0048_status_read_timeout_indexes.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0048", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0048")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestStatusReadTimeoutIndexesMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(module.revision, "0048_status_read_timeout_indexes")
+        self.assertEqual(
+            module.down_revision,
+            "0047_order_feed_source_window_classification_counts",
+        )
+
+    def test_index_names_fit_postgres_identifier_limit(self) -> None:
+        module = _load_migration_module()
+
+        for index_name, _table_name, _create_sql in module._INDEXES:
+            self.assertLessEqual(len(index_name), 63, index_name)
+
+    def test_upgrade_adds_postgres_status_read_indexes(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        self.assertEqual(execute.call_count, len(module._INDEXES))
+        sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+        self.assertIn("window_ended_at DESC NULLS LAST", sql)
+        self.assertIn("ix_strategy_promotion_decisions_status_lookup", sql)
+        self.assertIn("WHERE avg_fill_price IS NOT NULL", sql)
+        self.assertIn("ix_execution_tca_metrics_account_symbol_computed", sql)
+        self.assertIn("ix_options_catalog_active_last_seen_desc", sql)
+        self.assertIn("WHERE status = 'active'", sql)
+
+    def test_upgrade_skips_non_postgres(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        execute.assert_not_called()
+
+    def test_downgrade_drops_existing_indexes(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.downgrade()
+
+        sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+        self.assertIn(
+            "DROP INDEX IF EXISTS ix_strategy_hyp_windows_hyp_ended_desc", sql
+        )
+        self.assertIn(
+            "DROP INDEX IF EXISTS ix_options_catalog_active_last_seen_desc",
+            sql,
+        )


### PR DESCRIPTION
## Summary

- Bounded the non-authoritative TCA runtime-ledger lineage sample used by `/trading/status` so status reads no longer load every matching execution audit row under live account/symbol scope.
- Marked truncated TCA lineage summaries as non-exact, blocked, and not promotion authority, preserving fail-closed profitability semantics.
- Added Postgres indexes for the live timeout query shapes: certificate window ordering, promotion-decision lookup, filled execution status scans, TCA account/symbol scans, and active options freshness ordering.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen python -m py_compile app/config.py app/trading/tca.py migrations/versions/0048_status_read_timeout_indexes.py tests/test_execution_tca.py tests/test_status_read_timeout_indexes_migration.py`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_tca.py::TestExecutionTcaCostLineage::test_build_tca_gate_inputs_bounds_lineage_sample_fail_closed tests/test_execution_tca.py::TestExecutionTcaCostLineage::test_upsert_repairs_source_backed_cost_lineage tests/test_status_read_timeout_indexes_migration.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_tca.py tests/test_tca_adaptive_policy.py tests/test_status_read_timeout_indexes_migration.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_tca.py tests/test_tca_adaptive_policy.py tests/test_status_read_timeout_indexes_migration.py tests/test_trading_api.py -k "tca_summary or options_catalog_freshness or bounds_lineage_sample or source_backed_cost_lineage or StatusReadTimeout" -q`
- `cd services/torghut && uv run --frozen ruff check app/config.py app/trading/tca.py migrations/versions/0048_status_read_timeout_indexes.py tests/test_execution_tca.py tests/test_status_read_timeout_indexes_migration.py`
- `cd services/torghut && uv run --frozen ruff format --check app/config.py app/trading/tca.py migrations/versions/0048_status_read_timeout_indexes.py tests/test_execution_tca.py tests/test_status_read_timeout_indexes_migration.py`
- `cd services/torghut && uv run --frozen python scripts/check_migration_graph.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check HEAD~1 HEAD`

## Breaking Changes

Adds Alembic migration `0048_status_read_timeout_indexes`; deployment must run Torghut migrations before relying on the new indexes.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
