### PR TITLE
feat(torghut): add hawkes replay excitation stress

### DIFF
--- a/services/torghut/app/trading/discovery/cluster_lob_features.py
+++ b/services/torghut/app/trading/discovery/cluster_lob_features.py
@@ -12,8 +12,9 @@ import json
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
-from math import isfinite, log
+from math import exp, isfinite, log
 from typing import Any, cast
 
 from app.trading.discovery.order_flow_features import (
@@ -25,11 +26,30 @@ from app.trading.discovery.order_flow_features import (
 )
 from app.trading.models import SignalEnvelope
 
-HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION = "torghut.hpairs-clusterlob-features.v1"
+HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION = "torghut.hpairs-clusterlob-features.v2"
 HPAIRS_CLUSTER_LOB_FEATURE_CONTRACT_SCHEMA_VERSION = (
-    "torghut.hpairs-clusterlob-feature-contract.v1"
+    "torghut.hpairs-clusterlob-feature-contract.v2"
 )
 HPAIRS_CLUSTER_LOB_PROOF_SEMANTICS_LABEL = "hpairs_clusterlob_order_flow_features_preview_only_exact_replay_and_runtime_ledger_required"
+HAWKES_EXCITATION_KERNEL_SECONDS = 5.0
+HAWKES_EXCITATION_LOOKBACK_SECONDS = 30.0
+HPAIRS_CLUSTER_LOB_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2510.08085",
+        "url": "https://arxiv.org/abs/2510.08085",
+        "mechanism": "deterministic_lob_hawkes_order_flow_clustering",
+    },
+    {
+        "source_id": "arxiv-2604.23961",
+        "url": "https://arxiv.org/abs/2604.23961",
+        "mechanism": "state_dependent_hawkes_volatility_signature_stability",
+    },
+    {
+        "source_id": "arxiv-2502.17417",
+        "url": "https://arxiv.org/abs/2502.17417",
+        "mechanism": "neural_hawkes_lob_event_interaction_fill_stress",
+    },
+)
 
 _EXPLICIT_CLUSTER_FIELDS: tuple[str, ...] = (
     "cluster_lob_bucket",
@@ -52,6 +72,47 @@ _EVENT_FIELDS: tuple[str, ...] = (
 
 
 @dataclass(frozen=True)
+class HawkesExcitationSummary:
+    observed_event_time_count: int
+    mean_interarrival_seconds: float
+    p10_interarrival_seconds: float
+    burst_event_share: float
+    same_cluster_max_run: int
+    mean_self_excitation: float
+    hawkes_branching_proxy: float
+    local_supercriticality_flag: bool
+    replay_stress_score: float
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": "torghut.hpairs-hawkes-excitation-summary.v1",
+            "source_papers": [
+                dict(item) for item in HPAIRS_CLUSTER_LOB_PRIMARY_SOURCES
+            ],
+            "kernel_policy": {
+                "decay_kernel": "exp(-delta_seconds / 5)",
+                "lookback_seconds": _stable_float(HAWKES_EXCITATION_LOOKBACK_SECONDS),
+                "branching_proxy_cap": "1.5",
+                "local_supercriticality_threshold": "1.0",
+            },
+            "observed_event_time_count": self.observed_event_time_count,
+            "mean_interarrival_seconds": _stable_float(self.mean_interarrival_seconds),
+            "p10_interarrival_seconds": _stable_float(self.p10_interarrival_seconds),
+            "burst_event_share": _stable_float(self.burst_event_share),
+            "same_cluster_max_run": self.same_cluster_max_run,
+            "mean_self_excitation": _stable_float(self.mean_self_excitation),
+            "hawkes_branching_proxy": _stable_float(self.hawkes_branching_proxy),
+            "local_supercriticality_flag": self.local_supercriticality_flag,
+            "replay_stress_score": _stable_float(self.replay_stress_score),
+            "prefilter_only": True,
+            "research_ranking_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+        }
+
+
+@dataclass(frozen=True)
 class ClusterLOBFeatureSet:
     row_count: int
     symbol_count: int
@@ -61,6 +122,7 @@ class ClusterLOBFeatureSet:
     dominant_cluster_bin: str
     cluster_entropy: float
     cluster_switch_rate: float
+    hawkes_excitation_summary: HawkesExcitationSummary
     order_flow_payload: Mapping[str, Any]
     feature_schema_hash: str
 
@@ -78,6 +140,7 @@ class ClusterLOBFeatureSet:
             "dominant_cluster_bin": self.dominant_cluster_bin,
             "cluster_entropy": _stable_float(self.cluster_entropy),
             "cluster_switch_rate": _stable_float(self.cluster_switch_rate),
+            "hawkes_excitation": self.hawkes_excitation_summary.to_payload(),
             "order_flow": dict(self.order_flow_payload),
             "ranking_features": ranking_features,
             "prefilter_only": True,
@@ -100,17 +163,20 @@ class ClusterLOBFeatureSet:
             order_flow_ranking.get("imbalance_abs_mean")
         )
         missing_penalty = _float_or_zero(order_flow_ranking.get("missing_data_penalty"))
+        hawkes_stress_score = self.hawkes_excitation_summary.replay_stress_score
         return {
             "directional_alignment_score": _stable_float(directional_alignment),
             "imbalance_abs_mean": _stable_float(imbalance_abs_mean),
             "cluster_entropy": _stable_float(self.cluster_entropy),
             "cluster_switch_rate": _stable_float(self.cluster_switch_rate),
+            "hawkes_excitation_stress_score": _stable_float(hawkes_stress_score),
             "missing_data_penalty": _stable_float(missing_penalty),
             "preview_rank_feature_score": _stable_float(
                 (abs(directional_alignment) * 18.0)
                 + (imbalance_abs_mean * 10.0)
                 + (self.cluster_entropy * 4.0)
                 + (self.cluster_switch_rate * 2.0)
+                + (hawkes_stress_score * 3.0)
                 - (missing_penalty * 8.0)
             ),
         }
@@ -130,6 +196,15 @@ def cluster_lob_feature_contract(
         "explicit_cluster_fields": list(_EXPLICIT_CLUSTER_FIELDS),
         "event_fields": list(_EVENT_FIELDS),
         "bin_policy": "deterministic_explicit_bucket_or_order_event_fallback",
+        "hawkes_excitation_policy": {
+            "source_papers": [
+                dict(item) for item in HPAIRS_CLUSTER_LOB_PRIMARY_SOURCES
+            ],
+            "event_time_required_for_excitation": True,
+            "decay_kernel": "exp(-delta_seconds / 5)",
+            "lookback_seconds": _stable_float(HAWKES_EXCITATION_LOOKBACK_SECONDS),
+            "output_scope": "preview_replay_stress_ranking_only",
+        },
         "proof_neutrality": {
             "research_ranking_only": True,
             "prefilter_only": True,
@@ -159,12 +234,15 @@ def extract_cluster_lob_features(
         _cluster_bin(record, source_fields=source_fields) for record in ordered
     )
     counts: Counter[str] = Counter(bins)
+    hawkes_summary = extract_hawkes_excitation_summary(ordered, cluster_bins=bins)
     order_flow = extract_order_flow_features(ordered, horizons=horizons)
     warnings = list(order_flow.warnings)
     if not ordered:
         warnings.append("empty_cluster_lob_records")
     if "unknown_event_cluster" in counts:
         warnings.append("missing_cluster_lob_inputs")
+    if hawkes_summary.observed_event_time_count < 2:
+        warnings.append("insufficient_hawkes_event_timestamps")
     symbols = {
         symbol
         for record in ordered
@@ -173,15 +251,157 @@ def extract_cluster_lob_features(
     return ClusterLOBFeatureSet(
         row_count=len(ordered),
         symbol_count=len(symbols),
-        source_fields=tuple(sorted(source_fields | set(order_flow.source_fields))),
+        source_fields=tuple(
+            sorted(
+                source_fields
+                | set(order_flow.source_fields)
+                | ({"event_ts"} if hawkes_summary.observed_event_time_count else set())
+            )
+        ),
         warnings=tuple(dict.fromkeys(warnings)),
         cluster_bins=dict(counts),
         dominant_cluster_bin=_dominant_bin(counts),
         cluster_entropy=_normalized_entropy(counts),
         cluster_switch_rate=_switch_rate(bins),
+        hawkes_excitation_summary=hawkes_summary,
         order_flow_payload=order_flow.to_payload(),
         feature_schema_hash=build_cluster_lob_feature_schema_hash(horizons=horizons),
     )
+
+
+def extract_hawkes_excitation_summary(
+    records: Sequence[ReplayFeatureRecord],
+    *,
+    cluster_bins: Sequence[str] | None = None,
+) -> HawkesExcitationSummary:
+    """Build a deterministic Hawkes-style clustering proxy for replay stress.
+
+    This is not a fitted Hawkes model and never authorizes promotion. It actualizes
+    recent Hawkes/LOB papers into a cheap event-time stress feature: bursty
+    inter-arrivals and high self-excitation increase preview ranking pressure,
+    while exact replay, route TCA, and runtime-ledger proof remain mandatory.
+    """
+
+    ordered = tuple(sorted(records, key=_record_sort_key))
+    bins = (
+        tuple(cluster_bins)
+        if cluster_bins is not None
+        else tuple(_cluster_bin(record, source_fields=set()) for record in ordered)
+    )
+    event_pairs = tuple(
+        (timestamp, bins[index] if index < len(bins) else "unknown_event_cluster")
+        for index, record in enumerate(ordered)
+        if (timestamp := _event_time_seconds(record)) is not None
+    )
+    event_times = tuple(timestamp for timestamp, _ in event_pairs)
+    interarrivals = tuple(
+        max(0.001, current - previous)
+        for previous, current in zip(event_times, event_times[1:])
+        if current >= previous
+    )
+    mean_interarrival = _safe_mean(interarrivals)
+    p10_interarrival = _percentile(interarrivals, 10.0)
+    burst_threshold = min(1.0, max(0.001, mean_interarrival * 0.5))
+    burst_event_share = (
+        sum(1 for value in interarrivals if value <= burst_threshold)
+        / len(interarrivals)
+        if interarrivals
+        else 0.0
+    )
+    same_cluster_max_run = _same_cluster_max_run(
+        tuple(label for _, label in event_pairs)
+    )
+    excitations = tuple(
+        _hawkes_excitation_at(index, event_pairs) for index in range(len(event_pairs))
+    )
+    mean_self_excitation = _safe_mean(excitations)
+    hawkes_branching_proxy = min(1.5, mean_self_excitation / 3.0)
+    same_cluster_run_score = min(1.0, max(0, same_cluster_max_run - 1) / 5.0)
+    replay_stress_score = min(
+        1.0,
+        max(
+            0.0,
+            (min(1.0, hawkes_branching_proxy) * 0.55)
+            + (burst_event_share * 0.30)
+            + (same_cluster_run_score * 0.15),
+        ),
+    )
+    return HawkesExcitationSummary(
+        observed_event_time_count=len(event_pairs),
+        mean_interarrival_seconds=mean_interarrival,
+        p10_interarrival_seconds=p10_interarrival,
+        burst_event_share=burst_event_share,
+        same_cluster_max_run=same_cluster_max_run,
+        mean_self_excitation=mean_self_excitation,
+        hawkes_branching_proxy=hawkes_branching_proxy,
+        local_supercriticality_flag=hawkes_branching_proxy >= 1.0,
+        replay_stress_score=replay_stress_score,
+    )
+
+
+def _hawkes_excitation_at(
+    index: int, event_pairs: Sequence[tuple[float, str]]
+) -> float:
+    current_time, current_label = event_pairs[index]
+    excitation = 0.0
+    for previous_time, previous_label in reversed(event_pairs[:index]):
+        delta_seconds = current_time - previous_time
+        if delta_seconds < 0.0:
+            continue
+        if delta_seconds > HAWKES_EXCITATION_LOOKBACK_SECONDS:
+            break
+        same_cluster_weight = 1.2 if previous_label == current_label else 1.0
+        excitation += same_cluster_weight * exp(
+            -delta_seconds / HAWKES_EXCITATION_KERNEL_SECONDS
+        )
+    return excitation
+
+
+def _same_cluster_max_run(labels: Sequence[str]) -> int:
+    if not labels:
+        return 0
+    max_run = 1
+    current_run = 1
+    for previous, current in zip(labels, labels[1:]):
+        if previous == current:
+            current_run += 1
+        else:
+            max_run = max(max_run, current_run)
+            current_run = 1
+    return max(max_run, current_run)
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    clipped_percentile = max(0.0, min(100.0, percentile))
+    index = int(round((len(ordered) - 1) * clipped_percentile / 100.0))
+    return ordered[index]
+
+
+def _safe_mean(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _event_time_seconds(record: ReplayFeatureRecord) -> float | None:
+    value = _record_value(record, "event_ts")
+    if isinstance(value, datetime):
+        return value.timestamp()
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        parsed = float(value)
+        return parsed if isfinite(parsed) else None
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
 
 
 def _cluster_bin(record: ReplayFeatureRecord, *, source_fields: set[str]) -> str:
@@ -369,7 +589,10 @@ __all__ = [
     "HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION",
     "HPAIRS_CLUSTER_LOB_PROOF_SEMANTICS_LABEL",
     "ClusterLOBFeatureSet",
+    "HawkesExcitationSummary",
+    "HPAIRS_CLUSTER_LOB_PRIMARY_SOURCES",
     "build_cluster_lob_feature_schema_hash",
     "cluster_lob_feature_contract",
     "extract_cluster_lob_features",
+    "extract_hawkes_excitation_summary",
 ]

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -17,6 +17,7 @@ from app.trading.discovery.candidate_specs import CandidateSpec
 from app.trading.discovery.cluster_lob_features import (
     HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION,
     extract_cluster_lob_features,
+    extract_hawkes_excitation_summary,
 )
 from app.trading.discovery.microstructure_prefilter import (
     HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
@@ -39,6 +40,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "cluster_lob_event_clustering_proxy",
     "bounded_hpairs_clusterlob_ofi_candidate_prefilter",
     "offline_clusterlob_order_flow_feature_lane",
+    "hawkes_event_time_excitation_replay_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -370,6 +372,7 @@ class FastReplayPreviewResult:
             "implemented_mechanisms": {
                 "hpairs_clusterlob_ofi_prefilter": "deterministic bounded H-PAIRS candidate prefilter metadata only; never promotion authority",
                 "clusterlob_order_flow_feature_lane": "offline replay-tape/fixture ClusterLOB and horizon OFI features for preview ranking only",
+                "hawkes_event_time_excitation_replay_stress": "deterministic Hawkes-style event-time burst/self-excitation proxy from arXiv:2510.08085 and arXiv:2604.23961; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1716,8 +1719,16 @@ def _cluster_lob_activity_score(
         burstiness = float(np.clip(np.percentile(changes, 75), 0.0, 1.0))
     else:
         burstiness = 0.0
+    hawkes_stress = extract_hawkes_excitation_summary(rows).replay_stress_score
     return float(
-        np.clip(0.35 * label_entropy + 0.45 * pressure + 0.20 * burstiness, 0.0, 1.0)
+        np.clip(
+            0.30 * label_entropy
+            + 0.35 * pressure
+            + 0.15 * burstiness
+            + 0.20 * hawkes_stress,
+            0.0,
+            1.0,
+        )
     )
 
 

--- a/services/torghut/tests/test_cluster_lob_features.py
+++ b/services/torghut/tests/test_cluster_lob_features.py
@@ -5,8 +5,11 @@ from decimal import Decimal
 from unittest import TestCase
 
 from app.trading.discovery.cluster_lob_features import (
+    HPAIRS_CLUSTER_LOB_PRIMARY_SOURCES,
     build_cluster_lob_feature_schema_hash,
+    cluster_lob_feature_contract,
     extract_cluster_lob_features,
+    extract_hawkes_excitation_summary,
 )
 from app.trading.discovery.order_flow_features import (
     build_order_flow_feature_schema_hash,
@@ -134,6 +137,50 @@ class TestClusterLOBFeatures(TestCase):
         self.assertGreater(float(payload["cluster_entropy"]), 0.9)
         self.assertFalse(payload["promotion_authority"])
         self.assertFalse(payload["final_promotion_allowed"])
+        self.assertIn("hawkes_excitation", payload)
+        self.assertIn("hawkes_excitation_stress_score", payload["ranking_features"])
+
+    def test_hawkes_excitation_summary_records_primary_sources_and_stress(self) -> None:
+        clustered_rows = [
+            self._row(offset=offset, event_type="trade", side="buy", ofi="0.4")
+            for offset in (1, 2, 3, 4, 5, 6)
+        ]
+        sparse_rows = [
+            self._row(offset=offset, event_type="trade", side="buy", ofi="0.4")
+            for offset in (1, 61, 121, 181, 241, 301)
+        ]
+
+        clustered = extract_hawkes_excitation_summary(clustered_rows).to_payload()
+        sparse = extract_hawkes_excitation_summary(sparse_rows).to_payload()
+
+        self.assertGreater(
+            float(clustered["replay_stress_score"]),
+            float(sparse["replay_stress_score"]),
+        )
+        self.assertGreater(float(clustered["hawkes_branching_proxy"]), 0)
+        self.assertEqual(clustered["observed_event_time_count"], 6)
+        self.assertTrue(
+            {"arxiv-2510.08085", "arxiv-2604.23961"}.issubset(
+                {item["source_id"] for item in clustered["source_papers"]}
+            )
+        )
+        self.assertFalse(clustered["promotion_authority"])
+        self.assertFalse(clustered["proof_authority"])
+
+    def test_cluster_contract_exposes_hawkes_sources_without_promotion_authority(
+        self,
+    ) -> None:
+        contract = cluster_lob_feature_contract()
+        policy = contract["hawkes_excitation_policy"]
+
+        self.assertEqual(
+            [item["source_id"] for item in policy["source_papers"]],
+            [item["source_id"] for item in HPAIRS_CLUSTER_LOB_PRIMARY_SOURCES],
+        )
+        self.assertEqual(policy["output_scope"], "preview_replay_stress_ranking_only")
+        self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
+        self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertFalse(contract["proof_neutrality"]["promotion_proof"])
 
     def test_missing_partial_data_is_marked_without_authority(self) -> None:
         payload = extract_cluster_lob_features(

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -164,6 +164,10 @@ class TestFastReplayPreview(TestCase):
             "source_backed_runtime_ledger_proof_required", payload["blockers"]
         )
         self.assertIn("conformal_tail_risk", payload["implemented_mechanisms"])
+        self.assertIn(
+            "hawkes_event_time_excitation_replay_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",


### PR DESCRIPTION
## Summary

- Adds a v2 ClusterLOB replay feature contract with a deterministic Hawkes-style event-time excitation summary for replay stress/ranking only.
- Records primary-source paper metadata for arXiv:2510.08085, arXiv:2604.23961, and arXiv:2502.17417 directly in the executable feature payload/contract.
- Wires the Hawkes stress proxy into fast-replay ClusterLOB activity scoring while preserving proof semantics: no promotion authority, no synthetic PnL, and exact replay/runtime-ledger proof remain required.
- Adds regression coverage for paper-source metadata, stress discrimination between clustered and sparse event streams, and fast-replay mechanism reporting.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_cluster_lob_features.py tests/test_fast_replay.py -q`
- PASS: `cd services/torghut && uvx ruff format --check app/trading/discovery/cluster_lob_features.py app/trading/discovery/fast_replay.py tests/test_cluster_lob_features.py tests/test_fast_replay.py`
- PASS: `cd services/torghut && uvx ruff check app/trading/discovery/cluster_lob_features.py app/trading/discovery/fast_replay.py tests/test_cluster_lob_features.py tests/test_fast_replay.py`
- PASS: `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- BLOCKED (environment toolchain only): `cd services/torghut && uv sync --frozen --extra dev` could not build `crosshair-tool==0.0.102` because this container lacks `cc`; targeted pytest/ruff/pyright were run with `uv run --with ...`/`uvx` instead.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
