### PR TITLE
fix(torghut): stop aliasing replay artifacts as runtime proof

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1871,20 +1871,31 @@ def _runtime_ledger_target_metadata_blockers(
         if set(planned_refs) != set(loaded_refs):
             blockers.append("runtime_ledger_artifact_refs_mismatch")
 
-    for key, blocker in (
+    for keys, blocker in (
         (
-            "runtime_ledger_artifact_row_count",
+            (
+                "runtime_ledger_artifact_row_count",
+                "exact_replay_ledger_artifact_row_count",
+            ),
             "runtime_ledger_artifact_row_count_mismatch",
         ),
         (
-            "runtime_ledger_artifact_fill_count",
+            (
+                "runtime_ledger_artifact_fill_count",
+                "exact_replay_ledger_artifact_fill_count",
+            ),
             "runtime_ledger_artifact_fill_count_mismatch",
         ),
     ):
-        planned_count = _metadata_nonnegative_int_or_none(metadata.get(key))
+        planned_count: int | None = None
+        for key in keys:
+            count = _metadata_nonnegative_int_or_none(metadata.get(key))
+            if count is not None:
+                planned_count = count
+                break
         if planned_count is None:
             continue
-        loaded_count = _nonnegative_int(runtime_ledger_artifact_metadata.get(key))
+        loaded_count = _nonnegative_int(runtime_ledger_artifact_metadata.get(keys[0]))
         if planned_count != loaded_count:
             blockers.append(blocker)
 

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -3302,15 +3302,14 @@ def _candidate_sleeve_goal_proof_handoff_fields(
 ) -> dict[str, Any]:
     artifact_refs = list(evidence.replay_artifact_refs) if evidence is not None else []
     runtime_ledger_row = {**dict(scorecard), "replay_artifact_refs": artifact_refs}
-    runtime_ledger_artifact_refs = _candidate_board_runtime_ledger_refs(
+    exact_replay_ledger_artifact_refs = _candidate_board_exact_replay_ledger_refs(
         runtime_ledger_row
     )
     exact_replay_ledger_artifact_ref = _string(
         scorecard.get("exact_replay_ledger_artifact_ref")
     )
-    runtime_ledger_artifact_ref = _string(
-        scorecard.get("runtime_ledger_artifact_ref") or exact_replay_ledger_artifact_ref
-    )
+    if not exact_replay_ledger_artifact_ref and exact_replay_ledger_artifact_refs:
+        exact_replay_ledger_artifact_ref = exact_replay_ledger_artifact_refs[0]
     runtime_window_start, runtime_window_end = _candidate_board_runtime_window_bounds(
         scorecard
     )
@@ -3354,20 +3353,17 @@ def _candidate_sleeve_goal_proof_handoff_fields(
         "paper_required_evidence_count": paper_required_evidence_count,
         "runtime_window_start": runtime_window_start,
         "runtime_window_end": runtime_window_end,
-        "runtime_ledger_artifact_refs": list(runtime_ledger_artifact_refs),
+        "exact_replay_ledger_artifact_refs": list(exact_replay_ledger_artifact_refs),
         "exact_replay_ledger_artifact_ref": exact_replay_ledger_artifact_ref,
-        "runtime_ledger_artifact_ref": runtime_ledger_artifact_ref,
-        "runtime_ledger_artifact_row_count": _candidate_board_first_int_field(
+        "exact_replay_ledger_artifact_row_count": _candidate_board_first_int_field(
             scorecard,
             (
-                "runtime_ledger_artifact_row_count",
                 "exact_replay_ledger_artifact_row_count",
             ),
         ),
-        "runtime_ledger_artifact_fill_count": _candidate_board_first_int_field(
+        "exact_replay_ledger_artifact_fill_count": _candidate_board_first_int_field(
             scorecard,
             (
-                "runtime_ledger_artifact_fill_count",
                 "exact_replay_ledger_artifact_fill_count",
             ),
         ),
@@ -10394,13 +10390,13 @@ def _candidate_board_paper_probation_admission_blockers(
     row: Mapping[str, Any],
 ) -> list[str]:
     blockers: list[str] = []
-    runtime_ledger_refs = _candidate_board_runtime_ledger_refs(row)
-    if not runtime_ledger_refs:
-        blockers.append("paper_probation_runtime_ledger_artifact_missing")
-    if _candidate_board_int_field(row, "runtime_ledger_artifact_row_count") <= 0:
-        blockers.append("paper_probation_runtime_ledger_row_count_missing")
-    if _candidate_board_int_field(row, "runtime_ledger_artifact_fill_count") <= 0:
-        blockers.append("paper_probation_runtime_ledger_fill_count_missing")
+    exact_replay_ledger_refs = _candidate_board_exact_replay_ledger_refs(row)
+    if not exact_replay_ledger_refs:
+        blockers.append("paper_probation_exact_replay_ledger_artifact_missing")
+    if _candidate_board_int_field(row, "exact_replay_ledger_artifact_row_count") <= 0:
+        blockers.append("paper_probation_exact_replay_ledger_row_count_missing")
+    if _candidate_board_int_field(row, "exact_replay_ledger_artifact_fill_count") <= 0:
+        blockers.append("paper_probation_exact_replay_ledger_fill_count_missing")
     window_start, window_end = _candidate_board_runtime_window_bounds(row)
     if not window_start or not window_end:
         blockers.append("paper_probation_runtime_window_bounds_missing")
@@ -10746,19 +10742,13 @@ def _candidate_board_runtime_window_import_bounds(
     )
 
 
-def _candidate_board_runtime_ledger_refs(row: Mapping[str, Any]) -> tuple[str, ...]:
+def _candidate_board_exact_replay_ledger_refs(row: Mapping[str, Any]) -> tuple[str, ...]:
     refs: list[str] = []
-    for key in (
-        "exact_replay_ledger_artifact_ref",
-        "runtime_ledger_artifact_ref",
-    ):
+    for key in ("exact_replay_ledger_artifact_ref",):
         ref = _string(row.get(key))
         if ref:
             refs.append(ref)
-    for key in (
-        "exact_replay_ledger_artifact_refs",
-        "runtime_ledger_artifact_refs",
-    ):
+    for key in ("exact_replay_ledger_artifact_refs",):
         raw_refs = row.get(key)
         if isinstance(raw_refs, str):
             ref = _string(raw_refs)
@@ -10774,9 +10764,7 @@ def _candidate_board_runtime_ledger_refs(row: Mapping[str, Any]) -> tuple[str, .
         ref_lower = ref.lower()
         if ref and (
             "exact-replay-ledger" in ref_lower
-            or "runtime-ledger" in ref_lower
             or "exact_replay_ledger" in ref_lower
-            or "runtime_ledger" in ref_lower
         ):
             refs.append(ref)
     return tuple(dict.fromkeys(refs))
@@ -10814,9 +10802,12 @@ def _candidate_board_runtime_import_args(target: Mapping[str, Any]) -> list[str]
         "--dataset-snapshot-ref",
         _string(target.get("dataset_snapshot_ref")),
     ]
-    for artifact_ref in cast(
-        Sequence[Any], target.get("runtime_ledger_artifact_refs") or ()
-    ):
+    artifact_refs = (
+        target.get("exact_replay_ledger_artifact_refs")
+        or target.get("runtime_ledger_artifact_refs")
+        or ()
+    )
+    for artifact_ref in cast(Sequence[Any], artifact_refs):
         ref = _string(artifact_ref)
         if ref:
             args.extend(["--artifact-ref", ref])
@@ -10871,21 +10862,24 @@ def _candidate_board_runtime_window_import_plan(
         strategy_family = _string(row.get("runtime_family"))
         strategy_name = _string(row.get("runtime_strategy_name"))
         candidate_spec_id = _string(row.get("candidate_spec_id"))
-        runtime_ledger_artifact_refs = _candidate_board_runtime_ledger_refs(row)
+        exact_replay_ledger_artifact_refs = _candidate_board_exact_replay_ledger_refs(
+            row
+        )
         exact_replay_ledger_artifact_ref = _string(
             row.get("exact_replay_ledger_artifact_ref")
         )
         if not exact_replay_ledger_artifact_ref:
             exact_replay_ledger_artifact_ref = next(
-                (ref for ref in runtime_ledger_artifact_refs if "exact" in ref.lower()),
+                (
+                    ref
+                    for ref in exact_replay_ledger_artifact_refs
+                    if "exact" in ref.lower()
+                ),
                 "",
             )
-        runtime_ledger_artifact_ref = _string(row.get("runtime_ledger_artifact_ref"))
-        if not runtime_ledger_artifact_ref and runtime_ledger_artifact_refs:
-            runtime_ledger_artifact_ref = runtime_ledger_artifact_refs[0]
         window_start, window_end = _candidate_board_runtime_window_import_bounds(row)
         account_label = _string(row.get("account_label"))
-        if not account_label and runtime_ledger_artifact_refs:
+        if not account_label and exact_replay_ledger_artifact_refs:
             account_label = "TORGHUT_REPLAY"
         missing_fields = [
             field
@@ -10927,7 +10921,7 @@ def _candidate_board_runtime_window_import_plan(
             "window_start": window_start,
             "window_end": window_end,
             "source_kind": "simulation_exact_replay_runtime_ledger"
-            if runtime_ledger_artifact_refs
+            if exact_replay_ledger_artifact_refs
             else "paper_runtime_observed",
             "source_manifest_ref": _candidate_board_hypothesis_manifest_ref(
                 hypothesis_id
@@ -10938,14 +10932,15 @@ def _candidate_board_runtime_window_import_plan(
                 for ref in cast(Sequence[Any], row.get("replay_artifact_refs") or ())
                 if _string(ref)
             ],
-            "runtime_ledger_artifact_refs": list(runtime_ledger_artifact_refs),
-            "runtime_ledger_artifact_ref": runtime_ledger_artifact_ref,
-            "exact_replay_ledger_artifact_ref": exact_replay_ledger_artifact_ref,
-            "runtime_ledger_artifact_row_count": int(
-                _decimal(row.get("runtime_ledger_artifact_row_count"))
+            "exact_replay_ledger_artifact_refs": list(
+                exact_replay_ledger_artifact_refs
             ),
-            "runtime_ledger_artifact_fill_count": int(
-                _decimal(row.get("runtime_ledger_artifact_fill_count"))
+            "exact_replay_ledger_artifact_ref": exact_replay_ledger_artifact_ref,
+            "exact_replay_ledger_artifact_row_count": int(
+                _decimal(row.get("exact_replay_ledger_artifact_row_count"))
+            ),
+            "exact_replay_ledger_artifact_fill_count": int(
+                _decimal(row.get("exact_replay_ledger_artifact_fill_count"))
             ),
             "candidate_blockers": [
                 _string(blocker)
@@ -11266,10 +11261,6 @@ def _candidate_board_payload(
         exact_replay_ledger_artifact_ref = _string(
             scorecard.get("exact_replay_ledger_artifact_ref")
         )
-        runtime_ledger_artifact_ref = _string(
-            scorecard.get("runtime_ledger_artifact_ref")
-            or exact_replay_ledger_artifact_ref
-        )
         factor_acceptance_replay_metadata = (
             _candidate_factor_acceptance_replay_metadata(
                 spec=spec,
@@ -11531,22 +11522,19 @@ def _candidate_board_payload(
                 "runtime_window_start": runtime_window_start,
                 "runtime_window_end": runtime_window_end,
                 "account_label": _string(scorecard.get("account_label"))
-                or ("TORGHUT_REPLAY" if runtime_ledger_artifact_ref else ""),
+                or ("TORGHUT_REPLAY" if exact_replay_ledger_artifact_ref else ""),
                 "exact_replay_ledger_artifact_ref": exact_replay_ledger_artifact_ref,
-                "runtime_ledger_artifact_ref": runtime_ledger_artifact_ref,
-                "runtime_ledger_artifact_row_count": _candidate_board_first_int_field(
-                    scorecard,
-                    (
-                        "runtime_ledger_artifact_row_count",
-                        "exact_replay_ledger_artifact_row_count",
-                    ),
+                "exact_replay_ledger_artifact_row_count": (
+                    _candidate_board_first_int_field(
+                        scorecard,
+                        ("exact_replay_ledger_artifact_row_count",),
+                    )
                 ),
-                "runtime_ledger_artifact_fill_count": _candidate_board_first_int_field(
-                    scorecard,
-                    (
-                        "runtime_ledger_artifact_fill_count",
-                        "exact_replay_ledger_artifact_fill_count",
-                    ),
+                "exact_replay_ledger_artifact_fill_count": (
+                    _candidate_board_first_int_field(
+                        scorecard,
+                        ("exact_replay_ledger_artifact_fill_count",),
+                    )
                 ),
                 "replay_artifact_refs": list(evidence.replay_artifact_refs)
                 if evidence is not None

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -2306,11 +2306,8 @@ def _exact_replay_ledger_artifact_update(
     _write_json_output(artifact_path, artifact_payload)
     update: dict[str, Any] = {
         "exact_replay_ledger_artifact_ref": artifact_ref,
-        "runtime_ledger_artifact_ref": artifact_ref,
         "exact_replay_ledger_artifact_row_count": len(raw_rows),
         "exact_replay_ledger_artifact_fill_count": fill_row_count,
-        "runtime_ledger_artifact_row_count": len(raw_rows),
-        "runtime_ledger_artifact_fill_count": fill_row_count,
         "runtime_ledger_closed_trade_count": runtime_bucket.closed_trade_count,
         "runtime_ledger_open_position_count": runtime_bucket.open_position_count,
         "runtime_ledger_filled_notional": str(runtime_bucket.filled_notional),
@@ -2327,7 +2324,6 @@ def _exact_replay_ledger_artifact_update(
         "runtime_ledger_pnl_basis": POST_COST_PNL_BASIS,
         "runtime_ledger_pnl_source": "exact_replay_runtime_ledger",
         "exact_replay_ledger_artifact_proof_authority": False,
-        "runtime_ledger_artifact_proof_authority": False,
         "promotion_authority": False,
         "final_promotion_authority": False,
         "promotion_authority_blockers": [
@@ -2338,8 +2334,6 @@ def _exact_replay_ledger_artifact_update(
     if proof_only_reason:
         update["exact_replay_ledger_artifact_proof_only"] = True
         update["exact_replay_ledger_artifact_proof_only_reason"] = proof_only_reason
-        update["runtime_ledger_artifact_proof_only"] = True
-        update["runtime_ledger_artifact_proof_only_reason"] = proof_only_reason
     return update
 
 
@@ -4466,7 +4460,7 @@ def _build_economic_shortlist(
             )
         )
         != Decimal("0")
-        or item.get("runtime_ledger_artifact_ref")
+        or item.get("exact_replay_ledger_artifact_ref")
         or item.get("replay_artifact_refs")
     ]
     visible_items.sort(
@@ -4555,8 +4549,8 @@ def _build_economic_shortlist(
                         full_window_key="min_cash",
                     )
                 ),
-                "runtime_ledger_artifact_ref": str(
-                    item.get("runtime_ledger_artifact_ref") or ""
+                "exact_replay_ledger_artifact_ref": str(
+                    item.get("exact_replay_ledger_artifact_ref") or ""
                 ),
                 "replay_artifact_refs": [
                     str(ref)
@@ -4574,9 +4568,9 @@ def _build_economic_shortlist(
 
 def _candidate_artifact_refs(item: Mapping[str, Any]) -> list[str]:
     refs: list[str] = []
-    runtime_ref = str(item.get("runtime_ledger_artifact_ref") or "").strip()
-    if runtime_ref:
-        refs.append(runtime_ref)
+    exact_replay_ref = str(item.get("exact_replay_ledger_artifact_ref") or "").strip()
+    if exact_replay_ref:
+        refs.append(exact_replay_ref)
     refs.extend(
         str(ref).strip()
         for ref in cast(Sequence[Any], item.get("replay_artifact_refs") or ())
@@ -4585,21 +4579,15 @@ def _candidate_artifact_refs(item: Mapping[str, Any]) -> list[str]:
     return list(dict.fromkeys(refs))
 
 
-def _candidate_runtime_ledger_artifact_refs(item: Mapping[str, Any]) -> list[str]:
+def _candidate_exact_replay_ledger_artifact_refs(item: Mapping[str, Any]) -> list[str]:
     refs: list[str] = []
     scorecard = _mapping(item.get("objective_scorecard"))
     for source in (item, scorecard):
-        for key in (
-            "exact_replay_ledger_artifact_ref",
-            "runtime_ledger_artifact_ref",
-        ):
+        for key in ("exact_replay_ledger_artifact_ref",):
             ref = str(source.get(key) or "").strip()
             if ref:
                 refs.append(ref)
-        for key in (
-            "exact_replay_ledger_artifact_refs",
-            "runtime_ledger_artifact_refs",
-        ):
+        for key in ("exact_replay_ledger_artifact_refs",):
             raw_refs = source.get(key)
             if isinstance(raw_refs, str):
                 ref = raw_refs.strip()
@@ -4616,8 +4604,6 @@ def _candidate_runtime_ledger_artifact_refs(item: Mapping[str, Any]) -> list[str
         if ref and (
             "exact-replay-ledger" in ref_lower
             or "exact_replay_ledger" in ref_lower
-            or "runtime-ledger" in ref_lower
-            or "runtime_ledger" in ref_lower
         ):
             refs.append(ref)
     return list(dict.fromkeys(refs))
@@ -4785,8 +4771,8 @@ def _candidate_exact_replay_parity_ok(
     item: Mapping[str, Any],
     *,
     artifact_refs: Sequence[str],
-    runtime_ledger_row_count: int,
-    runtime_ledger_fill_count: int,
+    exact_replay_ledger_row_count: int,
+    exact_replay_ledger_fill_count: int,
 ) -> bool:
     scorecard = _mapping(item.get("objective_scorecard"))
     has_exact_ref = any(
@@ -4800,7 +4786,9 @@ def _candidate_exact_replay_parity_ok(
         ).strip()
     )
     return bool(
-        has_exact_ref and runtime_ledger_row_count > 0 and runtime_ledger_fill_count > 0
+        has_exact_ref
+        and exact_replay_ledger_row_count > 0
+        and exact_replay_ledger_fill_count > 0
     )
 
 
@@ -4809,8 +4797,8 @@ def _candidate_handoff_diagnostics(
     *,
     hard_vetoes: Sequence[str],
     artifact_refs: Sequence[str],
-    runtime_ledger_row_count: int,
-    runtime_ledger_fill_count: int,
+    exact_replay_ledger_row_count: int,
+    exact_replay_ledger_fill_count: int,
     source_lineage_ok: bool,
     exact_replay_parity_ok: bool,
 ) -> list[dict[str, Any]]:
@@ -4935,12 +4923,20 @@ def _candidate_handoff_diagnostics(
             {
                 "category": "failed_exact_replay_parity",
                 "artifact_refs": list(artifact_refs),
-                "runtime_ledger_artifact_row_count": runtime_ledger_row_count,
-                "runtime_ledger_artifact_fill_count": runtime_ledger_fill_count,
+                "exact_replay_ledger_artifact_row_count": (
+                    exact_replay_ledger_row_count
+                ),
+                "exact_replay_ledger_artifact_fill_count": (
+                    exact_replay_ledger_fill_count
+                ),
             }
         )
 
-    if artifact_refs and runtime_ledger_row_count > 0 and runtime_ledger_fill_count > 0:
+    if (
+        artifact_refs
+        and exact_replay_ledger_row_count > 0
+        and exact_replay_ledger_fill_count > 0
+    ):
         replay_tape_blockers = _candidate_replay_tape_metadata_blockers(item)
         if replay_tape_blockers:
             diagnostics.append(
@@ -5047,24 +5043,22 @@ def _build_paper_probation_shortlist(
         hard_vetoes = [
             str(reason) for reason in cast(Sequence[Any], item.get("hard_vetoes") or ())
         ]
-        artifact_refs = _candidate_runtime_ledger_artifact_refs(item)
-        runtime_ledger_row_count = _candidate_runtime_ledger_count(
+        artifact_refs = _candidate_exact_replay_ledger_artifact_refs(item)
+        exact_replay_ledger_row_count = _candidate_runtime_ledger_count(
             item,
-            "runtime_ledger_artifact_row_count",
             "exact_replay_ledger_artifact_row_count",
         )
-        runtime_ledger_fill_count = _candidate_runtime_ledger_count(
+        exact_replay_ledger_fill_count = _candidate_runtime_ledger_count(
             item,
-            "runtime_ledger_artifact_fill_count",
             "exact_replay_ledger_artifact_fill_count",
         )
         blockers: list[str] = []
         if not artifact_refs:
-            blockers.append("missing_exact_or_runtime_ledger_artifact")
-        if runtime_ledger_row_count <= 0:
-            blockers.append("missing_runtime_ledger_row_count")
-        if runtime_ledger_fill_count <= 0:
-            blockers.append("missing_runtime_ledger_fill_count")
+            blockers.append("missing_exact_replay_ledger_artifact")
+        if exact_replay_ledger_row_count <= 0:
+            blockers.append("missing_exact_replay_ledger_row_count")
+        if exact_replay_ledger_fill_count <= 0:
+            blockers.append("missing_exact_replay_ledger_fill_count")
         screening = _mapping(item.get("screening"))
         staged_search = _mapping(item.get("staged_search"))
         if (
@@ -5078,8 +5072,8 @@ def _build_paper_probation_shortlist(
         exact_replay_parity_ok = _candidate_exact_replay_parity_ok(
             item,
             artifact_refs=artifact_refs,
-            runtime_ledger_row_count=runtime_ledger_row_count,
-            runtime_ledger_fill_count=runtime_ledger_fill_count,
+            exact_replay_ledger_row_count=exact_replay_ledger_row_count,
+            exact_replay_ledger_fill_count=exact_replay_ledger_fill_count,
         )
         if not source_lineage_ok:
             blockers.append("missing_source_lineage")
@@ -5087,8 +5081,8 @@ def _build_paper_probation_shortlist(
             blockers.append("failed_exact_replay_parity")
         if (
             artifact_refs
-            and runtime_ledger_row_count > 0
-            and runtime_ledger_fill_count > 0
+            and exact_replay_ledger_row_count > 0
+            and exact_replay_ledger_fill_count > 0
         ):
             blockers.extend(_candidate_replay_tape_metadata_blockers(item))
             blockers.extend(_candidate_post_cost_proof_blockers(item))
@@ -5104,8 +5098,8 @@ def _build_paper_probation_shortlist(
             item,
             hard_vetoes=hard_vetoes,
             artifact_refs=artifact_refs,
-            runtime_ledger_row_count=runtime_ledger_row_count,
-            runtime_ledger_fill_count=runtime_ledger_fill_count,
+            exact_replay_ledger_row_count=exact_replay_ledger_row_count,
+            exact_replay_ledger_fill_count=exact_replay_ledger_fill_count,
             source_lineage_ok=source_lineage_ok,
             exact_replay_parity_ok=exact_replay_parity_ok,
         )
@@ -5139,9 +5133,13 @@ def _build_paper_probation_shortlist(
                     objective_veto_policy=objective_veto_policy,
                     hard_vetoes=hard_vetoes,
                 ),
-                "runtime_ledger_artifact_refs": artifact_refs,
-                "runtime_ledger_artifact_row_count": runtime_ledger_row_count,
-                "runtime_ledger_artifact_fill_count": runtime_ledger_fill_count,
+                "exact_replay_ledger_artifact_refs": artifact_refs,
+                "exact_replay_ledger_artifact_row_count": (
+                    exact_replay_ledger_row_count
+                ),
+                "exact_replay_ledger_artifact_fill_count": (
+                    exact_replay_ledger_fill_count
+                ),
                 "net_pnl_per_day": str(
                     _candidate_metric_value(
                         item,
@@ -5198,8 +5196,8 @@ def _build_paper_probation_shortlist(
                         full_window_key="min_cash",
                     )
                 ),
-                "runtime_ledger_artifact_ref": str(
-                    item.get("runtime_ledger_artifact_ref") or ""
+                "exact_replay_ledger_artifact_ref": str(
+                    item.get("exact_replay_ledger_artifact_ref") or ""
                 ),
                 "replay_artifact_refs": artifact_refs,
                 "hard_vetoes": hard_vetoes,
@@ -5259,15 +5257,14 @@ def _build_frontier_workflow_states(
     exact_replay_qualified = [
         {
             **_frontier_state_item(item),
-            "runtime_ledger_artifact_refs": _candidate_runtime_ledger_artifact_refs(
-                item
+            "exact_replay_ledger_artifact_refs": (
+                _candidate_exact_replay_ledger_artifact_refs(item)
             ),
         }
         for item in ranked_items
         if str(_mapping(item.get("staged_search")).get("stage") or "") == "full_replay"
         and _candidate_runtime_ledger_count(
             item,
-            "runtime_ledger_artifact_row_count",
             "exact_replay_ledger_artifact_row_count",
         )
         > 0

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6017,9 +6017,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                             "active_day_ratio": "1",
                             "positive_day_ratio": "1",
                             "exact_replay_ledger_artifact_ref": "direct-exact-ledger.json",
-                            "runtime_ledger_artifact_ref": "direct-runtime-ledger.json",
-                            "runtime_ledger_artifact_row_count": 12,
-                            "runtime_ledger_artifact_fill_count": 4,
+                            "exact_replay_ledger_artifact_row_count": 12,
+                            "exact_replay_ledger_artifact_fill_count": 4,
                             "runtime_window_start": "2026-05-18T13:30:00+00:00",
                             "runtime_window_end": "2026-05-18T20:00:00+00:00",
                         },
@@ -6152,11 +6151,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "runtime_ledger", direct_sleeve_row["paper_required_evidence_tokens"]
         )
         self.assertEqual(
-            direct_sleeve_row["runtime_ledger_artifact_refs"],
-            ["direct-exact-ledger.json", "direct-runtime-ledger.json"],
+            direct_sleeve_row["exact_replay_ledger_artifact_refs"],
+            ["direct-exact-ledger.json"],
         )
-        self.assertEqual(direct_sleeve_row["runtime_ledger_artifact_row_count"], 12)
-        self.assertEqual(direct_sleeve_row["runtime_ledger_artifact_fill_count"], 4)
+        self.assertNotIn("runtime_ledger_artifact_refs", direct_sleeve_row)
+        self.assertNotIn("runtime_ledger_artifact_ref", direct_sleeve_row)
+        self.assertEqual(direct_sleeve_row["exact_replay_ledger_artifact_row_count"], 12)
+        self.assertEqual(direct_sleeve_row["exact_replay_ledger_artifact_fill_count"], 4)
         source_compiler_mock.assert_not_called()
         candidate_compiler_mock.assert_not_called()
         selection_mock.assert_not_called()
@@ -7356,9 +7357,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "order_type_opportunity_cost_bps": "4",
                 "market_order_spread_bps": "4",
                 "exact_replay_ledger_artifact_ref": "sleeve-exact-replay-ledger.json",
-                "runtime_ledger_artifact_ref": "sleeve-runtime-ledger.json",
-                "runtime_ledger_artifact_row_count": 30,
-                "runtime_ledger_artifact_fill_count": 10,
+                "exact_replay_ledger_artifact_row_count": 30,
+                "exact_replay_ledger_artifact_fill_count": 10,
                 "runtime_window_start": "2026-05-18T13:30:00+00:00",
                 "runtime_window_end": "2026-05-18T20:00:00+00:00",
             },
@@ -7425,18 +7425,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertEqual(rows[0]["paper_required_evidence_count"], 2)
         self.assertEqual(
-            rows[0]["runtime_ledger_artifact_refs"],
-            ["sleeve-exact-replay-ledger.json", "sleeve-runtime-ledger.json"],
+            rows[0]["exact_replay_ledger_artifact_refs"],
+            ["sleeve-exact-replay-ledger.json"],
         )
         self.assertEqual(
             rows[0]["exact_replay_ledger_artifact_ref"],
             "sleeve-exact-replay-ledger.json",
         )
-        self.assertEqual(
-            rows[0]["runtime_ledger_artifact_ref"], "sleeve-runtime-ledger.json"
-        )
-        self.assertEqual(rows[0]["runtime_ledger_artifact_row_count"], 30)
-        self.assertEqual(rows[0]["runtime_ledger_artifact_fill_count"], 10)
+        self.assertNotIn("runtime_ledger_artifact_ref", rows[0])
+        self.assertNotIn("runtime_ledger_artifact_refs", rows[0])
+        self.assertEqual(rows[0]["exact_replay_ledger_artifact_row_count"], 30)
+        self.assertEqual(rows[0]["exact_replay_ledger_artifact_fill_count"], 10)
         self.assertEqual(rows[0]["runtime_window_start"], "2026-05-18T13:30:00+00:00")
         fallback_rows = runner._candidate_sleeve_goal_rows(
             candidate_specs=(spec,),
@@ -7506,9 +7505,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertTrue(portfolio_rows[0]["paper_contract_selected_for_replay"])
         self.assertEqual(
-            portfolio_rows[0]["runtime_ledger_artifact_refs"],
-            ["sleeve-exact-replay-ledger.json", "sleeve-runtime-ledger.json"],
+            portfolio_rows[0]["exact_replay_ledger_artifact_refs"],
+            ["sleeve-exact-replay-ledger.json"],
         )
+        self.assertNotIn("runtime_ledger_artifact_refs", portfolio_rows[0])
 
     def test_candidate_board_marks_portfolio_promotion_found_when_portfolio_oracle_passes(
         self,
@@ -8396,8 +8396,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "trade_count": 7,
                 "executable_replay_submitted_order_count": 7,
                 "exact_replay_ledger_artifact_ref": "paper-window-exact-replay-ledger.json",
-                "runtime_ledger_artifact_row_count": 21,
-                "runtime_ledger_artifact_fill_count": 7,
+                "exact_replay_ledger_artifact_row_count": 21,
+                "exact_replay_ledger_artifact_fill_count": 7,
                 "replay_lineage": {
                     "windows": {
                         "full_window": {
@@ -8610,8 +8610,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "orders_submitted_count": 9,
                 "trade_count": 9,
                 "exact_replay_ledger_artifact_ref": "paper-probation-exact-ledger.json",
-                "runtime_ledger_artifact_row_count": 27,
-                "runtime_ledger_artifact_fill_count": 9,
+                "exact_replay_ledger_artifact_row_count": 27,
+                "exact_replay_ledger_artifact_fill_count": 9,
                 "replay_lineage": {
                     "windows": {
                         "full_window": {
@@ -8737,15 +8737,16 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ["paper-probation.json", "paper-probation-exact-ledger.json"],
         )
         self.assertEqual(
-            target["runtime_ledger_artifact_refs"],
+            target["exact_replay_ledger_artifact_refs"],
             ["paper-probation-exact-ledger.json"],
         )
         self.assertEqual(
             target["exact_replay_ledger_artifact_ref"],
             "paper-probation-exact-ledger.json",
         )
-        self.assertEqual(target["runtime_ledger_artifact_row_count"], 27)
-        self.assertEqual(target["runtime_ledger_artifact_fill_count"], 9)
+        self.assertNotIn("runtime_ledger_artifact_refs", target)
+        self.assertEqual(target["exact_replay_ledger_artifact_row_count"], 27)
+        self.assertEqual(target["exact_replay_ledger_artifact_fill_count"], 9)
         self.assertEqual(
             target["replay_selection_reason"], "paper_contract_exploration"
         )
@@ -8766,11 +8767,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         import_metadata = json.loads(target["import_command_args"][metadata_arg_index])
         self.assertEqual(
-            import_metadata["runtime_ledger_artifact_refs"],
+            import_metadata["exact_replay_ledger_artifact_refs"],
             ["paper-probation-exact-ledger.json"],
         )
-        self.assertEqual(import_metadata["runtime_ledger_artifact_row_count"], 27)
-        self.assertEqual(import_metadata["runtime_ledger_artifact_fill_count"], 9)
+        self.assertNotIn("runtime_ledger_artifact_refs", import_metadata)
+        self.assertEqual(import_metadata["exact_replay_ledger_artifact_row_count"], 27)
+        self.assertEqual(import_metadata["exact_replay_ledger_artifact_fill_count"], 9)
         self.assertEqual(
             import_metadata["exact_replay_ledger_artifact_ref"],
             "paper-probation-exact-ledger.json",
@@ -8932,8 +8934,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "orders_submitted_count": 8,
                 "trade_count": 8,
                 "exact_replay_ledger_artifact_ref": "close-probation-exact-replay-ledger.json",
-                "runtime_ledger_artifact_row_count": 24,
-                "runtime_ledger_artifact_fill_count": 8,
+                "exact_replay_ledger_artifact_row_count": 24,
+                "exact_replay_ledger_artifact_fill_count": 8,
                 "replay_lineage": {
                     "windows": {
                         "full_window": {
@@ -8996,8 +8998,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "implementation_uncertainty_lower_net_pnl_per_day": "260",
             "conformal_tail_risk_adjusted_net_pnl_per_day": "260",
             "exact_replay_ledger_artifact_ref": "bridge-probation-exact-replay-ledger.json",
-            "runtime_ledger_artifact_row_count": 18,
-            "runtime_ledger_artifact_fill_count": 6,
+            "exact_replay_ledger_artifact_row_count": 18,
+            "exact_replay_ledger_artifact_fill_count": 6,
         }
         bridge_evidence = replace(
             close_evidence,
@@ -9121,8 +9123,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "candidate_spec_id": "spec-ledger-paper",
             "candidate_id": "cand-ledger-paper",
             "exact_replay_ledger_artifact_ref": "ledger-exact-replay-ledger.json",
-            "runtime_ledger_artifact_row_count": 18,
-            "runtime_ledger_artifact_fill_count": 6,
+            "exact_replay_ledger_artifact_row_count": 18,
+            "exact_replay_ledger_artifact_fill_count": 6,
             "runtime_window_start": "2026-05-18",
             "runtime_window_end": "2026-05-20",
         }
@@ -9130,9 +9132,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             runner._candidate_board_paper_probation_admission_blockers(generic_row),
             [
-                "paper_probation_runtime_ledger_artifact_missing",
-                "paper_probation_runtime_ledger_row_count_missing",
-                "paper_probation_runtime_ledger_fill_count_missing",
+                "paper_probation_exact_replay_ledger_artifact_missing",
+                "paper_probation_exact_replay_ledger_row_count_missing",
+                "paper_probation_exact_replay_ledger_fill_count_missing",
                 "paper_probation_runtime_window_bounds_missing",
             ],
         )
@@ -9155,8 +9157,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "submitted_order_count": 4,
             "filled_order_count": 4,
             "exact_replay_ledger_artifact_ref": "single-exact-replay-ledger.json",
-            "runtime_ledger_artifact_row_count": 12,
-            "runtime_ledger_artifact_fill_count": 4,
+            "exact_replay_ledger_artifact_row_count": 12,
+            "exact_replay_ledger_artifact_fill_count": 4,
             "runtime_window_start": "2026-05-18",
             "runtime_window_end": "2026-05-20",
             "net_pnl_per_day": "215",
@@ -9222,8 +9224,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "paper-runtime-plan-exact-replay-ledger.json",
             ],
             "exact_replay_ledger_artifact_ref": "paper-runtime-plan-exact-replay-ledger.json",
-            "runtime_ledger_artifact_row_count": 36,
-            "runtime_ledger_artifact_fill_count": 12,
+            "exact_replay_ledger_artifact_row_count": 36,
+            "exact_replay_ledger_artifact_fill_count": 12,
             "runtime_window_start": "2026-05-18T13:30:00+00:00",
             "runtime_window_end": "2026-05-20T20:00:00+00:00",
             "account_label": "TORGHUT_REPLAY",
@@ -9237,10 +9239,6 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "runtime_strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
             "dataset_snapshot_id": "snapshot-runtime-plan-fallback",
             "exact_replay_ledger_artifact_refs": "fallback-exact-replay-ledger.json",
-            "runtime_ledger_artifact_refs": [
-                "fallback-runtime-ledger.json",
-                "",
-            ],
             "runtime_window_start": "2026-05-21T13:30:00+00:00",
             "runtime_window_end": "2026-05-21T20:00:00+00:00",
         }
@@ -9290,9 +9288,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertEqual(plan["targets"][0]["candidate_blockers"], row["blockers"])
         self.assertEqual(
-            plan["targets"][0]["runtime_ledger_artifact_refs"],
+            plan["targets"][0]["exact_replay_ledger_artifact_refs"],
             ["paper-runtime-plan-exact-replay-ledger.json"],
         )
+        self.assertNotIn("runtime_ledger_artifact_refs", plan["targets"][0])
         self.assertEqual(
             plan["targets"][0]["window_start"], "2026-05-18T13:30:00+00:00"
         )
@@ -9314,30 +9313,25 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             plan["targets"][0]["import_command_args"][metadata_arg_index]
         )
         self.assertEqual(
-            import_metadata["runtime_ledger_artifact_refs"],
+            import_metadata["exact_replay_ledger_artifact_refs"],
             ["paper-runtime-plan-exact-replay-ledger.json"],
         )
-        self.assertEqual(import_metadata["runtime_ledger_artifact_row_count"], 36)
-        self.assertEqual(import_metadata["runtime_ledger_artifact_fill_count"], 12)
+        self.assertNotIn("runtime_ledger_artifact_refs", import_metadata)
+        self.assertEqual(import_metadata["exact_replay_ledger_artifact_row_count"], 36)
+        self.assertEqual(import_metadata["exact_replay_ledger_artifact_fill_count"], 12)
         self.assertEqual(import_metadata["window_start"], "2026-05-18T13:30:00+00:00")
         self.assertEqual(import_metadata["window_end"], "2026-05-20T20:00:00+00:00")
         self.assertEqual(fallback_plan["status"], "ready")
         self.assertEqual(fallback_plan["target_count"], 1)
         self.assertEqual(
-            fallback_plan["targets"][0]["runtime_ledger_artifact_refs"],
-            [
-                "fallback-exact-replay-ledger.json",
-                "fallback-runtime-ledger.json",
-            ],
+            fallback_plan["targets"][0]["exact_replay_ledger_artifact_refs"],
+            ["fallback-exact-replay-ledger.json"],
         )
         self.assertEqual(
             fallback_plan["targets"][0]["exact_replay_ledger_artifact_ref"],
             "fallback-exact-replay-ledger.json",
         )
-        self.assertEqual(
-            fallback_plan["targets"][0]["runtime_ledger_artifact_ref"],
-            "fallback-exact-replay-ledger.json",
-        )
+        self.assertNotIn("runtime_ledger_artifact_ref", fallback_plan["targets"][0])
         self.assertEqual(
             fallback_plan["targets"][0]["account_label"],
             "TORGHUT_REPLAY",

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -153,8 +153,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             self.assertTrue(exact_ledger_ref.exists())
             self.assertEqual(update["exact_replay_ledger_artifact_row_count"], 6)
             self.assertEqual(update["exact_replay_ledger_artifact_fill_count"], 2)
-            self.assertEqual(update["runtime_ledger_artifact_row_count"], 6)
-            self.assertEqual(update["runtime_ledger_artifact_fill_count"], 2)
+            self.assertNotIn("runtime_ledger_artifact_ref", update)
+            self.assertNotIn("runtime_ledger_artifact_row_count", update)
+            self.assertNotIn("runtime_ledger_artifact_fill_count", update)
+            self.assertNotIn("runtime_ledger_artifact_proof_authority", update)
             self.assertEqual(update["runtime_ledger_closed_trade_count"], 1)
             self.assertEqual(update["runtime_ledger_open_position_count"], 0)
             self.assertEqual(update["runtime_ledger_filled_notional"], "201")
@@ -1702,10 +1704,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 exact_ledger_ref.parent, root / "frontier-artifacts" / "frontier"
             )
             self.assertEqual(artifact_ref.parent, exact_ledger_ref.parent)
-            self.assertEqual(
-                payload["top"][0]["runtime_ledger_artifact_ref"],
-                str(exact_ledger_ref),
-            )
+            self.assertNotIn("runtime_ledger_artifact_ref", payload["top"][0])
             self.assertIn(
                 str(exact_ledger_ref), payload["top"][0]["replay_artifact_refs"]
             )
@@ -1732,10 +1731,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 exact_ledger_artifact["authority_blockers"],
             )
             self.assertFalse(scorecard["exact_replay_ledger_artifact_proof_authority"])
-            self.assertFalse(scorecard["runtime_ledger_artifact_proof_authority"])
+            self.assertNotIn("runtime_ledger_artifact_proof_authority", scorecard)
             self.assertFalse(scorecard["final_promotion_authority"])
-            self.assertEqual(scorecard["runtime_ledger_artifact_row_count"], 6)
-            self.assertEqual(scorecard["runtime_ledger_artifact_fill_count"], 2)
+            self.assertNotIn("runtime_ledger_artifact_row_count", scorecard)
+            self.assertNotIn("runtime_ledger_artifact_fill_count", scorecard)
             self.assertEqual(scorecard["runtime_ledger_closed_trade_count"], 1)
             self.assertEqual(scorecard["runtime_ledger_open_position_count"], 0)
             self.assertEqual(scorecard["runtime_ledger_filled_notional"], "201")
@@ -2619,7 +2618,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     "min_cash": "-15",
                 },
                 "full_window": {"net_per_day": "150", "net_pnl": "750"},
-                "runtime_ledger_artifact_ref": "/tmp/high-ledger.json",
+                "exact_replay_ledger_artifact_ref": "/tmp/high-ledger.json",
                 "replay_artifact_refs": ["/tmp/high-ledger.json"],
                 "hard_vetoes": ["min_cash_below_min"],
                 "ranking": {"vetoed": True, "pareto_tier": 999},
@@ -2631,7 +2630,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(shortlist[0]["candidate_id"], "vetoed-high")
         self.assertEqual(shortlist[0]["net_pnl_per_day"], "150")
         self.assertEqual(
-            shortlist[0]["runtime_ledger_artifact_ref"], "/tmp/high-ledger.json"
+            shortlist[0]["exact_replay_ledger_artifact_ref"], "/tmp/high-ledger.json"
         )
         self.assertEqual(shortlist[0]["hard_vetoes"], ["min_cash_below_min"])
         self.assertTrue(shortlist[0]["vetoed"])
@@ -2686,14 +2685,11 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     "min_cash": "-161171.80",
                 },
                 "full_window": {"net_per_day": "406.58", "net_pnl": "813.16"},
-                "runtime_ledger_artifact_ref": (
-                    "/tmp/microbar-exact-replay-ledger.json"
-                ),
                 "exact_replay_ledger_artifact_ref": (
                     "/tmp/microbar-exact-replay-ledger.json"
                 ),
-                "runtime_ledger_artifact_row_count": 12,
-                "runtime_ledger_artifact_fill_count": 4,
+                "exact_replay_ledger_artifact_row_count": 12,
+                "exact_replay_ledger_artifact_fill_count": 4,
                 "runtime_ledger_cost_basis_count": 4,
                 "runtime_ledger_post_cost_expectancy_bps": "25",
                 "runtime_ledger_pnl_basis": "realized_strategy_pnl_after_explicit_costs",
@@ -2770,9 +2766,9 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(
             shortlist[0]["probation_blockers"],
             [
-                "missing_exact_or_runtime_ledger_artifact",
-                "missing_runtime_ledger_row_count",
-                "missing_runtime_ledger_fill_count",
+                "missing_exact_replay_ledger_artifact",
+                "missing_exact_replay_ledger_row_count",
+                "missing_exact_replay_ledger_fill_count",
                 "missing_source_lineage",
                 "failed_exact_replay_parity",
             ],
@@ -2799,10 +2795,9 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                         "min_cash": "100",
                     },
                     "full_window": {"net_per_day": "125", "net_pnl": "250"},
-                    "runtime_ledger_artifact_ref": "/tmp/exact-replay-ledger.json",
                     "exact_replay_ledger_artifact_ref": "/tmp/exact-replay-ledger.json",
-                    "runtime_ledger_artifact_row_count": 6,
-                    "runtime_ledger_artifact_fill_count": 2,
+                    "exact_replay_ledger_artifact_row_count": 6,
+                    "exact_replay_ledger_artifact_fill_count": 2,
                     "runtime_ledger_open_position_count": 0,
                     "dataset_snapshot_id": "snapshot-post-cost",
                     "replay_lineage": {"lineage_hash": "lineage-post-cost"},
@@ -2858,10 +2853,9 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                         "min_cash": "100",
                     },
                     "full_window": {"net_per_day": "125", "net_pnl": "250"},
-                    "runtime_ledger_artifact_ref": "/tmp/exact-replay-ledger.json",
                     "exact_replay_ledger_artifact_ref": "/tmp/exact-replay-ledger.json",
-                    "runtime_ledger_artifact_row_count": 6,
-                    "runtime_ledger_artifact_fill_count": 2,
+                    "exact_replay_ledger_artifact_row_count": 6,
+                    "exact_replay_ledger_artifact_fill_count": 2,
                     "runtime_ledger_cost_basis_count": 2,
                     "runtime_ledger_post_cost_expectancy_bps": "25",
                     "runtime_ledger_pnl_basis": "realized_strategy_pnl_after_explicit_costs",
@@ -2928,7 +2922,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
         self.assertFalse(shortlist[0]["paper_probation_allowed"])
         self.assertIn(
-            "missing_exact_or_runtime_ledger_artifact",
+            "missing_exact_replay_ledger_artifact",
             shortlist[0]["probation_blockers"],
         )
 
@@ -2946,9 +2940,9 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                         "min_cash": "100",
                     },
                     "full_window": {"net_per_day": "225", "net_pnl": "450"},
-                    "runtime_ledger_artifact_ref": "/tmp/proof-only-ledger.json",
-                    "runtime_ledger_artifact_row_count": 12,
-                    "runtime_ledger_artifact_fill_count": 4,
+                    "exact_replay_ledger_artifact_ref": "/tmp/proof-only-ledger.json",
+                    "exact_replay_ledger_artifact_row_count": 12,
+                    "exact_replay_ledger_artifact_fill_count": 4,
                     "exact_replay_ledger_artifact_proof_only": True,
                     "screening": {"proof_only_full_window_replay_captured": True},
                     "staged_search": {
@@ -3103,8 +3097,8 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     "exact_replay_ledger_artifact_ref": (
                         "/tmp/candidate-exact-replay-ledger.json"
                     ),
-                    "runtime_ledger_artifact_row_count": 6,
-                    "runtime_ledger_artifact_fill_count": 2,
+                    "exact_replay_ledger_artifact_row_count": 6,
+                    "exact_replay_ledger_artifact_fill_count": 2,
                     "hard_vetoes": [],
                     "ranking": {"vetoed": False},
                 },


### PR DESCRIPTION
## Summary

- Stop frontier exact-replay ledger artifacts from being emitted under `runtime_ledger_artifact_*` alias fields.
- Stop whitepaper candidate-board sleeve rows and runtime-window import plans from republishing exact-replay artifacts as runtime-ledger artifact refs/counts.
- Allow runtime-window importer target metadata to validate exact-replay row/fill count keys against loaded diagnostic artifact metadata.
- Update focused regression tests so replay evidence stays explicit and runtime proof aliases are absent from candidate-facing outputs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py scripts/run_whitepaper_autoresearch_profit_target.py scripts/import_hypothesis_runtime_windows.py tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
