### PR TITLE
fix(torghut): refresh tigerbeetle reconcile on empty slices

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -105,6 +105,7 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             batch_size=5,
             max_batches=1,
             reconcile_limit=LIVE_RECONCILE_LIMIT,
+            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
         ),
     ]
@@ -139,6 +140,7 @@ def _sim_commands() -> list[JournalCronCommand]:
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
             **common,
         ),

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -764,13 +764,13 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             )
             if cronjob_name == "torghut-tigerbeetle-journal-order-events-live":
-                self.assertNotIn("--reconcile-empty-selection", runtime_argv)
+                self.assertIn("--reconcile-empty-selection", runtime_argv)
                 self.assertEqual(
                     runtime_argv[runtime_argv.index("--reconcile-limit") + 1],
                     str(cron_runner.LIVE_RECONCILE_LIMIT),
                 )
             else:
-                self.assertNotIn("--reconcile-empty-selection", runtime_argv)
+                self.assertIn("--reconcile-empty-selection", runtime_argv)
             self.assertIn("--fail-on-degraded", runtime_argv)
             self.assertIn("--allow-data-quality-degraded", runtime_argv)
 

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1717,6 +1717,22 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertTrue(live_order_event_command.skip_reconcile)
         self.assertTrue(live_order_event_command.allow_data_quality_degraded)
+        live_runtime_commands = [
+            command
+            for command in tigerbeetle_journal_runner._live_commands(
+                execution_batch_size=5
+            )
+            if command.source
+            == tigerbeetle_journal_runner.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET
+        ]
+        self.assertEqual(len(live_runtime_commands), 1)
+        live_runtime_command = live_runtime_commands[0]
+        self.assertFalse(live_runtime_command.skip_reconcile)
+        self.assertTrue(live_runtime_command.reconcile_empty_selection)
+        self.assertEqual(
+            live_runtime_command.reconcile_limit,
+            tigerbeetle_journal_runner.LIVE_RECONCILE_LIMIT,
+        )
 
         sim_env = {
             item.get("name"): item
@@ -1747,6 +1763,16 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("--max-batches", sim_args)
         self.assertNotIn("--event-scan-limit", sim_args)
         self.assertNotIn("--reconcile-limit", sim_args)
+        sim_runtime_commands = [
+            command
+            for command in tigerbeetle_journal_runner._sim_commands()
+            if command.source
+            == tigerbeetle_journal_runner.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET
+        ]
+        self.assertEqual(len(sim_runtime_commands), 1)
+        sim_runtime_command = sim_runtime_commands[0]
+        self.assertFalse(sim_runtime_command.skip_reconcile)
+        self.assertTrue(sim_runtime_command.reconcile_empty_selection)
 
     def test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db(
         self,

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -102,10 +102,12 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertFalse(commands[3].skip_reconcile)
-        self.assertFalse(commands[3].reconcile_empty_selection)
+        self.assertTrue(commands[3].reconcile_empty_selection)
         self.assertEqual(commands[3].reconcile_limit, runner.LIVE_RECONCILE_LIMIT)
 
-    def test_live_runtime_ledger_command_skips_empty_selection_reconcile(self) -> None:
+    def test_live_runtime_ledger_command_refreshes_empty_selection_reconcile(
+        self,
+    ) -> None:
         command = runner._live_commands(execution_batch_size=5)[-1]
 
         argv = runner._argv_for_command(
@@ -114,14 +116,16 @@ class RunTigerBeetleJournalCronTest(TestCase):
             supervise_timeout_seconds=45.0,
         )
 
-        self.assertNotIn("--reconcile-empty-selection", argv)
+        self.assertIn("--reconcile-empty-selection", argv)
         self.assertNotIn("--skip-reconcile", argv)
         self.assertEqual(
             argv[argv.index("--reconcile-limit") + 1],
             str(runner.LIVE_RECONCILE_LIMIT),
         )
 
-    def test_sim_runtime_ledger_command_skips_empty_selection_reconcile(self) -> None:
+    def test_sim_runtime_ledger_command_refreshes_empty_selection_reconcile(
+        self,
+    ) -> None:
         command = runner._sim_commands()[-1]
 
         argv = runner._argv_for_command(
@@ -130,7 +134,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
             supervise_timeout_seconds=45.0,
         )
 
-        self.assertNotIn("--reconcile-empty-selection", argv)
+        self.assertIn("--reconcile-empty-selection", argv)
         self.assertNotIn("--skip-reconcile", argv)
 
     def test_live_order_event_argv_keeps_slice_bounded_under_watchdog(self) -> None:


### PR DESCRIPTION
## Summary

- Enables the live and sim TigerBeetle runtime-ledger cron slices to pass `--reconcile-empty-selection`, so reconciliation freshness is refreshed even when no new runtime bucket rows are selected.
- Keeps execution, TCA, and order-event slices bounded and `--skip-reconcile`; real degraded reconciliation blockers remain visible and fail closed as non-authoritative telemetry.
- Adds runner, cron-manifest, and live-config regression coverage for the runtime-ledger empty-selection reconciliation refresh.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check origin/main...HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are covered by the regression tests and PR context.
