### PR TITLE
fix(torghut): filter confirmed paper materialization targets

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -571,6 +571,34 @@ def _confirmed_selected_plan_sources(value: object) -> set[str]:
     return {item.strip() for item in text.split(",") if item.strip()}
 
 
+def _confirmed_dynamic_target_filters(args: argparse.Namespace) -> dict[str, str]:
+    if not bool(args.commit) or not bool(args.allow_dynamic_target_plan):
+        return {}
+    filters = {
+        "hypothesis_id": _safe_text(args.confirm_hypothesis_id),
+        "runtime_strategy_name": _safe_text(args.confirm_runtime_strategy_name),
+        "candidate_id": _safe_text(args.confirm_candidate_id),
+        "target_plan_ref": _safe_text(args.confirm_target_plan_ref),
+    }
+    return {field: value for field, value in filters.items() if value}
+
+
+def _confirmed_dynamic_target_indexes(
+    summaries: Sequence[Mapping[str, Any]],
+    filters: Mapping[str, str],
+) -> list[int]:
+    if not filters:
+        return []
+    indexes: list[int] = []
+    for summary in summaries:
+        if all(
+            _safe_text(summary.get(field)) == expected
+            for field, expected in filters.items()
+        ):
+            indexes.append(int(summary.get("target_index", 0)))
+    return indexes
+
+
 def _plan_flag_blockers(plan: Mapping[str, Any]) -> list[str]:
     blockers: list[str] = []
     for field in PROMOTION_FLAG_FIELDS:
@@ -897,20 +925,32 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     source_summaries = _target_summaries(source_plan)
     materialization_plan = source_plan
     summaries = source_summaries
+    confirmed_dynamic_target_filter = _confirmed_dynamic_target_filters(args)
+    confirmed_dynamic_target_filter_applied = False
     active_target_window_filter_applied = False
     target_window_check: dict[str, Any] | None = None
     skip_reason: str | None = None
+    if confirmed_dynamic_target_filter:
+        confirmed_indexes = _confirmed_dynamic_target_indexes(
+            summaries,
+            confirmed_dynamic_target_filter,
+        )
+        materialization_plan = _plan_with_target_indexes(source_plan, confirmed_indexes)
+        summaries = _target_summaries(materialization_plan)
+        confirmed_dynamic_target_filter_applied = len(confirmed_indexes) != len(
+            source_summaries
+        )
     if bool(args.skip_unless_active_target_window) or bool(
         args.require_active_target_window
     ):
         target_window_check = _active_target_window_check(
-            source_summaries,
+            summaries,
             now=_resolve_now_utc(args),
         )
         active_target_indexes = _target_window_check_active_indexes(target_window_check)
-        if active_target_indexes and len(active_target_indexes) < len(source_summaries):
+        if active_target_indexes and len(active_target_indexes) < len(summaries):
             materialization_plan = _plan_with_target_indexes(
-                source_plan,
+                materialization_plan,
                 active_target_indexes,
             )
             summaries = _target_summaries(materialization_plan)
@@ -979,6 +1019,8 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "operator_confirmation_required": OPERATOR_CONFIRMATION if commit else None,
         "dynamic_target_plan_confirmation": bool(args.allow_dynamic_target_plan),
         "default_dynamic_selected_plan_source": DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
+        "confirmed_dynamic_target_filter": confirmed_dynamic_target_filter or None,
+        "confirmed_dynamic_target_filter_applied": confirmed_dynamic_target_filter_applied,
         "target_window_check": target_window_check,
         "active_target_window_filter_applied": active_target_window_filter_applied,
         "source_target_count": len(source_summaries),
@@ -997,7 +1039,8 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         ),
         "targets": summaries,
         "source_targets": source_summaries
-        if active_target_window_filter_applied
+        if confirmed_dynamic_target_filter_applied
+        or active_target_window_filter_applied
         else None,
         "materialization": materialization,
         "materialized_decision_count": int(

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -80,6 +80,44 @@ def _hpairs_target(**overrides: object) -> dict[str, Any]:
     return target
 
 
+def _tsmom_target(**overrides: object) -> dict[str, Any]:
+    target: dict[str, Any] = {
+        "hypothesis_id": "H-TSMOM-LIQ-01",
+        "candidate_id": "ca4e6e3c7d639e3363dc5860",
+        "runtime_strategy_name": "intraday-tsmom-profit-v3",
+        "strategy_name": "intraday-tsmom-profit-v3",
+        "account_label": "TORGHUT_SIM",
+        "source_plan_ref": "paper-route-plan:ca4e6e3c7d639e3363dc5860",
+        "source_manifest_ref": "config/trading/hypotheses/h-tsmom-liq-01.json",
+        "target_notional": "75000",
+        "target_quantity": "8",
+        "bounded_collection_stage": "paper",
+        "evidence_collection_stage": "paper",
+        "window_start": "2026-06-01T13:30:00+00:00",
+        "window_end": "2026-06-01T20:00:00+00:00",
+        "paper_route_probe_symbol_actions": {},
+        "paper_route_probe_symbol_quantities": {
+            "AAPL": "1",
+            "AMD": "1",
+            "AMZN": "1",
+            "AVGO": "1",
+            "GOOGL": "1",
+            "INTC": "1",
+            "NVDA": "1",
+            "ORCL": "1",
+        },
+        "bounded_evidence_collection_authorized": True,
+        "capital_promotion_allowed": False,
+        "promotion_allowed": False,
+        "final_authority_ok": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "live_capital_routing_enabled": False,
+    }
+    target.update(overrides)
+    return target
+
+
 def _plan(*targets: dict[str, Any], **overrides: object) -> dict[str, Any]:
     plan: dict[str, Any] = {
         "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
@@ -510,6 +548,13 @@ def test_paper_route_target_plan_json_and_scalar_helpers_preserve_report_encodin
     assert cli._json_default(Path("target-plan.json")) == "target-plan.json"
     assert cli._safe_decimal("not-a-number") == Decimal("0")
     assert cli._confirmed_selected_plan_sources(None) == set()
+    assert (
+        cli._confirmed_dynamic_target_filters(
+            Namespace(commit=False, allow_dynamic_target_plan=True)
+        )
+        == {}
+    )
+    assert cli._confirmed_dynamic_target_indexes([], {}) == []
     assert cli._truthy(1) is True
     assert cli._truthy(0) is False
 
@@ -929,6 +974,131 @@ def test_commit_dynamic_next_window_plan_at_configured_notional_writes_when_open
     assert report["route_submission_count"] == 2
     assert report["blockers"] == []
     assert _count_decisions(sqlite_dsn) == 2
+
+
+def test_commit_dynamic_next_window_plan_filters_to_confirmed_hpairs_target(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "next_paper_route_runtime_window_targets": _plan(
+            _tsmom_target(),
+            _hpairs_target(target_notional="75000"),
+        ),
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "75000",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--require-active-target-window",
+            "--now-utc",
+            "2026-06-01T14:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            HPAIRS_DYNAMIC_SELECTED_PLAN_SOURCE_CONFIRMATION,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "75000",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["blocked"] is False
+    assert report["materialized"] is True
+    assert report["source_target_count"] == 2
+    assert report["target_count"] == 1
+    assert report["confirmed_dynamic_target_filter"] == {
+        "hypothesis_id": "H-PAIRS-01",
+        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+    }
+    assert report["confirmed_dynamic_target_filter_applied"] is True
+    assert report["target_window_check"]["active"] is True
+    assert report["target_window_check"]["active_count"] == 1
+    assert report["source_targets"][0]["hypothesis_id"] == "H-TSMOM-LIQ-01"
+    assert report["targets"][0]["hypothesis_id"] == "H-PAIRS-01"
+    assert report["targets"][0]["symbol_actions"] == {"AAPL": "buy", "AMZN": "sell"}
+    assert report["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 2
+
+
+def test_commit_dynamic_next_window_plan_blocks_when_confirmed_target_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "next_paper_route_runtime_window_targets": _plan(_tsmom_target()),
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "75000",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--require-active-target-window",
+            "--now-utc",
+            "2026-06-01T14:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            HPAIRS_DYNAMIC_SELECTED_PLAN_SOURCE_CONFIRMATION,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "75000",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert report["blocked"] is True
+    assert report["materialized"] is False
+    assert report["source_target_count"] == 1
+    assert report["target_count"] == 0
+    assert report["confirmed_dynamic_target_filter_applied"] is True
+    assert report["source_targets"][0]["hypothesis_id"] == "H-TSMOM-LIQ-01"
+    assert (
+        "paper_route_materialization_target_plan_targets_missing" in report["blockers"]
+    )
+    assert (
+        "paper_route_materialization_commit_confirm_target_count_min_missing"
+        in report["blockers"]
+    )
+    assert _count_decisions(sqlite_dsn) == 0
 
 
 def test_commit_dynamic_plan_filters_to_active_target_window_subset(


### PR DESCRIPTION
## Summary

- Filters dynamic paper-route materialization plans to the explicitly confirmed target identity before safety checks run.
- Keeps mixed dynamic plans fail-closed: absent confirmed targets block instead of materializing another strategy.
- Adds regression coverage for the live mixed H-PAIRS/TSMOM next-window target-plan shape.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k bounded_paper_route_target_materialization_cronjob_is_sim_only`
- `uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py --cov=scripts.materialize_bounded_paper_route_targets --cov-report=term-missing`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
