### PR TITLE
fix(autotrader): expose session summary counts

### DIFF
--- a/apps/synthesis/src/routes/autotrader.tsx
+++ b/apps/synthesis/src/routes/autotrader.tsx
@@ -21,8 +21,8 @@ import type {
   AutotraderEvent,
   AutotraderOrder,
   AutotraderRiskCheck,
-  AutotraderSession,
   AutotraderSessionDetail,
+  AutotraderSessionSummary,
   AutotraderTradeTicket,
 } from '~/server/autotrader-schema'
 
@@ -36,7 +36,7 @@ export const Route = createFileRoute('/autotrader')({
 const cx = (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' ')
 
 type SessionsResponse = {
-  sessions: AutotraderSession[]
+  sessions: AutotraderSessionSummary[]
 }
 
 async function fetchSessions(): Promise<SessionsResponse> {
@@ -69,6 +69,8 @@ const formatNumber = (value: string | null | undefined) => {
   if (!Number.isFinite(parsed)) return value
   return new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(parsed)
 }
+
+const formatInteger = (value: number) => new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value)
 
 const formatMoney = (value: string | null | undefined) => {
   if (value == null) return 'n/a'
@@ -169,6 +171,16 @@ function AutotraderPage() {
                       <span>{session.tradingDate}</span>
                       <span>{formatDate(session.finalizedAt)}</span>
                     </div>
+                    <div className="mt-2 grid grid-cols-4 gap-x-2 gap-y-1 font-mono text-[0.625rem] text-[#71767b]">
+                      <SessionSummaryCount label="evt" value={session.eventCount} />
+                      <SessionSummaryCount label="tickets" value={session.tradeTicketCount} />
+                      <SessionSummaryCount label="orders" value={session.orderCount} />
+                      <SessionSummaryCount label="fills" value={session.fillCount} />
+                      <SessionSummaryCount label="risk" value={session.riskCheckCount} />
+                      <SessionSummaryCount label="pos" value={session.positionSnapshotCount} />
+                      <SessionSummaryCount label="scores" value={session.scorecardCount} />
+                      <SessionSummaryCount label="examples" value={session.setupExampleCount} />
+                    </div>
                   </button>
                 ))
               ) : (
@@ -218,6 +230,14 @@ function RailLink({
       <span className="[&>svg]:size-6">{icon}</span>
       <span>{children}</span>
     </a>
+  )
+}
+
+function SessionSummaryCount({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="min-w-0 truncate">
+      {label} {formatInteger(value)}
+    </span>
   )
 }
 

--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -514,6 +514,14 @@ describe('synthesis REST auth', () => {
       closingEquity: '38025',
       realizedPnl: '25',
       maxDrawdown: '12',
+      eventCount: 2,
+      tradeTicketCount: 1,
+      riskCheckCount: 0,
+      orderCount: 0,
+      fillCount: 0,
+      positionSnapshotCount: 0,
+      scorecardCount: 1,
+      setupExampleCount: 1,
     })
     expect(detailPayload.session.closingEquity).toBe('38025')
     expect(detailPayload.status.phase).toBe('no_trade')

--- a/apps/synthesis/src/server/autotrader-schema.ts
+++ b/apps/synthesis/src/server/autotrader-schema.ts
@@ -288,6 +288,17 @@ export type AutotraderSession = {
   summary: Record<string, unknown>
 }
 
+export type AutotraderSessionSummary = AutotraderSession & {
+  eventCount: number
+  tradeTicketCount: number
+  riskCheckCount: number
+  orderCount: number
+  fillCount: number
+  positionSnapshotCount: number
+  scorecardCount: number
+  setupExampleCount: number
+}
+
 export type AutotraderStatus = {
   sessionId: string
   cycle: number

--- a/apps/synthesis/src/server/autotrader-store.ts
+++ b/apps/synthesis/src/server/autotrader-store.ts
@@ -19,6 +19,7 @@ import type {
   AutotraderScorecardObservation,
   AutotraderSession,
   AutotraderSessionDetail,
+  AutotraderSessionSummary,
   AutotraderSetupExample,
   AutotraderStartSessionInput,
   AutotraderStatus,
@@ -40,7 +41,7 @@ export type AutotraderStore = {
     scorecards: AutotraderScorecard[]
     setupExamples: AutotraderSetupExample[]
   }>
-  listSessions(limit: number): Promise<AutotraderSession[]>
+  listSessions(limit: number): Promise<AutotraderSessionSummary[]>
   getSessionDetail(sessionId: string): Promise<AutotraderSessionDetail | null>
 }
 
@@ -625,10 +626,11 @@ class InMemoryAutotraderStore implements AutotraderStore {
     return { scorecards, setupExamples }
   }
 
-  async listSessions(limit: number): Promise<AutotraderSession[]> {
+  async listSessions(limit: number): Promise<AutotraderSessionSummary[]> {
     return [...this.sessions.values()]
       .sort((left, right) => Date.parse(right.startedAt) - Date.parse(left.startedAt))
       .slice(0, limit)
+      .map((session) => this.sessionSummary(session))
   }
 
   async getSessionDetail(sessionId: string): Promise<AutotraderSessionDetail | null> {
@@ -678,6 +680,44 @@ class InMemoryAutotraderStore implements AutotraderStore {
     if (!session) throw new Error(`Unknown autotrader session: ${sessionId}`)
     return session
   }
+
+  private sessionSummary(session: AutotraderSession): AutotraderSessionSummary {
+    const sessionId = session.id
+    const tickets = [...this.tickets.values()].filter((ticket) => ticket.sessionId === sessionId)
+    const examples = [...this.examples.values()].filter((example) => example.sessionId === sessionId)
+    const scorecardKeys = new Set([
+      ...examples.map((example) => example.scorecardKey),
+      ...tickets.map((ticket) =>
+        scorecardKeyFor({
+          symbol: ticket.symbol,
+          setupType: ticket.setupType,
+          setupGrade: ticket.setupGrade,
+          regime: ticket.regime,
+          timeBucket: ticket.timeBucket ?? 'unknown',
+        }),
+      ),
+    ])
+    const relationKeys = scorecardRelationKeySet(scorecardRelationsForTickets(tickets))
+    const positionSymbols = new Set(
+      [...this.positions.values()]
+        .filter((snapshot) => snapshot.sessionId === sessionId)
+        .map((snapshot) => snapshot.symbol),
+    )
+
+    return {
+      ...session,
+      eventCount: [...this.events.values()].filter((event) => event.sessionId === sessionId).length,
+      tradeTicketCount: tickets.length,
+      riskCheckCount: [...this.riskChecks.values()].filter((riskCheck) => riskCheck.sessionId === sessionId).length,
+      orderCount: [...this.orders.values()].filter((order) => order.sessionId === sessionId).length,
+      fillCount: [...this.fills.values()].filter((fill) => fill.sessionId === sessionId).length,
+      positionSnapshotCount: positionSymbols.size,
+      scorecardCount: [...this.scorecards.values()].filter(
+        (scorecard) => scorecardKeys.has(scorecard.key) || scorecardMatchesTicketRelation(scorecard, relationKeys),
+      ).length,
+      setupExampleCount: examples.length,
+    }
+  }
 }
 
 type SessionRow = {
@@ -699,6 +739,17 @@ type SessionRow = {
   finalized_at: Date | string | null
   terminal_reason: string | null
   summary: unknown
+}
+
+type SessionSummaryRow = SessionRow & {
+  event_count: number | string | null
+  trade_ticket_count: number | string | null
+  risk_check_count: number | string | null
+  order_count: number | string | null
+  fill_count: number | string | null
+  position_snapshot_count: number | string | null
+  scorecard_count: number | string | null
+  setup_example_count: number | string | null
 }
 
 type StatusRow = {
@@ -879,6 +930,23 @@ const mapSession = (row: SessionRow): AutotraderSession => ({
   finalizedAt: toIso(row.finalized_at),
   terminalReason: row.terminal_reason,
   summary: toPayload(row.summary),
+})
+
+const countFromRow = (value: number | string | null | undefined) => {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const mapSessionSummary = (row: SessionSummaryRow): AutotraderSessionSummary => ({
+  ...mapSession(row),
+  eventCount: countFromRow(row.event_count),
+  tradeTicketCount: countFromRow(row.trade_ticket_count),
+  riskCheckCount: countFromRow(row.risk_check_count),
+  orderCount: countFromRow(row.order_count),
+  fillCount: countFromRow(row.fill_count),
+  positionSnapshotCount: countFromRow(row.position_snapshot_count),
+  scorecardCount: countFromRow(row.scorecard_count),
+  setupExampleCount: countFromRow(row.setup_example_count),
 })
 
 const mapStatus = (row: StatusRow): AutotraderStatus => ({
@@ -1543,13 +1611,47 @@ class PostgresAutotraderStore implements AutotraderStore {
     return { scorecards, setupExamples }
   }
 
-  async listSessions(limit: number): Promise<AutotraderSession[]> {
+  async listSessions(limit: number): Promise<AutotraderSessionSummary[]> {
     await this.ensureSchema()
-    const result = await this.pool.query<SessionRow>(
-      `SELECT * FROM autotrader.sessions ORDER BY started_at DESC LIMIT $1`,
+    const result = await this.pool.query<SessionSummaryRow>(
+      `SELECT
+         s.*,
+         (SELECT COUNT(*)::int FROM autotrader.events e WHERE e.session_id = s.id) AS event_count,
+         (SELECT COUNT(*)::int FROM autotrader.trade_tickets t WHERE t.session_id = s.id)
+           AS trade_ticket_count,
+         (SELECT COUNT(*)::int FROM autotrader.risk_checks rc WHERE rc.session_id = s.id)
+           AS risk_check_count,
+         (SELECT COUNT(*)::int FROM autotrader.orders o WHERE o.session_id = s.id) AS order_count,
+         (SELECT COUNT(*)::int FROM autotrader.fills f WHERE f.session_id = s.id) AS fill_count,
+         (
+           SELECT COUNT(DISTINCT ps.symbol)::int
+           FROM autotrader.position_snapshots ps
+           WHERE ps.session_id = s.id
+         ) AS position_snapshot_count,
+         (
+           SELECT COUNT(*)::int
+           FROM autotrader.scorecards sc
+           WHERE EXISTS (
+             SELECT 1
+             FROM autotrader.setup_examples se
+             WHERE se.session_id = s.id AND se.scorecard_key = sc.key
+           )
+           OR EXISTS (
+             SELECT 1
+             FROM autotrader.trade_tickets t
+             WHERE t.session_id = s.id
+               AND upper(t.symbol) = upper(sc.symbol)
+               AND t.setup_type = sc.setup_type
+           )
+         ) AS scorecard_count,
+         (SELECT COUNT(*)::int FROM autotrader.setup_examples se WHERE se.session_id = s.id)
+           AS setup_example_count
+       FROM autotrader.sessions s
+       ORDER BY s.started_at DESC
+       LIMIT $1`,
       [limit],
     )
-    return result.rows.map(mapSession)
+    return result.rows.map(mapSessionSummary)
   }
 
   async getSessionDetail(sessionId: string): Promise<AutotraderSessionDetail | null> {


### PR DESCRIPTION
## Summary

- Adds `AutotraderSessionSummary` responses with per-session counts for events, tickets, risk checks, orders, fills, latest-position symbols, linked scorecards, and setup examples.
- Computes summary counts in both in-memory and Postgres autotrader stores without expanding full detail arrays.
- Shows the counts in the Synthesis autotrader session sidebar so operator readback no longer requires opening each session detail.
- Locks the REST count contract with an API regression test.

## Related Issues

None

## Testing

- `bun run --filter synthesis test -- src/server/__tests__/api.test.ts -t "serves canonical autotrader state"`
- `bunx oxfmt --check apps/synthesis/src/server/autotrader-schema.ts apps/synthesis/src/server/autotrader-store.ts apps/synthesis/src/routes/autotrader.tsx apps/synthesis/src/server/__tests__/api.test.ts`
- `bun run --filter synthesis test -- src/server/__tests__/api.test.ts`
- `bun run --filter synthesis lint`
- `bun run --filter synthesis build`
- Read-only live SQL aggregate query against `synthesis-db` returned counts for the latest 3 sessions.
- Browser smoke: opened `http://localhost:4273/autotrader` with Playwright and verified the route rendered the local empty-memory state.

## Screenshots (if applicable)

N/A. Local browser smoke verified route render; local memory storage had no sessions to show live counts.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
