### PR TITLE
perf(autotrader): parallelize cycle input fetches

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import json
 import os
 import re
 import shutil
 import subprocess
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -411,6 +413,10 @@ def write_json(path: Path, payload: Any) -> None:
     path.write_text(f"{json.dumps(payload, separators=(',', ':'), sort_keys=True)}\n", encoding="utf-8")
 
 
+def elapsed_ms(started_at: float) -> int:
+    return max(0, int(round((time.monotonic() - started_at) * 1000)))
+
+
 def market_open_start(now: datetime) -> str:
     market_day = now.astimezone(MARKET_TIMEZONE).date()
     market_open = datetime(market_day.year, market_day.month, market_day.day, 9, 30, tzinfo=MARKET_TIMEZONE)
@@ -480,30 +486,90 @@ def fetch_scan_inputs(
     scorecard_limit: int,
     broker_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    raw_broker_state = broker_state or fetch_broker_state(alpaca)
+    inputs, _ = fetch_scan_inputs_with_metrics(
+        alpaca=alpaca,
+        synthesis=synthesis,
+        symbols=symbols,
+        start=start,
+        end=end,
+        feed=feed,
+        scorecard_limit=scorecard_limit,
+        broker_state=broker_state,
+    )
+    return inputs
+
+
+def fetch_scan_inputs_with_metrics(
+    *,
+    alpaca: AlpacaRestClient,
+    synthesis: SynthesisClient,
+    symbols: list[str],
+    start: str,
+    end: str,
+    feed: str,
+    scorecard_limit: int,
+    broker_state: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    started_at = time.monotonic()
+    metrics: dict[str, Any] = {
+        "brokerStateSource": "provided" if broker_state is not None else "fetched",
+        "parallelFetchCount": 3,
+    }
+    if broker_state is None:
+        broker_started_at = time.monotonic()
+        raw_broker_state = fetch_broker_state(alpaca)
+        metrics["brokerStateMs"] = elapsed_ms(broker_started_at)
+    else:
+        raw_broker_state = broker_state
+        metrics["brokerStateMs"] = 0
+
     raw_account = raw_broker_state.get("account")
     if not isinstance(raw_account, dict):
         raise ValueError("broker account state must be an object")
     positions = raw_broker_state.get("positions")
     orders = raw_broker_state.get("orders")
     account = format_account(raw_account)
-    bars = alpaca.data_get(
-        "/stocks/bars",
-        {
-            "symbols": ",".join(symbols),
-            "timeframe": "1Min",
-            "start": start,
-            "end": end,
-            "limit": "1000",
-            "feed": feed,
-            "sort": "asc",
-        },
-    )
-    quotes = format_latest_quotes(
-        alpaca.data_get("/stocks/quotes/latest", {"symbols": ",".join(symbols), "feed": feed}),
-        symbols,
-    )
-    scorecards = synthesis.get("/api/autotrader/scorecards", {"limit": str(scorecard_limit)})
+
+    def timed_bars() -> tuple[Any, int]:
+        task_started_at = time.monotonic()
+        payload = alpaca.data_get(
+            "/stocks/bars",
+            {
+                "symbols": ",".join(symbols),
+                "timeframe": "1Min",
+                "start": start,
+                "end": end,
+                "limit": "1000",
+                "feed": feed,
+                "sort": "asc",
+            },
+        )
+        return payload, elapsed_ms(task_started_at)
+
+    def timed_quotes() -> tuple[Any, int]:
+        task_started_at = time.monotonic()
+        payload = format_latest_quotes(
+            alpaca.data_get("/stocks/quotes/latest", {"symbols": ",".join(symbols), "feed": feed}),
+            symbols,
+        )
+        return payload, elapsed_ms(task_started_at)
+
+    def timed_scorecards() -> tuple[Any, int]:
+        task_started_at = time.monotonic()
+        payload = synthesis.get("/api/autotrader/scorecards", {"limit": str(scorecard_limit)})
+        return payload, elapsed_ms(task_started_at)
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        futures = {
+            "bars": executor.submit(timed_bars),
+            "quotes": executor.submit(timed_quotes),
+            "scorecards": executor.submit(timed_scorecards),
+        }
+        bars, metrics["barsMs"] = futures["bars"].result()
+        quotes, metrics["quotesMs"] = futures["quotes"].result()
+        scorecards, metrics["scorecardsMs"] = futures["scorecards"].result()
+
+    metrics["totalMs"] = elapsed_ms(started_at)
     return {
         "account.json": account,
         "positions.json": {"positions": positions if isinstance(positions, list) else []},
@@ -512,7 +578,7 @@ def fetch_scan_inputs(
         "quotes.json": quotes,
         "scorecards.json": scorecards,
         "watchlist.json": {"watchlist": symbols},
-    }
+    }, metrics
 
 
 def summarize_scan(
@@ -881,6 +947,8 @@ def record_scan_tickets(
 
 
 def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
+    cycle_started_at = time.monotonic()
+    stage_timings: dict[str, Any] = {}
     symbols = normalize_watchlist(args.watchlist)
     work_dir = Path(args.work_dir or os.environ.get("AUTONOMOUS_TRADER_WORK_DIR", "/tmp/autonomous-trader-work"))
     cycle = args.cycle if args.cycle is not None else next_cycle_number(work_dir)
@@ -895,6 +963,7 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
     gate: dict[str, Any] | None = None
     recorded_account_gate: dict[str, Any] | None = None
     if args.respect_account_gate:
+        account_gate_started_at = time.monotonic()
         broker_state = fetch_broker_state(alpaca)
         gate = summarize_broker_state(broker_state)
         if args.session_id:
@@ -904,8 +973,12 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
                 cycle=cycle,
                 gate=gate,
             )
+        stage_timings["accountGateMs"] = elapsed_ms(account_gate_started_at)
         if gate.get("skipFullScan"):
+            prune_started_at = time.monotonic()
             removed_cycle_dirs = prune_old_cycle_dirs(work_dir, args.retain_cycles)
+            stage_timings["pruneOldCyclesMs"] = elapsed_ms(prune_started_at)
+            stage_timings["totalMs"] = elapsed_ms(cycle_started_at)
             return {
                 "ok": True,
                 "mode": "cycle",
@@ -920,8 +993,9 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
                 "topResults": [],
                 "action": gate.get("action"),
                 "skipFullScan": True,
+                "stageTimingsMs": stage_timings,
             }
-    inputs = fetch_scan_inputs(
+    inputs, input_fetch_metrics = fetch_scan_inputs_with_metrics(
         alpaca=alpaca,
         synthesis=synthesis,
         symbols=symbols,
@@ -931,25 +1005,35 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
         scorecard_limit=args.scorecard_limit,
         broker_state=broker_state,
     )
+    stage_timings["inputFetchMs"] = input_fetch_metrics["totalMs"]
+    stage_timings["inputFetch"] = input_fetch_metrics
     for name, payload in inputs.items():
         write_json(cycle_dir / name, payload)
+    scorecard_started_at = time.monotonic()
     scorecard_readback = scorecard_readback_summary(inputs.get("scorecards.json"))
+    stage_timings["scorecardReadbackSummaryMs"] = elapsed_ms(scorecard_started_at)
     recorded_scorecard_readback = None
     if args.session_id:
+        record_scorecard_started_at = time.monotonic()
         recorded_scorecard_readback = record_scorecard_readback(
             synthesis=synthesis,
             session_id=args.session_id,
             cycle=cycle,
             scorecard_readback=scorecard_readback,
         )
+        stage_timings["recordScorecardReadbackMs"] = elapsed_ms(record_scorecard_started_at)
     analysis_context = Path(args.analysis_context or work_dir / "analysis-context.json")
+    scan_started_at = time.monotonic()
     scan = run_stock_analysis_scan(
         stock_analysis_cli=stock_analysis_cli_path(args.stock_analysis_cli),
         cycle_dir=cycle_dir,
         analysis_context_path=analysis_context,
         watchlist=symbols,
     )
+    stage_timings["stockAnalysisScanMs"] = elapsed_ms(scan_started_at)
+    prune_started_at = time.monotonic()
     removed_cycle_dirs = prune_old_cycle_dirs(work_dir, args.retain_cycles)
+    stage_timings["pruneOldCyclesMs"] = elapsed_ms(prune_started_at)
     summary = summarize_scan(
         cycle,
         cycle_dir,
@@ -961,6 +1045,7 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
     summary["scorecardReadback"] = scorecard_readback
     summary["recordedScorecardReadback"] = recorded_scorecard_readback
     if args.record_tickets:
+        record_tickets_started_at = time.monotonic()
         summary["recordedTickets"] = record_scan_tickets(
             synthesis=synthesis,
             session_id=args.session_id or "",
@@ -968,11 +1053,14 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
             scan=scan,
             limit=args.max_recorded_tickets,
         )
+        stage_timings["recordTicketsMs"] = elapsed_ms(record_tickets_started_at)
     if gate is not None:
         summary["accountGate"] = gate
         summary["recordedAccountGate"] = recorded_account_gate
         summary["action"] = gate.get("action")
         summary["skipFullScan"] = False
+    stage_timings["totalMs"] = elapsed_ms(cycle_started_at)
+    summary["stageTimingsMs"] = stage_timings
     return summary
 
 

--- a/scripts/autotrader/market_open_cycle.py
+++ b/scripts/autotrader/market_open_cycle.py
@@ -197,6 +197,7 @@ def record_cycle_complete(
         "topResults": summary.get("topResults"),
         "marketWindow": summary.get("marketWindow"),
         "windowGate": summary.get("windowGate"),
+        "stageTimingsMs": summary.get("stageTimingsMs"),
     }
     status = synthesis.post(
         "/api/autotrader/status",

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import tempfile
+import threading
 import unittest
 from datetime import UTC, datetime
 from pathlib import Path
@@ -73,6 +74,48 @@ class LiveScanCycleTest(unittest.TestCase):
                 }
             },
         )
+
+    def test_fetch_scan_inputs_fetches_market_data_and_scorecards_concurrently(self) -> None:
+        case = self
+        barrier = threading.Barrier(3)
+
+        class FakeAlpaca:
+            def data_get(self, path: str, query: dict[str, str]) -> object:
+                case.assertIn(path, {"/stocks/bars", "/stocks/quotes/latest"})
+                barrier.wait(timeout=1)
+                if path == "/stocks/bars":
+                    return {"bars": {"NVDA": []}}
+                return {"quotes": {"NVDA": {"bp": 100.0, "ap": 100.1}}}
+
+        class FakeSynthesis:
+            def get(self, path: str, query: dict[str, str]) -> object:
+                case.assertEqual(path, "/api/autotrader/scorecards")
+                case.assertEqual(query, {"limit": "20"})
+                barrier.wait(timeout=1)
+                return {"scorecards": [{"symbol": "NVDA", "sampleSize": 5}], "setupExamples": []}
+
+        inputs, metrics = live_scan_cycle.fetch_scan_inputs_with_metrics(
+            alpaca=FakeAlpaca(),  # type: ignore[arg-type]
+            synthesis=FakeSynthesis(),  # type: ignore[arg-type]
+            symbols=["NVDA"],
+            start="2026-06-03T13:30:00Z",
+            end="2026-06-03T14:00:00Z",
+            feed="iex",
+            scorecard_limit=20,
+            broker_state={
+                "account": {"id": "paper-account", "equity": "30000", "buying_power": "60000"},
+                "positions": [],
+                "orders": [],
+            },
+        )
+
+        self.assertEqual(inputs["bars.json"], {"bars": {"NVDA": []}})
+        self.assertEqual(inputs["quotes.json"]["quotes"]["NVDA"]["bid"], 100.0)
+        self.assertEqual(inputs["scorecards.json"]["scorecards"][0]["symbol"], "NVDA")
+        self.assertEqual(metrics["brokerStateSource"], "provided")
+        self.assertEqual(metrics["brokerStateMs"], 0)
+        self.assertEqual(metrics["parallelFetchCount"], 3)
+        self.assertGreaterEqual(metrics["totalMs"], 0)
 
     def test_market_open_start_uses_new_york_timezone(self) -> None:
         self.assertEqual(
@@ -717,6 +760,10 @@ class LiveScanCycleTest(unittest.TestCase):
             self.assertEqual(summary["recordedScorecardReadback"]["riskCheckId"], "risk-scorecard")
             self.assertTrue(summary["recordedScorecardReadback"]["passed"])
             self.assertEqual(summary["scorecardInfluence"]["scorecardInfluencedResultCount"], 1)
+            self.assertGreaterEqual(summary["stageTimingsMs"]["totalMs"], 0)
+            self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["parallelFetchCount"], 3)
+            self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["brokerStateSource"], "fetched")
+            self.assertGreaterEqual(summary["stageTimingsMs"]["stockAnalysisScanMs"], 0)
             self.assertEqual(summary["recordedTickets"][0]["ticketId"], "ticket-nvda")
             self.assertEqual(summary["recordedTickets"][0]["status"], "blocked")
             self.assertEqual(summary["recordedTickets"][0]["scorecardSampleSize"], 5)

--- a/scripts/autotrader/test_market_open_cycle.py
+++ b/scripts/autotrader/test_market_open_cycle.py
@@ -74,6 +74,11 @@ class MarketOpenCycleTest(unittest.TestCase):
                     },
                     "skipFullScan": False,
                     "action": "scan",
+                    "stageTimingsMs": {
+                        "inputFetchMs": 41,
+                        "stockAnalysisScanMs": 22,
+                        "totalMs": 88,
+                    },
                 }
 
             args = market_open_cycle.build_parser().parse_args(
@@ -111,6 +116,7 @@ class MarketOpenCycleTest(unittest.TestCase):
         self.assertEqual(status_payload["phase"], "scan")
         self.assertEqual(status_payload["currentAction"], "market_open_cycle_complete; top=NVDA A vwap_reclaim")
         self.assertEqual(status_payload["payload"]["recordedTicketCount"], 1)
+        self.assertEqual(status_payload["payload"]["stageTimingsMs"]["totalMs"], 88)
         self.assertEqual(event_payload["eventType"], "market_open_cycle_complete")
 
     def test_reports_account_gated_cycle_without_scan(self) -> None:


### PR DESCRIPTION
## Summary

- Parallelizes the independent bars, latest-quotes, and Synthesis scorecard fetches used by each eligible live scan cycle.
- Adds stage timing metrics for account gate, input fetch, scorecard readback, stock-analysis scan, ticket recording, pruning, and total cycle time.
- Carries cycle timing metrics into market-open Synthesis status/event payloads for live bottleneck readback.
- Adds regression coverage proving concurrent fetch behavior and timing payload propagation.

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/market_open_cycle.py scripts/autotrader/test_live_scan_cycle.py scripts/autotrader/test_market_open_cycle.py`
- `cd scripts/autotrader && python3 -m unittest test_live_scan_cycle.py test_market_open_cycle.py`
- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/market_open_cycle.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
