### PR TITLE
fix(torghut): preserve hpairs import-ready state

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -6306,20 +6306,31 @@ def _hpairs_zero_activity_reason_flags(
     ).lower()
     audit_state = (_safe_text(runtime_window_import_audit.get("state")) or "").lower()
     import_ready = bool(runtime_window_import_audit.get("import_ready"))
-    no_market_window = bool(
-        {
-            "paper_route_session_window_not_open",
-            "paper_route_session_window_closed",
-            "paper_route_session_window_not_closed",
-            "paper_route_session_settlement_pending",
-            "market_session_closed",
-        }
-        & normalized
-    ) or session_state in {
-        "waiting_for_session_open",
-        "collecting_session_evidence",
-        "window_closed_settlement_pending",
+    window_import_ready = import_ready or audit_state in {
+        "import_due_source_activity_missing",
+        "import_due_runtime_ledger_missing",
+        "import_due_runtime_ledger_not_materialized",
+        "runtime_ledger_imported_but_not_evidence_grade",
+        "window_closed_import_ready",
     }
+    no_market_window = not window_import_ready and (
+        bool(
+            {
+                "paper_route_session_window_not_open",
+                "paper_route_session_window_closed",
+                "paper_route_session_window_not_closed",
+                "paper_route_session_settlement_pending",
+                "market_session_closed",
+            }
+            & normalized
+        )
+        or session_state
+        in {
+            "waiting_for_session_open",
+            "collecting_session_evidence",
+            "window_closed_settlement_pending",
+        }
+    )
     no_candidate_target_materialization = hpairs_target_count <= 0
     no_symbols = hpairs_symbol_count <= 0 or bool(
         {

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -36,6 +36,7 @@ from app.trading.paper_route_evidence import (
     _balanced_pair_probe_symbol_actions,
     _hpairs_round_trip_identity_blockers,
     _hpairs_zero_activity_reason_flags,
+    _hpairs_zero_activity_state,
     _next_regular_equities_session_window,
     _normalized_open_positions,
     _order_event_source_offset_refs,
@@ -5945,6 +5946,33 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertTrue(decisions_without_execution["source_executions_missing"])
         self.assertFalse(decisions_without_execution["source_tca_missing"])
         self.assertTrue(decisions_without_execution["runtime_ledger_bucket_missing"])
+
+        closed_import_ready_window = _hpairs_zero_activity_reason_flags(
+            blockers=[
+                "market_session_closed",
+                "paper_route_session_window_not_open",
+                "source_executions_missing",
+            ],
+            probe={"configured_enabled": True},
+            runtime_window_import_audit={
+                "import_ready": True,
+                "session_state": "window_closed_import_ready",
+                "state": "runtime_ledger_imported_but_not_evidence_grade",
+            },
+            hpairs_target_count=1,
+            hpairs_symbol_count=2,
+            hpairs_source_decision_ready_count=1,
+            hpairs_decision_count=2,
+            hpairs_submitted_order_count=0,
+            hpairs_tca_sample_count=0,
+            hpairs_runtime_bucket_count=0,
+        )
+        self.assertFalse(closed_import_ready_window["no_market_window"])
+        self.assertTrue(closed_import_ready_window["source_executions_missing"])
+        self.assertEqual(
+            _hpairs_zero_activity_state(closed_import_ready_window),
+            "source_ledger_import_not_running",
+        )
 
         executions_without_tca = _hpairs_zero_activity_reason_flags(
             blockers=[],


### PR DESCRIPTION
## Summary

- Preserve import-ready H-PAIRS diagnostic state when the current market session is closed.
- Treat closed-window import-ready audit states as real evidence windows instead of `no_market_window`.
- Add a regression test that fails under the old market-closed blocker precedence.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'hpairs_zero_activity_reason_flags_distinguish_source_stages' -q`
- Red check: same focused pytest command failed with the old condition restored, then passed again after restoring this fix.
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend diagnostic payload change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
