### PR TITLE
perf(autotrader): parallelize broker state reads

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -302,11 +302,50 @@ def summarize_account_gate(
 
 
 def fetch_broker_state(alpaca: AlpacaRestClient) -> dict[str, Any]:
-    return {
-        "account": alpaca.trading_get("/v2/account"),
-        "positions": alpaca.trading_get("/v2/positions"),
-        "orders": alpaca.trading_get("/v2/orders", {"status": "open", "nested": "true"}),
+    state, _ = fetch_broker_state_with_metrics(alpaca)
+    return state
+
+
+def fetch_broker_state_with_metrics(alpaca: AlpacaRestClient) -> tuple[dict[str, Any], dict[str, Any]]:
+    started_at = time.monotonic()
+
+    def timed_account() -> tuple[Any, int]:
+        task_started_at = time.monotonic()
+        payload = alpaca.trading_get("/v2/account")
+        return payload, elapsed_ms(task_started_at)
+
+    def timed_positions() -> tuple[Any, int]:
+        task_started_at = time.monotonic()
+        payload = alpaca.trading_get("/v2/positions")
+        return payload, elapsed_ms(task_started_at)
+
+    def timed_orders() -> tuple[Any, int]:
+        task_started_at = time.monotonic()
+        payload = alpaca.trading_get("/v2/orders", {"status": "open", "nested": "true"})
+        return payload, elapsed_ms(task_started_at)
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        futures = {
+            "account": executor.submit(timed_account),
+            "positions": executor.submit(timed_positions),
+            "orders": executor.submit(timed_orders),
+        }
+        account, account_ms = futures["account"].result()
+        positions, positions_ms = futures["positions"].result()
+        orders, orders_ms = futures["orders"].result()
+
+    metrics = {
+        "parallelFetchCount": 3,
+        "accountMs": account_ms,
+        "positionsMs": positions_ms,
+        "ordersMs": orders_ms,
+        "totalMs": elapsed_ms(started_at),
     }
+    return {
+        "account": account,
+        "positions": positions,
+        "orders": orders,
+    }, metrics
 
 
 def summarize_broker_state(raw_broker_state: dict[str, Any]) -> dict[str, Any]:
@@ -516,12 +555,17 @@ def fetch_scan_inputs_with_metrics(
         "parallelFetchCount": 3,
     }
     if broker_state is None:
-        broker_started_at = time.monotonic()
-        raw_broker_state = fetch_broker_state(alpaca)
-        metrics["brokerStateMs"] = elapsed_ms(broker_started_at)
+        raw_broker_state, broker_metrics = fetch_broker_state_with_metrics(alpaca)
+        metrics["brokerStateMs"] = broker_metrics["totalMs"]
+        metrics["brokerState"] = broker_metrics
     else:
         raw_broker_state = broker_state
         metrics["brokerStateMs"] = 0
+        metrics["brokerState"] = {
+            "parallelFetchCount": 0,
+            "totalMs": 0,
+            "source": "provided",
+        }
 
     raw_account = raw_broker_state.get("account")
     if not isinstance(raw_account, dict):
@@ -964,7 +1008,9 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
     recorded_account_gate: dict[str, Any] | None = None
     if args.respect_account_gate:
         account_gate_started_at = time.monotonic()
-        broker_state = fetch_broker_state(alpaca)
+        broker_state, broker_metrics = fetch_broker_state_with_metrics(alpaca)
+        stage_timings["brokerStateMs"] = broker_metrics["totalMs"]
+        stage_timings["brokerState"] = broker_metrics
         gate = summarize_broker_state(broker_state)
         if args.session_id:
             recorded_account_gate = record_account_gate(
@@ -1065,8 +1111,16 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def run_account_gate(args: argparse.Namespace) -> dict[str, Any]:
+    started_at = time.monotonic()
     alpaca = AlpacaRestClient(timeout_seconds=args.timeout_seconds)
-    return summarize_broker_state(fetch_broker_state(alpaca))
+    broker_state, broker_metrics = fetch_broker_state_with_metrics(alpaca)
+    summary = summarize_broker_state(broker_state)
+    summary["stageTimingsMs"] = {
+        "brokerStateMs": broker_metrics["totalMs"],
+        "brokerState": broker_metrics,
+        "totalMs": elapsed_ms(started_at),
+    }
+    return summary
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -75,6 +75,32 @@ class LiveScanCycleTest(unittest.TestCase):
             },
         )
 
+    def test_fetch_broker_state_fetches_account_positions_and_orders_concurrently(self) -> None:
+        case = self
+        barrier = threading.Barrier(3)
+
+        class FakeAlpaca:
+            def trading_get(self, path: str, query: dict[str, str] | None = None) -> object:
+                case.assertIn(path, {"/v2/account", "/v2/positions", "/v2/orders"})
+                if path == "/v2/orders":
+                    case.assertEqual(query, {"status": "open", "nested": "true"})
+                else:
+                    case.assertIsNone(query)
+                barrier.wait(timeout=1)
+                if path == "/v2/account":
+                    return {"id": "paper-account", "equity": "30000"}
+                if path == "/v2/positions":
+                    return [{"symbol": "NVDA"}]
+                return [{"id": "order-1"}]
+
+        state, metrics = live_scan_cycle.fetch_broker_state_with_metrics(FakeAlpaca())  # type: ignore[arg-type]
+
+        self.assertEqual(state["account"]["id"], "paper-account")
+        self.assertEqual(state["positions"][0]["symbol"], "NVDA")
+        self.assertEqual(state["orders"][0]["id"], "order-1")
+        self.assertEqual(metrics["parallelFetchCount"], 3)
+        self.assertGreaterEqual(metrics["totalMs"], 0)
+
     def test_fetch_scan_inputs_fetches_market_data_and_scorecards_concurrently(self) -> None:
         case = self
         barrier = threading.Barrier(3)
@@ -267,6 +293,8 @@ class LiveScanCycleTest(unittest.TestCase):
 
         self.assertEqual(summary["action"], "monitor_only")
         self.assertTrue(summary["skipFullScan"])
+        self.assertEqual(summary["stageTimingsMs"]["brokerState"]["parallelFetchCount"], 3)
+        self.assertGreaterEqual(summary["stageTimingsMs"]["totalMs"], 0)
 
     def test_summarizes_scan_without_runtime_ledger(self) -> None:
         summary = live_scan_cycle.summarize_scan(
@@ -569,6 +597,7 @@ class LiveScanCycleTest(unittest.TestCase):
             self.assertEqual(summary["resultCount"], 0)
             self.assertEqual(summary["recordedTickets"], [])
             self.assertEqual(summary["recordedAccountGate"]["riskCheckId"], "risk-1")
+            self.assertEqual(summary["stageTimingsMs"]["brokerState"]["parallelFetchCount"], 3)
             self.assertTrue((Path(directory) / "cycle-1").exists())
 
     def test_run_cycle_respects_account_gate_and_skips_scan_when_managing_existing_state(self) -> None:
@@ -645,6 +674,7 @@ class LiveScanCycleTest(unittest.TestCase):
             self.assertEqual(summary["recordedTickets"], [])
             self.assertEqual(summary["accountGate"]["openPositions"][0]["symbol"], "NVDA")
             self.assertEqual(summary["accountGate"]["openOrders"][0]["clientOrderId"], "agent-NVDA-protect")
+            self.assertEqual(summary["stageTimingsMs"]["brokerState"]["parallelFetchCount"], 3)
 
     def test_run_cycle_returns_summary_without_summary_file(self) -> None:
         case = self
@@ -763,6 +793,7 @@ class LiveScanCycleTest(unittest.TestCase):
             self.assertGreaterEqual(summary["stageTimingsMs"]["totalMs"], 0)
             self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["parallelFetchCount"], 3)
             self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["brokerStateSource"], "fetched")
+            self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["brokerState"]["parallelFetchCount"], 3)
             self.assertGreaterEqual(summary["stageTimingsMs"]["stockAnalysisScanMs"], 0)
             self.assertEqual(summary["recordedTickets"][0]["ticketId"], "ticket-nvda")
             self.assertEqual(summary["recordedTickets"][0]["status"], "blocked")


### PR DESCRIPTION
## Summary

- Parallelizes the independent Alpaca account, positions, and open-orders reads used by broker-state/account-gate paths.
- Adds broker-state stage timing details for account-gate-only, gated cycles, and scan input fetches.
- Keeps the existing `fetch_broker_state` API while adding a metrics-aware wrapper for live bottleneck readback.
- Adds regression coverage proving broker-state reads overlap and timing payloads are present.

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/test_live_scan_cycle.py`
- `cd scripts/autotrader && python3 -m unittest test_live_scan_cycle.py`
- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/market_open_cycle.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
