### PR TITLE
fix(synthesis): require autotrader blocked ticket reasons

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -28,7 +28,7 @@ data:
     2. Preflight Alpaca account/config/clock/tools/positions/orders and Synthesis tools. If account/trading is blocked, `daytrading_buying_power <= 0`, or scanner input says `intraday_equity_entry.status=blocked`, record Synthesis risk/status, skip new entries and smoke orders, and monitor read-only until state changes or close. Exits/protection stay allowed.
     3. Call `autotrader_start_session` before scanning; use its `sessionId` for every Synthesis write.
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py --account-gate-only`. If `skipFullScan=true`, record monitor status and skip candidate tickets. Otherwise call `autotrader_get_scorecard`, run full scan, then choose entry, exit/reduce/hedge/flatten, or no-trade.
-    5. Record selected or blocked scanned candidates with Synthesis ticket, risk, event, and status writes; link risk/order writes to returned ticket UUIDs.
+    5. Record selected/blocked scanned candidates in Synthesis. For blocked tickets set `noTradeReason`; pass returned `ticketId` to risk/order writes.
     6. Before any strategy entry, run `python3 /workspace/lab/scripts/autotrader/strategy_order_guard.py`; if `allowed=false`, record and do not submit.
     7. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
     8. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -670,6 +670,8 @@ describe('autonomous trader provider', () => {
     })
     expect(countWords(implText)).toBeLessThanOrEqual(120)
     expect(countWords(systemPromptText)).toBeLessThanOrEqual(650)
+    expect(systemPromptText).toContain('For blocked tickets set `noTradeReason`')
+    expect(systemPromptText).toContain('pass returned `ticketId` to risk/order writes')
     expect(activeMarketOpenLanes).toHaveLength(1)
     expect(previewMarketOpenLanes).toHaveLength(1)
     const activeMarketOpenLane = activeMarketOpenLanes[0]


### PR DESCRIPTION
## Summary

- Updates the autotrader operating prompt to require `noTradeReason` on blocked trade tickets.
- Requires linked risk/order writes to use the returned `ticketId` from each ticket.
- Adds a manifest smoke assertion so the prompt contract cannot silently drop this reason/linkage requirement.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account"`
- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | rg -n 'noTradeReason|ticketId|autonomous-trader-system-prompt' -C 2`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
