### PR TITLE
fix(torghut): keep hpairs stage flags count-based

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -6394,15 +6394,13 @@ def _hpairs_zero_activity_reason_flags(
         "import_due_runtime_ledger_missing",
         "import_due_runtime_ledger_not_materialized",
     }
-    source_decisions_missing = (
-        hpairs_target_count > 0 and hpairs_decision_count <= 0
-    ) or "source_decisions_missing" in normalized
-    source_executions_missing = (
-        hpairs_decision_count > 0 and hpairs_submitted_order_count <= 0
-    ) or "source_executions_missing" in normalized
-    source_tca_missing = (
-        hpairs_submitted_order_count > 0 and hpairs_tca_sample_count <= 0
-    ) or "source_tca_missing" in normalized
+    source_decisions_missing = hpairs_target_count > 0 and hpairs_decision_count <= 0
+    source_executions_missing = hpairs_decision_count > 0 and (
+        hpairs_submitted_order_count <= 0 or "source_executions_missing" in normalized
+    )
+    source_tca_missing = hpairs_submitted_order_count > 0 and (
+        hpairs_tca_sample_count <= 0 or "source_tca_missing" in normalized
+    )
     runtime_ledger_bucket_missing = (
         hpairs_decision_count > 0 and hpairs_runtime_bucket_count <= 0
     ) or bool(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5906,8 +5906,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(stage_diagnostics["source_tca_present"])
         self.assertFalse(stage_diagnostics["runtime_ledger_buckets_present"])
         self.assertIn("source_decisions_missing", stage_diagnostics["blockers"])
-        self.assertIn("source_executions_missing", stage_diagnostics["blockers"])
-        self.assertIn("source_tca_missing", stage_diagnostics["blockers"])
+        self.assertNotIn("source_executions_missing", stage_diagnostics["blockers"])
+        self.assertNotIn("source_tca_missing", stage_diagnostics["blockers"])
         self.assertIn("runtime_ledger_bucket_missing", stage_diagnostics["blockers"])
 
     def test_hpairs_zero_activity_reason_flags_distinguish_source_stages(
@@ -5973,6 +5973,31 @@ class TestPaperRouteEvidenceAudit(TestCase):
             _hpairs_zero_activity_state(closed_import_ready_window),
             "source_ledger_import_not_running",
         )
+
+        stale_stage_blockers_with_decisions = _hpairs_zero_activity_reason_flags(
+            blockers=[
+                "source_decisions_missing",
+                "source_executions_missing",
+                "source_tca_missing",
+                "runtime_ledger_bucket_missing",
+            ],
+            probe={"configured_enabled": True},
+            runtime_window_import_audit={"import_ready": True},
+            hpairs_target_count=1,
+            hpairs_symbol_count=2,
+            hpairs_source_decision_ready_count=1,
+            hpairs_decision_count=2,
+            hpairs_submitted_order_count=0,
+            hpairs_tca_sample_count=0,
+            hpairs_runtime_bucket_count=0,
+        )
+        self.assertFalse(
+            stale_stage_blockers_with_decisions["source_decisions_missing"]
+        )
+        self.assertTrue(
+            stale_stage_blockers_with_decisions["source_executions_missing"]
+        )
+        self.assertFalse(stale_stage_blockers_with_decisions["source_tca_missing"])
 
         executions_without_tca = _hpairs_zero_activity_reason_flags(
             blockers=[],


### PR DESCRIPTION
## Summary

- Keeps H-PAIRS zero-activity source-stage flags driven by observed stage counts instead of stale raw blocker strings.
- Prevents `source_decisions_missing` from staying true after H-PAIRS decisions are observed.
- Prevents downstream `source_tca_missing` from firing before submitted orders exist.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'hpairs_zero_activity_reason_flags_distinguish_source_stages' -q`
- Red check: the new regression failed before the implementation with `AssertionError: True is not false` on `source_decisions_missing`.
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'hpairs_zero_activity_reason_flags_distinguish_source_stages or hpairs_zero_activity_diagnostics_report_market_window_blocker' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
