### PR TITLE
fix(torghut): reuse reconciliation counts for status

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6998,6 +6998,22 @@ def _latest_reconciliation_ref_counts(
         "runtime_ledger_missing_signed_ref_count",
         "runtime_ledger_missing_account_ref_count",
     )
+    trusted_top_level_keys: set[str] | None = None
+    raw_field_names = latest_reconciliation.get("ref_count_field_names")
+    if isinstance(raw_field_names, Sequence) and not isinstance(
+        raw_field_names,
+        (str, bytes, bytearray),
+    ):
+        trusted_top_level_keys = {
+            str(item) for item in cast(Sequence[object], raw_field_names)
+        }
+    for key in required_keys:
+        if key in ref_counts or key not in latest_reconciliation:
+            continue
+        if trusted_top_level_keys is not None and key not in trusted_top_level_keys:
+            continue
+        if key not in ref_counts and key in latest_reconciliation:
+            ref_counts[key] = latest_reconciliation[key]
     if not all(key in ref_counts for key in required_keys):
         return None
     ref_counts.setdefault("schema_version", "torghut.tigerbeetle-ref-counts.v1")

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -862,6 +862,23 @@ def _latest_run_payload(
         if isinstance(raw_ref_counts, Mapping)
         else cast(Mapping[str, object], {})
     )
+    ref_count_field_names = sorted(
+        {
+            key
+            for key in (
+                "account_ref_count",
+                "transfer_ref_count",
+                "runtime_ledger_ref_count",
+                "runtime_ledger_signed_ref_count",
+                "runtime_ledger_missing_signed_ref_count",
+                "runtime_ledger_missing_account_ref_count",
+                "stable_ref_count",
+                "stable_ref_missing_count",
+                "stable_ref_mismatch_count",
+            )
+            if key in payload or key in ref_counts
+        }
+    )
     account_ref_count = _payload_int(payload, "account_ref_count") or _payload_int(
         ref_counts,
         "account_ref_count",
@@ -996,6 +1013,7 @@ def _latest_run_payload(
         or [],
         "blocker_details": payload.get("blocker_details") or {},
         "ref_counts": payload.get("ref_counts") or {},
+        "ref_count_field_names": ref_count_field_names,
         "started_at": row.started_at.isoformat(),
         "finished_at": row.finished_at.isoformat() if row.finished_at else None,
         "blockers": blockers,

--- a/services/torghut/migrations/versions/0049_tigerbeetle_reconciliation_status_lookup.py
+++ b/services/torghut/migrations/versions/0049_tigerbeetle_reconciliation_status_lookup.py
@@ -1,0 +1,48 @@
+"""Add TigerBeetle reconciliation status lookup index.
+
+Revision ID: 0049_tigerbeetle_reconciliation_status_lookup
+Revises: 0048_status_read_timeout_indexes
+Create Date: 2026-06-03 09:05:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0049_tigerbeetle_reconciliation_status_lookup"
+down_revision = "0048_status_read_timeout_indexes"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_tb_reconciliation_runs_cluster_started_desc"
+TABLE_NAME = "tigerbeetle_reconciliation_runs"
+CREATE_SQL = f"""
+CREATE INDEX IF NOT EXISTS {INDEX_NAME}
+ON {TABLE_NAME} (
+  cluster_id,
+  started_at DESC
+)
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    if not inspector.has_table(TABLE_NAME):
+        return
+    op.execute(sa.text(CREATE_SQL))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    if not inspector.has_table(TABLE_NAME):
+        return
+    op.execute(sa.text(f"DROP INDEX IF EXISTS {INDEX_NAME}"))

--- a/services/torghut/tests/test_tigerbeetle_reconciliation_status_lookup_migration.py
+++ b/services/torghut/tests/test_tigerbeetle_reconciliation_status_lookup_migration.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0049_tigerbeetle_reconciliation_status_lookup.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0049", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0049")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestTigerBeetleReconciliationStatusLookupMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(
+            module.revision,
+            "0049_tigerbeetle_reconciliation_status_lookup",
+        )
+        self.assertEqual(module.down_revision, "0048_status_read_timeout_indexes")
+
+    def test_index_name_fits_postgres_identifier_limit(self) -> None:
+        module = _load_migration_module()
+
+        self.assertLessEqual(len(module.INDEX_NAME), 63)
+
+    def test_upgrade_adds_reconciliation_status_lookup_index(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        sql = str(execute.call_args.args[0])
+        self.assertIn("ix_tb_reconciliation_runs_cluster_started_desc", sql)
+        self.assertIn("cluster_id", sql)
+        self.assertIn("started_at DESC", sql)
+
+    def test_upgrade_skips_non_postgres(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        execute.assert_not_called()
+
+    def test_downgrade_drops_index(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.downgrade()
+
+        sql = str(execute.call_args.args[0])
+        self.assertIn(
+            "DROP INDEX IF EXISTS ix_tb_reconciliation_runs_cluster_started_desc",
+            sql,
+        )

--- a/services/torghut/tests/test_tigerbeetle_status.py
+++ b/services/torghut/tests/test_tigerbeetle_status.py
@@ -135,6 +135,51 @@ class TestTigerBeetleStatus(TestCase):
         self.assertTrue(ref_counts["bounded_status_live_query_skipped"])
         self.assertNotIn("tigerbeetle_ref_counts_unavailable", payload["blockers"])
 
+    def test_status_reuses_latest_reconciliation_top_level_counts(self) -> None:
+        latest_reconciliation = {
+            "ok": True,
+            "status": "ok",
+            "age_seconds": 12,
+            "reconciliation_stale": False,
+            "blockers": [],
+            "account_ref_count": 54_129,
+            "transfer_ref_count": 28_993,
+            "runtime_ledger_ref_count": 26,
+            "runtime_ledger_signed_ref_count": 26,
+            "runtime_ledger_missing_signed_ref_count": 0,
+            "runtime_ledger_missing_account_ref_count": 0,
+            "ref_counts": {
+                "schema_version": "torghut.tigerbeetle-ref-counts.v1",
+                "cluster_id": 2001,
+                "by_source_type": {"strategy_runtime_ledger_bucket": 26},
+                "source_materialization": {},
+            },
+        }
+
+        with Session(self.engine) as session:
+            with (
+                patch(
+                    "app.main.latest_tigerbeetle_reconciliation_payload",
+                    return_value=latest_reconciliation,
+                ),
+                patch("app.main.tigerbeetle_ref_counts") as ref_counts_mock,
+            ):
+                payload = _build_tigerbeetle_ledger_status(session)
+
+        ref_counts_mock.assert_not_called()
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["claimed_by_runtime_evidence"])
+        self.assertEqual(payload["runtime_ledger_ref_count"], 26)
+        ref_counts = payload["ref_counts"]
+        self.assertIsInstance(ref_counts, dict)
+        assert isinstance(ref_counts, dict)
+        self.assertEqual(ref_counts["source"], "latest_tigerbeetle_reconciliation")
+        self.assertEqual(ref_counts["account_ref_count"], 54_129)
+        self.assertEqual(ref_counts["transfer_ref_count"], 28_993)
+        self.assertEqual(ref_counts["runtime_ledger_signed_ref_count"], 26)
+        self.assertTrue(ref_counts["bounded_status_live_query_skipped"])
+        self.assertNotIn("tigerbeetle_ref_counts_unavailable", payload["blockers"])
+
     def test_ref_count_failure_degrades_without_status_exception(self) -> None:
         with Session(self.engine) as session:
             with patch(


### PR DESCRIPTION
## Summary

- Reuse complete latest TigerBeetle reconciliation ref counts in status/readiness instead of falling back to the expensive live ref-count scan.
- Track which reconciliation count fields were actually present so generated default zero values do not hide missing signed/account-ref coverage.
- Add a Postgres composite index for the latest reconciliation lookup by `cluster_id` and descending `started_at`.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_tigerbeetle_status.py tests/test_tigerbeetle_reconciliation_status_lookup_migration.py tests/test_tigerbeetle_reconcile.py -q`
- `uv run --frozen ruff check app/main.py app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_status.py tests/test_tigerbeetle_reconciliation_status_lookup_migration.py migrations/versions/0049_tigerbeetle_reconciliation_status_lookup.py`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. This adds a non-breaking Alembic index migration for the TigerBeetle reconciliation status lookup.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
