### PR TITLE
fix(torghut): make journal transfer refs idempotent

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -1134,6 +1134,82 @@ def _assert_transfer_ref_matches(
         )
 
 
+def _find_transfer_ref(
+    session: Session,
+    *,
+    cluster_id: int,
+    transfer_id_text: str,
+    source_type: str,
+    source_id: str,
+    transfer_kind: str,
+) -> TigerBeetleTransferRef | None:
+    source_existing = session.execute(
+        select(TigerBeetleTransferRef).where(
+            TigerBeetleTransferRef.cluster_id == cluster_id,
+            TigerBeetleTransferRef.source_type == source_type,
+            TigerBeetleTransferRef.source_id == source_id,
+            TigerBeetleTransferRef.transfer_kind == transfer_kind,
+        )
+    ).scalar_one_or_none()
+    if source_existing is not None:
+        return source_existing
+    return session.execute(
+        select(TigerBeetleTransferRef).where(
+            TigerBeetleTransferRef.cluster_id == cluster_id,
+            TigerBeetleTransferRef.transfer_id == transfer_id_text,
+        )
+    ).scalar_one_or_none()
+
+
+def _merge_existing_transfer_ref(
+    session: Session,
+    existing: TigerBeetleTransferRef,
+    *,
+    transfer_spec: TigerBeetleTransferSpec,
+    trade_decision_id: object | None,
+    execution_id: object | None,
+    execution_order_event_id: object | None,
+    execution_tca_metric_id: object | None,
+    runtime_ledger_bucket_id: object | None,
+    event_fingerprint: str | None,
+    source_type: str,
+    source_id: str,
+    payload_json: Mapping[str, object],
+) -> TigerBeetleTransferRef:
+    _assert_transfer_ref_matches(existing, transfer_spec)
+    if existing.trade_decision_id is None:
+        existing.trade_decision_id = cast(Any, trade_decision_id)
+    if existing.execution_id is None:
+        existing.execution_id = cast(Any, execution_id)
+    if existing.execution_order_event_id is None:
+        existing.execution_order_event_id = cast(Any, execution_order_event_id)
+    if existing.execution_tca_metric_id is None:
+        existing.execution_tca_metric_id = cast(Any, execution_tca_metric_id)
+    if existing.runtime_ledger_bucket_id is None:
+        existing.runtime_ledger_bucket_id = cast(Any, runtime_ledger_bucket_id)
+    if existing.source_type is None:
+        existing.source_type = source_type
+    if existing.source_id is None:
+        existing.source_id = source_id
+    if existing.event_fingerprint is None:
+        existing.event_fingerprint = event_fingerprint
+    raw_existing_payload: object = existing.payload_json
+    existing_payload: Mapping[str, object] = (
+        cast(Mapping[str, object], raw_existing_payload)
+        if isinstance(raw_existing_payload, Mapping)
+        else {}
+    )
+    existing.payload_json = coerce_json_payload(
+        {
+            **existing_payload,
+            **payload_json,
+        }
+    )
+    session.add(existing)
+    session.flush()
+    return existing
+
+
 def _source_transfer_spec(
     *,
     transfer_id: int,
@@ -1337,11 +1413,12 @@ class TigerBeetleLedgerJournal:
         source_id: str,
         payload_json: Mapping[str, object],
     ) -> TigerBeetleTransferRef:
+        cluster_id = self._settings.tigerbeetle_cluster_id
         transfer_id_text = u128_decimal(transfer_spec.transfer_id)
         payload_json = {
             **payload_json,
             **tigerbeetle_stable_ref_payload(
-                cluster_id=self._settings.tigerbeetle_cluster_id,
+                cluster_id=cluster_id,
                 account_specs=account_specs,
                 transfer_spec=transfer_spec,
                 source_type=source_type,
@@ -1350,72 +1427,33 @@ class TigerBeetleLedgerJournal:
                 event_fingerprint=event_fingerprint,
             ),
         }
-        source_existing = session.execute(
-            select(TigerBeetleTransferRef).where(
-                TigerBeetleTransferRef.cluster_id
-                == self._settings.tigerbeetle_cluster_id,
-                TigerBeetleTransferRef.source_type == source_type,
-                TigerBeetleTransferRef.source_id == source_id,
-                TigerBeetleTransferRef.transfer_kind == transfer_spec.transfer_kind,
-            )
-        ).scalar_one_or_none()
-        if source_existing is not None:
-            _assert_transfer_ref_matches(source_existing, transfer_spec)
-            existing = source_existing
-        else:
-            existing = session.execute(
-                select(TigerBeetleTransferRef).where(
-                    TigerBeetleTransferRef.cluster_id
-                    == self._settings.tigerbeetle_cluster_id,
-                    TigerBeetleTransferRef.transfer_id == transfer_id_text,
-                )
-            ).scalar_one_or_none()
+        existing = _find_transfer_ref(
+            session,
+            cluster_id=cluster_id,
+            transfer_id_text=transfer_id_text,
+            source_type=source_type,
+            source_id=source_id,
+            transfer_kind=transfer_spec.transfer_kind,
+        )
         if existing is not None:
-            _assert_transfer_ref_matches(existing, transfer_spec)
-            if existing.trade_decision_id is None:
-                existing.trade_decision_id = cast(Any, trade_decision_id)
-            if existing.execution_id is None:
-                existing.execution_id = cast(Any, execution_id)
-            if existing.execution_order_event_id is None:
-                existing.execution_order_event_id = cast(
-                    Any,
-                    execution_order_event_id,
-                )
-            if existing.execution_tca_metric_id is None:
-                existing.execution_tca_metric_id = cast(
-                    Any,
-                    execution_tca_metric_id,
-                )
-            if existing.runtime_ledger_bucket_id is None:
-                existing.runtime_ledger_bucket_id = cast(
-                    Any,
-                    runtime_ledger_bucket_id,
-                )
-            if existing.source_type is None:
-                existing.source_type = source_type
-            if existing.source_id is None:
-                existing.source_id = source_id
-            if existing.event_fingerprint is None:
-                existing.event_fingerprint = event_fingerprint
-            raw_existing_payload: object = existing.payload_json
-            existing_payload: Mapping[str, object] = (
-                cast(Mapping[str, object], raw_existing_payload)
-                if isinstance(raw_existing_payload, Mapping)
-                else {}
+            return _merge_existing_transfer_ref(
+                session,
+                existing,
+                transfer_spec=transfer_spec,
+                trade_decision_id=trade_decision_id,
+                execution_id=execution_id,
+                execution_order_event_id=execution_order_event_id,
+                execution_tca_metric_id=execution_tca_metric_id,
+                runtime_ledger_bucket_id=runtime_ledger_bucket_id,
+                event_fingerprint=event_fingerprint,
+                source_type=source_type,
+                source_id=source_id,
+                payload_json=payload_json,
             )
-            existing.payload_json = coerce_json_payload(
-                {
-                    **existing_payload,
-                    **payload_json,
-                }
-            )
-            session.add(existing)
-            session.flush()
-            return existing
 
         _persist_account_refs(
             session,
-            cluster_id=self._settings.tigerbeetle_cluster_id,
+            cluster_id=cluster_id,
             account_specs=account_specs,
         )
         client = self._client_for_write()
@@ -1434,7 +1472,7 @@ class TigerBeetleLedgerJournal:
                 raise RuntimeError("tigerbeetle_duplicate_transfer_conflict")
 
         ref = TigerBeetleTransferRef(
-            cluster_id=self._settings.tigerbeetle_cluster_id,
+            cluster_id=cluster_id,
             transfer_id=transfer_id_text,
             transfer_kind=transfer_spec.transfer_kind,
             ledger=transfer_spec.ledger,
@@ -1452,8 +1490,35 @@ class TigerBeetleLedgerJournal:
             event_fingerprint=event_fingerprint,
             payload_json=coerce_json_payload(payload_json),
         )
-        session.add(ref)
-        session.flush()
+        try:
+            with session.begin_nested():
+                session.add(ref)
+                session.flush()
+        except IntegrityError:
+            existing = _find_transfer_ref(
+                session,
+                cluster_id=cluster_id,
+                transfer_id_text=transfer_id_text,
+                source_type=source_type,
+                source_id=source_id,
+                transfer_kind=transfer_spec.transfer_kind,
+            )
+            if existing is None:
+                raise
+            return _merge_existing_transfer_ref(
+                session,
+                existing,
+                transfer_spec=transfer_spec,
+                trade_decision_id=trade_decision_id,
+                execution_id=execution_id,
+                execution_order_event_id=execution_order_event_id,
+                execution_tca_metric_id=execution_tca_metric_id,
+                runtime_ledger_bucket_id=runtime_ledger_bucket_id,
+                event_fingerprint=event_fingerprint,
+                source_type=source_type,
+                source_id=source_id,
+                payload_json=payload_json,
+            )
         return ref
 
     def backfill_stable_ref_payloads(

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -5,7 +5,7 @@ import sys
 from datetime import datetime, timezone
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -85,10 +85,10 @@ class NumericExistsFakeTigerBeetleClient(FakeTigerBeetleClient):
 
 
 class _ScalarResult:
-    def __init__(self, value: TigerBeetleAccountRef | None) -> None:
+    def __init__(self, value: object | None) -> None:
         self._value = value
 
-    def scalar_one_or_none(self) -> TigerBeetleAccountRef | None:
+    def scalar_one_or_none(self) -> Any:
         return self._value
 
 
@@ -125,6 +125,36 @@ class _RacingAccountRefSession:
         raise IntegrityError(
             "insert tigerbeetle account ref", {}, RuntimeError("duplicate")
         )
+
+
+class _RacingTransferRefSession:
+    def __init__(
+        self, existing_after_integrity_error: TigerBeetleTransferRef | None
+    ) -> None:
+        self._existing_after_integrity_error = existing_after_integrity_error
+        self.execute_count = 0
+        self.flush_count = 0
+        self.added_refs: list[TigerBeetleTransferRef] = []
+
+    def execute(self, statement: object) -> _ScalarResult:
+        del statement
+        self.execute_count += 1
+        if self.execute_count < 3:
+            return _ScalarResult(None)
+        return _ScalarResult(self._existing_after_integrity_error)
+
+    def begin_nested(self) -> _NestedTransaction:
+        return _NestedTransaction()
+
+    def add(self, value: TigerBeetleTransferRef) -> None:
+        self.added_refs.append(value)
+
+    def flush(self) -> None:
+        self.flush_count += 1
+        if self.flush_count == 1:
+            raise IntegrityError(
+                "insert tigerbeetle transfer ref", {}, RuntimeError("duplicate")
+            )
 
 
 def _settings(*, enabled: bool = True, journal_enabled: bool = True) -> Settings:
@@ -1616,6 +1646,53 @@ class TestTigerBeetleLedgerJournal(TestCase):
                 cluster_id=2001,
                 account_specs=(spec,),
             )
+
+    def test_persist_transfer_accepts_matching_concurrent_insert(self) -> None:
+        transfer_spec = TigerBeetleTransferSpec(
+            transfer_id=12345,
+            transfer_kind=TRANSFER_KIND_EXECUTION_FILL,
+            debit_account_id=101,
+            credit_account_id=202,
+            amount=1000,
+            ledger=LEDGER_USD_MICRO,
+            code=2010,
+        )
+        existing = TigerBeetleTransferRef(
+            cluster_id=2001,
+            transfer_id=u128_decimal(transfer_spec.transfer_id),
+            transfer_kind=transfer_spec.transfer_kind,
+            ledger=transfer_spec.ledger,
+            code=transfer_spec.code,
+            amount=Decimal(transfer_spec.amount),
+            status="created",
+            result_code="created",
+            source_type="execution",
+            source_id="execution-race-row",
+            payload_json={
+                "debit_account_id": u128_decimal(transfer_spec.debit_account_id),
+                "credit_account_id": u128_decimal(transfer_spec.credit_account_id),
+            },
+        )
+        session = _RacingTransferRefSession(existing)
+
+        ref = TigerBeetleLedgerJournal(
+            settings_obj=_settings(),
+            client=FakeTigerBeetleClient(),
+        )._persist_transfer(
+            cast(Session, session),
+            account_specs=(),
+            transfer_spec=transfer_spec,
+            source_type="execution",
+            source_id="execution-race-row",
+            payload_json={"source": "execution"},
+        )
+
+        self.assertIs(ref, existing)
+        self.assertEqual(session.execute_count, 3)
+        self.assertEqual(session.flush_count, 2)
+        self.assertEqual(len(session.added_refs), 2)
+        self.assertEqual(existing.source_type, "execution")
+        self.assertEqual(existing.source_id, "execution-race-row")
 
     def test_journal_ignores_non_transfer_and_missing_amount_events(self) -> None:
         with Session(self.engine) as session:


### PR DESCRIPTION
## Summary

- Makes TigerBeetle transfer-ref persistence tolerant of a matching concurrent insert after the pre-check.
- Reuses existing transfer-ref validation and metadata backfill so conflicting duplicate refs still fail closed.
- Adds a regression test for the duplicate-key race observed when overlapping journal jobs touched the same execution rows.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_tigerbeetle_journal.py -k 'persist_transfer_accepts_matching_concurrent_insert or repeated_same_event_creates_one_transfer_ref or persist_account_refs_accepts_matching_concurrent_insert'`
- `uv run --frozen pytest tests/test_tigerbeetle_journal.py`
- `uv run --frozen ruff check app/trading/tigerbeetle_journal.py tests/test_tigerbeetle_journal.py`
- `uv run --frozen ruff format --check app/trading/tigerbeetle_journal.py tests/test_tigerbeetle_journal.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
