### PR TITLE
fix(torghut): sign source fill closeouts

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -3080,7 +3080,11 @@ def _unavailable_source_activity(
     }
 
 
-def _order_event_signed_filled_qty(row: ExecutionOrderEvent) -> Decimal:
+def _order_event_signed_filled_qty(
+    row: ExecutionOrderEvent,
+    *,
+    execution_side_by_id: Mapping[object, str] | None = None,
+) -> Decimal:
     qty = _safe_decimal(row.filled_qty_delta)
     if qty == 0:
         qty = _safe_decimal(row.filled_qty)
@@ -3092,6 +3096,8 @@ def _order_event_signed_filled_qty(row: ExecutionOrderEvent) -> Decimal:
         if text := _safe_text(raw_event.get(key)):
             side = text.lower()
             break
+    if not side and execution_side_by_id is not None and row.execution_id is not None:
+        side = execution_side_by_id.get(row.execution_id, "").lower()
     if not side:
         client_order_id = (_safe_text(row.client_order_id) or "").lower()
         if "sell" in client_order_id or "short" in client_order_id:
@@ -3284,10 +3290,18 @@ def _source_activity_lifecycle_summary(
         )
     net_filled_qty_by_symbol: dict[str, Decimal] = {}
     fill_event_rows = [row for row in order_event_rows if _order_event_is_fill(row)]
+    execution_side_by_id: dict[object, str] = {
+        row.id: (_safe_text(row.side) or "")
+        for row in execution_rows
+        if _safe_text(row.side) is not None
+    }
     if fill_event_rows:
         for row in fill_event_rows:
             symbol = (_safe_text(row.symbol) or "missing").upper()
-            signed_qty = _order_event_signed_filled_qty(row)
+            signed_qty = _order_event_signed_filled_qty(
+                row,
+                execution_side_by_id=execution_side_by_id,
+            )
             if signed_qty != 0:
                 net_filled_qty_by_symbol[symbol] = (
                     net_filled_qty_by_symbol.get(symbol, Decimal("0")) + signed_qty

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -6525,6 +6525,203 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertNotIn("source_tca_missing", import_audit["blockers"])
 
+    def test_source_activity_signs_order_feed_fills_from_linked_execution_side(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        event_at = window_start + timedelta(minutes=20)
+        strategy_name = "order-feed-linked-side"
+        candidate_id = "candidate-linked-side"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="paper route source activity signs linked execution side",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed",
+                source_topic="trade_updates",
+                source_partition=0,
+                alpaca_account_label="TORGHUT_SIM",
+                assignment_mode="group",
+                collector_identity="test-order-feed",
+                source_revision="alpaca_trade_updates_v1",
+                window_started_at=event_at,
+                window_ended_at=event_at + timedelta(minutes=1),
+                start_offset=10,
+                end_offset=11,
+                consumed_count=2,
+                inserted_count=2,
+                status="inserted",
+                status_reason="linked_execution_and_decision",
+                payload_json={},
+            )
+            session.add(source_window)
+            session.flush()
+            for index, side in enumerate(("buy", "sell"), start=1):
+                opaque_order_id = f"linked-side-order-{index}"
+                opaque_client_order_id = f"linked-side-client-{index}"
+                decision = TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    timeframe="1Min",
+                    decision_json={
+                        "action": side,
+                        "qty": "1",
+                        "candidate_id": candidate_id,
+                        "hypothesis_id": "H-LINKED-SIDE",
+                    },
+                    rationale="linked execution side fixture",
+                    status="executed",
+                    created_at=event_at + timedelta(seconds=index),
+                    executed_at=event_at + timedelta(seconds=index),
+                )
+                session.add(decision)
+                session.flush()
+                execution = Execution(
+                    trade_decision_id=decision.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    alpaca_order_id=opaque_order_id,
+                    client_order_id=opaque_client_order_id,
+                    symbol="AAPL",
+                    side=side,
+                    order_type="limit",
+                    time_in_force="day",
+                    submitted_qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("100"),
+                    status="filled",
+                    raw_order={},
+                    created_at=event_at + timedelta(seconds=index),
+                    updated_at=event_at + timedelta(seconds=index),
+                    last_update_at=event_at + timedelta(seconds=index),
+                    order_feed_last_event_ts=event_at + timedelta(seconds=index),
+                )
+                session.add(execution)
+                session.flush()
+                session.add(
+                    ExecutionOrderEvent(
+                        event_fingerprint=f"linked-side-fill-event-{side}",
+                        source_topic="trade_updates",
+                        source_partition=0,
+                        source_offset=10 + index,
+                        alpaca_account_label="TORGHUT_SIM",
+                        feed_seq=10 + index,
+                        event_ts=event_at + timedelta(seconds=index),
+                        symbol="AAPL",
+                        alpaca_order_id=opaque_order_id,
+                        client_order_id=opaque_client_order_id,
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        filled_qty_delta=Decimal("1"),
+                        avg_fill_price=Decimal("100"),
+                        filled_notional_delta=Decimal("100"),
+                        raw_event={
+                            "event": "fill",
+                            "order": {
+                                "id": opaque_order_id,
+                                "client_order_id": opaque_client_order_id,
+                                "symbol": "AAPL",
+                                "status": "filled",
+                                "qty": "1",
+                                "filled_qty": "1",
+                                "filled_avg_price": "100",
+                            },
+                        },
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        source_window_id=source_window.id,
+                        created_at=event_at + timedelta(seconds=index),
+                    )
+                )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
+            self._add_flat_account_close_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_end=window_end,
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-LINKED-SIDE",
+                                "candidate_id": candidate_id,
+                                "observed_stage": "paper",
+                                "strategy_family": "intraday_tsmom_consistent",
+                                "strategy_name": strategy_name,
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": "config/trading/hypotheses/h-linked-side.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": ["AAPL"],
+                                "paper_probation_authorized": True,
+                                "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                    },
+                },
+                generated_at=window_end + timedelta(hours=2),
+            )
+
+        source_activity = payload["targets"][0]["source_activity"]
+        lifecycle = source_activity["source_lifecycle"]
+        self.assertEqual(source_activity["execution_count"], 2)
+        self.assertEqual(source_activity["fill_order_event_count"], 2)
+        self.assertEqual(lifecycle["net_filled_qty_by_symbol"], {"AAPL": "0"})
+        self.assertEqual(lifecycle["open_symbols_after_source_fills"], [])
+        self.assertTrue(lifecycle["closed_round_trip_evidence"])
+        self.assertNotIn(
+            "source_close_missing",
+            source_activity["source_lifecycle_blockers"],
+        )
+        self.assertNotIn(
+            "source_closed_round_trip_missing",
+            source_activity["source_lifecycle_blockers"],
+        )
+
     def test_hpairs_collection_blocks_missing_lifecycle_costs_and_flatten(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Uses the linked execution side when paper-route order-feed fill events omit raw side, so sell closeouts are signed correctly in source lifecycle readback.
- Fixes the source lifecycle summary that could report flat closeout executions as open long exposure when order events lacked side fields.
- Adds a regression covering buy and sell linked fill events with opaque client order IDs and no raw side.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_trading_paper_route_evidence_endpoint_audits_probation_targets -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
