### PR TITLE
fix(torghut): precompute runtime import source order refs

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -3713,6 +3713,7 @@ def _runtime_execution_ledger_fill_from_row(
     row: Mapping[str, object],
     *,
     order_lifecycle_rows: Sequence[Mapping[str, object]] | None,
+    event_sourced_fill_economics_order_ids: set[str] | None = None,
 ) -> tuple[RuntimeLedgerFill | None, list[datetime]]:
     computed_at = row.get("computed_at")
     execution_event_at = row.get("execution_event_at")
@@ -3797,9 +3798,12 @@ def _runtime_execution_ledger_fill_from_row(
     )
     if price is None or price <= 0 or signed_qty == 0:
         return None, []
-    if order_id is not None and order_id in _event_sourced_fill_economics_order_ids(
-        order_lifecycle_rows or []
-    ):
+    event_sourced_order_ids = (
+        event_sourced_fill_economics_order_ids
+        if event_sourced_fill_economics_order_ids is not None
+        else _event_sourced_fill_economics_order_ids(order_lifecycle_rows or [])
+    )
+    if order_id is not None and order_id in event_sourced_order_ids:
         return None, []
     event_times = [ledger_computed_at]
     if isinstance(fill_event_at, datetime):
@@ -3965,6 +3969,9 @@ def _build_realized_strategy_pnl_rows(
         )
         for row in carry_in_order_lifecycle_rows or []
     ]
+    event_sourced_fill_economics_order_ids = _event_sourced_fill_economics_order_ids(
+        order_lifecycle_rows
+    )
     for row in decision_lifecycle_rows or []:
         lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type="decision")
         if lifecycle_row is None:
@@ -4041,6 +4048,9 @@ def _build_realized_strategy_pnl_rows(
         ledger_fill, ledger_event_times = _runtime_execution_ledger_fill_from_row(
             row,
             order_lifecycle_rows=order_lifecycle_rows,
+            event_sourced_fill_economics_order_ids=(
+                event_sourced_fill_economics_order_ids
+            ),
         )
         if ledger_fill is None:
             continue
@@ -4110,10 +4120,16 @@ def _build_realized_strategy_pnl_rows(
         *(carry_in_order_lifecycle_rows or []),
         *(order_lifecycle_rows or []),
     ]
+    combined_event_sourced_fill_economics_order_ids = (
+        _event_sourced_fill_economics_order_ids(combined_order_lifecycle_rows)
+    )
     for row in carry_in_execution_rows or []:
         ledger_fill, _ledger_event_times = _runtime_execution_ledger_fill_from_row(
             row,
             order_lifecycle_rows=combined_order_lifecycle_rows,
+            event_sourced_fill_economics_order_ids=(
+                combined_event_sourced_fill_economics_order_ids
+            ),
         )
         if ledger_fill is not None:
             carry_in_ledger_rows.append(ledger_fill)

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -3459,6 +3459,71 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
 
+    def test_build_realized_strategy_pnl_rows_precomputes_event_sourced_orders(
+        self,
+    ) -> None:
+        def execution_row(
+            execution_id: str,
+            event_at: datetime,
+            side: str,
+            price: str,
+            order_id: str,
+        ) -> dict[str, object]:
+            return {
+                "execution_id": execution_id,
+                "computed_at": event_at,
+                "execution_event_at": event_at,
+                "symbol": "AAPL",
+                "side": side,
+                "filled_qty": Decimal("1"),
+                "avg_fill_price": Decimal(price),
+                "cost_amount": Decimal("0.01"),
+                "cost_basis": "broker_reported_commission_and_fees",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "alpaca_order_id": order_id,
+            }
+
+        current_rows = [
+            execution_row(
+                "execution-current-buy",
+                datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                "buy",
+                "100",
+                "order-current-buy",
+            ),
+            execution_row(
+                "execution-current-sell",
+                datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                "sell",
+                "101",
+                "order-current-sell",
+            ),
+        ]
+        carry_in_rows = [
+            execution_row(
+                f"execution-carry-{index}",
+                datetime(2026, 3, 6, 14, 30 + index, tzinfo=timezone.utc),
+                "buy" if index % 2 == 0 else "sell",
+                "100",
+                f"order-carry-{index}",
+            )
+            for index in range(6)
+        ]
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows._event_sourced_fill_economics_order_ids",
+            return_value=set(),
+        ) as event_sourced_order_ids:
+            rows = _build_realized_strategy_pnl_rows(
+                current_rows,
+                carry_in_execution_rows=carry_in_rows,
+                allow_authoritative_runtime_ledger_materialization=True,
+            )
+
+        self.assertTrue(rows)
+        self.assertLessEqual(event_sourced_order_ids.call_count, 3)
+
     def test_build_realized_strategy_pnl_rows_authorizes_source_backed_short_round_trip(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Precomputes event-sourced order IDs once for current and carry-in runtime-window source rows instead of re-walking source order-event payloads once per execution.
- Keeps runtime-ledger promotion authority fail-closed: no synthetic fills/orders/TCA, no promotion gate relaxation, and source-backed blockers remain surfaced.
- Adds a regression test that guards against per-execution recomputation while preserving carry-in materialization coverage.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — passed after installing `gcc`/`libc6-dev` in the workspace so `crosshair-tool` could build.
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py` — passed, 134 tests.
- `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py` — passed.
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` — passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` — passed.
- `git diff --check` — passed.
- Runtime readback: `scripts/import_hypothesis_runtime_windows.py --audit-only --json` against the 2026-06-02 Torghut-sim H-TSMOM-LIQ-01 paper-route target completed in 59.37s and reported real source activity (`decision_count=6`, `execution_count=7`, `order_lifecycle_rows_after_lineage_filter=41`, `runtime_ledger_source_bucket_count=6`) with `runtime_ledger_source_execution_materialized_bucket_count=6`; promotion remained blocked by source/profit blockers.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
