### PR TITLE
fix(torghut): extend runtime ledger journal reconcile timeout

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -32,6 +32,7 @@ LIVE_EXECUTION_SLICE_COUNT = 5
 LIVE_TCA_METRIC_BATCH_SIZE = 5
 LIVE_TCA_METRIC_MAX_BATCHES = 1
 LIVE_RECONCILE_LIMIT = 500
+RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS = 120.0
 
 
 @dataclass(frozen=True)
@@ -49,6 +50,7 @@ class JournalCronCommand:
     commit_each_row: bool = False
     progress_interval: int | None = None
     repeat_count: int = 1
+    supervise_timeout_seconds: float | None = None
 
 
 def _parse_args() -> argparse.Namespace:
@@ -107,6 +109,7 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             reconcile_limit=LIVE_RECONCILE_LIMIT,
             reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
+            supervise_timeout_seconds=RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
         ),
     ]
 
@@ -142,6 +145,7 @@ def _sim_commands() -> list[JournalCronCommand]:
             source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
+            supervise_timeout_seconds=RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
             **common,
         ),
     ]
@@ -197,7 +201,14 @@ def _argv_for_command(
         argv.append("--commit-each-row")
     if command.progress_interval is not None:
         argv.extend(["--progress-interval", str(max(0, command.progress_interval))])
-    argv.extend(["--supervise-timeout-seconds", str(supervise_timeout_seconds)])
+    effective_supervise_timeout_seconds = max(
+        float(supervise_timeout_seconds),
+        float(command.supervise_timeout_seconds or 0.0),
+        0.001,
+    )
+    argv.extend(
+        ["--supervise-timeout-seconds", str(effective_supervise_timeout_seconds)]
+    )
     if json_output:
         argv.append("--json")
     return argv
@@ -299,9 +310,7 @@ def main() -> int:
                 _argv_for_command(
                     command,
                     json_output=bool(args.json),
-                    supervise_timeout_seconds=max(
-                        float(args.supervise_timeout_seconds), 0.001
-                    ),
+                    supervise_timeout_seconds=float(args.supervise_timeout_seconds),
                 ),
                 source=command.source,
                 json_output=bool(args.json),

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -119,6 +119,10 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertIn("--reconcile-empty-selection", argv)
         self.assertNotIn("--skip-reconcile", argv)
         self.assertEqual(
+            argv[argv.index("--supervise-timeout-seconds") + 1],
+            str(runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS),
+        )
+        self.assertEqual(
             argv[argv.index("--reconcile-limit") + 1],
             str(runner.LIVE_RECONCILE_LIMIT),
         )
@@ -136,6 +140,23 @@ class RunTigerBeetleJournalCronTest(TestCase):
 
         self.assertIn("--reconcile-empty-selection", argv)
         self.assertNotIn("--skip-reconcile", argv)
+        self.assertEqual(
+            argv[argv.index("--supervise-timeout-seconds") + 1],
+            str(runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS),
+        )
+
+    def test_runtime_ledger_reconcile_timeout_does_not_leak_to_other_slices(
+        self,
+    ) -> None:
+        commands = runner._live_commands(execution_batch_size=5)
+
+        self.assertIsNone(commands[0].supervise_timeout_seconds)
+        self.assertIsNone(commands[1].supervise_timeout_seconds)
+        self.assertIsNone(commands[2].supervise_timeout_seconds)
+        self.assertEqual(
+            commands[3].supervise_timeout_seconds,
+            runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+        )
 
     def test_live_order_event_argv_keeps_slice_bounded_under_watchdog(self) -> None:
         [command] = [
@@ -384,6 +405,11 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(
             [source for _, source, _ in observed[: runner.LIVE_EXECUTION_SLICE_COUNT]],
             [SOURCE_TYPE_EXECUTION] * runner.LIVE_EXECUTION_SLICE_COUNT,
+        )
+        runtime_argv = observed[-1][0]
+        self.assertEqual(
+            runtime_argv[runtime_argv.index("--supervise-timeout-seconds") + 1],
+            str(runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS),
         )
         self.assertTrue(all(json_output for _, _, json_output in observed))
 


### PR DESCRIPTION
## Summary

- Gives the runtime-ledger TigerBeetle journal reconciliation slice a command-specific 120s supervised timeout while keeping execution, order-event, and TCA slices on the normal budget.
- Keeps empty-selection runtime-ledger reconciliation enabled so the cron still checks bounded TigerBeetle/runtime-ledger refs instead of skipping the proof gate.
- Adds runner regression coverage that prevents the wider timeout from leaking to other journal slices.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
