### PR TITLE
fix(torghut): trust flat-start snapshots for carry-in

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -78,6 +78,8 @@ EXACT_REPLAY_ARTIFACT_AUTHORITY_BLOCKERS = (
 )
 RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
 RUNTIME_LEDGER_CARRY_IN_LOOKBACK = timedelta(days=5)
+RUNTIME_LEDGER_FLAT_START_SNAPSHOT_STALE_SECONDS = 900
+RUNTIME_LEDGER_FLAT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS = 300
 RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
 RUNTIME_LEDGER_EXECUTION_TCA_REFS_MISSING_BLOCKER = (
     "runtime_ledger_execution_tca_refs_missing"
@@ -327,6 +329,20 @@ def _as_mapping(value: Any) -> dict[str, Any]:
     )
 
 
+def _as_sequence(value: Any) -> list[Any] | None:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return None
+        return _as_sequence(parsed)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return list(value)
+    return None
+
+
 def _parse_target_metadata(raw: str) -> dict[str, Any]:
     text = str(raw or "").strip()
     if not text:
@@ -489,6 +505,71 @@ def _first_bool(row: Mapping[str, object], *keys: str) -> bool | None:
             if (parsed := _bool_value(payload.get(key))) is not None:
                 return parsed
     return None
+
+
+def _position_snapshot_open_position_count(positions: object) -> int | None:
+    position_rows = _as_sequence(positions)
+    if position_rows is None:
+        return None
+    count = 0
+    for raw_position in position_rows:
+        position = _as_mapping(raw_position)
+        if not position:
+            return None
+        qty = _decimal_or_none(
+            position.get("qty")
+            or position.get("quantity")
+            or position.get("filled_qty")
+            or position.get("position_qty")
+        )
+        if qty is None:
+            return None
+        if qty != 0:
+            count += 1
+    return count
+
+
+def _flat_start_position_snapshot_authority(
+    snapshot: Mapping[str, object] | None,
+) -> dict[str, object] | None:
+    if not snapshot:
+        return None
+    snapshot_id = _text_or_none(
+        snapshot.get("snapshot_id")
+        or snapshot.get("position_snapshot_id")
+        or snapshot.get("id")
+    )
+    snapshot_as_of = _text_or_none(
+        snapshot.get("snapshot_as_of")
+        or snapshot.get("position_snapshot_as_of")
+        or snapshot.get("as_of")
+    )
+    if snapshot_id is None or snapshot_as_of is None:
+        return None
+    if _metadata_text_list(snapshot.get("blockers")):
+        return None
+    explicit_flat = _first_bool(
+        snapshot, "flat", "account_flat", "zero_open_position_evidence"
+    )
+    positions = snapshot.get("positions")
+    position_count = _nonnegative_int(snapshot.get("position_count"))
+    if positions is not None:
+        position_count = _position_snapshot_open_position_count(positions)
+        if position_count is None:
+            return None
+    if explicit_flat is not True or position_count != 0:
+        return None
+    return {
+        "flat_start_position_snapshot_id": snapshot_id,
+        "flat_start_position_snapshot_as_of": snapshot_as_of,
+        "flat_start_position_snapshot_source": _text_or_none(
+            snapshot.get("snapshot_source") or snapshot.get("source")
+        )
+        or "position_snapshots",
+        "flat_start_position_snapshot_scope": _text_or_none(snapshot.get("scope"))
+        or "account_position_snapshot_at_runtime_window_start",
+        "carry_in_rows_suppressed_by_flat_start_snapshot": True,
+    }
 
 
 def _source_decision_priority_payloads(
@@ -3335,6 +3416,96 @@ def _filter_carry_in_source_rows_for_active_lots(
     return filtered or None
 
 
+def _flat_start_position_snapshot_from_cursor(
+    cur: Any,
+    *,
+    account_label: str,
+    window_start: datetime,
+) -> dict[str, object] | None:
+    window_start_utc = (
+        window_start.astimezone(timezone.utc)
+        if window_start.tzinfo is not None
+        else window_start.replace(tzinfo=timezone.utc)
+    )
+    cur.execute(
+        """
+        with before_snapshot as (
+            select
+                id::text,
+                as_of,
+                positions,
+                'latest_before_window_start' as snapshot_source
+            from position_snapshots
+            where alpaca_account_label = %s
+              and as_of <= %s
+            order by as_of desc
+            limit 1
+        ),
+        after_snapshot as (
+            select
+                id::text,
+                as_of,
+                positions,
+                'first_after_window_start' as snapshot_source
+            from position_snapshots
+            where alpaca_account_label = %s
+              and as_of > %s
+              and as_of <= %s
+            order by as_of asc
+            limit 1
+        )
+        select id, as_of, positions, snapshot_source, 0 as snapshot_priority
+        from before_snapshot
+        union all
+        select id, as_of, positions, snapshot_source, 1 as snapshot_priority
+        from after_snapshot
+        order by snapshot_priority
+        limit 1
+        """,
+        (
+            account_label,
+            window_start_utc,
+            account_label,
+            window_start_utc,
+            window_start_utc
+            + timedelta(
+                seconds=RUNTIME_LEDGER_FLAT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS
+            ),
+        ),
+    )
+    rows = list(cur.fetchall())
+    if not rows:
+        return None
+    snapshot_id, snapshot_as_of, positions, snapshot_source, _snapshot_priority = rows[
+        0
+    ]
+    parsed_as_of = _parse_dt_or_none(snapshot_as_of)
+    if parsed_as_of is None:
+        return None
+    offset_seconds = int((parsed_as_of - window_start_utc).total_seconds())
+    blockers: list[str] = []
+    if offset_seconds < -RUNTIME_LEDGER_FLAT_START_SNAPSHOT_STALE_SECONDS:
+        blockers.append("runtime_ledger_flat_start_position_snapshot_stale")
+    position_count = _position_snapshot_open_position_count(positions)
+    if position_count is None:
+        blockers.append("runtime_ledger_flat_start_position_snapshot_positions_invalid")
+        position_count = 0
+    if position_count > 0:
+        blockers.append("runtime_ledger_flat_start_position_snapshot_not_flat")
+    return {
+        "schema_version": "torghut.runtime-ledger-flat-start-position-snapshot.v1",
+        "scope": "account_position_snapshot_at_runtime_window_start",
+        "account_label": account_label,
+        "snapshot_id": str(snapshot_id),
+        "snapshot_as_of": parsed_as_of.isoformat(),
+        "snapshot_source": str(snapshot_source or "position_snapshots"),
+        "snapshot_offset_seconds": offset_seconds,
+        "flat": position_count == 0 and not blockers,
+        "position_count": position_count,
+        "blockers": blockers,
+    }
+
+
 def _runtime_order_rows_for_bucket(
     *,
     bucket: RuntimeLedgerBucket,
@@ -4139,9 +4310,17 @@ def _build_realized_strategy_pnl_rows(
     carry_in_execution_rows: list[dict[str, object]] | None = None,
     carry_in_decision_lifecycle_rows: list[dict[str, object]] | None = None,
     carry_in_order_lifecycle_rows: list[dict[str, object]] | None = None,
+    flat_start_position_snapshot: Mapping[str, object] | None = None,
     allow_authoritative_runtime_ledger_materialization: bool = False,
     split_mixed_source_decision_modes: bool = True,
 ) -> list[dict[str, object]]:
+    flat_start_authority = _flat_start_position_snapshot_authority(
+        flat_start_position_snapshot
+    )
+    if flat_start_authority is not None:
+        carry_in_execution_rows = None
+        carry_in_decision_lifecycle_rows = None
+        carry_in_order_lifecycle_rows = None
     if split_mixed_source_decision_modes:
         partitions = _partition_runtime_source_rows_by_decision_mode(
             execution_rows=execution_rows,
@@ -4172,6 +4351,7 @@ def _build_realized_strategy_pnl_rows(
                     carry_in_execution_rows=partition_carry_in_execution_rows,
                     carry_in_decision_lifecycle_rows=partition_carry_in_decision_rows,
                     carry_in_order_lifecycle_rows=partition_carry_in_order_rows,
+                    flat_start_position_snapshot=flat_start_position_snapshot,
                     allow_authoritative_runtime_ledger_materialization=(
                         allow_authoritative_runtime_ledger_materialization
                     ),
@@ -4539,6 +4719,13 @@ def _build_realized_strategy_pnl_rows(
         equity_denominator = cast(
             tuple[Decimal, str] | None, source_context["equity_denominator"]
         )
+        if flat_start_authority is not None and isinstance(bucket_payload, Mapping):
+            row.update(flat_start_authority)
+            bucket_payload = {
+                **dict(bucket_payload),
+                **flat_start_authority,
+            }
+            row["runtime_ledger_bucket"] = bucket_payload
         if source_account_labels and isinstance(bucket_payload, Mapping):
             bucket_payload = {
                 **dict(bucket_payload),
@@ -5440,6 +5627,7 @@ def _query_timestamps(
     carry_in_execution_rows: list[dict[str, object]] = []
     carry_in_decision_lifecycle_rows: list[dict[str, object]] = []
     carry_in_order_lifecycle_rows: list[dict[str, object]] = []
+    flat_start_position_snapshot: dict[str, object] | None = None
     carry_in_window_start = window_start - RUNTIME_LEDGER_CARRY_IN_LOOKBACK
     symbol_filter = _metadata_symbol_list(symbols or ())
     if source_activity_diagnostics is not None:
@@ -6339,6 +6527,58 @@ def _query_timestamps(
                 source_activity_diagnostics["order_feed_fill_lifecycle_blockers"] = (
                     lifecycle_blockers
                 )
+            if allow_authoritative_runtime_ledger_materialization:
+                try:
+                    flat_start_position_snapshot = (
+                        _flat_start_position_snapshot_from_cursor(
+                            cur,
+                            account_label=canonical_account_label,
+                            window_start=window_start,
+                        )
+                    )
+                except Exception as exc:
+                    flat_start_position_snapshot = None
+                    if source_activity_diagnostics is not None:
+                        source_activity_diagnostics[
+                            "flat_start_position_snapshot_query_error"
+                        ] = type(exc).__name__
+                if source_activity_diagnostics is not None:
+                    flat_start_authority = _flat_start_position_snapshot_authority(
+                        flat_start_position_snapshot
+                    )
+                    source_activity_diagnostics[
+                        "flat_start_position_snapshot_present"
+                    ] = flat_start_position_snapshot is not None
+                    if flat_start_position_snapshot is not None:
+                        source_activity_diagnostics.update(
+                            {
+                                "flat_start_position_snapshot_id": (
+                                    flat_start_position_snapshot.get("snapshot_id")
+                                ),
+                                "flat_start_position_snapshot_as_of": (
+                                    flat_start_position_snapshot.get("snapshot_as_of")
+                                ),
+                                "flat_start_position_snapshot_source": (
+                                    flat_start_position_snapshot.get("snapshot_source")
+                                ),
+                                "flat_start_position_snapshot_offset_seconds": (
+                                    flat_start_position_snapshot.get(
+                                        "snapshot_offset_seconds"
+                                    )
+                                ),
+                                "flat_start_position_snapshot_flat": (
+                                    flat_start_position_snapshot.get("flat")
+                                ),
+                                "flat_start_position_snapshot_position_count": (
+                                    flat_start_position_snapshot.get("position_count")
+                                ),
+                                "flat_start_position_snapshot_blockers": (
+                                    flat_start_position_snapshot.get("blockers")
+                                ),
+                            }
+                        )
+                    if flat_start_authority is not None:
+                        source_activity_diagnostics.update(flat_start_authority)
     decision_lifecycle_rows = _retarget_source_rows_for_materialization(
         decision_lifecycle_rows,
         target_account_label=materialized_account_label,
@@ -6383,6 +6623,7 @@ def _query_timestamps(
             carry_in_execution_rows=carry_in_execution_rows,
             carry_in_decision_lifecycle_rows=carry_in_decision_lifecycle_rows,
             carry_in_order_lifecycle_rows=carry_in_order_lifecycle_rows,
+            flat_start_position_snapshot=flat_start_position_snapshot,
             allow_authoritative_runtime_ledger_materialization=(
                 allow_authoritative_runtime_ledger_materialization
             ),

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -24,6 +24,8 @@ from scripts.import_hypothesis_runtime_windows import (
     _active_carry_in_ledger_rows,
     _build_realized_strategy_pnl_rows,
     _execution_signed_qty,
+    _flat_start_position_snapshot_authority,
+    _flat_start_position_snapshot_from_cursor,
     _filter_carry_in_source_rows_for_active_lots,
     _fill_quantity_basis,
     _first_bool,
@@ -1568,6 +1570,223 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         bucket = rows[0]["runtime_ledger_bucket"]
         assert isinstance(bucket, dict)
         self.assertNotIn("window-carry-unrelated-order", bucket["source_window_ids"])
+        self.assertNotIn(
+            "route_acquisition_probe",
+            bucket["source_decision_mode_counts"],
+        )
+
+    def test_flat_start_snapshot_authority_requires_clean_flat_account(
+        self,
+    ) -> None:
+        valid = _flat_start_position_snapshot_authority(
+            {
+                "snapshot_id": "snapshot-flat",
+                "snapshot_as_of": "2026-06-02T14:30:00+00:00",
+                "flat": True,
+                "position_count": 0,
+                "positions": "[]",
+                "blockers": [],
+            }
+        )
+
+        self.assertIsNotNone(valid)
+        assert valid is not None
+        self.assertEqual(valid["flat_start_position_snapshot_id"], "snapshot-flat")
+        self.assertTrue(valid["carry_in_rows_suppressed_by_flat_start_snapshot"])
+
+        for name, snapshot in {
+            "missing_id": {
+                "snapshot_as_of": "2026-06-02T14:30:00+00:00",
+                "flat": True,
+                "position_count": 0,
+            },
+            "blocked": {
+                "snapshot_id": "snapshot-blocked",
+                "snapshot_as_of": "2026-06-02T14:30:00+00:00",
+                "flat": True,
+                "position_count": 0,
+                "blockers": ["runtime_ledger_flat_start_position_snapshot_stale"],
+            },
+            "nonflat_count": {
+                "snapshot_id": "snapshot-nonflat-count",
+                "snapshot_as_of": "2026-06-02T14:30:00+00:00",
+                "flat": True,
+                "position_count": 1,
+            },
+            "nonflat_positions": {
+                "snapshot_id": "snapshot-nonflat-positions",
+                "snapshot_as_of": "2026-06-02T14:30:00+00:00",
+                "flat": True,
+                "positions": [{"symbol": "AAPL", "qty": "1"}],
+            },
+            "invalid_positions_json": {
+                "snapshot_id": "snapshot-invalid-positions-json",
+                "snapshot_as_of": "2026-06-02T14:30:00+00:00",
+                "flat": True,
+                "positions": "not-json",
+            },
+            "invalid_positions_bytes": {
+                "snapshot_id": "snapshot-invalid-positions-bytes",
+                "snapshot_as_of": "2026-06-02T14:30:00+00:00",
+                "flat": True,
+                "positions": b"[]",
+            },
+            "invalid_position_row": {
+                "snapshot_id": "snapshot-invalid-position-row",
+                "snapshot_as_of": "2026-06-02T14:30:00+00:00",
+                "flat": True,
+                "positions": [{"symbol": "AAPL"}],
+            },
+            "not_explicitly_flat": {
+                "snapshot_id": "snapshot-not-flat",
+                "snapshot_as_of": "2026-06-02T14:30:00+00:00",
+                "flat": False,
+                "position_count": 0,
+            },
+        }.items():
+            with self.subTest(name=name):
+                self.assertIsNone(_flat_start_position_snapshot_authority(snapshot))
+
+    def test_flat_start_snapshot_query_marks_stale_and_nonflat_blockers(
+        self,
+    ) -> None:
+        cursor = _FakeCursor()
+        cursor._results = [
+            [
+                (
+                    "snapshot-stale",
+                    datetime(2026, 6, 2, 14, 0, tzinfo=timezone.utc),
+                    [{"symbol": "AAPL", "qty": "1"}],
+                    "latest_before_window_start",
+                    0,
+                )
+            ]
+        ]
+
+        snapshot = _flat_start_position_snapshot_from_cursor(
+            cursor,
+            account_label="TORGHUT_SIM",
+            window_start=datetime(2026, 6, 2, 14, 30, tzinfo=timezone.utc),
+        )
+
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot["snapshot_id"], "snapshot-stale")
+        self.assertFalse(snapshot["flat"])
+        self.assertEqual(snapshot["position_count"], 1)
+        self.assertEqual(
+            snapshot["blockers"],
+            [
+                "runtime_ledger_flat_start_position_snapshot_stale",
+                "runtime_ledger_flat_start_position_snapshot_not_flat",
+            ],
+        )
+        query, params = cursor.executed[0]
+        self.assertIn("from position_snapshots", query)
+        self.assertIn("order by snapshot_priority", query)
+        self.assertEqual(params[0], "TORGHUT_SIM")
+
+    def test_flat_start_snapshot_query_rejects_invalid_snapshot_payloads(
+        self,
+    ) -> None:
+        invalid_time_cursor = _FakeCursor()
+        invalid_time_cursor._results = [
+            [
+                (
+                    "snapshot-invalid-time",
+                    "not-a-timestamp",
+                    [],
+                    "latest_before_window_start",
+                    0,
+                )
+            ]
+        ]
+
+        self.assertIsNone(
+            _flat_start_position_snapshot_from_cursor(
+                invalid_time_cursor,
+                account_label="TORGHUT_SIM",
+                window_start=datetime(2026, 6, 2, 14, 30, tzinfo=timezone.utc),
+            )
+        )
+
+        invalid_positions_cursor = _FakeCursor()
+        invalid_positions_cursor._results = [
+            [
+                (
+                    "snapshot-invalid-positions",
+                    datetime(2026, 6, 2, 14, 30, tzinfo=timezone.utc),
+                    "not-json",
+                    "latest_before_window_start",
+                    0,
+                )
+            ]
+        ]
+
+        snapshot = _flat_start_position_snapshot_from_cursor(
+            invalid_positions_cursor,
+            account_label="TORGHUT_SIM",
+            window_start=datetime(2026, 6, 2, 14, 30, tzinfo=timezone.utc),
+        )
+
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertFalse(snapshot["flat"])
+        self.assertEqual(
+            snapshot["blockers"],
+            ["runtime_ledger_flat_start_position_snapshot_positions_invalid"],
+        )
+
+    def test_clean_flat_start_snapshot_suppresses_stale_carry_in_rows(
+        self,
+    ) -> None:
+        decision_rows, order_rows, execution_rows = _source_backed_runtime_split_rows()
+
+        rows = _build_realized_strategy_pnl_rows(
+            execution_rows,
+            decision_lifecycle_rows=decision_rows,
+            order_lifecycle_rows=order_rows,
+            carry_in_execution_rows=[
+                {
+                    "execution_id": "stale-route-buy-exec",
+                    "trade_decision_id": "stale-route-buy-decision",
+                    "computed_at": _runtime_split_ts(-60),
+                    "execution_event_at": _runtime_split_ts(-59),
+                    "symbol": "NVDA",
+                    "side": "buy",
+                    "filled_qty": Decimal("2"),
+                    "avg_fill_price": Decimal("90"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "paper",
+                    "strategy_id": "strategy-1",
+                    "decision_hash": "stale-route-buy-hash",
+                    "alpaca_order_id": "stale-route-buy-order",
+                    "execution_policy_hash": "old-route-policy",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                    "profit_proof_eligible": False,
+                }
+            ],
+            flat_start_position_snapshot={
+                "snapshot_id": "snapshot-flat",
+                "snapshot_as_of": "2026-05-21T14:30:00+00:00",
+                "flat": True,
+                "position_count": 0,
+                "blockers": [],
+            },
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertTrue(row["carry_in_rows_suppressed_by_flat_start_snapshot"])
+        self.assertEqual(row["flat_start_position_snapshot_id"], "snapshot-flat")
+        bucket = row["runtime_ledger_bucket"]
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["open_position_count"], 0)
+        self.assertNotIn("unclosed_position", bucket["blockers"])
         self.assertNotIn(
             "route_acquisition_probe",
             bucket["source_decision_mode_counts"],
@@ -7967,7 +8186,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 )
             ],
             [],
-            [],
         ]
         connection = _FakeConnection(cursor)
         diagnostics: dict[str, object] = {}
@@ -8264,7 +8482,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 ),
             ],
             [],
-            [],
         ]
         connection = _FakeConnection(cursor)
         diagnostics: dict[str, object] = {}
@@ -8284,7 +8501,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 source_activity_diagnostics=diagnostics,
             )
 
-        self.assertEqual(len(cursor.executed), 7)
+        self.assertEqual(len(cursor.executed), 8)
         carry_decision_query, carry_decision_params = cursor.executed[3]
         carry_execution_query, carry_execution_params = cursor.executed[4]
         carry_order_query, carry_order_params = cursor.executed[5]
@@ -8343,6 +8560,59 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(
             bucket["source_window_end"], "2026-03-06T14:40:00.000001+00:00"
         )
+        self.assertFalse(diagnostics["flat_start_position_snapshot_present"])
+        self.assertEqual(
+            diagnostics["flat_start_position_snapshot_query_error"], "IndexError"
+        )
+
+    def test_query_timestamps_records_clean_flat_start_snapshot_diagnostics(
+        self,
+    ) -> None:
+        cursor = _FakeCursor()
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        cursor._results = [
+            *cursor._results,
+            [],
+            [],
+            [],
+            [
+                (
+                    "snapshot-flat",
+                    window_start,
+                    [],
+                    "latest_before_window_start",
+                    0,
+                )
+            ],
+        ]
+        connection = _FakeConnection(cursor)
+        diagnostics: dict[str, object] = {}
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            _, _, tca_rows = _query_timestamps(
+                dsn="postgresql://example",
+                strategy_names=["intraday_tsmom_v1@paper"],
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                allow_authoritative_runtime_ledger_materialization=True,
+                source_activity_diagnostics=diagnostics,
+            )
+
+        self.assertTrue(diagnostics["flat_start_position_snapshot_present"])
+        self.assertEqual(
+            diagnostics["flat_start_position_snapshot_id"], "snapshot-flat"
+        )
+        self.assertTrue(diagnostics["flat_start_position_snapshot_flat"])
+        self.assertTrue(diagnostics["carry_in_rows_suppressed_by_flat_start_snapshot"])
+        self.assertEqual(len(tca_rows), 1)
+        self.assertTrue(tca_rows[0]["carry_in_rows_suppressed_by_flat_start_snapshot"])
+        bucket = tca_rows[0]["runtime_ledger_bucket"]
+        assert isinstance(bucket, dict)
+        self.assertTrue(bucket["carry_in_rows_suppressed_by_flat_start_snapshot"])
 
     def test_source_activity_diagnostic_blockers_classify_materialization_gap(
         self,


### PR DESCRIPTION
## Summary

- Adds flat-start position snapshot authority for runtime-window imports so stale pre-window carry-in rows are suppressed only when a clean account-flat snapshot exists.
- Threads snapshot metadata into runtime-ledger rows and source diagnostics, while stale, malformed, non-flat, missing, or unavailable snapshot data remains fail-closed.
- Covers snapshot parsing/query blockers, clean carry-in suppression, and query diagnostics in the Torghut importer tests.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py --cov=app --cov=scripts --cov-report=xml -q` (focused XML generation; expected global fail-under warning because this is not the full suite)
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
