### PR TITLE
chore(torghut): promote image 5aad543b

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.592.0-99-g9d2fb4077
+              value: v0.592.1-1-g5aad543bd
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9d2fb407789ab30a80a47db868f49988d2023093
+              value: 5aad543bded593af4f496022e2cf72324cebc18f
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.592.0-99-g9d2fb4077
+              value: v0.592.1-1-g5aad543bd
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9d2fb407789ab30a80a47db868f49988d2023093
+              value: 5aad543bded593af4f496022e2cf72324cebc18f
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -127,7 +127,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+                  value: sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-02T23:42:05Z"
+        client.knative.dev/updateTimestamp: "2026-06-03T00:08:15Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           ports:
             - name: http1
               containerPort: 8181
@@ -531,11 +531,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.592.0-99-g9d2fb4077
+              value: v0.592.1-1-g5aad543bd
             - name: TORGHUT_COMMIT
-              value: 9d2fb407789ab30a80a47db868f49988d2023093
+              value: 5aad543bded593af4f496022e2cf72324cebc18f
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+              value: sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-02T23:42:05Z"
+        client.knative.dev/updateTimestamp: "2026-06-03T00:08:15Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           ports:
             - name: http1
               containerPort: 8181
@@ -373,11 +373,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.592.0-99-g9d2fb4077
+              value: v0.592.1-1-g5aad543bd
             - name: TORGHUT_COMMIT
-              value: 9d2fb407789ab30a80a47db868f49988d2023093
+              value: 5aad543bded593af4f496022e2cf72324cebc18f
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+              value: sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -83,7 +83,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+                  value: sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -119,7 +119,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -188,6 +188,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+                  value: sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: 9d2fb407789ab30a80a47db868f49988d2023093
+            value: 5aad543bded593af4f496022e2cf72324cebc18f
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+            value: sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f2186653520ee8669b617761bb118e02aa21371df1aec654666efc8ab4dd7f74
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- Promote Torghut GitOps manifests to image digest `sha256:0fc298a1e51f17094fae8d6e4774bcb80e80359695eb4d4f16e043b7c0cc01c3`.
- Set Torghut runtime metadata to source commit `5aad543bded593af4f496022e2cf72324cebc18f` and image tag `5aad543b`.
- Update Torghut service, sim service, workflow, cronjob, job, and options deployment manifests consistently.

## Related Issues

None

## Testing

- `torghut-build-push` run `26855334512` completed successfully and produced the release contract for source commit `5aad543bded593af4f496022e2cf72324cebc18f`.
- `torghut-release` run `26855493098` completed successfully and created this deploy PR.
- PR checks are required before merge: `argo-lint`, `kubeconform`, `torghut-ci` release manifest check, semantic title/commit checks, and deploy automerge gate.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
