### PR TITLE
fix(torghut): retire market context repair lane

### DIFF
--- a/services/torghut/app/trading/evidence_clock_arbiter.py
+++ b/services/torghut/app/trading/evidence_clock_arbiter.py
@@ -322,55 +322,6 @@ def _quant_clock(quant_evidence: Mapping[str, Any]) -> dict[str, object]:
     )
 
 
-def _market_context_clock(
-    market_context_status: Mapping[str, Any],
-) -> dict[str, object]:
-    if not market_context_status:
-        return _clock(
-            name="market_context",
-            state="missing",
-            affected_value_gates=[
-                "zero_notional_or_stale_evidence_rate",
-                "routeable_candidate_count",
-            ],
-            reason_codes=["market_context_missing"],
-        )
-    reasons = [
-        *_strings(market_context_status.get("blocking_reasons")),
-        *_strings(market_context_status.get("reason_codes")),
-        *_strings(market_context_status.get("stale_domains")),
-        *_strings(market_context_status.get("market_context_stale_domains")),
-    ]
-    status = _state_from_status(market_context_status)
-    if status in _BAD_STATES:
-        reasons.append(f"market_context_{status}")
-    domains = _mapping(
-        market_context_status.get("last_domain_states")
-        or market_context_status.get("domain_states")
-        or market_context_status.get("domains")
-    )
-    for domain_name, raw_domain in domains.items():
-        domain = _mapping(raw_domain)
-        domain_status = _state_from_status(domain)
-        if domain_status in _BAD_STATES or _bool(domain.get("stale")):
-            reasons.append(f"market_context_{domain_name}_stale")
-    return _clock(
-        name="market_context",
-        state="current" if not reasons else "stale",
-        affected_value_gates=[
-            "zero_notional_or_stale_evidence_rate",
-            "routeable_candidate_count",
-        ],
-        reason_codes=reasons,
-        as_of=_timestamp_from(
-            market_context_status, "updated_at", "last_updated_at", "last_snapshot_at"
-        ),
-        source_ref=market_context_status.get("receipt_id")
-        or market_context_status.get("bundle_id"),
-        details={"status": status},
-    )
-
-
 def _tca_clock(
     tca_summary: Mapping[str, Any],
     *,
@@ -745,7 +696,6 @@ def _repair_class_for_clock(clock_name: str) -> str:
     return {
         "clickhouse_ta": "market_data_clock_refresh",
         "torghut_quant": "quant_ingestion_repair",
-        "market_context": "market_context_domain_refresh",
         "postgres_tca": "execution_tca_refresh",
         "empirical_replay": "empirical_job_refresh",
         "hypothesis_lineage": "promotion_candidate_generation",
@@ -910,6 +860,7 @@ def build_evidence_clock_arbiter_and_exchange(
     """Build shadow-only clock and candidate projections from existing payloads."""
 
     observed_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    _ = market_context_status
     clocks = [
         _clickhouse_ta_clock(
             _mapping(clickhouse_ta_status),
@@ -917,7 +868,6 @@ def build_evidence_clock_arbiter_and_exchange(
             max_age_seconds=max_clock_age_seconds,
         ),
         _quant_clock(quant_evidence),
-        _market_context_clock(market_context_status),
         _tca_clock(tca_summary, now=observed_at, max_age_seconds=max_clock_age_seconds),
         _empirical_clock(empirical_jobs_status),
         _hypothesis_clock(hypothesis_payload),

--- a/services/torghut/app/trading/freshness_carry.py
+++ b/services/torghut/app/trading/freshness_carry.py
@@ -25,7 +25,6 @@ _MIN_EXPECTED_SHORTFALL_COVERAGE = Decimal("0.50")
 
 _VALUE_GATE_BY_DIMENSION = {
     "ta_signals": "zero_notional_or_stale_evidence_rate",
-    "market_context": "zero_notional_or_stale_evidence_rate",
     "tca": "fill_tca_or_slippage_quality",
     "empirical": "post_cost_daily_net_pnl",
     "quant_evidence": "routeable_candidate_count",
@@ -34,7 +33,6 @@ _VALUE_GATE_BY_DIMENSION = {
 
 _OUTPUT_RECEIPT_BY_DIMENSION = {
     "ta_signals": "torghut.ta-freshness-repair-receipt.v1",
-    "market_context": "torghut.market-context-freshness-receipt.v1",
     "tca": "torghut.execution-tca-refresh-receipt.v1",
     "empirical": "torghut.empirical-proof-refresh-receipt.v1",
     "quant_evidence": "torghut.quant-evidence-refresh-receipt.v1",
@@ -164,7 +162,7 @@ def _dimension(
         "lag_seconds": lag_seconds,
         "low_memory_fallback_count": low_memory_fallback_count,
         "stale_reason_codes": reasons,
-        "required_repair_receipt": _OUTPUT_RECEIPT_BY_DIMENSION[dimension_id],
+        "required_repair_receipt": _OUTPUT_RECEIPT_BY_DIMENSION.get(dimension_id),
         "source_ref": _text(source_ref) or None,
         "max_notional": _ZERO_NOTIONAL,
     }
@@ -389,7 +387,10 @@ def _repair_slos(
         state = _text(dimension.get("state"))
         if not dimension_id or state == "current":
             continue
-        output_receipt = _OUTPUT_RECEIPT_BY_DIMENSION[dimension_id]
+        output_receipt = _OUTPUT_RECEIPT_BY_DIMENSION.get(dimension_id)
+        target_value_gate = _VALUE_GATE_BY_DIMENSION.get(dimension_id)
+        if output_receipt is None or target_value_gate is None:
+            continue
         dispatchable = source_serving_current or dimension_id == "source_serving"
         slos.append(
             {
@@ -403,7 +404,7 @@ def _repair_slos(
                     },
                 ),
                 "target_dimension_id": dimension_id,
-                "target_value_gate": _VALUE_GATE_BY_DIMENSION[dimension_id],
+                "target_value_gate": target_value_gate,
                 "expected_delta": "0.25",
                 "max_runtime_seconds": 900,
                 "max_retries": 1,
@@ -449,10 +450,12 @@ def _capital_posture(
         _text(dimension.get("dimension_id"))
         for dimension in dimensions
         if _text(dimension.get("state")) != "current"
+        and _text(dimension.get("dimension_id")) in _VALUE_GATE_BY_DIMENSION
     ]
     reason_codes = [
         reason
         for dimension in dimensions
+        if _text(dimension.get("dimension_id")) in _VALUE_GATE_BY_DIMENSION
         for reason in _strings(dimension.get("stale_reason_codes"))
     ]
     route_reason = _route_warrant_reason(route_warrant_exchange)
@@ -503,9 +506,20 @@ def _value_gate_impacts(
         state = _text(dimension.get("state"))
         if not dimension_id:
             continue
+        value_gate = _VALUE_GATE_BY_DIMENSION.get(dimension_id)
+        if value_gate is None:
+            impacts.append(
+                {
+                    "value_gate": "diagnostic",
+                    "dimension_id": dimension_id,
+                    "state": state,
+                    "capital_effect": "no_capital_change",
+                }
+            )
+            continue
         impacts.append(
             {
-                "value_gate": _VALUE_GATE_BY_DIMENSION[dimension_id],
+                "value_gate": value_gate,
                 "dimension_id": dimension_id,
                 "state": state,
                 "capital_effect": "max_notional_held_at_zero"

--- a/services/torghut/app/trading/profit_carry_passports.py
+++ b/services/torghut/app/trading/profit_carry_passports.py
@@ -36,17 +36,14 @@ _ACTION_CLASS_DECISIONS = {
 _RECEIPTS_BY_REPAIR_CLASS = {
     "route_rehab": [
         "torghut.execution-tca-current-receipt.v1",
-        "torghut.market-context-current-receipt.v1",
         "torghut.alpha-readiness-current-receipt.v1",
     ],
     "scoped_proof_refill": [
         "torghut.execution-tca-current-receipt.v1",
         "torghut.route-universe-current-receipt.v1",
-        "torghut.market-context-current-receipt.v1",
     ],
     "missing_symbol_breadth_probe": [
         "torghut.route-coverage-current-receipt.v1",
-        "torghut.market-context-current-receipt.v1",
     ],
     "alpha_window_evidence_refill": [
         "torghut.alpha-readiness-current-receipt.v1",

--- a/services/torghut/app/trading/profit_freshness_frontier.py
+++ b/services/torghut/app/trading/profit_freshness_frontier.py
@@ -24,7 +24,6 @@ _BAD_STATES = {"blocked", "degraded", "fail", "missing", "repair", "stale", "unk
 _DIMENSION_EXPECTED_BPS: Mapping[str, Decimal] = {
     "empirical_proof": Decimal("24"),
     "tca_fill_quality": Decimal("22"),
-    "market_context": Decimal("20"),
     "signal_ingestion": Decimal("18"),
     "route_readiness": Decimal("17"),
     "feature_coverage": Decimal("16"),
@@ -35,7 +34,6 @@ _DIMENSION_EXPECTED_BPS: Mapping[str, Decimal] = {
 _DIMENSION_REPAIR_COST: Mapping[str, str] = {
     "empirical_proof": "medium",
     "tca_fill_quality": "medium",
-    "market_context": "low",
     "signal_ingestion": "medium",
     "route_readiness": "medium",
     "feature_coverage": "medium",
@@ -50,7 +48,6 @@ _REPAIR_COST_PENALTY: Mapping[str, Decimal] = {
 }
 _DIMENSION_ACTION: Mapping[str, str] = {
     "signal_ingestion": "refresh_scoped_quant_pipeline_stage_receipts",
-    "market_context": "refresh_stale_market_context_domains",
     "empirical_proof": "renew_empirical_proof_jobs",
     "feature_coverage": "rebuild_required_feature_rows",
     "drift_checks": "rerun_drift_checks_for_blocked_hypotheses",
@@ -61,7 +58,6 @@ _DIMENSION_ACTION: Mapping[str, str] = {
 }
 _DIMENSION_REPAIR_CLASSES: Mapping[str, tuple[str, ...]] = {
     "signal_ingestion": ("quant", "scoped_quant", "signal", "signal_ingestion"),
-    "market_context": ("market_context",),
     "empirical_proof": ("empirical", "empirical_proof", "replay", "simulation"),
     "feature_coverage": ("feature", "feature_coverage"),
     "drift_checks": ("drift", "drift_checks"),
@@ -83,7 +79,6 @@ _DAILY_NET_PNL_UNLOCK_KEYS = (
 )
 _DIMENSION_SUCCESS: Mapping[str, str] = {
     "signal_ingestion": "scoped quant metrics and stage receipts are current",
-    "market_context": "required market-context domains are fresh for the active symbol set",
     "empirical_proof": "all required empirical jobs are fresh, truthful, and promotion eligible",
     "feature_coverage": "required feature rows are present for blocked hypotheses",
     "drift_checks": "drift checks are present for blocked hypotheses",
@@ -92,6 +87,7 @@ _DIMENSION_SUCCESS: Mapping[str, str] = {
     "schema_migration_state": "schema and migration lineage blockers are absent",
     "jangar_settlement": "Jangar reliability settlement allows paper canary consideration",
 }
+_REPAIRABLE_DIMENSIONS = frozenset(_DIMENSION_ACTION)
 _ROUTEABILITY_ONLY_TCA_REASON_CODES = {
     "execution_tca_route_universe_exclusions_applied",
     "execution_tca_symbol_missing",
@@ -1237,6 +1233,7 @@ def build_profit_freshness_frontier(
         )
         for dimension in dimensions
         if _text(dimension.get("state")) != "current"
+        and _text(dimension.get("dimension")) in _REPAIRABLE_DIMENSIONS
     ]
     active_lots.sort(
         key=lambda lot: (

--- a/services/torghut/app/trading/repair_bid_settlement.py
+++ b/services/torghut/app/trading/repair_bid_settlement.py
@@ -94,15 +94,6 @@ _ALPHA_READINESS_STRIKE_REASONS = {
 _PROFIT_FRESHNESS_REPAIR_PRIORITY = 99
 _ZERO_NOTIONAL_TEXT = {"", "0", "0.0", "0.00", "0.0000"}
 _PROFIT_FRESHNESS_ACTION_CONTRACTS: Mapping[str, Mapping[str, object]] = {
-    "refresh_stale_market_context_domains": {
-        "lot_class": "market_context_refresh",
-        "target_value_gate": "zero_notional_or_stale_evidence_rate",
-        "required_output_receipt": "torghut.market-context-freshness-receipt.v1",
-        "validation_command": (
-            "pytest services/torghut/tests/test_zero_notional_repair_executor.py "
-            "-k dispatch_ticket"
-        ),
-    },
     "renew_empirical_proof_jobs": {
         "lot_class": "empirical_replay",
         "target_value_gate": "zero_notional_or_stale_evidence_rate",

--- a/services/torghut/app/trading/repair_receipt_frontier.py
+++ b/services/torghut/app/trading/repair_receipt_frontier.py
@@ -44,7 +44,6 @@ _LOT_CLASS_MAP = {
 }
 _DIMENSION_LOT_CLASS = {
     "signal_ingestion": "signal_ingestion",
-    "market_context": "market_context",
     "empirical_proof": "empirical_proof",
     "feature_coverage": "feature_rows",
     "drift_checks": "feature_rows",
@@ -55,7 +54,6 @@ _DIMENSION_LOT_CLASS = {
 }
 _DIMENSION_VALUE_GATE = {
     "signal_ingestion": "zero_notional_or_stale_evidence_rate",
-    "market_context": "zero_notional_or_stale_evidence_rate",
     "empirical_proof": "post_cost_daily_net_pnl",
     "feature_coverage": "zero_notional_or_stale_evidence_rate",
     "drift_checks": "zero_notional_or_stale_evidence_rate",
@@ -67,7 +65,6 @@ _DIMENSION_VALUE_GATE = {
 _LOT_COST_CLASS = {
     "source_serving": "low",
     "signal_ingestion": "medium",
-    "market_context": "low",
     "empirical_proof": "medium",
     "feature_rows": "medium",
     "execution_tca": "medium",
@@ -300,9 +297,11 @@ def _frontier_lot_from_profit_repair(
     repair: Mapping[str, Any],
     source_serving_ledger: Mapping[str, Any],
     source_current: bool,
-) -> dict[str, object]:
+) -> dict[str, object] | None:
     dimension = _text(repair.get("blocked_dimension"), "unknown")
-    lot_class = _DIMENSION_LOT_CLASS.get(dimension, "feature_rows")
+    lot_class = _DIMENSION_LOT_CLASS.get(dimension)
+    if lot_class is None:
+        return None
     hold_reasons: list[str] = []
     dispatchable, hold_reasons = _lot_dispatchable(
         lot_class=lot_class,
@@ -677,17 +676,20 @@ def build_repair_receipt_frontier(
         for raw_lot in _sequence(repair_bid_settlement_ledger.get("compacted_lots"))
         if _mapping(raw_lot)
     ]
-    profit_lots = [
-        _frontier_lot_from_profit_repair(
-            repair=_mapping(raw_repair),
+    profit_lots: list[dict[str, object]] = []
+    for raw_repair in _sequence(
+        profit_freshness_frontier.get("selected_zero_notional_repairs")
+    ):
+        repair = _mapping(raw_repair)
+        if not repair:
+            continue
+        lot = _frontier_lot_from_profit_repair(
+            repair=repair,
             source_serving_ledger=source_ledger,
             source_current=source_current,
         )
-        for raw_repair in _sequence(
-            profit_freshness_frontier.get("selected_zero_notional_repairs")
-        )
-        if _mapping(raw_repair)
-    ]
+        if lot is not None:
+            profit_lots.append(lot)
     source_lot = _source_serving_lot(source_ledger)
     lots = _dedupe_lots(
         [*([source_lot] if source_lot else []), *compacted_lots, *profit_lots]

--- a/services/torghut/app/trading/route_warrant_exchange.py
+++ b/services/torghut/app/trading/route_warrant_exchange.py
@@ -62,13 +62,6 @@ _WARRANT_DEPENDENCIES = {
         "output_receipt": "torghut.empirical-replay-current-receipt.v1",
         "source_ref": "vnext_empirical_job_runs",
     },
-    "market_context": {
-        "target_dependency": "market_context",
-        "target_value_gate": "zero_notional_or_stale_evidence_rate",
-        "repair_class": "market_context_domain_refresh",
-        "output_receipt": "torghut.market-context-current-receipt.v1",
-        "source_ref": "market_context",
-    },
     "hypothesis_lineage": {
         "target_dependency": "forecast_registry",
         "target_value_gate": "routeable_candidate_count",
@@ -110,7 +103,6 @@ _WITNESS_GROUP_BY_DEPENDENCY = {
     "ingestion_materialization": "ingestion_materialization_witnesses",
     "active_tca": "active_tca_witnesses",
     "empirical": "empirical_replay_witnesses",
-    "market_context": "market_context_witnesses",
     "submission": "capital_submission_witnesses",
     "routeability": "routeability_witnesses",
     "profit_signal": "profit_signal_witnesses",
@@ -283,7 +275,6 @@ def _source_for_clock(
     quant_evidence: Mapping[str, Any],
     tca_summary: Mapping[str, Any],
     empirical_jobs_status: Mapping[str, Any],
-    market_context_status: Mapping[str, Any],
     routeability_repair_acceptance_ledger: Mapping[str, Any],
     live_submission_gate: Mapping[str, Any],
     build: Mapping[str, Any],
@@ -293,7 +284,6 @@ def _source_for_clock(
         "torghut_quant": quant_evidence,
         "postgres_tca": tca_summary,
         "empirical_replay": empirical_jobs_status,
-        "market_context": market_context_status,
         "routeability_acceptance": routeability_repair_acceptance_ledger,
         "capital_gate": live_submission_gate,
         "rollout": build,
@@ -316,12 +306,6 @@ def _source_observed_at(
         ),
         "postgres_tca": ("last_computed_at", "computed_at"),
         "empirical_replay": ("updated_at", "newest_updated_at", "last_completed_at"),
-        "market_context": (
-            "updated_at",
-            "last_updated_at",
-            "last_snapshot_at",
-            "last_checked_at",
-        ),
     }
     return _first_timestamp(
         source,
@@ -626,13 +610,13 @@ def build_route_warrant_exchange(
     """Build a shadow-first route warrant without widening paper or live notional."""
 
     observed_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    _ = market_context_status
     clocks = _clock_by_name(evidence_clock_arbiter)
     required_clock_names = [
         "clickhouse_ta",
         "torghut_quant",
         "postgres_tca",
         "empirical_replay",
-        "market_context",
         "hypothesis_lineage",
         "rollout",
         "routeability_acceptance",
@@ -648,7 +632,6 @@ def build_route_warrant_exchange(
                     quant_evidence=quant_evidence,
                     tca_summary=tca_summary,
                     empirical_jobs_status=empirical_jobs_status,
-                    market_context_status=market_context_status,
                     routeability_repair_acceptance_ledger=routeability_repair_acceptance_ledger,
                     live_submission_gate=live_submission_gate,
                     build=build,

--- a/services/torghut/app/trading/routeability_repair_acceptance.py
+++ b/services/torghut/app/trading/routeability_repair_acceptance.py
@@ -9,13 +9,6 @@ from hashlib import sha256
 import json
 from typing import Any, cast
 
-from .market_context_domains import (
-    ACTIVE_MARKET_CONTEXT_DOMAINS,
-    active_market_context_reasons,
-    is_active_market_context_domain,
-)
-
-
 ROUTEABILITY_REPAIR_ACCEPTANCE_LEDGER_SCHEMA_VERSION = (
     "torghut.routeability-repair-acceptance-ledger.v1"
 )
@@ -33,10 +26,6 @@ _FORECAST_READY = {
     "pass",
     "ready",
     "shadow_ready",
-}
-_MARKET_STALE_COUNT_FIELDS = {
-    "technicals": "stale_technicals_count",
-    "regime": "stale_regime_count",
 }
 _PROMOTION_FRAGMENTS = (
     "autoresearch",
@@ -479,62 +468,6 @@ def _quant_blockers(quant_evidence: Mapping[str, Any]) -> list[str]:
     )
 
 
-def _market_domain_states(
-    market_context_status: Mapping[str, Any],
-) -> Mapping[str, Any]:
-    for field in ("last_domain_states", "domain_states", "domains"):
-        domains = _mapping(market_context_status.get(field))
-        if domains:
-            return domains
-    health = _mapping(market_context_status.get("health"))
-    return _mapping(health.get("domain_states"))
-
-
-def _market_context_blockers(market_context_status: Mapping[str, Any]) -> list[str]:
-    if not market_context_status:
-        return ["market_context_missing"]
-    blockers = active_market_context_reasons(
-        [
-            *_strings(market_context_status.get("blocking_reasons")),
-            *_strings(market_context_status.get("reason_codes")),
-        ]
-    )
-    health = _mapping(market_context_status.get("health"))
-    status = _text(
-        health.get("status")
-        or market_context_status.get("status")
-        or market_context_status.get("state")
-        or market_context_status.get("last_reason")
-    ).lower()
-    if status and status not in _ACCEPTED_STATES and status != "fresh":
-        blockers.append(f"market_context_{status}")
-
-    stale_domains = [
-        domain
-        for domain in _strings(
-            market_context_status.get("stale_domains")
-            or market_context_status.get("market_context_stale_domains")
-        )
-        if is_active_market_context_domain(domain)
-    ]
-    for domain_name, raw_domain in _market_domain_states(market_context_status).items():
-        if not is_active_market_context_domain(domain_name):
-            continue
-        domain = _mapping(raw_domain)
-        domain_status = _text(domain.get("status") or domain.get("state")).lower()
-        if domain.get("stale") is True or domain_status in {
-            "degraded",
-            "missing",
-            "stale",
-        }:
-            stale_domains.append(str(domain_name))
-    for domain_name, field_name in _MARKET_STALE_COUNT_FIELDS.items():
-        if _int(market_context_status.get(field_name)) > 0:
-            stale_domains.append(domain_name)
-    blockers.extend([f"market_context_{domain}_stale" for domain in stale_domains])
-    return _unique(blockers)
-
-
 def _alpha_blockers(
     *,
     proof_floor_receipt: Mapping[str, Any],
@@ -787,6 +720,7 @@ def build_routeability_repair_acceptance_ledger(
     """Build an observe-only acceptance ledger for routeability repair lots."""
 
     observed_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    _ = market_context_status
     generated_at = observed_at.isoformat()
     account = account_label or _text(proof_floor_receipt.get("account_label")) or None
     route_rows = _rows(route_reacquisition_board)
@@ -796,7 +730,6 @@ def build_routeability_repair_acceptance_ledger(
         if _row_state(row) in {"blocked", "missing", "probing"}
     ]
     alpha_rows = [row for row in route_rows if _strings(row.get("hypothesis_ids"))]
-    market_blockers = _market_context_blockers(market_context_status)
     quant_blockers = _quant_blockers(quant_evidence)
     alpha_blockers = _alpha_blockers(
         proof_floor_receipt=proof_floor_receipt,
@@ -844,22 +777,6 @@ def build_routeability_repair_acceptance_ledger(
             acceptance_condition="scoped quant latest metrics and pipeline stages are current",
             next_repair_action="refresh_scoped_quant_pipeline_stage_receipts",
             rollback_trigger="routeability acceptance counts a candidate while scoped quant stages are missing",
-        ),
-        _lot(
-            account=account,
-            window=window,
-            trading_mode=trading_mode,
-            lot_type="market_context_domain_repair",
-            value_gate="zero_notional_or_stale_evidence_rate",
-            expected_gate_delta="retire_stale_market_context_domains",
-            required_receipts=["market_context_domain_receipt"],
-            blockers=market_blockers,
-            acceptance_condition=(
-                f"{', '.join(ACTIVE_MARKET_CONTEXT_DOMAINS)} domains are fresh or not required"
-            ),
-            next_repair_action="refresh_stale_market_context_domains",
-            rollback_trigger="market-context repair accepts a stale domain",
-            symbols=_symbols(route_repair_rows),
         ),
         _lot(
             account=account,

--- a/services/torghut/app/trading/zero_notional_repair_executor.py
+++ b/services/torghut/app/trading/zero_notional_repair_executor.py
@@ -24,13 +24,6 @@ _ALLOWLIST: Mapping[str, Mapping[str, object]] = {
         "value_gate": "zero_notional_or_stale_evidence_rate",
         "rollback_path": "cancel empirical renewal run and keep stale proof lot queued at max_notional=0",
     },
-    "refresh_stale_market_context_domains": {
-        "executor": "market_context_refresh",
-        "runner_required": True,
-        "requires_torghut_admission": True,
-        "value_gate": "zero_notional_or_stale_evidence_rate",
-        "rollback_path": "discard refreshed context receipt and keep prior last-good context decision",
-    },
     "recompute_route_tca_and_fill_quality": {
         "executor": "route_tca_recompute",
         "runner_required": False,
@@ -55,7 +48,6 @@ _ALLOWLIST: Mapping[str, Mapping[str, object]] = {
 }
 _FRESHNESS_DIMENSION_BY_ACTION: Mapping[str, str] = {
     "renew_empirical_proof_jobs": "empirical",
-    "refresh_stale_market_context_domains": "market_context",
     "recompute_route_tca_and_fill_quality": "tca",
 }
 

--- a/services/torghut/tests/test_evidence_clock_arbiter.py
+++ b/services/torghut/tests/test_evidence_clock_arbiter.py
@@ -142,6 +142,31 @@ def test_all_current_clocks_mint_routeable_candidate_with_zero_notional() -> Non
     assert exchange["routeable_candidates"][0]["candidate_id"] == "candidate-micro"
     assert exchange["routeable_candidates"][0]["max_notional"] == "0"
     assert exchange["zero_notional_repair_lots"] == []
+    assert _clock(arbiter, "postgres_tca")["state"] == "current"
+    assert all(clock["name"] != "market_context" for clock in arbiter["clocks"])
+
+
+def test_stale_market_context_is_diagnostic_not_routeability_clock() -> None:
+    arbiter, exchange = _build(
+        market_context_status={
+            "status": "degraded",
+            "last_updated_at": (NOW - timedelta(days=2)).isoformat(),
+            "last_domain_states": {
+                "technicals": {"state": "stale"},
+                "regime": {"state": "stale"},
+            },
+            "blocking_reasons": ["market_context_technicals_stale"],
+        }
+    )
+
+    assert arbiter["routeable_candidate_count"] == 1
+    assert exchange["routeable_candidates"][0]["candidate_id"] == "candidate-micro"
+    assert exchange["zero_notional_repair_lots"] == []
+    assert all(clock["name"] != "market_context" for clock in arbiter["clocks"])
+    assert all(
+        lot["repair_class"] != "market_context_domain_refresh"
+        for lot in exchange["zero_notional_repair_lots"]
+    )
 
 
 def test_fresh_clickhouse_cannot_mint_candidate_when_postgres_tca_is_stale() -> None:

--- a/services/torghut/tests/test_freshness_carry.py
+++ b/services/torghut/tests/test_freshness_carry.py
@@ -287,10 +287,26 @@ def test_malformed_freshness_inputs_are_repair_only_with_typed_reasons() -> None
     assert _dimension(ledger, "tca")["state"] == "missing"
     assert "tca_computed_at_missing" in _dimension(ledger, "tca")["stale_reason_codes"]
     assert _dimension(ledger, "empirical")["state"] == "stale"
-    assert _dimension(ledger, "market_context")["state"] == "stale"
+    market_dimension = _dimension(ledger, "market_context")
+    assert market_dimension["state"] == "stale"
+    assert market_dimension["required_repair_receipt"] is None
     assert (
         "market_context_health_error"
-        in _dimension(ledger, "market_context")["stale_reason_codes"]
+        in market_dimension["stale_reason_codes"]
+    )
+    assert not any(
+        slo["target_dimension_id"] == "market_context"
+        for slo in ledger["repair_proof_slos"]
+    )
+    assert {
+        "value_gate": "diagnostic",
+        "dimension_id": "market_context",
+        "state": "stale",
+        "capital_effect": "no_capital_change",
+    } in ledger["value_gate_impacts"]
+    assert (
+        "market_context"
+        not in ledger["capital_posture"]["non_current_dimension_ids"]
     )
     assert _dimension(ledger, "quant_evidence")["state"] == "stale"
     assert _dimension(ledger, "source_serving")["state"] == "unknown"

--- a/services/torghut/tests/test_profit_carry_passports.py
+++ b/services/torghut/tests/test_profit_carry_passports.py
@@ -185,6 +185,11 @@ def test_profit_carry_passports_cover_named_repair_hypotheses() -> None:
         "torghut.hypothesis-window-evidence-current-receipt.v1",
     ]
     assert all(
+        "torghut.market-context-current-receipt.v1"
+        not in passport["required_receipts"]
+        for passport in passports.values()
+    )
+    assert all(
         passport["schema_version"] == PROFIT_CARRY_PASSPORT_SCHEMA_VERSION
         and passport["max_notional"] == "0"
         and passport["required_receipts"]

--- a/services/torghut/tests/test_profit_freshness_frontier.py
+++ b/services/torghut/tests/test_profit_freshness_frontier.py
@@ -158,9 +158,7 @@ def test_profit_freshness_frontier_ranks_stale_proof_as_zero_notional_repairs() 
 
     assert frontier["schema_version"] == PROFIT_FRESHNESS_FRONTIER_SCHEMA_VERSION
     assert frontier["frontier_state"] == "held"
-    assert (
-        frontier["next_zero_notional_action"] == "refresh_stale_market_context_domains"
-    )
+    assert frontier["next_zero_notional_action"] == "rebuild_required_feature_rows"
     assert frontier["capital_posture"]["capital_state"] == "zero_notional"
     assert frontier["capital_posture"]["paper_notional_limit"] == "0"
     assert frontier["capital_posture"]["live_notional_limit"] == "0"
@@ -170,9 +168,14 @@ def test_profit_freshness_frontier_ranks_stale_proof_as_zero_notional_repairs() 
 
     selected = cast(list[Mapping[str, Any]], frontier["selected_zero_notional_repairs"])
     assert len(selected) == 1
+    assert selected[0]["blocked_dimension"] == "feature_coverage"
     assert selected[0]["state"] == "selected_zero_notional_repair"
     assert selected[0]["paper_notional_limit"] == "0"
     assert selected[0]["live_notional_limit"] == "0"
+    assert "market_context" not in {
+        repair["blocked_dimension"]
+        for repair in cast(list[Mapping[str, Any]], frontier["repair_lots"])
+    }
 
 
 def test_daily_net_pnl_unlock_outranks_bps_proxy_when_profit_packets_are_available() -> (
@@ -183,7 +186,7 @@ def test_daily_net_pnl_unlock_outranks_bps_proxy_when_profit_packets_are_availab
             "frontier_id": "quality-frontier:pnl-unlock",
             "packets": [
                 {
-                    "packet_id": "qapf:market-context-small-unlock",
+                    "packet_id": "qapf:retired-market-context-small-unlock",
                     "repair_class": "market_context",
                     "hypothesis_ref": "H-NVDA",
                     "expected_daily_net_pnl_unlock": "1.25",
@@ -205,7 +208,7 @@ def test_daily_net_pnl_unlock_outranks_bps_proxy_when_profit_packets_are_availab
     assert selected[0]["repair_priority_basis"] == "expected_daily_net_pnl_unlock"
     assert selected[0]["profit_unlock_refs"] == ["qapf:empirical-large-unlock"]
     assert frontier["next_zero_notional_action"] == "renew_empirical_proof_jobs"
-    assert frontier["summary"]["ranked_daily_net_pnl_repair_count"] == 2
+    assert frontier["summary"]["ranked_daily_net_pnl_repair_count"] == 1
     assert frontier["summary"]["selected_expected_daily_net_pnl_unlock"] == "250.5"
     assert frontier["capital_posture"]["capital_state"] == "zero_notional"
 
@@ -436,6 +439,10 @@ def test_stale_market_context_and_empirical_jobs_are_explicit_dimensions() -> No
     assert "market_context_technicals_stale" in market["reason_codes"]
     assert "market_context:regime" in market["evidence_refs"]
     assert "market_context:news" not in market["evidence_refs"]
+    assert "market_context" not in {
+        repair["blocked_dimension"]
+        for repair in cast(list[Mapping[str, Any]], frontier["repair_lots"])
+    }
     assert empirical["state"] == "stale"
     assert "empirical_job_stale:benchmark_parity" in empirical["reason_codes"]
     assert "dataset-nvda" in empirical["evidence_refs"]

--- a/services/torghut/tests/test_repair_bid_settlement.py
+++ b/services/torghut/tests/test_repair_bid_settlement.py
@@ -278,6 +278,41 @@ def test_profit_freshness_selected_repair_becomes_ticketable_zero_notional_lot()
             "frontier_id": "profit-freshness-frontier:test",
             "selected_zero_notional_repairs": [
                 {
+                    "lot_id": "profit-freshness-repair-lot:empirical",
+                    "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                    "blocked_dimension": "empirical_proof",
+                    "zero_notional_action": "renew_empirical_proof_jobs",
+                    "before_refs": ["empirical:INTC"],
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "state": "selected_zero_notional_repair",
+                }
+            ],
+        },
+    )
+    lots_by_id = {lot["lot_id"]: lot for lot in ledger["compacted_lots"]}
+    profit_lot = lots_by_id["profit-freshness-repair-lot:empirical"]
+
+    assert profit_lot["lot_class"] == "empirical_replay"
+    assert profit_lot["target_value_gate"] == "zero_notional_or_stale_evidence_rate"
+    assert (
+        profit_lot["required_output_receipt"]
+        == "torghut.empirical-proof-refresh-receipt.v1"
+    )
+    assert profit_lot["state"] == "selected"
+    assert profit_lot["dispatchable"] is True
+    assert profit_lot["max_notional"] == "0"
+    assert "profit-freshness-repair-lot:empirical" in ledger["selected_lot_ids"]
+    assert "profit-freshness-repair-lot:empirical" in ledger["dispatchable_lot_ids"]
+    assert ledger["max_notional"] == "0"
+
+
+def test_retired_market_context_profit_freshness_repair_is_not_ticketable() -> None:
+    ledger = _build(
+        profit_freshness_frontier={
+            "frontier_id": "profit-freshness-frontier:test",
+            "selected_zero_notional_repairs": [
+                {
                     "lot_id": "profit-freshness-repair-lot:market-context",
                     "candidate_id": "chip-paper-microbar-composite@execution-proof",
                     "blocked_dimension": "market_context",
@@ -290,23 +325,10 @@ def test_profit_freshness_selected_repair_becomes_ticketable_zero_notional_lot()
             ],
         },
     )
-    lots_by_id = {lot["lot_id"]: lot for lot in ledger["compacted_lots"]}
-    profit_lot = lots_by_id["profit-freshness-repair-lot:market-context"]
 
-    assert profit_lot["lot_class"] == "market_context_refresh"
-    assert profit_lot["target_value_gate"] == "zero_notional_or_stale_evidence_rate"
-    assert (
-        profit_lot["required_output_receipt"]
-        == "torghut.market-context-freshness-receipt.v1"
-    )
-    assert profit_lot["state"] == "selected"
-    assert profit_lot["dispatchable"] is True
-    assert profit_lot["max_notional"] == "0"
-    assert "profit-freshness-repair-lot:market-context" in ledger["selected_lot_ids"]
-    assert (
-        "profit-freshness-repair-lot:market-context" in ledger["dispatchable_lot_ids"]
-    )
-    assert ledger["max_notional"] == "0"
+    assert "profit-freshness-repair-lot:market-context" not in {
+        lot["lot_id"] for lot in ledger["compacted_lots"]
+    }
 
 
 def test_profit_freshness_nonzero_repair_is_not_compacted_for_dispatch() -> None:
@@ -316,8 +338,8 @@ def test_profit_freshness_nonzero_repair_is_not_compacted_for_dispatch() -> None
             "selected_zero_notional_repairs": [
                 {
                     "lot_id": "profit-freshness-repair-lot:nonzero",
-                    "blocked_dimension": "market_context",
-                    "zero_notional_action": "refresh_stale_market_context_domains",
+                    "blocked_dimension": "empirical_proof",
+                    "zero_notional_action": "renew_empirical_proof_jobs",
                     "paper_notional_limit": "10",
                     "live_notional_limit": "0",
                     "state": "selected_zero_notional_repair",

--- a/services/torghut/tests/test_repair_receipt_frontier.py
+++ b/services/torghut/tests/test_repair_receipt_frontier.py
@@ -194,6 +194,31 @@ def test_converged_source_allows_compacted_lot_dispatch_without_notional() -> No
     assert frontier["selected_lot_id"] in frontier["dispatchable_lot_ids"]
 
 
+def test_retired_market_context_profit_repair_is_not_frontier_lot() -> None:
+    frontier = _build(
+        source_ledger=_source_ledger(state="converged", reasons=[]),
+        repair_bid_ledger=_repair_bid_ledger(compacted_lots=[]),
+        profit_frontier=_profit_frontier(
+            selected_repairs=[
+                {
+                    "lot_id": "profit-freshness-repair-lot:market-context",
+                    "blocked_dimension": "market_context",
+                    "zero_notional_action": "refresh_stale_market_context_domains",
+                    "expected_profit_unlock_bps": 20,
+                    "repair_cost_class": "low",
+                    "before_refs": ["market_context:diagnostic"],
+                    "state": "selected_zero_notional_repair",
+                }
+            ]
+        ),
+    )
+
+    assert {
+        lot["source_lot_ref"]
+        for lot in cast(list[Mapping[str, Any]], frontier["lots"])
+    }.isdisjoint({"profit-freshness-repair-lot:market-context"})
+
+
 def test_paper_cutover_blocking_lots_rank_ahead_of_generic_stale_evidence() -> None:
     frontier = _build(
         source_ledger=_source_ledger(state="converged", reasons=[]),

--- a/services/torghut/tests/test_routeability_repair_acceptance.py
+++ b/services/torghut/tests/test_routeability_repair_acceptance.py
@@ -156,8 +156,8 @@ def test_routeability_acceptance_ledger_projects_all_doc185_lots_at_zero_notiona
     assert (
         ledger["profit_repair_settlement_ref"] == "profit-repair-settlement-ledger:test"
     )
-    assert ledger["summary"]["lot_count"] == 8
-    assert ledger["summary"]["zero_notional_lot_count"] == 8
+    assert ledger["summary"]["lot_count"] == 7
+    assert ledger["summary"]["zero_notional_lot_count"] == 7
 
     lots = cast(list[Mapping[str, Any]], ledger["lots"])
     assert {lot["paper_notional_limit"] for lot in lots} == {"0"}
@@ -166,7 +166,6 @@ def test_routeability_acceptance_ledger_projects_all_doc185_lots_at_zero_notiona
     assert ledger["promotion_authority"] is False
     assert {lot["lot_type"] for lot in lots} == {
         "quant_scoped_stage_repair",
-        "market_context_domain_repair",
         "alpha_readiness_repair",
         "route_universe_tca_repair",
         "forecast_and_promotion_repair",
@@ -209,18 +208,15 @@ def test_optional_unconfigured_quant_health_does_not_create_routeability_lot() -
     )
 
 
-def test_stale_market_context_domains_keep_acceptance_unsettled() -> None:
+def test_stale_market_context_domains_do_not_create_repair_lot() -> None:
     ledger = _ledger()
-    market_lot = _lot(ledger, "market_context_domain_repair")
 
-    assert market_lot["current_state"] == "stale"
-    assert (
-        market_lot["acceptance_condition"]
-        == "technicals, regime domains are fresh or not required"
-    )
-    assert "market_context_technicals_stale" in market_lot["blocking_reason_codes"]
-    assert "market_context_news_stale" not in market_lot["blocking_reason_codes"]
-    assert "market_context_regime_stale" in market_lot["blocking_reason_codes"]
+    assert "market_context_domain_repair" not in {
+        lot["lot_type"] for lot in cast(list[Mapping[str, Any]], ledger["lots"])
+    }
+    assert "refresh_stale_market_context_domains" not in ledger[
+        "next_safe_repair_actions"
+    ]
 
 
 def test_repair_only_route_tca_and_submit_gate_keep_candidate_count_zero() -> None:
@@ -393,7 +389,7 @@ def test_all_receipts_must_settle_before_accepting_routeable_candidates() -> Non
 
     assert ledger["aggregate_state"] == "accepted"
     assert ledger["accepted_routeable_candidate_count"] == 1
-    assert ledger["summary"]["accepted_lot_count"] == 8
+    assert ledger["summary"]["accepted_lot_count"] == 7
 
 
 def test_blocked_autoresearch_portfolios_keep_promotion_repair_unsettled() -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -2504,7 +2504,7 @@ class TestTradingApi(TestCase):
             routeability["schema_version"],
             "torghut.routeability-repair-acceptance-ledger.v1",
         )
-        self.assertEqual(routeability["summary"]["zero_notional_lot_count"], 8)
+        self.assertEqual(routeability["summary"]["zero_notional_lot_count"], 7)
         self.assertEqual(routeability["accepted_routeable_candidate_count"], 0)
         clearinghouse = payload["route_evidence_clearinghouse_packet"]
         self.assertEqual(
@@ -3732,7 +3732,7 @@ class TestTradingApi(TestCase):
             "torghut.routeability-repair-acceptance-ledger.v1",
         )
         self.assertEqual(status_routeability["accepted_routeable_candidate_count"], 0)
-        self.assertEqual(status_routeability["summary"]["zero_notional_lot_count"], 8)
+        self.assertEqual(status_routeability["summary"]["zero_notional_lot_count"], 7)
         self.assertEqual(
             health_routeability["schema_version"],
             status_routeability["schema_version"],

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -124,12 +124,10 @@ def _paper_route_pre_session_snapshot_as_of(generated_at: datetime) -> datetime:
 def _freshness_carry_ledger_for_test(dimension_id: str) -> dict[str, object]:
     output_receipt_by_dimension = {
         "empirical": "torghut.empirical-proof-refresh-receipt.v1",
-        "market_context": "torghut.market-context-freshness-receipt.v1",
         "tca": "torghut.execution-tca-refresh-receipt.v1",
     }
     value_gate_by_dimension = {
         "empirical": "post_cost_daily_net_pnl",
-        "market_context": "zero_notional_or_stale_evidence_rate",
         "tca": "fill_tca_or_slippage_quality",
     }
     return {
@@ -6909,7 +6907,7 @@ class TestTradingApi(TestCase):
         status_payload = {
             "active_revision": "torghut-00320",
             "freshness_carry_ledger": _freshness_carry_ledger_for_test(
-                "market_context"
+                "empirical"
             ),
             "profit_freshness_frontier": {
                 "frontier_id": "profit-freshness-frontier:test",
@@ -6924,9 +6922,9 @@ class TestTradingApi(TestCase):
                         "lot_id": "profit-freshness-repair-lot:test",
                         "candidate_id": "candidate-a",
                         "hypothesis_id": "H-AAPL",
-                        "blocked_dimension": "market_context",
-                        "zero_notional_action": "refresh_stale_market_context_domains",
-                        "before_refs": ["market_context:AAPL"],
+                        "blocked_dimension": "empirical_proof",
+                        "zero_notional_action": "renew_empirical_proof_jobs",
+                        "before_refs": ["empirical:H-AAPL"],
                         "paper_notional_limit": "0",
                         "live_notional_limit": "0",
                         "state": "selected_zero_notional_repair",
@@ -6950,23 +6948,23 @@ class TestTradingApi(TestCase):
         self.assertFalse(payload["order_submission_enabled"])
         self.assertEqual(payload["paper_notional_limit"], "0")
         self.assertEqual(payload["live_notional_limit"], "0")
-        self.assertEqual(payload["before_refs"], ["market_context:AAPL"])
+        self.assertEqual(payload["before_refs"], ["empirical:H-AAPL"])
         self.assertEqual(
             payload["freshness_carry_ledger_ref"],
             "freshness-carry-ledger:test",
         )
         self.assertEqual(payload["freshness_citation_state"], "cited")
-        self.assertEqual(payload["freshness_dimension_id"], "market_context")
+        self.assertEqual(payload["freshness_dimension_id"], "empirical")
         self.assertEqual(
             payload["freshness_repair_proof_slo_ref"],
-            "freshness-repair-slo:market_context",
+            "freshness-repair-slo:empirical",
         )
 
     def test_zero_notional_repair_endpoint_accepts_dispatch_ticket_body(self) -> None:
         status_payload = {
             "active_revision": "torghut-00320",
             "freshness_carry_ledger": _freshness_carry_ledger_for_test(
-                "market_context"
+                "empirical"
             ),
             "profit_freshness_frontier": {
                 "frontier_id": "profit-freshness-frontier:test",
@@ -6981,9 +6979,9 @@ class TestTradingApi(TestCase):
                         "lot_id": "profit-freshness-repair-lot:test",
                         "candidate_id": "candidate-a",
                         "hypothesis_id": "H-AAPL",
-                        "blocked_dimension": "market_context",
-                        "zero_notional_action": "refresh_stale_market_context_domains",
-                        "before_refs": ["market_context:AAPL"],
+                        "blocked_dimension": "empirical_proof",
+                        "zero_notional_action": "renew_empirical_proof_jobs",
+                        "before_refs": ["empirical:H-AAPL"],
                         "paper_notional_limit": "0",
                         "live_notional_limit": "0",
                         "state": "selected_zero_notional_repair",
@@ -6996,10 +6994,10 @@ class TestTradingApi(TestCase):
             "ticket_id": "repair-lot-dispatch-ticket:test",
             "admission_receipt_id": "repair-bid-admission-receipt:test",
             "torghut_lot_id": "profit-freshness-repair-lot:test",
-            "lot_class": "market_context_refresh",
+            "lot_class": "empirical_replay",
             "target_value_gate": "zero_notional_or_stale_evidence_rate",
             "dedupe_key": "torghut-repair:test",
-            "required_output_receipt": "torghut.market-context-current-receipt.v1",
+            "required_output_receipt": "torghut.empirical-proof-refresh-receipt.v1",
             "launch_allowed": True,
             "launch_reason": "current_zero_notional_compacted_lot",
             "stop_conditions": ["fresh_until_expired", "dedupe_key_became_active"],
@@ -7027,7 +7025,7 @@ class TestTradingApi(TestCase):
             "repair-lot-dispatch-ticket:test",
         )
         self.assertEqual(payload["freshness_citation_state"], "cited")
-        self.assertEqual(payload["freshness_dimension_id"], "market_context")
+        self.assertEqual(payload["freshness_dimension_id"], "empirical")
         self.assertTrue(payload["repair_lot_dispatch_ticket_launch_allowed"])
         self.assertFalse(payload["order_submission_enabled"])
 

--- a/services/torghut/tests/test_zero_notional_repair_executor.py
+++ b/services/torghut/tests/test_zero_notional_repair_executor.py
@@ -15,7 +15,7 @@ from app.trading.zero_notional_repair_executor import (
 NOW = datetime(2026, 5, 13, 0, 20, tzinfo=timezone.utc)
 
 
-def _frontier(action: str = "refresh_stale_market_context_domains") -> dict[str, Any]:
+def _frontier(action: str = "renew_empirical_proof_jobs") -> dict[str, Any]:
     return {
         "schema_version": "torghut.profit-freshness-frontier.v1",
         "frontier_id": "profit-freshness-frontier:test",
@@ -30,9 +30,9 @@ def _frontier(action: str = "refresh_stale_market_context_domains") -> dict[str,
                 "lot_id": "profit-freshness-repair-lot:test",
                 "candidate_id": "candidate-a",
                 "hypothesis_id": "H-AAPL",
-                "blocked_dimension": "market_context",
+                "blocked_dimension": "empirical_proof",
                 "zero_notional_action": action,
-                "before_refs": ["market_context:AAPL"],
+                "before_refs": ["empirical:H-AAPL"],
                 "paper_notional_limit": "0",
                 "live_notional_limit": "0",
                 "state": "selected_zero_notional_repair",
@@ -50,10 +50,10 @@ def _dispatch_ticket(
         "ticket_id": "repair-lot-dispatch-ticket:test",
         "admission_receipt_id": "repair-bid-admission-receipt:test",
         "torghut_lot_id": lot_id,
-        "lot_class": "market_context_refresh",
+        "lot_class": "empirical_replay",
         "target_value_gate": "zero_notional_or_stale_evidence_rate",
         "dedupe_key": "torghut-repair:test",
-        "required_output_receipt": "torghut.market-context-current-receipt.v1",
+        "required_output_receipt": "torghut.empirical-proof-refresh-receipt.v1",
         "launch_allowed": True,
         "launch_reason": "current_zero_notional_compacted_lot",
         "stop_conditions": ["fresh_until_expired", "dedupe_key_became_active"],
@@ -68,18 +68,16 @@ def _dispatch_ticket(
 
 
 def _freshness_carry_ledger(
-    dimension_id: str = "market_context",
+    dimension_id: str = "empirical",
     *,
     dispatchable: bool = True,
 ) -> dict[str, object]:
     output_receipt_by_dimension = {
         "empirical": "torghut.empirical-proof-refresh-receipt.v1",
-        "market_context": "torghut.market-context-freshness-receipt.v1",
         "tca": "torghut.execution-tca-refresh-receipt.v1",
     }
     value_gate_by_dimension = {
         "empirical": "post_cost_daily_net_pnl",
-        "market_context": "zero_notional_or_stale_evidence_rate",
         "tca": "fill_tca_or_slippage_quality",
     }
     return {
@@ -126,17 +124,17 @@ def test_dry_run_receipt_keeps_selected_repair_zero_notional() -> None:
     assert receipt["order_submission_enabled"] is False
     assert receipt["paper_notional_limit"] == "0"
     assert receipt["live_notional_limit"] == "0"
-    assert receipt["before_refs"] == ["market_context:AAPL"]
+    assert receipt["before_refs"] == ["empirical:H-AAPL"]
     assert receipt["value_gate"] == "zero_notional_or_stale_evidence_rate"
     assert receipt["freshness_carry_ledger_ref"] == "freshness-carry-ledger:test"
     assert receipt["freshness_citation_required"] is True
     assert receipt["freshness_citation_state"] == "cited"
-    assert receipt["freshness_dimension_id"] == "market_context"
+    assert receipt["freshness_dimension_id"] == "empirical"
     assert receipt["freshness_repair_proof_slo_ref"] == (
-        "freshness-repair-slo:market_context"
+        "freshness-repair-slo:empirical"
     )
     assert receipt["freshness_required_output_receipts"] == [
-        "torghut.market-context-freshness-receipt.v1"
+        "torghut.empirical-proof-refresh-receipt.v1"
     ]
     assert receipt["requires_repair_lot_dispatch_ticket"] is True
     assert receipt["repair_lot_dispatch_ticket_ref"] is None
@@ -173,6 +171,23 @@ def test_execute_runs_allowlisted_tca_runner_without_widening_notional() -> None
     assert receipt["capital_behavior_changed"] is False
     assert receipt["paper_notional_limit"] == "0"
     assert receipt["live_notional_limit"] == "0"
+
+
+def test_retired_market_context_action_is_unsupported() -> None:
+    receipt = build_zero_notional_repair_execution_receipt(
+        account_label="paper",
+        trading_mode="live",
+        torghut_revision="torghut-00320",
+        source_commit="abc123",
+        profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
+        execute=False,
+        now=NOW,
+    )
+
+    assert receipt["execution_state"] == "unsupported_action"
+    assert receipt["command_exit_code"] == 78
+    assert receipt["executor"] is None
+    assert receipt["order_submission_enabled"] is False
 
 
 def test_execute_runs_allowlisted_drift_runner_without_widening_notional() -> None:
@@ -375,10 +390,10 @@ def test_runner_required_action_does_not_call_runner_without_dispatch_ticket() -
         trading_mode="live",
         torghut_revision="torghut-00320",
         source_commit="abc123",
-        profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
+        profit_freshness_frontier=_frontier("renew_empirical_proof_jobs"),
         execute=True,
         runners={
-            "refresh_stale_market_context_domains": lambda repair: (
+            "renew_empirical_proof_jobs": lambda repair: (
                 called.append(repair)
                 or {
                     "execution_state": "executed",
@@ -405,17 +420,17 @@ def test_runner_required_action_executes_with_matching_dispatch_ticket() -> None
         trading_mode="live",
         torghut_revision="torghut-00320",
         source_commit="abc123",
-        profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
+        profit_freshness_frontier=_frontier("renew_empirical_proof_jobs"),
         execute=True,
         repair_lot_dispatch_ticket=_dispatch_ticket(),
         freshness_carry_ledger=_freshness_carry_ledger(),
         runners={
-            "refresh_stale_market_context_domains": lambda repair: (
+            "renew_empirical_proof_jobs": lambda repair: (
                 called.append(repair)
                 or {
                     "execution_state": "executed",
                     "command_exit_code": 0,
-                    "after_refs": ["market_context:AAPL:refreshed"],
+                    "after_refs": ["empirical:H-AAPL:renewed"],
                 }
             ),
         },
@@ -427,7 +442,7 @@ def test_runner_required_action_executes_with_matching_dispatch_ticket() -> None
     ]
     assert receipt["execution_state"] == "executed"
     assert receipt["command_exit_code"] == 0
-    assert receipt["after_refs"] == ["market_context:AAPL:refreshed"]
+    assert receipt["after_refs"] == ["empirical:H-AAPL:renewed"]
     assert receipt["requires_repair_lot_dispatch_ticket"] is True
     assert (
         receipt["repair_lot_dispatch_ticket_ref"] == "repair-lot-dispatch-ticket:test"
@@ -438,7 +453,7 @@ def test_runner_required_action_executes_with_matching_dispatch_ticket() -> None
     )
     assert receipt["repair_lot_dispatch_ticket_launch_allowed"] is True
     assert receipt["freshness_citation_state"] == "cited"
-    assert receipt["freshness_dimension_id"] == "market_context"
+    assert receipt["freshness_dimension_id"] == "empirical"
     assert receipt["freshness_repair_proof_slo_dispatchable"] is True
     assert receipt["paper_notional_limit"] == "0"
     assert receipt["live_notional_limit"] == "0"
@@ -453,7 +468,7 @@ def test_runner_required_action_rejects_mismatched_dispatch_ticket() -> None:
         trading_mode="live",
         torghut_revision="torghut-00320",
         source_commit="abc123",
-        profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
+        profit_freshness_frontier=_frontier("renew_empirical_proof_jobs"),
         execute=True,
         repair_lot_dispatch_ticket=_dispatch_ticket(
             "profit-freshness-repair-lot:other",
@@ -464,7 +479,7 @@ def test_runner_required_action_rejects_mismatched_dispatch_ticket() -> None:
             },
         ),
         runners={
-            "refresh_stale_market_context_domains": lambda repair: (
+            "renew_empirical_proof_jobs": lambda repair: (
                 called.append(repair)
                 or {
                     "execution_state": "executed",
@@ -498,7 +513,7 @@ def test_runner_required_action_rejects_malformed_dispatch_ticket() -> None:
         trading_mode="live",
         torghut_revision="torghut-00320",
         source_commit="abc123",
-        profit_freshness_frontier=_frontier("refresh_stale_market_context_domains"),
+        profit_freshness_frontier=_frontier("renew_empirical_proof_jobs"),
         execute=True,
         repair_lot_dispatch_ticket={
             "schema_version": "jangar.repair-lot-dispatch-ticket.v0",
@@ -511,7 +526,7 @@ def test_runner_required_action_rejects_malformed_dispatch_ticket() -> None:
             "max_runtime_seconds": "not-a-ttl",
         },
         runners={
-            "refresh_stale_market_context_domains": lambda repair: (
+            "renew_empirical_proof_jobs": lambda repair: (
                 called.append(repair)
                 or {
                     "execution_state": "executed",


### PR DESCRIPTION
## Summary

- Retired market context from the active Torghut repair/proof lane while keeping market-context status as diagnostic readback.
- Removed market-context clocks, route-warrant dependencies, routeability repair lots, repair-bid/frontier contracts, passport receipt requirements, and zero-notional executor support.
- Added regressions proving stale market context no longer creates routeability blockers, repair SLOs, pressure refs, repair packets, or ticketable repair lots.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_profit_freshness_frontier.py tests/test_repair_bid_settlement.py tests/test_zero_notional_repair_executor.py tests/test_repair_receipt_frontier.py tests/test_routeability_repair_acceptance.py tests/test_freshness_carry.py tests/test_route_warrant_exchange.py tests/test_profit_carry_passports.py tests/test_evidence_clock_arbiter.py tests/test_clock_settlement.py tests/test_trading_api.py::TestTradingApi::test_zero_notional_repair_endpoint_returns_dry_run_receipt tests/test_trading_api.py::TestTradingApi::test_zero_notional_repair_endpoint_accepts_dispatch_ticket_body -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/evidence_clock_arbiter.py app/trading/freshness_carry.py app/trading/profit_carry_passports.py app/trading/profit_freshness_frontier.py app/trading/repair_bid_settlement.py app/trading/repair_receipt_frontier.py app/trading/route_warrant_exchange.py app/trading/routeability_repair_acceptance.py app/trading/zero_notional_repair_executor.py tests/test_clock_settlement.py tests/test_evidence_clock_arbiter.py tests/test_freshness_carry.py tests/test_profit_carry_passports.py tests/test_profit_freshness_frontier.py tests/test_repair_bid_settlement.py tests/test_repair_receipt_frontier.py tests/test_route_warrant_exchange.py tests/test_routeability_repair_acceptance.py tests/test_trading_api.py tests/test_zero_notional_repair_executor.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_freshness_carry.py tests/test_profit_carry_passports.py -q`
- `cd services/torghut && uv run --frozen ruff check tests/test_freshness_carry.py tests/test_profit_carry_passports.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
