### PR TITLE
fix(torghut): skip empty runtime ledger reconcile

### DIFF
--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -107,7 +107,6 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             batch_size=5,
             max_batches=1,
             reconcile_limit=LIVE_RECONCILE_LIMIT,
-            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
             supervise_timeout_seconds=RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
         ),
@@ -143,7 +142,6 @@ def _sim_commands() -> list[JournalCronCommand]:
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
-            reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
             supervise_timeout_seconds=RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
             **common,

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -766,13 +766,13 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             )
             if cronjob_name == "torghut-tigerbeetle-journal-order-events-live":
-                self.assertIn("--reconcile-empty-selection", runtime_argv)
+                self.assertNotIn("--reconcile-empty-selection", runtime_argv)
                 self.assertEqual(
                     runtime_argv[runtime_argv.index("--reconcile-limit") + 1],
                     str(cron_runner.LIVE_RECONCILE_LIMIT),
                 )
             else:
-                self.assertIn("--reconcile-empty-selection", runtime_argv)
+                self.assertNotIn("--reconcile-empty-selection", runtime_argv)
             self.assertIn("--fail-on-degraded", runtime_argv)
             self.assertIn("--allow-data-quality-degraded", runtime_argv)
 

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1728,7 +1728,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(len(live_runtime_commands), 1)
         live_runtime_command = live_runtime_commands[0]
         self.assertFalse(live_runtime_command.skip_reconcile)
-        self.assertTrue(live_runtime_command.reconcile_empty_selection)
+        self.assertFalse(live_runtime_command.reconcile_empty_selection)
         self.assertEqual(
             live_runtime_command.reconcile_limit,
             tigerbeetle_journal_runner.LIVE_RECONCILE_LIMIT,
@@ -1772,7 +1772,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(len(sim_runtime_commands), 1)
         sim_runtime_command = sim_runtime_commands[0]
         self.assertFalse(sim_runtime_command.skip_reconcile)
-        self.assertTrue(sim_runtime_command.reconcile_empty_selection)
+        self.assertFalse(sim_runtime_command.reconcile_empty_selection)
 
     def test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db(
         self,

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -102,10 +102,10 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertFalse(commands[3].skip_reconcile)
-        self.assertTrue(commands[3].reconcile_empty_selection)
+        self.assertFalse(commands[3].reconcile_empty_selection)
         self.assertEqual(commands[3].reconcile_limit, runner.LIVE_RECONCILE_LIMIT)
 
-    def test_live_runtime_ledger_command_refreshes_empty_selection_reconcile(
+    def test_live_runtime_ledger_command_reconciles_only_selected_rows(
         self,
     ) -> None:
         command = runner._live_commands(execution_batch_size=5)[-1]
@@ -116,7 +116,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
             supervise_timeout_seconds=45.0,
         )
 
-        self.assertIn("--reconcile-empty-selection", argv)
+        self.assertNotIn("--reconcile-empty-selection", argv)
         self.assertNotIn("--skip-reconcile", argv)
         self.assertEqual(
             argv[argv.index("--supervise-timeout-seconds") + 1],
@@ -127,7 +127,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
             str(runner.LIVE_RECONCILE_LIMIT),
         )
 
-    def test_sim_runtime_ledger_command_refreshes_empty_selection_reconcile(
+    def test_sim_runtime_ledger_command_reconciles_only_selected_rows(
         self,
     ) -> None:
         command = runner._sim_commands()[-1]
@@ -138,7 +138,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
             supervise_timeout_seconds=45.0,
         )
 
-        self.assertIn("--reconcile-empty-selection", argv)
+        self.assertNotIn("--reconcile-empty-selection", argv)
         self.assertNotIn("--skip-reconcile", argv)
         self.assertEqual(
             argv[argv.index("--supervise-timeout-seconds") + 1],


### PR DESCRIPTION
## Summary

- Stops the runtime-ledger journal cron from forcing reconciliation when no runtime-ledger buckets were selected.
- Keeps runtime-ledger reconciliation enabled for selected-row batches, preserving the actual journaling parity path.
- Updates runner and live manifest contract tests so the empty-selection cron path cannot reintroduce the timed-out flag.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
