### PR TITLE
fix(autotrader): checkout repo for readback runner

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-readback-agentprovider.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-readback-agentprovider.yaml
@@ -74,6 +74,7 @@ spec:
         set -euo pipefail
 
         report_path="/workspace/.agentrun/autonomous-trader/report.md"
+        repo_dir="${AUTONOMOUS_TRADER_REPO_DIR:-/workspace/lab}"
         work_dir="${AUTONOMOUS_TRADER_WORK_DIR:-/tmp/autonomous-trader-readback}"
         python_bin="${PYTHON_BIN:-python3}"
 
@@ -85,6 +86,35 @@ spec:
         if [ "${trader_mode}" != "scorecard-readback" ]; then
           printf 'autonomous-trader readback runner only accepts scorecard-readback mode, got %s\n' "${trader_mode}" >&2
           exit 64
+        fi
+
+        git_token="${GIT_ASKPASS_TOKEN:-${VCS_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}}"
+        if [ -n "${git_token}" ]; then
+          askpass_path="${work_dir}/git-askpass.sh"
+          cat > "${askpass_path}" <<'EOF'
+        #!/usr/bin/env sh
+        case "$1" in
+          *Username*) printf '%s\n' "${GIT_ASKPASS_USERNAME:-x-access-token}" ;;
+          *) printf '%s\n' "${GIT_ASKPASS_TOKEN:-${VCS_TOKEN:-${GITHUB_TOKEN:-${GH_TOKEN:-}}}}" ;;
+        esac
+        EOF
+          chmod 700 "${askpass_path}"
+          export GIT_ASKPASS="${askpass_path}"
+          export GIT_ASKPASS_TOKEN="${git_token}"
+          export GIT_TERMINAL_PROMPT=0
+        fi
+
+        repo="${VCS_REPOSITORY:-proompteng/lab}"
+        base_branch="${VCS_BASE_BRANCH:-main}"
+        clone_base_url="${VCS_CLONE_BASE_URL:-https://github.com}"
+        clone_url="${clone_base_url%/}/${repo}.git"
+        mkdir -p "$(dirname "${repo_dir}")"
+        if [ ! -d "${repo_dir}/.git" ]; then
+          rm -rf "${repo_dir}"
+          git clone --filter=blob:none --depth=1 --branch "${base_branch}" "${clone_url}" "${repo_dir}"
+        else
+          git -C "${repo_dir}" fetch --prune --filter=blob:none --depth=1 origin "${base_branch}"
+          git -C "${repo_dir}" checkout --force FETCH_HEAD
         fi
 
         reconcile_enabled="$(printf '%s' "${AUTONOMOUS_TRADER_SESSION_RECONCILE_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')"
@@ -100,7 +130,7 @@ spec:
           readback_args+=(--backfill-finalized-flat)
         fi
 
-        exec "${python_bin}" /workspace/lab/scripts/autotrader/scorecard_readback.py "${readback_args[@]}"
+        exec "${python_bin}" "${repo_dir}/scripts/autotrader/scorecard_readback.py" "${readback_args[@]}"
   outputArtifacts:
     - name: autonomous-trader-report
       path: /workspace/.agentrun/autonomous-trader/report.md

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -965,9 +965,17 @@ describe('autonomous trader provider', () => {
     expect(readbackScriptContent).toContain('scorecard_readback.py')
     expect(readbackScriptContent).toContain('trader_mode="$(printf')
     expect(readbackScriptContent).toContain('exit 64')
+    expect(readbackScriptContent).toContain('repo_dir="${AUTONOMOUS_TRADER_REPO_DIR:-/workspace/lab}"')
+    expect(readbackScriptContent).toContain('GIT_TERMINAL_PROMPT=0')
+    expect(readbackScriptContent).toContain('git clone --filter=blob:none --depth=1 --branch "${base_branch}"')
+    expect(readbackScriptContent).toContain(
+      'git -C "${repo_dir}" fetch --prune --filter=blob:none --depth=1 origin "${base_branch}"',
+    )
+    expect(readbackScriptContent).toContain(
+      'exec "${python_bin}" "${repo_dir}/scripts/autotrader/scorecard_readback.py"',
+    )
     expect(readbackScriptContent).toContain('readback_args+=(--finalize-stale-flat)')
     expect(readbackScriptContent).toContain('readback_args+=(--backfill-finalized-flat)')
-    expect(readbackScriptContent).not.toContain('git ')
     expect(readbackScriptContent).not.toContain('stock_analysis')
     expect(outputArtifactNames).toEqual(['autonomous-trader-report', 'runner-log', 'runner-status'])
     const goal = objectAt(templateSpec, 'goal') as Record<string, unknown>


### PR DESCRIPTION
## Summary

- Makes the dedicated autonomous-trader readback runner shallow-checkout the lab repo before invoking repo-owned Python helpers.
- Uses the controller-provided read-only VCS environment and token via a temporary `GIT_ASKPASS` helper.
- Adds smoke-test assertions for the checkout path while preserving the no-analysis-clone readback lane.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "schedules a post-close scorecard readback proof without broker mutations"`
- `kubectl kustomize argocd/applications/autotrader`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `bun run lint:argocd`
- `ruby -ryaml -e 'docs = YAML.load_stream(File.read("argocd/applications/autotrader/autonomous-trader-readback-agentprovider.yaml")); provider = docs.find { |doc| doc["kind"] == "AgentProvider" }; script = provider["spec"]["inputFiles"].find { |f| f["path"] == "/root/autonomous-trader-scorecard-readback.sh" }["content"]; File.write("/tmp/autonomous-trader-scorecard-readback.sh", script)' && bash -n /tmp/autonomous-trader-scorecard-readback.sh`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
