### PR TITLE
fix(torghut): enable sim audit for live paper route targets

### DIFF
--- a/docs/superpowers/plans/2026-06-03-torghut-profitability-proof.md
+++ b/docs/superpowers/plans/2026-06-03-torghut-profitability-proof.md
@@ -1,0 +1,56 @@
+# Torghut Profitability Proof Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove Torghut can produce at least `$500/day` post-cost profitability from source-linked live-paper/runtime-ledger evidence, then promote only through existing GitOps gates.
+
+**Architecture:** Keep readiness, promotion, and profitability proof separate. Remove false evidence-collection blockers, run bounded SIM/live-paper collection through real sessions, import runtime windows after settlement, assemble a proof packet, and only mark completion when live runtime-ledger readback shows source decisions, executions, fills, TCA/cost refs, closed trips or flat positions, and promotion authority.
+
+**Tech Stack:** FastAPI, SQLAlchemy, Torghut runtime-ledger models, `services/torghut/scripts/renew_latest_empirical_promotion_jobs.py`, `scripts/assemble_runtime_ledger_proof_packet.py`, GitHub Actions, Argo CD, Knative, TigerBeetle.
+
+---
+
+### Task 1: Remove False SIM Audit Blocker
+
+**Files:**
+- Modify: `services/torghut/app/main.py`
+- Modify: `services/torghut/tests/test_trading_api.py`
+
+- [x] Add tests proving live-mode paper-route endpoints enable read-only `TORGHUT_SIM` target-account audit for explicit SIM/paper evidence targets.
+- [x] Add a negative test proving non-SIM/live targets still keep the audit disabled.
+- [x] Replace the coarse `settings.trading_mode == "paper"` predicate with a helper that allows audit only for paper mode or explicit SIM evidence plans.
+- [x] Run `uv run --frozen pytest tests/test_trading_api.py -k 'target_account_audit or paper_route_evidence'`.
+
+### Task 2: Runtime Window Collection Readiness
+
+**Files:**
+- Inspect: `services/torghut/app/trading/paper_route_evidence.py`
+- Inspect: `services/torghut/scripts/renew_latest_empirical_promotion_jobs.py`
+- Inspect: `argocd/applications/torghut/*paper*runtime*`
+
+- [ ] Re-read `/trading/paper-route-evidence` after the market session opens.
+- [ ] Verify `paper_route_session_window_not_open` clears during the session.
+- [ ] Verify target-account audit produces clean-window state instead of `paper_route_target_account_audit_unavailable`.
+- [ ] If clean-window audit still blocks, patch the exact readback path with a regression test.
+
+### Task 3: Post-Session Import And Proof Packet
+
+**Files:**
+- Inspect: `services/torghut/scripts/renew_latest_empirical_promotion_jobs.py`
+- Inspect: `services/torghut/scripts/assemble_runtime_ledger_proof_packet.py`
+
+- [ ] After `2026-06-03T21:00:00Z`, run the runtime-window import from the paper-route target plan with exclusive target-plan flags.
+- [ ] Assemble the runtime-ledger proof packet from `/readyz`, `/trading/status`, `/trading/paper-route-evidence`, and runtime-window import output.
+- [ ] Verify blockers for `source_decisions_missing`, `source_executions_missing`, `source_tca_missing`, `closed_round_trip_missing`, `unclosed_position`, and `runtime_ledger_source_materialization_missing`.
+- [ ] Patch the highest-current blocker with a regression test; do not weaken promotion gates.
+
+### Task 4: Promotion And Live Verification
+
+**Files:**
+- Modify only the files required by the blocker found in Task 3.
+
+- [ ] Run `uv sync --frozen --extra dev`.
+- [ ] Run targeted pytest for touched files.
+- [ ] Run all three Torghut pyright profiles.
+- [ ] Push a PR, wait for green CI, merge, release, and verify Argo/Knative/post-deploy.
+- [ ] Re-read live proof packet and decide whether the profitability goal is complete or which blocker remains.

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -134,6 +134,7 @@ from .trading.paper_route_evidence import (
     DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
     MAX_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
     MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+    PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
     build_paper_route_evidence_audit,
     build_paper_route_target_plan_payload,
 )
@@ -6076,7 +6077,9 @@ def trading_paper_route_evidence(
             route_reacquisition_book=route_reacquisition_book,
             lookback_hours=lookback_hours,
             target_limit=target_limit,
-            target_account_audit_available=settings.trading_mode == "paper",
+            target_account_audit_available=_paper_route_target_account_audit_available(
+                cast(Mapping[str, Any], live_submission_gate)
+            ),
         )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
@@ -6179,13 +6182,48 @@ def trading_paper_route_target_plan() -> JSONResponse:
             # Keep this provider endpoint bounded; proof-grade runtime import
             # audits run only after the runtime window is import-ready.
             include_runtime_window_import_audit=None,
-            target_account_audit_available=settings.trading_mode == "paper",
+            target_account_audit_available=_paper_route_target_account_audit_available(
+                cast(Mapping[str, Any], live_submission_gate)
+            ),
         )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
 
 def _mapping_items(value: object) -> list[dict[str, Any]]:
     return _shared_mapping_items(value)
+
+
+def _normalized_paper_route_text(value: object) -> str:
+    return str(value or "").strip().upper()
+
+
+def _paper_route_mapping_targets_sim_account(value: Mapping[str, Any]) -> bool:
+    return (
+        _normalized_paper_route_text(value.get("account_label"))
+        == PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL
+        or _normalized_paper_route_text(value.get("target_dsn_env")) == "SIM_DB_DSN"
+        or _normalized_paper_route_text(value.get("source_dsn_env")) == "SIM_DB_DSN"
+        or _normalized_paper_route_text(value.get("observed_stage")) == "PAPER"
+    )
+
+
+def _paper_route_target_account_audit_available(
+    live_submission_gate: Mapping[str, Any],
+) -> bool:
+    if settings.trading_mode == "paper":
+        return True
+    if settings.trading_mode != "live":
+        return False
+    plan = live_submission_gate.get("runtime_ledger_paper_probation_import_plan")
+    if not isinstance(plan, Mapping):
+        return False
+    normalized_plan = cast(Mapping[str, Any], plan)
+    if _paper_route_mapping_targets_sim_account(normalized_plan):
+        return True
+    return any(
+        _paper_route_mapping_targets_sim_account(target)
+        for target in _shared_mapping_items(normalized_plan.get("targets"))
+    )
 
 
 def _paper_route_target_plan_probe_symbols(plan: Mapping[str, Any]) -> list[str]:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -6906,9 +6906,7 @@ class TestTradingApi(TestCase):
     def test_zero_notional_repair_endpoint_returns_dry_run_receipt(self) -> None:
         status_payload = {
             "active_revision": "torghut-00320",
-            "freshness_carry_ledger": _freshness_carry_ledger_for_test(
-                "empirical"
-            ),
+            "freshness_carry_ledger": _freshness_carry_ledger_for_test("empirical"),
             "profit_freshness_frontier": {
                 "frontier_id": "profit-freshness-frontier:test",
                 "capital_posture": {
@@ -6963,9 +6961,7 @@ class TestTradingApi(TestCase):
     def test_zero_notional_repair_endpoint_accepts_dispatch_ticket_body(self) -> None:
         status_payload = {
             "active_revision": "torghut-00320",
-            "freshness_carry_ledger": _freshness_carry_ledger_for_test(
-                "empirical"
-            ),
+            "freshness_carry_ledger": _freshness_carry_ledger_for_test("empirical"),
             "profit_freshness_frontier": {
                 "frontier_id": "profit-freshness-frontier:test",
                 "capital_posture": {
@@ -10461,6 +10457,195 @@ class TestTradingApi(TestCase):
                     del app.state.trading_scheduler
             else:
                 app.state.trading_scheduler = original_scheduler
+
+    def test_live_paper_route_evidence_enables_sim_target_account_audit(self) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        original_mode = settings.trading_mode
+        settings.trading_mode = "live"
+        settings.trading_paper_route_target_plan_url = ""
+        live_gate = {
+            "allowed": False,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [
+                    {
+                        "candidate_id": "sim-runtime-target",
+                        "account_label": "TORGHUT_SIM",
+                        "target_dsn_env": "SIM_DB_DSN",
+                        "source_dsn_env": "SIM_DB_DSN",
+                        "observed_stage": "paper",
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ],
+            },
+        }
+
+        try:
+            app.state.trading_scheduler = SimpleNamespace(
+                state=SimpleNamespace(market_session_open=False),
+                llm_status=lambda: {"dspy_runtime": {}},
+                market_context_status=lambda: {},
+            )
+            with (
+                patch("app.main._empirical_jobs_status", return_value={}),
+                patch("app.main.load_quant_evidence_status", return_value={}),
+                patch("app.main._load_tca_summary", return_value={}),
+                patch(
+                    "app.main._build_hypothesis_runtime_payload",
+                    return_value=({}, {}, {}),
+                ),
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value=live_gate,
+                ),
+                patch("app.main._build_simple_lane_status_payload", return_value={}),
+                patch(
+                    "app.main._paper_route_probe_book_from_target_plan",
+                    return_value={},
+                ),
+                patch(
+                    "app.main.build_paper_route_evidence_audit",
+                    return_value={
+                        "schema_version": "torghut.paper-route-evidence.v1",
+                        "summary": {"target_count": 1},
+                    },
+                ) as audit_builder,
+            ):
+                response = self.client.get("/trading/paper-route-evidence")
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(
+                audit_builder.call_args.kwargs["target_account_audit_available"]
+            )
+        finally:
+            settings.trading_mode = original_mode
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
+    def test_live_paper_route_target_plan_enables_sim_target_account_audit(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        original_mode = settings.trading_mode
+        settings.trading_mode = "live"
+        settings.trading_paper_route_target_plan_url = ""
+        live_gate = {
+            "allowed": False,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [
+                    {
+                        "candidate_id": "sim-runtime-target",
+                        "account_label": "TORGHUT_SIM",
+                        "target_dsn_env": "SIM_DB_DSN",
+                        "source_dsn_env": "SIM_DB_DSN",
+                        "observed_stage": "paper",
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ],
+            },
+        }
+
+        try:
+            app.state.trading_scheduler = SimpleNamespace(
+                state=SimpleNamespace(market_session_open=False),
+                _last_live_submission_gate=live_gate,
+            )
+            with (
+                patch(
+                    "app.main._paper_route_cached_live_submission_gate",
+                    return_value=live_gate,
+                ),
+                patch("app.main._build_simple_lane_status_payload", return_value={}),
+                patch(
+                    "app.main._paper_route_probe_book_from_target_plan",
+                    return_value={},
+                ),
+                patch(
+                    "app.main.build_paper_route_target_plan_payload",
+                    return_value={
+                        "schema_version": "torghut.paper-route-target-plan.v1",
+                        "target_count": 1,
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                        "targets": [{"candidate_id": "sim-runtime-target"}],
+                    },
+                ) as target_plan_builder,
+            ):
+                response = self.client.get("/trading/paper-route-target-plan")
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(
+                target_plan_builder.call_args.kwargs["target_account_audit_available"]
+            )
+        finally:
+            settings.trading_mode = original_mode
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
+    def test_live_target_account_audit_stays_disabled_for_non_sim_target(self) -> None:
+        original_mode = settings.trading_mode
+        try:
+            settings.trading_mode = "disabled"
+            self.assertFalse(
+                main_module._paper_route_target_account_audit_available({})
+            )
+
+            settings.trading_mode = "live"
+            self.assertFalse(
+                main_module._paper_route_target_account_audit_available({})
+            )
+
+            self.assertFalse(
+                main_module._paper_route_target_account_audit_available(
+                    {
+                        "runtime_ledger_paper_probation_import_plan": {
+                            "targets": [
+                                {
+                                    "account_label": "PA3SX7FYNUTF",
+                                    "target_dsn_env": "LIVE_DB_DSN",
+                                    "source_dsn_env": "LIVE_DB_DSN",
+                                    "observed_stage": "live",
+                                }
+                            ]
+                        }
+                    }
+                )
+            )
+
+            self.assertTrue(
+                main_module._paper_route_target_account_audit_available(
+                    {
+                        "runtime_ledger_paper_probation_import_plan": {
+                            "account_label": "TORGHUT_SIM",
+                            "target_dsn_env": "SIM_DB_DSN",
+                            "source_dsn_env": "SIM_DB_DSN",
+                            "observed_stage": "paper",
+                            "targets": [],
+                        }
+                    }
+                )
+            )
+        finally:
+            settings.trading_mode = original_mode
 
     def test_paper_route_target_plan_releases_db_session_before_external_plan_fetch(
         self,


### PR DESCRIPTION
## Summary

- Enables read-only `TORGHUT_SIM` target-account audit for explicit SIM/paper evidence plans even when the live Torghut service hosts the paper-route endpoints.
- Keeps the audit disabled for non-SIM/live targets so live-capital promotion gates are not loosened.
- Adds a tracked profitability-proof execution plan and marks the first false-blocker tranche complete.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_evidence or paper_route_target_plan or target_account_audit' --cov=app.main --cov=tests.test_trading_api --cov-report=xml --cov-fail-under=0`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
