### PR TITLE
fix(torghut): preserve runtime target metadata

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2219,23 +2219,24 @@ def _runtime_window_import_proof_hygiene_blockers(
     drift_ok: str,
 ) -> list[str]:
     blockers: list[str] = []
+    normalized_source_kind = source_kind.strip().lower().replace("-", "_")
     if not target_metadata and not _runtime_window_source_kind_is_informational(
         source_kind=source_kind,
         target_metadata=target_metadata,
     ):
         blockers.append("runtime_window_target_metadata_missing")
-    if (
-        source_kind.strip().lower().replace("-", "_")
-        == "runtime_ledger_source_collection_candidate"
-    ):
+    source_collection_candidate = (
+        normalized_source_kind == "runtime_ledger_source_collection_candidate"
+    )
+    if source_collection_candidate:
         blockers.extend(
             _source_collection_target_authorization_blockers(target_metadata)
         )
-    if not dependency_quorum_decision.strip():
+    if not source_collection_candidate and not dependency_quorum_decision.strip():
         blockers.append("dependency_quorum_decision_missing")
-    if not continuity_ok.strip():
+    if not source_collection_candidate and not continuity_ok.strip():
         blockers.append("continuity_gate_missing")
-    if not drift_ok.strip():
+    if not source_collection_candidate and not drift_ok.strip():
         blockers.append("drift_gate_missing")
     for key in (
         "runtime_ledger_target_metadata_blockers",

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -189,7 +189,9 @@ def _parse_args() -> argparse.Namespace:
             "Supported keys: hypothesis_id,candidate_id,strategy_family,"
             "strategy_name,account_label,source_account_label,observed_stage,"
             "source_dsn_env,target_dsn_env,dataset_snapshot_ref,source_manifest_ref,"
-            "source_kind,delay_adjusted_depth_stress_report_ref."
+            "source_kind,dependency_quorum_decision,continuity_ok,drift_ok,"
+            "delay_adjusted_depth_stress_report_ref,artifact_refs, and target "
+            "metadata keys accepted by runtime-window target plans."
         ),
     )
     parser.add_argument(
@@ -570,7 +572,7 @@ def _runtime_window_target_is_paper_route_collection(
     )
 
 
-def _parse_runtime_window_target_spec(spec: str) -> dict[str, str]:
+def _parse_runtime_window_target_spec(spec: str) -> dict[str, Any]:
     text = spec.strip()
     if not text:
         return {}
@@ -579,7 +581,7 @@ def _parse_runtime_window_target_spec(spec: str) -> dict[str, str]:
         if not isinstance(payload, Mapping):
             raise RuntimeError("runtime_window_target_json_not_mapping")
         return {
-            str(key).replace("-", "_"): str(value)
+            str(key).replace("-", "_"): value
             for key, value in payload.items()
             if value is not None
         }
@@ -1700,8 +1702,16 @@ def _runtime_window_targets(
                     "delay_adjusted_depth_stress_report_ref",
                     "runtime_window_delay_adjusted_depth_stress_report_ref",
                 ),
+                dependency_quorum_decision=value(
+                    "dependency_quorum_decision",
+                    "runtime_window_dependency_quorum_decision",
+                ),
+                continuity_ok=value("continuity_ok", "runtime_window_continuity_ok"),
+                drift_ok=value("drift_ok", "runtime_window_drift_ok"),
                 window_start=value("window_start", "runtime_window_start"),
                 window_end=value("window_end", "runtime_window_end"),
+                artifact_refs=_runtime_window_target_artifact_refs(payload),
+                target_metadata=_runtime_window_target_metadata(payload),
                 source_account_label=value(
                     "source_account_label",
                     "runtime_window_source_account_label",

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -3051,6 +3051,28 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             _runtime_window_import_proof_hygiene_blockers(
                 source_kind="runtime_ledger_source_collection_candidate",
                 target_metadata={
+                    "source_collection_authorized": True,
+                    "source_collection_authorization_scope": (
+                        "source_window_evidence_collection_only"
+                    ),
+                    "runtime_ledger_target_metadata_blockers": [
+                        "runtime_ledger_source_collection_only",
+                        "live_runtime_ledger_required",
+                    ],
+                },
+                dependency_quorum_decision="",
+                continuity_ok="",
+                drift_ok="",
+            ),
+            [
+                "runtime_ledger_source_collection_only",
+                "live_runtime_ledger_required",
+            ],
+        )
+        self.assertEqual(
+            _runtime_window_import_proof_hygiene_blockers(
+                source_kind="runtime_ledger_source_collection_candidate",
+                target_metadata={
                     "source_collection_authorization_scope": (
                         "source_window_evidence_collection_only"
                     )

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from datetime import datetime, timezone
 from decimal import Decimal
+import json
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -171,6 +172,60 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
             {("live", "PA3SX7FYNUTF"), ("paper", "TORGHUT_SIM")},
         )
 
+    def test_explicit_runtime_window_target_preserves_metadata_and_gates(self) -> None:
+        args = argparse.Namespace(
+            runtime_window_target=[
+                json.dumps(
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "observed_stage": "paper",
+                        "strategy_family": "microbar_cross_sectional_pairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "account_label": "TORGHUT_REPLAY",
+                        "source_account_label": "TORGHUT_REPLAY",
+                        "source_dsn_env": "SIM_DB_DSN",
+                        "target_dsn_env": "SIM_DB_DSN",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_manifest_ref": (
+                            "config/trading/hypotheses/h-pairs-01.json"
+                        ),
+                        "dependency_quorum_decision": "allow",
+                        "continuity_ok": "true",
+                        "drift_ok": "true",
+                        "artifact_refs": ["runtime-ledger-proof.json"],
+                        "source_collection_authorized": True,
+                        "source_collection_reason_codes": [
+                            "runtime_ledger_source_window_missing"
+                        ],
+                    }
+                )
+            ],
+            runtime_window_target_plan_required=False,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+        )
+
+        targets = renew._runtime_window_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        target = targets[0]
+        self.assertEqual(target.dependency_quorum_decision, "allow")
+        self.assertEqual(target.continuity_ok, "true")
+        self.assertEqual(target.drift_ok, "true")
+        self.assertEqual(target.artifact_refs, ("runtime-ledger-proof.json",))
+        assert target.target_metadata is not None
+        self.assertIs(target.target_metadata["source_collection_authorized"], True)
+        self.assertEqual(
+            target.target_metadata["source_collection_authorization_scope"],
+            "source_window_evidence_collection_only",
+        )
+        self.assertEqual(
+            target.target_metadata["source_collection_reason_codes"],
+            ["runtime_ledger_source_window_missing"],
+        )
+
     def test_observed_strategy_source_collection_plan_target_parses_for_import(
         self,
     ) -> None:
@@ -263,19 +318,13 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
                             "strategy_family": "microbar_cross_sectional_pairs",
                             "strategy_name": "microbar-cross-sectional-pairs-v1",
                             "account_label": "TORGHUT_REPLAY",
-                            "source_kind": (
-                                "simulation_exact_replay_runtime_ledger"
-                            ),
+                            "source_kind": ("simulation_exact_replay_runtime_ledger"),
                             "source_manifest_ref": (
                                 "config/trading/hypotheses/h-pairs-01.json"
                             ),
                             "artifact_refs": ["exact-ledger.json"],
-                            "exact_replay_ledger_artifact_refs": [
-                                "exact-ledger.json"
-                            ],
-                            "exact_replay_ledger_artifact_ref": (
-                                "exact-ledger.json"
-                            ),
+                            "exact_replay_ledger_artifact_refs": ["exact-ledger.json"],
+                            "exact_replay_ledger_artifact_ref": ("exact-ledger.json"),
                             "exact_replay_ledger_artifact_row_count": 6,
                             "exact_replay_ledger_artifact_fill_count": 2,
                             "promotion_allowed": False,


### PR DESCRIPTION
## Summary

- Preserve typed JSON metadata for explicit Torghut runtime-window targets instead of stringifying booleans/lists.
- Pass explicit target health-gate fields, artifact refs, and target metadata through renewal imports.
- Keep source-collection-only targets blocked by collection/live authority blockers without adding missing dependency, continuity, or drift gate noise.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen ruff check app tests scripts migrations`
- `COVERAGE_FILE=.coverage.local uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report= tests/test_renew_latest_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py && COVERAGE_FILE=.coverage.local uv run --frozen python -m coverage xml --fail-under=0 -o coverage.xml && GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 && rm -f .coverage.local coverage.xml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
