### PR TITLE
fix(torghut): keep close snapshots pending until window closes

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -4695,7 +4695,7 @@ def _account_window_close_snapshot_audit(
     symbol_filters = {
         str(item).strip().upper() for item in symbols if str(item).strip()
     }
-    required = generated_at >= window_end
+    required = generated_at > window_end
     base_payload: dict[str, object] = {
         "schema_version": "torghut.paper-route-account-window-close-snapshot-audit.v1",
         "scope": "account_position_snapshot_after_runtime_window_close",
@@ -6571,7 +6571,7 @@ def _database_unavailable_target_audit(
             "symbols": _target_probe_symbols(target, probe),
             "generated_at": _isoformat(generated_at),
             "window_end": _isoformat(window_end),
-            "required": generated_at >= window_end,
+            "required": generated_at > window_end,
             "state": "database_unavailable",
             "flat": None,
             "zero_open_position_evidence": False,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -4916,6 +4916,38 @@ class TestPaperRouteEvidenceAudit(TestCase):
             ["paper_route_session_window_not_closed"],
         )
 
+        close_boundary_payload = build(window_end)
+        close_boundary_readiness = close_boundary_payload[
+            "next_paper_route_runtime_window_targets"
+        ]["session_readiness"]
+        self.assertEqual(
+            close_boundary_readiness["state"],
+            "collecting_session_evidence",
+        )
+        self.assertTrue(close_boundary_readiness["window_open"])
+        self.assertFalse(close_boundary_readiness["window_closed"])
+        close_boundary_target_audit = close_boundary_payload[
+            "next_runtime_window_target_audits"
+        ][0]
+        close_boundary_close_state = close_boundary_target_audit["account_close_state"]
+        self.assertFalse(close_boundary_close_state["required"])
+        self.assertEqual(
+            close_boundary_close_state["state"],
+            "pending_until_window_close",
+        )
+        self.assertEqual(close_boundary_close_state["blockers"], [])
+        close_boundary_import_audit = close_boundary_payload[
+            "runtime_window_import_audit"
+        ]
+        self.assertEqual(
+            close_boundary_import_audit["state"],
+            "collecting_session_evidence",
+        )
+        self.assertEqual(
+            close_boundary_import_audit["blockers"],
+            ["paper_route_session_window_not_closed"],
+        )
+
         settlement_payload = build(datetime(2026, 5, 26, 20, 30, tzinfo=timezone.utc))
         settlement_readiness = settlement_payload[
             "next_paper_route_runtime_window_targets"


### PR DESCRIPTION
## Summary

- Align paper-route close-snapshot proof with session readiness by requiring close snapshots only after the runtime window is actually closed.
- Keep degraded database-unavailable target audits on the same boundary so normal and fail-closed paths agree.
- Add regression coverage for the exact session-close timestamp, where import remains in `collecting_session_evidence` and close proof stays pending.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'next_paper_route_session_readiness_tracks_collection_and_import'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
