### PR TITLE
fix(torghut): keep exact replay handoffs out of runtime proof

### DIFF
--- a/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
+++ b/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
@@ -146,7 +146,7 @@ def _build_runtime_window_import_plan(
             runtime_ledger_blockers=runtime_ledger_blockers,
         )
         probation_allowed = not search_blockers
-        artifact_counts = _runtime_ledger_artifact_counts(artifact_ref)
+        artifact_counts = _exact_replay_ledger_artifact_counts(artifact_ref)
         replay_window_metadata = _target_replay_window_metadata(
             best_candidate=best_candidate,
             ranking_policy=ranking_policy,
@@ -165,8 +165,7 @@ def _build_runtime_window_import_plan(
             "source_manifest_ref": source_manifest_ref,
             "dataset_snapshot_ref": dataset_snapshot_ref,
             "artifact_refs": [artifact_ref],
-            "runtime_ledger_artifact_refs": [artifact_ref],
-            "runtime_ledger_artifact_ref": artifact_ref,
+            "exact_replay_ledger_artifact_refs": [artifact_ref],
             "exact_replay_ledger_artifact_ref": artifact_ref,
             "window_start": window_start,
             "window_end": window_end,
@@ -190,9 +189,13 @@ def _build_runtime_window_import_plan(
             "promotion_gate": "runtime_ledger_live_or_live_paper_required",
         }
         if artifact_counts["row_count"] is not None:
-            target["runtime_ledger_artifact_row_count"] = artifact_counts["row_count"]
+            target["exact_replay_ledger_artifact_row_count"] = artifact_counts[
+                "row_count"
+            ]
         if artifact_counts["fill_count"] is not None:
-            target["runtime_ledger_artifact_fill_count"] = artifact_counts["fill_count"]
+            target["exact_replay_ledger_artifact_fill_count"] = artifact_counts[
+                "fill_count"
+            ]
         targets.append(target)
     return {
         "schema_version": RUNTIME_WINDOW_IMPORT_PLAN_SCHEMA_VERSION,
@@ -250,7 +253,7 @@ def _plan_blockers(
     if not artifact_ref:
         blockers.append(
             {
-                "blocker": "runtime_ledger_artifact_ref_missing",
+                "blocker": "exact_replay_ledger_artifact_ref_missing",
                 "candidate_id": candidate_id,
                 "remediation": "enable_exact_replay_ledger_artifact_output",
             }
@@ -373,7 +376,7 @@ def _infer_dataset_snapshot_ref(frontier: Mapping[str, Any]) -> str:
     )
 
 
-def _runtime_ledger_artifact_counts(artifact_ref: str) -> dict[str, int | None]:
+def _exact_replay_ledger_artifact_counts(artifact_ref: str) -> dict[str, int | None]:
     payload = _load_json_mapping(artifact_ref)
     rows = _runtime_ledger_rows(payload)
     row_count = _int_or_none(payload.get("row_count")) or (len(rows) if rows else None)

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -54,6 +54,8 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "exact_replay_ledger_artifact_ref",
     "runtime_ledger_artifact_row_count",
     "runtime_ledger_artifact_fill_count",
+    "exact_replay_ledger_artifact_row_count",
+    "exact_replay_ledger_artifact_fill_count",
     "runtime_ledger_target_metadata_blockers",
     "runtime_ledger_bucket_ref",
     "dependency_quorum_decision",
@@ -2075,14 +2077,12 @@ def _offline_replay_artifact_refs(item: Mapping[str, Any]) -> list[str]:
 def _offline_replay_exact_artifact_refs(item: Mapping[str, Any]) -> list[str]:
     refs: list[str] = []
     metadata = _as_dict(item.get("target_metadata"))
-    for key in ("exact_replay_ledger_artifact_ref", "runtime_ledger_artifact_ref"):
-        ref = _as_text(metadata.get(key))
-        if ref is not None and ref not in refs:
+    ref = _as_text(metadata.get("exact_replay_ledger_artifact_ref"))
+    if ref is not None:
+        refs.append(ref)
+    for ref in _as_text_list(metadata.get("exact_replay_ledger_artifact_refs")):
+        if ref not in refs:
             refs.append(ref)
-    for key in ("exact_replay_ledger_artifact_refs", "runtime_ledger_artifact_refs"):
-        for ref in _as_text_list(metadata.get(key)):
-            if ref not in refs:
-                refs.append(ref)
     return refs
 
 

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -2096,16 +2096,12 @@ def _exact_replay_ledger_refs(value: Any) -> list[str]:
     refs: list[str] = []
     if isinstance(value, Mapping):
         for key, item in value.items():
-            if key in {
-                "exact_replay_ledger_artifact_ref",
-            }:
+            if key == "exact_replay_ledger_artifact_ref":
                 ref = _string(item)
                 if ref:
                     refs.append(ref)
                 continue
-            if key in {
-                "exact_replay_ledger_artifact_refs",
-            }:
+            if key == "exact_replay_ledger_artifact_refs":
                 if isinstance(item, (list, tuple)):
                     refs.extend(ref for raw in item if (ref := _string(raw)))
                 else:

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -247,6 +247,90 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
         self.assertTrue(target.target_metadata["source_collection_authorized"])
         self.assertNotIn("paper_route_probe_symbols", target.target_metadata)
 
+    def test_exact_replay_runtime_window_plan_preserves_exact_counts(
+        self,
+    ) -> None:
+        plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "runtime_window_import_plan": {
+                    "schema_version": "torghut.runtime-window-import-plan.v1",
+                    "source": "exact_replay_ledger_runtime_window_handoff",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "candidate-exact",
+                            "observed_stage": "paper",
+                            "strategy_family": "microbar_cross_sectional_pairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "account_label": "TORGHUT_REPLAY",
+                            "source_kind": (
+                                "simulation_exact_replay_runtime_ledger"
+                            ),
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-pairs-01.json"
+                            ),
+                            "artifact_refs": ["exact-ledger.json"],
+                            "exact_replay_ledger_artifact_refs": [
+                                "exact-ledger.json"
+                            ],
+                            "exact_replay_ledger_artifact_ref": (
+                                "exact-ledger.json"
+                            ),
+                            "exact_replay_ledger_artifact_row_count": 6,
+                            "exact_replay_ledger_artifact_fill_count": 2,
+                            "promotion_allowed": False,
+                            "final_promotion_authorized": False,
+                        }
+                    ],
+                }
+            }
+        )
+
+        targets = renew._runtime_window_targets_from_plan(
+            plan=plan,
+            ref="exact-replay-plan-fixture",
+            args=argparse.Namespace(),
+        )
+
+        self.assertEqual(len(targets), 1)
+        target = targets[0]
+        self.assertEqual(target.artifact_refs, ("exact-ledger.json",))
+        self.assertEqual(
+            target.target_metadata["exact_replay_ledger_artifact_refs"],
+            ["exact-ledger.json"],
+        )
+        self.assertEqual(
+            target.target_metadata["exact_replay_ledger_artifact_ref"],
+            "exact-ledger.json",
+        )
+        self.assertEqual(
+            target.target_metadata["exact_replay_ledger_artifact_row_count"],
+            6,
+        )
+        self.assertEqual(
+            target.target_metadata["exact_replay_ledger_artifact_fill_count"],
+            2,
+        )
+        self.assertNotIn("runtime_ledger_artifact_ref", target.target_metadata)
+        self.assertNotIn("runtime_ledger_artifact_refs", target.target_metadata)
+
+    def test_offline_exact_replay_refs_ignore_runtime_aliases(self) -> None:
+        refs = renew._offline_replay_exact_artifact_refs(
+            {
+                "target_metadata": {
+                    "runtime_ledger_artifact_ref": "runtime-alias.json",
+                    "runtime_ledger_artifact_refs": ["runtime-alias-2.json"],
+                    "exact_replay_ledger_artifact_ref": "exact-ledger.json",
+                    "exact_replay_ledger_artifact_refs": [
+                        "exact-ledger.json",
+                        "exact-ledger-2.json",
+                    ],
+                }
+            }
+        )
+
+        self.assertEqual(refs, ["exact-ledger.json", "exact-ledger-2.json"])
+
     def test_hpairs_source_proof_census_status_is_non_authority_renewal_evidence(
         self,
     ) -> None:

--- a/services/torghut/tests/test_replay_runtime_window_plan.py
+++ b/services/torghut/tests/test_replay_runtime_window_plan.py
@@ -190,9 +190,15 @@ def test_handoff_builds_non_promotional_runtime_window_target(
     assert target["strategy_family"] == "microbar_cross_sectional_pairs"
     assert target["strategy_name"] == "microbar-cross-sectional-pairs-v1"
     assert target["dataset_snapshot_ref"] == "snapshot-1"
-    assert target["runtime_ledger_artifact_refs"] == [str(artifact_path.resolve())]
-    assert target["runtime_ledger_artifact_row_count"] == 6
-    assert target["runtime_ledger_artifact_fill_count"] == 2
+    assert target["exact_replay_ledger_artifact_refs"] == [
+        str(artifact_path.resolve())
+    ]
+    assert target["exact_replay_ledger_artifact_row_count"] == 6
+    assert target["exact_replay_ledger_artifact_fill_count"] == 2
+    assert "runtime_ledger_artifact_ref" not in target
+    assert "runtime_ledger_artifact_refs" not in target
+    assert "runtime_ledger_artifact_row_count" not in target
+    assert "runtime_ledger_artifact_fill_count" not in target
     assert target["replay_window_weekday_count"] == 5
     assert target["replay_min_window_weekday_count"] == 20
     assert target["replay_target_net_pnl_per_day"] == "500"

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -3462,7 +3462,11 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         )
         self.assertEqual(
             triage["candidates"][0]["exact_replay_ledger_artifact_refs"],
-            ["proof/exact-replay-ledger-a.json", "proof/runtime-ledger-a.json"],
+            ["proof/exact-replay-ledger-a.json"],
+        )
+        self.assertIn(
+            "proof/runtime-ledger-a.json",
+            triage["candidates"][0]["source_artifact_refs"],
         )
 
     def test_offline_replay_triage_artifact_payload_variants(

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -771,8 +771,12 @@ class TestStrategyAutoresearch(TestCase):
                 target["exact_replay_ledger_artifact_row_count"],
                 "6",
             )
-            self.assertNotIn("runtime_ledger_artifact_refs", target)
+            self.assertEqual(
+                target["exact_replay_ledger_artifact_fill_count"],
+                "2",
+            )
             self.assertNotIn("runtime_ledger_artifact_ref", target)
+            self.assertNotIn("runtime_ledger_artifact_refs", target)
             self.assertNotIn("runtime_ledger_artifact_row_count", target)
             self.assertNotIn("runtime_ledger_artifact_fill_count", target)
             self.assertFalse(target["promotion_allowed"])
@@ -800,7 +804,6 @@ class TestStrategyAutoresearch(TestCase):
             artifact_path.parent.mkdir(parents=True)
             artifact_path.write_text("{}", encoding="utf-8")
             absolute_path = root / "absolute-exact-replay-ledger.json"
-            relative_runtime_ref = "runtime-ledger.json"
             result_path = experiment_root / "result.json"
             result_path.write_text(
                 json.dumps(
@@ -813,7 +816,7 @@ class TestStrategyAutoresearch(TestCase):
                                     "",
                                 ],
                                 "nested": {
-                                    "runtime_ledger_artifact_ref": relative_runtime_ref,
+                                    "runtime_ledger_artifact_ref": "runtime-ledger.json",
                                     "runtime_ledger_artifact_refs": "scalar-runtime-ledger.json",
                                 },
                             }


### PR DESCRIPTION
## Summary

- Removes exact-replay-to-runtime-ledger artifact alias fields from strategy autoresearch history rows, runtime-window import plans, and exact replay artifact discovery.
- Updates the standalone replay runtime-window handoff builder to emit `exact_replay_ledger_artifact_*` metadata only for exact replay artifacts.
- Preserves exact replay row/fill counts through renewal target metadata and stops offline exact-replay triage from reading runtime artifact aliases.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_strategy_autoresearch.py tests/test_replay_runtime_window_plan.py tests/test_renew_latest_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_renew_latest_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_autoresearch.py tests/test_replay_runtime_window_plan.py tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/replay_runtime_window_plan.py scripts/renew_latest_empirical_promotion_jobs.py scripts/run_strategy_autoresearch_loop.py tests/test_renew_latest_empirical_promotion_jobs.py tests/test_replay_runtime_window_plan.py tests/test_strategy_autoresearch.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
