### PR TITLE
fix(torghut): materialize active paper route target subsets

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -523,6 +523,37 @@ def _active_target_window_check(
     }
 
 
+def _target_window_check_active_indexes(
+    target_window_check: Mapping[str, Any] | None,
+) -> list[int]:
+    if not isinstance(target_window_check, Mapping):
+        return []
+    indexes: list[int] = []
+    for target in cast(Sequence[object], target_window_check.get("targets", [])):
+        if not isinstance(target, Mapping):
+            continue
+        target_mapping = cast(Mapping[str, Any], target)
+        if _safe_text(target_mapping.get("state")) != "open":
+            continue
+        indexes.append(int(target_mapping.get("target_index", 0)))
+    return indexes
+
+
+def _plan_with_target_indexes(
+    plan: Mapping[str, Any],
+    target_indexes: Sequence[int],
+) -> dict[str, Any]:
+    selected_indexes = set(target_indexes)
+    return {
+        **dict(plan),
+        "targets": [
+            target
+            for index, target in enumerate(paper_route_target_plan_targets(plan))
+            if index in selected_indexes
+        ],
+    }
+
+
 def _unique_texts(values: Sequence[object]) -> list[str]:
     return sorted({text for value in values if (text := _safe_text(value))})
 
@@ -847,29 +878,45 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         plan_source = {"kind": "unavailable"}
         load_blockers = [f"paper_route_materialization_plan_load_failed:{exc}"]
 
-    summaries = _target_summaries(plan)
-    blockers = load_blockers + _safety_blockers(
-        args=args,
-        plan=plan,
-        plan_source=plan_source,
-        summaries=summaries,
-        dsn=dsn,
-        dsn_env=dsn_env,
-    )
+    source_plan = plan
+    source_summaries = _target_summaries(source_plan)
+    materialization_plan = source_plan
+    summaries = source_summaries
+    active_target_window_filter_applied = False
     target_window_check: dict[str, Any] | None = None
     skip_reason: str | None = None
     if bool(args.skip_unless_active_target_window) or bool(
         args.require_active_target_window
     ):
         target_window_check = _active_target_window_check(
-            summaries,
+            source_summaries,
             now=_resolve_now_utc(args),
         )
-        if not bool(target_window_check["active"]):
-            if bool(args.skip_unless_active_target_window) and not blockers:
-                skip_reason = ACTIVE_TARGET_WINDOW_SKIP_REASON
-            else:
-                blockers.append(ACTIVE_TARGET_WINDOW_REQUIRED_BLOCKER)
+        active_target_indexes = _target_window_check_active_indexes(target_window_check)
+        if active_target_indexes and len(active_target_indexes) < len(source_summaries):
+            materialization_plan = _plan_with_target_indexes(
+                source_plan,
+                active_target_indexes,
+            )
+            summaries = _target_summaries(materialization_plan)
+            active_target_window_filter_applied = True
+
+    blockers = load_blockers + _safety_blockers(
+        args=args,
+        plan=materialization_plan,
+        plan_source=plan_source,
+        summaries=summaries,
+        dsn=dsn,
+        dsn_env=dsn_env,
+    )
+    if (
+        target_window_check is not None
+        and not _target_window_check_active_indexes(target_window_check)
+    ):
+        if bool(args.skip_unless_active_target_window) and not blockers:
+            skip_reason = ACTIVE_TARGET_WINDOW_SKIP_REASON
+        else:
+            blockers.append(ACTIVE_TARGET_WINDOW_REQUIRED_BLOCKER)
 
     materialization: dict[str, Any] = {}
     if not blockers and skip_reason is None and dsn is not None:
@@ -879,14 +926,14 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 if commit:
                     materialization = _run_materialization(
                         session=session,
-                        plan=plan,
+                        plan=materialization_plan,
                         max_notional=max_notional,
                         commit=True,
                     )
                 else:
                     materialization = _run_dry_run_materialization(
                         source_session=session,
-                        plan=plan,
+                        plan=materialization_plan,
                         max_notional=max_notional,
                         summaries=summaries,
                     )
@@ -919,6 +966,8 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "dynamic_target_plan_confirmation": bool(args.allow_dynamic_target_plan),
         "default_dynamic_selected_plan_source": DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
         "target_window_check": target_window_check,
+        "active_target_window_filter_applied": active_target_window_filter_applied,
+        "source_target_count": len(source_summaries),
         "target_count": len(summaries),
         "hypothesis_ids": _unique_texts(
             [item.get("hypothesis_id") for item in summaries]
@@ -933,6 +982,9 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             [item.get("target_plan_ref") for item in summaries]
         ),
         "targets": summaries,
+        "source_targets": source_summaries
+        if active_target_window_filter_applied
+        else None,
         "materialization": materialization,
         "materialized_decision_count": int(
             materialization.get("materialized_decision_count", 0)

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -804,6 +804,80 @@ def test_commit_dynamic_plan_skips_before_active_target_window_without_writes(
     assert _count_decisions(sqlite_dsn) == 0
 
 
+def test_commit_dynamic_plan_filters_to_active_target_window_subset(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    future_target = _hpairs_target(
+        candidate_id="future-window-candidate",
+        source_plan_ref="paper-route-plan:future-window-candidate",
+        window_start="2026-06-01T15:00:00+00:00",
+        window_end="2026-06-01T16:00:00+00:00",
+    )
+    payload = {
+        "live_submission_gate": {
+            "runtime_ledger_paper_probation_import_plan": _plan(
+                _hpairs_target(),
+                future_target,
+            )
+        },
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "25",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--skip-unless-active-target-window",
+            "--now-utc",
+            "2026-06-01T14:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            cli.DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "25",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["materialized"] is True
+    assert report["skipped"] is False
+    assert report["source_target_count"] == 2
+    assert report["target_count"] == 1
+    assert report["active_target_window_filter_applied"] is True
+    assert report["target_window_check"]["active"] is False
+    assert report["target_window_check"]["active_count"] == 1
+    assert report["target_window_check"]["inactive_count"] == 1
+    assert report["candidate_ids"] == ["c88421d619759b2cfaa6f4d0"]
+    assert report["source_targets"][1]["candidate_id"] == "future-window-candidate"
+    assert report["materialized_decision_count"] == 2
+    assert report["route_submission_count"] == 2
+    assert report["promotion_allowed"] is False
+    assert report["final_promotion_allowed"] is False
+    assert report["capital_promotion_allowed"] is False
+    assert report["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 2
+
+
 def test_commit_dynamic_plan_requires_active_target_window_without_skip(
     monkeypatch: pytest.MonkeyPatch,
     sqlite_dsn: str,


### PR DESCRIPTION
## Summary

- Let the bounded paper-route materializer select the currently open target-window subset when a dynamic H-PAIRS plan contains mixed active and inactive targets.
- Preserve all TORGHUT_SIM, max-notional, promotion-blocked, and operator-confirmation guards while materializing only the active subset.
- Add report fields for source target count, active-window filtering, and original source targets when filtering is applied.
- Add a regression proving mixed active/future dynamic plans write only the active H-PAIRS source decisions.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
