### PR TITLE
fix(torghut): degrade tca status query timeouts

### DIFF
--- a/services/torghut/app/trading/tca.py
+++ b/services/torghut/app/trading/tca.py
@@ -12,6 +12,7 @@ from decimal import ROUND_CEILING, Decimal
 from typing import Any, Optional, cast
 
 from sqlalchemy import func, or_, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, load_only
 
 from ..config import settings
@@ -862,21 +863,48 @@ def build_tca_gate_inputs(
         stmt = stmt.where(ExecutionTCAMetric.symbol.in_(normalized_symbols))
 
     row = session.execute(stmt).one()
-    execution_stmt = _tca_execution_coverage_stmt(
-        strategy_id=strategy_id,
-        account_label=normalized_account_label,
-        symbols=normalized_symbols,
-    )
-    unsettled_execution_stmt = _tca_execution_coverage_stmt(
-        strategy_id=strategy_id,
-        account_label=normalized_account_label,
-        symbols=normalized_symbols,
-        only_unsettled=True,
-    )
-    execution_count, latest_execution_created_at = session.execute(execution_stmt).one()
-    unsettled_execution_count = int(
-        session.execute(unsettled_execution_stmt).scalar_one() or 0
-    )
+    symbol_breakdown_reason: str | None = None
+    try:
+        symbol_breakdown = _build_tca_symbol_breakdown(
+            session,
+            strategy_id=strategy_id,
+            account_label=normalized_account_label,
+            symbols=normalized_symbols,
+        )
+    except SQLAlchemyError as exc:
+        logger.warning("TCA symbol breakdown unavailable: %s", exc)
+        session.rollback()
+        symbol_breakdown_reason = "execution_tca_symbol_breakdown_query_unavailable"
+        symbol_breakdown = _unavailable_tca_symbol_breakdown(
+            symbols=normalized_symbols,
+            reason=symbol_breakdown_reason,
+        )
+    execution_coverage_reason: str | None = None
+    try:
+        execution_stmt = _tca_execution_coverage_stmt(
+            strategy_id=strategy_id,
+            account_label=normalized_account_label,
+            symbols=normalized_symbols,
+        )
+        unsettled_execution_stmt = _tca_execution_coverage_stmt(
+            strategy_id=strategy_id,
+            account_label=normalized_account_label,
+            symbols=normalized_symbols,
+            only_unsettled=True,
+        )
+        execution_count, latest_execution_created_at = session.execute(
+            execution_stmt
+        ).one()
+        unsettled_execution_count = int(
+            session.execute(unsettled_execution_stmt).scalar_one() or 0
+        )
+    except SQLAlchemyError as exc:
+        logger.warning("TCA execution coverage unavailable: %s", exc)
+        session.rollback()
+        execution_coverage_reason = "execution_tca_execution_coverage_query_unavailable"
+        execution_count = 0
+        latest_execution_created_at = None
+        unsettled_execution_count = 0
     order_count = int(row[0] or 0)
     avg_slippage = _decimal_or_none(row[1])
     avg_abs_slippage = _decimal_or_none(row[2])
@@ -895,20 +923,41 @@ def build_tca_gate_inputs(
     expected_shortfall_coverage = (
         Decimal(expected_count) / Decimal(order_count) if order_count > 0 else None
     )
-    symbol_breakdown = _build_tca_symbol_breakdown(
-        session,
-        strategy_id=strategy_id,
-        account_label=normalized_account_label,
-        symbols=normalized_symbols,
-    )
     filled_execution_count = int(execution_count or 0)
-    runtime_ledger_lineage = _build_tca_runtime_ledger_lineage_summary(
-        session,
-        strategy_id=strategy_id,
-        account_label=normalized_account_label,
-        symbols=normalized_symbols,
-        total_filled_execution_count=filled_execution_count,
-    )
+    lineage_unavailable_reason = execution_coverage_reason
+    if lineage_unavailable_reason is None:
+        try:
+            runtime_ledger_lineage = _build_tca_runtime_ledger_lineage_summary(
+                session,
+                strategy_id=strategy_id,
+                account_label=normalized_account_label,
+                symbols=normalized_symbols,
+                total_filled_execution_count=filled_execution_count,
+            )
+        except SQLAlchemyError as exc:
+            logger.warning("TCA runtime ledger lineage unavailable: %s", exc)
+            session.rollback()
+            lineage_unavailable_reason = "runtime_tca_cost_lineage_query_unavailable"
+            runtime_ledger_lineage = _unavailable_tca_runtime_ledger_lineage_summary(
+                reason=lineage_unavailable_reason,
+                total_filled_execution_count=filled_execution_count,
+            )
+    else:
+        runtime_ledger_lineage = _unavailable_tca_runtime_ledger_lineage_summary(
+            reason=lineage_unavailable_reason,
+            total_filled_execution_count=None,
+        )
+    reason_codes = [
+        reason
+        for reason in (
+            symbol_breakdown_reason,
+            execution_coverage_reason,
+            lineage_unavailable_reason
+            if lineage_unavailable_reason != execution_coverage_reason
+            else None,
+        )
+        if reason is not None
+    ]
     return {
         "account_label": normalized_account_label or None,
         "scope_symbols": list(normalized_symbols),
@@ -952,6 +1001,8 @@ def build_tca_gate_inputs(
         "unsettled_execution_count": unsettled_execution_count,
         "symbol_breakdown": symbol_breakdown,
         "runtime_ledger_lineage": runtime_ledger_lineage,
+        "read_model_status": "degraded" if reason_codes else "ok",
+        "reason_codes": reason_codes,
     }
 
 
@@ -1095,6 +1146,43 @@ def _mark_tca_lineage_summary_fail_closed(
     summary["promotion_authority"] = False
 
 
+def _unavailable_tca_runtime_ledger_lineage_summary(
+    *,
+    reason: str,
+    total_filled_execution_count: int | None,
+) -> dict[str, object]:
+    summary = _execution_lineage_summary([])
+    sample_limit = _tca_status_lineage_sample_limit()
+    missing_count = max(
+        1,
+        int(total_filled_execution_count)
+        if total_filled_execution_count is not None
+        else 1,
+    )
+    summary.update(
+        {
+            "bounded": True,
+            "coverage_exact": False,
+            "query_limit": sample_limit,
+            "sampled_execution_count": 0,
+            "truncated": total_filled_execution_count is not None
+            and total_filled_execution_count > 0,
+            "read_model_unavailable": True,
+            "read_model_status": "timeout",
+        }
+    )
+    if total_filled_execution_count is not None:
+        summary["total_filled_execution_count"] = max(
+            0, int(total_filled_execution_count)
+        )
+    _mark_tca_lineage_summary_fail_closed(
+        summary,
+        reason=reason,
+        missing_count=missing_count,
+    )
+    return summary
+
+
 def _execution_lineage_summary(executions: Collection[Execution]) -> dict[str, object]:
     blocker_counts: dict[str, int] = {}
     source_backed_count = 0
@@ -1176,6 +1264,27 @@ def _normalize_tca_symbols(symbols: Collection[str] | None) -> tuple[str, ...]:
             {str(symbol).strip().upper() for symbol in symbols if str(symbol).strip()}
         )
     )
+
+
+def _unavailable_tca_symbol_breakdown(
+    *,
+    symbols: tuple[str, ...],
+    reason: str,
+) -> list[dict[str, object]]:
+    return [
+        {
+            "symbol": symbol,
+            "order_count": 0,
+            "avg_abs_slippage_bps": None,
+            "max_abs_slippage_bps": None,
+            "avg_realized_shortfall_bps": None,
+            "last_computed_at": None,
+            "read_model_unavailable": True,
+            "read_model_status": "timeout",
+            "reason_codes": [reason],
+        }
+        for symbol in symbols
+    ]
 
 
 def _build_tca_symbol_breakdown(

--- a/services/torghut/tests/test_execution_tca.py
+++ b/services/torghut/tests/test_execution_tca.py
@@ -4,8 +4,10 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from sqlalchemy import create_engine, func, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import settings
@@ -124,6 +126,199 @@ class TestExecutionTcaCostLineage(TestCase):
             "runtime_tca_cost_lineage_sample_truncated",
             runtime_lineage["blockers"],
         )
+
+    def test_build_tca_gate_inputs_keeps_tca_rows_when_coverage_times_out(
+        self,
+    ) -> None:
+        computed_at = datetime(2026, 6, 3, 13, 0, tzinfo=timezone.utc)
+        aggregate_result = MagicMock()
+        aggregate_result.one.return_value = (
+            3,
+            Decimal("1.1"),
+            Decimal("1.5"),
+            Decimal("0.03"),
+            Decimal("0.03"),
+            Decimal("0.02"),
+            Decimal("0.4"),
+            Decimal("0.4"),
+            3,
+            Decimal("2.0"),
+            Decimal("4.0"),
+            Decimal("0.7"),
+            Decimal("0.7"),
+            Decimal("1.3"),
+            computed_at,
+        )
+        symbol_result = MagicMock()
+        symbol_result.all.return_value = [
+            (
+                "AMZN",
+                3,
+                Decimal("1.5"),
+                Decimal("2.1"),
+                computed_at,
+                Decimal("0.7"),
+            )
+        ]
+        session = MagicMock()
+        session.execute.side_effect = [
+            aggregate_result,
+            symbol_result,
+            SQLAlchemyError("statement timeout"),
+        ]
+
+        summary = build_tca_gate_inputs(
+            session,
+            account_label="paper",
+            symbols=["AMZN"],
+        )
+
+        self.assertEqual(summary["order_count"], 3)
+        self.assertEqual(summary["scope_symbols"], ["AMZN"])
+        self.assertEqual(summary["read_model_status"], "degraded")
+        self.assertEqual(
+            summary["reason_codes"],
+            ["execution_tca_execution_coverage_query_unavailable"],
+        )
+        self.assertEqual(summary["filled_execution_count"], 0)
+        self.assertEqual(summary["unsettled_execution_count"], 0)
+        self.assertEqual(summary["last_computed_at"], computed_at)
+        symbol_breakdown = summary["symbol_breakdown"]
+        assert isinstance(symbol_breakdown, list)
+        self.assertEqual(symbol_breakdown[0]["symbol"], "AMZN")
+        self.assertEqual(symbol_breakdown[0]["order_count"], 3)
+        runtime_lineage = summary["runtime_ledger_lineage"]
+        assert isinstance(runtime_lineage, dict)
+        self.assertEqual(runtime_lineage["status"], "blocked")
+        self.assertTrue(runtime_lineage["read_model_unavailable"])
+        self.assertIn(
+            "execution_tca_execution_coverage_query_unavailable",
+            runtime_lineage["blockers"],
+        )
+        session.rollback.assert_called_once()
+
+    def test_build_tca_gate_inputs_marks_symbol_breakdown_timeout(self) -> None:
+        computed_at = datetime(2026, 6, 3, 13, 5, tzinfo=timezone.utc)
+        aggregate_result = MagicMock()
+        aggregate_result.one.return_value = (
+            2,
+            Decimal("1.1"),
+            Decimal("1.5"),
+            Decimal("0.03"),
+            Decimal("0.03"),
+            Decimal("0.02"),
+            Decimal("0.4"),
+            Decimal("0.4"),
+            2,
+            Decimal("2.0"),
+            Decimal("4.0"),
+            Decimal("0.7"),
+            Decimal("0.7"),
+            Decimal("1.3"),
+            computed_at,
+        )
+        execution_result = MagicMock()
+        execution_result.one.return_value = (0, None)
+        unsettled_result = MagicMock()
+        unsettled_result.scalar_one.return_value = 0
+        lineage_result = MagicMock()
+        lineage_result.scalars.return_value.all.return_value = []
+        session = MagicMock()
+        session.execute.side_effect = [
+            aggregate_result,
+            SQLAlchemyError("symbol timeout"),
+            execution_result,
+            unsettled_result,
+            lineage_result,
+        ]
+
+        summary = build_tca_gate_inputs(
+            session,
+            account_label="paper",
+            symbols=["AMZN"],
+        )
+
+        self.assertEqual(summary["read_model_status"], "degraded")
+        self.assertEqual(
+            summary["reason_codes"],
+            ["execution_tca_symbol_breakdown_query_unavailable"],
+        )
+        symbol_breakdown = summary["symbol_breakdown"]
+        assert isinstance(symbol_breakdown, list)
+        self.assertEqual(symbol_breakdown[0]["symbol"], "AMZN")
+        self.assertEqual(symbol_breakdown[0]["order_count"], 0)
+        self.assertTrue(symbol_breakdown[0]["read_model_unavailable"])
+        self.assertEqual(
+            symbol_breakdown[0]["reason_codes"],
+            ["execution_tca_symbol_breakdown_query_unavailable"],
+        )
+        session.rollback.assert_called_once()
+
+    def test_build_tca_gate_inputs_marks_lineage_timeout(self) -> None:
+        computed_at = datetime(2026, 6, 3, 13, 10, tzinfo=timezone.utc)
+        aggregate_result = MagicMock()
+        aggregate_result.one.return_value = (
+            2,
+            Decimal("1.1"),
+            Decimal("1.5"),
+            Decimal("0.03"),
+            Decimal("0.03"),
+            Decimal("0.02"),
+            Decimal("0.4"),
+            Decimal("0.4"),
+            2,
+            Decimal("2.0"),
+            Decimal("4.0"),
+            Decimal("0.7"),
+            Decimal("0.7"),
+            Decimal("1.3"),
+            computed_at,
+        )
+        symbol_result = MagicMock()
+        symbol_result.all.return_value = [
+            (
+                "AMZN",
+                2,
+                Decimal("1.5"),
+                Decimal("2.1"),
+                computed_at,
+                Decimal("0.7"),
+            )
+        ]
+        execution_result = MagicMock()
+        execution_result.one.return_value = (2, computed_at)
+        unsettled_result = MagicMock()
+        unsettled_result.scalar_one.return_value = 0
+        session = MagicMock()
+        session.execute.side_effect = [
+            aggregate_result,
+            symbol_result,
+            execution_result,
+            unsettled_result,
+            SQLAlchemyError("lineage timeout"),
+        ]
+
+        summary = build_tca_gate_inputs(
+            session,
+            account_label="paper",
+            symbols=["AMZN"],
+        )
+
+        self.assertEqual(summary["read_model_status"], "degraded")
+        self.assertEqual(
+            summary["reason_codes"],
+            ["runtime_tca_cost_lineage_query_unavailable"],
+        )
+        runtime_lineage = summary["runtime_ledger_lineage"]
+        assert isinstance(runtime_lineage, dict)
+        self.assertTrue(runtime_lineage["read_model_unavailable"])
+        self.assertTrue(runtime_lineage["truncated"])
+        self.assertEqual(runtime_lineage["total_filled_execution_count"], 2)
+        self.assertIn(
+            "runtime_tca_cost_lineage_query_unavailable",
+            runtime_lineage["blockers"],
+        )
+        session.rollback.assert_called_once()
 
     def test_upsert_blocks_missing_explicit_cost_without_inference(self) -> None:
         with self.session_local() as session:


### PR DESCRIPTION
## Summary

- Keep aggregate TCA gate inputs available when downstream coverage or lineage queries time out.
- Return explicit degraded read-model status and reason codes instead of dropping the whole status surface.
- Add fail-closed unavailable summaries for symbol breakdown and runtime-ledger lineage subqueries.
- Add a regression test for coverage-query timeouts preserving existing AMZN TCA rows.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_tca.py`
- `cd services/torghut && uv run --frozen pytest tests/test_tca_adaptive_policy.py -k build_tca_gate_inputs`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/tca.py tests/test_execution_tca.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/tca.py tests/test_execution_tca.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/test_execution_tca.py tests/test_tca_adaptive_policy.py -k "execution_tca or build_tca_gate_inputs"`
- `cd services/torghut && GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
