### PR TITLE
fix(synthesis): reconcile stale autotrader sessions

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -84,6 +84,7 @@ spec:
     ANALYSIS_REQUIRED_COMMIT: 56be940b69bf1a56578040eda9bf2e3699c5220e
     AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED: "{{parameters.brokerMutationEnabled}}"
     AUTONOMOUS_TRADER_MODE: "{{parameters.mode}}"
+    AUTONOMOUS_TRADER_SESSION_RECONCILE_ENABLED: "{{parameters.sessionReconcileEnabled}}"
     AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE: "{{parameters.synthesisSessionMode}}"
     AUTONOMOUS_TRADER_TARGET_EQUITY_USD: "{{parameters.targetEquityUsd}}"
     AUTONOMOUS_TRADER_WORK_DIR: /tmp/autonomous-trader-work
@@ -167,6 +168,18 @@ spec:
 
         if [ ! -e "${report_path}" ]; then
           printf '# Autonomous Trader Report\n\nstatus: bootstrapping\n' > "${report_path}"
+        fi
+
+        reconcile_enabled="$(printf '%s' "${AUTONOMOUS_TRADER_SESSION_RECONCILE_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')"
+        if [ "${reconcile_enabled}" = "true" ] || [ "${reconcile_enabled}" = "1" ] || [ "${reconcile_enabled}" = "yes" ]; then
+          if "${python_bin}" /workspace/lab/scripts/autotrader/session_reconciler.py \
+            --finalize-stale-flat \
+            --limit 50 \
+            --grace-minutes 5; then
+            printf '\nsession_reconciliation: completed\n' >> "${report_path}"
+          else
+            printf '\nsession_reconciliation: failed_or_unavailable\n' >> "${report_path}"
+          fi
         fi
 
         git_auth=()

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
@@ -38,6 +38,7 @@ spec:
     mode: market-open
     synthesisSessionMode: market_open
     brokerMutationEnabled: "true"
+    sessionReconcileEnabled: "true"
     accountType: paper
     targetEquityUsd: "500000"
     marketOpenTimezone: America/New_York

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-green-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-green-agentrun-template.yaml
@@ -38,6 +38,7 @@ spec:
     mode: market-open
     synthesisSessionMode: market_open
     brokerMutationEnabled: "false"
+    sessionReconcileEnabled: "false"
     accountType: paper
     targetEquityUsd: "500000"
     marketOpenTimezone: America/New_York

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-market-open-recovery-20260602.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-market-open-recovery-20260602.yaml
@@ -42,6 +42,7 @@ spec:
     mode: market-open
     synthesisSessionMode: market_open
     brokerMutationEnabled: "true"
+    sessionReconcileEnabled: "true"
     accountType: paper
     targetEquityUsd: "500000"
     marketOpenTimezone: America/New_York

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-scorecard-readback-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-scorecard-readback-template.yaml
@@ -34,6 +34,7 @@ spec:
     mode: scorecard-readback
     synthesisSessionMode: scorecard_readback
     brokerMutationEnabled: "false"
+    sessionReconcileEnabled: "true"
     accountType: paper
     targetEquityUsd: "500000"
     marketOpenTimezone: America/New_York

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -743,6 +743,7 @@ describe('autonomous trader provider', () => {
       expect(objectAt(parameters, 'mode')).toBe('market-open')
       expect(objectAt(parameters, 'synthesisSessionMode')).toBe('market_open')
       expect(objectAt(parameters, 'brokerMutationEnabled')).toBe(role === 'active' ? 'true' : 'false')
+      expect(objectAt(parameters, 'sessionReconcileEnabled')).toBe(role === 'active' ? 'true' : 'false')
       expect(objectAt(parameters, 'accountType')).toBe('paper')
       expect(objectAt(parameters, 'targetEquityUsd')).toBe('500000')
     }
@@ -754,6 +755,9 @@ describe('autonomous trader provider', () => {
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_ACCOUNT_TYPE')).toBe('{{parameters.accountType}}')
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED')).toBe(
       '{{parameters.brokerMutationEnabled}}',
+    )
+    expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_SESSION_RECONCILE_ENABLED')).toBe(
+      '{{parameters.sessionReconcileEnabled}}',
     )
     expect(
       (secretEnv ?? [])
@@ -792,6 +796,7 @@ describe('autonomous trader provider', () => {
     expect(objectAt(parameters, 'mode')).toBe('scorecard-readback')
     expect(objectAt(parameters, 'synthesisSessionMode')).toBe('scorecard_readback')
     expect(objectAt(parameters, 'brokerMutationEnabled')).toBe('false')
+    expect(objectAt(parameters, 'sessionReconcileEnabled')).toBe('true')
     const goal = objectAt(templateSpec, 'goal') as Record<string, unknown>
     expect(Object.hasOwn(goal, 'tokenBudget')).toBe(false)
     expect(secrets).toContain('synthesis-env')
@@ -852,6 +857,9 @@ describe('autonomous trader provider', () => {
     )
     expect(bootstrapContent).toContain('report_path="/workspace/.agentrun/autonomous-trader/report.md"')
     expect(bootstrapContent).toContain('work_dir="${AUTONOMOUS_TRADER_WORK_DIR:-/tmp/autonomous-trader-work}"')
+    expect(bootstrapContent).toContain('AUTONOMOUS_TRADER_SESSION_RECONCILE_ENABLED')
+    expect(bootstrapContent).toContain('/workspace/lab/scripts/autotrader/session_reconciler.py')
+    expect(bootstrapContent).toContain('--finalize-stale-flat')
     expect(bootstrapContent).toContain('analysis_context_path="${work_dir}/analysis-context.json"')
     expect(bootstrapContent).toContain('analysis_fetch_timeout_seconds="${ANALYSIS_FETCH_TIMEOUT_SECONDS:-180}"')
     expect(bootstrapContent).toContain('fetch --prune --filter=blob:none --depth="${analysis_fetch_depth}"')

--- a/scripts/autotrader/session_reconciler.py
+++ b/scripts/autotrader/session_reconciler.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from protective_preflight import AlpacaClient
+from synthesis_autotrader_client import SynthesisClient
+
+
+MARKET_SESSION_MODES = {"market_open", "market_session"}
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def decimal_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        Decimal(text)
+    except InvalidOperation:
+        return None
+    return text
+
+
+def as_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [entry for entry in value if isinstance(entry, dict)]
+
+
+def is_stale_market_session(session: dict[str, Any], *, now: datetime, grace: timedelta, current_agent_run: str) -> bool:
+    if session.get("finalizedAt"):
+        return False
+    if session.get("mode") not in MARKET_SESSION_MODES:
+        return False
+    if current_agent_run and session.get("agentRunName") == current_agent_run:
+        return False
+    market_close = parse_timestamp(session.get("marketCloseAt"))
+    if market_close is None:
+        return False
+    return now >= market_close + grace
+
+
+def broker_readback(alpaca: AlpacaClient) -> dict[str, Any]:
+    account = alpaca.get("/v2/account")
+    positions = as_list(alpaca.get("/v2/positions"))
+    orders = as_list(alpaca.get("/v2/orders?status=open&nested=true"))
+    return {
+        "account": account if isinstance(account, dict) else {},
+        "openPositions": positions,
+        "openOrders": orders,
+        "flat": len(positions) == 0 and len(orders) == 0,
+    }
+
+
+def session_counts(detail: dict[str, Any]) -> dict[str, int]:
+    return {
+        "events": len(as_list(detail.get("events"))),
+        "tradeTickets": len(as_list(detail.get("tradeTickets"))),
+        "riskChecks": len(as_list(detail.get("riskChecks"))),
+        "orders": len(as_list(detail.get("orders"))),
+        "fills": len(as_list(detail.get("fills"))),
+        "positionSnapshots": len(as_list(detail.get("positionSnapshots"))),
+    }
+
+
+def finalization_payload(session: dict[str, Any], detail: dict[str, Any], broker: dict[str, Any]) -> dict[str, Any]:
+    status = detail.get("status") if isinstance(detail.get("status"), dict) else {}
+    account = broker.get("account") if isinstance(broker.get("account"), dict) else {}
+    closing_equity = decimal_text(account.get("equity")) or decimal_text(status.get("equity"))
+    realized_pnl = decimal_text(status.get("realizedPnl")) or decimal_text(session.get("realizedPnl"))
+    summary = {
+        "reconciledBy": "autotrader-session-reconciler",
+        "reconcileReason": "stale_post_close_flat_broker_state",
+        "agentRunName": session.get("agentRunName"),
+        "tradingDate": session.get("tradingDate"),
+        "marketCloseAt": session.get("marketCloseAt"),
+        "brokerFlat": broker.get("flat") is True,
+        "brokerOpenPositionCount": len(as_list(broker.get("openPositions"))),
+        "brokerOpenOrderCount": len(as_list(broker.get("openOrders"))),
+        "sourceCounts": session_counts(detail),
+        "lastRecordedStatus": status,
+    }
+    return {
+        "sessionId": session["id"],
+        "terminalReason": "market_closed",
+        "summary": summary,
+        **({"closingEquity": closing_equity} if closing_equity is not None else {}),
+        **({"realizedPnl": realized_pnl} if realized_pnl is not None else {}),
+    }
+
+
+def reconcile_sessions(
+    *,
+    synthesis: SynthesisClient,
+    alpaca: AlpacaClient,
+    now: datetime,
+    limit: int,
+    grace_minutes: int,
+    finalize_stale_flat: bool,
+    current_agent_run: str,
+) -> dict[str, Any]:
+    sessions_payload = synthesis.get("/api/autotrader/sessions", {"limit": str(limit)})
+    sessions = as_list(sessions_payload.get("sessions") if isinstance(sessions_payload, dict) else None)
+    grace = timedelta(minutes=grace_minutes)
+    candidates = [
+        session
+        for session in sessions
+        if is_stale_market_session(session, now=now, grace=grace, current_agent_run=current_agent_run)
+    ]
+    broker = broker_readback(alpaca) if candidates else {"flat": None, "openPositions": [], "openOrders": []}
+    reconciled: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+
+    for session in candidates:
+        session_id = str(session.get("id") or "")
+        if not session_id:
+            skipped.append({"sessionId": None, "reason": "missing_session_id"})
+            continue
+        detail = synthesis.get(f"/api/autotrader/sessions/{session_id}")
+        if not isinstance(detail, dict):
+            skipped.append({"sessionId": session_id, "reason": "invalid_session_detail"})
+            continue
+        if broker.get("flat") is not True:
+            skipped.append(
+                {
+                    "sessionId": session_id,
+                    "agentRunName": session.get("agentRunName"),
+                    "reason": "broker_state_not_flat",
+                    "brokerOpenPositionCount": len(as_list(broker.get("openPositions"))),
+                    "brokerOpenOrderCount": len(as_list(broker.get("openOrders"))),
+                }
+            )
+            continue
+        payload = finalization_payload(session, detail, broker)
+        if finalize_stale_flat:
+            synthesis.post("/api/autotrader/finalize", payload)
+        reconciled.append(
+            {
+                "sessionId": session_id,
+                "agentRunName": session.get("agentRunName"),
+                "terminalReason": payload["terminalReason"],
+                "finalized": finalize_stale_flat,
+            }
+        )
+
+    return {
+        "ok": True,
+        "checkedSessions": len(sessions),
+        "candidateCount": len(candidates),
+        "reconciled": reconciled,
+        "skipped": skipped,
+        "brokerFlat": broker.get("flat"),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Reconcile stale Synthesis autotrader sessions.")
+    parser.add_argument("--base-url")
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--grace-minutes", type=int, default=5)
+    parser.add_argument("--finalize-stale-flat", action="store_true")
+    parser.add_argument("--now")
+    parser.add_argument("--current-agent-run-name", default=os.environ.get("AGENT_RUN_NAME", ""))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    now = parse_timestamp(args.now) if args.now else datetime.now(UTC)
+    if now is None:
+        raise SystemExit("--now must be an ISO timestamp")
+    result = reconcile_sessions(
+        synthesis=SynthesisClient(base_url=args.base_url, timeout_seconds=args.timeout_seconds),
+        alpaca=AlpacaClient(timeout_seconds=args.timeout_seconds),
+        now=now,
+        limit=args.limit,
+        grace_minutes=args.grace_minutes,
+        finalize_stale_flat=args.finalize_stale_flat,
+        current_agent_run=args.current_agent_run_name.strip(),
+    )
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/autotrader/test_session_reconciler.py
+++ b/scripts/autotrader/test_session_reconciler.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from datetime import UTC, datetime
+from typing import Any
+
+import session_reconciler
+
+
+class FakeSynthesis:
+    def __init__(self, sessions: list[dict[str, Any]], details: dict[str, dict[str, Any]]) -> None:
+        self.sessions = sessions
+        self.details = details
+        self.finalized: list[dict[str, Any]] = []
+
+    def get(self, path: str, query: dict[str, str] | None = None) -> Any:
+        if path == "/api/autotrader/sessions":
+            return {"sessions": self.sessions[: int((query or {}).get("limit", "50"))]}
+        prefix = "/api/autotrader/sessions/"
+        if path.startswith(prefix):
+            return self.details[path[len(prefix) :]]
+        raise AssertionError(f"unexpected GET {path}")
+
+    def post(self, path: str, payload: dict[str, Any]) -> Any:
+        if path != "/api/autotrader/finalize":
+            raise AssertionError(f"unexpected POST {path}")
+        self.finalized.append(payload)
+        return {"ok": True}
+
+
+class FakeAlpaca:
+    def __init__(
+        self,
+        *,
+        account: dict[str, Any] | None = None,
+        positions: list[dict[str, Any]] | None = None,
+        orders: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.account = account or {"equity": "30001.25"}
+        self.positions = positions or []
+        self.orders = orders or []
+
+    def get(self, path: str) -> Any:
+        if path == "/v2/account":
+            return self.account
+        if path == "/v2/positions":
+            return self.positions
+        if path == "/v2/orders?status=open&nested=true":
+            return self.orders
+        raise AssertionError(f"unexpected Alpaca GET {path}")
+
+
+def stale_session(**overrides: Any) -> dict[str, Any]:
+    session = {
+        "id": "session-1",
+        "agentRunName": "autonomous-trader-market-open-abcde",
+        "mode": "market_open",
+        "tradingDate": "2026-06-02",
+        "marketCloseAt": "2026-06-02T20:00:00.000Z",
+        "finalizedAt": None,
+        "realizedPnl": "-11.17",
+    }
+    session.update(overrides)
+    return session
+
+
+class SessionReconcilerTest(unittest.TestCase):
+    def test_finalizes_stale_market_session_when_broker_is_flat(self) -> None:
+        synthesis = FakeSynthesis(
+            [stale_session()],
+            {
+                "session-1": {
+                    "status": {"equity": "29990.03", "realizedPnl": "-11.17"},
+                    "events": [{"seq": 1}],
+                    "tradeTickets": [{"id": "ticket-1"}],
+                    "riskChecks": [],
+                    "orders": [{"clientOrderId": "order-1"}],
+                    "fills": [{"brokerFillId": "fill-1"}],
+                    "positionSnapshots": [],
+                }
+            },
+        )
+
+        result = session_reconciler.reconcile_sessions(
+            synthesis=synthesis,  # type: ignore[arg-type]
+            alpaca=FakeAlpaca(),  # type: ignore[arg-type]
+            now=datetime(2026, 6, 2, 20, 10, tzinfo=UTC),
+            limit=50,
+            grace_minutes=5,
+            finalize_stale_flat=True,
+            current_agent_run="autonomous-trader-market-open-next",
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["candidateCount"], 1)
+        self.assertEqual(result["reconciled"][0]["sessionId"], "session-1")
+        self.assertEqual(len(synthesis.finalized), 1)
+        payload = synthesis.finalized[0]
+        self.assertEqual(payload["sessionId"], "session-1")
+        self.assertEqual(payload["terminalReason"], "market_closed")
+        self.assertEqual(payload["closingEquity"], "30001.25")
+        self.assertEqual(payload["realizedPnl"], "-11.17")
+        self.assertEqual(payload["summary"]["sourceCounts"]["events"], 1)
+        self.assertTrue(payload["summary"]["brokerFlat"])
+
+    def test_does_not_finalize_when_current_broker_state_is_open(self) -> None:
+        synthesis = FakeSynthesis([stale_session()], {"session-1": {"status": {}, "events": []}})
+
+        result = session_reconciler.reconcile_sessions(
+            synthesis=synthesis,  # type: ignore[arg-type]
+            alpaca=FakeAlpaca(positions=[{"symbol": "GOOGL", "qty": "5"}]),  # type: ignore[arg-type]
+            now=datetime(2026, 6, 2, 20, 10, tzinfo=UTC),
+            limit=50,
+            grace_minutes=5,
+            finalize_stale_flat=True,
+            current_agent_run="",
+        )
+
+        self.assertEqual(synthesis.finalized, [])
+        self.assertEqual(result["skipped"][0]["reason"], "broker_state_not_flat")
+        self.assertEqual(result["skipped"][0]["brokerOpenPositionCount"], 1)
+
+    def test_ignores_finalized_current_and_within_grace_sessions(self) -> None:
+        sessions = [
+            stale_session(id="finalized", finalizedAt="2026-06-02T20:01:00Z"),
+            stale_session(id="current", agentRunName="autonomous-trader-market-open-current"),
+            stale_session(id="within-grace", marketCloseAt="2026-06-02T20:04:00Z"),
+        ]
+        synthesis = FakeSynthesis(sessions, {})
+
+        result = session_reconciler.reconcile_sessions(
+            synthesis=synthesis,  # type: ignore[arg-type]
+            alpaca=FakeAlpaca(),  # type: ignore[arg-type]
+            now=datetime(2026, 6, 2, 20, 5, tzinfo=UTC),
+            limit=50,
+            grace_minutes=5,
+            finalize_stale_flat=True,
+            current_agent_run="autonomous-trader-market-open-current",
+        )
+
+        self.assertEqual(result["candidateCount"], 0)
+        self.assertIsNone(result["brokerFlat"])
+        self.assertEqual(synthesis.finalized, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds an autotrader session reconciler that detects stale post-close market sessions and finalizes only when live Alpaca readback proves the paper account has no open positions or open orders.
- Wires the reconciler into the autonomous-trader bootstrap behind `sessionReconcileEnabled`; active blue, recovery, and scorecard readback enable it while green preview stays disabled.
- Extends autotrader tests and provider smoke coverage so stale-session reconciliation cannot regress silently.

## Related Issues

None

## Testing

- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 -m py_compile scripts/autotrader/session_reconciler.py scripts/autotrader/test_session_reconciler.py`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "autonomous trader provider"`
- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | kubectl apply --dry-run=server -f -`
- `git diff --check origin/main..HEAD`

## Screenshots (if applicable)

N/A - autotrader runtime and GitOps change.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
