### PR TITLE
fix(torghut): retry post-deploy target mirror readback

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -415,7 +415,48 @@ jobs:
           export TORGHUT_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-readyz.json"
           export TORGHUT_PAPER_ROUTE_EVIDENCE="${EVIDENCE_DIR}/torghut-paper-route-evidence.json"
           export TORGHUT_SIM_PAPER_ROUTE_EVIDENCE="${EVIDENCE_DIR}/torghut-sim-paper-route-evidence.json"
-          bun run packages/scripts/src/torghut/post-deploy-evidence.ts
+
+          validate_post_deploy_evidence() {
+            local attempt
+            local status
+            local output_path="${EVIDENCE_DIR}/post-deploy-evidence-validator.out"
+
+            for attempt in $(seq 1 48); do
+              set +e
+              bun run packages/scripts/src/torghut/post-deploy-evidence.ts > "${output_path}" 2>&1
+              status=$?
+              set -e
+
+              if [ "${status}" -eq 0 ]; then
+                cat "${output_path}"
+                return 0
+              fi
+
+              if ! grep -Eq 'torghut-sim paper-route target plan (is empty while live torghut exposes targets|missing live target)' "${output_path}"; then
+                cat "${output_path}" >&2
+                return "${status}"
+              fi
+
+              if [ "${attempt}" -eq 48 ]; then
+                echo "Torghut sim paper-route target mirror did not materialize after bounded retry window" >&2
+                cat "${output_path}" >&2
+                return "${status}"
+              fi
+
+              echo "Attempt ${attempt}: Torghut sim paper-route target mirror not materialized yet; refreshing evidence payloads" >&2
+              fetch_json_2xx \
+                http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
+                "${EVIDENCE_DIR}/torghut-paper-route-evidence.json" \
+                "Torghut /trading/paper-route-evidence"
+              fetch_json_2xx \
+                http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
+                "${EVIDENCE_DIR}/torghut-sim-paper-route-evidence.json" \
+                "Torghut sim /trading/paper-route-evidence"
+              sleep 10
+            done
+          }
+
+          validate_post_deploy_evidence
 
       - name: Close superseded Torghut rollback pull requests
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -84,6 +84,18 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('TORGHUT_SIM_PAPER_ROUTE_EVIDENCE')
   })
 
+  it('retries transient sim paper-route target mirror gaps before rollback', () => {
+    expect(workflow).toContain('validate_post_deploy_evidence()')
+    expect(workflow).toContain('post-deploy-evidence-validator.out')
+    expect(workflow).toContain(
+      'torghut-sim paper-route target plan (is empty while live torghut exposes targets|missing live target)',
+    )
+    expect(workflow).toContain(
+      'Torghut sim paper-route target mirror not materialized yet; refreshing evidence payloads',
+    )
+    expect(workflow).toContain('Torghut sim paper-route target mirror did not materialize after bounded retry window')
+  })
+
   it('requests Argo refresh before polling deployed revisions', () => {
     expect(workflow).toContain('argocd.argoproj.io/refresh=hard --overwrite')
     expect(workflow).toContain('for app in torghut torghut-options; do')


### PR DESCRIPTION
## Summary

 - Wrap Torghut post-deploy evidence validation in a bounded retry for transient sim paper-route target mirror materialization gaps.
- Refresh live and sim paper-route evidence payloads between retry attempts while keeping all other validator failures immediate.
- Add workflow test coverage for the retry path.

## Related Issues

None

## Testing

 - `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
