### PR TITLE
fix(autotrader): run readback through deterministic runner

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-green-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-green-system-prompt-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     autonomous-trader.proompteng.ai/deployment-role: preview
 data:
   system-prompt.md: |-
-    You are the Synthesis autonomous paper-trader agent.
+    You are the autonomous-trader runtime agent.
 
     Mission:
     - Grow the dedicated Alpaca paper account to 500000 USD equity.
@@ -29,7 +29,7 @@ data:
     - Read `AUTONOMOUS_TRADER_MODE` and `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE`; pass the session mode exactly when non-empty.
 
     Execution loop:
-    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`. In `scorecard-readback`, bootstrap reads scorecards, reconciles sessions, reports, finalizes, and exits. No analysis clone or scan. Other modes read `/workspace/analysis/docs/daytrading-agent-bootstrap.md` and self-test helpers.
+    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`. In `scorecard-readback`, bootstrap reads scorecards, reconciles sessions, reports, finalizes, and exits. Other modes read bootstrap docs and self-test helpers.
     2. Preflight Alpaca account/config/clock/tools/positions/orders and Synthesis tools. If account/trading is blocked, `daytrading_buying_power <= 0`, or scanner input says `intraday_equity_entry.status=blocked`, record Synthesis risk/status, skip new entries and smoke orders, and monitor read-only until state changes or close. Exits/protection stay allowed.
     3. Call `autotrader_start_session` before scanning; use its `sessionId` for every Synthesis write.
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py --account-gate-only`. If `skipFullScan=true`, record monitor status and skip candidate tickets. Otherwise call `autotrader_get_scorecard`, run full scan, then choose entry, exit/reduce/hedge/flatten, or no-trade.
@@ -41,7 +41,7 @@ data:
 
     Mode behavior:
     - `dry-run`: no Alpaca mutations; do one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
-    - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; complete goal if available and stop.
+    - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.
     - `preflight`: prove readiness and, only when safe, one tiny non-marketable paper bracket or OTO proof that is reconciled and canceled.
     - `market-open`: pass account eligibility, then run one bounded smoke/protective preflight before entries. If helper returns `entry_ineligible_smoke_skipped`, record it and do not retry until account state changes. Preflight success/skip, smoke success, no-trade, rejections, quiet markets, account-gated monitoring, and protected positions are cycle outcomes, not terminal outcomes. Do not complete or answer finally until close, target, or hard stop.
 

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-agent.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-agent.yaml
@@ -1,10 +1,9 @@
-apiVersion: schedules.proompteng.ai/v1alpha1
-kind: Schedule
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: Agent
 metadata:
-  name: autonomous-trader-scorecard-readback
+  name: autonomous-trader-readback-agent
   namespace: synthesis
   annotations:
-    argocd.argoproj.io/sync-options: Prune=false
     autonomous-trader.proompteng.ai/deployment-color: blue
     autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
   labels:
@@ -13,9 +12,12 @@ metadata:
     autonomous-trader.proompteng.ai/deployment-color: blue
     autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
 spec:
-  cron: "20 16 * * 1-5"
-  timezone: America/New_York
-  targetRef:
-    apiVersion: agents.proompteng.ai/v1alpha1
-    kind: AgentRun
-    name: autonomous-trader-scorecard-readback-template
+  providerRef:
+    name: autonomous-trader-readback-runner
+  security:
+    allowedSecrets:
+      - autonomous-trader-alpaca-mcp
+      - agents-artifacts
+      - synthesis-env
+    allowedServiceAccounts:
+      - agents-sa

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-agentprovider.yaml
@@ -1,0 +1,110 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentProvider
+metadata:
+  name: autonomous-trader-readback-runner
+  namespace: synthesis
+  annotations:
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
+  labels:
+    app.kubernetes.io/part-of: synthesis
+    app.kubernetes.io/component: autonomous-trader
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
+spec:
+  binary: /usr/local/bin/agent-runner
+  adapter:
+    type: exec
+    exec:
+      binary: /usr/bin/env
+      argsTemplate:
+        - bash
+        - /root/autonomous-trader-scorecard-readback.sh
+  argsTemplate: []
+  secretEnv:
+    - name: APCA_API_KEY_ID
+      secretName: autonomous-trader-alpaca-mcp
+      key: APCA_API_KEY_ID
+    - name: APCA_API_SECRET_KEY
+      secretName: autonomous-trader-alpaca-mcp
+      key: APCA_API_SECRET_KEY
+    - name: APCA_API_BASE_URL
+      secretName: autonomous-trader-alpaca-mcp
+      key: APCA_API_BASE_URL
+    - name: ALPACA_API_KEY
+      secretName: autonomous-trader-alpaca-mcp
+      key: ALPACA_API_KEY
+    - name: ALPACA_API_KEY_ID
+      secretName: autonomous-trader-alpaca-mcp
+      key: ALPACA_API_KEY_ID
+    - name: ALPACA_SECRET_KEY
+      secretName: autonomous-trader-alpaca-mcp
+      key: ALPACA_SECRET_KEY
+    - name: AGENTS_ARTIFACTS_ACCESS_KEY_ID
+      secretName: agents-artifacts
+      key: AWS_ACCESS_KEY_ID
+    - name: AGENTS_ARTIFACTS_SECRET_ACCESS_KEY
+      secretName: agents-artifacts
+      key: AWS_SECRET_ACCESS_KEY
+    - name: SYNTHESIS_API_TOKEN
+      secretName: synthesis-env
+      key: SYNTHESIS_API_TOKEN
+  envTemplate:
+    AGENT_RUN_NAME: "{{agentRun.name}}"
+    AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
+    AGENTS_ARTIFACTS_BUCKET: agents-artifacts
+    AGENTS_ARTIFACTS_ENDPOINT: http://rook-ceph-rgw-objectstore.rook-ceph.svc:80
+    AGENTS_ARTIFACTS_SECURE: "false"
+    ALPACA_PAPER_TRADE: "true"
+    AUTONOMOUS_TRADER_ACCOUNT_TYPE: "{{parameters.accountType}}"
+    AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED: "{{parameters.brokerMutationEnabled}}"
+    AUTONOMOUS_TRADER_MODE: "{{parameters.mode}}"
+    AUTONOMOUS_TRADER_SESSION_RECONCILE_ENABLED: "{{parameters.sessionReconcileEnabled}}"
+    AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE: "{{parameters.synthesisSessionMode}}"
+    AUTONOMOUS_TRADER_TARGET_EQUITY_USD: "{{parameters.targetEquityUsd}}"
+    AUTONOMOUS_TRADER_WORK_DIR: /tmp/autonomous-trader-readback
+    HOME: /root
+    PYTHON_BIN: python3
+    SYNTHESIS_API_TOKEN_FILE: /var/run/synthesis/SYNTHESIS_API_TOKEN
+    SYNTHESIS_BASE_URL: http://synthesis.synthesis.svc.cluster.local:3000
+  inputFiles:
+    - path: /root/autonomous-trader-scorecard-readback.sh
+      content: |-
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        report_path="/workspace/.agentrun/autonomous-trader/report.md"
+        work_dir="${AUTONOMOUS_TRADER_WORK_DIR:-/tmp/autonomous-trader-readback}"
+        python_bin="${PYTHON_BIN:-python3}"
+
+        mkdir -p "${work_dir}"
+        mkdir -p "$(dirname "${report_path}")"
+        printf '# Autonomous Trader Report\n\nstatus: scorecard_readback_bootstrapping\n' > "${report_path}"
+
+        trader_mode="$(printf '%s' "${AUTONOMOUS_TRADER_MODE:-}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')"
+        if [ "${trader_mode}" != "scorecard-readback" ]; then
+          printf 'autonomous-trader readback runner only accepts scorecard-readback mode, got %s\n' "${trader_mode}" >&2
+          exit 64
+        fi
+
+        reconcile_enabled="$(printf '%s' "${AUTONOMOUS_TRADER_SESSION_RECONCILE_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')"
+        readback_args=(
+          --report-path "${report_path}"
+          --scorecard-limit 20
+          --agent-run-name "${AGENT_RUN_NAME:-autonomous-trader-readback}"
+          --session-mode "${AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE:-scorecard_readback}"
+          --goal-equity "${AUTONOMOUS_TRADER_TARGET_EQUITY_USD:-500000}"
+        )
+        if [ "${reconcile_enabled}" = "true" ] || [ "${reconcile_enabled}" = "1" ] || [ "${reconcile_enabled}" = "yes" ]; then
+          readback_args+=(--finalize-stale-flat)
+        fi
+
+        exec "${python_bin}" /workspace/lab/scripts/autotrader/scorecard_readback.py "${readback_args[@]}"
+  outputArtifacts:
+    - name: autonomous-trader-report
+      path: /workspace/.agentrun/autonomous-trader/report.md
+      key: synthesis/autonomous-trader/{{ agentRun.name }}/report.md
+    - name: runner-log
+      path: /workspace/.agent/runner.log
+    - name: runner-status
+      path: /workspace/.agent/status.json

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-implspec.yaml
@@ -1,0 +1,29 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: ImplementationSpec
+metadata:
+  name: autonomous-trader-readback-v1
+  namespace: synthesis
+  annotations:
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
+  labels:
+    app.kubernetes.io/part-of: synthesis
+    app.kubernetes.io/component: autonomous-trader
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
+spec:
+  summary: Deterministic autonomous-trader scorecard readback and flat-session reconciliation runner
+  source:
+    provider: custom
+    externalId: autonomous-trader-readback-v1
+  labels:
+    - synthesis
+    - autonomous-trader
+    - scorecard-readback
+    - paper-trading
+  acceptanceCriteria:
+    - Run only in `scorecard-readback` mode with Alpaca broker mutations disabled.
+    - Read broker state and Synthesis scorecards, finalize stale flat sessions only when broker state is flat, and write `report.md`.
+    - Do not clone the analysis repo, run Codex, scan candidates, or submit Alpaca broker mutations.
+  text: |-
+    Execute the autonomous-trader scorecard readback helper directly. This runner is deterministic: it reads Alpaca broker state, reads Synthesis autotrader scorecards, safely reconciles stale flat sessions when enabled, finalizes the readback session, and writes `report.md`. It must not run Codex, clone analysis, scan candidates, or mutate Alpaca.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-secretbinding.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-readback-secretbinding.yaml
@@ -1,10 +1,9 @@
-apiVersion: schedules.proompteng.ai/v1alpha1
-kind: Schedule
+apiVersion: security.proompteng.ai/v1alpha1
+kind: SecretBinding
 metadata:
-  name: autonomous-trader-scorecard-readback
+  name: autonomous-trader-readback-secrets
   namespace: synthesis
   annotations:
-    argocd.argoproj.io/sync-options: Prune=false
     autonomous-trader.proompteng.ai/deployment-color: blue
     autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
   labels:
@@ -13,9 +12,10 @@ metadata:
     autonomous-trader.proompteng.ai/deployment-color: blue
     autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
 spec:
-  cron: "20 16 * * 1-5"
-  timezone: America/New_York
-  targetRef:
-    apiVersion: agents.proompteng.ai/v1alpha1
-    kind: AgentRun
-    name: autonomous-trader-scorecard-readback-template
+  subjects:
+    - kind: Agent
+      name: autonomous-trader-readback-agent
+  allowedSecrets:
+    - autonomous-trader-alpaca-mcp
+    - agents-artifacts
+    - synthesis-env

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-scorecard-readback-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-scorecard-readback-template.yaml
@@ -5,16 +5,20 @@ metadata:
   namespace: synthesis
   annotations:
     agents.proompteng.ai/template: "true"
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
   labels:
     app.kubernetes.io/part-of: synthesis
     app.kubernetes.io/component: autonomous-trader
+    autonomous-trader.proompteng.ai/deployment-color: blue
+    autonomous-trader.proompteng.ai/deployment-role: scorecard-readback
 spec:
   agentRef:
-    name: autonomous-trader-agent
+    name: autonomous-trader-readback-agent
   implementationSpecRef:
-    name: autonomous-trader-v1
+    name: autonomous-trader-readback-v1
   goal:
-    objective: Prove the next autonomous-trader AgentRun reads finalized Synthesis scorecards before candidate grading, without broker mutations.
+    objective: Run deterministic autonomous-trader scorecard readback, safe flat-session reconciliation, and report writing without Codex, analysis clone, candidate scanning, or Alpaca broker mutations.
   vcsRef:
     name: github
   vcsPolicy:
@@ -41,8 +45,6 @@ spec:
   secrets:
     - autonomous-trader-alpaca-mcp
     - agents-artifacts
-    - codex-auth
-    - github-token
     - synthesis-env
   workload:
     volumes:

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-secretbinding.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-secretbinding.yaml
@@ -10,6 +10,8 @@ spec:
   subjects:
     - kind: Agent
       name: autonomous-trader-agent
+    - kind: Agent
+      name: autonomous-trader-agent-green
   allowedSecrets:
     - autonomous-trader-alpaca-mcp
     - agents-artifacts

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     autonomous-trader.proompteng.ai/deployment-role: active
 data:
   system-prompt.md: |-
-    You are the Synthesis autonomous paper-trader agent.
+    You are the autonomous-trader runtime agent.
 
     Mission:
     - Grow the dedicated Alpaca paper account to 500000 USD equity.
@@ -29,7 +29,7 @@ data:
     - Read `AUTONOMOUS_TRADER_MODE` and `AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE`; pass the session mode exactly when non-empty.
 
     Execution loop:
-    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`. In `scorecard-readback`, bootstrap reads scorecards, reconciles sessions, reports, finalizes, and exits. No analysis clone or scan. Other modes read `/workspace/analysis/docs/daytrading-agent-bootstrap.md` and self-test helpers.
+    1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`. In `scorecard-readback`, bootstrap reads scorecards, reconciles sessions, reports, finalizes, and exits. Other modes read bootstrap docs and self-test helpers.
     2. Preflight Alpaca account/config/clock/tools/positions/orders and Synthesis tools. If account/trading is blocked, `daytrading_buying_power <= 0`, or scanner input says `intraday_equity_entry.status=blocked`, record Synthesis risk/status, skip new entries and smoke orders, and monitor read-only until state changes or close. Exits/protection stay allowed.
     3. Call `autotrader_start_session` before scanning; use its `sessionId` for every Synthesis write.
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/live_scan_cycle.py --account-gate-only`. If `skipFullScan=true`, record monitor status and skip candidate tickets. Otherwise call `autotrader_get_scorecard`, run full scan, then choose entry, exit/reduce/hedge/flatten, or no-trade.
@@ -41,7 +41,7 @@ data:
 
     Mode behavior:
     - `dry-run`: no Alpaca mutations; do one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
-    - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; complete goal if available and stop.
+    - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.
     - `preflight`: prove readiness and, only when safe, one tiny non-marketable paper bracket or OTO proof that is reconciled and canceled.
     - `market-open`: pass account eligibility, then run one bounded smoke/protective preflight before entries. If helper returns `entry_ineligible_smoke_skipped`, record it and do not retry until account state changes. Preflight success/skip, smoke success, no-trade, rejections, quiet markets, account-gated monitoring, and protected positions are cycle outcomes, not terminal outcomes. Do not complete or answer finally until close, target, or hard stop.
 

--- a/argocd/applications/synthesis/agents-domain/kustomization.yaml
+++ b/argocd/applications/synthesis/agents-domain/kustomization.yaml
@@ -13,9 +13,13 @@ resources:
   - autonomous-trader-serviceaccount.yaml
   - autonomous-trader-versioncontrolprovider.yaml
   - autonomous-trader-agentprovider.yaml
+  - autonomous-trader-readback-agentprovider.yaml
   - autonomous-trader-agent.yaml
+  - autonomous-trader-readback-agent.yaml
   - autonomous-trader-secretbinding.yaml
+  - autonomous-trader-readback-secretbinding.yaml
   - autonomous-trader-implspec.yaml
+  - autonomous-trader-readback-implspec.yaml
   - autonomous-trader-agentrun-template.yaml
   - autonomous-trader-schedule.yaml
   - autonomous-trader-market-open-recovery-20260602.yaml

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -683,6 +683,10 @@ describe('autonomous trader provider', () => {
     expect(resources).toContain('autonomous-trader-green-implspec.yaml')
     expect(resources).toContain('autonomous-trader-green-schedule.yaml')
     expect(resources).toContain('autonomous-trader-green-agentrun-template.yaml')
+    expect(resources).toContain('autonomous-trader-readback-agentprovider.yaml')
+    expect(resources).toContain('autonomous-trader-readback-agent.yaml')
+    expect(resources).toContain('autonomous-trader-readback-secretbinding.yaml')
+    expect(resources).toContain('autonomous-trader-readback-implspec.yaml')
     expect(resources).toContain('autonomous-trader-stale-session-reconcile-20260602.yaml')
     expect(
       existsSync(
@@ -780,29 +784,121 @@ describe('autonomous trader provider', () => {
   })
 
   it('schedules a post-close scorecard readback proof without broker mutations', () => {
+    const kustomization = readYamlObjects('argocd/applications/synthesis/agents-domain/kustomization.yaml')[0]
+    const resources = objectAt(kustomization, 'resources') as string[] | undefined
+    const deploymentColorKey = 'autonomous-trader.proompteng.ai/deployment-color'
+    const deploymentRoleKey = 'autonomous-trader.proompteng.ai/deployment-role'
     const schedule = readYamlObjects(
       'argocd/applications/synthesis/agents-domain/autonomous-trader-scorecard-readback-schedule.yaml',
     ).find((manifest) => objectAt(manifest, 'kind') === 'Schedule')
     const template = readYamlObjects(
       'argocd/applications/synthesis/agents-domain/autonomous-trader-scorecard-readback-template.yaml',
     ).find((manifest) => objectAt(manifest, 'kind') === 'AgentRun')
+    const provider = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-readback-agentprovider.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'AgentProvider')
+    const agent = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-readback-agent.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'Agent')
+    const implementationSpec = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-readback-implspec.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'ImplementationSpec')
+    const secretBinding = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-readback-secretbinding.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'SecretBinding')
+    const scheduleMetadata = objectAt(schedule, 'metadata')
+    const templateMetadata = objectAt(template, 'metadata')
     const scheduleSpec = objectAt(schedule, 'spec')
     const templateSpec = objectAt(template, 'spec')
+    const providerSpec = objectAt(provider, 'spec')
+    const providerMetadata = objectAt(provider, 'metadata')
+    const agentSpec = objectAt(agent, 'spec')
+    const agentMetadata = objectAt(agent, 'metadata')
+    const implementationMetadata = objectAt(implementationSpec, 'metadata')
+    const adapter = objectAt(providerSpec, 'adapter')
+    const execAdapter = objectAt(adapter, 'exec')
+    const envTemplate = objectAt(providerSpec, 'envTemplate')
+    const secretEnv = objectAt(providerSpec, 'secretEnv') as Record<string, unknown>[] | undefined
+    const inputFiles = objectAt(providerSpec, 'inputFiles') as Record<string, unknown>[] | undefined
+    const outputArtifacts = objectAt(providerSpec, 'outputArtifacts') as Record<string, unknown>[] | undefined
+    const secretBindingSpec = objectAt(secretBinding, 'spec')
+    const secretBindingSecrets = objectAt(secretBindingSpec, 'allowedSecrets') as unknown[]
+    const secretBindingSubjects = objectAt(secretBindingSpec, 'subjects') as Record<string, unknown>[]
+    const readbackScript = (inputFiles ?? []).find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/autonomous-trader-scorecard-readback.sh',
+    )
+    const readbackScriptContent = String(objectAt(readbackScript, 'content') ?? '')
+    const outputArtifactNames = (outputArtifacts ?? []).map((artifact) => objectAt(artifact, 'name'))
     const parameters = objectAt(templateSpec, 'parameters')
     const secrets = objectAt(templateSpec, 'secrets') as unknown[]
+    const autotraderSecretNames = (secretEnv ?? [])
+      .filter(
+        (entry) =>
+          String(objectAt(entry, 'name') ?? '').includes('ALPACA') ||
+          String(objectAt(entry, 'name') ?? '').includes('APCA'),
+      )
+      .map((entry) => objectAt(entry, 'secretName'))
 
+    expect(resources).toContain('autonomous-trader-readback-agentprovider.yaml')
+    expect(resources).toContain('autonomous-trader-readback-agent.yaml')
+    expect(resources).toContain('autonomous-trader-readback-secretbinding.yaml')
+    expect(resources).toContain('autonomous-trader-readback-implspec.yaml')
     expect(objectAt(scheduleSpec, 'cron')).toBe('20 16 * * 1-5')
     expect(objectAt(scheduleSpec, 'timezone')).toBe('America/New_York')
     expect(objectAt(objectAt(scheduleSpec, 'targetRef'), 'name')).toBe('autonomous-trader-scorecard-readback-template')
+    for (const resource of [
+      scheduleMetadata,
+      templateMetadata,
+      providerMetadata,
+      agentMetadata,
+      implementationMetadata,
+    ]) {
+      expect(objectAt(objectAt(resource, 'annotations'), deploymentColorKey)).toBe('blue')
+      expect(objectAt(objectAt(resource, 'labels'), deploymentColorKey)).toBe('blue')
+      expect(objectAt(objectAt(resource, 'annotations'), deploymentRoleKey)).toBe('scorecard-readback')
+      expect(objectAt(objectAt(resource, 'labels'), deploymentRoleKey)).toBe('scorecard-readback')
+    }
+    expect(objectAt(objectAt(templateSpec, 'agentRef'), 'name')).toBe('autonomous-trader-readback-agent')
+    expect(objectAt(objectAt(templateSpec, 'implementationSpecRef'), 'name')).toBe('autonomous-trader-readback-v1')
+    expect(objectAt(objectAt(agentSpec, 'providerRef'), 'name')).toBe('autonomous-trader-readback-runner')
+    expect(secretBindingSubjects).toEqual([{ kind: 'Agent', name: 'autonomous-trader-readback-agent' }])
+    expect(secretBindingSecrets).toEqual(['autonomous-trader-alpaca-mcp', 'agents-artifacts', 'synthesis-env'])
+    expect(objectAt(providerSpec, 'binary')).toBe('/usr/local/bin/agent-runner')
+    expect(objectAt(adapter, 'type')).toBe('exec')
+    expect(objectAt(execAdapter, 'binary')).toBe('/usr/bin/env')
+    expect(objectAt(execAdapter, 'argsTemplate')).toEqual(['bash', '/root/autonomous-trader-scorecard-readback.sh'])
     expect(objectAt(parameters, 'mode')).toBe('scorecard-readback')
     expect(objectAt(parameters, 'synthesisSessionMode')).toBe('scorecard_readback')
     expect(objectAt(parameters, 'brokerMutationEnabled')).toBe('false')
     expect(objectAt(parameters, 'sessionReconcileEnabled')).toBe('true')
+    expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_MODE')).toBe('{{parameters.mode}}')
+    expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_BROKER_MUTATION_ENABLED')).toBe(
+      '{{parameters.brokerMutationEnabled}}',
+    )
+    expect(objectAt(envTemplate, 'SYNTHESIS_BASE_URL')).toBe('http://synthesis.synthesis.svc.cluster.local:3000')
+    expect(autotraderSecretNames).toEqual([
+      'autonomous-trader-alpaca-mcp',
+      'autonomous-trader-alpaca-mcp',
+      'autonomous-trader-alpaca-mcp',
+      'autonomous-trader-alpaca-mcp',
+      'autonomous-trader-alpaca-mcp',
+      'autonomous-trader-alpaca-mcp',
+    ])
+    expect(readbackScriptContent).toContain('scorecard_readback.py')
+    expect(readbackScriptContent).toContain('trader_mode="$(printf')
+    expect(readbackScriptContent).toContain('exit 64')
+    expect(readbackScriptContent).toContain('readback_args+=(--finalize-stale-flat)')
+    expect(readbackScriptContent).not.toContain('git ')
+    expect(readbackScriptContent).not.toContain('stock_analysis')
+    expect(outputArtifactNames).toEqual(['autonomous-trader-report', 'runner-log', 'runner-status'])
     const goal = objectAt(templateSpec, 'goal') as Record<string, unknown>
     expect(Object.hasOwn(goal, 'tokenBudget')).toBe(false)
     expect(secrets).toContain('synthesis-env')
     expect(secrets).toContain('autonomous-trader-alpaca-mcp')
+    expect(secrets).toContain('agents-artifacts')
     expect(secrets).not.toContain('alpaca-mcp')
+    expect(secrets).not.toContain('codex-auth')
+    expect(secrets).not.toContain('github-token')
   })
 
   it('runs a one-off stale session reconcile through the read-only autotrader lane', () => {


### PR DESCRIPTION
## Summary

- Add a dedicated `autonomous-trader-readback-runner` exec AgentProvider for post-close scorecard readback and safe flat-session reconciliation.
- Wire the scheduled autotrader readback template to the direct readback agent/spec and remove Codex/GitHub secrets from that future readback template.
- Keep market-open blue/green on the Codex trader while labeling the readback schedule/template as an autotrader scorecard-readback lane with a minimal SecretBinding.
- Extend smoke coverage so autotrader continuity requires exactly this direct exec readback contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t 'autonomous trader provider'`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 scripts/autotrader/scorecard_readback.py --self-test`
- `kubectl kustomize argocd/applications/synthesis/agents-domain | kubectl apply --dry-run=server -f -`
- `bun run lint:argocd`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
