### PR TITLE
fix(autotrader): allow readback auth secret

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-readback-agent.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-readback-agent.yaml
@@ -18,6 +18,7 @@ spec:
     allowedSecrets:
       - autonomous-trader-alpaca-mcp
       - agents-artifacts
+      - codex-auth
       - synthesis-env
     allowedServiceAccounts:
       - agents-sa

--- a/argocd/applications/autotrader/autonomous-trader-readback-secretbinding.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-readback-secretbinding.yaml
@@ -18,4 +18,5 @@ spec:
   allowedSecrets:
     - autonomous-trader-alpaca-mcp
     - agents-artifacts
+    - codex-auth
     - synthesis-env

--- a/argocd/applications/autotrader/autonomous-trader-scorecard-readback-template.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-scorecard-readback-template.yaml
@@ -45,6 +45,7 @@ spec:
   secrets:
     - autonomous-trader-alpaca-mcp
     - agents-artifacts
+    - codex-auth
     - synthesis-env
   workload:
     volumes:

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -926,7 +926,12 @@ describe('autonomous trader provider', () => {
     expect(objectAt(objectAt(templateSpec, 'implementationSpecRef'), 'name')).toBe('autonomous-trader-readback-v1')
     expect(objectAt(objectAt(agentSpec, 'providerRef'), 'name')).toBe('autonomous-trader-readback-runner')
     expect(secretBindingSubjects).toEqual([{ kind: 'Agent', name: 'autonomous-trader-readback-agent' }])
-    expect(secretBindingSecrets).toEqual(['autonomous-trader-alpaca-mcp', 'agents-artifacts', 'synthesis-env'])
+    expect(secretBindingSecrets).toEqual([
+      'autonomous-trader-alpaca-mcp',
+      'agents-artifacts',
+      'codex-auth',
+      'synthesis-env',
+    ])
     expect(objectAt(providerSpec, 'binary')).toBe('/usr/local/bin/agent-runner')
     expect(objectAt(adapter, 'type')).toBe('exec')
     expect(objectAt(execAdapter, 'binary')).toBe('/usr/bin/env')
@@ -961,8 +966,8 @@ describe('autonomous trader provider', () => {
     expect(secrets).toContain('synthesis-env')
     expect(secrets).toContain('autonomous-trader-alpaca-mcp')
     expect(secrets).toContain('agents-artifacts')
+    expect(secrets).toContain('codex-auth')
     expect(secrets).not.toContain('alpaca-mcp')
-    expect(secrets).not.toContain('codex-auth')
     expect(secrets).not.toContain('github-token')
   })
 


### PR DESCRIPTION
## Summary

- Allow the dedicated autonomous-trader readback Agent and SecretBinding to use the controller-required `codex-auth` secret.
- Add `codex-auth` to the scorecard-readback AgentRun template secrets so scheduled readbacks validate before job creation.
- Update the autonomous-trader smoke test to lock the readback auth-secret contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "schedules a post-close scorecard readback proof without broker mutations"`
- `kubectl kustomize argocd/applications/autotrader`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
