### PR TITLE
chore(synthesis): promote image 0.592.1

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.592.0
+    newTag: 0.592.1
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promotes the Synthesis GitOps image tag from `0.592.0` to `0.592.1`.
- Deploys the image built from merged PR #9981 so live autotrader session summaries expose count fields.
- Keeps the change scoped to `argocd/applications/synthesis/kustomization.yaml`.

## Related Issues

None

## Testing

- `git diff --check`
- `kubectl kustomize argocd/applications/synthesis | rg -n "image: registry.ide-newton.ts.net/lab/synthesis|kind: Deployment|name: synthesis" -C 3`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A. GitOps image-tag promotion only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
