### PR TITLE
chore(torghut): promote image 2ce62300

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.592.0-89-gab49cc419
+              value: v0.592.0-96-g2ce62300d
             - name: TORGHUT_OPTIONS_COMMIT
-              value: ab49cc419db51b346e9d0251b19abba233b18bfa
+              value: 2ce62300dfe00d0a551e31bc0d90e3cb70cd81ae
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.592.0-89-gab49cc419
+              value: v0.592.0-96-g2ce62300d
             - name: TORGHUT_OPTIONS_COMMIT
-              value: ab49cc419db51b346e9d0251b19abba233b18bfa
+              value: 2ce62300dfe00d0a551e31bc0d90e3cb70cd81ae
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -127,7 +127,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+                  value: sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-02T22:56:33Z"
+        client.knative.dev/updateTimestamp: "2026-06-02T23:30:52Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           ports:
             - name: http1
               containerPort: 8181
@@ -531,11 +531,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.592.0-89-gab49cc419
+              value: v0.592.0-96-g2ce62300d
             - name: TORGHUT_COMMIT
-              value: ab49cc419db51b346e9d0251b19abba233b18bfa
+              value: 2ce62300dfe00d0a551e31bc0d90e3cb70cd81ae
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+              value: sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-02T22:56:33Z"
+        client.knative.dev/updateTimestamp: "2026-06-02T23:30:52Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           ports:
             - name: http1
               containerPort: 8181
@@ -373,11 +373,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.592.0-89-gab49cc419
+              value: v0.592.0-96-g2ce62300d
             - name: TORGHUT_COMMIT
-              value: ab49cc419db51b346e9d0251b19abba233b18bfa
+              value: 2ce62300dfe00d0a551e31bc0d90e3cb70cd81ae
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+              value: sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -83,7 +83,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+                  value: sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -119,7 +119,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -188,6 +188,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+                  value: sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: ab49cc419db51b346e9d0251b19abba233b18bfa
+            value: 2ce62300dfe00d0a551e31bc0d90e3cb70cd81ae
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+            value: sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b1330996769ecdecdc10bffd6e24b95681591fd98e0a11d269cabe0fc76eec5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `2ce62300dfe00d0a551e31bc0d90e3cb70cd81ae`
- Image tag: `2ce62300`
- Image digest: `sha256:009efa3b0243d13d054b3fec14a84311eb5dac4489470b2668c5f2c7a9c310f5`