### PR TITLE
fix(torghut): preserve import health gate readback

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -8261,6 +8261,43 @@ def _target_is_runtime_ledger_source_collection(
     )
 
 
+def _runtime_window_import_target_metadata(
+    target: Mapping[str, Any],
+) -> dict[str, object]:
+    metadata: dict[str, object] = {}
+    for key in (
+        "dependency_quorum_decision",
+        "continuity_ok",
+        "continuity_reason",
+        "drift_ok",
+        "drift_reason",
+        "paper_route_session_readiness_state",
+        "paper_route_runtime_window_import_not_before",
+    ):
+        value = _safe_text(target.get(key))
+        if value is not None:
+            metadata[key] = value
+    for key in (
+        "runtime_window_import_health_gate_blockers",
+        "runtime_window_import_promotion_blockers",
+        "paper_route_session_import_blockers",
+    ):
+        if key in target:
+            metadata[key] = _unique_text_items(target.get(key))
+    for key in (
+        "runtime_window_import_health_gate",
+        "paper_route_runtime_import_handoff",
+    ):
+        value = _as_mapping(target.get(key))
+        if value:
+            metadata[key] = dict(value)
+    if "paper_route_session_import_ready" in target:
+        metadata["paper_route_session_import_ready"] = bool(
+            target.get("paper_route_session_import_ready")
+        )
+    return metadata
+
+
 def _sanitized_runtime_ledger_source_collection_target(
     target: Mapping[str, Any],
 ) -> dict[str, object]:
@@ -8365,6 +8402,7 @@ def _sanitized_runtime_ledger_source_collection_target(
             or target.get("final_promotion_authorized")
         ),
     }
+    sanitized.update(_runtime_window_import_target_metadata(target))
     if runtime_ledger_bucket_ref := _safe_text(target.get("runtime_ledger_bucket_ref")):
         sanitized["runtime_ledger_bucket_ref"] = runtime_ledger_bucket_ref
     observed_from_contaminated_target = _as_mapping(
@@ -8563,6 +8601,7 @@ def _observed_strategy_source_collection_target(
         "selected_by": "paper_route_observed_strategy_source_collection",
         "selection_reason": "foreign_strategy_source_activity_observed_in_paper_route_window",
         "max_notional": "0",
+        **_runtime_window_import_target_metadata(contaminated_target),
         "observed_from_contaminated_target": {
             "hypothesis_id": _safe_text(contaminated_target.get("hypothesis_id")),
             "candidate_id": _safe_text(contaminated_target.get("candidate_id")),
@@ -8572,6 +8611,21 @@ def _observed_strategy_source_collection_target(
         },
     }
     return _sanitized_runtime_ledger_source_collection_target(target)
+
+
+def _runtime_window_import_plan_metadata(plan: Mapping[str, Any]) -> dict[str, object]:
+    metadata: dict[str, object] = {}
+    for key in (
+        "session_window",
+        "session_readiness",
+        "runtime_window_import_handoff",
+        "runtime_window_import_health_gate",
+        "source_decision_readiness",
+    ):
+        value = _as_mapping(plan.get(key))
+        if value:
+            metadata[key] = dict(value)
+    return metadata
 
 
 def _observed_strategy_source_collection_import_plan(
@@ -8591,6 +8645,7 @@ def _observed_strategy_source_collection_import_plan(
     targets: list[dict[str, object]] = []
     skipped_targets: list[dict[str, object]] = []
     seen_keys: set[tuple[str, str, str, str, str]] = set()
+    selected_plan: Mapping[str, Any] | None = None
     for plan in candidate_plans:
         if len(targets) >= limit:
             break
@@ -8656,6 +8711,8 @@ def _observed_strategy_source_collection_import_plan(
                 if key in seen_keys:
                     continue
                 seen_keys.add(key)
+                if selected_plan is None:
+                    selected_plan = plan
                 targets.append(target)
     if not targets:
         return {}
@@ -8674,6 +8731,7 @@ def _observed_strategy_source_collection_import_plan(
         "final_promotion_authorized": False,
         "final_promotion_allowed": False,
         "target_count": len(targets),
+        **_runtime_window_import_plan_metadata(selected_plan or {}),
         "paper_probation_target_count": 0,
         "source_collection_target_count": len(targets),
         "skipped_target_count": len(skipped_targets),

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1051,6 +1051,52 @@ class TestRuntimeLedgerProofPacket(TestCase):
             "c88421d619759b2cfaa6f4d0",
         )
 
+    def test_packet_preserves_selected_import_plan_health_gate_readback(
+        self,
+    ) -> None:
+        evidence = _paper_route_evidence()
+        import_plan = json.loads(
+            json.dumps(evidence["next_paper_route_runtime_window_targets"])
+        )
+        import_plan["source"] = "paper_route_observed_strategy_source_collection"
+        import_plan["purpose"] = (
+            "observed_strategy_runtime_ledger_source_collection_import"
+        )
+        import_plan["targets"][0]["source_kind"] = (
+            "runtime_ledger_source_collection_candidate"
+        )
+        import_plan["targets"][0]["selected_by"] = (
+            "paper_route_observed_strategy_source_collection"
+        )
+        evidence["runtime_window_import_plan"] = import_plan
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(blockers=["runtime_ledger_source_collection_pending"]),
+            proof_mode="authority",
+            paper_route_evidence=evidence,
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("runtime_ledger_source_collection_pending", result["blockers"])
+        for blocker in (
+            "runtime_window_import_health_gate_missing",
+            "dependency_quorum_not_allow",
+            "continuity_not_ok",
+        ):
+            self.assertNotIn(blocker, result["blockers"])
+        health_gate = result["evidence"]["paper_route_target_plan"][
+            "runtime_window_import_health_gate"
+        ]
+        self.assertTrue(health_gate["ready"])
+        self.assertEqual(health_gate["ready_target_count"], 1)
+        self.assertEqual(health_gate["blockers"], [])
+
     def test_authority_packet_allows_reconciled_tigerbeetle_runtime_refs(
         self,
     ) -> None:

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -8493,6 +8493,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     "allowed": False,
                     "reason": "paper_route_probe_only",
                     "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": "true",
+                    "continuity_reason": "expected_market_closed_staleness",
+                    "drift_ok": "false",
+                    "drift_reason": "drift_live_promotion_ineligible",
                     "runtime_ledger_repair_candidates": [
                         {
                             "hypothesis_id": "H-TSMOM-LIQ-01",
@@ -8567,6 +8572,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
             runtime_plan["source"], "paper_route_observed_strategy_source_collection"
         )
         self.assertEqual(runtime_plan["target_count"], 1)
+        self.assertTrue(runtime_plan["session_readiness"]["import_ready"])
+        self.assertTrue(runtime_plan["runtime_window_import_handoff"]["import_ready"])
+        self.assertEqual(
+            runtime_plan["runtime_window_import_health_gate"]["blocked_target_count"],
+            0,
+        )
         target = runtime_plan["targets"][0]
         self.assertEqual(target["candidate_id"], "candidate-tsmom")
         self.assertEqual(target["hypothesis_id"], "H-TSMOM-LIQ-01")
@@ -8578,6 +8589,15 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertTrue(target["source_collection_authorized"])
         self.assertFalse(target["promotion_allowed"])
         self.assertNotIn("paper_route_probe_symbols", target)
+        self.assertEqual(target["dependency_quorum_decision"], "allow")
+        self.assertEqual(target["continuity_ok"], "true")
+        self.assertEqual(target["drift_ok"], "false")
+        self.assertTrue(target["runtime_window_import_health_gate"]["ready"])
+        self.assertEqual(target["runtime_window_import_health_gate_blockers"], [])
+        self.assertEqual(
+            target["runtime_window_import_promotion_blockers"],
+            ["drift_checks_not_ok"],
+        )
         self.assertEqual(
             target["observed_from_contaminated_target"]["strategy_name"],
             "intraday-tsmom-profit-v3",
@@ -8698,6 +8718,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     "allowed": False,
                     "reason": "paper_route_probe_only",
                     "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": "true",
+                    "continuity_reason": "expected_market_closed_staleness",
+                    "drift_ok": "false",
+                    "drift_reason": "drift_live_promotion_ineligible",
                     "runtime_ledger_repair_candidates": [
                         {
                             "hypothesis_id": "H-TSMOM-LIQ-01",
@@ -8783,10 +8808,28 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(
             runtime_plan["source"], "paper_route_observed_strategy_source_collection"
         )
+        self.assertTrue(runtime_plan["session_readiness"]["import_ready"])
+        self.assertTrue(runtime_plan["runtime_window_import_handoff"]["import_ready"])
+        self.assertEqual(
+            runtime_plan["runtime_window_import_health_gate"]["blocked_target_count"],
+            0,
+        )
         self.assertEqual(runtime_plan["targets"][0]["candidate_id"], "candidate-tsmom")
         self.assertEqual(
             runtime_plan["targets"][0]["selected_by"],
             "paper_route_observed_strategy_source_collection",
+        )
+        self.assertEqual(
+            runtime_plan["targets"][0]["dependency_quorum_decision"], "allow"
+        )
+        self.assertEqual(runtime_plan["targets"][0]["continuity_ok"], "true")
+        self.assertEqual(runtime_plan["targets"][0]["drift_ok"], "false")
+        self.assertTrue(
+            runtime_plan["targets"][0]["runtime_window_import_health_gate"]["ready"]
+        )
+        self.assertEqual(
+            runtime_plan["targets"][0]["runtime_window_import_health_gate_blockers"],
+            [],
         )
         self.assertFalse(runtime_plan["targets"][0]["promotion_allowed"])
         self.assertIn(


### PR DESCRIPTION
## Summary

- Preserve runtime-window import health-gate metadata when observed-strategy source collection becomes the selected import plan.
- Carry selected plan session readiness and import handoff into the runtime import plan envelope.
- Add regression coverage so proof packets block on real source-collection evidence instead of synthetic missing health-gate blockers.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'observed_strategy_source_collection or observed_foreign_strategy_source_collection' -q`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -k 'selected_import_plan_health_gate_readback or prefers_importable_paper_route_plan' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
