### PR TITLE
fix(torghut): materialize clean runtime ledger source buckets

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -621,6 +621,16 @@ def _order_lifecycle_blockers(
         row.order_id for row in fill_lifecycle_rows if row.order_id is not None
     }
     fill_order_ids = {row.order_id for row in usable_fills if row.order_id is not None}
+    cancelled_order_ids = {
+        row.order_id
+        for row in lifecycle_rows
+        if row.event_type in _CANCELLED_ORDER_EVENTS and row.order_id is not None
+    }
+    rejected_order_ids = {
+        row.order_id
+        for row in lifecycle_rows
+        if row.event_type in _REJECTED_ORDER_EVENTS and row.order_id is not None
+    }
     if any(row.order_id is None for row in usable_fills):
         blockers.append("fill_order_linkage_missing")
     if any(row.order_id is None for row in fill_lifecycle_rows):
@@ -629,7 +639,12 @@ def _order_lifecycle_blockers(
         blockers.append("fill_order_submission_missing")
     if fill_order_ids - fill_lifecycle_order_ids:
         blockers.append("order_feed_lifecycle_missing")
-    if submitted_order_ids - fill_lifecycle_order_ids:
+    if (
+        submitted_order_ids
+        - fill_lifecycle_order_ids
+        - cancelled_order_ids
+        - rejected_order_ids
+    ):
         blockers.append("unfilled_order_present")
     if rejected_order_count > 0:
         blockers.append("rejected_order_present")

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from contextlib import contextmanager
+from dataclasses import replace
 import hashlib
 import json
 import os
@@ -664,11 +665,14 @@ def _partition_runtime_source_rows_by_decision_mode(
     ]
     | None
 ):
-    source_rows: list[dict[str, object]] = [
+    current_source_rows: list[dict[str, object]] = [
         *execution_rows,
         *(decision_lifecycle_rows or []),
         *(order_lifecycle_rows or []),
         *(unlinked_order_lifecycle_rows or []),
+    ]
+    source_rows: list[dict[str, object]] = [
+        *current_source_rows,
         *(carry_in_execution_rows or []),
         *(carry_in_decision_lifecycle_rows or []),
         *(carry_in_order_lifecycle_rows or []),
@@ -681,7 +685,7 @@ def _partition_runtime_source_rows_by_decision_mode(
     )
     partition_relevant_source_rows = [
         row
-        for row in source_rows
+        for row in current_source_rows
         if not _source_row_is_paper_route_probe_exit_or_linked(
             row,
             paper_route_probe_exit_identifiers=paper_route_probe_exit_identifiers,
@@ -2772,19 +2776,44 @@ def _execution_id_by_order_id(
     }
 
 
+def _execution_side_by_order_id(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[str, str]:
+    sides_by_order_id: dict[str, set[str]] = {}
+    for row in rows:
+        order_id = _runtime_order_id(row)
+        side = _first_text(row, "side", "order_side")
+        if order_id is None or side is None:
+            continue
+        sides_by_order_id.setdefault(order_id, set()).add(side)
+    return {
+        order_id: next(iter(sides))
+        for order_id, sides in sides_by_order_id.items()
+        if len(sides) == 1
+    }
+
+
 def _with_linked_execution_id(
     row: Mapping[str, object],
     *,
     execution_id_by_order_id: Mapping[str, str],
+    execution_side_by_order_id: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
     payload = dict(row)
-    if _first_text(payload, "execution_id") is not None:
-        return payload
     order_id = _runtime_order_id(payload)
-    if order_id is not None and (
-        execution_id := execution_id_by_order_id.get(order_id)
+    if (
+        _first_text(payload, "execution_id") is None
+        and order_id is not None
+        and (execution_id := execution_id_by_order_id.get(order_id))
     ):
         payload["execution_id"] = execution_id
+    if (
+        _first_text(payload, "side", "order_side") is None
+        and order_id is not None
+        and execution_side_by_order_id is not None
+        and (side := execution_side_by_order_id.get(order_id))
+    ):
+        payload["side"] = side
     return payload
 
 
@@ -3054,6 +3083,256 @@ def _runtime_source_decision_ids(rows: Sequence[Mapping[str, object]]) -> set[st
             if value is not None:
                 identifiers.add(value)
     return identifiers
+
+
+def _ledger_row_value(
+    row: RuntimeLedgerFill | Mapping[str, object],
+    *keys: str,
+) -> object | None:
+    if isinstance(row, Mapping):
+        for key in keys:
+            if key in row:
+                return row.get(key)
+        return None
+    for key in keys:
+        value = getattr(row, key, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _ledger_row_text(
+    row: RuntimeLedgerFill | Mapping[str, object],
+    *keys: str,
+) -> str | None:
+    for key in keys:
+        value = _ledger_row_value(row, key)
+        if (text := _text_or_none(value)) is not None:
+            return text
+    return None
+
+
+def _ledger_row_decimal(
+    row: RuntimeLedgerFill | Mapping[str, object],
+    *keys: str,
+) -> Decimal | None:
+    for key in keys:
+        value = _ledger_row_value(row, key)
+        if (parsed := _decimal_or_none(value)) is not None:
+            return parsed
+    return None
+
+
+def _ledger_row_time(row: RuntimeLedgerFill | Mapping[str, object]) -> datetime | None:
+    if isinstance(row, Mapping):
+        return _runtime_ledger_row_time({str(key): value for key, value in row.items()})
+    value = getattr(row, "executed_at", None)
+    return value if isinstance(value, datetime) else None
+
+
+def _ledger_row_event_type(row: RuntimeLedgerFill | Mapping[str, object]) -> str:
+    if isinstance(row, Mapping):
+        return _runtime_ledger_event_type(
+            {str(key): value for key, value in row.items()}
+        )
+    return str(getattr(row, "event_type", "") or "").strip().lower()
+
+
+def _ledger_row_order_id(row: RuntimeLedgerFill | Mapping[str, object]) -> str | None:
+    return _ledger_row_text(
+        row,
+        "order_id",
+        "alpaca_order_id",
+        "client_order_id",
+        "execution_correlation_id",
+    )
+
+
+def _ledger_row_decision_id(
+    row: RuntimeLedgerFill | Mapping[str, object],
+) -> str | None:
+    return _ledger_row_text(row, "decision_id", "trade_decision_id", "decision_hash")
+
+
+def _ledger_row_symbol(row: RuntimeLedgerFill | Mapping[str, object]) -> str | None:
+    symbol = _ledger_row_text(row, "symbol", "ticker")
+    return symbol.upper() if symbol is not None else None
+
+
+def _ledger_row_position_key(
+    row: RuntimeLedgerFill | Mapping[str, object],
+) -> tuple[str | None, str | None, str | None]:
+    return (
+        _ledger_row_text(row, "account_label", "alpaca_account_label"),
+        _ledger_row_text(row, "strategy_id", "strategy_name"),
+        _ledger_row_symbol(row),
+    )
+
+
+def _ledger_row_side_sign(row: RuntimeLedgerFill | Mapping[str, object]) -> Decimal:
+    side = (_ledger_row_text(row, "side", "order_side") or "").strip().lower()
+    if side in {"buy", "long", "b"}:
+        return Decimal("1")
+    if side in {"sell", "short", "s"}:
+        return Decimal("-1")
+    return Decimal("0")
+
+
+def _adjust_carry_in_lot_row(
+    row: RuntimeLedgerFill | Mapping[str, object],
+    *,
+    remaining_qty: Decimal,
+    original_qty: Decimal,
+) -> RuntimeLedgerFill | dict[str, object]:
+    ratio = remaining_qty / original_qty if original_qty > 0 else Decimal("1")
+    price = _ledger_row_decimal(
+        row,
+        "avg_fill_price",
+        "filled_avg_price",
+        "filled_average_price",
+        "average_fill_price",
+        "fill_price",
+        "filled_price",
+    )
+    filled_notional = remaining_qty * price if price is not None else None
+    cost_amount = _ledger_row_decimal(row, "cost_amount")
+    adjusted_cost = cost_amount * ratio if cost_amount is not None else None
+    if isinstance(row, RuntimeLedgerFill):
+        return replace(
+            row,
+            filled_qty=remaining_qty,
+            filled_notional=filled_notional,
+            cost_amount=adjusted_cost,
+        )
+    adjusted = dict(row)
+    adjusted["filled_qty"] = remaining_qty
+    if "filled_qty_delta" in adjusted:
+        adjusted["filled_qty_delta"] = remaining_qty
+    if filled_notional is not None:
+        adjusted["filled_notional"] = filled_notional
+        if "filled_notional_delta" in adjusted:
+            adjusted["filled_notional_delta"] = filled_notional
+    if adjusted_cost is not None:
+        adjusted["cost_amount"] = adjusted_cost
+    return adjusted
+
+
+def _active_carry_in_ledger_rows(
+    rows: Sequence[RuntimeLedgerFill | Mapping[str, object]],
+    *,
+    bucket_start: datetime,
+) -> tuple[list[RuntimeLedgerFill | dict[str, object]], set[str], set[str]]:
+    lots_by_key: dict[
+        tuple[str | None, str | None, str | None],
+        list[dict[str, object]],
+    ] = {}
+    for row in sorted(
+        rows,
+        key=lambda item: (
+            _ledger_row_time(item) or bucket_start,
+            _ledger_row_order_id(item) or "",
+        ),
+    ):
+        event_time = _ledger_row_time(row)
+        if event_time is None or event_time >= bucket_start:
+            continue
+        if _ledger_row_event_type(row) not in _RUNTIME_LEDGER_FILL_EVENTS:
+            continue
+        side_sign = _ledger_row_side_sign(row)
+        if side_sign == 0:
+            continue
+        qty = _ledger_row_decimal(
+            row, "filled_qty", "filled_quantity", "qty", "quantity"
+        )
+        price = _ledger_row_decimal(
+            row,
+            "avg_fill_price",
+            "filled_avg_price",
+            "filled_average_price",
+            "average_fill_price",
+            "fill_price",
+            "filled_price",
+        )
+        if qty is None or qty <= 0 or price is None or price <= 0:
+            continue
+        key = _ledger_row_position_key(row)
+        lots = lots_by_key.setdefault(key, [])
+        remaining_qty = qty
+        for lot in list(lots):
+            if remaining_qty <= 0:
+                break
+            if cast(Decimal, lot["side_sign"]) == side_sign:
+                continue
+            lot_qty = cast(Decimal, lot["remaining_qty"])
+            close_qty = min(remaining_qty, lot_qty)
+            lot["remaining_qty"] = lot_qty - close_qty
+            remaining_qty -= close_qty
+            if cast(Decimal, lot["remaining_qty"]) <= 0:
+                lots.remove(lot)
+        if remaining_qty > 0:
+            lots.append(
+                {
+                    "row": row,
+                    "side_sign": side_sign,
+                    "remaining_qty": remaining_qty,
+                    "original_qty": qty,
+                }
+            )
+
+    active_rows: list[RuntimeLedgerFill | dict[str, object]] = []
+    active_order_ids: set[str] = set()
+    active_decision_ids: set[str] = set()
+    for lots in lots_by_key.values():
+        for lot in lots:
+            remaining_qty = cast(Decimal, lot["remaining_qty"])
+            original_qty = cast(Decimal, lot["original_qty"])
+            if remaining_qty <= 0 or original_qty <= 0:
+                continue
+            row = cast(RuntimeLedgerFill | Mapping[str, object], lot["row"])
+            adjusted = _adjust_carry_in_lot_row(
+                row,
+                remaining_qty=remaining_qty,
+                original_qty=original_qty,
+            )
+            active_rows.append(adjusted)
+            if (order_id := _ledger_row_order_id(adjusted)) is not None:
+                active_order_ids.add(order_id)
+            if (decision_id := _ledger_row_decision_id(adjusted)) is not None:
+                active_decision_ids.add(decision_id)
+    linked_lifecycle_rows: list[RuntimeLedgerFill | dict[str, object]] = []
+    for row in rows:
+        event_time = _ledger_row_time(row)
+        if event_time is None or event_time >= bucket_start:
+            continue
+        if _ledger_row_event_type(row) in _RUNTIME_LEDGER_FILL_EVENTS:
+            continue
+        order_id = _ledger_row_order_id(row)
+        decision_id = _ledger_row_decision_id(row)
+        if (order_id is not None and order_id in active_order_ids) or (
+            decision_id is not None and decision_id in active_decision_ids
+        ):
+            linked_lifecycle_rows.append(dict(row) if isinstance(row, Mapping) else row)
+    return [*linked_lifecycle_rows, *active_rows], active_order_ids, active_decision_ids
+
+
+def _filter_carry_in_source_rows_for_active_lots(
+    rows: list[dict[str, object]] | None,
+    *,
+    active_order_ids: set[str],
+    active_decision_ids: set[str],
+) -> list[dict[str, object]] | None:
+    if not rows or (not active_order_ids and not active_decision_ids):
+        return None
+    filtered = [
+        row
+        for row in rows
+        if (
+            (order_id := _runtime_order_id(row)) is not None
+            and order_id in active_order_ids
+        )
+        or bool(_runtime_source_decision_ids([row]) & active_decision_ids)
+    ]
+    return filtered or None
 
 
 def _runtime_order_rows_for_bucket(
@@ -3955,10 +4234,15 @@ def _build_realized_strategy_pnl_rows(
     carry_in_execution_id_by_order_id = _execution_id_by_order_id(
         carry_in_execution_rows or []
     )
+    execution_side_by_order_id = _execution_side_by_order_id(execution_rows)
+    carry_in_execution_side_by_order_id = _execution_side_by_order_id(
+        carry_in_execution_rows or []
+    )
     order_lifecycle_rows = [
         _with_linked_execution_id(
             row,
             execution_id_by_order_id=execution_id_by_order_id,
+            execution_side_by_order_id=execution_side_by_order_id,
         )
         for row in order_lifecycle_rows or []
     ]
@@ -3966,6 +4250,7 @@ def _build_realized_strategy_pnl_rows(
         _with_linked_execution_id(
             row,
             execution_id_by_order_id=carry_in_execution_id_by_order_id,
+            execution_side_by_order_id=carry_in_execution_side_by_order_id,
         )
         for row in carry_in_order_lifecycle_rows or []
     ]
@@ -4136,6 +4421,29 @@ def _build_realized_strategy_pnl_rows(
     if not event_times:
         return []
     unique_times = sorted(set(event_times))
+    (
+        carry_in_ledger_rows,
+        active_carry_in_order_ids,
+        active_carry_in_decision_ids,
+    ) = _active_carry_in_ledger_rows(
+        carry_in_ledger_rows,
+        bucket_start=unique_times[0],
+    )
+    carry_in_execution_rows = _filter_carry_in_source_rows_for_active_lots(
+        carry_in_execution_rows,
+        active_order_ids=active_carry_in_order_ids,
+        active_decision_ids=active_carry_in_decision_ids,
+    )
+    carry_in_decision_lifecycle_rows = _filter_carry_in_source_rows_for_active_lots(
+        carry_in_decision_lifecycle_rows,
+        active_order_ids=active_carry_in_order_ids,
+        active_decision_ids=active_carry_in_decision_ids,
+    )
+    carry_in_order_lifecycle_rows = _filter_carry_in_source_rows_for_active_lots(
+        carry_in_order_lifecycle_rows,
+        active_order_ids=active_carry_in_order_ids,
+        active_decision_ids=active_carry_in_decision_ids,
+    )
     bucket_ranges = [(unique_times[0], unique_times[-1] + timedelta(microseconds=1))]
     realized_rows: list[dict[str, object]] = []
     for bucket in build_runtime_ledger_buckets(

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -21,8 +21,10 @@ from scripts.import_hypothesis_runtime_windows import (
     POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
     POST_COST_BASIS_RUNTIME_LEDGER,
     _alpaca_2026_equity_fee_schedule_hash,
+    _active_carry_in_ledger_rows,
     _build_realized_strategy_pnl_rows,
     _execution_signed_qty,
+    _filter_carry_in_source_rows_for_active_lots,
     _fill_quantity_basis,
     _first_bool,
     _first_lineage_digest,
@@ -1244,6 +1246,46 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             bucket["cost_basis_counts"], {"broker_reported_commission_and_fees": 2}
         )
 
+    def test_side_less_order_feed_fills_use_linked_execution_side_for_authority(
+        self,
+    ) -> None:
+        decision_rows, order_rows, execution_rows = _source_backed_runtime_split_rows()
+        for row in order_rows:
+            row.pop("side", None)
+            if row["event_type"] != "fill":
+                continue
+            if row["alpaca_order_id"] == "order-buy":
+                row["filled_qty"] = Decimal("1")
+                row["filled_qty_delta"] = Decimal("1")
+                row["avg_fill_price"] = Decimal("100")
+                row["filled_notional_delta"] = Decimal("100")
+            else:
+                row["filled_qty"] = Decimal("1")
+                row["filled_qty_delta"] = Decimal("1")
+                row["avg_fill_price"] = Decimal("101")
+                row["filled_notional_delta"] = Decimal("101")
+            row["fill_quantity_basis"] = "cumulative_to_delta"
+            row["cost_amount"] = Decimal("0.01")
+            row["cost_basis"] = "broker_reported_commission_and_fees"
+
+        rows = _build_realized_strategy_pnl_rows(
+            execution_rows,
+            decision_lifecycle_rows=decision_rows,
+            order_lifecycle_rows=order_rows,
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertTrue(row["authoritative"])
+        self.assertEqual(row["runtime_ledger_blockers"], [])
+        bucket = row["runtime_ledger_bucket"]
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["source_materialization"], "execution_order_events")
+        self.assertEqual(bucket["closed_trade_count"], 1)
+        self.assertEqual(bucket["open_position_count"], 0)
+        self.assertNotIn("unclosed_position", bucket["blockers"])
+
     def test_source_backed_lifecycle_only_blocks_missing_execution_economics(
         self,
     ) -> None:
@@ -1471,6 +1513,54 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "lineage_hash": "lineage",
                 },
             ],
+            carry_in_execution_rows=[
+                {
+                    "execution_id": "old-route-buy-exec",
+                    "trade_decision_id": "old-route-buy-decision",
+                    "computed_at": datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 6, 1, 14, 0, 2, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("2"),
+                    "avg_fill_price": Decimal("90"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "intraday-tsmom-profit-v3",
+                    "decision_hash": "old-route-buy-hash",
+                    "alpaca_order_id": "old-route-buy-order",
+                    "execution_policy_hash": "old-route-policy",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                    "profit_proof_eligible": False,
+                },
+                {
+                    "execution_id": "old-route-sell-exec",
+                    "trade_decision_id": "old-route-sell-decision",
+                    "computed_at": datetime(2026, 6, 1, 14, 5, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 6, 1, 14, 5, 2, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("2"),
+                    "avg_fill_price": Decimal("91"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "intraday-tsmom-profit-v3",
+                    "decision_hash": "old-route-sell-hash",
+                    "alpaca_order_id": "old-route-sell-order",
+                    "execution_policy_hash": "old-route-policy",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                    "profit_proof_eligible": False,
+                },
+            ],
             allow_authoritative_runtime_ledger_materialization=True,
         )
 
@@ -1478,6 +1568,145 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         bucket = rows[0]["runtime_ledger_bucket"]
         assert isinstance(bucket, dict)
         self.assertNotIn("window-carry-unrelated-order", bucket["source_window_ids"])
+        self.assertNotIn(
+            "route_acquisition_probe",
+            bucket["source_decision_mode_counts"],
+        )
+
+    def test_active_carry_in_rows_keep_only_open_residual_lots_and_refs(
+        self,
+    ) -> None:
+        bucket_start = datetime(2026, 6, 2, 14, 10, tzinfo=timezone.utc)
+        rows: list[dict[str, object]] = [
+            {
+                "event_ts": datetime(2026, 6, 2, 13, 58, tzinfo=timezone.utc),
+                "event_type": "new",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "intraday-tsmom-profit-v3",
+                "symbol": "AAPL",
+                "alpaca_order_id": "stale-buy-order",
+                "trade_decision_id": "stale-buy-decision",
+            },
+            {
+                "event_ts": datetime(2026, 6, 2, 13, 59, tzinfo=timezone.utc),
+                "event_type": "new",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "intraday-tsmom-profit-v3",
+                "symbol": "AAPL",
+                "alpaca_order_id": "active-buy-order",
+                "trade_decision_id": "active-buy-decision",
+            },
+            {
+                "executed_at": datetime(2026, 6, 2, 14, 0, tzinfo=timezone.utc),
+                "event_type": "fill",
+                "side": "buy",
+                "filled_qty": Decimal("2"),
+                "avg_fill_price": Decimal("90"),
+                "cost_amount": Decimal("0.20"),
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "intraday-tsmom-profit-v3",
+                "symbol": "AAPL",
+                "alpaca_order_id": "stale-buy-order",
+                "trade_decision_id": "stale-buy-decision",
+            },
+            {
+                "executed_at": datetime(2026, 6, 2, 14, 1, tzinfo=timezone.utc),
+                "event_type": "fill",
+                "side": "sell",
+                "filled_qty": Decimal("2"),
+                "avg_fill_price": Decimal("91"),
+                "cost_amount": Decimal("0.20"),
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "intraday-tsmom-profit-v3",
+                "symbol": "AAPL",
+                "alpaca_order_id": "stale-sell-order",
+                "trade_decision_id": "stale-sell-decision",
+            },
+            {
+                "executed_at": datetime(2026, 6, 2, 14, 2, tzinfo=timezone.utc),
+                "event_type": "fill",
+                "side": "buy",
+                "filled_qty": Decimal("5"),
+                "avg_fill_price": Decimal("100"),
+                "cost_amount": Decimal("0.50"),
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "intraday-tsmom-profit-v3",
+                "symbol": "AAPL",
+                "alpaca_order_id": "active-buy-order",
+                "trade_decision_id": "active-buy-decision",
+            },
+            {
+                "executed_at": datetime(2026, 6, 2, 14, 3, tzinfo=timezone.utc),
+                "event_type": "fill",
+                "side": "sell",
+                "filled_qty": Decimal("2"),
+                "avg_fill_price": Decimal("101"),
+                "cost_amount": Decimal("0.20"),
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "intraday-tsmom-profit-v3",
+                "symbol": "AAPL",
+                "alpaca_order_id": "partial-sell-order",
+                "trade_decision_id": "partial-sell-decision",
+            },
+        ]
+
+        active_rows, order_ids, decision_ids = _active_carry_in_ledger_rows(
+            rows,
+            bucket_start=bucket_start,
+        )
+
+        self.assertEqual(order_ids, {"active-buy-order"})
+        self.assertEqual(decision_ids, {"active-buy-decision"})
+        self.assertEqual(len(active_rows), 2)
+        active_fill = next(
+            row
+            for row in active_rows
+            if isinstance(row, dict) and row.get("event_type") == "fill"
+        )
+        self.assertEqual(active_fill["filled_qty"], Decimal("3"))
+        self.assertEqual(active_fill["filled_notional"], Decimal("300"))
+        self.assertEqual(active_fill["cost_amount"], Decimal("0.30"))
+        self.assertEqual(
+            [
+                row.get("alpaca_order_id")
+                for row in active_rows
+                if isinstance(row, dict)
+            ],
+            ["active-buy-order", "active-buy-order"],
+        )
+
+    def test_filter_carry_in_source_rows_keeps_active_lot_lineage_only(
+        self,
+    ) -> None:
+        rows = [
+            {
+                "alpaca_order_id": "active-buy-order",
+                "trade_decision_id": "active-buy-decision",
+                "source_window_id": "active-window",
+            },
+            {
+                "alpaca_order_id": "stale-buy-order",
+                "trade_decision_id": "stale-buy-decision",
+                "source_window_id": "stale-window",
+            },
+            {
+                "trade_decision_id": "active-buy-decision",
+                "source_window_id": "active-decision-window",
+            },
+        ]
+
+        filtered = _filter_carry_in_source_rows_for_active_lots(
+            rows,
+            active_order_ids={"active-buy-order"},
+            active_decision_ids={"active-buy-decision"},
+        )
+
+        self.assertIsNotNone(filtered)
+        assert filtered is not None
+        self.assertEqual(
+            [row["source_window_id"] for row in filtered],
+            ["active-window", "active-decision-window"],
+        )
 
     def test_runtime_ledger_source_context_merges_gap_metadata(self) -> None:
         bucket = _with_runtime_ledger_source_authority_context(

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -2516,7 +2516,7 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(ledger_bucket.closed_trade_count, 1)
         self.assertNotIn("unclosed_position", ledger_bucket.blockers)
         self.assertNotIn("cost_model_hash_missing", ledger_bucket.blockers)
-        self.assertIn("unfilled_order_present", ledger_bucket.blockers)
+        self.assertNotIn("unfilled_order_present", ledger_bucket.blockers)
 
     def test_run_replay_enriches_day_two_open_with_prev_day_open45_ranks(self) -> None:
         strategy = Strategy(

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -2482,3 +2482,48 @@ def test_exact_replay_ledger_blocks_unfilled_or_unhashed_order_lifecycle() -> No
     assert "zero_fill_runtime_ledger" in bucket.blockers
     assert "unfilled_order_present" in bucket.blockers
     assert "cost_model_hash_missing" in bucket.blockers
+
+
+def test_cancelled_zero_fill_order_does_not_remain_unfilled() -> None:
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                "event_type": "decision",
+                "executed_at": _ts(1),
+                "decision_id": "decision-exit",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "execution_policy_hash": "policy-sha",
+                "lineage_hash": "lineage-sha",
+            },
+            {
+                "event_type": "order_submitted",
+                "executed_at": _ts(2),
+                "decision_id": "decision-exit",
+                "order_id": "order-exit",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "execution_policy_hash": "policy-sha",
+                "lineage_hash": "lineage-sha",
+            },
+            {
+                "event_type": "order_cancelled",
+                "executed_at": _ts(3),
+                "decision_id": "decision-exit",
+                "order_id": "order-exit",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "execution_policy_hash": "policy-sha",
+                "lineage_hash": "lineage-sha",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.cancelled_order_count == 1
+    assert "zero_fill_runtime_ledger" in bucket.blockers
+    assert "unfilled_order_present" not in bucket.blockers


### PR DESCRIPTION
## Summary

- Filters runtime-window import carry-in rows down to active residual lots before bucket materialization and source-context attribution.
- Carries linked execution side onto side-less order-feed lifecycle fill rows so delta fill events can materialize source-backed runtime-ledger buckets.
- Treats canceled or rejected zero-fill submitted orders as terminal lifecycle outcomes instead of still-open unfilled proof blockers.
- Adds regression coverage for stale carry-in route rows, side-less order-feed fills, residual lot filtering, and canceled zero-fill orders.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py -q`
- `uv run --frozen ruff check app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py`
- `uv run --frozen ruff format --check app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py`
- `uv run --frozen python -m coverage run -m pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py -q && uv run --frozen python -m coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Read-only live sim audit with `scripts/import_hypothesis_runtime_windows.py --audit-only --source-kind paper_route_probe_runtime_observed` for the 2026-06-02 full session: source-execution materialized buckets stayed at `3`, reconstruction buckets stayed at `0`, and `unfilled_order_present` dropped from runtime-ledger blockers; remaining blockers are `runtime_ledger_post_cost_expectancy_not_promotion_grade`, `source_decision_mode_not_profit_proof_eligible`, and `unclosed_position` from pre-window carry-in proof state.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
