### PR TITLE
fix(autotrader): block negative scorecard candidates

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -886,6 +886,10 @@ def result_no_trade_reason(result: dict[str, Any], grade: str, type_: str) -> st
         return "scanner_blocked_grade"
     if type_ == "no_trade":
         return "scanner_no_trade"
+    scorecard_sample_size = int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize"))
+    scorecard_avg_r = decimal_value(result.get("scorecard_avg_realized_r") or result.get("scorecardAvgRealizedR"))
+    if scorecard_sample_size > 0 and scorecard_avg_r is not None and scorecard_avg_r < 0:
+        return "scorecard_avg_realized_r_negative"
     expected_r = decimal_value(result.get("expected_r") or result.get("expectedR"))
     if expected_r is None:
         return "missing_expected_r"

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -545,6 +545,55 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["blockedResultCount"], 1)
         self.assertIsNone(summary["bestCandidate"])
 
+    def test_decision_summary_blocks_negative_scorecard_history(self) -> None:
+        rejected = {
+            "symbol": "TSLA",
+            "setup_type": "vwap_reclaim",
+            "setup_grade": "A",
+            "expected_r": "4.5",
+            "scorecard_sample_size": 1,
+            "scorecard_avg_realized_r": "-1.009091",
+            "scorecard_confidence": "0.0909",
+        }
+        accepted = {
+            "symbol": "AMD",
+            "setup_type": "vwap_reclaim",
+            "setup_grade": "A",
+            "expected_r": "3.0",
+            "scorecard_sample_size": 1,
+            "scorecard_avg_realized_r": "3.042857",
+            "scorecard_confidence": "0.0909",
+        }
+        rejected_payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=9,
+            index=1,
+            result=rejected,
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=9,
+            scan={"results": [rejected, accepted]},
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-9-1-TSLA-vwap_reclaim-A",
+                    "ticketId": "ticket-tsla",
+                },
+                {
+                    "idempotencyKey": "scan-cycle-9-2-AMD-vwap_reclaim-A",
+                    "ticketId": "ticket-amd",
+                },
+            ],
+        )
+
+        assert rejected_payload is not None
+        self.assertEqual(rejected_payload["status"], "blocked")
+        self.assertEqual(rejected_payload["noTradeReason"], "scorecard_avg_realized_r_negative")
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["actionableCandidateCount"], 1)
+        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertEqual(summary["bestCandidate"]["symbol"], "AMD")
+        self.assertEqual(summary["candidateSymbols"], ["AMD"])
+
     def test_decision_summary_reports_no_actionable_candidate(self) -> None:
         summary = live_scan_cycle.decision_summary_for_scan(
             cycle=5,


### PR DESCRIPTION
## Summary

- Blocks live-scan candidates when nonzero scorecard history for the exact result has negative average realized R.
- Records those candidates as blocked tickets with `scorecard_avg_realized_r_negative`, keeping them out of strategy guard and broker mutation flow.
- Adds a regression proving a high-expected-R TSLA candidate with negative scorecard history loses to a lower-expected-R AMD candidate with positive scorecard history.

## Related Issues

None

## Testing

- `python3 -m py_compile live_scan_cycle.py test_live_scan_cycle.py`
- `python3 -m unittest test_live_scan_cycle.py`
- `python3 -m unittest discover -v`
- `git diff --check`
- Live evidence check: `GET /api/autotrader/scorecards?limit=100` showed 9 actionable-grade setup scorecards with negative average realized R.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
