### PR TITLE
fix(torghut): tolerate slow proof evidence reads

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -86,6 +86,7 @@ spec:
                     --status-service-base-url http://torghut.torghut.svc.cluster.local \
                     --paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local \
                     --completion-service-base-url http://torghut.torghut.svc.cluster.local \
+                    --timeout-seconds 30 \
                     --proof-mode authority \
                     --runtime-window-import-file "${RENEWAL_OUTPUT}" \
                     --min-runtime-ledger-net-pnl 10000 \

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -81,6 +81,7 @@ RUNTIME_IMPORT_MATERIALIZATION_PROMOTION_ONLY_BLOCKERS = frozenset(
         "runtime_ledger_stage_not_live",
     }
 )
+DEFAULT_SERVICE_FETCH_TIMEOUT_SECONDS = 30.0
 
 
 class _ObjectStoreClient(Protocol):
@@ -3311,7 +3312,15 @@ def _parser() -> argparse.ArgumentParser:
         help="Maximum share of post-cost runtime-ledger PnL attributable to one symbol.",
     )
     parser.add_argument("--generated-at", default=None)
-    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_SERVICE_FETCH_TIMEOUT_SECONDS,
+        help=(
+            "Timeout for service-backed status, paper-route, completion, and "
+            "runtime-window import JSON reads."
+        ),
+    )
     parser.add_argument("--output-file", type=Path, default=None)
     parser.add_argument(
         "--artifact-prefix",

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -3665,7 +3665,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 return json.dumps(self.body).encode("utf-8")
 
         def open_url(url: str, *, timeout: float) -> _Response:
-            self.assertEqual(timeout, 10.0)
+            self.assertEqual(timeout, packet.DEFAULT_SERVICE_FETCH_TIMEOUT_SECONDS)
             payloads = {
                 "http://torghut.local/trading/status": _status(),
                 "http://torghut.local/trading/paper-route-evidence": (
@@ -3729,7 +3729,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 return json.dumps(self.body).encode("utf-8")
 
         def open_url(url: str, *, timeout: float) -> _Response:
-            self.assertEqual(timeout, 10.0)
+            self.assertEqual(timeout, packet.DEFAULT_SERVICE_FETCH_TIMEOUT_SECONDS)
             payloads = {
                 "http://torghut-live.local/trading/status": _status(),
                 "http://torghut-sim.local/trading/paper-route-evidence": (
@@ -3802,7 +3802,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 return json.dumps(self.body).encode("utf-8")
 
         def open_url(url: str, *, timeout: float) -> _Response:
-            self.assertEqual(timeout, 10.0)
+            self.assertEqual(timeout, packet.DEFAULT_SERVICE_FETCH_TIMEOUT_SECONDS)
             if url == "http://torghut-live.local/trading/status":
                 return _Response(_status())
             if url == "http://torghut-sim.local/trading/paper-route-evidence":

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1904,6 +1904,7 @@ class TestLiveConfigManifestContract(TestCase):
             "--completion-service-base-url http://torghut.torghut.svc.cluster.local",
             args,
         )
+        self.assertIn("--timeout-seconds 30", args)
         self.assertIn("--proof-mode authority", args)
         self.assertIn('--runtime-window-import-file "${RENEWAL_OUTPUT}"', args)
         self.assertIn("--min-runtime-ledger-net-pnl 10000", args)


### PR DESCRIPTION
## Summary

- Raised the proof-packet assembler service fetch timeout default from 10s to 30s.
- Made the empirical promotion renewal CronJob pass `--timeout-seconds 30` explicitly when assembling runtime-ledger proof packets.
- Updated assembler and live-manifest contract tests so slow but healthy paper-route/status endpoints are not recorded as missing proof evidence.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py::TestRuntimeLedgerProofPacket::test_cli_can_assemble_from_service_base_url tests/test_assemble_runtime_ledger_proof_packet.py::TestRuntimeLedgerProofPacket::test_cli_can_assemble_from_split_live_and_paper_route_services tests/test_assemble_runtime_ledger_proof_packet.py::TestRuntimeLedgerProofPacket::test_cli_records_degraded_paper_route_fetch_as_blocked_packet -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db -q`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py`
- `bun run lint:argocd`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
