### PR TITLE
fix(synthesis): gate autotrader smoke by entry eligibility

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -19,7 +19,7 @@ spec:
   acceptanceCriteria:
     - Trade only the dedicated Alpaca paper account and record trader state in Synthesis autotrader tables.
     - Bootstrap the analysis repo, read scorecards before grading, and use the live scan-cycle helper for candidate ranking.
-    - Submit broker mutations only after Synthesis risk/order records, protective preflight, strategy guard approval, and deterministic client order ids.
+    - Submit strategy broker mutations only after Synthesis risk/order records, protective preflight success, strategy guard approval, and deterministic client order ids; helper-proven entry-ineligible smoke skips must stand down from entries.
     - Keep market-open runs cycling until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
     - Finalize sessions with realized scorecard observations and write `report.md` as the only operator-facing artifact.
   text: |-

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -38,7 +38,7 @@ data:
     - `dry-run`: no Alpaca mutations; do one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `scorecard-readback`: no Alpaca mutations; prove scorecards are read before grading, finalize with `scorecard_readback_waiting` or `scorecard_readback_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `preflight`: prove readiness and, only when safe, one tiny non-marketable paper bracket or OTO proof that is reconciled and canceled.
-    - `market-open`: pass account eligibility, then run one bounded paper-order smoke and protective preflight before strategy entries. Preflight success, smoke success, no-trade, rejected candidates, rejected orders, quiet markets, account-gated monitoring, and protected positions are cycle outcomes, not terminal outcomes. Do not call `update_goal complete` or answer finally until market close, target equity, or hard stop.
+    - `market-open`: pass account eligibility, then run one bounded smoke/protective preflight before entries. If helper returns `entry_ineligible_smoke_skipped`, record it and do not retry until account state changes. Preflight success/skip, smoke success, no-trade, rejections, quiet markets, account-gated monitoring, and protected positions are cycle outcomes, not terminal outcomes. Do not complete or answer finally until close, target, or hard stop.
 
     Safety:
     - Route orders only to the Alpaca paper account.

--- a/scripts/autotrader/protective_preflight.py
+++ b/scripts/autotrader/protective_preflight.py
@@ -9,6 +9,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
@@ -159,6 +160,72 @@ def assert_paper_base_url(base_url: str) -> None:
     hostname = (urllib.parse.urlparse(base_url).hostname or "").lower()
     if hostname != PAPER_ALPACA_HOST:
         raise RuntimeError(f"protective preflight requires Alpaca paper API host {PAPER_ALPACA_HOST}; got {hostname}")
+
+
+def account_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
+def parse_account_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return Decimal(text)
+    except InvalidOperation:
+        return None
+
+
+def parse_account_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def account_summary(account: dict[str, Any]) -> dict[str, Any]:
+    daytrading_buying_power = account.get("daytrading_buying_power") or account.get("daytrade_buying_power")
+    return {
+        "id": account.get("id"),
+        "equity": account.get("equity"),
+        "cash": account.get("cash"),
+        "buying_power": account.get("buying_power"),
+        "daytrading_buying_power": daytrading_buying_power,
+        "daytrade_count": account.get("daytrade_count"),
+        "pattern_day_trader": account_bool(account.get("pattern_day_trader", False)),
+        "trading_blocked": account_bool(account.get("trading_blocked", False)),
+        "account_blocked": account_bool(account.get("account_blocked", False)),
+    }
+
+
+def entry_ineligible_smoke_reasons(account: dict[str, Any]) -> list[str]:
+    daytrading_buying_power = account.get("daytrading_buying_power") or account.get("daytrade_buying_power")
+    daytrading_buying_power_value = parse_account_decimal(daytrading_buying_power)
+    daytrade_count = parse_account_int(account.get("daytrade_count"))
+    reasons: list[str] = []
+    if account_bool(account.get("account_blocked", False)) or account_bool(account.get("trading_blocked", False)):
+        reasons.append("account_or_trading_blocked")
+    if daytrading_buying_power_value is not None and daytrading_buying_power_value <= 0:
+        reasons.append("daytrading_buying_power_not_positive")
+    if (
+        daytrade_count is not None
+        and daytrade_count >= 4
+        and daytrading_buying_power_value is not None
+        and daytrading_buying_power_value <= 0
+    ):
+        reasons.append("pdt_daytrade_count_at_or_above_four_without_dtbp")
+    return reasons
 
 
 def record_order(
@@ -415,6 +482,31 @@ def run_preflight(args: argparse.Namespace) -> dict[str, Any]:
         return report
 
     alpaca = AlpacaClient(base_url=args.alpaca_base_url, timeout_seconds=args.timeout_seconds)
+    account = alpaca.get("/v2/account")
+    account_payload = account if isinstance(account, dict) else {}
+    report["account"] = account_summary(account_payload)
+    entry_blockers = (
+        entry_ineligible_smoke_reasons(account_payload) if isinstance(account, dict) else ["account_read_invalid"]
+    )
+    if entry_blockers:
+        report["ok"] = True
+        report["mode"] = "entry_ineligible_smoke_skipped"
+        report["skipReason"] = "entry_ineligible_for_intraday_equity_smoke"
+        report["entryBlockers"] = entry_blockers
+        append_event(
+            synthesis,
+            session_id=args.synthesis_session_id,
+            seq=args.event_seq_base + 1,
+            event_type="protective_preflight_skipped",
+            payload={
+                "clientOrderId": payload["client_order_id"],
+                "symbol": payload["symbol"],
+                "skipReason": report["skipReason"],
+                "entryBlockers": entry_blockers,
+                "account": report["account"],
+            },
+        )
+        return report
     config_before = alpaca.get("/v2/account/configurations")
     report["accountConfigurationBefore"] = config_before
     if args.ensure_dtbp_entry and config_before.get("dtbp_check") != "entry":

--- a/scripts/autotrader/test_protective_preflight.py
+++ b/scripts/autotrader/test_protective_preflight.py
@@ -80,5 +80,77 @@ class SmokeExposureReadbackTest(unittest.TestCase):
         self.assertEqual(fake_alpaca.open_order_reads, 2)
 
 
+class EntryGateTest(unittest.TestCase):
+    def test_skips_submitted_smoke_when_account_is_entry_ineligible(self) -> None:
+        class FakeAlpaca:
+            def __init__(self, *, base_url: str | None, timeout_seconds: float) -> None:
+                self.base_url = base_url
+                self.timeout_seconds = timeout_seconds
+                self.calls: list[tuple[str, str]] = []
+
+            def get(self, path: str) -> dict[str, object]:
+                self.calls.append(("GET", path))
+                if path == "/v2/account":
+                    return {
+                        "id": "paper-account",
+                        "equity": "29989.14",
+                        "cash": "29989.14",
+                        "buying_power": "59978.28",
+                        "daytrading_buying_power": "0",
+                        "daytrade_count": 5,
+                    }
+                raise AssertionError(f"unexpected GET {path}")
+
+            def patch(self, path: str, payload: dict[str, object]) -> dict[str, object]:
+                raise AssertionError(f"unexpected PATCH {path}")
+
+            def post(self, path: str, payload: dict[str, object]) -> dict[str, object]:
+                raise AssertionError(f"unexpected POST {path}")
+
+            def delete(self, path: str) -> dict[str, object]:
+                raise AssertionError(f"unexpected DELETE {path}")
+
+        fake_alpaca = FakeAlpaca(base_url=None, timeout_seconds=10.0)
+        args = protective_preflight.build_parser().parse_args(
+            [
+                "--submit-smoke",
+                "--client-order-id",
+                "autonomous-trader-test-protective-preflight-0001",
+            ]
+        )
+
+        with patch.object(protective_preflight, "AlpacaClient", lambda **kwargs: fake_alpaca):
+            report = protective_preflight.run_preflight(args)
+
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["mode"], "entry_ineligible_smoke_skipped")
+        self.assertFalse(report["submitted"])
+        self.assertEqual(report["skipReason"], "entry_ineligible_for_intraday_equity_smoke")
+        self.assertEqual(
+            report["entryBlockers"],
+            [
+                "daytrading_buying_power_not_positive",
+                "pdt_daytrade_count_at_or_above_four_without_dtbp",
+            ],
+        )
+        self.assertEqual(fake_alpaca.calls, [("GET", "/v2/account")])
+
+    def test_skips_submitted_smoke_when_account_read_shape_is_invalid(self) -> None:
+        class FakeAlpaca:
+            def get(self, path: str) -> list[object]:
+                if path == "/v2/account":
+                    return []
+                raise AssertionError(f"unexpected GET {path}")
+
+        args = protective_preflight.build_parser().parse_args(["--submit-smoke"])
+
+        with patch.object(protective_preflight, "AlpacaClient", lambda **kwargs: FakeAlpaca()):
+            report = protective_preflight.run_preflight(args)
+
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["mode"], "entry_ineligible_smoke_skipped")
+        self.assertEqual(report["entryBlockers"], ["account_read_invalid"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds a deterministic account-entry gate inside `protective_preflight.py` before any submitted smoke order.
- Skips smoke as a successful no-risk outcome when Alpaca reports zero daytrading buying power, PDT day-trade exhaustion, trading/account block, or invalid account read shape.
- Updates the autonomous-trader prompt and ImplementationSpec so entry-ineligible smoke skips are recorded and do not trigger retry churn.

## Related Issues

None

## Testing

- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 -m py_compile scripts/autotrader/protective_preflight.py scripts/autotrader/test_protective_preflight.py`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "autonomous trader provider"`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | rg -n "entry_ineligible_smoke_skipped|helper-proven entry-ineligible|autonomous-trader-system-prompt|autonomous-trader-v1" -C 2`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
