### PR TITLE
fix(torghut): schedule bounded target materialization

### DIFF
--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-bounded-paper-route-target-materialization
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: bounded-paper-route-target-materialization
+spec:
+  schedule: "*/5 10-15 * * 1-5"
+  timeZone: America/New_York
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
+          containers:
+            - name: materialize-targets
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d88a1823257bb9e074ae5dcb2febf23ff67f3b160cc0c6fcc828aeeb40991738
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  if ! /opt/venv/bin/python scripts/materialize_bounded_paper_route_targets.py --help | grep -q -- '--allow-dynamic-target-plan'; then
+                    echo "stage=bounded_paper_route_target_materialization skipped reason=old_image_missing_dynamic_target_plan_guard"
+                    exit 0
+                  fi
+                  /opt/venv/bin/python scripts/materialize_bounded_paper_route_targets.py \
+                    --plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan \
+                    --plan-url-timeout-seconds 45 \
+                    --plan-url-attempts 3 \
+                    --database-dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --max-notional 25 \
+                    --commit \
+                    --allow-dynamic-target-plan \
+                    --confirm-account-label TORGHUT_SIM \
+                    --confirm-dsn-env SIM_DB_DSN \
+                    --confirm-hypothesis-id H-PAIRS-01 \
+                    --confirm-runtime-strategy-name microbar-cross-sectional-pairs-v1 \
+                    --confirm-selected-plan-source live_submission_gate.runtime_ledger_paper_probation_import_plan \
+                    --confirm-target-count-min 1 \
+                    --confirm-max-notional 25 \
+                    --operator-confirmation MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS
+              env:
+                - name: TORGHUT_SIM_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: host
+                - name: TORGHUT_SIM_DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: port
+                - name: TORGHUT_SIM_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: username
+                - name: TORGHUT_SIM_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: password
+                - name: SIM_DB_DSN
+                  value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
+                - name: PYTHONUNBUFFERED
+                  value: "1"

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -37,6 +37,7 @@ resources:
   - empirical-artifacts-objectbucketclaim.yaml
   - empirical-jobs-backfill-job.yaml
   - empirical-promotion-renewal-cronjob.yaml
+  - bounded-paper-route-target-materialization-cronjob.yaml
   - order-feed-source-window-repair-cronjob.yaml
   - empirical-artifacts-retention-cronjob.yaml
   - execution-tca-refresh-cronjob.yaml

--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -22,12 +22,16 @@ from sqlalchemy.pool import StaticPool
 from app.models import Base, Strategy
 from app.trading.paper_route_target_plan import (
     PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
+    PAPER_ROUTE_MATERIALIZATION_HPAIRS_HYPOTHESIS_ID,
     materialize_bounded_paper_route_target_plan,
     paper_route_target_plan_targets,
 )
 
 SCHEMA_VERSION = "torghut.bounded-paper-route-target-materialization-cli.v1"
 OPERATOR_CONFIRMATION = "MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS"
+DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE = (
+    "live_submission_gate.runtime_ledger_paper_probation_import_plan"
+)
 PROMOTION_FLAG_FIELDS = (
     "promotion_allowed",
     "promotion_authorized",
@@ -181,7 +185,10 @@ def _nested_mapping(payload: Mapping[str, Any], *keys: str) -> dict[str, Any]:
 
 def _target_materialization_score(target: Mapping[str, Any]) -> tuple[int, int, int]:
     return (
-        int(_safe_text(target.get("hypothesis_id")) == "H-PAIRS-01"),
+        int(
+            _safe_text(target.get("hypothesis_id"))
+            == PAPER_ROUTE_MATERIALIZATION_HPAIRS_HYPOTHESIS_ID
+        ),
         int(
             bool(_target_symbol_actions(target))
             and _target_notional(target) > 0
@@ -446,12 +453,14 @@ def _confirmation_blockers(
     *,
     args: argparse.Namespace,
     summaries: Sequence[Mapping[str, Any]],
+    plan_source: Mapping[str, Any],
     dsn_env: str,
 ) -> list[str]:
     if not bool(args.commit):
         return []
 
     blockers: list[str] = []
+    dynamic_target_plan = bool(args.allow_dynamic_target_plan)
     confirmations = {
         "account_label": (
             _safe_text(args.confirm_account_label),
@@ -462,20 +471,10 @@ def _confirmation_blockers(
             _safe_text(args.confirm_hypothesis_id),
             ",".join(_unique_texts([item.get("hypothesis_id") for item in summaries])),
         ),
-        "candidate_id": (
-            _safe_text(args.confirm_candidate_id),
-            ",".join(_unique_texts([item.get("candidate_id") for item in summaries])),
-        ),
         "runtime_strategy_name": (
             _safe_text(args.confirm_runtime_strategy_name),
             ",".join(
                 _unique_texts([item.get("runtime_strategy_name") for item in summaries])
-            ),
-        ),
-        "target_plan_ref": (
-            _safe_text(args.confirm_target_plan_ref),
-            ",".join(
-                _unique_texts([item.get("target_plan_ref") for item in summaries])
             ),
         ),
         "max_notional": (
@@ -489,6 +488,43 @@ def _confirmation_blockers(
                 f"paper_route_materialization_commit_confirm_{name}_missing"
             )
 
+    if not dynamic_target_plan:
+        exact_confirmations = {
+            "candidate_id": (
+                _safe_text(args.confirm_candidate_id),
+                ",".join(
+                    _unique_texts([item.get("candidate_id") for item in summaries])
+                ),
+            ),
+            "target_plan_ref": (
+                _safe_text(args.confirm_target_plan_ref),
+                ",".join(
+                    _unique_texts([item.get("target_plan_ref") for item in summaries])
+                ),
+            ),
+        }
+        for name, (observed, expected) in exact_confirmations.items():
+            if expected is None or not observed or observed != expected:
+                blockers.append(
+                    f"paper_route_materialization_commit_confirm_{name}_missing"
+                )
+    else:
+        selected_plan = _safe_text(plan_source.get("selected_plan"))
+        confirmed_selected_plan = _safe_text(args.confirm_selected_plan_source)
+        if (
+            not selected_plan
+            or not confirmed_selected_plan
+            or confirmed_selected_plan != selected_plan
+        ):
+            blockers.append(
+                "paper_route_materialization_commit_confirm_selected_plan_source_missing"
+            )
+        minimum_target_count = int(args.confirm_target_count_min or 0)
+        if minimum_target_count <= 0 or len(summaries) < minimum_target_count:
+            blockers.append(
+                "paper_route_materialization_commit_confirm_target_count_min_missing"
+            )
+
     if _safe_text(args.operator_confirmation) != OPERATOR_CONFIRMATION:
         blockers.append("paper_route_materialization_operator_confirmation_missing")
     return blockers
@@ -498,6 +534,7 @@ def _safety_blockers(
     *,
     args: argparse.Namespace,
     plan: Mapping[str, Any],
+    plan_source: Mapping[str, Any],
     summaries: Sequence[Mapping[str, Any]],
     dsn: str | None,
     dsn_env: str,
@@ -578,7 +615,12 @@ def _safety_blockers(
             )
 
     blockers.extend(
-        _confirmation_blockers(args=args, summaries=summaries, dsn_env=dsn_env)
+        _confirmation_blockers(
+            args=args,
+            summaries=summaries,
+            plan_source=plan_source,
+            dsn_env=dsn_env,
+        )
     )
     return sorted(dict.fromkeys(blockers))
 
@@ -717,6 +759,7 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     blockers = load_blockers + _safety_blockers(
         args=args,
         plan=plan,
+        plan_source=plan_source,
         summaries=summaries,
         dsn=dsn,
         dsn_env=dsn_env,
@@ -765,6 +808,8 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "final_promotion_allowed": False,
         "capital_promotion_allowed": False,
         "operator_confirmation_required": OPERATOR_CONFIRMATION if commit else None,
+        "dynamic_target_plan_confirmation": bool(args.allow_dynamic_target_plan),
+        "default_dynamic_selected_plan_source": DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
         "target_count": len(summaries),
         "hypothesis_ids": _unique_texts(
             [item.get("hypothesis_id") for item in summaries]
@@ -821,7 +866,10 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--confirm-candidate-id", default=None)
     parser.add_argument("--confirm-runtime-strategy-name", default=None)
     parser.add_argument("--confirm-target-plan-ref", default=None)
+    parser.add_argument("--confirm-selected-plan-source", default=None)
+    parser.add_argument("--confirm-target-count-min", type=int, default=None)
     parser.add_argument("--confirm-max-notional", default=None)
+    parser.add_argument("--allow-dynamic-target-plan", action="store_true")
     parser.add_argument("--operator-confirmation", default=None)
     parser.add_argument("--output", type=Path, default=None)
     return parser.parse_args(argv)

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -912,6 +912,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("tigerbeetle-smoke-job.yaml", resources)
         self.assertIn("tigerbeetle-journal-order-events-cronjob.yaml", resources)
         self.assertIn(
+            "bounded-paper-route-target-materialization-cronjob.yaml",
+            resources,
+        )
+        self.assertIn(
             "whitepaper-autoresearch-replay-materialization-cronworkflow.yaml",
             resources,
         )
@@ -1380,6 +1384,121 @@ class TestLiveConfigManifestContract(TestCase):
             security_context.get("seccompProfile", {}),
         )
         self.assertEqual(seccomp_profile.get("type"), "Unconfined")
+
+    def test_bounded_paper_route_target_materialization_cronjob_is_sim_only(
+        self,
+    ) -> None:
+        spec, container = _load_cronjob_container(
+            "argocd/applications/torghut/"
+            "bounded-paper-route-target-materialization-cronjob.yaml"
+        )
+
+        self.assertEqual(spec.get("schedule"), "*/5 10-15 * * 1-5")
+        self.assertEqual(spec.get("timeZone"), "America/New_York")
+        self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
+        self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
+        job_spec = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], spec.get("jobTemplate", {})).get("spec", {}),
+        )
+        template = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], job_spec.get("template", {})),
+        )
+        pod_spec = cast(Mapping[str, object], template.get("spec", {}))
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 300)
+        self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
+        self.assertEqual(
+            pod_spec.get("nodeSelector"),
+            {"kubernetes.io/arch": "arm64"},
+        )
+        resources = cast(Mapping[str, object], container.get("resources", {}))
+        self.assertEqual(
+            resources,
+            {
+                "requests": {
+                    "cpu": "100m",
+                    "memory": "256Mi",
+                    "ephemeral-storage": "128Mi",
+                },
+                "limits": {
+                    "cpu": "500m",
+                    "memory": "512Mi",
+                    "ephemeral-storage": "512Mi",
+                },
+            },
+        )
+        self.assertIn(
+            "registry.ide-newton.ts.net/lab/torghut@sha256:",
+            str(container.get("image")),
+        )
+
+        env = {
+            item.get("name"): item
+            for item in cast(list[Mapping[str, object]], container.get("env", []))
+        }
+        self.assertEqual(
+            env["SIM_DB_DSN"].get("value"),
+            "postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@"
+            "$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default",
+        )
+        self.assertEqual(env["PYTHONUNBUFFERED"].get("value"), "1")
+        for name, key in {
+            "TORGHUT_SIM_DB_HOST": "host",
+            "TORGHUT_SIM_DB_PORT": "port",
+            "TORGHUT_SIM_DB_USER": "username",
+            "TORGHUT_SIM_DB_PASSWORD": "password",
+        }.items():
+            value_from = cast(Mapping[str, object], env[name].get("valueFrom", {}))
+            self.assertEqual(
+                value_from.get("secretKeyRef"),
+                {"name": "torghut-db-app", "key": key},
+            )
+
+        args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/materialize_bounded_paper_route_targets.py", args)
+        self.assertIn("--help | grep -q -- '--allow-dynamic-target-plan'", args)
+        self.assertIn(
+            "old_image_missing_dynamic_target_plan_guard",
+            args,
+        )
+        self.assertIn(
+            "--plan-url "
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            args,
+        )
+        self.assertIn("--plan-url-timeout-seconds 45", args)
+        self.assertIn("--plan-url-attempts 3", args)
+        self.assertIn("--database-dsn-env SIM_DB_DSN", args)
+        self.assertIn("--account-label TORGHUT_SIM", args)
+        self.assertIn("--max-notional 25", args)
+        self.assertIn("--commit", args)
+        self.assertIn("--allow-dynamic-target-plan", args)
+        self.assertIn("--confirm-account-label TORGHUT_SIM", args)
+        self.assertIn("--confirm-dsn-env SIM_DB_DSN", args)
+        self.assertIn("--confirm-hypothesis-id H-PAIRS-01", args)
+        self.assertIn(
+            "--confirm-runtime-strategy-name microbar-cross-sectional-pairs-v1",
+            args,
+        )
+        self.assertIn(
+            "--confirm-selected-plan-source "
+            "live_submission_gate.runtime_ledger_paper_probation_import_plan",
+            args,
+        )
+        self.assertIn("--confirm-target-count-min 1", args)
+        self.assertIn("--confirm-max-notional 25", args)
+        self.assertIn(
+            "--operator-confirmation MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS",
+            args,
+        )
+        self.assertNotIn("--confirm-candidate-id", args)
+        self.assertNotIn("--confirm-target-plan-ref", args)
+        self.assertNotIn("--promotion-allowed", args)
+        self.assertNotIn("--final-promotion-allowed", args)
+        self.assertNotIn("--capital-promotion-allowed", args)
+        self.assertNotIn("--final-authority-ok", args)
+        self.assertNotIn("PA3SX7FYNUTF", args)
 
     def test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim(
         self,

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -629,6 +629,128 @@ def test_url_payload_prefers_nested_hpairs_materialization_plan(
     assert _count_decisions(sqlite_dsn) == 0
 
 
+def test_commit_url_nested_plan_with_dynamic_confirmation_writes_targets(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "schema_version": "torghut.paper-route-target-plan.v1",
+        "targets": [
+            {
+                "hypothesis_id": "H-TSMOM-LIQ-01",
+                "candidate_id": "source-window-only",
+                "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                "account_label": "TORGHUT_SIM",
+                "source_manifest_ref": "config/trading/hypotheses/h-tsmom-liq-01.json",
+                "observed_stage": "paper",
+                "source_collection_authorized": True,
+                "max_notional": "0",
+            }
+        ],
+        "live_submission_gate": {
+            "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
+        },
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "25",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            cli.DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "25",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["mode"] == "commit"
+    assert report["materialized"] is True
+    assert report["dynamic_target_plan_confirmation"] is True
+    assert (
+        report["plan_source"]["selected_plan"]
+        == cli.DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE
+    )
+    assert report["candidate_ids"] == ["c88421d619759b2cfaa6f4d0"]
+    assert report["target_plan_refs"] == ["paper-route-plan:c88421d619759b2cfaa6f4d0"]
+    assert report["materialized_decision_count"] == 2
+    assert report["route_submission_count"] == 2
+    assert report["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 2
+
+
+def test_commit_dynamic_confirmation_rejects_wrong_selected_plan_source(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "live_submission_gate": {
+            "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
+        },
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "25",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            "payload",
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "25",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert (
+        "paper_route_materialization_commit_confirm_selected_plan_source_missing"
+        in report["blockers"]
+    )
+    assert report["materialized"] is False
+    assert _count_decisions(sqlite_dsn) == 0
+
+
 def test_paper_route_target_plan_missing_dsn_live_capital_mode_and_empty_plan_are_blockers(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Add dynamic nested-plan commit confirmations to the bounded paper-route target materializer so URL plans can commit without hard-coding a changing candidate id, while still requiring TORGHUT_SIM, SIM_DB_DSN, H-PAIRS-01, the runtime strategy, the selected nested plan source, target-count minimum, max notional, and operator confirmation.
- Add a GitOps CronJob that runs the materializer every 5 minutes during 10:00-15:55 America/New_York market hours against the promoted Torghut image digest and TORGHUT_SIM database.
- Add regression and manifest-contract coverage for successful nested URL materialization, wrong selected-plan rejection, and the sim-only CronJob wiring.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py -k "bounded_paper_route_target_materialization or torghut_kustomization_includes_tigerbeetle_cluster or materialize_bounded_paper_route_targets" -q`
- `uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`
- `git diff --check origin/main..HEAD`

## Screenshots (if applicable)

N/A - backend and GitOps change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
