### PR TITLE
fix(torghut): remove tca proxy runtime evidence

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -37,9 +37,8 @@ _LIFECYCLE_EVENTS = (
     | _REJECTED_ORDER_EVENTS
     | _UNFILLED_ORDER_EVENTS
 )
-_TCA_PNL_BASES = frozenset(
+_NON_RUNTIME_PNL_TCA_BASIS_ALIASES = frozenset(
     {
-        "tca_shortfall_proxy",
         "tca_shortfall",
         "shortfall_proxy",
         "realized_pnl_proxy_from_tca_shortfall",
@@ -1311,13 +1310,24 @@ def _has_tca_pnl_shortcut(row: RuntimeLedgerFill | Mapping[str, object]) -> bool
             "cost_basis",
         )
     )
-    if basis is not None and basis.lower().replace("-", "_") in _TCA_PNL_BASES:
+    if basis is not None and _basis_claims_tca_pnl_shortcut(basis):
         return True
     return (
         _row_value(row, "post_cost_expectancy_bps") is not None
         and _row_value(row, "shortfall_notional", "realized_pnl_proxy_notional")
         is not None
     )
+
+
+def _basis_claims_tca_pnl_shortcut(basis: str) -> bool:
+    normalized = basis.lower().replace("-", "_")
+    if normalized in _NON_RUNTIME_PNL_TCA_BASIS_ALIASES:
+        return True
+    tokens = {token for token in normalized.split("_") if token}
+    return (
+        ("tca" in tokens or "shortfall" in tokens)
+        and ("proxy" in tokens or "estimate" in tokens)
+    ) or ("realized" in tokens and "pnl" in tokens and "proxy" in tokens)
 
 
 def _tigerbeetle_journal_blockers(

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -237,7 +237,7 @@ def runtime_ledger_promotion_source_authority_blockers(
 def _post_cost_expectancy_basis(value: Any) -> str:
     text = _text(value)
     if text is None:
-        return "tca_shortfall_proxy"
+        return "post_cost_basis_missing"
     return text.lower().replace("-", "_")
 
 

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -57,7 +57,6 @@ POST_COST_BASIS_RUNTIME_LEDGER = POST_COST_PNL_BASIS
 POST_COST_BASIS_EXECUTION_RECONSTRUCTION = (
     "execution_reconstructed_pnl_after_explicit_costs"
 )
-POST_COST_BASIS_TCA_PROXY = "tca_shortfall_proxy"
 RUNTIME_LEDGER_ARTIFACT_SCHEMAS = frozenset(
     {
         EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
@@ -1583,6 +1582,18 @@ def _execution_query_row(row: Sequence[object]) -> dict[str, object]:
 
 def _execution_query_row_has_time(row: Sequence[object]) -> bool:
     return (row[3] if len(row) >= 19 else row[1]) is not None
+
+
+def _execution_query_row_has_tca_ref(row: Mapping[str, object]) -> bool:
+    return (
+        _first_text(
+            row,
+            "execution_tca_metric_id",
+            "execution_tca_metric_ref",
+            "execution_tca_id",
+        )
+        is not None
+    )
 
 
 def _source_window_query_context(
@@ -3512,17 +3523,14 @@ def _source_activity_diagnostics_blockers(
     order_query_count = _nonnegative_int(
         diagnostics.get("order_lifecycle_rows_before_lineage_filter")
     )
-    tca_query_count = _nonnegative_int(
-        diagnostics.get("tca_rows_before_lineage_filter")
-    )
     decision_lineage_count = _nonnegative_int(
         diagnostics.get("decision_rows_after_lineage_filter")
     )
     execution_lineage_count = _nonnegative_int(
         diagnostics.get("execution_rows_after_lineage_filter")
     )
-    tca_lineage_count = _nonnegative_int(
-        diagnostics.get("tca_rows_after_lineage_filter")
+    execution_tca_lineage_count = _nonnegative_int(
+        diagnostics.get("execution_tca_rows_after_lineage_filter")
     )
     source_bucket_count = _nonnegative_int(
         diagnostics.get("runtime_ledger_source_bucket_count")
@@ -3540,18 +3548,14 @@ def _source_activity_diagnostics_blockers(
     else:
         strategy_unlinked_fill_lifecycle_count = unlinked_fill_lifecycle_count
 
-    if (
-        decision_query_count
-        or execution_query_count
-        or order_query_count
-        or tca_query_count
-    ) and not (decision_lineage_count or execution_lineage_count or tca_lineage_count):
+    if (decision_query_count or execution_query_count or order_query_count) and not (
+        decision_lineage_count or execution_lineage_count
+    ):
         add("source_lineage_filter_excluded_activity")
     elif not (
         decision_query_count
         or execution_query_count
         or order_query_count
-        or tca_query_count
         or source_bucket_count
     ):
         add("strategy_account_symbol_window_source_activity_missing")
@@ -3560,7 +3564,7 @@ def _source_activity_diagnostics_blockers(
         add("execution_rows_missing_for_matched_decisions")
     if execution_lineage_count > 0 and order_query_count <= 0:
         add(ORDER_FEED_FILL_LIFECYCLE_MISSING_BLOCKER)
-    if execution_lineage_count > 0 and tca_lineage_count <= 0:
+    if execution_lineage_count > 0 and execution_tca_lineage_count <= 0:
         add("execution_tca_rows_missing")
     if strategy_unlinked_fill_lifecycle_count > 0:
         add(ORDER_FEED_UNLINKED_FILL_LIFECYCLE_PRESENT_BLOCKER)
@@ -5177,6 +5181,11 @@ def _query_timestamps(
                 source_activity_diagnostics[
                     "fill_execution_rows_before_lineage_filter"
                 ] = sum(1 for row in execution_rows if _execution_row_has_fill(row))
+                source_activity_diagnostics[
+                    "execution_tca_rows_before_lineage_filter"
+                ] = sum(
+                    1 for row in execution_rows if _execution_query_row_has_tca_ref(row)
+                )
             execution_rows = [
                 row
                 for row in execution_rows
@@ -5194,6 +5203,11 @@ def _query_timestamps(
                 source_activity_diagnostics[
                     "fill_execution_rows_after_lineage_filter"
                 ] = sum(1 for row in execution_rows if _execution_row_has_fill(row))
+                source_activity_diagnostics[
+                    "execution_tca_rows_after_lineage_filter"
+                ] = sum(
+                    1 for row in execution_rows if _execution_query_row_has_tca_ref(row)
+                )
             execution_rows = _attach_source_lineage_context(
                 execution_rows,
                 candidate_id=candidate_id,
@@ -5494,6 +5508,13 @@ def _query_timestamps(
                         for row in carry_in_execution_rows
                         if _execution_row_has_fill(row)
                     )
+                    source_activity_diagnostics[
+                        "carry_in_execution_tca_rows_before_lineage_filter"
+                    ] = sum(
+                        1
+                        for row in carry_in_execution_rows
+                        if _execution_query_row_has_tca_ref(row)
+                    )
                 carry_in_execution_rows = [
                     row
                     for row in carry_in_execution_rows
@@ -5514,6 +5535,13 @@ def _query_timestamps(
                         1
                         for row in carry_in_execution_rows
                         if _execution_row_has_fill(row)
+                    )
+                    source_activity_diagnostics[
+                        "carry_in_execution_tca_rows_after_lineage_filter"
+                    ] = sum(
+                        1
+                        for row in carry_in_execution_rows
+                        if _execution_query_row_has_tca_ref(row)
                     )
                 carry_in_execution_rows = _attach_source_lineage_context(
                     carry_in_execution_rows,
@@ -5855,88 +5883,7 @@ def _query_timestamps(
                         "event_fingerprint",
                     )
                 unlinked_order_lifecycle_rows = strategy_unlinked_order_lifecycle_rows
-            cur.execute(
-                f"""
-                select
-                    coalesce(
-                        e.order_feed_last_event_ts,
-                        e.last_update_at,
-                        e.updated_at,
-                        e.created_at
-                    ) as execution_event_at,
-                    t.computed_at as tca_computed_at,
-                    abs(coalesce(t.realized_shortfall_bps, t.slippage_bps)) as abs_slippage_bps,
-                    (-coalesce(t.realized_shortfall_bps, t.slippage_bps)) as post_cost_expectancy_bps,
-                    d.decision_hash,
-                    d.decision_json
-                from execution_tca_metrics t
-                join executions e on e.id = t.execution_id
-                join trade_decisions d on d.id = e.trade_decision_id
-                join strategies s on s.id = d.strategy_id
-                where s.name = any(%s)
-                  and d.alpaca_account_label = %s
-                  and coalesce(t.alpaca_account_label, e.alpaca_account_label, d.alpaca_account_label) = %s
-                  and coalesce(
-                        e.order_feed_last_event_ts,
-                        e.last_update_at,
-                        e.updated_at,
-                        e.created_at
-                      ) >= %s
-                  and coalesce(
-                        e.order_feed_last_event_ts,
-                        e.last_update_at,
-                        e.updated_at,
-                        e.created_at
-                      ) < %s
-                  {execution_symbol_clause}
-                order by coalesce(
-                    e.order_feed_last_event_ts,
-                    e.last_update_at,
-                    e.updated_at,
-                    e.created_at
-                )
-                """,
-                (
-                    strategy_names,
-                    canonical_account_label,
-                    canonical_account_label,
-                    window_start,
-                    window_end,
-                    *execution_symbol_params,
-                ),
-            )
-            tca_rows = [
-                {
-                    "computed_at": row[0],
-                    "tca_computed_at": row[1],
-                    "abs_slippage_bps": row[2] or Decimal("0"),
-                    "post_cost_expectancy_bps": row[3] or Decimal("0"),
-                    "decision_hash": row[4],
-                    "decision_json": row[5],
-                    "post_cost_expectancy_basis": POST_COST_BASIS_TCA_PROXY,
-                    "post_cost_promotion_eligible": False,
-                }
-                for row in cur.fetchall()
-                if row[0] is not None
-            ]
             if source_activity_diagnostics is not None:
-                source_activity_diagnostics["tca_rows_before_lineage_filter"] = len(
-                    tca_rows
-                )
-            tca_rows = [
-                row
-                for row in tca_rows
-                if _source_row_matches_lineage(
-                    row,
-                    candidate_id=candidate_id,
-                    hypothesis_id=hypothesis_id,
-                    require_source_lineage=require_source_lineage,
-                )
-            ]
-            if source_activity_diagnostics is not None:
-                source_activity_diagnostics["tca_rows_after_lineage_filter"] = len(
-                    tca_rows
-                )
                 lifecycle_blockers = _order_feed_fill_lifecycle_blockers(
                     execution_rows=execution_rows,
                     order_lifecycle_rows=order_lifecycle_rows,
@@ -6035,8 +5982,8 @@ def _source_activity_missing_summary(
         "window_start": window_start.isoformat(),
         "window_end": window_end.isoformat(),
         "remediation": (
-            "Run live-paper replay or route/TCA repair until the source database contains "
-            "execution-eligible trade_decisions, executions, or TCA rows for this target "
+            "Run live-paper replay or route repair until the source database contains "
+            "execution-eligible trade_decisions, executions, and source-backed runtime-ledger rows for this target "
             "before importing promotion evidence."
         ),
     }

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -1037,7 +1037,7 @@ class TestHypothesisReadiness(TestCase):
                         "submitted_order_count": 45,
                         "post_cost_expectancy_bps": "8",
                         "ledger_schema_version": "unknown",
-                        "pnl_basis": "tca_shortfall_proxy",
+                        "pnl_basis": "broker_tca_shortfall_estimate",
                         "execution_policy_hash_counts": {},
                         "cost_model_hash_counts": {},
                         "lineage_hash_counts": {},

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -20,7 +20,6 @@ from scripts.import_hypothesis_runtime_windows import (
     EXECUTION_ELIGIBLE_DECISION_STATUSES,
     POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
     POST_COST_BASIS_RUNTIME_LEDGER,
-    POST_COST_BASIS_TCA_PROXY,
     _alpaca_2026_equity_fee_schedule_hash,
     _build_realized_strategy_pnl_rows,
     _execution_signed_qty,
@@ -118,6 +117,7 @@ class _FakeCursor:
                     "alpaca-order-1",
                     "client-order-1",
                     "filled",
+                    "tca-id-1",
                 )
             ],
             [
@@ -152,16 +152,6 @@ class _FakeCursor:
                         "cost_model_hash": "cost-sha",
                         "lineage_hash": "lineage-sha",
                     },
-                )
-            ],
-            [
-                (
-                    datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
-                    datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
-                    Decimal("1.25"),
-                    Decimal("0.50"),
-                    "decision-sha",
-                    {},
                 )
             ],
         ]
@@ -574,7 +564,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("12"),
-                    "post_cost_expectancy_basis": POST_COST_BASIS_TCA_PROXY,
+                    "post_cost_expectancy_basis": "broker_tca_shortfall_estimate",
                     "post_cost_promotion_eligible": False,
                 }
             ],
@@ -7139,24 +7129,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(
             executions, [datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)]
         )
-        self.assertEqual(len(tca_rows), 2)
-        self.assertEqual(tca_rows[0]["abs_slippage_bps"], Decimal("1.25"))
-        self.assertEqual(tca_rows[0]["post_cost_expectancy_bps"], Decimal("0.50"))
+        self.assertEqual(len(tca_rows), 1)
         self.assertEqual(
-            tca_rows[0]["computed_at"],
-            datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
-        )
-        self.assertEqual(
-            tca_rows[0]["tca_computed_at"],
-            datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
-        )
-        self.assertEqual(
-            tca_rows[0]["post_cost_expectancy_basis"], POST_COST_BASIS_TCA_PROXY
+            tca_rows[0]["post_cost_expectancy_basis"],
+            POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
         )
         self.assertEqual(tca_rows[0]["post_cost_promotion_eligible"], False)
-        self.assertEqual(tca_rows[1]["post_cost_promotion_eligible"], False)
-        self.assertIn("unclosed_position", tca_rows[1]["runtime_ledger_blockers"])
-        self.assertEqual(len(cursor.executed), 4)
+        self.assertIn("unclosed_position", tca_rows[0]["runtime_ledger_blockers"])
+        self.assertEqual(len(cursor.executed), 3)
         decision_query, decision_params = cursor.executed[0]
         self.assertIn("s.name = any(%s)", decision_query)
         self.assertIn("d.status = any(%s)", decision_query)
@@ -7169,7 +7149,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
         )
         order_event_query, _ = cursor.executed[2]
-        tca_query, _ = cursor.executed[3]
         execution_query, _ = cursor.executed[1]
         self.assertIn("left join execution_tca_metrics", execution_query)
         self.assertIn("e.alpaca_account_label = %s", execution_query)
@@ -7187,26 +7166,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("coalesce(oe.event_ts, oe.created_at) < %s", order_event_query)
         self.assertNotIn("and d.created_at >= %s", order_event_query)
         self.assertNotIn("and d.created_at < %s", order_event_query)
-        self.assertIn("as execution_event_at", tca_query)
-        self.assertIn("t.computed_at as tca_computed_at", tca_query)
-        self.assertIn(
-            "coalesce(t.alpaca_account_label, e.alpaca_account_label, d.alpaca_account_label) = %s",
-            tca_query,
-        )
-        self.assertIn("e.order_feed_last_event_ts", tca_query)
-        self.assertIn("e.last_update_at", tca_query)
-        self.assertIn("e.updated_at", tca_query)
-        self.assertIn("e.created_at", tca_query)
-        self.assertNotIn("t.computed_at >= %s", tca_query)
-        self.assertNotIn("t.computed_at < %s", tca_query)
-        self.assertNotIn("and d.created_at >= %s", tca_query)
-        self.assertNotIn("and d.created_at < %s", tca_query)
         self.assertEqual(diagnostics["decision_rows_before_lineage_filter"], 1)
         self.assertEqual(diagnostics["decision_rows_after_lineage_filter"], 1)
         self.assertEqual(diagnostics["execution_rows_before_lineage_filter"], 1)
         self.assertEqual(diagnostics["execution_rows_after_lineage_filter"], 1)
+        self.assertEqual(diagnostics["execution_tca_rows_before_lineage_filter"], 1)
+        self.assertEqual(diagnostics["execution_tca_rows_after_lineage_filter"], 1)
         self.assertEqual(diagnostics["order_lifecycle_rows_before_lineage_filter"], 1)
-        self.assertEqual(diagnostics["tca_rows_before_lineage_filter"], 1)
 
     def test_query_timestamps_records_unattributed_fill_lifecycle_diagnostics(
         self,
@@ -7260,7 +7226,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 source_activity_diagnostics=diagnostics,
             )
 
-        self.assertEqual(len(cursor.executed), 5)
+        self.assertEqual(len(cursor.executed), 4)
         unlinked_query, unlinked_params = cursor.executed[3]
         self.assertIn("from execution_order_events oe", unlinked_query)
         self.assertIn("left join lateral", unlinked_query)
@@ -7491,7 +7457,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         decision_params = cursor.executed[0][1]
         execution_params = cursor.executed[1][1]
         order_event_query, order_event_params = cursor.executed[2]
-        tca_params = cursor.executed[3][1]
         self.assertEqual(decision_params[1], "TORGHUT_SIM")
         self.assertEqual(execution_params[1], "TORGHUT_SIM")
         self.assertEqual(execution_params[2], "TORGHUT_SIM")
@@ -7507,11 +7472,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "PA3SX7FYNUTF",
             ),
         )
-        self.assertEqual(tca_params[1], "TORGHUT_SIM")
-        self.assertEqual(tca_params[2], "TORGHUT_SIM")
         self.assertEqual(diagnostics["account_label"], "TORGHUT_SIM")
         self.assertEqual(diagnostics["source_account_label"], "PA3SX7FYNUTF")
-        runtime_bucket = tca_rows[1]["runtime_ledger_bucket"]
+        runtime_bucket = tca_rows[0]["runtime_ledger_bucket"]
         self.assertEqual(runtime_bucket["account_label"], "TORGHUT_SIM")
         self.assertEqual(runtime_bucket["source_account_label"], "PA3SX7FYNUTF")
         self.assertEqual(
@@ -7736,7 +7699,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 source_activity_diagnostics=diagnostics,
             )
 
-        self.assertEqual(len(cursor.executed), 8)
+        self.assertEqual(len(cursor.executed), 7)
         carry_decision_query, carry_decision_params = cursor.executed[3]
         carry_execution_query, carry_execution_params = cursor.executed[4]
         carry_order_query, carry_order_params = cursor.executed[5]
@@ -7837,7 +7800,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_rows_before_lineage_filter": 1,
                     "execution_rows_after_lineage_filter": 1,
                     "order_lifecycle_rows_before_lineage_filter": 1,
-                    "tca_rows_after_lineage_filter": 1,
+                    "execution_tca_rows_after_lineage_filter": 1,
                     "runtime_ledger_source_bucket_count": 1,
                     "runtime_ledger_source_bucket_profit_proof_count": 0,
                     "runtime_ledger_source_bucket_profit_proof_blockers": [
@@ -7873,12 +7836,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 symbols=[" aapl ", "AAPL"],
             )
 
-        self.assertEqual(len(cursor.executed), 5)
+        self.assertEqual(len(cursor.executed), 4)
         decision_query, decision_params = cursor.executed[0]
         execution_query, execution_params = cursor.executed[1]
         order_event_query, order_event_params = cursor.executed[2]
         unlinked_query, unlinked_params = cursor.executed[3]
-        tca_query, tca_params = cursor.executed[4]
         self.assertIn("upper(d.symbol) = any(%s)", decision_query)
         self.assertEqual(decision_params[-1], ["AAPL"])
         self.assertIn("upper(d.symbol) = any(%s)", execution_query)
@@ -7901,9 +7863,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("d_match.decision_hash = oe.client_order_id", unlinked_query)
         self.assertIn("upper(oe.symbol) = any(%s)", unlinked_query)
         self.assertEqual(unlinked_params[-1], ["AAPL"])
-        self.assertIn("upper(d.symbol) = any(%s)", tca_query)
-        self.assertIn("upper(e.symbol) = any(%s)", tca_query)
-        self.assertEqual(tca_params[-2:], (["AAPL"], ["AAPL"]))
 
     def test_query_timestamps_requires_source_lineage_for_candidate_import(
         self,
@@ -8065,14 +8024,17 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(
             executions, [datetime(2026, 3, 6, 14, 35, 30, tzinfo=timezone.utc)]
         )
-        proxy_rows = [
-            row
-            for row in tca_rows
-            if row.get("post_cost_expectancy_basis") == POST_COST_BASIS_TCA_PROXY
-        ]
-        self.assertEqual(len(proxy_rows), 1)
-        self.assertEqual(proxy_rows[0]["decision_hash"], "decision-matched")
-        self.assertEqual(proxy_rows[0]["post_cost_expectancy_bps"], Decimal("0.50"))
+        self.assertTrue(tca_rows)
+        self.assertTrue(
+            all(
+                row.get("post_cost_expectancy_basis")
+                in {
+                    POST_COST_BASIS_RUNTIME_LEDGER,
+                    POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
+                }
+                for row in tca_rows
+            )
+        )
 
     def test_query_timestamps_requires_strategy_name_candidates(self) -> None:
         window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -681,7 +681,7 @@ def test_tca_shortfall_rows_do_not_count_as_strategy_pnl() -> None:
                 "symbol": "NVDA",
                 "shortfall_notional": "-120.50",
                 "post_cost_expectancy_bps": "32.5",
-                "post_cost_expectancy_basis": "tca_shortfall_proxy",
+                "post_cost_expectancy_basis": "broker_tca_shortfall_estimate",
                 "filled_notional": "10000",
             }
         ]

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -594,6 +594,39 @@ class TestRuntimeWindowImport(TestCase):
             {"realized_strategy_pnl": 1},
         )
 
+    def test_build_observed_runtime_buckets_marks_missing_post_cost_basis(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    6,
+                )
+            ],
+            decision_times=[datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+            execution_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("50"),
+                    "post_cost_promotion_eligible": True,
+                }
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        self.assertEqual(buckets[0].post_cost_expectancy_bps, Decimal("0"))
+        self.assertEqual(buckets[0].post_cost_promotion_sample_count, 0)
+        self.assertEqual(
+            buckets[0].post_cost_basis_counts,
+            {"post_cost_basis_missing": 1},
+        )
+
     def test_build_observed_runtime_buckets_requires_runtime_ledger_bucket_for_pnl_basis(
         self,
     ) -> None:
@@ -2754,7 +2787,9 @@ class TestRuntimeWindowImport(TestCase):
             summary["promotion_blocking_reasons"],
         )
 
-    def test_persist_observed_runtime_windows_blocks_tca_proxy_expectancy(self) -> None:
+    def test_persist_observed_runtime_windows_blocks_tca_shortfall_expectancy(
+        self,
+    ) -> None:
         buckets = build_observed_runtime_buckets(
             bucket_ranges=[
                 (
@@ -2781,14 +2816,14 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("80"),
-                    "post_cost_expectancy_basis": "tca_shortfall_proxy",
+                    "post_cost_expectancy_basis": "broker_tca_shortfall_estimate",
                     "post_cost_promotion_eligible": False,
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("5"),
                     "post_cost_expectancy_bps": Decimal("80"),
-                    "post_cost_expectancy_basis": "tca_shortfall_proxy",
+                    "post_cost_expectancy_basis": "broker_tca_shortfall_estimate",
                     "post_cost_promotion_eligible": False,
                 },
             ],
@@ -2800,8 +2835,8 @@ class TestRuntimeWindowImport(TestCase):
         with self.session_local() as session:
             summary = persist_observed_runtime_windows(
                 session=session,
-                run_id="import-live-tca-proxy",
-                candidate_id="cand-tca-proxy",
+                run_id="import-live-tca-shortfall",
+                candidate_id="cand-tca-shortfall",
                 hypothesis_id="H-CONT-01",
                 observed_stage="live",
                 strategy_family="intraday_continuation",
@@ -2813,7 +2848,10 @@ class TestRuntimeWindowImport(TestCase):
 
         self.assertEqual(summary["promotion_allowed"], False)
         self.assertEqual(summary["post_cost_promotion_sample_count"], 0)
-        self.assertEqual(summary["post_cost_basis_counts"], {"tca_shortfall_proxy": 2})
+        self.assertEqual(
+            summary["post_cost_basis_counts"],
+            {"broker_tca_shortfall_estimate": 2},
+        )
         self.assertIn(
             "post_cost_pnl_basis_missing",
             summary["promotion_blocking_reasons"],
@@ -2912,7 +2950,7 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("80"),
-                    "post_cost_expectancy_basis": "tca_shortfall_proxy",
+                    "post_cost_expectancy_basis": "broker_tca_shortfall_estimate",
                     "post_cost_promotion_eligible": True,
                 }
             ],
@@ -2923,7 +2961,10 @@ class TestRuntimeWindowImport(TestCase):
 
         self.assertEqual(buckets[0].post_cost_promotion_sample_count, 0)
         self.assertEqual(buckets[0].post_cost_expectancy_bps, Decimal("0"))
-        self.assertEqual(buckets[0].post_cost_basis_counts, {"tca_shortfall_proxy": 1})
+        self.assertEqual(
+            buckets[0].post_cost_basis_counts,
+            {"broker_tca_shortfall_estimate": 1},
+        )
 
     def test_persist_observed_runtime_windows_skips_idle_buckets(self) -> None:
         buckets = build_observed_runtime_buckets(

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -2444,7 +2444,7 @@ class TestSubmissionCouncil(TestCase):
             slippage_budget_bps="12",
             payload_json={
                 "post_cost_promotion_sample_count": 0,
-                "post_cost_basis_counts": {"tca_shortfall_proxy": 3},
+                "post_cost_basis_counts": {"broker_tca_shortfall_estimate": 3},
             },
         )
 


### PR DESCRIPTION
## Summary

- Removed standalone `tca_shortfall_proxy` runtime-window evidence generation from `import_hypothesis_runtime_windows.py`.
- Switched source-activity diagnostics to count execution TCA refs carried on execution rows instead of treating TCA rows as standalone proof activity.
- Marked missing post-cost bases as `post_cost_basis_missing` instead of defaulting them to the proxy basis.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
