### PR TITLE
fix(torghut): summarize selected source activity readback

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -9211,23 +9211,41 @@ def build_paper_route_evidence_audit(
         next_targets=runtime_window_import_plan,
         runtime_window_import_audit=runtime_window_import_audit,
     )
+    summary_target_audits: Sequence[Mapping[str, object]]
+    summary_target_audit_source: str
+    if (
+        _as_mapping_items(observed_strategy_source_targets.get("targets"))
+        and runtime_window_import_target_audits
+    ):
+        summary_target_audits = runtime_window_import_target_audits
+        summary_target_audit_source = "runtime_window_import_target_audits"
+    else:
+        summary_target_audits = target_audits
+        summary_target_audit_source = "paper_route_source_target_audits"
+    source_plan_target_counts = _runtime_window_target_counts(target_audits)
+    summary_target_counts = _runtime_window_target_counts(summary_target_audits)
     summary_blockers = sorted(
         {
             str(blocker)
-            for audit in target_audits
+            for audit in summary_target_audits
             for blocker in _as_sequence(
                 _as_mapping(audit.get("readiness")).get("blockers")
             )
         }
+        | {
+            str(blocker).strip()
+            for blocker in _as_sequence(runtime_window_import_audit.get("blockers"))
+            if str(blocker).strip()
+        }
     )
     if not targets:
-        summary_blockers.append("paper_probation_import_plan_missing")
+        summary_blockers = ["paper_probation_import_plan_missing"]
     readback_items = [
-        _as_mapping(audit.get("evidence_readback")) for audit in target_audits
+        _as_mapping(audit.get("evidence_readback")) for audit in summary_target_audits
     ]
     source_activity_limits = [
         _as_mapping(_as_mapping(audit.get("source_activity")).get("query_limits"))
-        for audit in target_audits
+        for audit in summary_target_audits
     ]
     truncated_source_names = sorted(
         {
@@ -9344,52 +9362,36 @@ def build_paper_route_evidence_audit(
             "runtime_window_import_plan_source": _safe_text(
                 runtime_window_import_plan.get("source")
             ),
-            "target_with_source_activity_count": sum(
-                int(not bool(_as_mapping(audit.get("source_activity")).get("missing")))
-                for audit in target_audits
+            "summary_target_count": len(summary_target_audits),
+            "summary_target_audit_source": summary_target_audit_source,
+            "source_plan_target_with_source_activity_count": (
+                source_plan_target_counts["source_activity"]
             ),
-            "target_with_rejected_signal_activity_count": sum(
-                int(
-                    _safe_int(
-                        _as_mapping(audit.get("rejected_signal_activity")).get(
-                            "event_count"
-                        )
-                    )
-                    > 0
-                )
-                for audit in target_audits
+            "source_plan_target_with_rejected_signal_activity_count": (
+                source_plan_target_counts["rejected_signal_activity"]
             ),
-            "target_with_runtime_ledger_count": sum(
-                int(
-                    _safe_int(
-                        _as_mapping(audit.get("runtime_ledger")).get("bucket_count")
-                    )
-                    > 0
-                )
-                for audit in target_audits
+            "source_plan_target_with_runtime_ledger_count": (
+                source_plan_target_counts["runtime_ledger"]
             ),
-            "target_with_evidence_grade_runtime_ledger_count": sum(
-                int(
-                    _safe_int(
-                        _as_mapping(audit.get("runtime_ledger")).get(
-                            "evidence_grade_bucket_count"
-                        )
-                    )
-                    > 0
-                )
-                for audit in target_audits
+            "source_plan_target_with_evidence_grade_runtime_ledger_count": (
+                source_plan_target_counts["evidence_grade_runtime_ledger"]
             ),
-            "target_with_promotion_decision_count": sum(
-                int(
-                    _safe_int(
-                        _as_mapping(audit.get("promotion_decisions")).get(
-                            "decision_count"
-                        )
-                    )
-                    > 0
-                )
-                for audit in target_audits
+            "source_plan_target_with_promotion_decision_count": (
+                source_plan_target_counts["promotion_decision"]
             ),
+            "target_with_source_activity_count": summary_target_counts[
+                "source_activity"
+            ],
+            "target_with_rejected_signal_activity_count": summary_target_counts[
+                "rejected_signal_activity"
+            ],
+            "target_with_runtime_ledger_count": summary_target_counts["runtime_ledger"],
+            "target_with_evidence_grade_runtime_ledger_count": summary_target_counts[
+                "evidence_grade_runtime_ledger"
+            ],
+            "target_with_promotion_decision_count": summary_target_counts[
+                "promotion_decision"
+            ],
             "readback": {
                 "schema_version": "torghut.paper-route-evidence-readback-summary.v1",
                 "target_count": len(readback_items),
@@ -9442,7 +9444,7 @@ def build_paper_route_evidence_audit(
                         )
                     )
                 )
-                for audit in target_audits
+                for audit in summary_target_audits
             ),
             "final_promotion_allowed_count": sum(
                 int(
@@ -9452,7 +9454,7 @@ def build_paper_route_evidence_audit(
                         )
                     )
                 )
-                for audit in target_audits
+                for audit in summary_target_audits
             ),
             "stripped_source_promotion_authority_count": sum(
                 int(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -8432,43 +8432,66 @@ class TestPaperRouteEvidenceAudit(TestCase):
             )
             session.add(decision)
             session.flush()
-            session.add(
-                Execution(
-                    trade_decision_id=decision.id,
-                    alpaca_account_label="TORGHUT_SIM",
-                    alpaca_order_id="tsmom-source-order",
-                    client_order_id="tsmom-source-client",
-                    symbol="AAPL",
-                    side="buy",
-                    order_type="market",
-                    time_in_force="day",
-                    submitted_qty=Decimal("1"),
-                    filled_qty=Decimal("1"),
-                    avg_fill_price=Decimal("100"),
-                    status="filled",
-                    raw_order={},
-                    created_at=event_at,
-                    updated_at=event_at,
-                    last_update_at=event_at,
-                )
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="tsmom-source-order",
+                client_order_id="tsmom-source-client",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=event_at,
+                updated_at=event_at,
+                last_update_at=event_at,
             )
-            session.add(
-                ExecutionOrderEvent(
-                    event_fingerprint="tsmom-source-order-event",
-                    source_topic="trade_updates",
-                    source_partition=0,
-                    source_offset=101,
-                    alpaca_account_label="TORGHUT_SIM",
-                    event_ts=event_at,
-                    symbol="AAPL",
-                    alpaca_order_id="tsmom-source-order",
-                    client_order_id="tsmom-source-client",
-                    event_type="fill",
-                    status="filled",
-                    raw_event={},
-                    trade_decision_id=decision.id,
-                    created_at=event_at,
-                )
+            session.add(execution)
+            session.flush()
+            session.add_all(
+                [
+                    ExecutionOrderEvent(
+                        event_fingerprint="tsmom-source-order-event",
+                        source_topic="trade_updates",
+                        source_partition=0,
+                        source_offset=101,
+                        alpaca_account_label="TORGHUT_SIM",
+                        event_ts=event_at,
+                        symbol="AAPL",
+                        alpaca_order_id="tsmom-source-order",
+                        client_order_id="tsmom-source-client",
+                        event_type="fill",
+                        status="filled",
+                        raw_event={},
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        created_at=event_at,
+                    ),
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=tsmom_strategy.id,
+                        alpaca_account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        side="buy",
+                        arrival_price=Decimal("99"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=Decimal("1"),
+                        slippage_bps=Decimal("10"),
+                        shortfall_notional=Decimal("1"),
+                        realized_shortfall_bps=Decimal("10"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=event_at,
+                        created_at=event_at,
+                        updated_at=event_at,
+                    ),
+                ]
             )
             session.commit()
 
@@ -8579,6 +8602,25 @@ class TestPaperRouteEvidenceAudit(TestCase):
             payload["summary"]["selected_next_runtime_window_plan_source"],
             "paper_route_observed_strategy_source_collection",
         )
+        summary = payload["summary"]
+        self.assertEqual(
+            summary["summary_target_audit_source"],
+            "runtime_window_import_target_audits",
+        )
+        self.assertEqual(summary["source_plan_target_with_source_activity_count"], 0)
+        self.assertEqual(summary["target_with_source_activity_count"], 1)
+        self.assertEqual(summary["target_with_runtime_ledger_count"], 0)
+        self.assertEqual(
+            summary["runtime_window_import_target_with_source_activity_count"], 1
+        )
+        self.assertEqual(summary["readback"]["source_decisions_present_count"], 1)
+        self.assertEqual(summary["readback"]["submitted_lifecycle_present_count"], 1)
+        self.assertEqual(summary["readback"]["fills_or_executions_present_count"], 1)
+        self.assertEqual(summary["readback"]["source_refs_present_count"], 1)
+        self.assertNotIn("source_decisions_missing", summary["blockers"])
+        self.assertNotIn("source_executions_missing", summary["blockers"])
+        self.assertNotIn("source_tca_missing", summary["blockers"])
+        self.assertIn("runtime_ledger_bucket_missing", summary["blockers"])
 
     def test_observed_strategy_source_collection_plan_limits_targets(self) -> None:
         target_template = {


### PR DESCRIPTION
## Summary

- Summarize paper-route evidence from the selected runtime-window import audits when a source-collection plan replaces the raw source plan.
- Keep raw source-plan source-activity counts visible under explicit `source_plan_target_with_*` fields.
- Add a regression for observed TSMOM source collection with executions, fills, TCA, and raw H-PAIRS source-activity misses.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_trading_paper_route_evidence_endpoint_audits_probation_targets -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
