### PR TITLE
fix(torghut): surface observed source runtime blockers

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -7333,13 +7333,39 @@ def _runtime_window_import_audit(
     )
     import_ready = bool(session_readiness.get("import_ready"))
     session_state = _safe_text(session_readiness.get("state")) or "unknown"
+    plan_source = _safe_text(next_targets.get("source")) or ""
+    # Observed source-backed runtime-window plans are assembled from already
+    # materialized source activity and may not carry the next-session
+    # ``session_readiness`` envelope.  Treat that absence as an observability
+    # gap, not as a reason to hide the concrete source/materialization blockers
+    # behind a generic "wait_for_runtime_window_import_readiness" state.  This
+    # does not grant import or promotion authority: the returned ``import_ready``
+    # remains the explicit session-readiness value and ``proof_allowed`` remains
+    # false.
+    observed_source_evidence_ready_for_diagnostics = (
+        not import_ready
+        and not import_blockers
+        and session_state == "unknown"
+        and plan_source == "paper_route_observed_strategy_source_collection"
+        and current_target_count > 0
+        and any(
+            count > 0
+            for count in (
+                targets_with_source_activity,
+                targets_with_rejected_signal_activity,
+                targets_with_runtime_ledger,
+                targets_with_evidence_grade_runtime_ledger,
+                targets_with_promotion_decision,
+            )
+        )
+    )
     blockers: list[str]
     evidence_window_state = "clean_window_collection_pending"
     if source_plan_target_count <= 0:
         state = "paper_probation_import_plan_missing"
         next_action = "repair_runtime_ledger_paper_probation_import_plan"
         blockers = ["paper_probation_import_plan_missing", "paper_route_target_missing"]
-    elif not import_ready:
+    elif not import_ready and not observed_source_evidence_ready_for_diagnostics:
         state = session_state
         next_action = {
             "waiting_for_session_open": "wait_for_regular_session_open",
@@ -7404,7 +7430,7 @@ def _runtime_window_import_audit(
         evidence_window_state = "clean_source_backed_window_ready_for_gate_review"
     if source_plan_target_count <= 0:
         evidence_window_state = "clean_window_required"
-    elif not import_ready:
+    elif not import_ready and not observed_source_evidence_ready_for_diagnostics:
         evidence_window_state = "clean_window_collection_pending"
     elif current_target_count <= 0:
         evidence_window_state = "clean_window_required"
@@ -7432,6 +7458,9 @@ def _runtime_window_import_audit(
             "source_lifecycle_blockers": source_lifecycle_blockers,
             "runtime_ledger_blockers": runtime_ledger_blockers,
             "target_blockers_effective_when": "runtime_window_import_ready",
+            "observed_source_evidence_ready_for_diagnostics": (
+                observed_source_evidence_ready_for_diagnostics
+            ),
         },
         "target_blockers": target_blockers,
         "counts": {

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5450,6 +5450,84 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 0,
             )
 
+    def test_runtime_window_import_audit_reports_observed_source_blockers_without_session_readiness(
+        self,
+    ) -> None:
+        audit = paper_route_evidence._runtime_window_import_audit(
+            next_targets={
+                "target_count": 1,
+                "source": "paper_route_observed_strategy_source_collection",
+                "targets": [
+                    {
+                        "hypothesis_id": "H-TSMOM-LIQ-01",
+                        "candidate_id": "ca4e6e3c7d639e3363dc5860",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                        "account_label": "TORGHUT_SIM",
+                    }
+                ],
+            },
+            target_audits=[
+                {
+                    "source_activity": {"missing": False, "decision_count": 8},
+                    "runtime_ledger": {
+                        "bucket_count": 1,
+                        "evidence_grade_bucket_count": 0,
+                        "blockers": [
+                            "runtime_ledger_source_offsets_missing",
+                            "runtime_ledger_source_materialization_missing",
+                        ],
+                    },
+                    "promotion_decisions": {"decision_count": 1},
+                }
+            ],
+            next_target_audits=[
+                {
+                    "target": {
+                        "hypothesis_id": "H-TSMOM-LIQ-01",
+                        "candidate_id": "ca4e6e3c7d639e3363dc5860",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                        "account_label": "TORGHUT_SIM",
+                    },
+                    "source_activity": {"missing": False, "decision_count": 8},
+                    "runtime_ledger": {
+                        "bucket_count": 1,
+                        "evidence_grade_bucket_count": 0,
+                        "blockers": [
+                            "runtime_ledger_source_offsets_missing",
+                            "runtime_ledger_source_materialization_missing",
+                        ],
+                    },
+                    "promotion_decisions": {"decision_count": 1},
+                }
+            ],
+        )
+
+        self.assertEqual(
+            audit["state"], "runtime_ledger_imported_but_not_evidence_grade"
+        )
+        self.assertEqual(
+            audit["next_action"], "repair_runtime_ledger_bucket_authority_or_candidate"
+        )
+        self.assertFalse(audit["import_ready"])
+        self.assertFalse(audit["proof_allowed"])
+        self.assertEqual(
+            audit["evidence_window_state"],
+            "runtime_ledger_evidence_grade_required",
+        )
+        self.assertEqual(
+            audit["blockers"],
+            [
+                "runtime_ledger_evidence_grade_bucket_missing",
+                "runtime_ledger_source_materialization_missing",
+                "runtime_ledger_source_offsets_missing",
+            ],
+        )
+        self.assertTrue(
+            audit["diagnostics"]["observed_source_evidence_ready_for_diagnostics"]
+        )
+
     def test_runtime_window_import_audit_explains_quote_rejected_source_activity(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Surface observed source-backed runtime-window materialization blockers when the observed plan has source/runtime evidence but no next-session readiness envelope.
- Keep authority fail-closed: `import_ready` and `proof_allowed` remain false unless explicit readiness says otherwise.
- Add regression coverage for TORGHUT_SIM-style observed source activity with non-evidence-grade runtime-ledger buckets.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q -k "observed_source_blockers_without_session_readiness or runtime_window_import_audit_tracks_missing_and_non_grade_ledger"` — PASS
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q -k "observed_source_blockers_without_session_readiness or runtime_window_import_audit_tracks_missing_and_non_grade_ledger or target_plan_can_defer_full_runtime_window_audit"` — PASS
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q` — PASS
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py` — PASS
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py` — PASS
- `cd services/torghut && uv sync --frozen --extra dev` — PASS
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — PASS
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — PASS
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — PASS
- `git diff --check` — PASS

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
