### PR TITLE
fix(autotrader): weight repeated scorecard edge

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -39,6 +39,7 @@ SYNTHESIS_SIDES = {
 }
 ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
 MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
+MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE = 2
 MAX_SCORECARD_RISK_MULTIPLIER = Decimal("2.0")
 
 
@@ -1101,20 +1102,35 @@ def scorecard_edge_values(result: dict[str, Any]) -> tuple[int, Decimal | None, 
     return sample_size, avg_realized_r, confidence
 
 
+def scorecard_edge_weight(sample_size: int) -> Decimal:
+    if sample_size <= 0:
+        return Decimal("0")
+    return min(Decimal("1"), Decimal(sample_size) / Decimal(MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE))
+
+
 def scorecard_risk_directive(result: dict[str, Any]) -> dict[str, Any] | None:
     sample_size, avg_realized_r, confidence = scorecard_edge_values(result)
     if sample_size <= 0 or avg_realized_r is None or avg_realized_r <= 0:
         return None
-    risk_multiplier = min(MAX_SCORECARD_RISK_MULTIPLIER, max(Decimal("1.0"), avg_realized_r))
+    risk_multiplier = (
+        min(MAX_SCORECARD_RISK_MULTIPLIER, max(Decimal("1.0"), avg_realized_r))
+        if sample_size >= MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE
+        else Decimal("1.0")
+    )
     directive: dict[str, Any] = {
         "source": "scorecard_realized_r",
         "mode": "scale_positive_realized_edge",
         "riskMultiplier": str(risk_multiplier),
         "maxRiskMultiplier": str(MAX_SCORECARD_RISK_MULTIPLIER),
+        "minimumScaleSampleSize": MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE,
         "scorecardSampleSize": sample_size,
         "scorecardAvgRealizedR": str(avg_realized_r),
         "scorecardConfidence": str(confidence),
-        "reason": "positive_scorecard_edge",
+        "reason": (
+            "positive_scorecard_edge"
+            if sample_size >= MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE
+            else "positive_scorecard_edge_pending_repeat_sample"
+        ),
     }
     risk_dollars = decimal_value(result.get("risk_dollars") or result.get("riskDollars"))
     if risk_dollars is not None and risk_dollars > 0:
@@ -1129,7 +1145,9 @@ def candidate_score(result: dict[str, Any]) -> tuple[Decimal, Decimal, int, int,
     expected_r = decimal_value(result.get("expected_r") or result.get("expectedR")) or Decimal("0")
     sample_size, avg_realized_r, confidence = scorecard_edge_values(result)
     scorecard_edge = (
-        avg_realized_r if sample_size > 0 and avg_realized_r is not None and avg_realized_r > 0 else Decimal("0")
+        avg_realized_r * scorecard_edge_weight(sample_size)
+        if sample_size > 0 and avg_realized_r is not None and avg_realized_r > 0
+        else Decimal("0")
     )
     return expected_r + scorecard_edge, expected_r, grade_score, sample_size, confidence
 

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -668,18 +668,60 @@ class LiveScanCycleTest(unittest.TestCase):
             {
                 "source": "scorecard_realized_r",
                 "mode": "scale_positive_realized_edge",
-                "riskMultiplier": "2.0",
+                "riskMultiplier": "1.0",
                 "maxRiskMultiplier": "2.0",
+                "minimumScaleSampleSize": 2,
                 "scorecardSampleSize": 1,
                 "scorecardAvgRealizedR": "3.042857",
                 "scorecardConfidence": "0.0909",
-                "reason": "positive_scorecard_edge",
+                "reason": "positive_scorecard_edge_pending_repeat_sample",
                 "baseRiskDollars": "100",
-                "recommendedRiskDollars": "200.0",
+                "recommendedRiskDollars": "100.0",
             },
         )
         self.assertEqual(summary["bestCandidate"]["ticketId"], "ticket-amd")
         self.assertEqual(summary["candidateSymbols"], ["AMD"])
+
+    def test_decision_summary_prefers_repeated_positive_edge_over_one_off_boost(self) -> None:
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=11,
+            scan={
+                "results": [
+                    {
+                        "symbol": "AMD",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A",
+                        "expected_r": "3.0",
+                        "scorecard_sample_size": 1,
+                        "scorecard_avg_realized_r": "3.0",
+                        "scorecard_confidence": "0.0909",
+                    },
+                    {
+                        "symbol": "AVGO",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A",
+                        "expected_r": "3.0",
+                        "scorecard_sample_size": 2,
+                        "scorecard_avg_realized_r": "2.0",
+                        "scorecard_confidence": "0.1667",
+                    },
+                ]
+            },
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-11-1-AMD-vwap_reclaim-A",
+                    "ticketId": "ticket-amd",
+                },
+                {
+                    "idempotencyKey": "scan-cycle-11-2-AVGO-vwap_reclaim-A",
+                    "ticketId": "ticket-avgo",
+                },
+            ],
+        )
+
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["bestCandidate"]["symbol"], "AVGO")
+        self.assertEqual(summary["candidateSymbols"], ["AVGO", "AMD"])
 
     def test_ticket_payload_records_scorecard_risk_directive_for_positive_edge(self) -> None:
         payload = live_scan_cycle.ticket_payload_for_scan_result(
@@ -706,6 +748,7 @@ class LiveScanCycleTest(unittest.TestCase):
                 "mode": "scale_positive_realized_edge",
                 "riskMultiplier": "1.4",
                 "maxRiskMultiplier": "2.0",
+                "minimumScaleSampleSize": 2,
                 "scorecardSampleSize": 2,
                 "scorecardAvgRealizedR": "1.4",
                 "scorecardConfidence": "0.25",


### PR DESCRIPTION
## Summary

- Discounted one-off positive scorecard edge in candidate ranking so repeated positive history outranks a single lucky observation.
- Kept candidates with one positive scorecard observation eligible, but their `riskDirective` now stays at base `1.0x` until at least two positive samples exist.
- Preserved aggressive scaling for repeated positive scorecard edge, capped at `2.0x`.

## Related Issues

None

## Testing

- `python3 -m py_compile live_scan_cycle.py test_live_scan_cycle.py market_open_cycle.py`
- `python3 -m unittest test_live_scan_cycle.py`
- `python3 -m unittest discover -v`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/market_open_cycle.py --self-test`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
