### PR TITLE
fix(torghut): run import-ready target-plan audits

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6177,8 +6177,8 @@ def trading_paper_route_target_plan() -> JSONResponse:
             live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
             route_reacquisition_book=route_reacquisition_book,
             # Keep this provider endpoint bounded; proof-grade runtime import
-            # audits run from /trading/paper-route-evidence.
-            include_runtime_window_import_audit=False,
+            # audits run only after the runtime window is import-ready.
+            include_runtime_window_import_audit=None,
             target_account_audit_available=settings.trading_mode == "paper",
         )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -7701,11 +7701,33 @@ def _truthy_plan_value(value: object) -> bool:
 def _live_gate_has_source_collection_pending(
     live_submission_gate: Mapping[str, Any],
 ) -> bool:
-    return RUNTIME_LEDGER_SOURCE_COLLECTION_PENDING_BLOCKER in {
+    blocked_reasons = {
         str(reason or "").strip()
         for reason in _as_sequence(live_submission_gate.get("blocked_reasons"))
         if str(reason or "").strip()
     }
+    if RUNTIME_LEDGER_SOURCE_COLLECTION_PENDING_BLOCKER in blocked_reasons:
+        return True
+    if _as_mapping_items(
+        live_submission_gate.get("runtime_ledger_source_collection_candidates")
+    ):
+        return True
+    if (
+        _safe_int(
+            live_submission_gate.get("runtime_ledger_source_collection_candidate_total")
+        )
+        > 0
+    ):
+        return True
+    plan = _as_mapping(
+        live_submission_gate.get("runtime_ledger_paper_probation_import_plan")
+    )
+    if _safe_int(plan.get("source_collection_target_count")) > 0:
+        return True
+    return any(
+        _target_is_runtime_ledger_source_collection(target)
+        for target in _as_mapping_items(plan.get("targets"))
+    )
 
 
 def _target_is_runtime_ledger_source_collection(
@@ -7915,11 +7937,24 @@ def _runtime_ledger_repair_candidates_by_strategy_name(
     live_submission_gate: Mapping[str, Any],
 ) -> dict[str, Mapping[str, Any]]:
     candidates_by_name: dict[str, Mapping[str, Any]] = {}
-    for candidate in _as_mapping_items(
-        live_submission_gate.get("runtime_ledger_repair_candidates")
-    ):
-        for name in _runtime_ledger_repair_candidate_lookup_names(candidate):
-            candidates_by_name.setdefault(name, candidate)
+    candidate_sources = [
+        *[
+            _as_mapping_items(live_submission_gate.get(key))
+            for key in (
+                "runtime_ledger_repair_candidates",
+                "runtime_ledger_source_collection_candidates",
+            )
+        ],
+        _as_mapping_items(
+            _as_mapping(
+                live_submission_gate.get("runtime_ledger_paper_probation_import_plan")
+            ).get("targets")
+        ),
+    ]
+    for candidates in candidate_sources:
+        for candidate in candidates:
+            for name in _runtime_ledger_repair_candidate_lookup_names(candidate):
+                candidates_by_name.setdefault(name, candidate)
     return candidates_by_name
 
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -8418,6 +8418,75 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target["observed_from_contaminated_target"]["order_event_count"], 2
         )
 
+    def test_observed_strategy_source_collection_plan_uses_plan_count_pending(
+        self,
+    ) -> None:
+        plan = paper_route_evidence._observed_strategy_source_collection_import_plan(
+            live_submission_gate={
+                "blocked_reasons": [],
+                "runtime_ledger_repair_candidates": [
+                    {
+                        "hypothesis_id": "H-TSMOM-LIQ-01",
+                        "candidate_id": "candidate-tsmom",
+                        "strategy_family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                    }
+                ],
+                "runtime_ledger_paper_probation_import_plan": {
+                    "source_collection_target_count": 1,
+                    "targets": [],
+                },
+            },
+            candidate_plans=[
+                {
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "candidate-hpairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "window_start": "2026-06-02T13:30:00+00:00",
+                            "window_end": "2026-06-02T20:00:00+00:00",
+                            "paper_route_account_contamination_state": {
+                                "foreign_strategy_counts": {
+                                    "intraday-tsmom-profit-v3": 3,
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+            target_limit=5,
+        )
+
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["candidate_id"], "candidate-tsmom")
+        self.assertEqual(target["runtime_strategy_name"], "intraday-tsmom-profit-v3")
+        self.assertEqual(
+            target["selected_by"], "paper_route_observed_strategy_source_collection"
+        )
+
+    def test_source_collection_pending_accepts_candidate_shapes(self) -> None:
+        self.assertTrue(
+            paper_route_evidence._live_gate_has_source_collection_pending(
+                {
+                    "blocked_reasons": [],
+                    "runtime_ledger_source_collection_candidates": [
+                        {"candidate_id": "candidate-tsmom"}
+                    ],
+                }
+            )
+        )
+        self.assertTrue(
+            paper_route_evidence._live_gate_has_source_collection_pending(
+                {
+                    "blocked_reasons": [],
+                    "runtime_ledger_source_collection_candidate_total": 1,
+                }
+            )
+        )
+
     def test_observed_strategy_source_collection_plan_skips_unmapped_noise(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -9133,7 +9133,7 @@ class TestTradingApi(TestCase):
                     ],
                     live_gate["runtime_ledger_paper_probation_import_plan"],
                 )
-                self.assertFalse(kwargs["include_runtime_window_import_audit"])
+                self.assertIsNone(kwargs["include_runtime_window_import_audit"])
                 self.assertTrue(kwargs["route_reacquisition_book"])
                 return {
                     "schema_version": "torghut.paper-route-target-plan.v1",
@@ -10139,7 +10139,7 @@ class TestTradingApi(TestCase):
             *args: object, **kwargs: object
         ) -> dict[str, object]:
             self.assertEqual(kwargs["route_reacquisition_book"], {})
-            self.assertFalse(kwargs["include_runtime_window_import_audit"])
+            self.assertIsNone(kwargs["include_runtime_window_import_audit"])
             return {
                 "schema_version": "torghut.paper-route-target-plan.v1",
                 "target_count": 1,


### PR DESCRIPTION
## Summary

- Lets `/trading/paper-route-target-plan` defer runtime-window import audits until the runtime window is import-ready instead of hard-disabling them.
- Recognizes source-collection pending state from explicit candidate lists, candidate totals, import-plan source counts, and import-plan targets, not only blocked reasons.
- Indexes observed strategy source-collection candidates from repair candidates, source-collection candidates, and import-plan targets so contaminated observed strategies can resolve to the right source target.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format app/main.py app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_renew_latest_empirical_promotion_jobs.py --cov=app --cov=scripts --cov-report=xml:coverage.xml --cov-report=term` (test body passed with `276 passed`; aggregate fail-under is expected for this focused subset)
- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
