### PR TITLE
fix(torghut): query source account for runtime ledger import

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -5616,7 +5616,11 @@ def _query_timestamps(
     materialized_account_label = (
         str(target_account_label or "").strip() or source_account_label
     )
-    canonical_account_label = materialized_account_label
+    # Source DB queries must stay on the account that produced the real activity.
+    # Rows are retargeted below when the governance bucket should be materialized
+    # under a distinct account label (for example a paper/live-paper source account
+    # feeding the TORGHUT_SIM proof ledger).
+    source_query_account_label = source_account_label
     decisions: list[datetime] = []
     executions: list[datetime] = []
     tca_rows: list[dict[str, object]] = []
@@ -5700,7 +5704,7 @@ def _query_timestamps(
                 """,
                 (
                     strategy_names,
-                    canonical_account_label,
+                    source_query_account_label,
                     list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
                     window_start,
                     window_end,
@@ -5797,8 +5801,8 @@ def _query_timestamps(
                 """,
                 (
                     strategy_names,
-                    canonical_account_label,
-                    canonical_account_label,
+                    source_query_account_label,
+                    source_query_account_label,
                     window_start,
                     window_end,
                     *execution_symbol_params,
@@ -5953,10 +5957,10 @@ def _query_timestamps(
                 order by coalesce(oe.event_ts, oe.created_at), oe.created_at
                 """,
                 (
-                    canonical_account_label,
-                    canonical_account_label,
+                    source_query_account_label,
+                    source_query_account_label,
                     strategy_names,
-                    canonical_account_label,
+                    source_query_account_label,
                     source_account_label,
                     window_start,
                     window_end,
@@ -6028,7 +6032,7 @@ def _query_timestamps(
                     """,
                     (
                         strategy_names,
-                        canonical_account_label,
+                        source_query_account_label,
                         list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
                         carry_in_window_start,
                         window_start,
@@ -6120,8 +6124,8 @@ def _query_timestamps(
                     """,
                     (
                         strategy_names,
-                        canonical_account_label,
-                        canonical_account_label,
+                        source_query_account_label,
+                        source_query_account_label,
                         carry_in_window_start,
                         window_start,
                         *execution_symbol_params,
@@ -6283,10 +6287,10 @@ def _query_timestamps(
                     order by coalesce(oe.event_ts, oe.created_at), oe.created_at
                     """,
                     (
-                        canonical_account_label,
-                        canonical_account_label,
+                        source_query_account_label,
+                        source_query_account_label,
                         strategy_names,
-                        canonical_account_label,
+                        source_query_account_label,
                         source_account_label,
                         carry_in_window_start,
                         window_start,
@@ -6443,8 +6447,8 @@ def _query_timestamps(
                     order by coalesce(oe.event_ts, oe.created_at), oe.created_at
                     """,
                     (
-                        canonical_account_label,
-                        canonical_account_label,
+                        source_query_account_label,
+                        source_query_account_label,
                         source_account_label,
                         window_start,
                         window_end,
@@ -6532,7 +6536,7 @@ def _query_timestamps(
                     flat_start_position_snapshot = (
                         _flat_start_position_snapshot_from_cursor(
                             cur,
-                            account_label=canonical_account_label,
+                            account_label=source_query_account_label,
                             window_start=window_start,
                         )
                     )

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -8234,9 +8234,12 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self,
     ) -> None:
         cursor = _FakeCursor()
-        cursor._results[2] = [
-            tuple("PA3SX7FYNUTF" if item == "TORGHUT_SIM" else item for item in row)
-            for row in cursor._results[2]
+        cursor._results = [
+            [
+                tuple("PA3SX7FYNUTF" if item == "TORGHUT_SIM" else item for item in row)
+                for row in rows
+            ]
+            for rows in cursor._results
         ]
         connection = _FakeConnection(cursor)
         window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
@@ -8260,18 +8263,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         decision_params = cursor.executed[0][1]
         execution_params = cursor.executed[1][1]
         order_event_query, order_event_params = cursor.executed[2]
-        self.assertEqual(decision_params[1], "TORGHUT_SIM")
-        self.assertEqual(execution_params[1], "TORGHUT_SIM")
-        self.assertEqual(execution_params[2], "TORGHUT_SIM")
+        self.assertEqual(decision_params[1], "PA3SX7FYNUTF")
+        self.assertEqual(execution_params[1], "PA3SX7FYNUTF")
+        self.assertEqual(execution_params[2], "PA3SX7FYNUTF")
         self.assertIn("e_match.alpaca_account_label = %s", order_event_query)
         self.assertIn("d_match.alpaca_account_label = %s", order_event_query)
         self.assertEqual(
             order_event_params[:5],
             (
-                "TORGHUT_SIM",
-                "TORGHUT_SIM",
+                "PA3SX7FYNUTF",
+                "PA3SX7FYNUTF",
                 ["intraday_tsmom_v1@paper"],
-                "TORGHUT_SIM",
+                "PA3SX7FYNUTF",
                 "PA3SX7FYNUTF",
             ),
         )


### PR DESCRIPTION
## Summary

- Fixed runtime-window imports so source DB queries use `--source-account-label` for trade decisions, executions, order-feed lifecycle joins, carry-in lookback, unlinked fill scans, and flat-start position snapshots.
- Kept materialized governance/runtime-ledger rows retargeted to `--account-label`, preserving source-account lineage in bucket payloads.
- Updated the source/target account regression test to model live-paper source rows feeding a TORGHUT_SIM proof ledger and to assert the SQL account parameters stay on the source account.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'query_timestamps_uses_source_events_but_materializes_target_account or query_timestamps_filters_to_execution_eligible_decisions or query_timestamps_materializes_source_backed_carry_in'`
- PASS: `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py`
- PASS: `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- PASS: `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
