### PR TITLE
fix(autotrader): score reconciled round trips

### DIFF
--- a/scripts/autotrader/session_reconciler.py
+++ b/scripts/autotrader/session_reconciler.py
@@ -13,6 +13,11 @@ from synthesis_autotrader_client import SynthesisClient
 
 
 MARKET_SESSION_MODES = {"market_open", "market_session"}
+OBSERVATION_SOURCE = "session_reconciler_recorded_round_trip"
+SCRATCH_R_THRESHOLD = Decimal("0.10")
+SCRATCH_PNL_THRESHOLD = Decimal("1.00")
+BUY_SIDES = {"buy", "buy_to_cover", "buy_to_open", "buy_to_close"}
+SELL_SIDES = {"sell", "sell_short", "sell_to_open", "sell_to_close"}
 
 
 def parse_timestamp(value: Any) -> datetime | None:
@@ -45,13 +50,35 @@ def decimal_text(value: Any) -> str | None:
     return text
 
 
+def decimal_value(value: Any) -> Decimal | None:
+    text = decimal_text(value)
+    if text is None:
+        return None
+    return Decimal(text)
+
+
+def text_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def format_decimal(value: Decimal, *, places: str = "0.000001") -> str:
+    rounded = value.quantize(Decimal(places)).normalize()
+    text = format(rounded, "f")
+    return "0" if text == "-0" else text
+
+
 def as_list(value: Any) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         return []
     return [entry for entry in value if isinstance(entry, dict)]
 
 
-def is_stale_market_session(session: dict[str, Any], *, now: datetime, grace: timedelta, current_agent_run: str) -> bool:
+def is_stale_market_session(
+    session: dict[str, Any], *, now: datetime, grace: timedelta, current_agent_run: str
+) -> bool:
     if session.get("finalizedAt"):
         return False
     if session.get("mode") not in MARKET_SESSION_MODES:
@@ -87,11 +114,154 @@ def session_counts(detail: dict[str, Any]) -> dict[str, int]:
     }
 
 
+def scorecard_observations(detail: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    tickets = {
+        str(ticket["id"]): ticket for ticket in as_list(detail.get("tradeTickets")) if text_value(ticket.get("id"))
+    }
+    orders = as_list(detail.get("orders"))
+    fills = as_list(detail.get("fills"))
+    order_by_client_id = {
+        str(order["clientOrderId"]): order for order in orders if text_value(order.get("clientOrderId"))
+    }
+    fills_by_ticket_id: dict[str, list[dict[str, Any]]] = {}
+    skipped = {
+        "unlinkedFills": 0,
+        "unknownTicketFills": 0,
+        "invalidFills": 0,
+        "incompleteRoundTrips": 0,
+        "missingTicketFields": 0,
+        "missingRoundTripSides": 0,
+    }
+
+    for fill in fills:
+        client_order_id = text_value(fill.get("clientOrderId"))
+        order = order_by_client_id.get(client_order_id or "")
+        ticket_id = text_value(fill.get("ticketId")) or text_value(order.get("ticketId") if order else None)
+        if ticket_id is None:
+            skipped["unlinkedFills"] += 1
+            continue
+        if ticket_id not in tickets:
+            skipped["unknownTicketFills"] += 1
+            continue
+        fills_by_ticket_id.setdefault(ticket_id, []).append(fill)
+
+    observations: list[dict[str, Any]] = []
+    for ticket_id, ticket_fills in sorted(fills_by_ticket_id.items()):
+        ticket = tickets[ticket_id]
+        symbol = text_value(ticket.get("symbol"))
+        setup_type = text_value(ticket.get("setupType"))
+        setup_grade = text_value(ticket.get("setupGrade"))
+        regime = text_value(ticket.get("regime"))
+        time_bucket = text_value(ticket.get("timeBucket"))
+        if not all([symbol, setup_type, setup_grade, regime, time_bucket]):
+            skipped["missingTicketFields"] += 1
+            continue
+
+        net_quantity = Decimal("0")
+        pnl = Decimal("0")
+        saw_buy = False
+        saw_sell = False
+        invalid = False
+        fill_times: list[datetime] = []
+        client_order_ids: list[str] = []
+        for fill in ticket_fills:
+            side = str(fill.get("side") or "").strip().lower()
+            quantity = decimal_value(fill.get("quantity"))
+            price = decimal_value(fill.get("price"))
+            if quantity is None or price is None or quantity <= 0:
+                invalid = True
+                break
+            if side in BUY_SIDES:
+                saw_buy = True
+                net_quantity += quantity
+                pnl -= quantity * price
+            elif side in SELL_SIDES:
+                saw_sell = True
+                net_quantity -= quantity
+                pnl += quantity * price
+            else:
+                invalid = True
+                break
+            filled_at = parse_timestamp(fill.get("filledAt"))
+            if filled_at is not None:
+                fill_times.append(filled_at)
+            client_order_id = text_value(fill.get("clientOrderId"))
+            if client_order_id is not None:
+                client_order_ids.append(client_order_id)
+
+        if invalid:
+            skipped["invalidFills"] += 1
+            continue
+        if not saw_buy or not saw_sell:
+            skipped["missingRoundTripSides"] += 1
+            continue
+        if net_quantity != 0:
+            skipped["incompleteRoundTrips"] += 1
+            continue
+
+        risk_dollars = decimal_value(ticket.get("riskDollars"))
+        realized_r = pnl / risk_dollars if risk_dollars and risk_dollars > 0 else None
+        if realized_r is not None:
+            if realized_r > SCRATCH_R_THRESHOLD:
+                outcome = "win"
+            elif realized_r < -SCRATCH_R_THRESHOLD:
+                outcome = "loss"
+            else:
+                outcome = "scratch"
+        elif pnl > SCRATCH_PNL_THRESHOLD:
+            outcome = "win"
+        elif pnl < -SCRATCH_PNL_THRESHOLD:
+            outcome = "loss"
+        else:
+            outcome = "scratch"
+
+        tags = ["stale_session_reconciled", "completed_round_trip"]
+        if outcome == "win":
+            tags.append("realized_win")
+        elif outcome == "loss":
+            tags.append("realized_loss")
+        else:
+            tags.append("scratch_trade")
+
+        realized_r_text = format_decimal(realized_r) if realized_r is not None else "n/a"
+        observation: dict[str, Any] = {
+            "ticketId": ticket_id,
+            "symbol": symbol,
+            "setupType": setup_type,
+            "setupGrade": setup_grade,
+            "regime": regime,
+            "timeBucket": time_bucket,
+            "outcome": outcome,
+            "mistakeTags": tags,
+            "notes": (
+                "Reconciler scored completed recorded round trip: "
+                f"pnl={format_decimal(pnl)}, realizedR={realized_r_text}."
+            ),
+            "payload": {
+                "source": OBSERVATION_SOURCE,
+                "fillCount": len(ticket_fills),
+                "pnlDollars": format_decimal(pnl),
+                "netQuantity": format_decimal(net_quantity),
+                "riskDollars": format_decimal(risk_dollars) if risk_dollars is not None else None,
+                "clientOrderIds": client_order_ids,
+            },
+        }
+        if realized_r is not None:
+            observation["realizedR"] = format_decimal(realized_r)
+        if len(fill_times) >= 2:
+            hold_seconds = max(fill_times) - min(fill_times)
+            observation["holdSeconds"] = str(int(hold_seconds.total_seconds()))
+        observations.append(observation)
+
+    return observations, {"source": OBSERVATION_SOURCE, "generated": len(observations), "skipped": skipped}
+
+
 def finalization_payload(session: dict[str, Any], detail: dict[str, Any], broker: dict[str, Any]) -> dict[str, Any]:
     status = detail.get("status") if isinstance(detail.get("status"), dict) else {}
     account = broker.get("account") if isinstance(broker.get("account"), dict) else {}
     closing_equity = decimal_text(account.get("equity")) or decimal_text(status.get("equity"))
     realized_pnl = decimal_text(status.get("realizedPnl")) or decimal_text(session.get("realizedPnl"))
+    observations, observation_summary = scorecard_observations(detail)
     summary = {
         "reconciledBy": "autotrader-session-reconciler",
         "reconcileReason": "stale_post_close_flat_broker_state",
@@ -102,12 +272,14 @@ def finalization_payload(session: dict[str, Any], detail: dict[str, Any], broker
         "brokerOpenPositionCount": len(as_list(broker.get("openPositions"))),
         "brokerOpenOrderCount": len(as_list(broker.get("openOrders"))),
         "sourceCounts": session_counts(detail),
+        "scorecardObservationSummary": observation_summary,
         "lastRecordedStatus": status,
     }
     return {
         "sessionId": session["id"],
         "terminalReason": "market_closed",
         "summary": summary,
+        "scorecardObservations": observations,
         **({"closingEquity": closing_equity} if closing_equity is not None else {}),
         **({"realizedPnl": realized_pnl} if realized_pnl is not None else {}),
     }
@@ -164,6 +336,7 @@ def reconcile_sessions(
                 "agentRunName": session.get("agentRunName"),
                 "terminalReason": payload["terminalReason"],
                 "finalized": finalize_stale_flat,
+                "scorecardObservationCount": len(as_list(payload.get("scorecardObservations"))),
             }
         )
 

--- a/scripts/autotrader/test_session_reconciler.py
+++ b/scripts/autotrader/test_session_reconciler.py
@@ -103,6 +103,120 @@ class SessionReconcilerTest(unittest.TestCase):
         self.assertEqual(payload["realizedPnl"], "-11.17")
         self.assertEqual(payload["summary"]["sourceCounts"]["events"], 1)
         self.assertTrue(payload["summary"]["brokerFlat"])
+        self.assertEqual(payload["scorecardObservations"], [])
+        self.assertEqual(payload["summary"]["scorecardObservationSummary"]["generated"], 0)
+
+    def test_scores_completed_round_trips_for_stale_session_finalization(self) -> None:
+        synthesis = FakeSynthesis(
+            [stale_session()],
+            {
+                "session-1": {
+                    "status": {"equity": "30010.00", "realizedPnl": "10"},
+                    "events": [],
+                    "tradeTickets": [
+                        {
+                            "id": "ticket-win",
+                            "symbol": "AMD",
+                            "setupType": "vwap_reclaim",
+                            "setupGrade": "A",
+                            "regime": "regular_session",
+                            "timeBucket": "mid_session",
+                            "riskDollars": "10",
+                        },
+                        {
+                            "id": "ticket-open",
+                            "symbol": "GOOGL",
+                            "setupType": "opening_range_breakout",
+                            "setupGrade": "B",
+                            "regime": "regular_session",
+                            "timeBucket": "mid_session",
+                            "riskDollars": "5",
+                        },
+                    ],
+                    "riskChecks": [],
+                    "orders": [
+                        {
+                            "ticketId": "ticket-win",
+                            "clientOrderId": "amd-entry",
+                            "symbol": "AMD",
+                            "side": "buy",
+                            "quantity": "10",
+                            "status": "filled",
+                        },
+                        {
+                            "ticketId": "ticket-win",
+                            "clientOrderId": "amd-exit",
+                            "symbol": "AMD",
+                            "side": "sell",
+                            "quantity": "10",
+                            "status": "filled",
+                        },
+                        {
+                            "ticketId": "ticket-open",
+                            "clientOrderId": "googl-entry",
+                            "symbol": "GOOGL",
+                            "side": "buy",
+                            "quantity": "5",
+                            "status": "filled",
+                        },
+                    ],
+                    "fills": [
+                        {
+                            "clientOrderId": "amd-entry",
+                            "brokerFillId": "fill-entry",
+                            "symbol": "AMD",
+                            "side": "buy",
+                            "quantity": "10",
+                            "price": "100",
+                            "filledAt": "2026-06-02T15:00:00Z",
+                        },
+                        {
+                            "clientOrderId": "amd-exit",
+                            "brokerFillId": "fill-exit",
+                            "symbol": "AMD",
+                            "side": "sell",
+                            "quantity": "10",
+                            "price": "101",
+                            "filledAt": "2026-06-02T15:05:00Z",
+                        },
+                        {
+                            "clientOrderId": "googl-entry",
+                            "brokerFillId": "fill-open",
+                            "symbol": "GOOGL",
+                            "side": "buy",
+                            "quantity": "5",
+                            "price": "200",
+                            "filledAt": "2026-06-02T16:00:00Z",
+                        },
+                    ],
+                    "positionSnapshots": [],
+                }
+            },
+        )
+
+        session_reconciler.reconcile_sessions(
+            synthesis=synthesis,  # type: ignore[arg-type]
+            alpaca=FakeAlpaca(account={"equity": "30010.00"}),  # type: ignore[arg-type]
+            now=datetime(2026, 6, 2, 20, 10, tzinfo=UTC),
+            limit=50,
+            grace_minutes=5,
+            finalize_stale_flat=True,
+            current_agent_run="",
+        )
+
+        payload = synthesis.finalized[0]
+        self.assertEqual(len(payload["scorecardObservations"]), 1)
+        observation = payload["scorecardObservations"][0]
+        self.assertEqual(observation["ticketId"], "ticket-win")
+        self.assertEqual(observation["symbol"], "AMD")
+        self.assertEqual(observation["outcome"], "win")
+        self.assertEqual(observation["realizedR"], "1")
+        self.assertEqual(observation["holdSeconds"], "300")
+        self.assertEqual(observation["payload"]["pnlDollars"], "10")
+        self.assertEqual(observation["payload"]["clientOrderIds"], ["amd-entry", "amd-exit"])
+        summary = payload["summary"]["scorecardObservationSummary"]
+        self.assertEqual(summary["generated"], 1)
+        self.assertEqual(summary["skipped"]["missingRoundTripSides"], 1)
 
     def test_does_not_finalize_when_current_broker_state_is_open(self) -> None:
         synthesis = FakeSynthesis([stale_session()], {"session-1": {"status": {}, "events": []}})


### PR DESCRIPTION
## Summary

- Builds scorecard observations during stale flat-session reconciliation from recorded order/fill round trips.
- Maps fills back to tickets through `clientOrderId` and skips unlinked, malformed, or one-sided/incomplete records instead of guessing outcomes.
- Adds a finalization summary with generated and skipped observation counts so readback shows exactly what was learned.

## Related Issues

None

## Testing

- `(cd scripts/autotrader && python3 -m unittest test_session_reconciler.py)`
- `python3 -m py_compile scripts/autotrader/session_reconciler.py scripts/autotrader/test_session_reconciler.py`
- `git diff --check`
- `(cd scripts/autotrader && python3 -m unittest test_scorecard_readback.py)`
- `(cd scripts/autotrader && python3 -m unittest test_live_scan_cycle.py test_protective_preflight.py test_scorecard_readback.py test_session_reconciler.py test_strategy_order_guard.py)`
- Dry-ran `scorecard_observations` against captured live session `autonomous-trader-market-open-lxhgb`: generated 4 observations from completed round trips and skipped 1 one-sided record.

## Screenshots (if applicable)

N/A (script-only autotrader helper change).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
