### PR TITLE
fix(autotrader): allow readback vcs secret

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-readback-agent.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-readback-agent.yaml
@@ -24,6 +24,7 @@ spec:
       - autonomous-trader-alpaca-mcp
       - agents-artifacts
       - codex-auth
+      - github-token
       - synthesis-env
     allowedServiceAccounts:
       - agents-sa

--- a/argocd/applications/autotrader/autonomous-trader-readback-secretbinding.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-readback-secretbinding.yaml
@@ -19,4 +19,5 @@ spec:
     - autonomous-trader-alpaca-mcp
     - agents-artifacts
     - codex-auth
+    - github-token
     - synthesis-env

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -879,6 +879,7 @@ describe('autonomous trader provider', () => {
     const agentSpec = objectAt(agent, 'spec')
     const agentMetadata = objectAt(agent, 'metadata')
     const readbackSystemPromptRef = objectAt(objectAt(agentSpec, 'defaults'), 'systemPromptRef')
+    const agentAllowedSecrets = objectAt(objectAt(agentSpec, 'security'), 'allowedSecrets') as unknown[]
     const implementationMetadata = objectAt(implementationSpec, 'metadata')
     const adapter = objectAt(providerSpec, 'adapter')
     const execAdapter = objectAt(adapter, 'exec')
@@ -936,8 +937,10 @@ describe('autonomous trader provider', () => {
       'autonomous-trader-alpaca-mcp',
       'agents-artifacts',
       'codex-auth',
+      'github-token',
       'synthesis-env',
     ])
+    expect(agentAllowedSecrets).toEqual(secretBindingSecrets)
     expect(objectAt(providerSpec, 'binary')).toBe('/usr/local/bin/agent-runner')
     expect(objectAt(adapter, 'type')).toBe('exec')
     expect(objectAt(execAdapter, 'binary')).toBe('/usr/bin/env')


### PR DESCRIPTION
## Summary

- Allows the dedicated autonomous-trader readback Agent to use the `github-token` VCS provider secret.
- Adds `github-token` to the readback SecretBinding allowlist while keeping it out of mounted readback runtime secrets.
- Extends the scorecard-readback smoke test to assert Agent and SecretBinding allowlists stay aligned.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "schedules a post-close scorecard readback proof without broker mutations"`
- `kubectl kustomize argocd/applications/autotrader`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
