### PR TITLE
fix(torghut): select observed source plans in evidence

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -8597,8 +8597,12 @@ def build_paper_route_evidence_audit(
         )
         for target in _as_mapping_items(next_targets.get("targets"))
     ]
+    raw_next_targets: Mapping[str, Any] = next_targets
+    raw_next_target_audits: list[dict[str, object]] = next_target_audits
     runtime_window_import_plan = next_targets
     runtime_window_import_target_audits = next_target_audits
+    source_targets: Mapping[str, Any] = source_collection_import_plan
+    observed_strategy_source_targets: Mapping[str, Any] = {}
     next_clean_after_discard_targets: Mapping[str, Any] = {}
     latest_closed_runtime_window_import_selection = (
         _runtime_window_import_candidate_selection(
@@ -8671,6 +8675,31 @@ def build_paper_route_evidence_audit(
                     runtime_window_import_plan.get("targets")
                 )
             ]
+    observed_strategy_source_targets = _observed_strategy_source_collection_import_plan(
+        live_submission_gate=live_submission_gate,
+        candidate_plans=(
+            runtime_window_import_plan,
+            latest_closed_targets,
+            raw_next_targets,
+        ),
+        target_limit=effective_target_limit,
+    )
+    if _as_mapping_items(observed_strategy_source_targets.get("targets")):
+        source_targets = observed_strategy_source_targets
+        runtime_window_import_plan = observed_strategy_source_targets
+        runtime_window_import_target_audits = [
+            _target_audit_fail_closed(
+                session,
+                raw_target=target,
+                probe=probe,
+                generated_at=resolved_generated_at,
+                lookback_hours=effective_lookback_hours,
+                error_source="paper_route_observed_strategy_source_target_audit",
+            )
+            for target in _as_mapping_items(runtime_window_import_plan.get("targets"))
+        ]
+        next_targets = observed_strategy_source_targets
+        next_target_audits = runtime_window_import_target_audits
     runtime_window_import_audit = _runtime_window_import_audit(
         next_targets=runtime_window_import_plan,
         target_audits=target_audits,
@@ -8712,10 +8741,10 @@ def build_paper_route_evidence_audit(
     hpairs_zero_activity_diagnostics = _hpairs_zero_activity_diagnostics(
         generated_at=resolved_generated_at,
         probe=probe,
-        next_targets=next_targets,
+        next_targets=raw_next_targets,
         runtime_window_import_audit=runtime_window_import_audit,
         target_audits=target_audits,
-        runtime_window_import_target_audits=runtime_window_import_target_audits,
+        runtime_window_import_target_audits=raw_next_target_audits,
     )
     return {
         "schema_version": PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION,
@@ -8773,8 +8802,15 @@ def build_paper_route_evidence_audit(
         },
         "paper_route_probe": probe,
         "next_paper_route_runtime_window_targets": next_targets,
+        "raw_next_paper_route_runtime_window_targets": (
+            raw_next_targets if raw_next_targets is not next_targets else {}
+        ),
         "latest_closed_paper_route_runtime_window_targets": latest_closed_targets,
         "runtime_window_import_plan": runtime_window_import_plan,
+        "source_runtime_window_import_plan": source_targets,
+        "observed_strategy_source_runtime_window_import_plan": (
+            observed_strategy_source_targets
+        ),
         "latest_closed_runtime_window_import_selection": (
             latest_closed_runtime_window_import_selection
         ),
@@ -8782,11 +8818,34 @@ def build_paper_route_evidence_audit(
             next_clean_after_discard_targets
         ),
         "next_runtime_window_target_audits": next_target_audits,
+        "raw_next_runtime_window_target_audits": (
+            raw_next_target_audits
+            if raw_next_target_audits is not next_target_audits
+            else []
+        ),
         "runtime_window_import_target_audits": runtime_window_import_target_audits,
         "runtime_window_import_audit": runtime_window_import_audit,
         "runtime_ledger_proof_packet_handoff": proof_packet_handoff,
         "summary": {
             "target_count": len(targets),
+            "source_runtime_window_target_count": _safe_int(
+                source_targets.get("target_count")
+            ),
+            "observed_strategy_source_runtime_window_target_count": _safe_int(
+                observed_strategy_source_targets.get("target_count")
+            ),
+            "raw_next_runtime_window_target_count": _safe_int(
+                raw_next_targets.get("target_count")
+            ),
+            "selected_next_runtime_window_target_count": _safe_int(
+                next_targets.get("target_count")
+            ),
+            "selected_next_runtime_window_plan_source": _safe_text(
+                next_targets.get("source")
+            ),
+            "runtime_window_import_plan_source": _safe_text(
+                runtime_window_import_plan.get("source")
+            ),
             "target_with_source_activity_count": sum(
                 int(not bool(_as_mapping(audit.get("source_activity")).get("missing")))
                 for audit in target_audits

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -8358,6 +8358,195 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "paper_route_observed_strategy_source_collection",
         )
 
+    def test_evidence_selects_observed_strategy_source_collection_plan(self) -> None:
+        generated_at = datetime(2026, 6, 2, 22, 30, tzinfo=timezone.utc)
+        window_start = datetime(2026, 6, 2, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 2, 20, tzinfo=timezone.utc)
+        event_at = window_start + timedelta(minutes=30)
+
+        with Session(self.engine) as session:
+            hpairs_strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+            )
+            tsmom_strategy = Strategy(
+                name="intraday-tsmom-profit-v3",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+            )
+            session.add_all([hpairs_strategy, tsmom_strategy])
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=tsmom_strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-tsmom",
+                    "hypothesis_id": "H-TSMOM-LIQ-01",
+                },
+                rationale="foreign TSMOM source collection fixture",
+                status="executed",
+                created_at=event_at,
+                executed_at=event_at,
+            )
+            session.add(decision)
+            session.flush()
+            session.add(
+                Execution(
+                    trade_decision_id=decision.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    alpaca_order_id="tsmom-source-order",
+                    client_order_id="tsmom-source-client",
+                    symbol="AAPL",
+                    side="buy",
+                    order_type="market",
+                    time_in_force="day",
+                    submitted_qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("100"),
+                    status="filled",
+                    raw_order={},
+                    created_at=event_at,
+                    updated_at=event_at,
+                    last_update_at=event_at,
+                )
+            )
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="tsmom-source-order-event",
+                    source_topic="trade_updates",
+                    source_partition=0,
+                    source_offset=101,
+                    alpaca_account_label="TORGHUT_SIM",
+                    event_ts=event_at,
+                    symbol="AAPL",
+                    alpaca_order_id="tsmom-source-order",
+                    client_order_id="tsmom-source-client",
+                    event_type="fill",
+                    status="filled",
+                    raw_event={},
+                    trade_decision_id=decision.id,
+                    created_at=event_at,
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "runtime_ledger_repair_candidates": [
+                        {
+                            "hypothesis_id": "H-TSMOM-LIQ-01",
+                            "candidate_id": "candidate-tsmom",
+                            "observed_stage": "paper",
+                            "strategy_family": "intraday_tsmom_consistent",
+                            "strategy_name": "intraday-tsmom-profit-v3",
+                            "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                            "strategy_id": "intraday_tsmom_v2@research",
+                            "account": "TORGHUT_SIM",
+                            "dataset_snapshot_ref": (
+                                "portfolio-profit-autoresearch-500-v1"
+                            ),
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-tsmom-liq-01.json"
+                            ),
+                            "reason_codes": [
+                                "runtime_ledger_source_collection_pending"
+                            ],
+                        }
+                    ],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": (
+                            "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                        ),
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-hpairs",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": hpairs_strategy.name,
+                                "strategy_id": "hpairs_target_strategy@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": (
+                                    "config/trading/hypotheses/h-pairs-01.json"
+                                ),
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                                "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_active_symbols": ["AAPL", "AMZN"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                        "eligible_symbols": ["AAPL", "AMZN"],
+                    },
+                },
+                generated_at=generated_at,
+            )
+
+        next_plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(
+            next_plan["source"], "paper_route_observed_strategy_source_collection"
+        )
+        self.assertEqual(next_plan["targets"][0]["candidate_id"], "candidate-tsmom")
+        self.assertEqual(
+            next_plan["targets"][0]["selected_by"],
+            "paper_route_observed_strategy_source_collection",
+        )
+        self.assertFalse(next_plan["targets"][0]["promotion_allowed"])
+        self.assertIn(
+            "runtime_ledger_source_collection_only",
+            next_plan["targets"][0]["final_promotion_blockers"],
+        )
+        self.assertEqual(
+            payload["runtime_window_import_plan"]["targets"][0]["candidate_id"],
+            "candidate-tsmom",
+        )
+        self.assertEqual(
+            payload["source_runtime_window_import_plan"]["source"],
+            "paper_route_observed_strategy_source_collection",
+        )
+        raw_next_plan = payload["raw_next_paper_route_runtime_window_targets"]
+        self.assertEqual(
+            raw_next_plan["targets"][0]["candidate_id"], "candidate-hpairs"
+        )
+        self.assertEqual(
+            raw_next_plan["targets"][0]["paper_route_account_contamination_state"][
+                "foreign_strategy_counts"
+            ],
+            {"intraday-tsmom-profit-v3": 1},
+        )
+        self.assertEqual(
+            payload["summary"]["selected_next_runtime_window_plan_source"],
+            "paper_route_observed_strategy_source_collection",
+        )
+
     def test_observed_strategy_source_collection_plan_limits_targets(self) -> None:
         target_template = {
             "hypothesis_id": "H-PAIRS-01",


### PR DESCRIPTION
## Summary

- Select observed runtime-ledger source-collection plans in `/trading/paper-route-evidence` when contaminated H-PAIRS paper-route windows reveal a mapped foreign strategy source target.
- Preserve the rejected H-PAIRS next-window plan under raw diagnostic fields instead of exposing it as the selected import target.
- Add summary counts and source fields so evidence consumers can distinguish raw next-session targets from selected observed source-collection imports.
- Add a regression covering a contaminated H-PAIRS window with observed TSMOM source activity.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_api.py tests/test_renew_latest_empirical_promotion_jobs.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_renew_latest_empirical_promotion_jobs.py -q` passed all 279 tests and produced `coverage.xml`; the command exited 1 because the partial-suite total coverage was 23.16% against the repo-wide 70% fail-under.
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
