### PR TITLE
fix(torghut): flush runtime ledger bucket before disabled journal parity

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -2376,6 +2376,7 @@ def _journal_tigerbeetle_runtime_ledger_bucket(
     session: Session,
     row: StrategyRuntimeLedgerBucket,
 ) -> None:
+    session.flush()
     if not settings.tigerbeetle_enabled or not settings.tigerbeetle_journal_enabled:
         _mark_runtime_ledger_bucket_tigerbeetle_journal(
             session,
@@ -2385,7 +2386,6 @@ def _journal_tigerbeetle_runtime_ledger_bucket(
             blockers=[TIGERBEETLE_BLOCKER_JOURNAL_DISABLED],
         )
         return
-    session.flush()
     try:
         with TigerBeetleLedgerJournal() as journal, session.begin_nested():
             ref = journal.journal_runtime_ledger_bucket(session, row)

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -349,7 +349,6 @@ class TestRuntimeWindowImport(TestCase):
                 payload_json={},
             )
             session.add(row)
-            session.flush()
 
             with (
                 patch.object(
@@ -370,6 +369,16 @@ class TestRuntimeWindowImport(TestCase):
             self.assertEqual(parity["status"], "non_authority_blocked")
             self.assertEqual(parity["blockers"], ["tigerbeetle_journal_disabled"])
             self.assertEqual(parity["transfer_ids"], [])
+            self.assertIsNotNone(row.id)
+            self.assertEqual(parity["runtime_ledger_bucket_id"], str(row.id))
+            self.assertIn(
+                f"postgres:strategy_runtime_ledger_buckets:{row.id}",
+                parity["source_refs"],
+            )
+            self.assertNotIn(
+                "postgres:strategy_runtime_ledger_buckets:None",
+                row.payload_json["source_refs"],
+            )
 
     def test_runtime_bucket_journal_unavailable_records_non_authority_blocker(
         self,


### PR DESCRIPTION
## Summary

- Flushes runtime-ledger bucket rows before recording disabled TigerBeetle journal parity.
- Prevents disabled-journal payloads from recording `postgres:strategy_runtime_ledger_buckets:None`.
- Extends the disabled-journal regression to cover unflushed rows and assert durable bucket refs.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- Red check: `uv run --frozen pytest tests/test_runtime_window_import.py -k 'journal_disabled_records_non_authority_blocker' -q` failed before the flush fix with `runtime_ledger_bucket_id` equal to `None`.
- `uv run --frozen pytest tests/test_runtime_window_import.py -k 'journal_disabled_records_non_authority_blocker' -q`
- `uv run --frozen pytest tests/test_runtime_window_import.py -q`
- `uv run --frozen ruff check app/trading/runtime_window_import.py tests/test_runtime_window_import.py`
- `uv run --frozen ruff format --check app/trading/runtime_window_import.py tests/test_runtime_window_import.py`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
