### PR TITLE
fix(torghut): keep linked closeout rows with source entries

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -526,20 +526,6 @@ def _source_row_is_paper_route_probe_exit(row: Mapping[str, object]) -> bool:
     return False
 
 
-def _source_decision_mode_counts(
-    rows: Sequence[Mapping[str, object]],
-) -> dict[str, int]:
-    counts: dict[str, int] = {}
-    for row in rows:
-        if _source_row_is_paper_route_probe_exit(row):
-            continue
-        mode = _source_decision_mode(row)
-        if mode is None:
-            continue
-        counts[mode] = counts.get(mode, 0) + 1
-    return dict(sorted(counts.items()))
-
-
 def _source_decision_identifier_values(row: Mapping[str, object]) -> set[str]:
     return _text_values(
         row,
@@ -547,6 +533,46 @@ def _source_decision_identifier_values(row: Mapping[str, object]) -> set[str]:
         "decision_id",
         "decision_hash",
     )
+
+
+def _paper_route_probe_exit_identifiers(
+    rows: Sequence[Mapping[str, object]],
+) -> set[str]:
+    identifiers: set[str] = set()
+    for row in rows:
+        if _source_row_is_paper_route_probe_exit(row):
+            identifiers.update(_source_decision_identifier_values(row))
+    return identifiers
+
+
+def _source_row_is_paper_route_probe_exit_or_linked(
+    row: Mapping[str, object],
+    *,
+    paper_route_probe_exit_identifiers: set[str],
+) -> bool:
+    if _source_row_is_paper_route_probe_exit(row):
+        return True
+    return bool(
+        _source_decision_identifier_values(row) & paper_route_probe_exit_identifiers
+    )
+
+
+def _source_decision_mode_counts(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    paper_route_probe_exit_identifiers = _paper_route_probe_exit_identifiers(rows)
+    for row in rows:
+        if _source_row_is_paper_route_probe_exit_or_linked(
+            row,
+            paper_route_probe_exit_identifiers=paper_route_probe_exit_identifiers,
+        ):
+            continue
+        mode = _source_decision_mode(row)
+        if mode is None:
+            continue
+        counts[mode] = counts.get(mode, 0) + 1
+    return dict(sorted(counts.items()))
 
 
 def _source_decision_mode_lookup(
@@ -623,8 +649,16 @@ def _partition_runtime_source_rows_by_decision_mode(
     if not source_rows:
         return None
     modes_by_identifier = _source_decision_mode_lookup(source_rows)
+    paper_route_probe_exit_identifiers = _paper_route_probe_exit_identifiers(
+        source_rows
+    )
     partition_relevant_source_rows = [
-        row for row in source_rows if not _source_row_is_paper_route_probe_exit(row)
+        row
+        for row in source_rows
+        if not _source_row_is_paper_route_probe_exit_or_linked(
+            row,
+            paper_route_probe_exit_identifiers=paper_route_probe_exit_identifiers,
+        )
     ]
     relevant_mode_keys = {
         _source_decision_mode_partition_key(
@@ -743,8 +777,12 @@ def _source_decision_rows_profit_proof_eligible(
     if source_decision_mode_counts_have_non_profit_proof_modes(modes):
         return False
     explicit: list[bool] = []
+    paper_route_probe_exit_identifiers = _paper_route_probe_exit_identifiers(rows)
     for row in rows:
-        if _source_row_is_paper_route_probe_exit(row):
+        if _source_row_is_paper_route_probe_exit_or_linked(
+            row,
+            paper_route_probe_exit_identifiers=paper_route_probe_exit_identifiers,
+        ):
             continue
         value = _source_decision_profit_proof_flag(row)
         if value is not None:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -6532,6 +6532,12 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 },
             }
         }
+        linked_exit_lifecycle_json = {
+            "params": {
+                "source_decision_mode": "route_acquisition_probe",
+                "profit_proof_eligible": False,
+            }
+        }
 
         rows = _build_realized_strategy_pnl_rows(
             [
@@ -6575,7 +6581,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "intraday-tsmom-profit-v3",
                     "decision_hash": "exit-hash",
-                    "decision_json": exit_decision_json,
+                    "decision_json": linked_exit_lifecycle_json,
                     "alpaca_order_id": "exit-order",
                     "execution_policy_hash": "exit-policy",
                     "cost_model_hash": "cost-sha",
@@ -6676,7 +6682,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "intraday-tsmom-profit-v3",
                     "decision_hash": "exit-hash",
-                    "decision_json": exit_decision_json,
+                    "decision_json": linked_exit_lifecycle_json,
                     "alpaca_order_id": "exit-order",
                     "event_type": "new",
                     "source_topic": "alpaca-trade-updates",
@@ -6699,7 +6705,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "intraday-tsmom-profit-v3",
                     "decision_hash": "exit-hash",
-                    "decision_json": exit_decision_json,
+                    "decision_json": linked_exit_lifecycle_json,
                     "alpaca_order_id": "exit-order",
                     "event_type": "fill",
                     "filled_qty": Decimal("1"),


### PR DESCRIPTION
## Summary

- Keeps paper-route closeout execution/order rows linked to their source entry decision mode when building runtime-ledger import buckets.
- Excludes linked `paper_route_exit` lifecycle rows from source-decision-mode proof eligibility counts so closeout mechanics do not become false non-proof blockers.
- Updates the importer regression to match the live shape where only the decision row has `paper_route_probe_exit` metadata and linked rows carry inherited `route_acquisition_probe` fields.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "keeps_probe_exit_with_source_entry or marks_route_acquisition_not_profit_proof or partitions_mixed_source_decision_modes"`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
