### PR TITLE
chore(synthesis): run autotrader readback proof

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-proof-20260602.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-proof-20260602.yaml
@@ -1,0 +1,68 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentRun
+metadata:
+  name: autonomous-trader-readback-proof-20260602
+  namespace: synthesis
+  annotations:
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: scorecard-readback-proof
+    autonomous-trader.proompteng.ai/proof-for: pr-9947
+    autonomous-trader.proompteng.ai/proof-date: "2026-06-02"
+  labels:
+    app.kubernetes.io/part-of: synthesis
+    app.kubernetes.io/component: autonomous-trader
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: scorecard-readback-proof
+spec:
+  agentRef:
+    name: autonomous-trader-agent
+  implementationSpecRef:
+    name: autonomous-trader-v1
+  goal:
+    objective: >-
+      Prove the autotrader scorecard-readback lane executes through the dedicated read-only
+      helper, reads scorecards and broker state, reconciles stale flat sessions when safe, writes
+      report.md, and submits no Alpaca broker mutations.
+  vcsRef:
+    name: github
+  vcsPolicy:
+    required: true
+    mode: read-only
+  runtime:
+    type: job
+    config:
+      serviceAccountName: agents-sa
+      backoffLimit: 0
+      logRetentionSeconds: 604800
+  parameters:
+    repository: proompteng/lab
+    base: main
+    head: codex/synthesis-autonomous-trader-readback-proof
+    mode: scorecard-readback
+    synthesisSessionMode: scorecard_readback
+    brokerMutationEnabled: "false"
+    sessionReconcileEnabled: "true"
+    accountType: paper
+    targetEquityUsd: "500000"
+    marketOpenTimezone: America/New_York
+  secrets:
+    - autonomous-trader-alpaca-mcp
+    - agents-artifacts
+    - codex-auth
+    - github-token
+    - synthesis-env
+  workload:
+    volumes:
+      - type: secret
+        name: synthesis-env
+        secretName: synthesis-env
+        mountPath: /var/run/synthesis
+        readOnly: true
+    resources:
+      requests:
+        cpu: "2"
+        memory: 4Gi
+        ephemeral-storage: 2Gi
+      limits:
+        memory: 16Gi
+        ephemeral-storage: 16Gi

--- a/argocd/applications/synthesis/agents-domain/kustomization.yaml
+++ b/argocd/applications/synthesis/agents-domain/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - autonomous-trader-schedule.yaml
   - autonomous-trader-market-open-recovery-20260602.yaml
   - autonomous-trader-stale-session-reconcile-20260602.yaml
+  - autonomous-trader-readback-proof-20260602.yaml
   - autonomous-trader-green-system-prompt-configmap.yaml
   - autonomous-trader-green-agent.yaml
   - autonomous-trader-green-implspec.yaml


### PR DESCRIPTION
## Summary

- Adds a GitOps-managed one-off `AgentRun` named `autonomous-trader-readback-proof-20260602`.
- Runs the active blue autotrader agent in `scorecard-readback` mode with broker mutations disabled and stale-session reconciliation enabled.
- Keeps the proof run declarative through Argo CD so the new autotrader readback helper can be verified without direct cluster apply.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/synthesis/agents-domain | rg -n "autonomous-trader-readback-proof-20260602|scorecard-readback-proof|brokerMutationEnabled|sessionReconcileEnabled" -C 4`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | kubectl apply --dry-run=server -f -`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t 'autonomous trader provider'`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
