### PR TITLE
fix(torghut): remove replay runtime artifact aliases

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -415,7 +415,6 @@ def _artifact_refs_from_scorecard(scorecard: Mapping[str, Any]) -> tuple[str, ..
         "market_impact_stress_artifact_ref",
         "delay_adjusted_depth_stress_artifact_ref",
         "exact_replay_ledger_artifact_ref",
-        "runtime_ledger_artifact_ref",
     ):
         ref = _string(scorecard.get(key))
         if ref:
@@ -426,7 +425,6 @@ def _artifact_refs_from_scorecard(scorecard: Mapping[str, Any]) -> tuple[str, ..
         "market_limit_order_mix_artifact_refs",
         "order_type_ablation_artifact_refs",
         "exact_replay_ledger_artifact_refs",
-        "runtime_ledger_artifact_refs",
     ):
         raw_refs = scorecard.get(key)
         if isinstance(raw_refs, str):

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -456,8 +456,6 @@ def _exact_replay_ledger_artifact_refs(bundle: CandidateEvidenceBundle) -> list[
         scorecard,
         "exact_replay_ledger_artifact_ref",
         "exact_replay_ledger_artifact_refs",
-        "runtime_ledger_artifact_ref",
-        "runtime_ledger_artifact_refs",
     )
 
 
@@ -468,7 +466,6 @@ def _exact_replay_ledger_row_count(bundle: CandidateEvidenceBundle) -> int:
         int(
             _decimal(
                 scorecard.get("exact_replay_ledger_artifact_row_count")
-                or scorecard.get("runtime_ledger_artifact_row_count")
             )
         ),
     )
@@ -481,7 +478,6 @@ def _exact_replay_ledger_fill_count(bundle: CandidateEvidenceBundle) -> int:
         int(
             _decimal(
                 scorecard.get("exact_replay_ledger_artifact_fill_count")
-                or scorecard.get("runtime_ledger_artifact_fill_count")
             )
         ),
     )
@@ -1680,14 +1676,8 @@ def _portfolio_scorecard(
         "exact_replay_ledger_artifact_ref": exact_replay_ledger_artifact_refs[0]
         if exact_replay_ledger_artifact_refs
         else "",
-        "runtime_ledger_artifact_refs": exact_replay_ledger_artifact_refs,
-        "runtime_ledger_artifact_ref": exact_replay_ledger_artifact_refs[0]
-        if exact_replay_ledger_artifact_refs
-        else "",
         "exact_replay_ledger_artifact_row_count": exact_replay_ledger_row_count,
-        "runtime_ledger_artifact_row_count": exact_replay_ledger_row_count,
         "exact_replay_ledger_artifact_fill_count": exact_replay_ledger_fill_count,
-        "runtime_ledger_artifact_fill_count": exact_replay_ledger_fill_count,
         "executable_replay_account_buying_power": str(
             min(executable_buying_powers, default=Decimal("0"))
         ),

--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -1089,17 +1089,13 @@ def evaluate_profit_target_oracle(
         scorecard,
         "exact_replay_ledger_artifact_ref",
         "exact_replay_ledger_artifact_refs",
-        "runtime_ledger_artifact_ref",
-        "runtime_ledger_artifact_refs",
     )
     exact_replay_ledger_artifact_present = bool(exact_replay_ledger_artifact_refs)
     exact_replay_ledger_row_count = _nonnegative_int(
         scorecard.get("exact_replay_ledger_artifact_row_count")
-        or scorecard.get("runtime_ledger_artifact_row_count")
     )
     exact_replay_ledger_fill_count = _nonnegative_int(
         scorecard.get("exact_replay_ledger_artifact_fill_count")
-        or scorecard.get("runtime_ledger_artifact_fill_count")
     )
     checks.extend(
         (
@@ -1108,7 +1104,7 @@ def evaluate_profit_target_oracle(
                 "observed": str(exact_replay_ledger_artifact_present).lower(),
                 "operator": "eq",
                 "threshold": "true",
-                "source_marker": "exact_replay_runtime_ledger_authority",
+                "source_marker": "exact_replay_ledger_probation_gate",
                 "passed": exact_replay_ledger_artifact_present
                 if policy.require_exact_replay_ledger
                 else True,
@@ -1134,7 +1130,7 @@ def evaluate_profit_target_oracle(
                 "observed": portfolio_post_cost_net_pnl_basis,
                 "operator": "in",
                 "threshold": sorted(_ACCEPTED_LEDGER_PNL_BASES),
-                "source_marker": "exact_replay_runtime_ledger_authority",
+                "source_marker": "exact_replay_ledger_probation_gate",
                 "passed": (
                     portfolio_post_cost_net_pnl_basis in _ACCEPTED_LEDGER_PNL_BASES
                 )
@@ -1146,7 +1142,7 @@ def evaluate_profit_target_oracle(
                 "observed": portfolio_post_cost_net_pnl_source,
                 "operator": "in",
                 "threshold": sorted(_ACCEPTED_LEDGER_PNL_SOURCES),
-                "source_marker": "exact_replay_runtime_ledger_authority",
+                "source_marker": "exact_replay_ledger_probation_gate",
                 "passed": (
                     portfolio_post_cost_net_pnl_source in _ACCEPTED_LEDGER_PNL_SOURCES
                 )

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -98,7 +98,7 @@ def _executable_scorecard_fields(index: int | str = 0) -> dict[str, object]:
 
 
 class TestPortfolioOptimizer(TestCase):
-    def test_exact_replay_ledger_helpers_accept_list_refs_and_runtime_artifact_counts(
+    def test_exact_replay_ledger_helpers_accept_exact_replay_refs_and_counts(
         self,
     ) -> None:
         bundle = evidence_bundle_from_frontier_candidate(
@@ -111,9 +111,8 @@ class TestPortfolioOptimizer(TestCase):
                         "s3://proof/exact-ledger.json",
                         "s3://proof/exact-ledger.json",
                     ],
-                    "runtime_ledger_artifact_refs": ["s3://proof/runtime-ledger.json"],
-                    "runtime_ledger_artifact_row_count": "7",
-                    "runtime_ledger_artifact_fill_count": "6",
+                    "exact_replay_ledger_artifact_row_count": "7",
+                    "exact_replay_ledger_artifact_fill_count": "6",
                 },
             },
             dataset_snapshot_id="snapshot-ledger-list",
@@ -124,7 +123,6 @@ class TestPortfolioOptimizer(TestCase):
             portfolio_optimizer_module._exact_replay_ledger_artifact_refs(bundle),
             [
                 "s3://proof/exact-ledger.json",
-                "s3://proof/runtime-ledger.json",
             ],
         )
         self.assertEqual(
@@ -136,7 +134,7 @@ class TestPortfolioOptimizer(TestCase):
             6,
         )
 
-    def test_exact_replay_ledger_helpers_reject_non_artifact_count_aliases(
+    def test_exact_replay_ledger_helpers_reject_runtime_and_non_artifact_aliases(
         self,
     ) -> None:
         bundle = evidence_bundle_from_frontier_candidate(
@@ -144,6 +142,10 @@ class TestPortfolioOptimizer(TestCase):
             candidate={
                 "candidate_id": "cand-ledger-summary-alias",
                 "objective_scorecard": {
+                    "runtime_ledger_artifact_ref": "s3://proof/runtime-ledger.json",
+                    "runtime_ledger_artifact_refs": ["s3://proof/runtime-ledger.json"],
+                    "runtime_ledger_artifact_row_count": "7",
+                    "runtime_ledger_artifact_fill_count": "6",
                     "exact_replay_ledger_row_count": "7",
                     "runtime_ledger_row_count": "7",
                     "exact_replay_ledger_fill_count": "6",
@@ -154,6 +156,14 @@ class TestPortfolioOptimizer(TestCase):
             result_path="/tmp/cand-ledger-summary-alias.json",
         )
 
+        self.assertEqual(
+            portfolio_optimizer_module._exact_replay_ledger_artifact_refs(bundle),
+            [],
+        )
+        self.assertNotIn(
+            "s3://proof/runtime-ledger.json",
+            bundle.replay_artifact_refs,
+        )
         self.assertEqual(
             portfolio_optimizer_module._exact_replay_ledger_row_count(bundle),
             0,

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -1334,7 +1334,9 @@ class TestProfitTargetOracle(TestCase):
         self.assertIn("portfolio_post_cost_net_pnl_basis_failed", result["blockers"])
         self.assertIn("portfolio_post_cost_net_pnl_source_failed", result["blockers"])
 
-    def test_profit_target_oracle_accepts_runtime_ledger_aliases(self) -> None:
+    def test_profit_target_oracle_rejects_runtime_ledger_artifact_aliases(
+        self,
+    ) -> None:
         scorecard = {
             key: value
             for key, value in _passing_scorecard().items()
@@ -1353,7 +1355,10 @@ class TestProfitTargetOracle(TestCase):
             target_net_pnl_per_day=Decimal("500"),
         )
 
-        self.assertTrue(result["passed"])
+        self.assertFalse(result["passed"])
+        self.assertIn("exact_replay_ledger_artifact_present_failed", result["blockers"])
+        self.assertIn("exact_replay_ledger_artifact_row_count_failed", result["blockers"])
+        self.assertIn("exact_replay_ledger_artifact_fill_count_failed", result["blockers"])
 
     def test_profit_target_oracle_rejects_capital_unsafe_replay(self) -> None:
         result = evaluate_profit_target_oracle(


### PR DESCRIPTION
## Summary

- Removed `runtime_ledger_artifact_*` fallback aliases from exact-replay ledger artifact checks in the portfolio optimizer and profit-target oracle.
- Stopped portfolio scorecards from copying exact-replay artifact refs/counts into runtime-ledger artifact fields.
- Stopped evidence bundles from inheriting `runtime_ledger_artifact_*` refs as replay artifacts, and added regressions that keep runtime aliases from satisfying exact-replay gates.
- Renamed the remaining exact-replay check marker from authority wording to a probation-gate marker.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_portfolio_optimizer.py::TestPortfolioOptimizer::test_exact_replay_ledger_helpers_accept_exact_replay_refs_and_counts tests/test_portfolio_optimizer.py::TestPortfolioOptimizer::test_exact_replay_ledger_helpers_reject_runtime_and_non_artifact_aliases tests/test_profit_target_oracle.py::TestProfitTargetOracle::test_profit_target_oracle_rejects_runtime_ledger_artifact_aliases -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/evidence_bundles.py app/trading/discovery/portfolio_optimizer.py app/trading/discovery/profit_target_oracle.py tests/test_portfolio_optimizer.py tests/test_profit_target_oracle.py`
- `cd services/torghut && uv run --frozen pytest tests/test_portfolio_optimizer.py tests/test_profit_target_oracle.py -q`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
