### PR TITLE
fix(torghut): remove artifact proof shortcuts

### DIFF
--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -6071,20 +6071,7 @@ def _runtime_observation_contract_payload(
 def _runtime_observation_has_ledger_profit_proof(
     runtime_observation_payload: Mapping[str, Any],
 ) -> bool:
-    if bool(runtime_observation_payload.get('runtime_ledger_profit_proof_present')):
-        return True
-    artifact_fill_count = _decimal_or_zero(
-        runtime_observation_payload.get('runtime_ledger_artifact_fill_count')
-    )
-    artifact_row_count = _decimal_or_zero(
-        runtime_observation_payload.get('runtime_ledger_artifact_row_count')
-    )
-    artifact_tca_row_count = _decimal_or_zero(
-        runtime_observation_payload.get('runtime_ledger_artifact_tca_row_count')
-    )
-    return artifact_fill_count > 0 and (
-        artifact_row_count > 0 or artifact_tca_row_count > 0
-    )
+    return bool(runtime_observation_payload.get('runtime_ledger_profit_proof_present'))
 
 
 def _resolve_hypothesis_window_evidence(

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1538,10 +1538,6 @@ def _runtime_import_materialization_summary(
         "runtime_ledger_durable_bucket_profit_proof_count": 0,
         "runtime_ledger_artifact_tca_row_count": 0,
     }
-    profit_proof_authority_reasons = {
-        "runtime_ledger_profit_proof",
-        "runtime_ledger_profit_proof_present",
-    }
     for item in items:
         summary = _mapping(item.get("summary"))
         observation = _mapping(summary.get("runtime_observation"))
@@ -1571,14 +1567,8 @@ def _runtime_import_materialization_summary(
         durable_profit_proof_count = _int(
             observation.get("runtime_ledger_durable_bucket_profit_proof_count")
         )
-        authority_reason_implies_profit_proof = (
-            authority_reason in profit_proof_authority_reasons
-        )
         profit_proof_count = max(
-            1
-            if _bool(observation.get("runtime_ledger_profit_proof_present"))
-            or authority_reason_implies_profit_proof
-            else 0,
+            1 if _bool(observation.get("runtime_ledger_profit_proof_present")) else 0,
             tca_profit_proof_count,
             source_profit_proof_count,
             durable_profit_proof_count,

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -369,7 +369,7 @@ def _runtime_import(
         "promotion_allowed": authoritative,
         "runtime_observation": {
             "authoritative": authoritative,
-            "authority_reason": "runtime_ledger_profit_proof_present"
+            "authority_reason": "runtime_ledger_profit_proof"
             if authoritative
             else "runtime_without_runtime_ledger_profit_proof",
             "runtime_ledger_profit_proof_present": authoritative,
@@ -2997,6 +2997,42 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertIn(
             "runtime_window_import_runtime_ledger_materialization_missing",
             result["promotion_authority"]["blocking_reasons"],
+        )
+
+    def test_packet_does_not_count_authority_reason_as_profit_proof(self) -> None:
+        runtime_import = _runtime_import(authoritative=False)
+        observation = runtime_import["imports"][0]["summary"]["runtime_observation"]
+        assert isinstance(observation, dict)
+        observation.update(
+            {
+                "authoritative": True,
+                "authority_reason": "runtime_ledger_profit_proof",
+                "runtime_ledger_profit_proof_present": False,
+                "runtime_ledger_tca_profit_proof_count": 0,
+                "runtime_ledger_source_bucket_profit_proof_count": 0,
+                "runtime_ledger_durable_bucket_profit_proof_count": 0,
+            }
+        )
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertEqual(materialization["runtime_ledger_profit_proof_count"], 0)
+        self.assertEqual(
+            materialization["authoritative_runtime_ledger_profit_proof_count"],
+            0,
+        )
+        self.assertIn(
+            "runtime_window_import_target_profit_proof_missing",
+            materialization["unmaterialized_targets"][0]["blockers"],
         )
 
     def test_packet_blocks_runtime_import_without_materialized_runtime_ledger(

--- a/services/torghut/tests/test_autonomous_lane.py
+++ b/services/torghut/tests/test_autonomous_lane.py
@@ -143,7 +143,7 @@ class TestAutonomousLane(TestCase):
         )
         self.assertFalse(qualification["qualified_runtime_observation"])
 
-    def test_runtime_observation_evidence_keeps_simulation_replay_only_with_ledger_profit_proof(
+    def test_runtime_observation_evidence_keeps_artifact_counts_diagnostic_only(
         self,
     ) -> None:
         provenance, maturity, capital_stage, qualification = (
@@ -168,7 +168,7 @@ class TestAutonomousLane(TestCase):
         self.assertEqual(capital_stage, "shadow")
         self.assertEqual(
             qualification["runtime_observation_has_runtime_ledger_profit_proof"],
-            True,
+            False,
         )
         self.assertFalse(qualification["qualified_runtime_observation"])
         self.assertEqual(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -3502,7 +3502,7 @@ class TestRuntimeWindowImport(TestCase):
                 buckets=buckets,
                 runtime_observation_payload={
                     "runtime_ledger_profit_proof_present": True,
-                    "promotion_authority": "runtime_ledger_profit_proof_present",
+                    "promotion_authority": "runtime_ledger",
                 },
             )
             session.commit()


### PR DESCRIPTION
## Summary

- Removed the autonomy-lane fallback that treated runtime-ledger artifact row/fill counts as profit proof.
- Tightened runtime-ledger proof-packet materialization so authority-reason strings alone no longer create proof counts.
- Updated regressions so replay/artifact counts stay diagnostic-only and claimed proof without materialized rows remains blocked.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check app/trading/autonomy/lane.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_autonomous_lane.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py`
- `cd services/torghut && uv run --frozen pytest tests/test_autonomous_lane.py::TestAutonomousLane::test_runtime_observation_evidence_keeps_artifact_counts_diagnostic_only tests/test_autonomous_lane.py::TestAutonomousLane::test_runtime_observation_evidence_keeps_simulation_replay_only_with_explicit_ledger_profit_proof_flag tests/test_assemble_runtime_ledger_proof_packet.py::TestRuntimeLedgerProofPacket::test_packet_does_not_count_authority_reason_as_profit_proof tests/test_assemble_runtime_ledger_proof_packet.py::TestRuntimeLedgerProofPacket::test_packet_surfaces_runtime_import_materialization_summary -q`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_persist_observed_runtime_windows_blocks_claimed_ledger_proof_without_rows -q`
- `cd services/torghut && uv run --frozen pytest tests/test_autonomous_lane.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py -k "runtime_observation or authority_reason or runtime_import_materialization or materialization_summary or claimed_ledger or claimed_ledger_proof or non_authoritative or profit_proof_is_only_non_authoritative" -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
