### PR TITLE
fix(torghut): skip empty live runtime ledger reconcile

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -105,7 +105,6 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             batch_size=5,
             max_batches=1,
             reconcile_limit=LIVE_RECONCILE_LIMIT,
-            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
         ),
     ]

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -764,7 +764,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             )
             if cronjob_name == "torghut-tigerbeetle-journal-order-events-live":
-                self.assertIn("--reconcile-empty-selection", runtime_argv)
+                self.assertNotIn("--reconcile-empty-selection", runtime_argv)
                 self.assertEqual(
                     runtime_argv[runtime_argv.index("--reconcile-limit") + 1],
                     str(cron_runner.LIVE_RECONCILE_LIMIT),

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -102,10 +102,10 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertFalse(commands[3].skip_reconcile)
-        self.assertTrue(commands[3].reconcile_empty_selection)
+        self.assertFalse(commands[3].reconcile_empty_selection)
         self.assertEqual(commands[3].reconcile_limit, runner.LIVE_RECONCILE_LIMIT)
 
-    def test_live_runtime_ledger_command_reconciles_empty_selection(self) -> None:
+    def test_live_runtime_ledger_command_skips_empty_selection_reconcile(self) -> None:
         command = runner._live_commands(execution_batch_size=5)[-1]
 
         argv = runner._argv_for_command(
@@ -114,7 +114,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
             supervise_timeout_seconds=45.0,
         )
 
-        self.assertIn("--reconcile-empty-selection", argv)
+        self.assertNotIn("--reconcile-empty-selection", argv)
         self.assertNotIn("--skip-reconcile", argv)
         self.assertEqual(
             argv[argv.index("--reconcile-limit") + 1],


### PR DESCRIPTION
## Summary

- Stop the live TigerBeetle journal runner from forcing empty-selection reconciliation for `strategy_runtime_ledger_bucket`.
- Preserve runtime-ledger journaling and reconciliation when source rows are actually selected.
- Update runner and cron coverage so the live runtime-ledger slice no longer emits `--reconcile-empty-selection`.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py -k 'tigerbeetle_journal_order_events_cronjob_covers_live_and_sim or run_tigerbeetle_journal_cron or live_runtime_ledger or main_skips_backfill_and_reconcile_when_source_selects_no_rows or main_can_reconcile_when_source_selects_no_rows'`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
