### PR TITLE
fix(torghut): keep autoresearch replay refs exact

### DIFF
--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -1230,10 +1230,6 @@ def _history_record(
             scorecard.get("exact_replay_ledger_artifact_ref")
             or candidate_payload.get("exact_replay_ledger_artifact_ref")
         ),
-        "runtime_ledger_artifact_ref": _string(
-            scorecard.get("runtime_ledger_artifact_ref")
-            or candidate_payload.get("runtime_ledger_artifact_ref")
-        ),
         "exact_replay_ledger_artifact_row_count": _string(
             scorecard.get("exact_replay_ledger_artifact_row_count")
             or candidate_payload.get("exact_replay_ledger_artifact_row_count")
@@ -1241,14 +1237,6 @@ def _history_record(
         "exact_replay_ledger_artifact_fill_count": _string(
             scorecard.get("exact_replay_ledger_artifact_fill_count")
             or candidate_payload.get("exact_replay_ledger_artifact_fill_count")
-        ),
-        "runtime_ledger_artifact_row_count": _string(
-            scorecard.get("runtime_ledger_artifact_row_count")
-            or candidate_payload.get("runtime_ledger_artifact_row_count")
-        ),
-        "runtime_ledger_artifact_fill_count": _string(
-            scorecard.get("runtime_ledger_artifact_fill_count")
-            or candidate_payload.get("runtime_ledger_artifact_fill_count")
         ),
         "runtime_ledger_pnl_basis": _string(
             scorecard.get("runtime_ledger_pnl_basis")
@@ -1485,7 +1473,7 @@ def _exact_replay_runtime_window_blockers(
     if not artifact_refs:
         blockers.append(
             {
-                "blocker": "runtime_ledger_artifact_ref_missing",
+                "blocker": "exact_replay_ledger_artifact_ref_missing",
                 "candidate_id": candidate_id,
                 "remediation": "enable exact replay ledger artifact output",
             }
@@ -1555,7 +1543,6 @@ def _strategy_autoresearch_runtime_window_import_plan(
             best_exact_replay_ledger_candidate.get("artifact_ref")
             if best_exact_replay_ledger_candidate is not None
             else "",
-            history_row.get("runtime_ledger_artifact_ref") if history_row else "",
             history_row.get("exact_replay_ledger_artifact_ref") if history_row else "",
         ]
     )
@@ -1581,8 +1568,8 @@ def _strategy_autoresearch_runtime_window_import_plan(
                 "paper_probation_evidence_collection_only",
             ]
         )
-        row_count = _string(history_row.get("runtime_ledger_artifact_row_count"))
-        fill_count = _string(history_row.get("runtime_ledger_artifact_fill_count"))
+        row_count = _string(history_row.get("exact_replay_ledger_artifact_row_count"))
+        fill_count = _string(history_row.get("exact_replay_ledger_artifact_fill_count"))
         search_blockers = [
             blocker
             for blocker in _dedupe_nonempty_strings(
@@ -1607,8 +1594,7 @@ def _strategy_autoresearch_runtime_window_import_plan(
             "dataset_snapshot_ref": _string(history_row.get("dataset_snapshot_id"))
             or hypothesis_manifest["dataset_snapshot_ref"],
             "artifact_refs": artifact_refs,
-            "runtime_ledger_artifact_refs": artifact_refs,
-            "runtime_ledger_artifact_ref": artifact_refs[0],
+            "exact_replay_ledger_artifact_refs": artifact_refs,
             "exact_replay_ledger_artifact_ref": artifact_refs[0],
             "window_start": window_start,
             "window_end": window_end,
@@ -1631,9 +1617,9 @@ def _strategy_autoresearch_runtime_window_import_plan(
             "promotion_gate": "runtime_ledger_live_or_live_paper_required",
         }
         if row_count:
-            target["runtime_ledger_artifact_row_count"] = row_count
+            target["exact_replay_ledger_artifact_row_count"] = row_count
         if fill_count:
-            target["runtime_ledger_artifact_fill_count"] = fill_count
+            target["exact_replay_ledger_artifact_fill_count"] = fill_count
         targets.append(target)
     return {
         "schema_version": "torghut.runtime-window-import-plan.v1",
@@ -2112,7 +2098,6 @@ def _exact_replay_ledger_refs(value: Any) -> list[str]:
         for key, item in value.items():
             if key in {
                 "exact_replay_ledger_artifact_ref",
-                "runtime_ledger_artifact_ref",
             }:
                 ref = _string(item)
                 if ref:
@@ -2120,7 +2105,6 @@ def _exact_replay_ledger_refs(value: Any) -> list[str]:
                 continue
             if key in {
                 "exact_replay_ledger_artifact_refs",
-                "runtime_ledger_artifact_refs",
             }:
                 if isinstance(item, (list, tuple)):
                     refs.extend(ref for raw in item if (ref := _string(raw)))

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -264,7 +264,7 @@ class TestStrategyAutoresearch(TestCase):
         blocker_names = {item["blocker"] for item in missing_handoff_blockers}
         self.assertIn("hypothesis_manifest_missing", blocker_names)
         self.assertIn("runtime_harness_metadata_missing", blocker_names)
-        self.assertIn("runtime_ledger_artifact_ref_missing", blocker_names)
+        self.assertIn("exact_replay_ledger_artifact_ref_missing", blocker_names)
         missing_history_blockers = runner._exact_replay_runtime_window_blockers(
             best_exact_replay_ledger_candidate={"candidate_id": "candidate-1"},
             history_row=None,
@@ -709,11 +709,8 @@ class TestStrategyAutoresearch(TestCase):
                             "runtime_family": "microbar_cross_sectional_pairs",
                             "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
                             "exact_replay_ledger_artifact_ref": str(artifact_path),
-                            "runtime_ledger_artifact_ref": str(artifact_path),
                             "exact_replay_ledger_artifact_row_count": "6",
                             "exact_replay_ledger_artifact_fill_count": "2",
-                            "runtime_ledger_artifact_row_count": "6",
-                            "runtime_ledger_artifact_fill_count": "2",
                         }
                     ],
                     manifest=manifest,
@@ -771,9 +768,13 @@ class TestStrategyAutoresearch(TestCase):
                 artifact_path.resolve(strict=False),
             )
             self.assertEqual(
-                target["runtime_ledger_artifact_row_count"],
+                target["exact_replay_ledger_artifact_row_count"],
                 "6",
             )
+            self.assertNotIn("runtime_ledger_artifact_refs", target)
+            self.assertNotIn("runtime_ledger_artifact_ref", target)
+            self.assertNotIn("runtime_ledger_artifact_row_count", target)
+            self.assertNotIn("runtime_ledger_artifact_fill_count", target)
             self.assertFalse(target["promotion_allowed"])
             self.assertFalse(target["final_promotion_authorized"])
             self.assertEqual(
@@ -833,8 +834,6 @@ class TestStrategyAutoresearch(TestCase):
                 (
                     artifact_path,
                     absolute_path,
-                    experiment_root / relative_runtime_ref,
-                    experiment_root / "scalar-runtime-ledger.json",
                 ),
             )
 


### PR DESCRIPTION
## Summary

- Remove `runtime_ledger_artifact_*` alias fields from strategy-autoresearch history records when the evidence is exact-replay derived.
- Emit exact-replay artifact refs and counts on runtime-window handoff targets without republishing them as runtime-ledger proof.
- Keep exact-replay ref collection from traversing nested runtime-ledger alias fields.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_strategy_autoresearch.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_autoresearch.py -k 'exact_replay_ledger or runtime_window' -q`
- `cd services/torghut && uv run --frozen ruff check scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
