### PR TITLE
fix(torghut): preserve paper-route source lineage

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -948,6 +948,13 @@ def _merge_unique_texts(target: list[str], values: Sequence[str]) -> None:
             target.append(value)
 
 
+def _single_lineage_text(value: object) -> str | None:
+    values = _lineage_text_values(value)
+    if len(values) != 1:
+        return None
+    return values[0]
+
+
 def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[str, Any]:
     payloads: list[Mapping[str, Any]] = [params]
     for key in (
@@ -973,16 +980,25 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
     collection_lineage: dict[str, Any] = {}
     for payload in payloads:
         _merge_unique_texts(
+            candidate_ids, _lineage_text_values(payload.get("candidate_id"))
+        )
+        _merge_unique_texts(
             candidate_ids, _lineage_text_values(payload.get("source_candidate_id"))
         )
         _merge_unique_texts(
             candidate_ids, _lineage_text_values(payload.get("source_candidate_ids"))
         )
         _merge_unique_texts(
+            hypothesis_ids, _lineage_text_values(payload.get("hypothesis_id"))
+        )
+        _merge_unique_texts(
             hypothesis_ids, _lineage_text_values(payload.get("source_hypothesis_id"))
         )
         _merge_unique_texts(
             hypothesis_ids, _lineage_text_values(payload.get("source_hypothesis_ids"))
+        )
+        _merge_unique_texts(
+            strategy_names, _lineage_text_values(payload.get("runtime_strategy_name"))
         )
         _merge_unique_texts(
             strategy_names, _lineage_text_values(payload.get("source_strategy_name"))
@@ -1035,10 +1051,19 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
     lineage: dict[str, Any] = {}
     if candidate_ids:
         lineage["source_candidate_ids"] = candidate_ids
+    single_candidate_id = _single_lineage_text(candidate_ids)
+    if single_candidate_id is not None:
+        lineage["candidate_id"] = single_candidate_id
     if hypothesis_ids:
         lineage["source_hypothesis_ids"] = hypothesis_ids
+    single_hypothesis_id = _single_lineage_text(hypothesis_ids)
+    if single_hypothesis_id is not None:
+        lineage["hypothesis_id"] = single_hypothesis_id
     if strategy_names:
         lineage["source_strategy_names"] = strategy_names
+    single_strategy_name = _single_lineage_text(strategy_names)
+    if single_strategy_name is not None:
+        lineage.setdefault("runtime_strategy_name", single_strategy_name)
     if lineage_targets:
         lineage["paper_route_probe_lineage_targets"] = lineage_targets
     if source_decision_mode:
@@ -1172,6 +1197,20 @@ def _merge_paper_route_probe_lineage(
         current = target.setdefault(key, [])
         if isinstance(current, list):
             _merge_unique_texts(cast(list[str], current), values)
+
+    identity_fallbacks = {
+        "candidate_id": "source_candidate_ids",
+        "hypothesis_id": "source_hypothesis_ids",
+        "runtime_strategy_name": "source_strategy_names",
+    }
+    for key, source_key in identity_fallbacks.items():
+        if _safe_text(target.get(key)) is not None:
+            continue
+        value = _safe_text(lineage.get(key)) or _single_lineage_text(
+            lineage.get(source_key)
+        )
+        if value is not None:
+            target[key] = value
 
     for key in ("source_decision_mode", "profit_proof_eligible"):
         if key in lineage and key not in target:
@@ -4554,6 +4593,10 @@ class SimpleTradingPipeline(TradingPipeline):
                     params["exit_minute_after_open"] = metadata[
                         "exit_minute_after_open"
                     ]
+                _merge_paper_route_probe_lineage(
+                    params,
+                    _paper_route_probe_lineage_from_params(params),
+                )
                 timeframe = (
                     _safe_text(target.get("timeframe"))
                     or _safe_text(target.get("base_timeframe"))
@@ -5517,6 +5560,10 @@ class SimpleTradingPipeline(TradingPipeline):
             "capital_stage": str(proof_floor.get("capital_state") or "zero_notional"),
             "target_source_notional_sized": target_source_authorized,
         }
+        _merge_paper_route_probe_lineage(
+            params,
+            _paper_route_probe_lineage_from_params(params),
+        )
         return decision.model_copy(update={"qty": capped_qty, "params": params})
 
     def _align_prechecked_paper_route_probe_cap(
@@ -5546,6 +5593,10 @@ class SimpleTradingPipeline(TradingPipeline):
 
         params["simple_lane"] = simple_lane
         params["paper_route_probe"] = probe_metadata
+        _merge_paper_route_probe_lineage(
+            params,
+            _paper_route_probe_lineage_from_params(params),
+        )
         return decision.model_copy(update={"params": params})
 
     @staticmethod

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -400,6 +400,47 @@ def _routeability_decision(
     )
 
 
+def test_paper_route_probe_cap_promotes_single_target_lineage_to_top_level() -> None:
+    pipeline = object.__new__(SimpleTradingPipeline)
+    decision = _routeability_decision(
+        params={
+            "price": Decimal("100"),
+            "paper_route_target_plan_source_decision": _bounded_hpairs_target(
+                candidate_id="cand-runtime-lineage",
+                hypothesis_id="H-RUNTIME-LINEAGE",
+                runtime_strategy_name="intraday-tsmom-profit-v3",
+                source_decision_mode="bounded_paper_route_collection",
+                profit_proof_eligible=True,
+                source_manifest_ref="runtime-ledger-source-window",
+            ),
+        }
+    )
+
+    capped = pipeline._paper_route_probe_capped_decision(
+        decision=decision,
+        proof_floor={"capital_state": "shadow"},
+        context={
+            "max_notional": "250",
+            "source_decision_mode": "bounded_paper_route_collection",
+            "profit_proof_eligible": True,
+            "target_source_authorized": True,
+        },
+    )
+
+    assert capped is not None
+    assert capped.qty == Decimal("2.5000")
+    params = capped.params
+    assert params["candidate_id"] == "cand-runtime-lineage"
+    assert params["hypothesis_id"] == "H-RUNTIME-LINEAGE"
+    assert params["runtime_strategy_name"] == "intraday-tsmom-profit-v3"
+    assert params["source_candidate_ids"] == ["cand-runtime-lineage"]
+    assert params["source_hypothesis_ids"] == ["H-RUNTIME-LINEAGE"]
+    assert "intraday-tsmom-profit-v3" in params["source_strategy_names"]
+    assert params["source_decision_mode"] == "bounded_paper_route_collection"
+    assert params["profit_proof_eligible"] is True
+    assert params["source_manifest_ref"] == "runtime-ledger-source-window"
+
+
 def test_paper_route_quote_routeability_uses_target_metadata_quote_snapshot() -> None:
     pipeline = object.__new__(SimpleTradingPipeline)
     target = _bounded_hpairs_target(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -7076,6 +7076,12 @@ class TestTradingPipeline(TestCase):
                 source_decision["paper_route_probe_effective_max_notional"], "250"
             )
             self.assertEqual(params["exit_minute_after_open"], 120)
+            self.assertEqual(params["candidate_id"], "cand-tsmom-liq")
+            self.assertEqual(params["hypothesis_id"], "H-TSMOM-LIQ")
+            self.assertEqual(
+                params["runtime_strategy_name"],
+                "intraday-tsmom-profit-v3",
+            )
             self.assertEqual(params["source_candidate_ids"], ["cand-tsmom-liq"])
             self.assertEqual(params["source_hypothesis_ids"], ["H-TSMOM-LIQ"])
             self.assertEqual(


### PR DESCRIPTION
## Summary

- Preserve paper-route candidate, hypothesis, and runtime-strategy identity at persisted top-level when the source lineage only exists inside target/probe metadata.
- Re-merge single-source lineage after target source-decision creation, probe cap sizing, and prechecked probe-cap alignment without relaxing proof eligibility or promotion blockers.
- Add regression coverage for capped probe lineage and submitted paper-route decision params.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_simple_pipeline.py -k "paper_route_probe_cap_promotes_single_target_lineage_to_top_level or source_collection_authorization_emits_bounded_lineage_decisions_without_candidate_hardcode"`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k "simple_pipeline_closes_strategy_signal_paper_with_linked_exit"`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k "paper_route"`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py tests/test_trading_pipeline.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately; screenshots are not applicable for this backend-only change.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no docs or release notes are needed for this internal lineage fix.
