### PR TITLE
fix(synthesis): keep autotrader green preview non-mutating

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-green-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-green-agentrun-template.yaml
@@ -37,7 +37,7 @@ spec:
     head: codex/synthesis-autonomous-trader-session-green
     mode: market-open
     synthesisSessionMode: market_open
-    brokerMutationEnabled: "true"
+    brokerMutationEnabled: "false"
     accountType: paper
     targetEquityUsd: "500000"
     marketOpenTimezone: America/New_York

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -706,7 +706,7 @@ describe('autonomous trader provider', () => {
       expect(objectAt(templateAnnotations, deploymentRoleKey)).toBe(role)
       expect(objectAt(parameters, 'mode')).toBe('market-open')
       expect(objectAt(parameters, 'synthesisSessionMode')).toBe('market_open')
-      expect(objectAt(parameters, 'brokerMutationEnabled')).toBe('true')
+      expect(objectAt(parameters, 'brokerMutationEnabled')).toBe(role === 'active' ? 'true' : 'false')
       expect(objectAt(parameters, 'accountType')).toBe('paper')
       expect(objectAt(parameters, 'targetEquityUsd')).toBe('500000')
     }


### PR DESCRIPTION
## Summary

- Keeps the suspended green autotrader market-open preview template non-mutating by setting `brokerMutationEnabled` to `false`.
- Preserves the active blue autotrader market-open schedule as the only mutating lane.
- Updates the autotrader smoke test so only the active lane may have broker mutations enabled; preview lanes must stay read-only until a GitOps promotion flips roles.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account"`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | rg -n "autonomous-trader-template-green|brokerMutationEnabled|autonomous-trader-market-open-green|deployment-role|deployment-color" -C 3`
- `git diff --check`
- `bun run lint:argocd`
- Live readback: `Schedule/autonomous-trader-market-open` is blue active, `Schedule/autonomous-trader-market-open-green` is green suspended, active CronJob uses `concurrencyPolicy=Forbid`, and no green CronJob exists while the preview schedule is suspended.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
