### PR TITLE
fix(synthesis): run autotrader stale session reconcile

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-stale-session-reconcile-20260602.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-stale-session-reconcile-20260602.yaml
@@ -1,0 +1,69 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: autonomous-trader-stale-reconcile-20260602
+  namespace: synthesis
+  annotations:
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: stale-session-reconcile
+    autonomous-trader.proompteng.ai/reconcile-for: autonomous-trader-market-open-lxhgb
+    autonomous-trader.proompteng.ai/reconcile-session: c41d58a4-5e50-4d02-96d5-2a0458193c90
+    autonomous-trader.proompteng.ai/reconcile-session-date: "2026-06-02"
+  labels:
+    app.kubernetes.io/part-of: synthesis
+    app.kubernetes.io/component: autonomous-trader
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: stale-session-reconcile
+spec:
+  agentRef:
+    name: autonomous-trader-agent
+  implementationSpecRef:
+    name: autonomous-trader-v1
+  goal:
+    objective: >-
+      Reconcile stale post-close Synthesis autotrader market-open sessions only after live Alpaca readback
+      proves the dedicated paper account has no open positions or open orders; do not submit broker mutations.
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-only
+  runtime:
+    type: job
+    config:
+      serviceAccountName: agents-sa
+      backoffLimit: 0
+      logRetentionSeconds: 604800
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/synthesis-autonomous-trader-stale-reconcile
+    mode: scorecard-readback
+    synthesisSessionMode: scorecard_readback
+    brokerMutationEnabled: "false"
+    sessionReconcileEnabled: "true"
+    accountType: paper
+    targetEquityUsd: "500000"
+    marketOpenTimezone: America/New_York
+    premarketBootstrapMinutes: "15"
+  secrets:
+    - autonomous-trader-alpaca-mcp
+    - agents-artifacts
+    - codex-auth
+    - github-token
+    - synthesis-env
+  workload:
+    volumes:
+      - type: secret
+        name: synthesis-env
+        secretName: synthesis-env
+        mountPath: /var/run/synthesis
+        readOnly: true
+    resources:
+      requests:
+        cpu: "2"
+        memory: 4Gi
+        ephemeral-storage: 2Gi
+      limits:
+        memory: 16Gi
+        ephemeral-storage: 16Gi

--- a/argocd/applications/synthesis/agents-domain/kustomization.yaml
+++ b/argocd/applications/synthesis/agents-domain/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - autonomous-trader-agentrun-template.yaml
   - autonomous-trader-schedule.yaml
   - autonomous-trader-market-open-recovery-20260602.yaml
+  - autonomous-trader-stale-session-reconcile-20260602.yaml
   - autonomous-trader-green-system-prompt-configmap.yaml
   - autonomous-trader-green-agent.yaml
   - autonomous-trader-green-implspec.yaml

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -683,6 +683,7 @@ describe('autonomous trader provider', () => {
     expect(resources).toContain('autonomous-trader-green-implspec.yaml')
     expect(resources).toContain('autonomous-trader-green-schedule.yaml')
     expect(resources).toContain('autonomous-trader-green-agentrun-template.yaml')
+    expect(resources).toContain('autonomous-trader-stale-session-reconcile-20260602.yaml')
     expect(
       existsSync(
         resolve(process.cwd(), 'argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml'),
@@ -802,6 +803,49 @@ describe('autonomous trader provider', () => {
     expect(secrets).toContain('synthesis-env')
     expect(secrets).toContain('autonomous-trader-alpaca-mcp')
     expect(secrets).not.toContain('alpaca-mcp')
+  })
+
+  it('runs a one-off stale session reconcile through the read-only autotrader lane', () => {
+    const kustomization = readYamlObjects('argocd/applications/synthesis/agents-domain/kustomization.yaml')[0]
+    const resources = objectAt(kustomization, 'resources') as string[] | undefined
+    const agentRun = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-stale-session-reconcile-20260602.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'AgentRun')
+    const metadata = objectAt(agentRun, 'metadata')
+    const annotations = objectAt(metadata, 'annotations')
+    const labels = objectAt(metadata, 'labels')
+    const spec = objectAt(agentRun, 'spec')
+    const parameters = objectAt(spec, 'parameters')
+    const secrets = objectAt(spec, 'secrets') as unknown[]
+    const workload = objectAt(spec, 'workload')
+    const resourcesSpec = objectAt(workload, 'resources')
+
+    expect(resources).toContain('autonomous-trader-stale-session-reconcile-20260602.yaml')
+    expect(objectAt(metadata, 'name')).toBe('autonomous-trader-stale-reconcile-20260602')
+    expect(objectAt(metadata, 'namespace')).toBe('synthesis')
+    expect(objectAt(annotations, 'autonomous-trader.proompteng.ai/deployment-color')).toBe('blue')
+    expect(objectAt(labels, 'autonomous-trader.proompteng.ai/deployment-color')).toBe('blue')
+    expect(objectAt(annotations, 'autonomous-trader.proompteng.ai/deployment-role')).toBe('stale-session-reconcile')
+    expect(objectAt(labels, 'autonomous-trader.proompteng.ai/deployment-role')).toBe('stale-session-reconcile')
+    expect(objectAt(annotations, 'autonomous-trader.proompteng.ai/reconcile-for')).toBe(
+      'autonomous-trader-market-open-lxhgb',
+    )
+    expect(objectAt(annotations, 'autonomous-trader.proompteng.ai/reconcile-session')).toBe(
+      'c41d58a4-5e50-4d02-96d5-2a0458193c90',
+    )
+    expect(objectAt(objectAt(spec, 'agentRef'), 'name')).toBe('autonomous-trader-agent')
+    expect(objectAt(objectAt(spec, 'implementationSpecRef'), 'name')).toBe('autonomous-trader-v1')
+    expect(objectAt(objectAt(spec, 'vcsPolicy'), 'mode')).toBe('read-only')
+    expect(objectAt(parameters, 'mode')).toBe('scorecard-readback')
+    expect(objectAt(parameters, 'synthesisSessionMode')).toBe('scorecard_readback')
+    expect(objectAt(parameters, 'brokerMutationEnabled')).toBe('false')
+    expect(objectAt(parameters, 'sessionReconcileEnabled')).toBe('true')
+    expect(Object.hasOwn(spec as Record<string, unknown>, 'ttlSecondsAfterFinished')).toBe(false)
+    expect(secrets).toContain('autonomous-trader-alpaca-mcp')
+    expect(secrets).toContain('synthesis-env')
+    expect(secrets).not.toContain('alpaca-mcp')
+    expect(objectAt(objectAt(resourcesSpec, 'requests'), 'cpu')).toBe('2')
+    expect(objectAt(objectAt(resourcesSpec, 'limits'), 'memory')).toBe('16Gi')
   })
 
   it('preinstalls day-trading Python dependencies in the Codex runner image', () => {


### PR DESCRIPTION
## Summary

- Adds a GitOps-managed one-off `AgentRun` for `autonomous-trader-stale-reconcile-20260602`.
- Runs reconciliation through the blue autotrader agent and implementation path with broker mutations disabled.
- Keeps session reconciliation enabled, pins the dedicated autotrader Alpaca secret, and avoids TTL-based rerun loops.
- Adds smoke coverage for the one-off read-only reconcile lane.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "autonomous trader provider"`
- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | kubectl apply --dry-run=server -f -`
- `git diff --check`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
