### PR TITLE
fix(autotrader): size risk from scorecard edge

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
@@ -22,7 +22,8 @@ data:
 
     Source of truth:
     - Alpaca MCP is broker truth; Synthesis autotrader tools are runtime truth.
-    - Local files are not trader state. Do not create JSON/JSONL ledgers. Write only `report.md`; scratch files are internal.
+    - Local files are not trader state. Ad hoc Python scripts and scratch files are allowed for immediate analysis, but they are not durable proof or trader state.
+    - Do not create JSON/JSONL ledgers. Write only `report.md` as the operator-facing artifact.
 
     Identity and mode:
     - Use `AGENT_RUN_NAME` unchanged for session identity, client order ids, dedupe keys, and reports.
@@ -35,9 +36,10 @@ data:
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/market_open_cycle.py`; runner owns session loading, market-hour waiting, account gate, scan, scorecard/tickets, best-candidate guard, `last-cycle.json`, and checkpoint.
     5. Do not manually scan, recreate tickets, run candidate guards, or smoke orders for runner candidates. Use runner `ticketId`, `noTradeReason`, `strategyGuard`, and `blocker` as authoritative.
     6. Only plan new broker risk after the runner returns `strategyGuard.allowed=true` for a candidate.
-    7. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
-    8. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
-    9. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    7. Size new broker risk from runner `decisionSummary.bestCandidate.riskDirective`: use `recommendedRiskDollars` when present, otherwise honor `riskMultiplier` inside account/day-trade limits. Positive scorecard edge should be acted on aggressively; unproven or negative history must not be enlarged or bypass gates.
+    8. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
+    9. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
+    10. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 
     Mode behavior:
     - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.

--- a/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
@@ -22,7 +22,8 @@ data:
 
     Source of truth:
     - Alpaca MCP is broker truth; Synthesis autotrader tools are runtime truth.
-    - Local files are not trader state. Do not create JSON/JSONL ledgers. Write only `report.md`; scratch files are internal.
+    - Local files are not trader state. Ad hoc Python scripts and scratch files are allowed for immediate analysis, but they are not durable proof or trader state.
+    - Do not create JSON/JSONL ledgers. Write only `report.md` as the operator-facing artifact.
 
     Identity and mode:
     - Use `AGENT_RUN_NAME` unchanged for session identity, client order ids, dedupe keys, and reports.
@@ -35,9 +36,10 @@ data:
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/market_open_cycle.py`; runner owns session loading, market-hour waiting, account gate, scan, scorecard/tickets, best-candidate guard, `last-cycle.json`, and checkpoint.
     5. Do not manually scan, recreate tickets, run candidate guards, or smoke orders for runner candidates. Use runner `ticketId`, `noTradeReason`, `strategyGuard`, and `blocker` as authoritative.
     6. Only plan new broker risk after the runner returns `strategyGuard.allowed=true` for a candidate.
-    7. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
-    8. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
-    9. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    7. Size new broker risk from runner `decisionSummary.bestCandidate.riskDirective`: use `recommendedRiskDollars` when present, otherwise honor `riskMultiplier` inside account/day-trade limits. Positive scorecard edge should be acted on aggressively; unproven or negative history must not be enlarged or bypass gates.
+    8. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
+    9. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
+    10. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 
     Mode behavior:
     - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -783,6 +783,7 @@ describe('autonomous trader provider', () => {
       const parameters = objectAt(templateSpec, 'parameters')
       const role = objectAt(scheduleSpec, 'suspend') === false ? 'active' : 'preview'
       const laneResources = [lane.schedule, lane.template, lane.agent, lane.implementationSpec, lane.systemPrompt]
+      const systemPromptText = String(objectAt(objectAt(lane.systemPrompt, 'data'), 'system-prompt.md') ?? '')
 
       expect(objectAt(scheduleSpec, 'cron')).toBe('15 9 * * 1-5')
       expect(objectAt(scheduleSpec, 'timezone')).toBe('America/New_York')
@@ -803,6 +804,10 @@ describe('autonomous trader provider', () => {
       expect(objectAt(parameters, 'sessionReconcileEnabled')).toBe(role === 'active' ? 'true' : 'false')
       expect(objectAt(parameters, 'accountType')).toBe('paper')
       expect(objectAt(parameters, 'targetEquityUsd')).toBe('500000')
+      expect(systemPromptText).toContain('Ad hoc Python scripts and scratch files are allowed for immediate analysis')
+      expect(systemPromptText).toContain('decisionSummary.bestCandidate.riskDirective')
+      expect(systemPromptText).toContain('recommendedRiskDollars')
+      expect(systemPromptText).toContain('Positive scorecard edge should be acted on aggressively')
     }
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_MODE')).toBe('{{parameters.mode}}')
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE')).toBe(

--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -39,6 +39,7 @@ SYNTHESIS_SIDES = {
 }
 ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
 MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
+MAX_SCORECARD_RISK_MULTIPLIER = Decimal("2.0")
 
 
 class AlpacaRestClient:
@@ -1011,6 +1012,7 @@ def ticket_payload_for_scan_result(
     )
     entry_trigger = optional_text(result.get("entry_trigger") or result.get("entryTrigger"), max_length=1200)
     invalidation = optional_text(result.get("invalidation"), max_length=1200)
+    risk_directive = scorecard_risk_directive(result)
 
     return {
         "sessionId": session_id,
@@ -1039,6 +1041,7 @@ def ticket_payload_for_scan_result(
             "source": "live_scan_cycle",
             "cycle": cycle,
             "resultIndex": index,
+            "riskDirective": risk_directive,
             "raw": result,
         },
         "status": "blocked" if blocked else "candidate",
@@ -1091,16 +1094,43 @@ def record_scan_tickets(
     return recorded
 
 
+def scorecard_edge_values(result: dict[str, Any]) -> tuple[int, Decimal | None, Decimal]:
+    sample_size = int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize"))
+    avg_realized_r = decimal_value(result.get("scorecard_avg_realized_r") or result.get("scorecardAvgRealizedR"))
+    confidence = decimal_value(result.get("scorecard_confidence") or result.get("scorecardConfidence")) or Decimal("0")
+    return sample_size, avg_realized_r, confidence
+
+
+def scorecard_risk_directive(result: dict[str, Any]) -> dict[str, Any] | None:
+    sample_size, avg_realized_r, confidence = scorecard_edge_values(result)
+    if sample_size <= 0 or avg_realized_r is None or avg_realized_r <= 0:
+        return None
+    risk_multiplier = min(MAX_SCORECARD_RISK_MULTIPLIER, max(Decimal("1.0"), avg_realized_r))
+    directive: dict[str, Any] = {
+        "source": "scorecard_realized_r",
+        "mode": "scale_positive_realized_edge",
+        "riskMultiplier": str(risk_multiplier),
+        "maxRiskMultiplier": str(MAX_SCORECARD_RISK_MULTIPLIER),
+        "scorecardSampleSize": sample_size,
+        "scorecardAvgRealizedR": str(avg_realized_r),
+        "scorecardConfidence": str(confidence),
+        "reason": "positive_scorecard_edge",
+    }
+    risk_dollars = decimal_value(result.get("risk_dollars") or result.get("riskDollars"))
+    if risk_dollars is not None and risk_dollars > 0:
+        directive["baseRiskDollars"] = str(risk_dollars)
+        directive["recommendedRiskDollars"] = str(risk_dollars * risk_multiplier)
+    return directive
+
+
 def candidate_score(result: dict[str, Any]) -> tuple[Decimal, Decimal, int, int, Decimal]:
     grade = setup_grade(result.get("setup_grade") or result.get("setupGrade"))
     grade_score = {"A+": 3, "A": 2, "B": 1}.get(grade, 0)
     expected_r = decimal_value(result.get("expected_r") or result.get("expectedR")) or Decimal("0")
-    sample_size = int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize"))
-    avg_realized_r = decimal_value(result.get("scorecard_avg_realized_r") or result.get("scorecardAvgRealizedR"))
+    sample_size, avg_realized_r, confidence = scorecard_edge_values(result)
     scorecard_edge = (
         avg_realized_r if sample_size > 0 and avg_realized_r is not None and avg_realized_r > 0 else Decimal("0")
     )
-    confidence = decimal_value(result.get("scorecard_confidence") or result.get("scorecardConfidence")) or Decimal("0")
     return expected_r + scorecard_edge, expected_r, grade_score, sample_size, confidence
 
 
@@ -1133,6 +1163,7 @@ def actionable_candidate_for_result(
         "targetPrice": payload.get("targetPrice"),
         "riskDollars": payload.get("riskDollars"),
         "plannedQuantity": payload.get("plannedQuantity"),
+        "riskDirective": scorecard_risk_directive(result),
         "scorecardSampleSize": int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize")),
         "scorecardAvgRealizedR": numeric_text(
             result.get("scorecard_avg_realized_r") or result.get("scorecardAvgRealizedR")

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -640,6 +640,7 @@ class LiveScanCycleTest(unittest.TestCase):
                         "setup_type": "vwap_reclaim",
                         "setup_grade": "A",
                         "expected_r": "3.0",
+                        "risk_dollars": "100",
                         "scorecard_sample_size": 1,
                         "scorecard_avg_realized_r": "3.042857",
                         "scorecard_confidence": "0.0909",
@@ -662,8 +663,57 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["bestCandidate"]["symbol"], "AMD")
         self.assertEqual(summary["bestCandidate"]["expectedR"], "3.0")
         self.assertEqual(summary["bestCandidate"]["scorecardAvgRealizedR"], "3.042857")
+        self.assertEqual(
+            summary["bestCandidate"]["riskDirective"],
+            {
+                "source": "scorecard_realized_r",
+                "mode": "scale_positive_realized_edge",
+                "riskMultiplier": "2.0",
+                "maxRiskMultiplier": "2.0",
+                "scorecardSampleSize": 1,
+                "scorecardAvgRealizedR": "3.042857",
+                "scorecardConfidence": "0.0909",
+                "reason": "positive_scorecard_edge",
+                "baseRiskDollars": "100",
+                "recommendedRiskDollars": "200.0",
+            },
+        )
         self.assertEqual(summary["bestCandidate"]["ticketId"], "ticket-amd")
         self.assertEqual(summary["candidateSymbols"], ["AMD"])
+
+    def test_ticket_payload_records_scorecard_risk_directive_for_positive_edge(self) -> None:
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=9,
+            index=2,
+            result={
+                "symbol": "AMD",
+                "setup_type": "vwap_reclaim",
+                "setup_grade": "A",
+                "expected_r": "3.0",
+                "risk_dollars": "125",
+                "scorecard_sample_size": 2,
+                "scorecard_avg_realized_r": "1.4",
+                "scorecard_confidence": "0.25",
+            },
+        )
+
+        assert payload is not None
+        self.assertEqual(
+            payload["brokerOrderPlan"]["riskDirective"],
+            {
+                "source": "scorecard_realized_r",
+                "mode": "scale_positive_realized_edge",
+                "riskMultiplier": "1.4",
+                "maxRiskMultiplier": "2.0",
+                "scorecardSampleSize": 2,
+                "scorecardAvgRealizedR": "1.4",
+                "scorecardConfidence": "0.25",
+                "reason": "positive_scorecard_edge",
+                "baseRiskDollars": "125",
+                "recommendedRiskDollars": "175.0",
+            },
+        )
 
     def test_decision_summary_blocks_unproven_raw_edge_without_positive_scorecard(self) -> None:
         result = {


### PR DESCRIPTION
## Summary

- Added a deterministic `riskDirective` to live scan candidates when positive realized scorecard edge exists, capped at `2.0x`.
- Stored that directive in the Synthesis ticket `brokerOrderPlan` and exposed it on `decisionSummary.bestCandidate`.
- Updated blue/green autotrader prompts to use the runner risk directive aggressively for positive scorecard edge while allowing ad hoc Python scripts for immediate analysis.

## Related Issues

None

## Testing

- `python3 -m py_compile live_scan_cycle.py test_live_scan_cycle.py market_open_cycle.py`
- `python3 -m unittest test_live_scan_cycle.py`
- `python3 -m unittest test_market_open_cycle.py`
- `python3 -m unittest discover -v`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/market_open_cycle.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
