### PR TITLE
fix(torghut): require explicit sim audit targets

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6203,7 +6203,6 @@ def _paper_route_mapping_targets_sim_account(value: Mapping[str, Any]) -> bool:
         == PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL
         or _normalized_paper_route_text(value.get("target_dsn_env")) == "SIM_DB_DSN"
         or _normalized_paper_route_text(value.get("source_dsn_env")) == "SIM_DB_DSN"
-        or _normalized_paper_route_text(value.get("observed_stage")) == "PAPER"
     )
 
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -10631,6 +10631,23 @@ class TestTradingApi(TestCase):
                 )
             )
 
+            self.assertFalse(
+                main_module._paper_route_target_account_audit_available(
+                    {
+                        "runtime_ledger_paper_probation_import_plan": {
+                            "targets": [
+                                {
+                                    "account_label": "PA3SX7FYNUTF",
+                                    "target_dsn_env": "LIVE_DB_DSN",
+                                    "source_dsn_env": "LIVE_DB_DSN",
+                                    "observed_stage": "paper",
+                                }
+                            ]
+                        }
+                    }
+                )
+            )
+
             self.assertTrue(
                 main_module._paper_route_target_account_audit_available(
                     {


### PR DESCRIPTION
## Summary

- Requires live-mode paper-route target-account audit to have an explicit `TORGHUT_SIM` or `SIM_DB_DSN` target signal.
- Removes the weaker `observed_stage=paper` shortcut so non-SIM live targets cannot enable SIM DB auditing.
- Adds a regression covering the live/non-SIM paper-stage case while preserving explicit SIM evidence plans.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_api.py -k 'target_account_audit or paper_route_evidence' -q`
- `uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
