### PR TITLE
fix(torghut): preserve proof packet readback lineage

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1735,12 +1735,30 @@ def _runtime_ledger_immutable_lineage(
 ) -> dict[str, Any]:
     source_row_ids: list[str] = []
     source_refs: list[str] = []
+    strategy_ledger_refs: list[str] = []
     bucket_ids: list[str] = []
     metric_window_ids: list[str] = []
     promotion_decision_ids: list[str] = []
+    _extend_unique(strategy_ledger_refs, list(ledger_refs))
 
     def collect_from(source: Mapping[str, Any]) -> None:
         for key in (
+            "trade_decision_id",
+            "trade_decision_ids",
+            "execution_id",
+            "execution_ids",
+            "execution_order_event_id",
+            "execution_order_event_ids",
+            "runtime_ledger_execution_order_event_id",
+            "runtime_ledger_execution_order_event_ids",
+            "execution_tca_metric_id",
+            "execution_tca_metric_ids",
+            "runtime_ledger_execution_tca_metric_id",
+            "runtime_ledger_execution_tca_metric_ids",
+            "source_window_id",
+            "source_window_ids",
+            "runtime_ledger_source_window_id",
+            "runtime_ledger_source_window_ids",
             "source_row_id",
             "source_row_ids",
             "source_execution_row_ids",
@@ -1777,10 +1795,37 @@ def _runtime_ledger_immutable_lineage(
                 text = _text(source.get(key))
                 if text:
                     _extend_unique(bucket_ids, [text])
-        _extend_unique(metric_window_ids, _text_list(source.get("metric_window_ids")))
+        for key in (
+            "runtime_ledger_bucket_ref",
+            "runtime_ledger_bucket_refs",
+            "strategy_runtime_ledger_bucket_ref",
+            "strategy_runtime_ledger_bucket_refs",
+            "evidence_grade_runtime_ledger_bucket_ref",
+            "evidence_grade_runtime_ledger_bucket_refs",
+        ):
+            _extend_unique(strategy_ledger_refs, _text_list(source.get(key)))
+            if not _sequence(source.get(key)):
+                text = _text(source.get(key))
+                if text:
+                    _extend_unique(strategy_ledger_refs, [text])
+        for key in (
+            "metric_window_id",
+            "metric_window_ids",
+            "metric_window_ref",
+            "metric_window_refs",
+        ):
+            _extend_unique(metric_window_ids, _text_list(source.get(key)))
+            if not _sequence(source.get(key)):
+                text = _text(source.get(key))
+                if text:
+                    _extend_unique(metric_window_ids, [text])
         promotion_decision_id = _text(source.get("promotion_decision_id"))
         if promotion_decision_id:
             _extend_unique(promotion_decision_ids, [promotion_decision_id])
+        _extend_unique(
+            promotion_decision_ids,
+            _text_list(source.get("promotion_decision_refs")),
+        )
 
     for target in paper_targets:
         collect_from(target)
@@ -1789,15 +1834,20 @@ def _runtime_ledger_immutable_lineage(
         summary = _mapping(item.get("summary"))
         collect_from(summary)
         collect_from(_mapping(summary.get("runtime_observation")))
-        collect_from(_mapping(summary.get("runtime_materialization_target")))
+        collect_from(_mapping(summary.get("runtime_window_import_readback")))
+        materialization_target = _mapping(summary.get("runtime_materialization_target"))
+        collect_from(materialization_target)
+        collect_from(_mapping(materialization_target.get("readback")))
     collect_from(runtime_summary)
-    for target in _sequence(materialization_summary.get("materialized_targets")):
-        materialized_target = _mapping(target)
-        collect_from(materialized_target)
-        tigerbeetle = _mapping(materialized_target.get("tigerbeetle"))
-        _extend_unique(source_refs, _text_list(tigerbeetle.get("source_refs")))
-        for bucket_ref in _sequence(tigerbeetle.get("runtime_ledger_buckets")):
-            collect_from(_mapping(bucket_ref))
+    for key in ("materialized_targets", "unmaterialized_targets"):
+        for target in _sequence(materialization_summary.get(key)):
+            materialized_target = _mapping(target)
+            collect_from(materialized_target)
+            collect_from(_mapping(materialized_target.get("readback")))
+            tigerbeetle = _mapping(materialized_target.get("tigerbeetle"))
+            _extend_unique(source_refs, _text_list(tigerbeetle.get("source_refs")))
+            for bucket_ref in _sequence(tigerbeetle.get("runtime_ledger_buckets")):
+                collect_from(_mapping(bucket_ref))
 
     runtime_strategy = _text(
         identity.get("runtime_strategy_name") or identity.get("strategy_name")
@@ -1832,7 +1882,7 @@ def _runtime_ledger_immutable_lineage(
         "window_end": _text(identity.get("window_end")),
         "source_row_ids": source_row_ids,
         "source_refs": source_refs,
-        "strategy_runtime_ledger_bucket_refs": list(ledger_refs),
+        "strategy_runtime_ledger_bucket_refs": strategy_ledger_refs,
         "unbacked_metric_window_refs": list(unbacked_refs),
         "runtime_ledger_bucket_ids": bucket_ids,
         "metric_window_ids": metric_window_ids,
@@ -1840,7 +1890,7 @@ def _runtime_ledger_immutable_lineage(
         "counts": {
             "source_row_id_count": len(source_row_ids),
             "source_ref_count": len(source_refs),
-            "strategy_runtime_ledger_bucket_ref_count": len(ledger_refs),
+            "strategy_runtime_ledger_bucket_ref_count": len(strategy_ledger_refs),
             "unbacked_metric_window_ref_count": len(unbacked_refs),
             "runtime_ledger_bucket_id_count": len(bucket_ids),
             "metric_window_id_count": len(metric_window_ids),

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -829,6 +829,55 @@ class TestRuntimeLedgerProofPacket(TestCase):
             ],
         )
 
+    def test_packet_lineage_preserves_runtime_window_readback_refs(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(ledger_refs=[]),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        lineage = result["lineage"]
+        self.assertEqual(
+            lineage["strategy_runtime_ledger_bucket_refs"],
+            ["strategy_runtime_ledger_buckets:runtime-ledger-bucket-1"],
+        )
+        self.assertEqual(
+            lineage["counts"]["strategy_runtime_ledger_bucket_ref_count"], 1
+        )
+        for source_row_id in (
+            "source-window-1",
+            "event-1",
+            "execution-1",
+            "tca-1",
+            "decision-1",
+        ):
+            self.assertIn(source_row_id, lineage["source_row_ids"])
+        self.assertEqual(lineage["counts"]["source_row_id_count"], 5)
+        self.assertCountEqual(
+            lineage["metric_window_ids"],
+            ["metric-window-1", "strategy_hypothesis_metric_windows:metric-window-1"],
+        )
+        self.assertCountEqual(
+            lineage["promotion_decision_ids"],
+            [
+                "promotion-decision-1",
+                "strategy_promotion_decisions:promotion-decision-1",
+            ],
+        )
+        for source_ref in (
+            "postgres:trade_decisions",
+            "postgres:executions",
+            "postgres:execution_order_events",
+            "postgres:order_feed_source_windows",
+        ):
+            self.assertIn(source_ref, lineage["source_refs"])
+
     def test_hpairs_source_proof_census_blockers_are_non_authority_packet_blockers(
         self,
     ) -> None:
@@ -1704,7 +1753,14 @@ class TestRuntimeLedgerProofPacket(TestCase):
             self.assertEqual(immutable_lineage["stage"], "paper")
             self.assertEqual(
                 immutable_lineage["strategy_runtime_ledger_bucket_refs"],
-                ["strategy-runtime-ledger-buckets:H-PAIRS-01:2026-05-26"],
+                [
+                    "strategy-runtime-ledger-buckets:H-PAIRS-01:2026-05-26",
+                    "strategy_runtime_ledger_buckets:runtime-ledger-bucket-1",
+                ],
+            )
+            self.assertEqual(
+                immutable_lineage["counts"]["strategy_runtime_ledger_bucket_ref_count"],
+                2,
             )
             self.assertEqual(
                 immutable_lineage["runtime_ledger_bucket_ids"],


### PR DESCRIPTION
## Summary

- Preserves runtime-window import readback source row refs, metric-window refs, promotion-decision refs, and runtime-ledger bucket refs in immutable proof-packet lineage.
- Carries ledger refs from both the completion gate and runtime-window import readback, including unmaterialized target diagnostics.
- Adds regression coverage for proof-packet lineage when completion-gate ledger refs are absent but runtime-window readback refs exist.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -k "lineage_preserves_runtime_window_readback_refs" -q`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
