### PR TITLE
fix(torghut): prefer selected target plans

### DIFF
--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -59,8 +59,18 @@ def paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, A
 
 def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     live_gate = _to_str_map(payload.get("live_submission_gate"))
+    top_level_target_plan = (
+        dict(payload)
+        if str(payload.get("schema_version") or "").strip()
+        == "torghut.paper-route-target-plan.v1"
+        and paper_route_target_plan_targets(payload)
+        else {}
+    )
     next_clean_after_discard_plan = _to_str_map(
         payload.get("next_clean_paper_route_runtime_window_targets_after_discard")
+    )
+    observed_strategy_source_plan = _to_str_map(
+        payload.get("observed_strategy_source_runtime_window_import_plan")
     )
     runtime_window_plan = _to_str_map(payload.get("runtime_window_import_plan"))
     source_runtime_window_plan = _to_str_map(
@@ -70,7 +80,9 @@ def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str
         payload.get("next_paper_route_runtime_window_targets")
     )
     candidate_plans = [
+        top_level_target_plan,
         next_clean_after_discard_plan,
+        observed_strategy_source_plan,
         next_paper_route_plan,
         source_runtime_window_plan,
         runtime_window_plan,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -10701,6 +10701,71 @@ class TestTradingApi(TestCase):
 
         self.assertEqual(plan["targets"][0]["candidate_id"], "c88421d619759b2cfaa6f4d0")
 
+    def test_paper_route_target_plan_payload_prefers_selected_top_level_targets(
+        self,
+    ) -> None:
+        selected_tsmom_target = {
+            "hypothesis_id": "H-TSMOM-LIQ-01",
+            "candidate_id": "ca4e6e3c7d639e3363dc5860",
+            "strategy_name": "intraday-tsmom-profit-v3",
+            "runtime_strategy_name": "intraday-tsmom-profit-v3",
+            "source_kind": "runtime_ledger_source_collection_candidate",
+            "selected_by": "paper_route_observed_strategy_source_collection",
+        }
+        raw_contaminated_hpairs_target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "selected_by": "paper_route_evidence_audit",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_account_contamination_state": {
+                "foreign_strategy_counts": {"intraday-tsmom-profit-v3": 26}
+            },
+        }
+
+        plan = _paper_route_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "source": "paper_route_target_plan_endpoint",
+                "purpose": "observed_strategy_runtime_ledger_source_collection_import",
+                "target_count": 1,
+                "targets": [selected_tsmom_target],
+                "runtime_window_import_plan": {
+                    "schema_version": (
+                        "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                    ),
+                    "source": "paper_route_observed_strategy_source_collection",
+                    "target_count": 1,
+                    "targets": [selected_tsmom_target],
+                },
+                "source_runtime_window_import_plan": {
+                    "schema_version": (
+                        "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                    ),
+                    "source": "paper_route_observed_strategy_source_collection",
+                    "target_count": 1,
+                    "targets": [selected_tsmom_target],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": (
+                        "torghut.next-paper-route-runtime-window-targets.v1"
+                    ),
+                    "source": "paper_route_evidence_audit",
+                    "target_count": 1,
+                    "targets": [raw_contaminated_hpairs_target],
+                },
+            }
+        )
+
+        self.assertEqual(plan["targets"][0]["candidate_id"], "ca4e6e3c7d639e3363dc5860")
+        self.assertEqual(
+            plan["targets"][0]["selected_by"],
+            "paper_route_observed_strategy_source_collection",
+        )
+        self.assertNotIn("paper_route_probe_symbols", plan["targets"][0])
+
     def test_paper_route_target_plan_payload_prefers_next_window_over_closed_import(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Make target-plan payload parsing trust top-level `torghut.paper-route-target-plan.v1` targets as the endpoint-selected plan before nested raw next-window context.
- Include observed strategy source import plans in parser preference before raw next-window plans so downstream target-plan URL consumers follow the selected TSMOM source-collection plan.
- Add a regression matching the live shape where selected TSMOM top-level targets coexist with raw contaminated H-PAIRS nested context.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_target_plan.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan_from_payload or paper_route_target_plan_payload_prefers_selected_top_level_targets' -q`
- `uv run --frozen ruff check app/trading/paper_route_target_plan.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_trading_api.py tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
