### PR TITLE
feat(autotrader): summarize actionable scan candidates

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -37,6 +37,7 @@ SYNTHESIS_SIDES = {
     "sell_to_open",
     "sell_to_close",
 }
+ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
 
 
 class AlpacaRestClient:
@@ -990,6 +991,118 @@ def record_scan_tickets(
     return recorded
 
 
+def candidate_score(result: dict[str, Any]) -> tuple[int, Decimal, int, Decimal]:
+    grade = setup_grade(result.get("setup_grade") or result.get("setupGrade"))
+    grade_score = {"A+": 3, "A": 2, "B": 1}.get(grade, 0)
+    expected_r = decimal_value(result.get("expected_r") or result.get("expectedR")) or Decimal("0")
+    sample_size = int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize"))
+    confidence = decimal_value(result.get("scorecard_confidence") or result.get("scorecardConfidence")) or Decimal("0")
+    return grade_score, expected_r, sample_size, confidence
+
+
+def actionable_candidate_for_result(
+    *,
+    cycle: int,
+    index: int,
+    result: dict[str, Any],
+    tickets_by_idempotency_key: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    payload = ticket_payload_for_scan_result(session_id="decision-summary", cycle=cycle, index=index, result=result)
+    if payload is None:
+        return None
+    grade = str(payload["setupGrade"])
+    expected_r = decimal_value(payload.get("expectedR"))
+    if payload.get("status") != "candidate" or grade not in ACTIONABLE_SETUP_GRADES:
+        return None
+    if expected_r is not None and expected_r <= 0:
+        return None
+    ticket = tickets_by_idempotency_key.get(str(payload["idempotencyKey"]), {})
+    return {
+        "resultIndex": index,
+        "symbol": payload["symbol"],
+        "setupType": payload["setupType"],
+        "setupGrade": grade,
+        "expectedR": payload.get("expectedR"),
+        "entryLimitPrice": payload.get("entryLimitPrice"),
+        "stopPrice": payload.get("stopPrice"),
+        "targetPrice": payload.get("targetPrice"),
+        "riskDollars": payload.get("riskDollars"),
+        "plannedQuantity": payload.get("plannedQuantity"),
+        "scorecardSampleSize": int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize")),
+        "scorecardAvgRealizedR": numeric_text(
+            result.get("scorecard_avg_realized_r") or result.get("scorecardAvgRealizedR")
+        ),
+        "scorecardConfidence": numeric_text(result.get("scorecard_confidence") or result.get("scorecardConfidence")),
+        "ticketId": ticket.get("ticketId"),
+        "idempotencyKey": payload["idempotencyKey"],
+        "entryTrigger": payload.get("entryTrigger"),
+        "invalidation": payload.get("invalidation"),
+        "protectionType": payload.get("protectionType"),
+    }
+
+
+def decision_summary_for_scan(
+    *,
+    cycle: int,
+    scan: dict[str, Any],
+    recorded_tickets: list[dict[str, Any]],
+) -> dict[str, Any]:
+    results = scan.get("results")
+    if not isinstance(results, list):
+        results = []
+    tickets_by_idempotency_key = {
+        str(ticket.get("idempotencyKey")): ticket
+        for ticket in recorded_tickets
+        if isinstance(ticket, dict) and optional_text(ticket.get("idempotencyKey"))
+    }
+    candidates: list[tuple[tuple[int, Decimal, int, Decimal], dict[str, Any]]] = []
+    blocked_count = 0
+    no_trade_count = 0
+    for index, result in enumerate(results, start=1):
+        if not isinstance(result, dict):
+            continue
+        candidate = actionable_candidate_for_result(
+            cycle=cycle,
+            index=index,
+            result=result,
+            tickets_by_idempotency_key=tickets_by_idempotency_key,
+        )
+        if candidate is not None:
+            candidates.append((candidate_score(result), candidate))
+            continue
+        reason = result_no_trade_reason(
+            result,
+            setup_grade(result.get("setup_grade") or result.get("setupGrade")),
+            setup_type(result.get("setup_type") or result.get("setupType")),
+        )
+        if reason:
+            blocked_count += 1
+        else:
+            no_trade_count += 1
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    actionable_candidates = [candidate for _, candidate in candidates]
+    best_candidate = actionable_candidates[0] if actionable_candidates else None
+    if best_candidate is None:
+        return {
+            "action": "no_actionable_candidate",
+            "reason": "scanner_returned_no_strategy_guard_candidate",
+            "actionableCandidateCount": 0,
+            "blockedResultCount": blocked_count,
+            "noTradeResultCount": no_trade_count,
+            "bestCandidate": None,
+            "candidateSymbols": [],
+        }
+    return {
+        "action": "run_strategy_order_guard",
+        "reason": "best_candidate_ready_for_strategy_guard",
+        "actionableCandidateCount": len(actionable_candidates),
+        "blockedResultCount": blocked_count,
+        "noTradeResultCount": no_trade_count,
+        "bestCandidate": best_candidate,
+        "candidateSymbols": [candidate["symbol"] for candidate in actionable_candidates[:10]],
+    }
+
+
 def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
     cycle_started_at = time.monotonic()
     stage_timings: dict[str, Any] = {}
@@ -1090,16 +1203,25 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
     )
     summary["scorecardReadback"] = scorecard_readback
     summary["recordedScorecardReadback"] = recorded_scorecard_readback
+    recorded_tickets: list[dict[str, Any]] = []
     if args.record_tickets:
         record_tickets_started_at = time.monotonic()
-        summary["recordedTickets"] = record_scan_tickets(
+        recorded_tickets = record_scan_tickets(
             synthesis=synthesis,
             session_id=args.session_id or "",
             cycle=cycle,
             scan=scan,
             limit=args.max_recorded_tickets,
         )
+        summary["recordedTickets"] = recorded_tickets
         stage_timings["recordTicketsMs"] = elapsed_ms(record_tickets_started_at)
+    else:
+        summary["recordedTickets"] = recorded_tickets
+    summary["decisionSummary"] = decision_summary_for_scan(
+        cycle=cycle,
+        scan=scan,
+        recorded_tickets=recorded_tickets,
+    )
     if gate is not None:
         summary["accountGate"] = gate
         summary["recordedAccountGate"] = recorded_account_gate

--- a/scripts/autotrader/market_open_cycle.py
+++ b/scripts/autotrader/market_open_cycle.py
@@ -136,6 +136,20 @@ def cycle_action(summary: dict[str, Any]) -> str:
             return f"market_open_cycle_market_closed; marketCloseAt={window.get('marketCloseAt')}"
         return f"market_open_cycle_account_gated; action={action}"
     top_results = summary.get("topResults")
+    decision = summary.get("decisionSummary")
+    if isinstance(decision, dict) and decision.get("action") == "run_strategy_order_guard":
+        candidate = decision.get("bestCandidate")
+        if isinstance(candidate, dict):
+            return (
+                "market_open_cycle_candidate; "
+                f"ticketId={candidate.get('ticketId')}; "
+                f"symbol={candidate.get('symbol')} "
+                f"{candidate.get('setupGrade')} "
+                f"{candidate.get('setupType')}; "
+                f"expectedR={candidate.get('expectedR')}"
+            )
+    if isinstance(decision, dict) and decision.get("action") == "no_actionable_candidate":
+        return "market_open_cycle_complete; no_actionable_candidate"
     if isinstance(top_results, list) and top_results:
         first = top_results[0] if isinstance(top_results[0], dict) else {}
         symbol = first.get("symbol") or "unknown"
@@ -195,6 +209,7 @@ def record_cycle_complete(
         "scorecardReadback": summary.get("scorecardReadback"),
         "recordedScorecardReadback": summary.get("recordedScorecardReadback"),
         "topResults": summary.get("topResults"),
+        "decisionSummary": summary.get("decisionSummary"),
         "marketWindow": summary.get("marketWindow"),
         "windowGate": summary.get("windowGate"),
         "stageTimingsMs": summary.get("stageTimingsMs"),

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -429,6 +429,72 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(payload["entryTrigger"], "blocked_by_scanner")
         self.assertEqual(payload["brokerOrderPlan"]["source"], "live_scan_cycle")
 
+    def test_decision_summary_selects_best_actionable_candidate_with_ticket(self) -> None:
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=3,
+            scan={
+                "results": [
+                    {
+                        "symbol": "AMD",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "B",
+                        "expected_r": "2.5",
+                        "scorecard_sample_size": 2,
+                    },
+                    {
+                        "symbol": "NVDA",
+                        "setup_type": "opening_range_breakout",
+                        "setup_grade": "A",
+                        "expected_r": "1.6",
+                        "scorecard_sample_size": 7,
+                        "scorecard_avg_realized_r": "0.9",
+                        "scorecard_confidence": "0.75",
+                    },
+                    {
+                        "symbol": "QQQ",
+                        "setup_type": "no_trade",
+                        "setup_grade": "C",
+                        "no_trade_reason": "wide_spread",
+                    },
+                ]
+            },
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-3-2-NVDA-opening_range_breakout-A",
+                    "ticketId": "ticket-nvda",
+                }
+            ],
+        )
+
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["actionableCandidateCount"], 2)
+        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertEqual(summary["bestCandidate"]["symbol"], "NVDA")
+        self.assertEqual(summary["bestCandidate"]["ticketId"], "ticket-nvda")
+        self.assertEqual(summary["bestCandidate"]["scorecardSampleSize"], 7)
+        self.assertEqual(summary["candidateSymbols"], ["NVDA", "AMD"])
+
+    def test_decision_summary_reports_no_actionable_candidate(self) -> None:
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=5,
+            scan={
+                "results": [
+                    {
+                        "symbol": "QQQ",
+                        "setup_type": "no_trade",
+                        "setup_grade": "C",
+                        "no_trade_reason": "wide_spread",
+                    }
+                ]
+            },
+            recorded_tickets=[],
+        )
+
+        self.assertEqual(summary["action"], "no_actionable_candidate")
+        self.assertEqual(summary["actionableCandidateCount"], 0)
+        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertIsNone(summary["bestCandidate"])
+
     def test_records_scan_tickets_to_synthesis_with_ticket_ids(self) -> None:
         class FakeSynthesis:
             def __init__(self) -> None:
@@ -790,6 +856,7 @@ class LiveScanCycleTest(unittest.TestCase):
             self.assertEqual(summary["recordedScorecardReadback"]["riskCheckId"], "risk-scorecard")
             self.assertTrue(summary["recordedScorecardReadback"]["passed"])
             self.assertEqual(summary["scorecardInfluence"]["scorecardInfluencedResultCount"], 1)
+            self.assertEqual(summary["decisionSummary"]["action"], "no_actionable_candidate")
             self.assertGreaterEqual(summary["stageTimingsMs"]["totalMs"], 0)
             self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["parallelFetchCount"], 3)
             self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["brokerStateSource"], "fetched")

--- a/scripts/autotrader/test_market_open_cycle.py
+++ b/scripts/autotrader/test_market_open_cycle.py
@@ -57,8 +57,21 @@ class MarketOpenCycleTest(unittest.TestCase):
                         {
                             "symbol": "NVDA",
                             "ticketId": "ticket-1",
+                            "idempotencyKey": "scan-cycle-3-1-NVDA-vwap_reclaim-A",
                         }
                     ],
+                    "decisionSummary": {
+                        "action": "run_strategy_order_guard",
+                        "reason": "best_candidate_ready_for_strategy_guard",
+                        "actionableCandidateCount": 1,
+                        "bestCandidate": {
+                            "symbol": "NVDA",
+                            "setupType": "vwap_reclaim",
+                            "setupGrade": "A",
+                            "expectedR": "2.1",
+                            "ticketId": "ticket-1",
+                        },
+                    },
                     "accountGate": {
                         "action": "scan",
                         "skipFullScan": False,
@@ -114,9 +127,13 @@ class MarketOpenCycleTest(unittest.TestCase):
         event_payload = synthesis.posts[1][1]
         self.assertEqual(status_payload["sessionId"], "session-market-open")
         self.assertEqual(status_payload["phase"], "scan")
-        self.assertEqual(status_payload["currentAction"], "market_open_cycle_complete; top=NVDA A vwap_reclaim")
+        self.assertEqual(
+            status_payload["currentAction"],
+            "market_open_cycle_candidate; ticketId=ticket-1; symbol=NVDA A vwap_reclaim; expectedR=2.1",
+        )
         self.assertEqual(status_payload["payload"]["recordedTicketCount"], 1)
         self.assertEqual(status_payload["payload"]["stageTimingsMs"]["totalMs"], 88)
+        self.assertEqual(status_payload["payload"]["decisionSummary"]["action"], "run_strategy_order_guard")
         self.assertEqual(event_payload["eventType"], "market_open_cycle_complete")
 
     def test_reports_account_gated_cycle_without_scan(self) -> None:


### PR DESCRIPTION
## Summary

- Adds a `decisionSummary` to each completed live scan cycle with the best actionable candidate and next action.
- Ranks actionable candidates by setup grade, expected R, scorecard sample size, and confidence.
- Carries the decision summary into market-open Synthesis status/event payloads and status text.
- Adds regression coverage for best-candidate selection and no-actionable-candidate scans.

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/market_open_cycle.py scripts/autotrader/test_live_scan_cycle.py scripts/autotrader/test_market_open_cycle.py`
- `cd scripts/autotrader && python3 -m unittest test_live_scan_cycle.py test_market_open_cycle.py`
- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/market_open_cycle.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- After rebase onto current `origin/main`: `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- After rebase onto current `origin/main`: `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account"`
- After rebase onto current `origin/main`: `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- After rebase onto current `origin/main`: `git diff --check origin/main..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
