### PR TITLE
fix(torghut): promote materializer cron image

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -61,6 +61,7 @@ jobs:
             'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml'
             'argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml'
             'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
+            'argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml'
             'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
             'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
             'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml'

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -258,6 +258,7 @@ jobs:
             argocd/applications/torghut/execution-tca-refresh-cronjob.yaml \
             argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml \
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml \
+            argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml \
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml \
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml \
             argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml \
@@ -301,6 +302,7 @@ jobs:
             argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
             argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+            argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
             argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -347,6 +349,7 @@ jobs:
             argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
             argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+            argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
             argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml

--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: materialize-targets
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:d88a1823257bb9e074ae5dcb2febf23ff67f3b160cc0c6fcc828aeeb40991738
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d9c2403da71486ef1a2b6cbac30ea0f703cde293213e48a2d761758874cfd174
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -23,6 +23,10 @@ const createFixture = () => {
   const executionTcaRefreshManifestPath = join(dir, 'execution-tca-refresh-cronjob.yaml')
   const orderFeedSourceWindowRepairManifestPath = join(dir, 'order-feed-source-window-repair-cronjob.yaml')
   const paperAccountFlattenManifestPath = join(dir, 'paper-account-flatten-cronjob.yaml')
+  const boundedPaperRouteTargetMaterializationManifestPath = join(
+    dir,
+    'bounded-paper-route-target-materialization-cronjob.yaml',
+  )
   const whitepaperSemanticBackfillManifestPath = join(dir, 'whitepaper-semantic-backfill-job.yaml')
   const tigerBeetleSmokeManifestPath = join(dir, 'tigerbeetle-smoke-job.yaml')
   const tigerBeetleJournalOrderEventsManifestPath = join(dir, 'tigerbeetle-journal-order-events-cronjob.yaml')
@@ -103,6 +107,7 @@ spec:
     executionTcaRefreshManifestPath,
     orderFeedSourceWindowRepairManifestPath,
     paperAccountFlattenManifestPath,
+    boundedPaperRouteTargetMaterializationManifestPath,
     whitepaperSemanticBackfillManifestPath,
     tigerBeetleSmokeManifestPath,
     tigerBeetleJournalOrderEventsManifestPath,
@@ -203,6 +208,7 @@ spec:
     executionTcaRefreshManifestPath,
     orderFeedSourceWindowRepairManifestPath,
     paperAccountFlattenManifestPath,
+    boundedPaperRouteTargetMaterializationManifestPath,
     whitepaperSemanticBackfillManifestPath,
     tigerBeetleSmokeManifestPath,
     tigerBeetleJournalOrderEventsManifestPath,
@@ -277,6 +283,10 @@ describe('update-manifests', () => {
       executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
       orderFeedSourceWindowRepairManifestPath: relative(repoRoot, fixture.orderFeedSourceWindowRepairManifestPath),
       paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
+      boundedPaperRouteTargetMaterializationManifestPath: relative(
+        repoRoot,
+        fixture.boundedPaperRouteTargetMaterializationManifestPath,
+      ),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       tigerBeetleSmokeManifestPath: relative(repoRoot, fixture.tigerBeetleSmokeManifestPath),
       tigerBeetleJournalOrderEventsManifestPath: relative(repoRoot, fixture.tigerBeetleJournalOrderEventsManifestPath),
@@ -302,6 +312,10 @@ describe('update-manifests', () => {
     const executionTcaRefreshManifest = readFileSync(fixture.executionTcaRefreshManifestPath, 'utf8')
     const orderFeedSourceWindowRepairManifest = readFileSync(fixture.orderFeedSourceWindowRepairManifestPath, 'utf8')
     const paperAccountFlattenManifest = readFileSync(fixture.paperAccountFlattenManifestPath, 'utf8')
+    const boundedPaperRouteTargetMaterializationManifest = readFileSync(
+      fixture.boundedPaperRouteTargetMaterializationManifestPath,
+      'utf8',
+    )
     const whitepaperSemanticBackfillManifest = readFileSync(fixture.whitepaperSemanticBackfillManifestPath, 'utf8')
     const tigerBeetleSmokeManifest = readFileSync(fixture.tigerBeetleSmokeManifestPath, 'utf8')
     const tigerBeetleJournalOrderEventsManifest = readFileSync(
@@ -343,6 +357,7 @@ describe('update-manifests', () => {
       executionTcaRefreshManifest,
       orderFeedSourceWindowRepairManifest,
       paperAccountFlattenManifest,
+      boundedPaperRouteTargetMaterializationManifest,
       whitepaperSemanticBackfillManifest,
       tigerBeetleSmokeManifest,
       tigerBeetleJournalOrderEventsManifest,
@@ -374,7 +389,7 @@ describe('update-manifests', () => {
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(20)
+    expect(result.changedPaths.length).toBe(21)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -405,6 +420,10 @@ describe('update-manifests', () => {
       executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
       orderFeedSourceWindowRepairManifestPath: relative(repoRoot, fixture.orderFeedSourceWindowRepairManifestPath),
       paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
+      boundedPaperRouteTargetMaterializationManifestPath: relative(
+        repoRoot,
+        fixture.boundedPaperRouteTargetMaterializationManifestPath,
+      ),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       tigerBeetleSmokeManifestPath: relative(repoRoot, fixture.tigerBeetleSmokeManifestPath),
       tigerBeetleJournalOrderEventsManifestPath: relative(repoRoot, fixture.tigerBeetleJournalOrderEventsManifestPath),

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -30,6 +30,8 @@ const defaultExecutionTcaRefreshManifestPath = 'argocd/applications/torghut/exec
 const defaultOrderFeedSourceWindowRepairManifestPath =
   'argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml'
 const defaultPaperAccountFlattenManifestPath = 'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
+const defaultBoundedPaperRouteTargetMaterializationManifestPath =
+  'argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml'
 const defaultWhitepaperSemanticBackfillManifestPath =
   'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
 const defaultTigerBeetleSmokeManifestPath = 'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
@@ -61,6 +63,7 @@ type UpdateManifestsOptions = {
   executionTcaRefreshManifestPath?: string
   orderFeedSourceWindowRepairManifestPath?: string
   paperAccountFlattenManifestPath?: string
+  boundedPaperRouteTargetMaterializationManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   tigerBeetleSmokeManifestPath?: string
   tigerBeetleJournalOrderEventsManifestPath?: string
@@ -91,6 +94,7 @@ type CliOptions = {
   executionTcaRefreshManifestPath?: string
   orderFeedSourceWindowRepairManifestPath?: string
   paperAccountFlattenManifestPath?: string
+  boundedPaperRouteTargetMaterializationManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   tigerBeetleSmokeManifestPath?: string
   tigerBeetleJournalOrderEventsManifestPath?: string
@@ -352,6 +356,12 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.paperAccountFlattenManifestPath ?? defaultPaperAccountFlattenManifestPath,
     'torghut-paper-account-flatten image reference',
   )
+  const boundedPaperRouteTargetMaterialization = updateImageOnlyManifest(
+    options,
+    options.boundedPaperRouteTargetMaterializationManifestPath ??
+      defaultBoundedPaperRouteTargetMaterializationManifestPath,
+    'torghut-bounded-paper-route-target-materialization image reference',
+  )
   const whitepaperSemanticBackfill = updateImageOnlyManifest(
     options,
     options.whitepaperSemanticBackfillManifestPath ?? defaultWhitepaperSemanticBackfillManifestPath,
@@ -399,6 +409,7 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     executionTcaRefresh,
     orderFeedSourceWindowRepair,
     paperAccountFlatten,
+    boundedPaperRouteTargetMaterialization,
     whitepaperSemanticBackfill,
     tigerBeetleSmoke,
     tigerBeetleJournalOrderEvents,
@@ -445,6 +456,7 @@ Options:
   --execution-tca-refresh-manifest-path <path>
   --order-feed-source-window-repair-manifest-path <path>
   --paper-account-flatten-manifest-path <path>
+  --bounded-paper-route-target-materialization-manifest-path <path>
   --whitepaper-semantic-backfill-manifest-path <path>
   --tigerbeetle-smoke-manifest-path <path>
   --tigerbeetle-journal-order-events-manifest-path <path>
@@ -532,6 +544,9 @@ Options:
         break
       case '--paper-account-flatten-manifest-path':
         options.paperAccountFlattenManifestPath = value
+        break
+      case '--bounded-paper-route-target-materialization-manifest-path':
+        options.boundedPaperRouteTargetMaterializationManifestPath = value
         break
       case '--whitepaper-semantic-backfill-manifest-path':
         options.whitepaperSemanticBackfillManifestPath = value


### PR DESCRIPTION
## Summary

- Adds the bounded paper-route target materialization CronJob to Torghut release manifest updates.
- Adds the same CronJob path to Torghut deploy auto-merge eligibility.
- Moves the live CronJob manifest to the `c6e7c718` promoted Torghut image digest so it can run the dynamic target-plan CLI instead of old-image skipping.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts .github/workflows/torghut-release.yml .github/workflows/torghut-deploy-automerge.yml argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-followup-render.yaml && rg -n 'torghut-bounded-paper-route-target-materialization|d9c2403|d88a182|allow-dynamic-target-plan' /tmp/torghut-followup-render.yaml`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'bounded_paper_route_target_materialization or torghut_kustomization_includes_tigerbeetle_cluster' -q`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
