### PR TITLE
fix(torghut): reconcile runtime ledger refs under bounded samples

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -759,6 +759,43 @@ def _runtime_ledger_ref_matches_expected_bucket(
     return direction_matches, metadata_matches
 
 
+def _reconciliation_transfer_refs(
+    session: Session,
+    *,
+    cluster_id: int,
+    limit: int,
+) -> list[TigerBeetleTransferRef]:
+    bounded_limit = max(1, limit)
+    recent_refs = (
+        session.execute(
+            select(TigerBeetleTransferRef)
+            .where(TigerBeetleTransferRef.cluster_id == cluster_id)
+            .order_by(TigerBeetleTransferRef.created_at.desc())
+            .limit(bounded_limit)
+        )
+        .scalars()
+        .all()
+    )
+    runtime_ledger_refs = (
+        session.execute(
+            select(TigerBeetleTransferRef)
+            .where(
+                TigerBeetleTransferRef.cluster_id == cluster_id,
+                TigerBeetleTransferRef.source_type == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                TigerBeetleTransferRef.transfer_kind == TRANSFER_KIND_RUNTIME_NET_PNL,
+            )
+            .order_by(TigerBeetleTransferRef.created_at.desc())
+            .limit(bounded_limit)
+        )
+        .scalars()
+        .all()
+    )
+    refs_by_id: dict[str, TigerBeetleTransferRef] = {}
+    for ref in (*recent_refs, *runtime_ledger_refs):
+        refs_by_id.setdefault(str(ref.id), ref)
+    return list(refs_by_id.values())
+
+
 def tigerbeetle_ref_counts(
     session: Session,
     *,
@@ -1047,17 +1084,10 @@ def reconcile_tigerbeetle_transfers(
     persist: bool = True,
 ) -> dict[str, object]:
     started_at = datetime.now(timezone.utc)
-    refs = (
-        session.execute(
-            select(TigerBeetleTransferRef)
-            .where(
-                TigerBeetleTransferRef.cluster_id == settings_obj.tigerbeetle_cluster_id
-            )
-            .order_by(TigerBeetleTransferRef.created_at.desc())
-            .limit(limit)
-        )
-        .scalars()
-        .all()
+    refs = _reconciliation_transfer_refs(
+        session,
+        cluster_id=settings_obj.tigerbeetle_cluster_id,
+        limit=limit,
     )
     checked_transfer_count = len(refs)
     missing_transfer_count = 0

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -630,6 +630,82 @@ class TestTigerBeetleReconcile(TestCase):
                 SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             )
 
+    def test_reconciliation_checks_runtime_ledger_refs_outside_recent_sample(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket = _runtime_bucket(net_pnl=Decimal("2.50"))
+            session.add(bucket)
+            session.flush()
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            self.assertIsNotNone(plan)
+            assert plan is not None
+            _add_account_refs_for_plan(session, plan)
+            runtime_transfer = plan.transfer_spec
+            old_created_at = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(runtime_transfer.transfer_id),
+                    transfer_kind=runtime_transfer.transfer_kind,
+                    ledger=runtime_transfer.ledger,
+                    code=runtime_transfer.code,
+                    amount=Decimal(runtime_transfer.amount),
+                    status="created",
+                    runtime_ledger_bucket_id=bucket.id,
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id=str(bucket.id),
+                    created_at=old_created_at,
+                    updated_at=old_created_at,
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "run_id": bucket.run_id,
+                        "candidate_id": bucket.candidate_id,
+                        "hypothesis_id": bucket.hypothesis_id,
+                        "observed_stage": bucket.observed_stage,
+                        "pnl_basis": bucket.pnl_basis,
+                        "ledger_schema_version": bucket.ledger_schema_version,
+                        "amount_source": str(plan.amount_source),
+                        "signed_amount_micros": plan.signed_amount_micros,
+                        "pnl_direction": plan.pnl_direction,
+                        "runtime_key": plan.runtime_key,
+                        "debit_account_id": str(runtime_transfer.debit_account_id),
+                        "credit_account_id": str(runtime_transfer.credit_account_id),
+                    },
+                )
+            )
+            client = FakeTigerBeetleClient()
+            client.transfers[runtime_transfer.transfer_id] = runtime_transfer
+            for offset, transfer_id in enumerate((1001, 1002, 1003), start=1):
+                created_at = datetime(2026, 6, 2, 12, offset, tzinfo=timezone.utc)
+                _add_ref(
+                    session,
+                    transfer_id=str(transfer_id),
+                    payload_json={"created_for": "recent_sample"},
+                )
+                recent_ref = session.execute(
+                    select(TigerBeetleTransferRef).where(
+                        TigerBeetleTransferRef.transfer_id == str(transfer_id)
+                    )
+                ).scalar_one()
+                recent_ref.created_at = created_at
+                recent_ref.updated_at = created_at
+                client.transfers[transfer_id] = _transfer(transfer_id=transfer_id)
+            session.flush()
+
+            payload = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+                limit=2,
+            )
+
+            self.assertTrue(payload["ok"], payload)
+            self.assertEqual(payload["checked_transfer_count"], 3)
+            self.assertEqual(payload["runtime_ledger_checked_transfer_count"], 1)
+            self.assertEqual(payload["runtime_ledger_signed_transfer_count"], 1)
+            self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 0)
+
     def test_reconciliation_reports_archived_runtime_ref_without_blocking_current_ref(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Ensures TigerBeetle reconciliation samples runtime-ledger PnL refs separately from generic recent transfer refs.
- Keeps the authority gate strict by still looking up runtime PnL transfers in TigerBeetle and validating direction plus metadata before counting them as signed transfers.
- Adds a regression where an older runtime-ledger ref is outside the bounded recent sample but still gets reconciled and counted.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_tigerbeetle_reconcile.py -k 'outside_recent_sample or signed_runtime_ledger_profit_and_loss_refs'`
- `uv run --frozen pytest tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_status.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen ruff check app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_reconcile.py`
- `uv run --frozen ruff format --check app/trading/tigerbeetle_reconcile.py tests/test_tigerbeetle_reconcile.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
