### PR TITLE
fix(autotrader): rank cycle candidates by edge

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -997,13 +997,13 @@ def record_scan_tickets(
     return recorded
 
 
-def candidate_score(result: dict[str, Any]) -> tuple[int, Decimal, int, Decimal]:
+def candidate_score(result: dict[str, Any]) -> tuple[Decimal, int, int, Decimal]:
     grade = setup_grade(result.get("setup_grade") or result.get("setupGrade"))
     grade_score = {"A+": 3, "A": 2, "B": 1}.get(grade, 0)
     expected_r = decimal_value(result.get("expected_r") or result.get("expectedR")) or Decimal("0")
     sample_size = int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize"))
     confidence = decimal_value(result.get("scorecard_confidence") or result.get("scorecardConfidence")) or Decimal("0")
-    return grade_score, expected_r, sample_size, confidence
+    return expected_r, grade_score, sample_size, confidence
 
 
 def actionable_candidate_for_result(

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -475,6 +475,43 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["bestCandidate"]["scorecardSampleSize"], 7)
         self.assertEqual(summary["candidateSymbols"], ["NVDA", "AMD"])
 
+    def test_decision_summary_prefers_edge_over_grade_after_threshold(self) -> None:
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=8,
+            scan={
+                "results": [
+                    {
+                        "symbol": "AVGO",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A+",
+                        "expected_r": "2.1",
+                    },
+                    {
+                        "symbol": "AMD",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A",
+                        "expected_r": "4.0",
+                    },
+                ]
+            },
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-8-1-AVGO-vwap_reclaim-A+",
+                    "ticketId": "ticket-avgo",
+                },
+                {
+                    "idempotencyKey": "scan-cycle-8-2-AMD-vwap_reclaim-A",
+                    "ticketId": "ticket-amd",
+                },
+            ],
+        )
+
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["bestCandidate"]["symbol"], "AMD")
+        self.assertEqual(summary["bestCandidate"]["expectedR"], "4.0")
+        self.assertEqual(summary["bestCandidate"]["ticketId"], "ticket-amd")
+        self.assertEqual(summary["candidateSymbols"], ["AMD", "AVGO"])
+
     def test_decision_summary_blocks_sub_two_r_candidates(self) -> None:
         result = {
             "symbol": "GOOGL",


### PR DESCRIPTION
## Summary

- Changes cycle candidate ranking to prefer higher expected R before setup grade after the hard 2R eligibility gate.
- Keeps setup grade, scorecard sample size, and scorecard confidence as tie-breakers.
- Adds a regression proving an A-grade 4R candidate beats an A+ 2.1R candidate.

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/test_live_scan_cycle.py`
- `python3 -m unittest test_live_scan_cycle.py` from `scripts/autotrader`
- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
