### PR TITLE
fix(synthesis): simplify autotrader bootstrap artifacts

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -82,8 +82,6 @@ spec:
     ANALYSIS_REPO_DIR: /workspace/analysis
     ANALYSIS_REPO_URL: https://github.com/gregkonush/analysis.git
     ANALYSIS_REQUIRED_COMMIT: 56be940b69bf1a56578040eda9bf2e3699c5220e
-    ANALYSIS_CONTEXT_PATH: /tmp/autonomous-trader-work/analysis-context.json
-    AUTONOMOUS_TRADER_ARTIFACT_DIR: /workspace/.agentrun/autonomous-trader
     AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED: "{{parameters.brokerMutationEnabled}}"
     AUTONOMOUS_TRADER_MODE: "{{parameters.mode}}"
     AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE: "{{parameters.synthesisSessionMode}}"
@@ -152,25 +150,23 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
 
-        artifact_dir="${AUTONOMOUS_TRADER_ARTIFACT_DIR:-/workspace/.agentrun/autonomous-trader}"
+        report_path="/workspace/.agentrun/autonomous-trader/report.md"
         work_dir="${AUTONOMOUS_TRADER_WORK_DIR:-/tmp/autonomous-trader-work}"
         analysis_dir="${ANALYSIS_REPO_DIR:-/workspace/analysis}"
         analysis_repo_url="${ANALYSIS_REPO_URL:-https://github.com/gregkonush/analysis.git}"
         required_commit="${ANALYSIS_REQUIRED_COMMIT:-56be940b69bf1a56578040eda9bf2e3699c5220e}"
-        analysis_context_path="${ANALYSIS_CONTEXT_PATH:-${work_dir}/analysis-context.json}"
-        analysis_bootstrap_status_path="${ANALYSIS_BOOTSTRAP_STATUS_PATH:-${work_dir}/analysis-bootstrap.json}"
+        analysis_context_path="${work_dir}/analysis-context.json"
         analysis_fetch_depth="${ANALYSIS_FETCH_DEPTH:-256}"
         analysis_fetch_deepen="${ANALYSIS_FETCH_DEEPEN:-2048}"
         analysis_fetch_deepen_attempts="${ANALYSIS_FETCH_DEEPEN_ATTEMPTS:-3}"
         analysis_fetch_timeout_seconds="${ANALYSIS_FETCH_TIMEOUT_SECONDS:-180}"
         python_bin="${PYTHON_BIN:-python3}"
 
-        mkdir -p "${artifact_dir}"
         mkdir -p "${work_dir}"
-        bootstrap_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        mkdir -p "$(dirname "${report_path}")"
 
-        if [ ! -e "${artifact_dir}/report.md" ]; then
-          printf '# Autonomous Trader Report\n\nstatus: bootstrapping\n' > "${artifact_dir}/report.md"
+        if [ ! -e "${report_path}" ]; then
+          printf '# Autonomous Trader Report\n\nstatus: bootstrapping\n' > "${report_path}"
         fi
 
         git_auth=()
@@ -234,8 +230,8 @@ spec:
         while ! git -C "${analysis_dir}" merge-base --is-ancestor "${required_commit}" HEAD; do
           if [ "$(git -C "${analysis_dir}" rev-parse --is-shallow-repository)" != "true" ] || \
             [ "${deepen_attempt}" -ge "${analysis_fetch_deepen_attempts}" ]; then
-            printf '{"ok":false,"reason":"analysis_repo_stale","analysis_head":"%s","required_commit":"%s","fetch_depth":"%s","deepen_attempts":"%s"}\n' \
-              "${analysis_head}" "${required_commit}" "${analysis_fetch_depth}" "${deepen_attempt}" > "${analysis_bootstrap_status_path}"
+            printf 'analysis repo stale: head=%s required_commit=%s fetch_depth=%s deepen_attempts=%s\n' \
+              "${analysis_head}" "${required_commit}" "${analysis_fetch_depth}" "${deepen_attempt}" >&2
             exit 42
           fi
           deepen_attempt=$((deepen_attempt + 1))
@@ -275,7 +271,7 @@ spec:
           fi
         fi
 
-        analysis_cli="${artifact_dir}/stock_analysis"
+        analysis_cli="${work_dir}/stock_analysis"
         {
           printf '#!/usr/bin/env bash\n'
           printf 'set -euo pipefail\n'
@@ -293,10 +289,6 @@ spec:
           --output "${analysis_context_path}"
         "${analysis_cli}" daytrading-validate-context \
           "${analysis_context_path}"
-
-        printf '{"ok":true,"analysis_head":"%s","required_commit":"%s","context_path":"%s","analysis_cli":"%s","install_method":"%s","started_at":"%s","finished_at":"%s"}\n' \
-          "${analysis_head}" "${required_commit}" "${analysis_context_path}" "${analysis_cli}" "${install_method}" "${bootstrap_started_at}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-          > "${analysis_bootstrap_status_path}"
     - path: /root/alpaca-mcp-stdio-bridge.py
       content: |-
         import json

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -32,6 +32,5 @@ spec:
     - account type: read `AUTONOMOUS_TRADER_ACCOUNT_TYPE`; it must be paper
     - analysis repo: bootstrap `/workspace/analysis` and require commit `56be940b69bf1a56578040eda9bf2e3699c5220e` or newer
     - operator report: `/workspace/.agentrun/autonomous-trader/report.md`
-    - temporary scanner work dir: `AUTONOMOUS_TRADER_WORK_DIR`
 
     Start with bootstrap/preflight, then run the mode-specific loop. Keep all live decisions, risk checks, broker actions, reconciliation results, and scorecard observations in Synthesis autotrader tables.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -17,14 +17,14 @@ data:
 
     Source of truth:
     - Alpaca MCP is broker truth; Synthesis autotrader tools are runtime truth.
-    - Local files are not trader state. Do not create JSON/JSONL ledgers. Write only `report.md`; temp files stay under `AUTONOMOUS_TRADER_WORK_DIR`.
+    - Local files are not trader state. Do not create JSON/JSONL ledgers. Write only `report.md`; scanner temp files are internal scratch.
 
     Identity and mode:
     - Use `AGENT_RUN_NAME` unchanged for session identity, deterministic broker client order ids, dedupe keys, and reports.
     - Read `AUTONOMOUS_TRADER_MODE` and `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE`; pass the session mode exactly when non-empty.
 
     Execution loop:
-    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, validate `ANALYSIS_CONTEXT_PATH`, and self-test Synthesis, live-scan, strategy-order, and protective-order helpers.
+    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`, read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`, and self-test Synthesis, live-scan, strategy-order, and protective-order helpers.
     2. Preflight Alpaca account/config/clock/tools/positions/orders and Synthesis tools. If account/trading is blocked, `daytrading_buying_power <= 0`, or scanner input says `intraday_equity_entry.status=blocked`, record Synthesis risk/status, skip new entries and smoke orders, and monitor read-only until state changes or close. Exits/protection stay allowed.
     3. Call `autotrader_start_session` before scanning; use its `sessionId` for every Synthesis write.
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py --account-gate-only`. If `skipFullScan=true`, record monitor status and skip candidate tickets. Otherwise call `autotrader_get_scorecard`, run full scan, then choose entry, exit/reduce/hedge/flatten, or no-trade.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -795,7 +795,8 @@ describe('autonomous trader provider', () => {
 
     expect(objectAt(envTemplate, 'ANALYSIS_REPO_URL')).toBe('https://github.com/gregkonush/analysis.git')
     expect(objectAt(envTemplate, 'ANALYSIS_REQUIRED_COMMIT')).toBe('56be940b69bf1a56578040eda9bf2e3699c5220e')
-    expect(objectAt(envTemplate, 'ANALYSIS_CONTEXT_PATH')).toBe('/tmp/autonomous-trader-work/analysis-context.json')
+    expect(objectAt(envTemplate, 'ANALYSIS_CONTEXT_PATH')).toBeUndefined()
+    expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_ARTIFACT_DIR')).toBeUndefined()
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_WORK_DIR')).toBe('/tmp/autonomous-trader-work')
     expect(objectAt(envTemplate, 'ANALYSIS_FETCH_DEPTH')).toBeUndefined()
     expect(objectAt(codex, 'model')).toBe('gpt-5.5')
@@ -813,10 +814,9 @@ describe('autonomous trader provider', () => {
     expect([...artifactNames, ...artifactPaths, ...artifactKeys].join('\n')).not.toMatch(
       /jsonl|analysis-(bootstrap|context)/,
     )
+    expect(bootstrapContent).toContain('report_path="/workspace/.agentrun/autonomous-trader/report.md"')
     expect(bootstrapContent).toContain('work_dir="${AUTONOMOUS_TRADER_WORK_DIR:-/tmp/autonomous-trader-work}"')
-    expect(bootstrapContent).toContain(
-      'analysis_context_path="${ANALYSIS_CONTEXT_PATH:-${work_dir}/analysis-context.json}"',
-    )
+    expect(bootstrapContent).toContain('analysis_context_path="${work_dir}/analysis-context.json"')
     expect(bootstrapContent).toContain('analysis_fetch_timeout_seconds="${ANALYSIS_FETCH_TIMEOUT_SECONDS:-180}"')
     expect(bootstrapContent).toContain('fetch --prune --filter=blob:none --depth="${analysis_fetch_depth}"')
     expect(bootstrapContent).toContain('fetch --filter=blob:none --deepen="${analysis_fetch_deepen}"')
@@ -828,6 +828,11 @@ describe('autonomous trader provider', () => {
     expect(bootstrapContent).not.toContain('checkout --force --detach origin/main')
     expect(bootstrapContent).not.toContain('reset --hard origin/main')
     expect(bootstrapContent).toContain('--output "${analysis_context_path}"')
+    expect(bootstrapContent).toContain('analysis_cli="${work_dir}/stock_analysis"')
+    expect(bootstrapContent).not.toContain('ANALYSIS_CONTEXT_PATH')
+    expect(bootstrapContent).not.toContain('ANALYSIS_BOOTSTRAP_STATUS_PATH')
+    expect(bootstrapContent).not.toContain('analysis_bootstrap_status_path')
+    expect(bootstrapContent).not.toContain('artifact_dir=')
     expect(bootstrapContent).not.toContain('"${artifact_dir}/analysis-context.json"')
     expect(bootstrapContent).not.toContain('"${artifact_dir}/analysis-bootstrap.json"')
     expect(bootstrapContent).not.toContain('"${artifact_dir}/analysis-venv"')

--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -274,8 +274,8 @@ def market_open_start(now: datetime) -> str:
 def stock_analysis_cli_path(value: str | None) -> str:
     if value:
         return value
-    artifact_dir = os.environ.get("AUTONOMOUS_TRADER_ARTIFACT_DIR", "/workspace/.agentrun/autonomous-trader")
-    return str(Path(artifact_dir) / "stock_analysis")
+    work_dir = os.environ.get("AUTONOMOUS_TRADER_WORK_DIR", "/tmp/autonomous-trader-work")
+    return str(Path(work_dir) / "stock_analysis")
 
 
 def run_stock_analysis_scan(
@@ -434,9 +434,7 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
     )
     for name, payload in inputs.items():
         write_json(cycle_dir / name, payload)
-    analysis_context = Path(
-        args.analysis_context or os.environ.get("ANALYSIS_CONTEXT_PATH") or work_dir / "analysis-context.json"
-    )
+    analysis_context = Path(args.analysis_context or work_dir / "analysis-context.json")
     scan = run_stock_analysis_scan(
         stock_analysis_cli=stock_analysis_cli_path(args.stock_analysis_cli),
         cycle_dir=cycle_dir,

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -84,6 +84,10 @@ class LiveScanCycleTest(unittest.TestCase):
             "2026-01-05T14:30:00Z",
         )
 
+    def test_stock_analysis_cli_defaults_to_work_dir(self) -> None:
+        with patch.dict("os.environ", {"AUTONOMOUS_TRADER_WORK_DIR": "/tmp/trader-work"}, clear=False):
+            self.assertEqual(live_scan_cycle.stock_analysis_cli_path(None), "/tmp/trader-work/stock_analysis")
+
     def test_formats_intraday_entry_gate_for_zero_dtbp(self) -> None:
         self.assertEqual(
             live_scan_cycle.format_account(


### PR DESCRIPTION
## Summary

- Simplifies the autonomous-trader bootstrap contract so model-facing state remains in Synthesis and only `report.md` is an operator artifact.
- Removes exported `ANALYSIS_CONTEXT_PATH` and `AUTONOMOUS_TRADER_ARTIFACT_DIR` provider env knobs, plus the bootstrap status JSON file write.
- Moves the generated `stock_analysis` helper into the temp work directory and updates tests to prevent artifact-dir scratch state from returning.

## Related Issues

None

## Testing

- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "autonomous trader provider"`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | rg -n "ANALYSIS_CONTEXT_PATH|ANALYSIS_BOOTSTRAP_STATUS_PATH|AUTONOMOUS_TRADER_ARTIFACT_DIR|analysis-bootstrap|analysis_context_path|analysis_cli=|autonomous-trader-system-prompt|autonomous-trader-codex" -C 2`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
