### PR TITLE
fix(torghut): align hpairs target materialization guard

### DIFF
--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -57,7 +57,7 @@ spec:
                     --plan-url-attempts 3 \
                     --database-dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
-                    --max-notional 25 \
+                    --max-notional 75000 \
                     --commit \
                     --allow-dynamic-target-plan \
                     --skip-unless-active-target-window \
@@ -65,9 +65,9 @@ spec:
                     --confirm-dsn-env SIM_DB_DSN \
                     --confirm-hypothesis-id H-PAIRS-01 \
                     --confirm-runtime-strategy-name microbar-cross-sectional-pairs-v1 \
-                    --confirm-selected-plan-source live_submission_gate.runtime_ledger_paper_probation_import_plan \
+                    --confirm-selected-plan-source live_submission_gate.runtime_ledger_paper_probation_import_plan,runtime_ledger_paper_probation_import_plan,next_paper_route_runtime_window_targets,next_clean_paper_route_runtime_window_targets_after_discard \
                     --confirm-target-count-min 1 \
-                    --confirm-max-notional 25 \
+                    --confirm-max-notional 75000 \
                     --operator-confirmation MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS
               env:
                 - name: TORGHUT_SIM_DB_HOST

--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -32,6 +32,12 @@ OPERATOR_CONFIRMATION = "MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS"
 DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE = (
     "live_submission_gate.runtime_ledger_paper_probation_import_plan"
 )
+DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCES = (
+    DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
+    "runtime_ledger_paper_probation_import_plan",
+    "next_paper_route_runtime_window_targets",
+    "next_clean_paper_route_runtime_window_targets_after_discard",
+)
 PROMOTION_FLAG_FIELDS = (
     "promotion_allowed",
     "promotion_authorized",
@@ -558,6 +564,13 @@ def _unique_texts(values: Sequence[object]) -> list[str]:
     return sorted({text for value in values if (text := _safe_text(value))})
 
 
+def _confirmed_selected_plan_sources(value: object) -> set[str]:
+    text = _safe_text(value)
+    if text is None:
+        return set()
+    return {item.strip() for item in text.split(",") if item.strip()}
+
+
 def _plan_flag_blockers(plan: Mapping[str, Any]) -> list[str]:
     blockers: list[str] = []
     for field in PROMOTION_FLAG_FIELDS:
@@ -633,11 +646,13 @@ def _confirmation_blockers(
                 )
     else:
         selected_plan = _safe_text(plan_source.get("selected_plan"))
-        confirmed_selected_plan = _safe_text(args.confirm_selected_plan_source)
+        confirmed_selected_plans = _confirmed_selected_plan_sources(
+            args.confirm_selected_plan_source
+        )
         if (
             not selected_plan
-            or not confirmed_selected_plan
-            or confirmed_selected_plan != selected_plan
+            or not confirmed_selected_plans
+            or selected_plan not in confirmed_selected_plans
         ):
             blockers.append(
                 "paper_route_materialization_commit_confirm_selected_plan_source_missing"
@@ -909,9 +924,8 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         dsn=dsn,
         dsn_env=dsn_env,
     )
-    if (
-        target_window_check is not None
-        and not _target_window_check_active_indexes(target_window_check)
+    if target_window_check is not None and not _target_window_check_active_indexes(
+        target_window_check
     ):
         if bool(args.skip_unless_active_target_window) and not blockers:
             skip_reason = ACTIVE_TARGET_WINDOW_SKIP_REASON
@@ -1032,7 +1046,9 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--confirm-max-notional", default=None)
     parser.add_argument("--allow-dynamic-target-plan", action="store_true")
     target_window = parser.add_mutually_exclusive_group()
-    target_window.add_argument("--skip-unless-active-target-window", action="store_true")
+    target_window.add_argument(
+        "--skip-unless-active-target-window", action="store_true"
+    )
     target_window.add_argument("--require-active-target-window", action="store_true")
     parser.add_argument("--now-utc", default=None)
     parser.add_argument("--operator-confirmation", default=None)

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1479,7 +1479,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--plan-url-attempts 3", args)
         self.assertIn("--database-dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
-        self.assertIn("--max-notional 25", args)
+        self.assertIn("--max-notional 75000", args)
         self.assertIn("--commit", args)
         self.assertIn("--allow-dynamic-target-plan", args)
         self.assertIn("--skip-unless-active-target-window", args)
@@ -1492,11 +1492,14 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertIn(
             "--confirm-selected-plan-source "
-            "live_submission_gate.runtime_ledger_paper_probation_import_plan",
+            "live_submission_gate.runtime_ledger_paper_probation_import_plan,"
+            "runtime_ledger_paper_probation_import_plan,"
+            "next_paper_route_runtime_window_targets,"
+            "next_clean_paper_route_runtime_window_targets_after_discard",
             args,
         )
         self.assertIn("--confirm-target-count-min 1", args)
-        self.assertIn("--confirm-max-notional 25", args)
+        self.assertIn("--confirm-max-notional 75000", args)
         self.assertIn(
             "--operator-confirmation MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS",
             args,

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -19,6 +19,10 @@ from app.trading.paper_route_target_plan import (
 )
 from scripts import materialize_bounded_paper_route_targets as cli
 
+HPAIRS_DYNAMIC_SELECTED_PLAN_SOURCE_CONFIRMATION = ",".join(
+    cli.DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCES
+)
+
 
 def _hpairs_target(**overrides: object) -> dict[str, Any]:
     target: dict[str, Any] = {
@@ -505,6 +509,7 @@ def test_paper_route_target_plan_json_and_scalar_helpers_preserve_report_encodin
     assert cli._json_default(generated_at) == generated_at.isoformat()
     assert cli._json_default(Path("target-plan.json")) == "target-plan.json"
     assert cli._safe_decimal("not-a-number") == Decimal("0")
+    assert cli._confirmed_selected_plan_sources(None) == set()
     assert cli._truthy(1) is True
     assert cli._truthy(0) is False
 
@@ -802,6 +807,128 @@ def test_commit_dynamic_plan_skips_before_active_target_window_without_writes(
     assert report["materialized_decision_count"] == 0
     assert report["route_submission_count"] == 0
     assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_commit_dynamic_next_window_plan_at_configured_notional_skips_before_open(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "next_paper_route_runtime_window_targets": _plan(
+            _hpairs_target(target_notional="75000")
+        ),
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "75000",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--skip-unless-active-target-window",
+            "--now-utc",
+            "2026-06-01T13:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            HPAIRS_DYNAMIC_SELECTED_PLAN_SOURCE_CONFIRMATION,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "75000",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["skipped"] is True
+    assert report["skip_reason"] == cli.ACTIVE_TARGET_WINDOW_SKIP_REASON
+    assert report["blocked"] is False
+    assert report["max_notional"] == "75000"
+    assert (
+        report["plan_source"]["selected_plan"]
+        == "next_paper_route_runtime_window_targets"
+    )
+    assert report["targets"][0]["target_notional"] == "75000"
+    assert report["target_window_check"]["active"] is False
+    assert report["materialized_decision_count"] == 0
+    assert report["route_submission_count"] == 0
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_commit_dynamic_next_window_plan_at_configured_notional_writes_when_open(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "next_paper_route_runtime_window_targets": _plan(
+            _hpairs_target(target_notional="75000")
+        ),
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "75000",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--require-active-target-window",
+            "--now-utc",
+            "2026-06-01T14:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            HPAIRS_DYNAMIC_SELECTED_PLAN_SOURCE_CONFIRMATION,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "75000",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["materialized"] is True
+    assert report["skipped"] is False
+    assert report["blocked"] is False
+    assert report["max_notional"] == "75000"
+    assert (
+        report["plan_source"]["selected_plan"]
+        == "next_paper_route_runtime_window_targets"
+    )
+    assert report["materialization"]["bounded_notional_limit"] == "75000"
+    assert report["materialized_decision_count"] == 2
+    assert report["route_submission_count"] == 2
+    assert report["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 2
 
 
 def test_commit_dynamic_plan_filters_to_active_target_window_subset(


### PR DESCRIPTION
## Summary

- Allow the bounded H-PAIRS materializer to confirm an explicit allowlist of dynamic plan sources, including `next_paper_route_runtime_window_targets`.
- Align the scheduled TORGHUT_SIM target materialization notional guard with the configured H-PAIRS paper evidence sleeve at `75000`.
- Add regressions for the next-window H-PAIRS plan skipping cleanly before market open and materializing source decisions during the active window.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k bounded_paper_route_target_materialization_cronjob_is_sim_only`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py -k 'materialize_bounded_paper_route_targets or bounded_paper_route_target_materialization_cronjob_is_sim_only'`
- `uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut | kubeconform -strict -summary -ignore-missing-schemas`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
