### PR TITLE
fix(torghut): guard bounded materializer windows

### DIFF
--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: bounded-paper-route-target-materialization
 spec:
-  schedule: "*/5 10-15 * * 1-5"
+  schedule: "*/5 9-15 * * 1-5"
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
@@ -47,6 +47,10 @@ spec:
                     echo "stage=bounded_paper_route_target_materialization skipped reason=old_image_missing_dynamic_target_plan_guard"
                     exit 0
                   fi
+                  if ! /opt/venv/bin/python scripts/materialize_bounded_paper_route_targets.py --help | grep -q -- '--skip-unless-active-target-window'; then
+                    echo "stage=bounded_paper_route_target_materialization skipped reason=old_image_missing_target_window_guard"
+                    exit 0
+                  fi
                   /opt/venv/bin/python scripts/materialize_bounded_paper_route_targets.py \
                     --plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan \
                     --plan-url-timeout-seconds 45 \
@@ -56,6 +60,7 @@ spec:
                     --max-notional 25 \
                     --commit \
                     --allow-dynamic-target-plan \
+                    --skip-unless-active-target-window \
                     --confirm-account-label TORGHUT_SIM \
                     --confirm-dsn-env SIM_DB_DSN \
                     --confirm-hypothesis-id H-PAIRS-01 \

--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -44,6 +44,12 @@ PROMOTION_FLAG_FIELDS = (
 )
 LIVE_LABEL_MARKERS = ("LIVE", "PROD", "REAL")
 TARGET_PLAN_RESPONSE_LIMIT_BYTES = 5_000_000
+ACTIVE_TARGET_WINDOW_SKIP_REASON = (
+    "paper_route_materialization_active_target_window_not_open"
+)
+ACTIVE_TARGET_WINDOW_REQUIRED_BLOCKER = (
+    "paper_route_materialization_active_target_window_required"
+)
 
 
 def _json_default(value: object) -> str:
@@ -164,6 +170,46 @@ def _target_plan_ref(target: Mapping[str, Any]) -> str | None:
         or _safe_text(target.get("source_manifest_ref"))
         or _safe_text(target.get("paper_route_target_plan_source"))
     )
+
+
+def _target_window_start(target: Mapping[str, Any]) -> str | None:
+    return (
+        _safe_text(target.get("window_start"))
+        or _safe_text(target.get("paper_route_probe_window_start"))
+        or _safe_text(target.get("source_window_start"))
+        or _safe_text(target.get("runtime_window_start"))
+    )
+
+
+def _target_window_end(target: Mapping[str, Any]) -> str | None:
+    return (
+        _safe_text(target.get("window_end"))
+        or _safe_text(target.get("paper_route_probe_window_end"))
+        or _safe_text(target.get("source_window_end"))
+        or _safe_text(target.get("runtime_window_end"))
+    )
+
+
+def _parse_utc_datetime(value: object) -> datetime | None:
+    text = _safe_text(value)
+    if text is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _resolve_now_utc(args: argparse.Namespace) -> datetime:
+    configured_now = _safe_text(getattr(args, "now_utc", None))
+    if configured_now:
+        parsed = _parse_utc_datetime(configured_now)
+        if parsed is not None:
+            return parsed
+    return datetime.now(timezone.utc)
 
 
 def _load_json_file(path: Path) -> dict[str, Any]:
@@ -413,6 +459,8 @@ def _target_summaries(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
                 "account_label": _safe_text(target.get("account_label")),
                 "target_plan_ref": _target_plan_ref(target),
                 "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
+                "window_start": _target_window_start(target),
+                "window_end": _target_window_end(target),
                 "bounded_collection_stage": _safe_text(
                     target.get("bounded_collection_stage")
                 )
@@ -429,6 +477,50 @@ def _target_summaries(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
             }
         )
     return summaries
+
+
+def _active_target_window_check(
+    summaries: Sequence[Mapping[str, Any]],
+    *,
+    now: datetime,
+) -> dict[str, Any]:
+    normalized_now = now.astimezone(timezone.utc)
+    targets: list[dict[str, Any]] = []
+    active_count = 0
+    missing_count = 0
+    inactive_count = 0
+    for summary in summaries:
+        target_index = int(summary.get("target_index", 0))
+        window_start = _parse_utc_datetime(summary.get("window_start"))
+        window_end = _parse_utc_datetime(summary.get("window_end"))
+        if window_start is None or window_end is None:
+            state = "missing_window"
+            missing_count += 1
+        elif window_start <= normalized_now < window_end:
+            state = "open"
+            active_count += 1
+        else:
+            state = "not_open"
+            inactive_count += 1
+        targets.append(
+            {
+                "target_index": target_index,
+                "state": state,
+                "window_start": summary.get("window_start"),
+                "window_end": summary.get("window_end"),
+            }
+        )
+    return {
+        "schema_version": "torghut.bounded-paper-route-target-window-check.v1",
+        "now_utc": normalized_now.isoformat(),
+        "required": bool(summaries),
+        "active": bool(summaries) and active_count == len(summaries),
+        "active_count": active_count,
+        "missing_count": missing_count,
+        "inactive_count": inactive_count,
+        "target_count": len(summaries),
+        "targets": targets,
+    }
 
 
 def _unique_texts(values: Sequence[object]) -> list[str]:
@@ -764,9 +856,23 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         dsn=dsn,
         dsn_env=dsn_env,
     )
+    target_window_check: dict[str, Any] | None = None
+    skip_reason: str | None = None
+    if bool(args.skip_unless_active_target_window) or bool(
+        args.require_active_target_window
+    ):
+        target_window_check = _active_target_window_check(
+            summaries,
+            now=_resolve_now_utc(args),
+        )
+        if not bool(target_window_check["active"]):
+            if bool(args.skip_unless_active_target_window) and not blockers:
+                skip_reason = ACTIVE_TARGET_WINDOW_SKIP_REASON
+            else:
+                blockers.append(ACTIVE_TARGET_WINDOW_REQUIRED_BLOCKER)
 
     materialization: dict[str, Any] = {}
-    if not blockers and dsn is not None:
+    if not blockers and skip_reason is None and dsn is not None:
         try:
             factory = _session_factory(dsn)
             with factory() as session:
@@ -795,7 +901,9 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "mode": "commit" if commit else "dry_run",
         "dry_run": dry_run,
         "commit": commit,
-        "materialized": commit and not blockers,
+        "skipped": skip_reason is not None,
+        "skip_reason": skip_reason,
+        "materialized": commit and not blockers and skip_reason is None,
         "account_label": _safe_text(args.account_label),
         "required_account_label": PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
         "database_dsn_env": dsn_env,
@@ -810,6 +918,7 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "operator_confirmation_required": OPERATOR_CONFIRMATION if commit else None,
         "dynamic_target_plan_confirmation": bool(args.allow_dynamic_target_plan),
         "default_dynamic_selected_plan_source": DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
+        "target_window_check": target_window_check,
         "target_count": len(summaries),
         "hypothesis_ids": _unique_texts(
             [item.get("hypothesis_id") for item in summaries]
@@ -870,6 +979,10 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--confirm-target-count-min", type=int, default=None)
     parser.add_argument("--confirm-max-notional", default=None)
     parser.add_argument("--allow-dynamic-target-plan", action="store_true")
+    target_window = parser.add_mutually_exclusive_group()
+    target_window.add_argument("--skip-unless-active-target-window", action="store_true")
+    target_window.add_argument("--require-active-target-window", action="store_true")
+    parser.add_argument("--now-utc", default=None)
     parser.add_argument("--operator-confirmation", default=None)
     parser.add_argument("--output", type=Path, default=None)
     return parser.parse_args(argv)

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1393,7 +1393,7 @@ class TestLiveConfigManifestContract(TestCase):
             "bounded-paper-route-target-materialization-cronjob.yaml"
         )
 
-        self.assertEqual(spec.get("schedule"), "*/5 10-15 * * 1-5")
+        self.assertEqual(spec.get("schedule"), "*/5 9-15 * * 1-5")
         self.assertEqual(spec.get("timeZone"), "America/New_York")
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
         self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
@@ -1463,6 +1463,14 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertIn(
+            "--help | grep -q -- '--skip-unless-active-target-window'",
+            args,
+        )
+        self.assertIn(
+            "old_image_missing_target_window_guard",
+            args,
+        )
+        self.assertIn(
             "--plan-url "
             "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
             args,
@@ -1474,6 +1482,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--max-notional 25", args)
         self.assertIn("--commit", args)
         self.assertIn("--allow-dynamic-target-plan", args)
+        self.assertIn("--skip-unless-active-target-window", args)
         self.assertIn("--confirm-account-label TORGHUT_SIM", args)
         self.assertIn("--confirm-dsn-env SIM_DB_DSN", args)
         self.assertIn("--confirm-hypothesis-id H-PAIRS-01", args)

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from argparse import Namespace
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -554,6 +555,45 @@ def test_paper_route_target_plan_target_summary_accepts_explicit_quantity_and_sy
             "symbols": ["AAPL", "AMZN"],
             "symbol_actions": {"AAPL": "buy", "AMZN": "sell"},
             "symbol_quantities": {"AAPL": "3", "AMZN": "3"},
+        }
+    ]
+
+
+def test_paper_route_materializer_window_datetime_helpers_handle_edge_cases() -> None:
+    assert cli._parse_utc_datetime(None) is None
+    assert cli._parse_utc_datetime("not-a-time") is None
+    assert cli._parse_utc_datetime("2026-06-01T13:30:00") == datetime(
+        2026,
+        6,
+        1,
+        13,
+        30,
+        tzinfo=timezone.utc,
+    )
+
+    before = datetime.now(timezone.utc)
+    fallback = cli._resolve_now_utc(Namespace(now_utc="not-a-time"))
+    after = datetime.now(timezone.utc)
+
+    assert before <= fallback <= after
+
+
+def test_paper_route_materializer_window_check_reports_missing_target_windows() -> None:
+    check = cli._active_target_window_check(
+        [{"target_index": 7, "window_start": None, "window_end": ""}],
+        now=datetime(2026, 6, 1, 14, tzinfo=timezone.utc),
+    )
+
+    assert check["active"] is False
+    assert check["active_count"] == 0
+    assert check["inactive_count"] == 0
+    assert check["missing_count"] == 1
+    assert check["targets"] == [
+        {
+            "target_index": 7,
+            "state": "missing_window",
+            "window_start": None,
+            "window_end": "",
         }
     ]
 

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -546,6 +546,8 @@ def test_paper_route_target_plan_target_summary_accepts_explicit_quantity_and_sy
             "account_label": "TORGHUT_SIM",
             "target_plan_ref": "paper-route-plan:c88421d619759b2cfaa6f4d0",
             "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+            "window_start": "2026-06-01T13:30:00+00:00",
+            "window_end": "2026-06-01T20:00:00+00:00",
             "bounded_collection_stage": "paper",
             "target_notional": "20",
             "target_quantity": "3",
@@ -664,6 +666,9 @@ def test_commit_url_nested_plan_with_dynamic_confirmation_writes_targets(
             "25",
             "--commit",
             "--allow-dynamic-target-plan",
+            "--require-active-target-window",
+            "--now-utc",
+            "2026-06-01T14:00:00+00:00",
             "--confirm-account-label",
             "TORGHUT_SIM",
             "--confirm-dsn-env",
@@ -687,6 +692,8 @@ def test_commit_url_nested_plan_with_dynamic_confirmation_writes_targets(
     assert exit_code == 0
     assert report["mode"] == "commit"
     assert report["materialized"] is True
+    assert report["skipped"] is False
+    assert report["target_window_check"]["active"] is True
     assert report["dynamic_target_plan_confirmation"] is True
     assert (
         report["plan_source"]["selected_plan"]
@@ -698,6 +705,116 @@ def test_commit_url_nested_plan_with_dynamic_confirmation_writes_targets(
     assert report["route_submission_count"] == 2
     assert report["blockers"] == []
     assert _count_decisions(sqlite_dsn) == 2
+
+
+def test_commit_dynamic_plan_skips_before_active_target_window_without_writes(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "live_submission_gate": {
+            "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
+        },
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "25",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--skip-unless-active-target-window",
+            "--now-utc",
+            "2026-06-01T13:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            cli.DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "25",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["skipped"] is True
+    assert report["skip_reason"] == cli.ACTIVE_TARGET_WINDOW_SKIP_REASON
+    assert report["materialized"] is False
+    assert report["blocked"] is False
+    assert report["target_window_check"]["active"] is False
+    assert report["target_window_check"]["inactive_count"] == 1
+    assert report["materialized_decision_count"] == 0
+    assert report["route_submission_count"] == 0
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_commit_dynamic_plan_requires_active_target_window_without_skip(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "live_submission_gate": {
+            "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
+        },
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "25",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--require-active-target-window",
+            "--now-utc",
+            "2026-06-01T13:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            cli.DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "25",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert cli.ACTIVE_TARGET_WINDOW_REQUIRED_BLOCKER in report["blockers"]
+    assert report["skipped"] is False
+    assert report["materialized"] is False
+    assert report["target_window_check"]["active"] is False
+    assert _count_decisions(sqlite_dsn) == 0
 
 
 def test_commit_dynamic_confirmation_rejects_wrong_selected_plan_source(


### PR DESCRIPTION
## Summary

- Adds active target-window checking to the bounded paper-route materializer, including explicit skip and require modes.
- Updates the Torghut bounded materialization CronJob to cover the 9:30 ET open while skipping cleanly before the active target window.
- Extends materializer and manifest contract tests for in-window writes, pre-window skips, and out-of-window blocking.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py -k 'bounded_paper_route_target_materialization or dynamic_plan or target_window' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py -q`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-rendered.yaml && rg -n "torghut-bounded-paper-route-target-materialization|skip-unless-active-target-window|old_image_missing_target_window_guard|\\*/5 9-15" /tmp/torghut-rendered.yaml`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
