### PR TITLE
fix(autotrader): boost positive scorecard edge

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -1001,13 +1001,17 @@ def record_scan_tickets(
     return recorded
 
 
-def candidate_score(result: dict[str, Any]) -> tuple[Decimal, int, int, Decimal]:
+def candidate_score(result: dict[str, Any]) -> tuple[Decimal, Decimal, int, int, Decimal]:
     grade = setup_grade(result.get("setup_grade") or result.get("setupGrade"))
     grade_score = {"A+": 3, "A": 2, "B": 1}.get(grade, 0)
     expected_r = decimal_value(result.get("expected_r") or result.get("expectedR")) or Decimal("0")
     sample_size = int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize"))
+    avg_realized_r = decimal_value(result.get("scorecard_avg_realized_r") or result.get("scorecardAvgRealizedR"))
+    scorecard_edge = (
+        avg_realized_r if sample_size > 0 and avg_realized_r is not None and avg_realized_r > 0 else Decimal("0")
+    )
     confidence = decimal_value(result.get("scorecard_confidence") or result.get("scorecardConfidence")) or Decimal("0")
-    return expected_r, grade_score, sample_size, confidence
+    return expected_r + scorecard_edge, expected_r, grade_score, sample_size, confidence
 
 
 def actionable_candidate_for_result(
@@ -1066,7 +1070,7 @@ def decision_summary_for_scan(
         for ticket in recorded_tickets
         if isinstance(ticket, dict) and optional_text(ticket.get("idempotencyKey"))
     }
-    candidates: list[tuple[tuple[int, Decimal, int, Decimal], dict[str, Any]]] = []
+    candidates: list[tuple[tuple[Decimal, Decimal, int, int, Decimal], dict[str, Any]]] = []
     blocked_count = 0
     no_trade_count = 0
     for index, result in enumerate(results, start=1):

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -512,6 +512,47 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["bestCandidate"]["ticketId"], "ticket-amd")
         self.assertEqual(summary["candidateSymbols"], ["AMD", "AVGO"])
 
+    def test_decision_summary_boosts_positive_scorecard_edge(self) -> None:
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=9,
+            scan={
+                "results": [
+                    {
+                        "symbol": "AVGO",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A+",
+                        "expected_r": "5.0",
+                    },
+                    {
+                        "symbol": "AMD",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A",
+                        "expected_r": "3.0",
+                        "scorecard_sample_size": 1,
+                        "scorecard_avg_realized_r": "3.042857",
+                        "scorecard_confidence": "0.0909",
+                    },
+                ]
+            },
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-9-1-AVGO-vwap_reclaim-A+",
+                    "ticketId": "ticket-avgo",
+                },
+                {
+                    "idempotencyKey": "scan-cycle-9-2-AMD-vwap_reclaim-A",
+                    "ticketId": "ticket-amd",
+                },
+            ],
+        )
+
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["bestCandidate"]["symbol"], "AMD")
+        self.assertEqual(summary["bestCandidate"]["expectedR"], "3.0")
+        self.assertEqual(summary["bestCandidate"]["scorecardAvgRealizedR"], "3.042857")
+        self.assertEqual(summary["bestCandidate"]["ticketId"], "ticket-amd")
+        self.assertEqual(summary["candidateSymbols"], ["AMD", "AVGO"])
+
     def test_decision_summary_blocks_sub_two_r_candidates(self) -> None:
         result = {
             "symbol": "GOOGL",


### PR DESCRIPTION
## Summary

- Boosts autotrader candidate ranking with positive realized scorecard edge, so known winning setup keys outrank higher raw expected-R candidates with no positive history.
- Keeps the existing 2R floor, actionable-grade filter, and negative scorecard-history block unchanged.
- Fixes the candidate score type annotation to match the actual tuple ordering.

## Related Issues

None

## Testing

- `python3 -m py_compile live_scan_cycle.py test_live_scan_cycle.py`
- `python3 -m unittest test_live_scan_cycle.py`
- `python3 -m unittest discover -v`
- `git diff --check`
- Live Synthesis readback: `/api/autotrader/scorecards?limit=100` showed 8 positive nonzero scorecard keys and 9 negative nonzero scorecard keys; this patch boosts only the positive-history side while the prior negative gate blocks known losers.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
