### PR TITLE
fix(autotrader): set readback system prompt

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-readback-agent.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-readback-agent.yaml
@@ -14,6 +14,11 @@ metadata:
 spec:
   providerRef:
     name: autonomous-trader-readback-runner
+  defaults:
+    systemPromptRef:
+      kind: ConfigMap
+      name: autonomous-trader-system-prompt
+      key: system-prompt.md
   security:
     allowedSecrets:
       - autonomous-trader-alpaca-mcp

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -878,6 +878,7 @@ describe('autonomous trader provider', () => {
     const providerMetadata = objectAt(provider, 'metadata')
     const agentSpec = objectAt(agent, 'spec')
     const agentMetadata = objectAt(agent, 'metadata')
+    const readbackSystemPromptRef = objectAt(objectAt(agentSpec, 'defaults'), 'systemPromptRef')
     const implementationMetadata = objectAt(implementationSpec, 'metadata')
     const adapter = objectAt(providerSpec, 'adapter')
     const execAdapter = objectAt(adapter, 'exec')
@@ -925,6 +926,11 @@ describe('autonomous trader provider', () => {
     expect(objectAt(objectAt(templateSpec, 'agentRef'), 'name')).toBe('autonomous-trader-readback-agent')
     expect(objectAt(objectAt(templateSpec, 'implementationSpecRef'), 'name')).toBe('autonomous-trader-readback-v1')
     expect(objectAt(objectAt(agentSpec, 'providerRef'), 'name')).toBe('autonomous-trader-readback-runner')
+    expect(readbackSystemPromptRef).toEqual({
+      kind: 'ConfigMap',
+      name: 'autonomous-trader-system-prompt',
+      key: 'system-prompt.md',
+    })
     expect(secretBindingSubjects).toEqual([{ kind: 'Agent', name: 'autonomous-trader-readback-agent' }])
     expect(secretBindingSecrets).toEqual([
       'autonomous-trader-alpaca-mcp',


### PR DESCRIPTION
## Summary

- Adds the required `Agent.spec.defaults.systemPromptRef` to the dedicated autonomous-trader readback Agent.
- Points readback mode at the existing autotrader system prompt, which already defines the `scorecard-readback` behavior.
- Adds a smoke-test regression assertion so the readback Agent cannot lose its system prompt reference silently.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "schedules a post-close scorecard readback proof without broker mutations"`
- `kubectl kustomize argocd/applications/autotrader`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
