### PR TITLE
fix(autotrader): gate weak cycle candidates

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-green-implspec.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-green-implspec.yaml
@@ -26,7 +26,7 @@ spec:
     - Keep the green lane read-only until a GitOps promotion makes it the only active mutating market-open lane.
     - Trade only the dedicated Alpaca paper account and record trader state in Synthesis autotrader tables.
     - Bootstrap the analysis repo, read scorecards before grading, and use the live scan-cycle helper for candidate ranking.
-    - Submit strategy broker mutations only after Synthesis risk/order records, protective preflight success, strategy guard approval, and deterministic client order ids; helper-proven entry-ineligible smoke skips must stand down from entries.
+    - Submit strategy broker mutations only after Synthesis risk/order records, runner strategy guard approval, and deterministic client order ids.
     - Keep market-open runs cycling until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
     - Finalize sessions with realized scorecard observations and write `report.md` as the only operator-facing artifact.
   text: |-
@@ -40,4 +40,4 @@ spec:
     - analysis repo: bootstrap `/workspace/analysis` and require commit `56be940b69bf1a56578040eda9bf2e3699c5220e` or newer
     - operator report: `/workspace/.agentrun/autonomous-trader/report.md`
 
-    Start with bootstrap/preflight, then run the mode-specific loop. Keep all live decisions, risk checks, broker actions, reconciliation results, and scorecard observations in Synthesis autotrader tables.
+    Start with bootstrap, then run the mode-specific runner loop. Keep all live decisions, risk checks, broker actions, reconciliation results, and scorecard observations in Synthesis autotrader tables.

--- a/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
@@ -30,20 +30,18 @@ data:
 
     Execution loop:
     1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`. In `scorecard-readback`, bootstrap reads/reconciles/finalizes and exits. In `market-open`, it validates analysis, starts the Synthesis session, records account gate/status, and writes `${AUTONOMOUS_TRADER_WORK_DIR}/session.json`.
-    2. Preflight Alpaca account/config/clock/tools/positions/orders and Synthesis tools. If account/trading is blocked, `daytrading_buying_power <= 0`, or scanner input says `intraday_equity_entry.status=blocked`, record Synthesis risk/status, skip new entries and smoke orders, and monitor read-only until state changes or close. Exits/protection stay allowed.
+    2. After bootstrap, use `market_open_cycle.py` as the only market-open decision runner. If it reports a blocker, account gate, `no_actionable_candidate`, or `strategyGuard.allowed=false`, record/report that state and stand down from new entries until runner output changes. Exits/protection for existing broker state stay allowed.
     3. Do not call `autotrader_start_session` unless `${AUTONOMOUS_TRADER_WORK_DIR}/session.json` is missing or invalid; otherwise reuse the recorded session.
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/market_open_cycle.py`; runner owns session loading, market-hour waiting, account gate, scan, scorecard/tickets, best-candidate guard, `last-cycle.json`, and checkpoint.
     5. Do not manually scan, recreate tickets, run candidate guards, or smoke orders for runner candidates. Use runner `ticketId`, `noTradeReason`, `strategyGuard`, and `blocker` as authoritative.
-    6. Only plan new broker risk after the runner returns an allowed guarded candidate.
+    6. Only plan new broker risk after the runner returns `strategyGuard.allowed=true` for a candidate.
     7. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
     8. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
     9. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 
     Mode behavior:
-    - `dry-run`: no Alpaca mutations; do one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.
-    - `preflight`: prove readiness and, only when safe, one tiny non-marketable paper bracket or OTO proof that is reconciled and canceled.
-    - `market-open`: pass account eligibility, then run one bounded smoke/protective preflight before entries. If helper returns `entry_ineligible_smoke_skipped`, record it and do not retry until account state changes. Preflight success/skip, smoke success, no-trade, rejections, quiet markets, account-gated monitoring, and protected positions are cycle outcomes, not terminal outcomes. Do not complete or answer finally until close, target, or hard stop.
+    - `market-open`: run bootstrap once, then repeat `market_open_cycle.py`. Candidate, no-trade, rejection, account-gated, and protected-position states are cycle outcomes, not terminal outcomes. Do not complete or answer finally until close, target, or hard stop.
 
     Safety:
     - Route orders only to the Alpaca paper account.

--- a/argocd/applications/autotrader/autonomous-trader-implspec.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-implspec.yaml
@@ -24,7 +24,7 @@ spec:
   acceptanceCriteria:
     - Trade only the dedicated Alpaca paper account and record trader state in Synthesis autotrader tables.
     - Bootstrap the analysis repo, read scorecards before grading, and use the live scan-cycle helper for candidate ranking.
-    - Submit strategy broker mutations only after Synthesis risk/order records, protective preflight success, strategy guard approval, and deterministic client order ids; helper-proven entry-ineligible smoke skips must stand down from entries.
+    - Submit strategy broker mutations only after Synthesis risk/order records, runner strategy guard approval, and deterministic client order ids.
     - Keep market-open runs cycling until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
     - Finalize sessions with realized scorecard observations and write `report.md` as the only operator-facing artifact.
   text: |-
@@ -38,4 +38,4 @@ spec:
     - analysis repo: bootstrap `/workspace/analysis` and require commit `56be940b69bf1a56578040eda9bf2e3699c5220e` or newer
     - operator report: `/workspace/.agentrun/autonomous-trader/report.md`
 
-    Start with bootstrap/preflight, then run the mode-specific loop. Keep all live decisions, risk checks, broker actions, reconciliation results, and scorecard observations in Synthesis autotrader tables.
+    Start with bootstrap, then run the mode-specific runner loop. Keep all live decisions, risk checks, broker actions, reconciliation results, and scorecard observations in Synthesis autotrader tables.

--- a/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
@@ -30,20 +30,18 @@ data:
 
     Execution loop:
     1. Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`. In `scorecard-readback`, bootstrap reads/reconciles/finalizes and exits. In `market-open`, it validates analysis, starts the Synthesis session, records account gate/status, and writes `${AUTONOMOUS_TRADER_WORK_DIR}/session.json`.
-    2. Preflight Alpaca account/config/clock/tools/positions/orders and Synthesis tools. If account/trading is blocked, `daytrading_buying_power <= 0`, or scanner input says `intraday_equity_entry.status=blocked`, record Synthesis risk/status, skip new entries and smoke orders, and monitor read-only until state changes or close. Exits/protection stay allowed.
+    2. After bootstrap, use `market_open_cycle.py` as the only market-open decision runner. If it reports a blocker, account gate, `no_actionable_candidate`, or `strategyGuard.allowed=false`, record/report that state and stand down from new entries until runner output changes. Exits/protection for existing broker state stay allowed.
     3. Do not call `autotrader_start_session` unless `${AUTONOMOUS_TRADER_WORK_DIR}/session.json` is missing or invalid; otherwise reuse the recorded session.
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/market_open_cycle.py`; runner owns session loading, market-hour waiting, account gate, scan, scorecard/tickets, best-candidate guard, `last-cycle.json`, and checkpoint.
     5. Do not manually scan, recreate tickets, run candidate guards, or smoke orders for runner candidates. Use runner `ticketId`, `noTradeReason`, `strategyGuard`, and `blocker` as authoritative.
-    6. Only plan new broker risk after the runner returns an allowed guarded candidate.
+    6. Only plan new broker risk after the runner returns `strategyGuard.allowed=true` for a candidate.
     7. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
     8. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
     9. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 
     Mode behavior:
-    - `dry-run`: no Alpaca mutations; do one read-only scanner/ticket/risk/status pass, finalize with `dry_run_complete`, write `report.md`, call `update_goal complete` if available, and stop.
     - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.
-    - `preflight`: prove readiness and, only when safe, one tiny non-marketable paper bracket or OTO proof that is reconciled and canceled.
-    - `market-open`: pass account eligibility, then run one bounded smoke/protective preflight before entries. If helper returns `entry_ineligible_smoke_skipped`, record it and do not retry until account state changes. Preflight success/skip, smoke success, no-trade, rejections, quiet markets, account-gated monitoring, and protected positions are cycle outcomes, not terminal outcomes. Do not complete or answer finally until close, target, or hard stop.
+    - `market-open`: run bootstrap once, then repeat `market_open_cycle.py`. Candidate, no-trade, rejection, account-gated, and protected-position states are cycle outcomes, not terminal outcomes. Do not complete or answer finally until close, target, or hard stop.
 
     Safety:
     - Route orders only to the Alpaca paper account.

--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -38,6 +38,7 @@ SYNTHESIS_SIDES = {
     "sell_to_close",
 }
 ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
+MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
 
 
 class AlpacaRestClient:
@@ -885,6 +886,11 @@ def result_no_trade_reason(result: dict[str, Any], grade: str, type_: str) -> st
         return "scanner_blocked_grade"
     if type_ == "no_trade":
         return "scanner_no_trade"
+    expected_r = decimal_value(result.get("expected_r") or result.get("expectedR"))
+    if expected_r is None:
+        return "missing_expected_r"
+    if expected_r < MIN_ACTIONABLE_EXPECTED_R:
+        return "expected_r_below_threshold"
     return None
 
 
@@ -1014,7 +1020,7 @@ def actionable_candidate_for_result(
     expected_r = decimal_value(payload.get("expectedR"))
     if payload.get("status") != "candidate" or grade not in ACTIONABLE_SETUP_GRADES:
         return None
-    if expected_r is not None and expected_r <= 0:
+    if expected_r is None or expected_r < MIN_ACTIONABLE_EXPECTED_R:
         return None
     ticket = tickets_by_idempotency_key.get(str(payload["idempotencyKey"]), {})
     return {

--- a/scripts/autotrader/market_open_cycle.py
+++ b/scripts/autotrader/market_open_cycle.py
@@ -150,17 +150,6 @@ def cycle_action(summary: dict[str, Any]) -> str:
             f"symbol={candidate.get('symbol')}; "
             f"reason={guard.get('reason')}"
         )
-    if isinstance(decision, dict) and decision.get("action") == "run_strategy_order_guard":
-        candidate = decision.get("bestCandidate")
-        if isinstance(candidate, dict):
-            return (
-                "market_open_cycle_candidate; "
-                f"ticketId={candidate.get('ticketId')}; "
-                f"symbol={candidate.get('symbol')} "
-                f"{candidate.get('setupGrade')} "
-                f"{candidate.get('setupType')}; "
-                f"expectedR={candidate.get('expectedR')}"
-            )
     if isinstance(decision, dict) and decision.get("action") == "no_actionable_candidate":
         return "market_open_cycle_complete; no_actionable_candidate"
     if isinstance(top_results, list) and top_results:

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -445,7 +445,7 @@ class LiveScanCycleTest(unittest.TestCase):
                         "symbol": "NVDA",
                         "setup_type": "opening_range_breakout",
                         "setup_grade": "A",
-                        "expected_r": "1.6",
+                        "expected_r": "2.6",
                         "scorecard_sample_size": 7,
                         "scorecard_avg_realized_r": "0.9",
                         "scorecard_confidence": "0.75",
@@ -474,6 +474,39 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["bestCandidate"]["ticketId"], "ticket-nvda")
         self.assertEqual(summary["bestCandidate"]["scorecardSampleSize"], 7)
         self.assertEqual(summary["candidateSymbols"], ["NVDA", "AMD"])
+
+    def test_decision_summary_blocks_sub_two_r_candidates(self) -> None:
+        result = {
+            "symbol": "GOOGL",
+            "setup_type": "vwap_reclaim",
+            "setup_grade": "B",
+            "expected_r": "1.786",
+            "last": "364.10",
+        }
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=7,
+            index=1,
+            result=result,
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=7,
+            scan={"results": [result]},
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-7-1-GOOGL-vwap_reclaim-B",
+                    "ticketId": "ticket-googl",
+                }
+            ],
+        )
+
+        assert payload is not None
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["noTradeReason"], "expected_r_below_threshold")
+        self.assertEqual(summary["action"], "no_actionable_candidate")
+        self.assertEqual(summary["actionableCandidateCount"], 0)
+        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertIsNone(summary["bestCandidate"])
 
     def test_decision_summary_reports_no_actionable_candidate(self) -> None:
         summary = live_scan_cycle.decision_summary_for_scan(
@@ -534,7 +567,8 @@ class LiveScanCycleTest(unittest.TestCase):
 
         self.assertEqual([path for path, _ in synthesis.posts], ["/api/autotrader/trade-tickets"] * 2)
         self.assertEqual(recorded[0]["ticketId"], "ticket-1")
-        self.assertEqual(recorded[0]["status"], "candidate")
+        self.assertEqual(recorded[0]["status"], "blocked")
+        self.assertEqual(recorded[0]["noTradeReason"], "expected_r_below_threshold")
         self.assertEqual(recorded[0]["scorecardSampleSize"], 3)
         self.assertEqual(recorded[0]["scorecardAvgRealizedR"], "0.75")
         self.assertEqual(recorded[0]["scorecardConfidence"], "0.6")


### PR DESCRIPTION
## Summary

- Adds a deterministic `expectedR >= 2.0` gate before scan results can become strategy-guard candidates.
- Records sub-2R or missing-R scan results as blocked tickets instead of candidate tickets.
- Simplifies the active and green autotrader prompt/ImplementationSpec language so bootstrap plus `market_open_cycle.py` is the single market-open decision path.
- Removes stale `market_open_cycle_candidate` status reporting; actionable candidates now report through `strategyGuard`.

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/market_open_cycle.py scripts/autotrader/test_live_scan_cycle.py`
- `python3 -m unittest test_live_scan_cycle.py test_market_open_cycle.py` from `scripts/autotrader`
- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "runs the market-open trader on its dedicated paper account|wires the analysis daytrading bootstrap into the trader provider"`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
