### PR TITLE
fix(torghut): unblock source runtime evidence readiness

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -170,6 +170,50 @@ describe('validatePostDeployEvidence', () => {
     expect(result.summaryLines.join('\n')).toContain('Sim target count: `1`')
   })
 
+  it('uses raw paper-route targets when source collection is the selected next plan', () => {
+    const rawLivePlan = buildPaperRouteEvidence([paperRouteTarget]).next_paper_route_runtime_window_targets
+    const rawSimPlan = buildPaperRouteEvidence([
+      { ...paperRouteTarget, source_account_label: 'TORGHUT_SIM' },
+    ]).next_paper_route_runtime_window_targets
+    const selectedSourceCollectionPlan = {
+      schema_version: 'torghut.runtime-ledger-paper-probation-import-plan.v1',
+      source: 'paper_route_observed_strategy_source_collection',
+      promotion_allowed: false,
+      final_promotion_allowed: false,
+      final_promotion_authorized: false,
+      target_count: 1,
+      targets: [
+        {
+          hypothesis_id: 'H-MICRO-01',
+          candidate_id: 'candidate-source-collection',
+          strategy_name: 'microbar-volume-continuation-long-top2-chip-v1',
+          source_kind: 'runtime_ledger_source_collection_candidate',
+        },
+      ],
+    }
+
+    const result = validatePostDeployEvidence({
+      readyzHttpStatus: '200',
+      readyz: { status: 'ok' },
+      revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+      tradingStatus: baseTradingStatus,
+      paperRouteEvidence: {
+        schema_version: 'torghut.paper-route-evidence.v1',
+        next_paper_route_runtime_window_targets: selectedSourceCollectionPlan,
+        raw_next_paper_route_runtime_window_targets: rawLivePlan,
+      },
+      simPaperRouteEvidence: {
+        schema_version: 'torghut.paper-route-evidence.v1',
+        next_paper_route_runtime_window_targets: selectedSourceCollectionPlan,
+        raw_next_paper_route_runtime_window_targets: rawSimPlan,
+      },
+    })
+
+    expect(result.summaryLines.join('\n')).toContain('Torghut Paper Route Target Mirror')
+    expect(result.summaryLines.join('\n')).toContain('Live target count: `1`')
+    expect(result.summaryLines.join('\n')).toContain('Sim target count: `1`')
+  })
+
   it('rejects an empty sim paper-route plan when live torghut exposes a target', () => {
     expect(() =>
       validatePostDeployEvidence({

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -237,6 +237,30 @@ const requireRuntimeWindowImportHealthGate = (
   return { dependencyQuorumDecision, continuityOk, driftOk }
 }
 
+const selectPaperRouteMirrorPlan = (payload: JsonObject, label: string): JsonObject => {
+  const selectedPlan = requireObject(
+    payload.next_paper_route_runtime_window_targets,
+    `${label} next_paper_route_runtime_window_targets`,
+  )
+  const selectedSchemaVersion = formatScalar(selectedPlan.schema_version, 'missing')
+  if (selectedSchemaVersion === PAPER_ROUTE_TARGETS_SCHEMA_VERSION) {
+    return selectedPlan
+  }
+
+  const rawPlanValue = payload.raw_next_paper_route_runtime_window_targets
+  if (rawPlanValue && typeof rawPlanValue === 'object' && !Array.isArray(rawPlanValue)) {
+    const rawPlan = rawPlanValue as JsonObject
+    const rawSchemaVersion = formatScalar(rawPlan.schema_version, 'missing')
+    if (rawSchemaVersion === PAPER_ROUTE_TARGETS_SCHEMA_VERSION) {
+      return rawPlan
+    }
+  }
+
+  throw new Error(
+    `${label} target plan schema mismatch: expected ${PAPER_ROUTE_TARGETS_SCHEMA_VERSION}, got ${selectedSchemaVersion}`,
+  )
+}
+
 const parsePaperRouteTargets = (
   evidence: unknown,
   label: string,
@@ -246,10 +270,7 @@ const parsePaperRouteTargets = (
   if (schemaVersion !== PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION) {
     throw new Error(`${label} schema mismatch: expected ${PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION}, got ${schemaVersion}`)
   }
-  const plan = requireObject(
-    payload.next_paper_route_runtime_window_targets,
-    `${label} next_paper_route_runtime_window_targets`,
-  )
+  const plan = selectPaperRouteMirrorPlan(payload, label)
   const planSchemaVersion = formatScalar(plan.schema_version, 'missing')
   if (planSchemaVersion !== PAPER_ROUTE_TARGETS_SCHEMA_VERSION) {
     throw new Error(

--- a/services/torghut/app/db.py
+++ b/services/torghut/app/db.py
@@ -101,8 +101,7 @@ def _has_unique_index(inspector: Any, table: str, columns: list[str]) -> bool:
     constraints = inspector.get_unique_constraints(table)
     for constraint in constraints:
         constraint_columns = [
-            _normalize_name(column)
-            for column in constraint.get("column_names", [])
+            _normalize_name(column) for column in constraint.get("column_names", [])
         ]
         if set(constraint_columns) == expected:
             return True
@@ -113,7 +112,8 @@ def _named_unique_constraint_present(
     inspector: Any, table: str, names: set[str]
 ) -> bool:
     constraint_names = {
-        _normalize_name(constraint.get("name")) for constraint in inspector.get_unique_constraints(table)
+        _normalize_name(constraint.get("name"))
+        for constraint in inspector.get_unique_constraints(table)
     }
     return any(name in constraint_names for name in names)
 
@@ -186,9 +186,7 @@ def check_account_scope_invariants(session: Session) -> dict[str, object]:
         ["source", "account_label"],
     )
     if not checks["trade_cursor_has_account_scoped_source_index"]:
-        errors.append(
-            "trade_cursor missing unique index on (source, account_label)"
-        )
+        errors.append("trade_cursor missing unique index on (source, account_label)")
 
     checks["legacy_executions_single_account_order_id_index_detected"] = (
         _has_unique_index(
@@ -220,26 +218,23 @@ def check_account_scope_invariants(session: Session) -> dict[str, object]:
             "legacy unique constraint/index detected for executions.client_order_id"
         )
 
-    checks["legacy_trade_cursor_source_only_source_index_detected"] = (
-        _has_unique_index(inspector, "trade_cursor", ["source"])
-        or _named_unique_constraint_present(
-            inspector,
-            "trade_cursor",
-            {"trade_cursor_source_key"},
-        )
+    checks["legacy_trade_cursor_source_only_source_index_detected"] = _has_unique_index(
+        inspector, "trade_cursor", ["source"]
+    ) or _named_unique_constraint_present(
+        inspector,
+        "trade_cursor",
+        {"trade_cursor_source_key"},
     )
     if checks["legacy_trade_cursor_source_only_source_index_detected"]:
-        errors.append(
-            "legacy unique constraint/index detected for trade_cursor.source"
-        )
+        errors.append("legacy unique constraint/index detected for trade_cursor.source")
 
     checks["legacy_executions_single_account_indexes_present"] = (
         checks["legacy_executions_single_account_order_id_index_detected"]
         or checks["legacy_executions_single_account_client_order_id_index_detected"]
     )
-    checks["legacy_trade_cursor_source_only_index_present"] = (
-        checks["legacy_trade_cursor_source_only_source_index_detected"]
-    )
+    checks["legacy_trade_cursor_source_only_index_present"] = checks[
+        "legacy_trade_cursor_source_only_source_index_detected"
+    ]
     checks["account_scope_ready"] = not errors
     checks["account_scope_index_names"] = {
         "execution_indexes": sorted(_index_names(inspector, "executions")),
@@ -273,7 +268,9 @@ def _alembic_config() -> AlembicConfig:
     if not _ALEMBIC_INI_PATH.exists():
         raise RuntimeError(f"Alembic config not found at {_ALEMBIC_INI_PATH}")
     if not _ALEMBIC_MIGRATIONS_PATH.exists():
-        raise RuntimeError(f"Alembic migrations directory not found at {_ALEMBIC_MIGRATIONS_PATH}")
+        raise RuntimeError(
+            f"Alembic migrations directory not found at {_ALEMBIC_MIGRATIONS_PATH}"
+        )
     config = AlembicConfig(str(_ALEMBIC_INI_PATH))
     config.set_main_option("script_location", str(_ALEMBIC_MIGRATIONS_PATH))
     config.set_main_option("sqlalchemy.url", settings.sqlalchemy_dsn)
@@ -283,7 +280,10 @@ def _alembic_config() -> AlembicConfig:
 def _extract_assignment_literal(tree: ast.Module, *, name: str, path: Path) -> object:
     for node in tree.body:
         if isinstance(node, ast.Assign):
-            if any(isinstance(target, ast.Name) and target.id == name for target in node.targets):
+            if any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            ):
                 try:
                     return ast.literal_eval(node.value)
                 except (ValueError, SyntaxError) as exc:
@@ -291,7 +291,11 @@ def _extract_assignment_literal(tree: ast.Module, *, name: str, path: Path) -> o
                         f"failed to parse '{name}' literal from migration file {path.name}"
                     ) from exc
         if isinstance(node, ast.AnnAssign):
-            if isinstance(node.target, ast.Name) and node.target.id == name and node.value is not None:
+            if (
+                isinstance(node.target, ast.Name)
+                and node.target.id == name
+                and node.value is not None
+            ):
                 try:
                     return ast.literal_eval(node.value)
                 except (ValueError, SyntaxError) as exc:
@@ -332,12 +336,18 @@ def _parse_migration_revision(path: Path) -> tuple[str, tuple[str, ...]]:
 
     revision_raw = _extract_assignment_literal(tree, name="revision", path=path)
     if not isinstance(revision_raw, str):
-        raise RuntimeError(f"migration file {path.name} missing string revision identifier")
+        raise RuntimeError(
+            f"migration file {path.name} missing string revision identifier"
+        )
     revision = revision_raw.strip()
     if not revision:
-        raise RuntimeError(f"migration file {path.name} has an empty revision identifier")
+        raise RuntimeError(
+            f"migration file {path.name} has an empty revision identifier"
+        )
 
-    down_revision_raw = _extract_assignment_literal(tree, name="down_revision", path=path)
+    down_revision_raw = _extract_assignment_literal(
+        tree, name="down_revision", path=path
+    )
     down_revisions = _normalize_down_revisions(down_revision_raw)
     return revision, down_revisions
 
@@ -366,13 +376,17 @@ def _parse_migration_graph(versions_dir: Path) -> dict[str, object]:
     if not versions_dir.exists():
         raise RuntimeError(f"migration versions directory not found at {versions_dir}")
     if not versions_dir.is_dir():
-        raise RuntimeError(f"migration versions path is not a directory: {versions_dir}")
+        raise RuntimeError(
+            f"migration versions path is not a directory: {versions_dir}"
+        )
 
     revision_to_files: dict[str, list[str]] = {}
     revision_to_parents: dict[str, tuple[str, ...]] = {}
     parsed_revisions: list[tuple[str, tuple[str, ...]]] = []
 
-    migration_files = sorted(path for path in versions_dir.glob("*.py") if path.is_file())
+    migration_files = sorted(
+        path for path in versions_dir.glob("*.py") if path.is_file()
+    )
     if not migration_files:
         raise RuntimeError(f"no migration files found in {versions_dir}")
 
@@ -392,9 +406,15 @@ def _parse_migration_graph(versions_dir: Path) -> dict[str, object]:
             parent_to_children.setdefault(parent, set()).add(child)
             edges.append((parent, child))
 
-    roots = sorted(revision for revision, parents in revision_to_parents.items() if not parents)
-    heads = sorted(revision for revision in revisions if revision not in parent_to_children)
-    orphan_parents = sorted(parent for parent in parent_to_children if parent not in revisions)
+    roots = sorted(
+        revision for revision, parents in revision_to_parents.items() if not parents
+    )
+    heads = sorted(
+        revision for revision in revisions if revision not in parent_to_children
+    )
+    orphan_parents = sorted(
+        parent for parent in parent_to_children if parent not in revisions
+    )
     duplicate_revisions = {
         revision: sorted(files)
         for revision, files in revision_to_files.items()
@@ -444,14 +464,41 @@ def _schema_heads_signature(heads: tuple[str, ...]) -> str:
     return hashlib.sha256(",".join(heads).encode("utf-8")).hexdigest()
 
 
+_POSTGRES_SCHEMA_HEAD_STATEMENT_TIMEOUT_MS = 150
+
+
+def _current_schema_heads(session: Session) -> list[str]:
+    connection = session.connection()
+    dialect_name = str(
+        getattr(getattr(connection, "dialect", None), "name", "")
+    ).lower()
+    if dialect_name == "postgresql":
+        connection.execute(
+            text(
+                f"SET LOCAL statement_timeout = {_POSTGRES_SCHEMA_HEAD_STATEMENT_TIMEOUT_MS}"
+            )
+        )
+        version_table = connection.execute(
+            text("SELECT to_regclass('alembic_version')")
+        ).scalar()
+        if version_table is None:
+            return []
+        raw_heads = connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalars()
+        return sorted(str(head).strip() for head in raw_heads if str(head).strip())
+
+    context = MigrationContext.configure(connection=connection)
+    return sorted(str(head) for head in context.get_current_heads())
+
+
 def check_schema_current(session: Session) -> dict[str, object]:
     """Report Alembic head alignment for readiness and diagnostics."""
 
     ping(session)
     expected_heads = _get_expected_schema_heads()
     expected_graph = _get_expected_schema_graph()
-    context = MigrationContext.configure(connection=session.connection())
-    current_heads = sorted(context.get_current_heads())
+    current_heads = _current_schema_heads(session)
     expected_heads_set = set(expected_heads)
     current_heads_set = set(current_heads)
     return {
@@ -467,7 +514,9 @@ def check_schema_current(session: Session) -> dict[str, object]:
         + len(current_heads_set - expected_heads_set),
         "schema_graph_signature": expected_graph.get("expected_schema_graph_signature"),
         "schema_graph_roots": expected_graph.get("expected_migration_roots", []),
-        "schema_graph_branch_count": expected_graph.get("expected_migration_branch_count"),
+        "schema_graph_branch_count": expected_graph.get(
+            "expected_migration_branch_count"
+        ),
         "schema_graph_parent_forks": expected_graph.get(
             "expected_migration_parent_forks",
             {},

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -828,34 +828,42 @@ def _runtime_window_target_plan_with_live_gate_source_collection(
 def _runtime_window_target_plan_from_payload(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
-    direct_plan = _as_dict(payload.get("runtime_window_import_plan"))
-    if direct_plan:
-        plan = direct_plan
+    source_runtime_window_plan = _as_dict(
+        payload.get("source_runtime_window_import_plan")
+    )
+    if _runtime_window_plan_target_items(source_runtime_window_plan):
+        plan = source_runtime_window_plan
     else:
-        paper_route_plan = _as_dict(
-            payload.get("next_paper_route_runtime_window_targets")
-        )
-        if (
-            str(payload.get("schema_version") or "").strip()
-            == "torghut.paper-route-evidence.v1"
-            and paper_route_plan
-        ):
-            plan = paper_route_plan
+        direct_plan = _as_dict(payload.get("runtime_window_import_plan"))
+        if direct_plan:
+            plan = direct_plan
         else:
-            gate = _as_dict(payload.get("live_submission_gate"))
-            gate_plan = _as_dict(gate.get("runtime_ledger_paper_probation_import_plan"))
-            if gate_plan:
-                plan = gate_plan
+            paper_route_plan = _as_dict(
+                payload.get("next_paper_route_runtime_window_targets")
+            )
+            if (
+                str(payload.get("schema_version") or "").strip()
+                == "torghut.paper-route-evidence.v1"
+                and paper_route_plan
+            ):
+                plan = paper_route_plan
             else:
-                top_level_gate_plan = _as_dict(
-                    payload.get("runtime_ledger_paper_probation_import_plan")
+                gate = _as_dict(payload.get("live_submission_gate"))
+                gate_plan = _as_dict(
+                    gate.get("runtime_ledger_paper_probation_import_plan")
                 )
-                if top_level_gate_plan:
-                    plan = top_level_gate_plan
-                elif paper_route_plan:
-                    plan = paper_route_plan
+                if gate_plan:
+                    plan = gate_plan
                 else:
-                    plan = _as_dict(payload)
+                    top_level_gate_plan = _as_dict(
+                        payload.get("runtime_ledger_paper_probation_import_plan")
+                    )
+                    if top_level_gate_plan:
+                        plan = top_level_gate_plan
+                    elif paper_route_plan:
+                        plan = paper_route_plan
+                    else:
+                        plan = _as_dict(payload)
     plan = _runtime_window_target_plan_with_live_gate_source_collection(
         payload=payload,
         plan=plan,

--- a/services/torghut/tests/test_db.py
+++ b/services/torghut/tests/test_db.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Iterator
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
@@ -171,6 +172,100 @@ class TestDbSchemaCurrent(TestCase):
         )
         self.assertEqual(status["schema_graph_duplicate_revisions"], {})
         self.assertEqual(status["schema_graph_orphan_parents"], [])
+
+    def test_check_schema_current_reads_postgres_alembic_heads_directly(
+        self,
+    ) -> None:
+        class FakeScalarResult:
+            def __init__(self, values: list[str]) -> None:
+                self._values = values
+
+            def __iter__(self) -> Iterator[str]:
+                return iter(self._values)
+
+        class FakeResult:
+            def __init__(
+                self,
+                *,
+                scalar_value: object | None = None,
+                scalar_values: list[str] | None = None,
+            ) -> None:
+                self._scalar_value = scalar_value
+                self._scalar_values = scalar_values or []
+
+            def scalar_one(self) -> int:
+                return 1
+
+            def scalar(self) -> object | None:
+                return self._scalar_value
+
+            def scalars(self) -> FakeScalarResult:
+                return FakeScalarResult(self._scalar_values)
+
+        class FakeDialect:
+            name = "postgresql"
+
+        class FakeConnection:
+            dialect = FakeDialect()
+
+            def __init__(self) -> None:
+                self.statements: list[str] = []
+
+            def execute(self, statement: object) -> FakeResult:
+                sql = str(statement)
+                self.statements.append(sql)
+                if "SET LOCAL statement_timeout" in sql:
+                    return FakeResult()
+                if "to_regclass('alembic_version')" in sql:
+                    return FakeResult(scalar_value="alembic_version")
+                if "SELECT version_num FROM alembic_version" in sql:
+                    return FakeResult(
+                        scalar_values=["0012_demo_beta", "0011_demo_alpha"]
+                    )
+                raise AssertionError(f"unexpected SQL: {sql}")
+
+        class FakeSession:
+            def __init__(self) -> None:
+                self.connection_obj = FakeConnection()
+
+            def execute(self, statement: object) -> FakeResult:
+                sql = str(statement)
+                if sql == "SELECT 1":
+                    return FakeResult(scalar_value=1)
+                raise AssertionError(f"unexpected session SQL: {sql}")
+
+            def connection(self) -> FakeConnection:
+                return self.connection_obj
+
+        fake_session = FakeSession()
+        with (
+            patch(
+                "app.db._get_expected_schema_heads",
+                return_value=("0011_demo_alpha", "0012_demo_beta"),
+            ),
+            patch(
+                "app.db._get_expected_schema_graph",
+                return_value={
+                    "expected_schema_graph_signature": "graph-signature-demo",
+                    "expected_migration_roots": [],
+                    "expected_migration_branch_count": 1,
+                    "expected_migration_parent_forks": {},
+                    "expected_migration_duplicate_revisions": {},
+                    "expected_migration_orphan_parents": [],
+                },
+            ),
+            patch("app.db.MigrationContext") as mock_migration_context,
+        ):
+            status = app_db.check_schema_current(fake_session)  # type: ignore[arg-type]
+
+        self.assertTrue(status["schema_current"])
+        self.assertEqual(status["current_heads"], ["0011_demo_alpha", "0012_demo_beta"])
+        mock_migration_context.configure.assert_not_called()
+        joined_sql = "\n".join(fake_session.connection_obj.statements)
+        self.assertIn("SET LOCAL statement_timeout", joined_sql)
+        self.assertIn("SELECT to_regclass('alembic_version')", joined_sql)
+        self.assertIn("SELECT version_num FROM alembic_version", joined_sql)
+        self.assertNotIn("pg_catalog.pg_class", joined_sql)
 
     def test_expected_schema_heads_cached(self) -> None:
         app_db._get_expected_schema_heads.cache_clear()

--- a/services/torghut/tests/test_db.py
+++ b/services/torghut/tests/test_db.py
@@ -267,6 +267,80 @@ class TestDbSchemaCurrent(TestCase):
         self.assertIn("SELECT version_num FROM alembic_version", joined_sql)
         self.assertNotIn("pg_catalog.pg_class", joined_sql)
 
+    def test_check_schema_current_treats_missing_postgres_alembic_table_as_empty(
+        self,
+    ) -> None:
+        class FakeResult:
+            def __init__(self, *, scalar_value: object | None = None) -> None:
+                self._scalar_value = scalar_value
+
+            def scalar_one(self) -> int:
+                return 1
+
+            def scalar(self) -> object | None:
+                return self._scalar_value
+
+        class FakeDialect:
+            name = "postgresql"
+
+        class FakeConnection:
+            dialect = FakeDialect()
+
+            def execute(self, statement: object) -> FakeResult:
+                sql = str(statement)
+                if "SET LOCAL statement_timeout" in sql:
+                    return FakeResult()
+                if "to_regclass('alembic_version')" in sql:
+                    return FakeResult(scalar_value=None)
+                raise AssertionError(f"unexpected SQL: {sql}")
+
+        class FakeSession:
+            def __init__(self) -> None:
+                self.connection_obj = FakeConnection()
+
+            def execute(self, statement: object) -> FakeResult:
+                sql = str(statement)
+                if sql == "SELECT 1":
+                    return FakeResult(scalar_value=1)
+                raise AssertionError(f"unexpected session SQL: {sql}")
+
+            def connection(self) -> FakeConnection:
+                return self.connection_obj
+
+        with (
+            patch("app.db._get_expected_schema_heads", return_value=("0011_demo",)),
+            patch(
+                "app.db._get_expected_schema_graph",
+                return_value={
+                    "expected_schema_graph_signature": "graph-signature-demo",
+                    "expected_migration_roots": [],
+                    "expected_migration_branch_count": 1,
+                    "expected_migration_parent_forks": {},
+                    "expected_migration_duplicate_revisions": {},
+                    "expected_migration_orphan_parents": [],
+                },
+            ),
+            patch("app.db.MigrationContext") as mock_migration_context,
+        ):
+            status = app_db.check_schema_current(FakeSession())  # type: ignore[arg-type]
+
+        self.assertEqual(status["current_heads"], [])
+        self.assertEqual(status["schema_missing_heads"], ["0011_demo"])
+        mock_migration_context.configure.assert_not_called()
+
+    def test_alembic_config_requires_migrations_directory(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            ini_path = base_dir / "alembic.ini"
+            ini_path.write_text("[alembic]\n", encoding="utf-8")
+
+            with (
+                patch("app.db._ALEMBIC_INI_PATH", ini_path),
+                patch("app.db._ALEMBIC_MIGRATIONS_PATH", base_dir / "missing"),
+                self.assertRaisesRegex(RuntimeError, "Alembic migrations directory"),
+            ):
+                app_db._alembic_config()
+
     def test_expected_schema_heads_cached(self) -> None:
         app_db._get_expected_schema_heads.cache_clear()
         with patch("app.db.ScriptDirectory.from_config") as mock_from_config:
@@ -292,7 +366,7 @@ class TestDbMigrationGraphParsing(TestCase):
         with TemporaryDirectory() as tmpdir:
             versions_dir = Path(tmpdir)
             (versions_dir / "0001_root.py").write_text(
-                "revision = '0001_root'\ndown_revision = None\n",
+                "revision: str = '0001_root'\ndown_revision = None\n",
                 encoding="utf-8",
             )
             (versions_dir / "0002_alpha.py").write_text(
@@ -345,3 +419,26 @@ class TestDbMigrationGraphParsing(TestCase):
             {"0001_first": ["0001_duplicate.py", "0001_first.py"]},
         )
         self.assertEqual(summary["expected_migration_orphan_parents"], ["0000_missing"])
+
+    def test_parse_migration_revision_rejects_missing_and_empty_revision(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            versions_dir = Path(tmpdir)
+            missing_revision = versions_dir / "missing_revision.py"
+            missing_revision.write_text("down_revision = None\n", encoding="utf-8")
+            empty_revision = versions_dir / "empty_revision.py"
+            empty_revision.write_text(
+                "revision = '   '\ndown_revision = None\n", encoding="utf-8"
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "missing string revision"):
+                app_db._parse_migration_revision(missing_revision)
+            with self.assertRaisesRegex(RuntimeError, "empty revision"):
+                app_db._parse_migration_revision(empty_revision)
+
+    def test_parse_migration_graph_rejects_versions_path_file(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            versions_path = Path(tmpdir) / "versions.py"
+            versions_path.write_text("", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "not a directory"):
+                app_db._parse_migration_graph(versions_path)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -788,6 +788,124 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(top_level_plan["targets"][0]["hypothesis_id"], "H-PAIRS-01")
         self.assertEqual(fallback_plan["targets"][0]["hypothesis_id"], "H-FALLBACK-01")
 
+    def test_runtime_window_target_plan_payload_prefers_source_runtime_plan(
+        self,
+    ) -> None:
+        plan = renewal._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "targets": [
+                        {
+                            "candidate_id": "cand-empty-hpairs",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "strategy_family": "microbar_cross_sectional_pairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                        }
+                    ]
+                },
+                "source_runtime_window_import_plan": {
+                    "source": "live_submission_gate_runtime_ledger_source_collection",
+                    "purpose": "runtime_ledger_source_collection_import",
+                    "targets": [
+                        {
+                            "candidate_id": "cand-source-volume",
+                            "hypothesis_id": "H-MICRO-01",
+                            "strategy_family": "microstructure_breakout",
+                            "strategy_name": (
+                                "microbar-volume-continuation-long-top2-chip-v1"
+                            ),
+                            "account_label": "TORGHUT_SIM",
+                            "source_account_label": "TORGHUT_SIM",
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                            "source_collection_authorized": True,
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-micro-01.json"
+                            ),
+                            "window_start": "2026-06-02T13:30:00+00:00",
+                            "window_end": "2026-06-02T20:00:00+00:00",
+                        }
+                    ],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "targets": [
+                        {
+                            "candidate_id": "cand-next-hpairs",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "strategy_family": "microbar_cross_sectional_pairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        }
+                    ]
+                },
+                "runtime_window_import_audit": {
+                    "state": "import_due_source_activity_missing",
+                    "blockers": ["paper_route_source_activity_missing"],
+                },
+            }
+        )
+
+        self.assertEqual(
+            plan["source"], "live_submission_gate_runtime_ledger_source_collection"
+        )
+        target = plan["targets"][0]
+        self.assertEqual(target["candidate_id"], "cand-source-volume")
+        self.assertEqual(
+            target["source_kind"], "runtime_ledger_source_collection_candidate"
+        )
+        self.assertEqual(
+            target["runtime_window_import_audit_state"],
+            "import_due_source_activity_missing",
+        )
+        self.assertIn(
+            "paper_route_source_activity_missing",
+            target["runtime_window_import_audit_blockers"],
+        )
+
+        args = SimpleNamespace(
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_target_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+            runtime_window_delay_adjusted_depth_stress_report_ref="",
+            runtime_window_dependency_quorum_decision="",
+            runtime_window_continuity_ok="",
+            runtime_window_drift_ok="",
+            runtime_window_source_account_label="",
+        )
+        import_targets = renewal._runtime_window_targets_from_plan(
+            plan=plan,
+            ref="target-plan-payload",
+            args=args,
+        )
+
+        self.assertEqual(len(import_targets), 1)
+        self.assertEqual(import_targets[0].candidate_id, "cand-source-volume")
+        self.assertEqual(
+            import_targets[0].source_kind,
+            "runtime_ledger_source_collection_candidate",
+        )
+        self.assertIsNone(
+            renewal._runtime_window_target_plan_import_blocked_result(
+                target=import_targets[0],
+                candidate_id=import_targets[0].candidate_id,
+                manifest_path=Path("config/trading/hypotheses/h-micro-01.json"),
+                window_start=datetime(2026, 6, 2, 13, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 6, 2, 20, tzinfo=timezone.utc),
+                window_selection="target-plan-payload",
+            )
+        )
+
     def test_runtime_window_target_plan_payload_marks_contaminated_import_audit(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Prefer explicit source runtime-window import plans when renewing empirical promotion jobs so source-collection targets are not skipped behind empty direct paper-route plans.
- Let post-deploy paper-route mirror validation fall back to raw paper-route targets when the selected next plan is a source-collection import plan.
- Replace the Postgres schema-head readiness path with a narrow `alembic_version` read under the bounded timeout, preserving exact Alembic head matching without broad inspector reflection.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_db.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -k "database_contract or account_scope or db_check or schema_current or readyz" -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen pytest tests/test_db.py tests/test_run_empirical_promotion_jobs.py tests/test_trading_api.py -k "database_contract or account_scope or db_check or schema_current or readyz or runtime_window_target_plan" -q`
- `uv run --frozen ruff check app/db.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_db.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff format --check app/db.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_db.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run --cwd packages/scripts lint:oxlint:type` exited 0 with existing unrelated warnings outside the touched Torghut files.
- `git diff --check`
- Live pod probe on `torghut-00964-deployment-5bf94cbc9c-lx456`: direct bounded Alembic query returned `heads=["0048_status_read_timeout_indexes"]` in `14.562ms` under `statement_timeout=150`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
