### PR TITLE
fix(autotrader): overlay scorecards before gating

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -676,6 +676,7 @@ def summarize_scan(
         "resultCount": len(results),
         "topResults": top_results,
         "scorecardInfluence": scorecard_usage_summary(scan),
+        "scorecardOverlay": scan.get("scorecardOverlay"),
     }
 
 
@@ -826,6 +827,93 @@ def scorecard_usage_summary(scan: dict[str, Any]) -> dict[str, Any]:
         "resultCount": len(results),
         "scorecardInfluencedResultCount": used_results,
         "topResults": top_results,
+    }
+
+
+def scorecard_match_text(value: Any) -> str | None:
+    text = optional_text(value)
+    return text.lower() if text else None
+
+
+def scorecard_overlay_for_result(result: dict[str, Any], scorecards: list[Any]) -> dict[str, str] | None:
+    symbol = optional_text(result.get("symbol"), max_length=32)
+    setup = scorecard_match_text(result.get("setup_type") or result.get("setupType"))
+    grade = setup_grade(result.get("setup_grade") or result.get("setupGrade"))
+    if not symbol or not setup or grade not in ACTIONABLE_SETUP_GRADES:
+        return None
+    regime = scorecard_match_text(result.get("regime"))
+    time_bucket = scorecard_match_text(result.get("time_bucket") or result.get("timeBucket"))
+    matches: list[dict[str, Any]] = []
+    for scorecard in scorecards:
+        if not isinstance(scorecard, dict):
+            continue
+        scorecard_symbol = optional_text(scorecard.get("symbol"), max_length=32)
+        if not scorecard_symbol or scorecard_symbol.upper() != symbol.upper():
+            continue
+        if scorecard_match_text(scorecard.get("setupType") or scorecard.get("setup_type")) != setup:
+            continue
+        if setup_grade(scorecard.get("setupGrade") or scorecard.get("setup_grade")) != grade:
+            continue
+        matches.append(scorecard)
+    if not matches:
+        return None
+    contextual_matches = [
+        scorecard
+        for scorecard in matches
+        if (not regime or scorecard_match_text(scorecard.get("regime")) == regime)
+        and (not time_bucket or scorecard_match_text(scorecard.get("timeBucket") or scorecard.get("time_bucket")) == time_bucket)
+    ]
+    selected = contextual_matches or matches
+    weighted_sum = Decimal("0")
+    sample_total = 0
+    confidence = Decimal("0")
+    for scorecard in selected:
+        sample_size = int_text_value(scorecard.get("sampleSize") or scorecard.get("sample_size"))
+        avg_r = decimal_value(scorecard.get("avgRealizedR") or scorecard.get("avg_realized_r"))
+        if sample_size <= 0 or avg_r is None:
+            continue
+        weighted_sum += avg_r * Decimal(sample_size)
+        sample_total += sample_size
+        confidence = max(confidence, decimal_value(scorecard.get("confidence")) or Decimal("0"))
+    if sample_total <= 0:
+        return None
+    return {
+        "scorecard_sample_size": str(sample_total),
+        "scorecard_avg_realized_r": str(weighted_sum / Decimal(sample_total)),
+        "scorecard_confidence": str(confidence),
+    }
+
+
+def overlay_scorecards_on_scan(scan: dict[str, Any], scorecard_payload: Any) -> dict[str, Any]:
+    results = scan.get("results")
+    if not isinstance(results, list):
+        return scan
+    scorecards = scorecard_collection(scorecard_payload, "scorecards")
+    if not scorecards:
+        return scan
+    enriched_results: list[Any] = []
+    applied_count = 0
+    for result in results:
+        if not isinstance(result, dict):
+            enriched_results.append(result)
+            continue
+        if int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize")) > 0:
+            enriched_results.append(result)
+            continue
+        overlay = scorecard_overlay_for_result(result, scorecards)
+        if overlay is None:
+            enriched_results.append(result)
+            continue
+        enriched = {**result, **overlay, "scorecard_overlay_source": "synthesis_scorecards"}
+        enriched_results.append(enriched)
+        applied_count += 1
+    return {
+        **scan,
+        "results": enriched_results,
+        "scorecardOverlay": {
+            "sourceScorecardCount": len(scorecards),
+            "appliedResultCount": applied_count,
+        },
     }
 
 
@@ -1206,6 +1294,7 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
         analysis_context_path=analysis_context,
         watchlist=symbols,
     )
+    scan = overlay_scorecards_on_scan(scan, inputs.get("scorecards.json"))
     stage_timings["stockAnalysisScanMs"] = elapsed_ms(scan_started_at)
     prune_started_at = time.monotonic()
     removed_cycle_dirs = prune_old_cycle_dirs(work_dir, args.retain_cycles)

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -375,6 +375,111 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["topScorecards"][0]["avgRealizedR"], "1.25")
         self.assertEqual(len(summary["payloadHash"]), 64)
 
+    def test_overlay_scorecards_on_scan_enables_positive_history_candidate(self) -> None:
+        scan = live_scan_cycle.overlay_scorecards_on_scan(
+            {
+                "results": [
+                    {
+                        "symbol": "amd",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A",
+                        "expected_r": "3.0",
+                        "last": "180.25",
+                    }
+                ]
+            },
+            {
+                "scorecards": [
+                    {
+                        "symbol": "AMD",
+                        "setupType": "vwap_reclaim",
+                        "setupGrade": "A",
+                        "sampleSize": 1,
+                        "avgRealizedR": "3.042857",
+                        "confidence": "0.0909",
+                    }
+                ]
+            },
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=11,
+            scan=scan,
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-11-1-AMD-vwap_reclaim-A",
+                    "ticketId": "ticket-amd",
+                }
+            ],
+        )
+
+        result = scan["results"][0]
+        self.assertEqual(scan["scorecardOverlay"]["appliedResultCount"], 1)
+        self.assertEqual(result["scorecard_sample_size"], "1")
+        self.assertEqual(result["scorecard_avg_realized_r"], "3.042857")
+        self.assertEqual(result["scorecard_overlay_source"], "synthesis_scorecards")
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["bestCandidate"]["symbol"], "AMD")
+        self.assertEqual(summary["candidateSymbols"], ["AMD"])
+
+    def test_overlay_scorecards_on_scan_preserves_negative_history_block(self) -> None:
+        scan = live_scan_cycle.overlay_scorecards_on_scan(
+            {
+                "results": [
+                    {
+                        "symbol": "F",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A",
+                        "expected_r": "5.0",
+                        "last": "12.34",
+                    }
+                ]
+            },
+            {
+                "scorecards": [
+                    {
+                        "symbol": "F",
+                        "setupType": "vwap_reclaim",
+                        "setupGrade": "A",
+                        "sampleSize": 2,
+                        "avgRealizedR": "-0.585",
+                        "confidence": "0.1667",
+                    },
+                    {
+                        "symbol": "F",
+                        "setupType": "vwap_reclaim",
+                        "setupGrade": "A",
+                        "sampleSize": 1,
+                        "avgRealizedR": "0",
+                        "confidence": "0.0909",
+                    },
+                ]
+            },
+        )
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=12,
+            index=1,
+            result=scan["results"][0],
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=12,
+            scan=scan,
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-12-1-F-vwap_reclaim-A",
+                    "ticketId": "ticket-f",
+                }
+            ],
+        )
+
+        assert payload is not None
+        self.assertEqual(scan["scorecardOverlay"]["appliedResultCount"], 1)
+        self.assertEqual(scan["results"][0]["scorecard_sample_size"], "3")
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["noTradeReason"], "scorecard_avg_realized_r_negative")
+        self.assertEqual(summary["action"], "no_actionable_candidate")
+        self.assertEqual(summary["blockedResultCount"], 1)
+
     def test_builds_ticket_payload_from_scanner_candidate(self) -> None:
         payload = live_scan_cycle.ticket_payload_for_scan_result(
             session_id="session-1",


### PR DESCRIPTION
## Summary

- Enriches scanner results with Synthesis scorecards before ticket creation, decision summary, and positive-edge gating.
- Keeps the stricter `positive_scorecard_edge_required` gate from accidentally blocking proven winners when the scanner omits scorecard fields.
- Aggregates matching scorecards by symbol, setup type, and grade, preserving negative-history blocks instead of cherry-picking positive rows.

## Related Issues

None

## Testing

- `python3 -m py_compile live_scan_cycle.py test_live_scan_cycle.py`
- `python3 -m unittest test_live_scan_cycle.py`
- `python3 -m unittest discover -v`
- `git diff --check`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/market_open_cycle.py --self-test`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
