### PR TITLE
feat(torghut): add execution schedule stress preview

### DIFF
--- a/services/torghut/app/trading/discovery/execution_schedule_stress.py
+++ b/services/torghut/app/trading/discovery/execution_schedule_stress.py
@@ -1,0 +1,366 @@
+"""Preview-only execution schedule stress features for replay candidate ranking.
+
+The helpers in this module actualize recent optimal-execution papers into a
+cheap, deterministic replay harness input. They do not simulate broker fills,
+do not write ledgers, and deliberately carry no promotion authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from math import isfinite, sqrt
+from typing import Any, cast
+
+from app.trading.models import SignalEnvelope
+
+EXECUTION_SCHEDULE_STRESS_SCHEMA_VERSION = "torghut.execution-schedule-stress.v1"
+EXECUTION_SCHEDULE_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.execution-schedule-stress-contract.v1"
+)
+EXECUTION_SCHEDULE_STRESS_PROOF_SEMANTICS_LABEL = "execution_schedule_stress_preview_only_exact_replay_route_tca_runtime_ledger_required"
+EXECUTION_SCHEDULE_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2603.28898",
+        "url": "https://arxiv.org/abs/2603.28898",
+        "mechanism": "mpc_execution_schedule_completion_impact_opportunity_cost",
+    },
+    {
+        "source_id": "arxiv-2507.06345",
+        "url": "https://arxiv.org/abs/2507.06345",
+        "mechanism": "market_limit_order_mix_allocation_fill_shortfall_tradeoff",
+    },
+)
+
+
+@dataclass(frozen=True)
+class ExecutionScheduleStressSummary:
+    row_count: int
+    observed_event_time_count: int
+    observed_window_seconds: float
+    schedule_deviation_bps: float
+    opportunity_cost_bps: float
+    impact_cost_bps: float
+    market_order_share: float
+    limit_order_share: float
+    shortfall_stress_bps: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": EXECUTION_SCHEDULE_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_execution_stress_ranking",
+            "source_papers": [
+                dict(item) for item in EXECUTION_SCHEDULE_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "observed_event_time_count": self.observed_event_time_count,
+            "observed_window_seconds": _stable_float(self.observed_window_seconds),
+            "schedule_deviation_bps": _stable_float(self.schedule_deviation_bps),
+            "opportunity_cost_bps": _stable_float(self.opportunity_cost_bps),
+            "impact_cost_bps": _stable_float(self.impact_cost_bps),
+            "market_order_share": _stable_float(self.market_order_share),
+            "limit_order_share": _stable_float(self.limit_order_share),
+            "shortfall_stress_bps": _stable_float(self.shortfall_stress_bps),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "schedule_deviation_bps": _stable_float(self.schedule_deviation_bps),
+                "opportunity_cost_bps": _stable_float(self.opportunity_cost_bps),
+                "impact_cost_bps": _stable_float(self.impact_cost_bps),
+                "market_order_share": _stable_float(self.market_order_share),
+                "limit_order_share": _stable_float(self.limit_order_share),
+                "shortfall_stress_bps": _stable_float(self.shortfall_stress_bps),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "mpc_schedule_trace_preview": True,
+            "market_limit_mix_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": EXECUTION_SCHEDULE_STRESS_PROOF_SEMANTICS_LABEL,
+        }
+
+
+def execution_schedule_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": EXECUTION_SCHEDULE_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": EXECUTION_SCHEDULE_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in EXECUTION_SCHEDULE_STRESS_PRIMARY_SOURCES
+        ],
+        "schedule_policy": "twap_baseline_vs_observed_volume_curve",
+        "stress_components": [
+            "schedule_deviation_bps",
+            "opportunity_cost_bps",
+            "impact_cost_bps",
+            "market_limit_order_mix_proxy",
+        ],
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_runtime_ledger": True,
+        },
+    }
+
+
+def build_execution_schedule_stress_schema_hash() -> str:
+    return _stable_hash(execution_schedule_stress_contract())
+
+
+def extract_execution_schedule_stress(
+    records: Sequence[SignalEnvelope],
+    *,
+    direction: int | float = 1,
+    max_notional: Decimal | int | float | str | None = None,
+) -> ExecutionScheduleStressSummary:
+    """Extract deterministic MPC-style schedule stress from replay rows.
+
+    ``direction`` is +1 for buy/long execution and -1 for sell/short execution.
+    The output is a ranking/stress input only; exact replay, route TCA, and
+    runtime-ledger proof still decide promotion.
+    """
+
+    ordered = tuple(
+        sorted(records, key=lambda item: (item.event_ts, item.symbol, item.seq))
+    )
+    event_times = tuple(_event_time_seconds(row.event_ts) for row in ordered)
+    observed_event_time_count = sum(1 for item in event_times if item is not None)
+    prices = tuple(_positive_float(row.payload.get("price")) for row in ordered)
+    volumes = tuple(
+        _nonnegative_float(_first_payload_value(row, _VOLUME_FIELDS)) for row in ordered
+    )
+    spreads = tuple(
+        _nonnegative_float(row.payload.get("spread_bps")) for row in ordered
+    )
+    notional = _nonnegative_float(max_notional)
+    warnings: list[str] = []
+    if len(ordered) < 2:
+        warnings.append("insufficient_execution_schedule_rows")
+    if observed_event_time_count < 2:
+        warnings.append("insufficient_execution_schedule_timestamps")
+    valid_prices = tuple(price for price in prices if price is not None and price > 0.0)
+    if len(valid_prices) < 2:
+        warnings.append("missing_execution_price_path")
+    positive_volumes = tuple(volume for volume in volumes if volume > 0.0)
+    if not positive_volumes:
+        warnings.append("missing_execution_volume_curve")
+    if notional <= 0.0:
+        warnings.append("missing_candidate_notional_for_execution_stress")
+
+    observed_window_seconds = _observed_window_seconds(event_times)
+    schedule_deviation_bps = _schedule_deviation_bps(positive_volumes)
+    opportunity_cost_bps = _opportunity_cost_bps(valid_prices, direction=direction)
+    median_spread_bps = _median(spreads)
+    median_price = _median(valid_prices)
+    median_volume = _median(positive_volumes)
+    impact_cost_bps = _impact_cost_bps(
+        notional=notional,
+        median_price=median_price,
+        median_volume=median_volume,
+        median_spread_bps=median_spread_bps,
+    )
+    shortfall_stress_bps = (
+        schedule_deviation_bps * 0.25 + opportunity_cost_bps + impact_cost_bps
+    )
+    urgency_score = min(
+        1.0, max(0.0, (opportunity_cost_bps + schedule_deviation_bps * 0.2) / 25.0)
+    )
+    liquidity_score = (
+        min(1.0, median_spread_bps / 12.0) if median_spread_bps > 0.0 else 0.0
+    )
+    market_order_share = min(
+        0.95, max(0.05, 0.30 + urgency_score * 0.45 - liquidity_score * 0.20)
+    )
+    limit_order_share = 1.0 - market_order_share
+    missing_penalty_bps = 6.0 * len(warnings)
+    replay_rank_penalty_bps = shortfall_stress_bps + missing_penalty_bps
+    return ExecutionScheduleStressSummary(
+        row_count=len(ordered),
+        observed_event_time_count=observed_event_time_count,
+        observed_window_seconds=observed_window_seconds,
+        schedule_deviation_bps=schedule_deviation_bps,
+        opportunity_cost_bps=opportunity_cost_bps,
+        impact_cost_bps=impact_cost_bps,
+        market_order_share=market_order_share,
+        limit_order_share=limit_order_share,
+        shortfall_stress_bps=shortfall_stress_bps,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=tuple(dict.fromkeys(warnings)),
+        feature_schema_hash=build_execution_schedule_stress_schema_hash(),
+    )
+
+
+_VOLUME_FIELDS = (
+    "microbar_volume",
+    "volume",
+    "qty",
+    "quantity",
+    "size",
+    "trade_size",
+    "last_size",
+)
+
+
+def _schedule_deviation_bps(volumes: Sequence[float]) -> float:
+    if len(volumes) < 2:
+        return 0.0
+    total = sum(volumes)
+    if total <= 0.0:
+        return 0.0
+    cumulative = 0.0
+    deviations: list[float] = []
+    for index, volume in enumerate(volumes, start=1):
+        cumulative += volume
+        observed_fraction = cumulative / total
+        twap_fraction = index / len(volumes)
+        deviations.append(abs(observed_fraction - twap_fraction))
+    return min(100.0, _mean(deviations) * 100.0)
+
+
+def _opportunity_cost_bps(prices: Sequence[float], *, direction: int | float) -> float:
+    if len(prices) < 2:
+        return 0.0
+    arrival = prices[0]
+    terminal = prices[-1]
+    if arrival <= 0.0:
+        return 0.0
+    signed_move_bps = float(direction) * (terminal - arrival) / arrival * 10_000.0
+    return max(0.0, signed_move_bps)
+
+
+def _impact_cost_bps(
+    *,
+    notional: float,
+    median_price: float,
+    median_volume: float,
+    median_spread_bps: float,
+) -> float:
+    if notional <= 0.0:
+        return 0.0
+    dollar_volume = max(0.0, median_price) * max(0.0, median_volume)
+    if dollar_volume <= 0.0:
+        return 25.0 + median_spread_bps
+    participation = notional / dollar_volume
+    return min(500.0, sqrt(max(0.0, participation)) * 75.0 + median_spread_bps * 0.35)
+
+
+def _observed_window_seconds(event_times: Sequence[float | None]) -> float:
+    values = tuple(item for item in event_times if item is not None)
+    if len(values) < 2:
+        return 0.0
+    return max(0.0, values[-1] - values[0])
+
+
+def _event_time_seconds(value: datetime | None) -> float | None:
+    if value is None:
+        return None
+    return value.timestamp()
+
+
+def _first_payload_value(record: SignalEnvelope, keys: Sequence[str]) -> Any:
+    for key in keys:
+        if key in record.payload:
+            return record.payload.get(key)
+    return None
+
+
+def _positive_float(value: Any) -> float | None:
+    parsed = _float_or_none(value)
+    if parsed is None or parsed <= 0.0:
+        return None
+    return parsed
+
+
+def _nonnegative_float(value: Any) -> float:
+    parsed = _float_or_none(value)
+    if parsed is None:
+        return 0.0
+    return max(0.0, parsed)
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, Decimal):
+        parsed = float(value)
+    elif isinstance(value, (int, float)):
+        parsed = float(value)
+    else:
+        try:
+            parsed = float(str(value).strip())
+        except ValueError:
+            return None
+    return parsed if isfinite(parsed) else None
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[midpoint]
+    return (ordered[midpoint - 1] + ordered[midpoint]) / 2.0
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _stable_float(value: float) -> str:
+    if not isfinite(value):
+        return "0"
+    return f"{value:.12g}"
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(_json_ready(payload), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[Any, Any], value)
+        return {
+            str(key): _json_ready(mapping[key])
+            for key in sorted(mapping.keys(), key=str)
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        sequence = cast(Sequence[Any], value)
+        return [_json_ready(item) for item in sequence]
+    return value
+
+
+__all__ = [
+    "EXECUTION_SCHEDULE_STRESS_PRIMARY_SOURCES",
+    "EXECUTION_SCHEDULE_STRESS_PROOF_SEMANTICS_LABEL",
+    "EXECUTION_SCHEDULE_STRESS_SCHEMA_VERSION",
+    "ExecutionScheduleStressSummary",
+    "build_execution_schedule_stress_schema_hash",
+    "execution_schedule_stress_contract",
+    "extract_execution_schedule_stress",
+]

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -19,6 +19,9 @@ from app.trading.discovery.cluster_lob_features import (
     extract_cluster_lob_features,
     extract_hawkes_excitation_summary,
 )
+from app.trading.discovery.execution_schedule_stress import (
+    extract_execution_schedule_stress,
+)
 from app.trading.discovery.microstructure_prefilter import (
     HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
     HPAIRS_PREFILTER_PROOF_SOURCE,
@@ -41,6 +44,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "bounded_hpairs_clusterlob_ofi_candidate_prefilter",
     "offline_clusterlob_order_flow_feature_lane",
     "hawkes_event_time_excitation_replay_stress",
+    "mpc_market_limit_execution_schedule_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -104,6 +108,9 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     clusterlob_order_flow_features: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    execution_schedule_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -193,6 +200,7 @@ class FastReplayPreviewRow:
             ),
             "exploration_score": str(self.exploration_score),
             "frontier_bucket": self.frontier_bucket,
+            "execution_schedule_stress": dict(self.execution_schedule_stress),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
             "exact_replay_required": True,
@@ -373,6 +381,7 @@ class FastReplayPreviewResult:
                 "hpairs_clusterlob_ofi_prefilter": "deterministic bounded H-PAIRS candidate prefilter metadata only; never promotion authority",
                 "clusterlob_order_flow_feature_lane": "offline replay-tape/fixture ClusterLOB and horizon OFI features for preview ranking only",
                 "hawkes_event_time_excitation_replay_stress": "deterministic Hawkes-style event-time burst/self-excitation proxy from arXiv:2510.08085 and arXiv:2604.23961; preview ranking only",
+                "mpc_market_limit_execution_schedule_stress": "deterministic MPC-style schedule deviation/opportunity-cost/market-limit-mix stress from arXiv:2603.28898 and arXiv:2507.06345; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -560,6 +569,7 @@ class _SymbolTapeStats:
     cluster_lob_activity_score: float
     liquidity_regime_score: float
     macro_stress_veto_score: float
+    source_rows: tuple[SignalEnvelope, ...]
 
 
 def build_fast_replay_preview(
@@ -778,6 +788,7 @@ def _build_symbol_stats(rows: Sequence[SignalEnvelope]) -> dict[str, _SymbolTape
                 row_count=len(ordered),
             ),
             macro_stress_veto_score=_macro_stress_veto_score(ordered),
+            source_rows=tuple(ordered),
         )
     return stats
 
@@ -1020,6 +1031,7 @@ def _score_candidate_spec(
             frontier_bucket="not_selected",
             microstructure_prefilter=dict(microstructure_prefilter),
             clusterlob_order_flow_features=dict(clusterlob_order_flow_features),
+            execution_schedule_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1065,6 +1077,20 @@ def _score_candidate_spec(
     macro_stress_veto_score = _weighted_average(
         [(stat.macro_stress_veto_score, stat.row_count) for stat in matched]
     )
+    matched_source_rows = tuple(row for stat in matched for row in stat.source_rows)
+    execution_schedule_stress = extract_execution_schedule_stress(
+        matched_source_rows,
+        direction=direction,
+        max_notional=_candidate_notional(spec),
+    ).to_payload()
+    execution_schedule_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(execution_schedule_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
@@ -1109,6 +1135,7 @@ def _score_candidate_spec(
         - return_tail_abs_bps * 0.02
         - impact_liquidity_penalty_bps * 0.18
         - square_root_impact_capacity_penalty_bps * 0.22
+        - execution_schedule_rank_penalty_bps * 0.14
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1138,6 +1165,7 @@ def _score_candidate_spec(
         - (macro_window_concentration or 0.0) * 3.0
         - conformal_tail_risk_penalty_bps * 0.04
         - square_root_impact_capacity_penalty_bps * 0.08
+        - execution_schedule_rank_penalty_bps * 0.05
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1173,6 +1201,7 @@ def _score_candidate_spec(
         frontier_bucket="not_selected",
         microstructure_prefilter=dict(microstructure_prefilter),
         clusterlob_order_flow_features=dict(clusterlob_order_flow_features),
+        execution_schedule_stress=dict(execution_schedule_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1207,8 +1236,14 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         float(row.robust_lower_percentile_post_cost_utility_bps)
         - float(row.macro_stress_veto_score) * 25.0
         - float(row.square_root_impact_capacity_penalty_bps) * 0.15
+        - _execution_schedule_rank_penalty_bps(row) * 0.08
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
+
+
+def _execution_schedule_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
+    ranking_features = _mapping(row.execution_schedule_stress.get("ranking_features"))
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
 
 def _row_explicitly_non_hpairs(row: FastReplayPreviewRow) -> bool:
@@ -1397,6 +1432,7 @@ def _row_with_rank_and_selection(
         frontier_bucket=frontier_bucket,
         microstructure_prefilter=dict(row.microstructure_prefilter),
         clusterlob_order_flow_features=dict(row.clusterlob_order_flow_features),
+        execution_schedule_stress=dict(row.execution_schedule_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -1454,6 +1490,7 @@ def _row_with_frontier_dedupe(
         frontier_bucket=row.frontier_bucket,
         microstructure_prefilter=dict(row.microstructure_prefilter),
         clusterlob_order_flow_features=dict(row.clusterlob_order_flow_features),
+        execution_schedule_stress=dict(row.execution_schedule_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,

--- a/services/torghut/tests/test_execution_schedule_stress.py
+++ b/services/torghut/tests/test_execution_schedule_stress.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.execution_schedule_stress import (
+    EXECUTION_SCHEDULE_STRESS_PRIMARY_SOURCES,
+    execution_schedule_stress_contract,
+    extract_execution_schedule_stress,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestExecutionScheduleStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        price: str,
+        volume: str,
+        spread_bps: str = "2",
+    ) -> SignalEnvelope:
+        return SignalEnvelope(
+            event_ts=datetime(2026, 3, 30, 13, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset),
+            symbol="AAA",
+            timeframe="1S",
+            seq=offset,
+            source="fixture",
+            payload={
+                "price": Decimal(price),
+                "microbar_volume": Decimal(volume),
+                "spread_bps": Decimal(spread_bps),
+            },
+            ingest_ts=datetime(2026, 3, 30, 13, 30, 1, tzinfo=timezone.utc),
+        )
+
+    def test_clustered_volume_and_adverse_price_path_raise_schedule_stress(
+        self,
+    ) -> None:
+        adverse_rows = [
+            self._row(offset=0, price="100", volume="100"),
+            self._row(offset=1, price="101", volume="100"),
+            self._row(offset=2, price="102", volume="10000"),
+            self._row(offset=3, price="103", volume="100"),
+        ]
+        benign_rows = [
+            self._row(offset=0, price="100", volume="1000"),
+            self._row(offset=1, price="100", volume="1000"),
+            self._row(offset=2, price="100", volume="1000"),
+            self._row(offset=3, price="100", volume="1000"),
+        ]
+
+        adverse = extract_execution_schedule_stress(
+            adverse_rows, direction=1, max_notional=Decimal("25000")
+        ).to_payload()
+        benign = extract_execution_schedule_stress(
+            benign_rows, direction=1, max_notional=Decimal("25000")
+        ).to_payload()
+
+        self.assertGreater(
+            float(adverse["schedule_deviation_bps"]),
+            float(benign["schedule_deviation_bps"]),
+        )
+        self.assertGreater(float(adverse["opportunity_cost_bps"]), 0)
+        self.assertGreater(
+            float(adverse["replay_rank_penalty_bps"]),
+            float(benign["replay_rank_penalty_bps"]),
+        )
+        self.assertTrue(adverse["mpc_schedule_trace_preview"])
+        self.assertTrue(adverse["market_limit_mix_preview"])
+        self.assertFalse(adverse["proof_authority"])
+        self.assertFalse(adverse["promotion_authority"])
+
+    def test_contract_records_primary_sources_without_promotion_authority(self) -> None:
+        contract = execution_schedule_stress_contract()
+
+        self.assertEqual(
+            [item["source_id"] for item in contract["source_papers"]],
+            [item["source_id"] for item in EXECUTION_SCHEDULE_STRESS_PRIMARY_SOURCES],
+        )
+        self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
+        self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
+        self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertFalse(contract["proof_neutrality"]["promotion_proof"])

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -168,11 +168,20 @@ class TestFastReplayPreview(TestCase):
             "hawkes_event_time_excitation_replay_stress",
             payload["implemented_mechanisms"],
         )
+        self.assertIn(
+            "mpc_market_limit_execution_schedule_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",
         )
         self.assertIn("observed_post_cost_expectancy_bps", row_payload)
+        self.assertIn("execution_schedule_stress", row_payload)
+        self.assertFalse(row_payload["execution_schedule_stress"]["proof_authority"])
+        self.assertFalse(
+            row_payload["execution_schedule_stress"]["promotion_authority"]
+        )
         self.assertIn("cost_impact_lineage", row_payload)
         self.assertIn("impact_capacity_lineage", row_payload)
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Adds a preview-only MPC/market-limit execution schedule stress harness for fast replay candidate ranking.
- Records arXiv:2603.28898 and arXiv:2507.06345 source metadata in the executable stress contract and payload.
- Wires schedule deviation, opportunity cost, impact cost, and market/limit mix stress into fast-replay ranking without creating proof artifacts or promotion authority.
- Adds regression coverage for source metadata, adverse schedule stress discrimination, and fast-replay payload authority boundaries.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_execution_schedule_stress.py tests/test_fast_replay.py -q`
- PASS: `cd services/torghut && uvx ruff format --check app/trading/discovery/execution_schedule_stress.py app/trading/discovery/fast_replay.py tests/test_execution_schedule_stress.py tests/test_fast_replay.py`
- PASS: `cd services/torghut && uvx ruff check app/trading/discovery/execution_schedule_stress.py app/trading/discovery/fast_replay.py tests/test_execution_schedule_stress.py tests/test_fast_replay.py`
- PASS: `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
