### PR TITLE
fix(autotrader): skip scans for managed broker state

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -13,7 +13,7 @@ import urllib.request
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from zoneinfo import ZoneInfo
 
 from protective_preflight import assert_paper_base_url, normalize_alpaca_base_url
@@ -224,6 +224,46 @@ def list_payload(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
 
 
+def summarized_position(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"raw": value}
+    return {
+        "symbol": value.get("symbol"),
+        "assetClass": value.get("asset_class") or value.get("assetClass"),
+        "side": value.get("side"),
+        "qty": numeric_text(value.get("qty")),
+        "marketValue": numeric_text(value.get("market_value") or value.get("marketValue")),
+        "avgEntryPrice": numeric_text(value.get("avg_entry_price") or value.get("avgEntryPrice")),
+        "currentPrice": numeric_text(value.get("current_price") or value.get("currentPrice")),
+        "unrealizedPnl": numeric_text(value.get("unrealized_pl") or value.get("unrealizedPnl")),
+    }
+
+
+def summarized_order(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"raw": value}
+    legs = value.get("legs")
+    return {
+        "id": value.get("id"),
+        "clientOrderId": value.get("client_order_id") or value.get("clientOrderId"),
+        "symbol": value.get("symbol"),
+        "side": value.get("side"),
+        "qty": numeric_text(value.get("qty")),
+        "filledQty": numeric_text(value.get("filled_qty") or value.get("filledQty")),
+        "type": value.get("type"),
+        "orderClass": value.get("order_class") or value.get("orderClass"),
+        "status": value.get("status"),
+        "limitPrice": numeric_text(value.get("limit_price") or value.get("limitPrice")),
+        "stopPrice": numeric_text(value.get("stop_price") or value.get("stopPrice")),
+        "submittedAt": value.get("submitted_at") or value.get("submittedAt"),
+        "legCount": len(legs) if isinstance(legs, list) else 0,
+    }
+
+
+def summarize_records(values: list[Any], summarize: Callable[[Any], dict[str, Any]], limit: int = 20) -> list[dict[str, Any]]:
+    return [summarize(value) for value in values[:limit]]
+
+
 def account_gate_action(account: dict[str, Any], positions: list[Any], orders: list[Any]) -> str:
     eligibility = account.get("intraday_equity_entry")
     entry_allowed = isinstance(eligibility, dict) and eligibility.get("status") == "allowed"
@@ -250,9 +290,11 @@ def summarize_account_gate(
         "account": account,
         "openPositionCount": len(positions),
         "openOrderCount": len(orders),
+        "openPositions": summarize_records(positions, summarized_position),
+        "openOrders": summarize_records(orders, summarized_order),
         "hasOpenBrokerState": bool(positions or orders),
         "action": action,
-        "skipFullScan": action == "monitor_only",
+        "skipFullScan": action != "scan",
     }
 
 

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -155,14 +155,44 @@ class LiveScanCycleTest(unittest.TestCase):
                 "daytrading_buying_power": "0",
                 "daytrade_count": 5,
             },
-            raw_positions=[{"symbol": "AAPL", "qty": "1"}],
-            raw_orders=[],
+            raw_positions=[
+                {
+                    "symbol": "AAPL",
+                    "qty": "1",
+                    "market_value": "180.50",
+                    "avg_entry_price": "179.00",
+                    "unrealized_pl": "1.50",
+                }
+            ],
+            raw_orders=[
+                {
+                    "id": "order-1",
+                    "client_order_id": "agent-AAPL-protect",
+                    "symbol": "AAPL",
+                    "status": "new",
+                }
+            ],
         )
 
         self.assertEqual(summary["action"], "manage_existing_broker_state")
-        self.assertFalse(summary["skipFullScan"])
+        self.assertTrue(summary["skipFullScan"])
         self.assertTrue(summary["hasOpenBrokerState"])
         self.assertEqual(summary["openPositionCount"], 1)
+        self.assertEqual(summary["openOrderCount"], 1)
+        self.assertEqual(
+            summary["openPositions"][0],
+            {
+                "symbol": "AAPL",
+                "assetClass": None,
+                "side": None,
+                "qty": "1",
+                "marketValue": "180.50",
+                "avgEntryPrice": "179.00",
+                "currentPrice": None,
+                "unrealizedPnl": "1.50",
+            },
+        )
+        self.assertEqual(summary["openOrders"][0]["clientOrderId"], "agent-AAPL-protect")
 
     def test_run_account_gate_fetches_only_broker_state(self) -> None:
         case = self
@@ -441,6 +471,81 @@ class LiveScanCycleTest(unittest.TestCase):
             self.assertEqual(summary["recordedTickets"], [])
             self.assertEqual(summary["recordedAccountGate"]["riskCheckId"], "risk-1")
             self.assertTrue((Path(directory) / "cycle-1").exists())
+
+    def test_run_cycle_respects_account_gate_and_skips_scan_when_managing_existing_state(self) -> None:
+        case = self
+
+        class FakeAlpaca:
+            def __init__(self, *, timeout_seconds: float) -> None:
+                self.timeout_seconds = timeout_seconds
+
+            def trading_get(self, path: str, query: dict[str, str] | None = None) -> object:
+                if path == "/v2/account":
+                    return {
+                        "id": "paper-account",
+                        "equity": "29989.14",
+                        "buying_power": "59978.28",
+                        "daytrading_buying_power": "0",
+                        "daytrade_count": "5",
+                    }
+                if path == "/v2/positions":
+                    case.assertIsNone(query)
+                    return [{"symbol": "NVDA", "qty": "2", "market_value": "240.00"}]
+                if path == "/v2/orders":
+                    case.assertEqual(query, {"status": "open", "nested": "true"})
+                    return [{"id": "order-1", "client_order_id": "agent-NVDA-protect", "symbol": "NVDA"}]
+                raise AssertionError(f"unexpected trading path {path}")
+
+            def data_get(self, path: str, query: dict[str, str]) -> object:
+                raise AssertionError(f"scanner data fetch should be skipped: {path} {query}")
+
+        class FakeSynthesis:
+            def __init__(self, *, base_url: str | None, timeout_seconds: float) -> None:
+                self.base_url = base_url
+                self.timeout_seconds = timeout_seconds
+                self.posts: list[tuple[str, dict[str, object]]] = []
+
+            def get(self, path: str, query: dict[str, str]) -> object:
+                raise AssertionError(f"scorecard fetch should be skipped: {path} {query}")
+
+            def post(self, path: str, payload: dict[str, object]) -> object:
+                self.posts.append((path, payload))
+                if path.endswith("/risk-checks"):
+                    return {"riskCheck": {"id": "risk-1"}}
+                if path.endswith("/status"):
+                    return {"status": {"sessionId": "session-1"}}
+                raise AssertionError(f"unexpected Synthesis path {path}")
+
+        with tempfile.TemporaryDirectory() as directory:
+            args = live_scan_cycle.build_parser().parse_args(
+                [
+                    "--work-dir",
+                    directory,
+                    "--watchlist",
+                    "NVDA",
+                    "--session-id",
+                    "session-1",
+                    "--record-tickets",
+                    "--respect-account-gate",
+                ]
+            )
+            with (
+                patch.object(live_scan_cycle, "AlpacaRestClient", FakeAlpaca),
+                patch.object(live_scan_cycle, "SynthesisClient", FakeSynthesis),
+                patch.object(
+                    live_scan_cycle,
+                    "run_stock_analysis_scan",
+                    lambda **_: (_ for _ in ()).throw(AssertionError("scanner should be skipped")),
+                ),
+            ):
+                summary = live_scan_cycle.run_cycle(args)
+
+            self.assertEqual(summary["action"], "manage_existing_broker_state")
+            self.assertTrue(summary["skipFullScan"])
+            self.assertEqual(summary["resultCount"], 0)
+            self.assertEqual(summary["recordedTickets"], [])
+            self.assertEqual(summary["accountGate"]["openPositions"][0]["symbol"], "NVDA")
+            self.assertEqual(summary["accountGate"]["openOrders"][0]["clientOrderId"], "agent-NVDA-protect")
 
     def test_run_cycle_returns_summary_without_summary_file(self) -> None:
         case = self


### PR DESCRIPTION
## Summary

- Makes `live_scan_cycle.py --respect-account-gate` skip market-data fetches, scorecard reads, scanner execution, and ticket creation for every non-`scan` account-gate outcome.
- Keeps `manage_existing_broker_state` focused on broker-state management by returning compact open position/order summaries instead of generating new entry candidates.
- Adds regression coverage for blocked flat monitoring and blocked-with-open-state management so gated runs cannot accidentally scan/ticket new entries.

## Related Issues

None

## Testing

- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/test_live_scan_cycle.py`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t 'autonomous trader provider'`
- `git diff --check origin/main...HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
