### PR TITLE
fix(torghut): preserve bounded paper-route evidence

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -9196,8 +9196,6 @@ def build_paper_route_evidence_audit(
             )
             for target in _as_mapping_items(runtime_window_import_plan.get("targets"))
         ]
-        next_targets = observed_strategy_source_targets
-        next_target_audits = runtime_window_import_target_audits
     runtime_window_import_audit = _runtime_window_import_audit(
         next_targets=runtime_window_import_plan,
         target_audits=target_audits,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -8545,38 +8545,55 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
         next_plan = payload["next_paper_route_runtime_window_targets"]
         self.assertEqual(
-            next_plan["source"], "paper_route_observed_strategy_source_collection"
+            next_plan["schema_version"],
+            paper_route_evidence.NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION,
         )
-        self.assertEqual(next_plan["targets"][0]["candidate_id"], "candidate-tsmom")
+        self.assertEqual(next_plan["source"], "paper_route_evidence_audit")
+        self.assertEqual(next_plan["targets"][0]["candidate_id"], "candidate-hpairs")
         self.assertEqual(
             next_plan["targets"][0]["selected_by"],
-            "paper_route_observed_strategy_source_collection",
+            "paper_route_evidence_audit",
         )
         self.assertFalse(next_plan["targets"][0]["promotion_allowed"])
         self.assertIn(
-            "runtime_ledger_source_collection_only",
+            "paper_route_runtime_ledger_import_pending",
             next_plan["targets"][0]["final_promotion_blockers"],
         )
+        runtime_plan = payload["runtime_window_import_plan"]
         self.assertEqual(
-            payload["runtime_window_import_plan"]["targets"][0]["candidate_id"],
-            "candidate-tsmom",
+            runtime_plan["source"], "paper_route_observed_strategy_source_collection"
+        )
+        self.assertEqual(runtime_plan["targets"][0]["candidate_id"], "candidate-tsmom")
+        self.assertEqual(
+            runtime_plan["targets"][0]["selected_by"],
+            "paper_route_observed_strategy_source_collection",
+        )
+        self.assertFalse(runtime_plan["targets"][0]["promotion_allowed"])
+        self.assertIn(
+            "runtime_ledger_source_collection_only",
+            runtime_plan["targets"][0]["final_promotion_blockers"],
         )
         self.assertEqual(
             payload["source_runtime_window_import_plan"]["source"],
             "paper_route_observed_strategy_source_collection",
         )
-        raw_next_plan = payload["raw_next_paper_route_runtime_window_targets"]
         self.assertEqual(
-            raw_next_plan["targets"][0]["candidate_id"], "candidate-hpairs"
+            payload["observed_strategy_source_runtime_window_import_plan"]["source"],
+            "paper_route_observed_strategy_source_collection",
         )
+        self.assertEqual(payload["raw_next_paper_route_runtime_window_targets"], {})
         self.assertEqual(
-            raw_next_plan["targets"][0]["paper_route_account_contamination_state"][
+            next_plan["targets"][0]["paper_route_account_contamination_state"][
                 "foreign_strategy_counts"
             ],
             {"intraday-tsmom-profit-v3": 1},
         )
         self.assertEqual(
             payload["summary"]["selected_next_runtime_window_plan_source"],
+            "paper_route_evidence_audit",
+        )
+        self.assertEqual(
+            payload["summary"]["runtime_window_import_plan_source"],
             "paper_route_observed_strategy_source_collection",
         )
 


### PR DESCRIPTION
## Summary

- Preserve the bounded `next_paper_route_runtime_window_targets` schema in `/trading/paper-route-evidence` when observed-strategy source collection is selected for runtime import.
- Keep the observed-strategy source collection plan in `runtime_window_import_plan` and source-plan fields instead of clobbering the public next-window target plan.
- Update the regression fixture to assert both contracts: bounded next-window evidence for post-deploy validation and observed-strategy import selection for runtime source collection.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_evidence_selects_observed_strategy_source_collection_plan -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_from_payload_prefers_next_window_targets tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_payload_prefers_selected_top_level_targets tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_payload_prefers_next_window_over_closed_import tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_from_payload_prefers_clean_after_discard tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_from_payload_falls_back_to_source_plan tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_from_payload_requires_targets -q`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
