### PR TITLE
fix(torghut): skip fresh empty journal reconciles

### DIFF
--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -42,7 +42,10 @@ from app.trading.tigerbeetle_ledger_model import (
     TRANSFER_KIND_EXECUTION_FILL,
     TRANSFER_KIND_RUNTIME_NET_PNL,
 )
-from app.trading.tigerbeetle_reconcile import reconcile_tigerbeetle_transfers
+from app.trading.tigerbeetle_reconcile import (
+    latest_tigerbeetle_reconciliation_payload,
+    reconcile_tigerbeetle_transfers,
+)
 
 DEFAULT_SOURCES = (
     SOURCE_TYPE_EXECUTION_ORDER_EVENT,
@@ -609,6 +612,62 @@ def _reset_session_identity_map(session: Any) -> None:
         expunge_all()
 
 
+def _fresh_reconciliation_for_empty_selection(
+    session: Any,
+    *,
+    settings_obj: Settings,
+) -> dict[str, object] | None:
+    latest = latest_tigerbeetle_reconciliation_payload(
+        session,
+        cluster_id=settings_obj.tigerbeetle_cluster_id,
+    )
+    if latest is None:
+        return None
+    if not bool(latest.get("ok")):
+        return None
+    if str(latest.get("status") or "") != "ok":
+        return None
+    if bool(latest.get("reconciliation_stale")):
+        return None
+    max_age_seconds = int(latest.get("reconciliation_max_age_seconds") or 0)
+    if max_age_seconds <= 0:
+        return None
+    raw_blockers = latest.get("blockers")
+    if isinstance(raw_blockers, Sequence) and not isinstance(
+        raw_blockers,
+        (str, bytes, bytearray),
+    ):
+        if any(str(item).strip() for item in raw_blockers):
+            return None
+    elif raw_blockers:
+        return None
+    if not bool(latest.get("client_lookup_ok", True)):
+        return None
+    return {
+        "ok": True,
+        "status": "skipped",
+        "reason": "fresh_reconciliation_available",
+        "fresh_reconciliation_available": True,
+        "latest_status": str(latest.get("status") or ""),
+        "latest_started_at": latest.get("started_at"),
+        "latest_finished_at": latest.get("finished_at"),
+        "age_seconds": int(latest.get("age_seconds") or 0),
+        "reconciliation_stale": False,
+        "reconciliation_max_age_seconds": max_age_seconds,
+        "checked_transfer_count": int(latest.get("checked_transfer_count") or 0),
+        "runtime_ledger_checked_transfer_count": int(
+            latest.get("runtime_ledger_checked_transfer_count") or 0
+        ),
+        "runtime_ledger_signed_transfer_count": int(
+            latest.get("runtime_ledger_signed_transfer_count") or 0
+        ),
+        "runtime_ledger_missing_signed_ref_count": int(
+            latest.get("runtime_ledger_missing_signed_ref_count") or 0
+        ),
+        "blockers": [],
+    }
+
+
 def _payload(
     *,
     args: argparse.Namespace,
@@ -1173,13 +1232,20 @@ def main() -> int:
                 or bool(getattr(args, "reconcile_empty_selection", False))
             )
         ):
-            reconciliation = reconcile_tigerbeetle_transfers(
-                session,
-                settings_obj=settings_obj,
-                client=journal.client_for_reconciliation(),
-                limit=max(1, int(args.reconcile_limit)),
-                persist=True,
-            )
+            reconciliation = None
+            if selected_source_rows == 0:
+                reconciliation = _fresh_reconciliation_for_empty_selection(
+                    session,
+                    settings_obj=settings_obj,
+                )
+            if reconciliation is None:
+                reconciliation = reconcile_tigerbeetle_transfers(
+                    session,
+                    settings_obj=settings_obj,
+                    client=journal.client_for_reconciliation(),
+                    limit=max(1, int(args.reconcile_limit)),
+                    persist=True,
+                )
             session.commit()
         elif not args.dry_run and not args.skip_reconcile and not stop_journaling:
             reconciliation = {

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -25,6 +26,7 @@ from app.models import (
     ExecutionOrderEvent,
     ExecutionTCAMetric,
     StrategyRuntimeLedgerBucket,
+    TigerBeetleReconciliationRun,
     TigerBeetleAccountRef,
     TigerBeetleTransferRef,
 )
@@ -1900,6 +1902,128 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             reconcile.call_args.kwargs["client"],
             FakeJournal.instances[0].reconciliation_client,
         )
+
+    def test_main_reuses_fresh_reconciliation_when_empty_source_selects_no_rows(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+            with Session(engine) as session:
+                observed_at = datetime.now(timezone.utc)
+                session.add(
+                    TigerBeetleReconciliationRun(
+                        cluster_id=2001,
+                        started_at=observed_at,
+                        finished_at=observed_at,
+                        status="ok",
+                        checked_transfer_count=26,
+                        missing_transfer_count=0,
+                        mismatched_transfer_count=0,
+                        source_missing_count=0,
+                        payload_json={
+                            "ok": True,
+                            "status": "ok",
+                            "blockers": [],
+                            "reconciliation_max_age_seconds": 300,
+                            "runtime_ledger_checked_transfer_count": 26,
+                            "runtime_ledger_signed_transfer_count": 26,
+                            "runtime_ledger_missing_signed_ref_count": 0,
+                        },
+                    )
+                )
+                session.commit()
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--sources",
+                        "strategy_runtime_ledger_bucket",
+                        "--batch-size",
+                        "5",
+                        "--reconcile-limit",
+                        "12",
+                        "--reconcile-empty-selection",
+                        "--fail-on-degraded",
+                        "--allow-data-quality-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(script, "reconcile_tigerbeetle_transfers") as reconcile,
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["selected"], 0)
+        self.assertEqual(payload["journaled"], 0)
+        self.assertEqual(payload["failed"], 0)
+        self.assertEqual(payload["reconciliation"]["status"], "skipped")
+        self.assertEqual(
+            payload["reconciliation"]["reason"],
+            "fresh_reconciliation_available",
+        )
+        self.assertEqual(
+            payload["reconciliation"]["latest_status"],
+            "ok",
+        )
+        self.assertFalse(payload["reconciliation"]["reconciliation_stale"])
+        self.assertEqual(FakeJournal.instances[0].runtime_buckets, [])
+        self.assertEqual(FakeJournal.instances[0].stable_ref_backfills, 0)
+        reconcile.assert_not_called()
+
+    def test_fresh_empty_selection_reconciliation_requires_clean_latest_payload(
+        self,
+    ) -> None:
+        base_payload: dict[str, object] = {
+            "ok": True,
+            "status": "ok",
+            "reconciliation_stale": False,
+            "reconciliation_max_age_seconds": 300,
+            "blockers": [],
+            "client_lookup_ok": True,
+        }
+        rejection_cases = [
+            {"ok": False},
+            {"status": "degraded"},
+            {"reconciliation_stale": True},
+            {"reconciliation_max_age_seconds": 0},
+            {"blockers": ["runtime_ledger_missing"]},
+            {"blockers": True},
+            {"client_lookup_ok": False},
+        ]
+
+        for override in rejection_cases:
+            with self.subTest(override=override):
+                payload = {**base_payload, **override}
+                session = object()
+                with patch.object(
+                    script,
+                    "latest_tigerbeetle_reconciliation_payload",
+                    return_value=payload,
+                ) as latest:
+                    result = script._fresh_reconciliation_for_empty_selection(
+                        session,
+                        settings_obj=cast(
+                            Settings,
+                            SimpleNamespace(tigerbeetle_cluster_id=2001),
+                        ),
+                    )
+
+                self.assertIsNone(result)
+                latest.assert_called_once_with(session, cluster_id=2001)
 
     def test_main_dry_run_rolls_back_without_reconcile(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Reuses a fresh clean TigerBeetle reconciliation payload when a scheduled runtime-ledger journal slice selects zero source rows.
- Keeps fail-closed behavior for missing, stale, blocked, or client-unhealthy reconciliation state so proof-grade runtime-ledger checks still run when needed.
- Adds a regression test for the empty runtime-ledger source path that previously invoked reconciliation and could hit `tigerbeetle_journal_worker_timeout`.

## Related Issues

None

## Testing

- Live failure reproduced from `kubectl -n torghut logs job/torghut-tigerbeetle-journal-order-events-live-29674734 --all-containers --tail=400`: source `strategy_runtime_ledger_bucket` selected `0`, emitted `source_batch_complete`, then timed out with `tigerbeetle_journal_worker_timeout`.
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py -k 'fresh_reconciliation_when_empty_source'` failed before the fix because empty selected rows still invoked `reconcile_tigerbeetle_transfers`.
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py -k 'fresh_reconciliation_when_empty_source'` passed after the fix.
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py` passed, 43 tests.
- `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py` passed, 16 tests.
- `cd services/torghut && uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py` passed.
- `cd services/torghut && uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py` passed.
- `cd services/torghut && uv sync --frozen --extra dev` passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json` passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json` passed.
- `cd services/torghut && NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json` passed.
- `git diff --check` passed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
