### PR TITLE
fix(torghut): route observed source strategy imports

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -7828,6 +7828,13 @@ def _sanitized_runtime_ledger_source_collection_target(
     }
     if runtime_ledger_bucket_ref := _safe_text(target.get("runtime_ledger_bucket_ref")):
         sanitized["runtime_ledger_bucket_ref"] = runtime_ledger_bucket_ref
+    observed_from_contaminated_target = _as_mapping(
+        target.get("observed_from_contaminated_target")
+    )
+    if observed_from_contaminated_target:
+        sanitized["observed_from_contaminated_target"] = dict(
+            observed_from_contaminated_target
+        )
     if artifact_refs := _unique_text_items(target.get("artifact_refs")):
         sanitized["artifact_refs"] = artifact_refs
     return sanitized
@@ -7874,6 +7881,252 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
         "skipped_target_count": 0,
         "targets": source_targets,
         "skipped_targets": [],
+    }
+
+
+def _hypothesis_manifest_ref(hypothesis_id: object) -> str:
+    text = str(hypothesis_id or "").strip().lower().replace("_", "-")
+    return f"config/trading/hypotheses/{text}.json" if text else ""
+
+
+def _runtime_ledger_repair_candidate_lookup_names(
+    candidate: Mapping[str, Any],
+) -> list[str]:
+    strategy_name = _safe_text(candidate.get("strategy_name"))
+    strategy_id = _safe_text(candidate.get("strategy_id"))
+    runtime_strategy_name = (
+        explicit_runtime_strategy_name_or_family_harness(
+            runtime_strategy_name=candidate.get("runtime_strategy_name"),
+            strategy_name=strategy_name,
+            strategy_id=strategy_id,
+        )
+        or strategy_name
+    )
+    return _strategy_lookup_names(
+        candidate.get("strategy_lookup_names"),
+        runtime_strategy_name,
+        strategy_name,
+        strategy_names_from_strategy_id(strategy_id),
+        derived_strategy_name_from_strategy_id(strategy_id),
+    )
+
+
+def _runtime_ledger_repair_candidates_by_strategy_name(
+    live_submission_gate: Mapping[str, Any],
+) -> dict[str, Mapping[str, Any]]:
+    candidates_by_name: dict[str, Mapping[str, Any]] = {}
+    for candidate in _as_mapping_items(
+        live_submission_gate.get("runtime_ledger_repair_candidates")
+    ):
+        for name in _runtime_ledger_repair_candidate_lookup_names(candidate):
+            candidates_by_name.setdefault(name, candidate)
+    return candidates_by_name
+
+
+def _observed_strategy_source_collection_target(
+    *,
+    candidate: Mapping[str, Any],
+    observed_strategy_name: str,
+    observed_count: int,
+    contaminated_target: Mapping[str, Any],
+) -> dict[str, object] | None:
+    hypothesis_id = _safe_text(candidate.get("hypothesis_id"))
+    candidate_id = _safe_text(candidate.get("candidate_id"))
+    strategy_family = _safe_text(candidate.get("strategy_family"))
+    strategy_id = _safe_text(candidate.get("strategy_id"))
+    strategy_name = (
+        explicit_runtime_strategy_name_or_family_harness(
+            runtime_strategy_name=candidate.get("runtime_strategy_name"),
+            strategy_name=candidate.get("strategy_name"),
+            strategy_id=strategy_id,
+        )
+        or observed_strategy_name
+    )
+    window_start = _safe_text(contaminated_target.get("window_start"))
+    window_end = _safe_text(contaminated_target.get("window_end"))
+    missing = [
+        value
+        for value in (
+            hypothesis_id,
+            candidate_id,
+            strategy_family,
+            strategy_name,
+            window_start,
+            window_end,
+        )
+        if value is None
+    ]
+    if missing:
+        return None
+    target = {
+        **dict(candidate),
+        "hypothesis_id": hypothesis_id,
+        "candidate_id": candidate_id,
+        "observed_stage": "paper",
+        "strategy_family": strategy_family,
+        "strategy_name": strategy_name,
+        "runtime_strategy_name": strategy_name,
+        "strategy_id": strategy_id or "",
+        "strategy_lookup_names": _strategy_lookup_names(
+            candidate.get("strategy_lookup_names"),
+            strategy_name,
+            observed_strategy_name,
+            strategy_names_from_strategy_id(strategy_id),
+            derived_strategy_name_from_strategy_id(strategy_id),
+        ),
+        "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+        "source_account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+        "source_dsn_env": "SIM_DB_DSN",
+        "target_dsn_env": "SIM_DB_DSN",
+        "source_manifest_ref": _safe_text(candidate.get("source_manifest_ref"))
+        or _hypothesis_manifest_ref(hypothesis_id),
+        "source_kind": RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND,
+        "window_start": window_start,
+        "window_end": window_end,
+        "source_collection_authorized": True,
+        "source_collection_authorization_scope": "source_window_evidence_collection_only",
+        "source_collection_reason_codes": _unique_text_items(
+            [
+                "paper_route_foreign_strategy_source_activity_observed",
+                RUNTIME_LEDGER_SOURCE_COLLECTION_PENDING_BLOCKER,
+                *(_unique_text_items(candidate.get("source_collection_reason_codes"))),
+            ]
+        ),
+        "final_promotion_blockers": list(
+            RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS
+        ),
+        "candidate_blockers": _unique_text_items(
+            [
+                "paper_route_runtime_ledger_import_pending",
+                "runtime_ledger_source_collection_only",
+                *(_unique_text_items(candidate.get("reason_codes"))),
+                *(_unique_text_items(candidate.get("candidate_blockers"))),
+            ]
+        ),
+        "runtime_ledger_target_metadata_blockers": list(
+            RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS
+        ),
+        "handoff": RUNTIME_LEDGER_SOURCE_COLLECTION_HANDOFF,
+        "promotion_gate": "runtime_ledger_live_or_live_paper_required",
+        "selected_by": "paper_route_observed_strategy_source_collection",
+        "selection_reason": "foreign_strategy_source_activity_observed_in_paper_route_window",
+        "max_notional": "0",
+        "observed_from_contaminated_target": {
+            "hypothesis_id": _safe_text(contaminated_target.get("hypothesis_id")),
+            "candidate_id": _safe_text(contaminated_target.get("candidate_id")),
+            "strategy_name": observed_strategy_name,
+            "order_event_count": observed_count,
+            "reason": "paper_route_account_contamination_strategy_observed",
+        },
+    }
+    return _sanitized_runtime_ledger_source_collection_target(target)
+
+
+def _observed_strategy_source_collection_import_plan(
+    *,
+    live_submission_gate: Mapping[str, Any],
+    candidate_plans: Sequence[Mapping[str, Any]],
+    target_limit: int,
+) -> dict[str, object]:
+    if not _live_gate_has_source_collection_pending(live_submission_gate):
+        return {}
+    candidates_by_strategy = _runtime_ledger_repair_candidates_by_strategy_name(
+        live_submission_gate
+    )
+    if not candidates_by_strategy:
+        return {}
+    limit = max(0, target_limit)
+    targets: list[dict[str, object]] = []
+    skipped_targets: list[dict[str, object]] = []
+    seen_keys: set[tuple[str, str, str, str, str]] = set()
+    for plan in candidate_plans:
+        if len(targets) >= limit:
+            break
+        for contaminated_target in _as_mapping_items(plan.get("targets")):
+            if len(targets) >= limit:
+                break
+            contamination = _as_mapping(
+                contaminated_target.get("paper_route_account_contamination_state")
+            )
+            foreign_strategy_counts = _as_mapping(
+                contamination.get("foreign_strategy_counts")
+            )
+            if not foreign_strategy_counts:
+                continue
+            sorted_strategy_counts = sorted(
+                (
+                    (str(strategy_name or "").strip(), _safe_int(count))
+                    for strategy_name, count in foreign_strategy_counts.items()
+                ),
+                key=lambda item: (-item[1], item[0]),
+            )
+            for observed_strategy_name, observed_count in sorted_strategy_counts:
+                if len(targets) >= limit:
+                    break
+                if not observed_strategy_name or observed_strategy_name == "missing":
+                    continue
+                candidate = candidates_by_strategy.get(observed_strategy_name)
+                if candidate is None:
+                    skipped_targets.append(
+                        {
+                            "strategy_name": observed_strategy_name,
+                            "window_start": _safe_text(
+                                contaminated_target.get("window_start")
+                            ),
+                            "window_end": _safe_text(
+                                contaminated_target.get("window_end")
+                            ),
+                            "reason": "observed_strategy_repair_candidate_missing",
+                        }
+                    )
+                    continue
+                target = _observed_strategy_source_collection_target(
+                    candidate=candidate,
+                    observed_strategy_name=observed_strategy_name,
+                    observed_count=observed_count,
+                    contaminated_target=contaminated_target,
+                )
+                if target is None:
+                    skipped_targets.append(
+                        {
+                            "strategy_name": observed_strategy_name,
+                            "reason": "observed_strategy_source_collection_target_missing_required_fields",
+                        }
+                    )
+                    continue
+                key = (
+                    str(target.get("hypothesis_id") or ""),
+                    str(target.get("candidate_id") or ""),
+                    str(target.get("runtime_strategy_name") or ""),
+                    str(target.get("window_start") or ""),
+                    str(target.get("window_end") or ""),
+                )
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                targets.append(target)
+    if not targets:
+        return {}
+    return {
+        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+        "source": "paper_route_observed_strategy_source_collection",
+        "purpose": "observed_strategy_runtime_ledger_source_collection_import",
+        "proof_mode": "probation",
+        "evidence_collection_ok": True,
+        "paper_probation_satisfied_for_bounded_live_paper_collection": False,
+        "canary_collection_authorized": False,
+        "bounded_live_paper_collection_authorized": False,
+        "capital_promotion_allowed": False,
+        "final_authority_ok": False,
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "target_count": len(targets),
+        "paper_probation_target_count": 0,
+        "source_collection_target_count": len(targets),
+        "skipped_target_count": len(skipped_targets),
+        "targets": targets,
+        "skipped_targets": skipped_targets,
     }
 
 
@@ -7924,6 +8177,7 @@ def build_paper_route_target_plan_payload(
     next_clean_after_discard_targets: Mapping[str, Any] = {}
     latest_closed_targets: Mapping[str, Any] = {}
     source_targets: Mapping[str, Any] = source_collection_import_plan
+    observed_strategy_source_targets: Mapping[str, Any] = {}
     latest_closed_runtime_window_import_target_audits: (
         list[dict[str, object]] | None
     ) = None
@@ -8012,6 +8266,20 @@ def build_paper_route_target_plan_payload(
                     target_account_audit_available=target_account_audit_available,
                 )
                 runtime_window_import_plan = next_clean_after_discard_targets
+        observed_strategy_source_targets = (
+            _observed_strategy_source_collection_import_plan(
+                live_submission_gate=live_submission_gate,
+                candidate_plans=(
+                    runtime_window_import_plan,
+                    latest_closed_targets,
+                    next_targets,
+                ),
+                target_limit=target_limit,
+            )
+        )
+        if _as_mapping_items(observed_strategy_source_targets.get("targets")):
+            source_targets = observed_strategy_source_targets
+            runtime_window_import_plan = observed_strategy_source_targets
     runtime_import_readiness = _as_mapping(
         runtime_window_import_plan.get("session_readiness")
     )
@@ -8075,6 +8343,7 @@ def build_paper_route_target_plan_payload(
     )
     effective_target_plan: Mapping[str, Any] = {}
     for candidate_plan in (
+        observed_strategy_source_targets,
         next_clean_after_discard_targets,
         next_targets,
         source_targets,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -8358,6 +8358,142 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "paper_route_observed_strategy_source_collection",
         )
 
+    def test_observed_strategy_source_collection_plan_limits_targets(self) -> None:
+        target_template = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "candidate-hpairs",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "window_start": "2026-06-02T13:30:00+00:00",
+            "window_end": "2026-06-02T20:00:00+00:00",
+            "paper_route_account_contamination_state": {
+                "foreign_strategy_counts": {
+                    "intraday-tsmom-profit-v3": 2,
+                    "other-observed-source-strategy": 1,
+                },
+            },
+        }
+
+        plan = paper_route_evidence._observed_strategy_source_collection_import_plan(
+            live_submission_gate={
+                "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                "runtime_ledger_repair_candidates": [
+                    {
+                        "hypothesis_id": "H-TSMOM-LIQ-01",
+                        "candidate_id": "candidate-tsmom",
+                        "strategy_family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                    },
+                    {
+                        "hypothesis_id": "H-OTHER",
+                        "candidate_id": "candidate-other",
+                        "strategy_family": "intraday_other",
+                        "strategy_name": "other-observed-source-strategy",
+                    },
+                ],
+            },
+            candidate_plans=[
+                {
+                    "targets": [
+                        dict(target_template),
+                        {
+                            **target_template,
+                            "candidate_id": "candidate-hpairs-second-window",
+                        },
+                    ],
+                },
+                {"targets": [dict(target_template)]},
+            ],
+            target_limit=1,
+        )
+
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["candidate_id"], "candidate-tsmom")
+        self.assertEqual(
+            target["source_manifest_ref"],
+            "config/trading/hypotheses/h-tsmom-liq-01.json",
+        )
+        self.assertEqual(
+            target["observed_from_contaminated_target"]["order_event_count"], 2
+        )
+
+    def test_observed_strategy_source_collection_plan_skips_unmapped_noise(
+        self,
+    ) -> None:
+        plan = paper_route_evidence._observed_strategy_source_collection_import_plan(
+            live_submission_gate={
+                "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                "runtime_ledger_repair_candidates": [
+                    {
+                        "hypothesis_id": "H-TSMOM-LIQ-01",
+                        "candidate_id": "candidate-tsmom",
+                        "strategy_family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                    }
+                ],
+            },
+            candidate_plans=[
+                {
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "candidate-hpairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "window_start": "2026-06-02T13:30:00+00:00",
+                            "window_end": "2026-06-02T20:00:00+00:00",
+                            "paper_route_account_contamination_state": {
+                                "foreign_strategy_counts": {
+                                    "missing": 5,
+                                    "unmapped-observed-strategy": 4,
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+            target_limit=5,
+        )
+
+        self.assertEqual(plan, {})
+
+    def test_observed_strategy_source_collection_plan_skips_incomplete_candidate(
+        self,
+    ) -> None:
+        plan = paper_route_evidence._observed_strategy_source_collection_import_plan(
+            live_submission_gate={
+                "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                "runtime_ledger_repair_candidates": [
+                    {
+                        "hypothesis_id": "H-TSMOM-LIQ-01",
+                        "strategy_family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                    }
+                ],
+            },
+            candidate_plans=[
+                {
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "candidate-hpairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "window_start": "2026-06-02T13:30:00+00:00",
+                            "window_end": "2026-06-02T20:00:00+00:00",
+                            "paper_route_account_contamination_state": {
+                                "foreign_strategy_counts": {
+                                    "intraday-tsmom-profit-v3": 1,
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+            target_limit=5,
+        )
+
+        self.assertEqual(plan, {})
+
     def test_account_contamination_summary_deduplicates_and_caps_order_event_refs(
         self,
     ) -> None:

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -8181,6 +8181,183 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "tsmom-AAPL-foreign-linked-1",
         )
 
+    def test_target_plan_uses_observed_foreign_strategy_source_collection(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 21, 5, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            target_strategy = Strategy(
+                name="hpairs-target-observed-contamination-strategy",
+                description="target bounded paper route strategy",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            foreign_strategy = Strategy(
+                name="intraday-tsmom-profit-v3",
+                description="observed paper account strategy",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN", "INTC"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add_all([target_strategy, foreign_strategy])
+            session.flush()
+            foreign_decision = TradeDecision(
+                strategy_id=foreign_strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-tsmom",
+                    "hypothesis_id": "H-TSMOM-LIQ-01",
+                },
+                rationale="observed foreign source collection fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=5),
+                executed_at=window_start + timedelta(minutes=6),
+            )
+            session.add(foreign_decision)
+            session.flush()
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="observed-tsmom-paper-event",
+                    source_topic="alpaca.trade_updates",
+                    source_partition=0,
+                    source_offset=44,
+                    alpaca_account_label="TORGHUT_SIM",
+                    event_ts=window_start + timedelta(minutes=20),
+                    symbol="AAPL",
+                    alpaca_order_id="observed-tsmom-order-1",
+                    client_order_id="tsmom-AAPL-observed-1",
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("101"),
+                    raw_event={"source": "foreign_tsmom_strategy"},
+                    execution_id=None,
+                    trade_decision_id=foreign_decision.id,
+                )
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
+            session.commit()
+
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "runtime_ledger_repair_candidates": [
+                        {
+                            "hypothesis_id": "H-TSMOM-LIQ-01",
+                            "candidate_id": "candidate-tsmom",
+                            "observed_stage": "paper",
+                            "strategy_family": "intraday_tsmom_consistent",
+                            "strategy_name": "intraday-tsmom-profit-v3",
+                            "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                            "strategy_id": "intraday_tsmom_v2@research",
+                            "account": "TORGHUT_SIM",
+                            "dataset_snapshot_ref": (
+                                "portfolio-profit-autoresearch-500-v1"
+                            ),
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-tsmom-liq-01.json"
+                            ),
+                            "fill_count": 1,
+                            "submitted_order_count": 1,
+                            "filled_notional": "101",
+                            "reason_codes": [
+                                "runtime_ledger_source_collection_pending",
+                                "closed_round_trip_missing",
+                            ],
+                        }
+                    ],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": (
+                            "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                        ),
+                        "target_count": "1",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-hpairs",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": target_strategy.name,
+                                "strategy_id": "hpairs_target_strategy@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": (
+                                    "config/trading/hypotheses/h-pairs-01.json"
+                                ),
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                                "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_active_symbols": ["AAPL", "AMZN"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                        "eligible_symbols": ["AAPL", "AMZN"],
+                    },
+                },
+                generated_at=now,
+            )
+
+        runtime_plan = payload["runtime_window_import_plan"]
+        self.assertEqual(
+            runtime_plan["source"], "paper_route_observed_strategy_source_collection"
+        )
+        self.assertEqual(runtime_plan["target_count"], 1)
+        target = runtime_plan["targets"][0]
+        self.assertEqual(target["candidate_id"], "candidate-tsmom")
+        self.assertEqual(target["hypothesis_id"], "H-TSMOM-LIQ-01")
+        self.assertEqual(target["runtime_strategy_name"], "intraday-tsmom-profit-v3")
+        self.assertEqual(target["source_account_label"], "TORGHUT_SIM")
+        self.assertEqual(
+            target["source_kind"], "runtime_ledger_source_collection_candidate"
+        )
+        self.assertTrue(target["source_collection_authorized"])
+        self.assertFalse(target["promotion_allowed"])
+        self.assertNotIn("paper_route_probe_symbols", target)
+        self.assertEqual(
+            target["observed_from_contaminated_target"]["strategy_name"],
+            "intraday-tsmom-profit-v3",
+        )
+        self.assertEqual(payload["targets"][0]["candidate_id"], "candidate-tsmom")
+        self.assertEqual(
+            payload["source_runtime_window_import_plan"]["source"],
+            "paper_route_observed_strategy_source_collection",
+        )
+
     def test_account_contamination_summary_deduplicates_and_caps_order_event_refs(
         self,
     ) -> None:

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -171,6 +171,82 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
             {("live", "PA3SX7FYNUTF"), ("paper", "TORGHUT_SIM")},
         )
 
+    def test_observed_strategy_source_collection_plan_target_parses_for_import(
+        self,
+    ) -> None:
+        plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "runtime_window_import_plan": {
+                    "schema_version": (
+                        "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                    ),
+                    "source": "paper_route_observed_strategy_source_collection",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-TSMOM-LIQ-01",
+                            "candidate_id": "candidate-tsmom",
+                            "observed_stage": "paper",
+                            "strategy_family": "intraday_tsmom_consistent",
+                            "strategy_name": "intraday-tsmom-profit-v3",
+                            "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                            "strategy_id": "intraday_tsmom_v2@research",
+                            "strategy_lookup_names": [
+                                "intraday-tsmom-profit-v3",
+                                "intraday_tsmom_v2@research",
+                            ],
+                            "account_label": "TORGHUT_SIM",
+                            "source_account_label": "TORGHUT_SIM",
+                            "source_dsn_env": "SIM_DB_DSN",
+                            "target_dsn_env": "SIM_DB_DSN",
+                            "dataset_snapshot_ref": (
+                                "portfolio-profit-autoresearch-500-v1"
+                            ),
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-tsmom-liq-01.json"
+                            ),
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                            "window_start": "2026-05-26T13:30:00+00:00",
+                            "window_end": "2026-05-26T20:00:00+00:00",
+                            "source_collection_authorized": True,
+                            "source_collection_authorization_scope": (
+                                "source_window_evidence_collection_only"
+                            ),
+                            "source_collection_reason_codes": [
+                                "paper_route_foreign_strategy_source_activity_observed"
+                            ],
+                            "promotion_allowed": False,
+                            "final_promotion_allowed": False,
+                            "final_promotion_authorized": False,
+                            "handoff": "runtime_ledger_source_collection_import",
+                            "selected_by": (
+                                "paper_route_observed_strategy_source_collection"
+                            ),
+                        }
+                    ],
+                }
+            }
+        )
+
+        targets = renew._runtime_window_targets_from_plan(
+            plan=plan,
+            ref="observed-plan-fixture",
+            args=argparse.Namespace(),
+        )
+
+        self.assertEqual(len(targets), 1)
+        target = targets[0]
+        self.assertEqual(target.hypothesis_id, "H-TSMOM-LIQ-01")
+        self.assertEqual(target.candidate_id, "candidate-tsmom")
+        self.assertEqual(target.strategy_name, "intraday-tsmom-profit-v3")
+        self.assertEqual(target.source_account_label, "TORGHUT_SIM")
+        self.assertEqual(
+            target.source_kind, "runtime_ledger_source_collection_candidate"
+        )
+        self.assertTrue(target.target_metadata["source_collection_authorized"])
+        self.assertNotIn("paper_route_probe_symbols", target.target_metadata)
+
     def test_hpairs_source_proof_census_status_is_non_authority_renewal_evidence(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Routes contaminated paper-route runtime-window imports to the observed foreign strategy when it maps to a runtime-ledger repair candidate.
- Keeps the generated observed-strategy target zero-notional, source-collection-only, and explicitly blocked from promotion authority.
- Adds regression coverage for the paper-route target-plan endpoint and the renewal job target-plan parser.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format tests/test_renew_latest_empirical_promotion_jobs.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "observed_foreign_strategy_source_collection"`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "account_contamination or observed_foreign_strategy or next_runtime_window_targets_dedupe or reserves_account_window"`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py -k "observed_strategy_source_collection_plan_target_parses_for_import"`
- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
