### PR TITLE
fix(torghut): keep hpairs blockers reason-coded

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -6251,8 +6251,29 @@ def _collect_hpairs_zero_activity_texts(*values: object) -> list[str]:
     texts: list[str] = []
     for value in values:
         if isinstance(value, Mapping):
-            for item in cast(Mapping[object, object], value).values():
-                texts.extend(_collect_hpairs_zero_activity_texts(item))
+            mapping = cast(Mapping[object, object], value)
+            for key, item in mapping.items():
+                key_text = str(key).strip().lower()
+                if key_text in {
+                    "blocker",
+                    "blockers",
+                    "blocking_reason",
+                    "blocking_reasons",
+                    "missing_reason",
+                    "missing_reasons",
+                    "source_lifecycle_blockers",
+                    "source_reference_blockers",
+                    "source_window_blockers",
+                    "submitted_order_blockers",
+                    "runtime_ledger_blockers",
+                    "source_activity_missing_reasons",
+                    "rejected_signal_diagnostic_reasons",
+                    "source_activity_to_runtime_ledger_blockers",
+                    "account_contamination_blockers",
+                    "account_state_blockers",
+                    "account_close_blockers",
+                }:
+                    texts.extend(_collect_hpairs_zero_activity_texts(item))
             continue
         if isinstance(value, Sequence) and not isinstance(
             value, (str, bytes, bytearray)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5891,6 +5891,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(diagnostics["counts"]["hpairs_target_count"], 1)
         self.assertEqual(diagnostics["counts"]["hpairs_symbol_count"], 2)
         self.assertEqual(diagnostics["counts"]["hpairs_decision_count"], 0)
+        self.assertIn("market_session_closed", diagnostics["blockers"])
+        self.assertNotIn("c88421d619759b2cfaa6f4d0", diagnostics["blockers"])
+        self.assertNotIn("H-PAIRS-01", diagnostics["blockers"])
+        self.assertNotIn("AAPL", diagnostics["blockers"])
+        self.assertNotIn("AMZN", diagnostics["blockers"])
+        self.assertNotIn("TORGHUT_SIM", diagnostics["blockers"])
         self.assertFalse(diagnostics["safe_to_promote"])
         self.assertFalse(diagnostics["proof_semantics"]["synthetic_orders_or_fills"])
         stage_diagnostics = diagnostics["source_activity_stage_diagnostics"]


### PR DESCRIPTION
## Summary

- Restrict HPAIRS zero-activity diagnostic blocker extraction to actual blocker and missing-reason fields.
- Stop candidate ids, symbols, timestamps, account labels, and other metadata from being reported as blockers.
- Add regression coverage for the polluted blocker list while preserving the real market-closed blocker signal.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'hpairs_zero_activity_diagnostics_report_market_window_blocker or hpairs_zero_activity_diagnostics_surface_route_vetoes or hpairs_zero_activity_reason_flags_distinguish_source_stages' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
