### PR TITLE
fix(torghut): select nested bounded paper route plans

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -6,11 +6,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import time
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
+from http.client import HTTPConnection, HTTPSConnection
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlsplit
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
@@ -19,9 +22,7 @@ from sqlalchemy.pool import StaticPool
 from app.models import Base, Strategy
 from app.trading.paper_route_target_plan import (
     PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
-    fetch_paper_route_target_plan_url,
     materialize_bounded_paper_route_target_plan,
-    paper_route_target_plan_from_payload,
     paper_route_target_plan_targets,
 )
 
@@ -38,6 +39,7 @@ PROMOTION_FLAG_FIELDS = (
     "live_capital_routing_enabled",
 )
 LIVE_LABEL_MARKERS = ("LIVE", "PROD", "REAL")
+TARGET_PLAN_RESPONSE_LIMIT_BYTES = 5_000_000
 
 
 def _json_default(value: object) -> str:
@@ -168,6 +170,180 @@ def _load_json_file(path: Path) -> dict[str, Any]:
     return dict(cast(Mapping[str, Any], payload))
 
 
+def _nested_mapping(payload: Mapping[str, Any], *keys: str) -> dict[str, Any]:
+    current: object = payload
+    for key in keys:
+        if not isinstance(current, Mapping):
+            return {}
+        current = cast(Mapping[str, Any], current).get(key)
+    return _to_str_map(current)
+
+
+def _target_materialization_score(target: Mapping[str, Any]) -> tuple[int, int, int]:
+    return (
+        int(_safe_text(target.get("hypothesis_id")) == "H-PAIRS-01"),
+        int(
+            bool(_target_symbol_actions(target))
+            and _target_notional(target) > 0
+            and _target_quantity(target) > 0
+        ),
+        int(_truthy(target.get("bounded_evidence_collection_authorized"))),
+    )
+
+
+def _plan_materialization_score(plan: Mapping[str, Any]) -> tuple[int, int, int, int]:
+    hpairs = 0
+    materializable_shape = 0
+    bounded_authorized = 0
+    targets = paper_route_target_plan_targets(plan)
+    for target in targets:
+        target_hpairs, target_shape, target_authorized = _target_materialization_score(
+            target
+        )
+        hpairs += target_hpairs
+        materializable_shape += target_shape
+        bounded_authorized += target_authorized
+    return (hpairs, materializable_shape, bounded_authorized, len(targets))
+
+
+def _candidate_materialization_plans(
+    payload: Mapping[str, Any],
+) -> list[tuple[str, dict[str, Any]]]:
+    return [
+        (
+            "live_submission_gate.runtime_ledger_paper_probation_import_plan",
+            _nested_mapping(
+                payload,
+                "live_submission_gate",
+                "runtime_ledger_paper_probation_import_plan",
+            ),
+        ),
+        (
+            "runtime_ledger_paper_probation_import_plan",
+            _to_str_map(payload.get("runtime_ledger_paper_probation_import_plan")),
+        ),
+        (
+            "next_paper_route_runtime_window_targets",
+            _to_str_map(payload.get("next_paper_route_runtime_window_targets")),
+        ),
+        (
+            "next_clean_paper_route_runtime_window_targets_after_discard",
+            _to_str_map(
+                payload.get(
+                    "next_clean_paper_route_runtime_window_targets_after_discard"
+                )
+            ),
+        ),
+        (
+            "source_runtime_window_import_plan",
+            _to_str_map(payload.get("source_runtime_window_import_plan")),
+        ),
+        (
+            "runtime_window_import_plan",
+            _to_str_map(payload.get("runtime_window_import_plan")),
+        ),
+        (
+            "observed_strategy_source_runtime_window_import_plan",
+            _to_str_map(
+                payload.get("observed_strategy_source_runtime_window_import_plan")
+            ),
+        ),
+        ("payload", dict(payload) if paper_route_target_plan_targets(payload) else {}),
+    ]
+
+
+def _materialization_plan_from_payload(
+    payload: Mapping[str, Any],
+) -> tuple[dict[str, Any], str | None]:
+    best_plan: dict[str, Any] = {}
+    best_source: str | None = None
+    best_score = (0, 0, 0, 0)
+    for source, plan in _candidate_materialization_plans(payload):
+        if not paper_route_target_plan_targets(plan):
+            continue
+        score = _plan_materialization_score(plan)
+        if score > best_score:
+            best_plan = dict(plan)
+            best_source = source
+            best_score = score
+    return best_plan, best_source
+
+
+def _fetch_plan_url_payload_once(url: str, *, timeout_seconds: float) -> dict[str, Any]:
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        return {
+            "load_error": f"paper_route_target_plan_invalid_scheme:{scheme or 'missing'}"
+        }
+    if not parsed.hostname:
+        return {"load_error": "paper_route_target_plan_invalid_host"}
+
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    connection_class = HTTPSConnection if scheme == "https" else HTTPConnection
+    connection = connection_class(
+        parsed.hostname,
+        parsed.port,
+        timeout=max(float(timeout_seconds), 0.1),
+    )
+    try:
+        connection.request(
+            "GET",
+            path,
+            headers={
+                "Accept": "application/json",
+                "Connection": "close",
+                "Host": parsed.netloc or parsed.hostname,
+            },
+        )
+        response = connection.getresponse()
+        if response.status < 200 or response.status >= 300:
+            return {
+                "load_error": f"paper_route_target_plan_http_status:{response.status}"
+            }
+        raw = response.read(TARGET_PLAN_RESPONSE_LIMIT_BYTES + 1)
+    except Exception as exc:
+        return {"load_error": f"paper_route_target_plan_fetch_failed:{exc}"}
+    finally:
+        connection.close()
+
+    if len(raw) > TARGET_PLAN_RESPONSE_LIMIT_BYTES:
+        return {"load_error": "paper_route_target_plan_response_too_large"}
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        return {"load_error": f"paper_route_target_plan_invalid_json:{exc}"}
+    if not isinstance(payload, Mapping):
+        return {"load_error": "paper_route_target_plan_invalid_payload"}
+    return dict(cast(Mapping[str, Any], payload))
+
+
+def _fetch_plan_url_payload(
+    url: str,
+    *,
+    timeout_seconds: float,
+    attempts: int,
+    retry_backoff_seconds: float = 0.25,
+) -> dict[str, Any]:
+    max_attempts = max(int(attempts), 1)
+    payload: dict[str, Any] = {}
+    for attempt in range(1, max_attempts + 1):
+        payload = _fetch_plan_url_payload_once(url, timeout_seconds=timeout_seconds)
+        if not _safe_text(payload.get("load_error")):
+            if attempt > 1:
+                payload = dict(payload)
+                payload["fetch_attempts"] = attempt
+            return payload
+        if attempt < max_attempts:
+            time.sleep(max(float(retry_backoff_seconds), 0.0))
+    if max_attempts > 1:
+        payload = dict(payload)
+        payload["fetch_attempts"] = max_attempts
+    return payload
+
+
 def _load_plan(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
     plan_file = cast(Path | None, args.plan_json)
     plan_url = _safe_text(args.plan_url)
@@ -178,29 +354,37 @@ def _load_plan(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]
 
     if plan_file is not None:
         payload = _load_json_file(plan_file)
-        plan = paper_route_target_plan_from_payload(payload) or payload
+        plan, selected_plan = _materialization_plan_from_payload(payload)
+        if not plan:
+            plan = payload
         return (
             dict(plan),
             {
                 "kind": "file",
                 "path": str(plan_file),
+                "selected_plan": selected_plan,
             },
         )
 
     assert plan_url is not None
-    plan = fetch_paper_route_target_plan_url(
+    payload = _fetch_plan_url_payload(
         plan_url,
         timeout_seconds=float(args.plan_url_timeout_seconds),
         attempts=max(int(args.plan_url_attempts), 1),
     )
-    load_error = _safe_text(plan.get("load_error"))
+    load_error = _safe_text(payload.get("load_error"))
     if load_error:
         raise ValueError(load_error)
+    plan, selected_plan = _materialization_plan_from_payload(payload)
+    if not plan:
+        raise ValueError("paper_route_target_plan_missing")
     return (
         dict(plan),
         {
             "kind": "url",
             "url": plan_url,
+            "selected_plan": selected_plan,
+            "fetch_attempts": payload.get("fetch_attempts"),
         },
     )
 

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -197,6 +197,55 @@ def _safe_commit_args(plan_path: Path) -> list[str]:
     ]
 
 
+class _FakeResponse:
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def read(self, limit: int = -1) -> bytes:
+        if limit < 0:
+            return self._body
+        return self._body[:limit]
+
+
+class _CapturingConnection:
+    response = _FakeResponse(200, b"{}")
+    instances: list["_CapturingConnection"] = []
+
+    def __init__(
+        self,
+        host: str,
+        port: int | None = None,
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.method: str | None = None
+        self.path: str | None = None
+        self.headers: dict[str, str] | None = None
+        self.closed = False
+        self.__class__.instances.append(self)
+
+    def request(self, method: str, path: str, *, headers: dict[str, str]) -> None:
+        self.method = method
+        self.path = path
+        self.headers = headers
+
+    def getresponse(self) -> _FakeResponse:
+        return self.response
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RaisingConnection(_CapturingConnection):
+    def request(self, method: str, path: str, *, headers: dict[str, str]) -> None:
+        super().request(method, path, headers=headers)
+        raise OSError("network down")
+
+
 def test_dry_run_is_default_and_rolls_back_materialization(
     tmp_path: Path,
     sqlite_dsn: str,
@@ -528,6 +577,58 @@ def test_paper_route_target_plan_invalid_payload_reports_load_blockers(
     assert "paper_route_materialization_target_plan_targets_missing" in blockers
 
 
+def test_url_payload_prefers_nested_hpairs_materialization_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "schema_version": "torghut.paper-route-target-plan.v1",
+        "targets": [
+            {
+                "hypothesis_id": "H-TSMOM-LIQ-01",
+                "candidate_id": "source-window-only",
+                "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                "account_label": "TORGHUT_SIM",
+                "source_manifest_ref": "config/trading/hypotheses/h-tsmom-liq-01.json",
+                "observed_stage": "paper",
+                "source_collection_authorized": True,
+                "max_notional": "0",
+            }
+        ],
+        "live_submission_gate": {
+            "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
+        },
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--max-notional",
+            "25",
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["plan_source"] == {
+        "kind": "url",
+        "url": "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+        "selected_plan": (
+            "live_submission_gate.runtime_ledger_paper_probation_import_plan"
+        ),
+        "fetch_attempts": None,
+    }
+    assert report["hypothesis_ids"] == ["H-PAIRS-01"]
+    assert report["candidate_ids"] == ["c88421d619759b2cfaa6f4d0"]
+    assert report["materialized_decision_count"] == 2
+    assert report["route_submission_count"] == 2
+    assert report["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 0
+
+
 def test_paper_route_target_plan_missing_dsn_live_capital_mode_and_empty_plan_are_blockers(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -631,6 +732,184 @@ def test_paper_route_target_plan_url_load_failure_is_reported_without_materializ
     assert exit_code == 2
     assert (
         "paper_route_materialization_plan_load_failed:paper_route_target_plan_invalid_scheme:file"
+        in payload["blockers"]
+    )
+    assert payload["plan_source"] == {"kind": "unavailable"}
+
+
+def test_plan_url_fetch_rejects_missing_host() -> None:
+    payload = cli._fetch_plan_url_payload_once("http://", timeout_seconds=1)
+
+    assert payload == {"load_error": "paper_route_target_plan_invalid_host"}
+
+
+def test_plan_url_fetch_requests_json_path_query_and_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _CapturingConnection.instances = []
+    _CapturingConnection.response = _FakeResponse(
+        200,
+        json.dumps({"targets": [_hpairs_target()]}).encode("utf-8"),
+    )
+    monkeypatch.setattr(cli, "HTTPConnection", _CapturingConnection)
+
+    payload = cli._fetch_plan_url_payload_once(
+        "http://torghut-sim.torghut.svc.cluster.local:8080/trading/paper-route-target-plan?target_limit=1",
+        timeout_seconds=0,
+    )
+
+    assert payload["targets"][0]["hypothesis_id"] == "H-PAIRS-01"
+    assert len(_CapturingConnection.instances) == 1
+    connection = _CapturingConnection.instances[0]
+    assert connection.host == "torghut-sim.torghut.svc.cluster.local"
+    assert connection.port == 8080
+    assert connection.timeout == 0.1
+    assert connection.method == "GET"
+    assert connection.path == "/trading/paper-route-target-plan?target_limit=1"
+    assert connection.headers == {
+        "Accept": "application/json",
+        "Connection": "close",
+        "Host": "torghut-sim.torghut.svc.cluster.local:8080",
+    }
+    assert connection.closed is True
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "expected_error"),
+    [
+        (503, b"temporarily unavailable", "paper_route_target_plan_http_status:503"),
+        (200, b"not-json", "paper_route_target_plan_invalid_json:"),
+        (200, b'["not", "an", "object"]', "paper_route_target_plan_invalid_payload"),
+    ],
+)
+def test_plan_url_fetch_reports_status_json_and_payload_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    body: bytes,
+    expected_error: str,
+) -> None:
+    _CapturingConnection.instances = []
+    _CapturingConnection.response = _FakeResponse(status, body)
+    monkeypatch.setattr(cli, "HTTPConnection", _CapturingConnection)
+
+    payload = cli._fetch_plan_url_payload_once(
+        "http://torghut-sim.torghut.svc.cluster.local/plan",
+        timeout_seconds=1,
+    )
+
+    error = str(payload["load_error"])
+    assert error.startswith(expected_error)
+    assert _CapturingConnection.instances[0].closed is True
+
+
+def test_plan_url_fetch_reports_oversized_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _CapturingConnection.instances = []
+    _CapturingConnection.response = _FakeResponse(200, b"abcdef")
+    monkeypatch.setattr(cli, "HTTPConnection", _CapturingConnection)
+    monkeypatch.setattr(cli, "TARGET_PLAN_RESPONSE_LIMIT_BYTES", 5)
+
+    payload = cli._fetch_plan_url_payload_once(
+        "http://torghut-sim.torghut.svc.cluster.local/plan",
+        timeout_seconds=1,
+    )
+
+    assert payload == {"load_error": "paper_route_target_plan_response_too_large"}
+    assert _CapturingConnection.instances[0].closed is True
+
+
+def test_plan_url_fetch_reports_request_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _RaisingConnection.instances = []
+    monkeypatch.setattr(cli, "HTTPConnection", _RaisingConnection)
+
+    payload = cli._fetch_plan_url_payload_once(
+        "http://torghut-sim.torghut.svc.cluster.local/plan",
+        timeout_seconds=1,
+    )
+
+    assert str(payload["load_error"]).startswith(
+        "paper_route_target_plan_fetch_failed:network down"
+    )
+    assert _RaisingConnection.instances[0].closed is True
+
+
+def test_plan_url_fetch_retries_and_records_attempt_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+    sleeps: list[float] = []
+
+    def fake_fetch_once(url: str, *, timeout_seconds: float) -> dict[str, Any]:
+        nonlocal attempts
+        attempts += 1
+        assert url == "http://torghut-sim.torghut.svc.cluster.local/plan"
+        assert timeout_seconds == 3
+        if attempts == 1:
+            return {"load_error": "temporary"}
+        return {"targets": [_hpairs_target()]}
+
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload_once", fake_fetch_once)
+    monkeypatch.setattr(cli.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    payload = cli._fetch_plan_url_payload(
+        "http://torghut-sim.torghut.svc.cluster.local/plan",
+        timeout_seconds=3,
+        attempts=2,
+        retry_backoff_seconds=0.01,
+    )
+
+    assert payload["fetch_attempts"] == 2
+    assert payload["targets"][0]["hypothesis_id"] == "H-PAIRS-01"
+    assert sleeps == [0.01]
+
+
+def test_plan_url_fetch_records_failed_attempt_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "_fetch_plan_url_payload_once",
+        lambda *_, **__: {"load_error": "still-down"},
+    )
+    monkeypatch.setattr(cli.time, "sleep", lambda _: None)
+
+    payload = cli._fetch_plan_url_payload(
+        "http://torghut-sim.torghut.svc.cluster.local/plan",
+        timeout_seconds=3,
+        attempts=2,
+        retry_backoff_seconds=0,
+    )
+
+    assert payload == {
+        "load_error": "still-down",
+        "fetch_attempts": 2,
+    }
+
+
+def test_plan_url_payload_without_materializable_plan_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        cli, "_fetch_plan_url_payload", lambda *_, **__: {"targets": []}
+    )
+
+    exit_code, payload = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--max-notional",
+            "25",
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert (
+        "paper_route_materialization_plan_load_failed:paper_route_target_plan_missing"
         in payload["blockers"]
     )
     assert payload["plan_source"] == {"kind": "unavailable"}


### PR DESCRIPTION
## Summary

- Adds a materializer-local target-plan selector that scores nested payloads and prefers bounded H-PAIRS source-decision collection plans over unusable top-level source-window-only targets.
- Fetches raw paper-route target-plan payloads for the materializer so nested `live_submission_gate.runtime_ledger_paper_probation_import_plan` targets are not discarded before safety checks.
- Covers the live-shaped regression where a selected top-level TSMOM source-window target has no symbol actions while the nested H-PAIRS plan is the materializable bounded paper route plan.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live read-only H-PAIRS source-proof census on `TORGHUT_SIM` reported candidate config match but zero durable decisions, submitted orders, fills, source windows, runtime-ledger buckets, trading days, filled notional, costs, and PnL.
- Live `torghut-sim` target-plan readback showed the top-level source-window target has no materializable symbol actions/notional, while H-PAIRS source-decision collection lives under `live_submission_gate.runtime_ledger_paper_probation_import_plan`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
