### PR TITLE
fix(torghut): normalize runtime ledger tca refs

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -309,6 +309,62 @@ def _string_list(value: Any) -> list[str]:
     ]
 
 
+_EXECUTION_TCA_REF_KEYS = (
+    "execution_tca_metric_ids",
+    "execution_tca_metric_refs",
+    "execution_tca_metric_id",
+    "execution_tca_metric_ref",
+    "execution_tca_metrics",
+    "execution_tca_ids",
+    "execution_tca_refs",
+    "execution_tca_id",
+    "execution_tca_ref",
+    "runtime_ledger_execution_tca_metric_ids",
+    "runtime_ledger_execution_tca_metric_refs",
+    "runtime_ledger_execution_tca_metric_id",
+    "runtime_ledger_execution_tca_metric_ref",
+    "runtime_ledger_execution_tca_ids",
+    "runtime_ledger_execution_tca_refs",
+    "runtime_ledger_execution_tca_id",
+    "runtime_ledger_execution_tca_ref",
+    "tca_metric_ids",
+    "tca_metric_refs",
+    "tca_metric_id",
+    "tca_metric_ref",
+    "tca_ids",
+    "tca_refs",
+    "tca_id",
+    "tca_ref",
+)
+
+
+def _runtime_ledger_tca_ref_texts(value: Any) -> list[str]:
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[object, object], value)
+        for key in _EXECUTION_TCA_REF_KEYS + ("id", "ref"):
+            if (text := _text(mapping.get(key))) is not None:
+                return [text]
+        return []
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        values: list[str] = []
+        for item in cast(Sequence[object], value):
+            if isinstance(item, Mapping):
+                values.extend(_runtime_ledger_tca_ref_texts(item))
+                continue
+            if (text := _text(item)) is not None:
+                values.append(text)
+        return values
+    text = _text(value)
+    return [text] if text is not None else []
+
+
+def _runtime_ledger_execution_tca_metric_refs(bucket: Mapping[str, Any]) -> list[str]:
+    refs: list[str] = []
+    for key in _EXECUTION_TCA_REF_KEYS:
+        refs.extend(_runtime_ledger_tca_ref_texts(bucket.get(key)))
+    return list(dict.fromkeys(refs))
+
+
 def _mapping(value: Any) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         return {}
@@ -426,11 +482,7 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
     source_row_counts = _mapping(bucket.get("source_row_counts"))
     execution_count = _observation_int(source_row_counts.get("executions"))
     tca_count = _observation_int(source_row_counts.get("execution_tca_metrics"))
-    execution_tca_ref_count = len(
-        _string_list(bucket.get("execution_tca_metric_ids"))
-        or _string_list(bucket.get("execution_tca_metric_refs"))
-        or _string_list(bucket.get("execution_tca_metrics"))
-    )
+    execution_tca_ref_count = len(_runtime_ledger_execution_tca_metric_refs(bucket))
     execution_tca_required = (
         _observation_bool(
             bucket.get("execution_tca_required") or bucket.get("requires_execution_tca")

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -115,6 +115,33 @@ ORDER_FEED_LIFECYCLE_MISSING_BLOCKER = "order_feed_lifecycle_missing"
 EXECUTION_ECONOMICS_MISSING_BLOCKER = "execution_economics_missing"
 ORDER_FEED_FILL_DELTA_BASIS_MISSING_BLOCKER = "order_feed_fill_delta_basis_missing"
 ORDER_FEED_FILL_DELTA_MISSING_BLOCKER = "order_feed_fill_delta_missing"
+_EXECUTION_TCA_REF_KEYS = (
+    "execution_tca_metric_ids",
+    "execution_tca_metric_refs",
+    "execution_tca_metric_id",
+    "execution_tca_metric_ref",
+    "execution_tca_metrics",
+    "execution_tca_ids",
+    "execution_tca_refs",
+    "execution_tca_id",
+    "execution_tca_ref",
+    "runtime_ledger_execution_tca_metric_ids",
+    "runtime_ledger_execution_tca_metric_refs",
+    "runtime_ledger_execution_tca_metric_id",
+    "runtime_ledger_execution_tca_metric_ref",
+    "runtime_ledger_execution_tca_ids",
+    "runtime_ledger_execution_tca_refs",
+    "runtime_ledger_execution_tca_id",
+    "runtime_ledger_execution_tca_ref",
+    "tca_metric_ids",
+    "tca_metric_refs",
+    "tca_metric_id",
+    "tca_metric_ref",
+    "tca_ids",
+    "tca_refs",
+    "tca_id",
+    "tca_ref",
+)
 _RUNTIME_LIFECYCLE_IDENTIFIER_KEYS = (
     "execution_id",
     "trade_decision_id",
@@ -1097,11 +1124,7 @@ def _runtime_ledger_bucket_profit_proof_blockers(
     tca_count = _nonnegative_int(
         _as_mapping(bucket.get("source_row_counts")).get("execution_tca_metrics")
     )
-    execution_tca_ref_count = len(
-        _metadata_text_list(bucket.get("execution_tca_metric_ids"))
-        or _metadata_text_list(bucket.get("execution_tca_metric_refs"))
-        or _metadata_text_list(bucket.get("execution_tca_metrics"))
-    )
+    execution_tca_ref_count = len(_runtime_ledger_execution_tca_metric_refs(bucket))
     execution_tca_required = (
         _first_bool(bucket, "execution_tca_required", "requires_execution_tca") is True
         or tca_count > 0
@@ -1828,6 +1851,35 @@ def _metadata_text_list(value: Any) -> list[str]:
     return [
         text for item in cast(Sequence[Any], value) if (text := str(item or "").strip())
     ]
+
+
+def _runtime_ledger_tca_ref_texts(value: Any) -> list[str]:
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[object, object], value)
+        for key in _EXECUTION_TCA_REF_KEYS + ("id", "ref"):
+            if (text := _text_or_none(mapping.get(key))) is not None:
+                return [text]
+        return []
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        refs: list[str] = []
+        for item in cast(Sequence[object], value):
+            if isinstance(item, Mapping):
+                refs.extend(_runtime_ledger_tca_ref_texts(item))
+                continue
+            if (text := _text_or_none(item)) is not None:
+                refs.append(text)
+        return refs
+    text = _text_or_none(value)
+    return [text] if text is not None else []
+
+
+def _runtime_ledger_execution_tca_metric_refs(
+    bucket: Mapping[str, object],
+) -> list[str]:
+    refs: list[str] = []
+    for key in _EXECUTION_TCA_REF_KEYS:
+        refs.extend(_runtime_ledger_tca_ref_texts(bucket.get(key)))
+    return list(dict.fromkeys(refs))
 
 
 def _metadata_symbol_list(value: Any) -> list[str]:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1322,6 +1322,59 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
+    def test_runtime_ledger_tca_refs_accept_readback_aliases(self) -> None:
+        readback_alias_bucket = _complete_runtime_ledger_bucket(
+            execution_tca_metric_ids=[],
+            runtime_ledger_execution_tca_metric_ids=["tca-buy", "tca-sell"],
+        )
+        readback_alias_blockers = _runtime_ledger_bucket_profit_proof_blockers(
+            readback_alias_bucket
+        )
+        self.assertNotIn("execution_tca_missing", readback_alias_blockers)
+        self.assertNotIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            readback_alias_blockers,
+        )
+
+        split_alias_bucket = _complete_runtime_ledger_bucket(
+            execution_tca_metric_ids=["tca-buy"],
+            runtime_ledger_execution_tca_metric_ids=["tca-sell"],
+        )
+        split_alias_blockers = _runtime_ledger_bucket_profit_proof_blockers(
+            split_alias_bucket
+        )
+        self.assertNotIn("execution_tca_missing", split_alias_blockers)
+        self.assertNotIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            split_alias_blockers,
+        )
+
+        mapping_alias_bucket = _complete_runtime_ledger_bucket(
+            execution_tca_metric_ids={"id": "tca-buy"},
+            runtime_ledger_execution_tca_metric_ids=[{"ref": "tca-sell"}],
+        )
+        mapping_alias_blockers = _runtime_ledger_bucket_profit_proof_blockers(
+            mapping_alias_bucket
+        )
+        self.assertNotIn("execution_tca_missing", mapping_alias_blockers)
+        self.assertNotIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            mapping_alias_blockers,
+        )
+
+        missing_ref_bucket = _complete_runtime_ledger_bucket(
+            execution_tca_metric_ids={"ignored": "not-a-ref"},
+            execution_tca_metric_refs=["tca-buy"],
+        )
+        missing_ref_blockers = _runtime_ledger_bucket_profit_proof_blockers(
+            missing_ref_bucket
+        )
+        self.assertIn("execution_tca_missing", missing_ref_blockers)
+        self.assertIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            missing_ref_blockers,
+        )
+
     def test_execution_economics_without_order_lifecycle_blocks_missing_lifecycle(
         self,
     ) -> None:

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -2583,6 +2583,53 @@ class TestRuntimeWindowImport(TestCase):
             "runtime_ledger_execution_order_event_refs_missing", alias_blockers
         )
 
+    def test_runtime_ledger_bucket_tca_refs_accept_readback_aliases(
+        self,
+    ) -> None:
+        readback_alias_bucket = _runtime_ledger_bucket(
+            execution_tca_metric_ids=[],
+            runtime_ledger_execution_tca_metric_ids=["tca-buy", "tca-sell"],
+        )
+        readback_alias_blockers = _runtime_ledger_bucket_blockers(readback_alias_bucket)
+        self.assertNotIn("execution_tca_missing", readback_alias_blockers)
+        self.assertNotIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            readback_alias_blockers,
+        )
+
+        split_alias_bucket = _runtime_ledger_bucket(
+            execution_tca_metric_ids=["tca-buy"],
+            runtime_ledger_execution_tca_metric_ids=["tca-sell"],
+        )
+        split_alias_blockers = _runtime_ledger_bucket_blockers(split_alias_bucket)
+        self.assertNotIn("execution_tca_missing", split_alias_blockers)
+        self.assertNotIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            split_alias_blockers,
+        )
+
+        mapping_alias_bucket = _runtime_ledger_bucket(
+            execution_tca_metric_ids={"id": "tca-buy"},
+            runtime_ledger_execution_tca_metric_ids=[{"ref": "tca-sell"}],
+        )
+        mapping_alias_blockers = _runtime_ledger_bucket_blockers(mapping_alias_bucket)
+        self.assertNotIn("execution_tca_missing", mapping_alias_blockers)
+        self.assertNotIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            mapping_alias_blockers,
+        )
+
+        missing_ref_bucket = _runtime_ledger_bucket(
+            execution_tca_metric_ids={"ignored": "not-a-ref"},
+            execution_tca_metric_refs=["tca-buy"],
+        )
+        missing_ref_blockers = _runtime_ledger_bucket_blockers(missing_ref_bucket)
+        self.assertIn("execution_tca_missing", missing_ref_blockers)
+        self.assertIn(
+            "runtime_ledger_execution_tca_refs_missing",
+            missing_ref_blockers,
+        )
+
     def test_runtime_ledger_bucket_requires_structured_source_offsets(self) -> None:
         for malformed_offsets in (
             ["alpaca.trade_updates:0:100"],


### PR DESCRIPTION
## Summary

- Normalizes runtime-ledger execution TCA refs across canonical, readback, mapping-shaped, and legacy alias fields.
- Preserves the existing fail-closed execution/TCA count gate: buckets still block when TCA refs are fewer than executions.
- Adds regression coverage for readback-only, split canonical/readback, and mapping-shaped TCA refs in both importer paths.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_runtime_window_import.py -k tca_refs_accept_readback_aliases`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k runtime_ledger_tca_refs_accept_readback_aliases`
- `uv run --frozen pytest tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py --cov=app.trading.runtime_window_import --cov=scripts.import_hypothesis_runtime_windows --cov-report=xml`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff check app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A; no UI changes.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
