### PR TITLE
fix(torghut): filter dynamic paper target materialization

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -560,6 +560,43 @@ def _plan_with_target_indexes(
     }
 
 
+def _dynamic_confirmation_filter_requested(args: argparse.Namespace) -> bool:
+    return any(
+        _safe_text(getattr(args, name, None)) is not None
+        for name in (
+            "confirm_hypothesis_id",
+            "confirm_runtime_strategy_name",
+            "confirm_candidate_id",
+            "confirm_target_plan_ref",
+        )
+    )
+
+
+def _dynamic_confirmation_target_indexes(
+    *,
+    args: argparse.Namespace,
+    summaries: Sequence[Mapping[str, Any]],
+) -> list[int]:
+    filters = {
+        "hypothesis_id": _safe_text(args.confirm_hypothesis_id),
+        "runtime_strategy_name": _safe_text(args.confirm_runtime_strategy_name),
+        "candidate_id": _safe_text(args.confirm_candidate_id),
+        "target_plan_ref": _safe_text(args.confirm_target_plan_ref),
+    }
+    active_filters = {key: value for key, value in filters.items() if value is not None}
+    if not active_filters:
+        return list(range(len(summaries)))
+
+    indexes: list[int] = []
+    for index, summary in enumerate(summaries):
+        if all(
+            _safe_text(summary.get(key)) == value
+            for key, value in active_filters.items()
+        ):
+            indexes.append(index)
+    return indexes
+
+
 def _unique_texts(values: Sequence[object]) -> list[str]:
     return sorted({text for value in values if (text := _safe_text(value))})
 
@@ -898,8 +935,23 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     materialization_plan = source_plan
     summaries = source_summaries
     active_target_window_filter_applied = False
+    dynamic_target_confirmation_filter_applied = False
     target_window_check: dict[str, Any] | None = None
     skip_reason: str | None = None
+    if bool(args.allow_dynamic_target_plan) and _dynamic_confirmation_filter_requested(
+        args
+    ):
+        dynamic_target_indexes = _dynamic_confirmation_target_indexes(
+            args=args,
+            summaries=summaries,
+        )
+        if len(dynamic_target_indexes) != len(summaries):
+            materialization_plan = _plan_with_target_indexes(
+                materialization_plan,
+                dynamic_target_indexes,
+            )
+            summaries = _target_summaries(materialization_plan)
+            dynamic_target_confirmation_filter_applied = True
     if bool(args.skip_unless_active_target_window) or bool(
         args.require_active_target_window
     ):
@@ -981,6 +1033,9 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "default_dynamic_selected_plan_source": DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
         "target_window_check": target_window_check,
         "active_target_window_filter_applied": active_target_window_filter_applied,
+        "dynamic_target_confirmation_filter_applied": (
+            dynamic_target_confirmation_filter_applied
+        ),
         "source_target_count": len(source_summaries),
         "target_count": len(summaries),
         "hypothesis_ids": _unique_texts(
@@ -998,6 +1053,7 @@ def build_report(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "targets": summaries,
         "source_targets": source_summaries
         if active_target_window_filter_applied
+        or dynamic_target_confirmation_filter_applied
         else None,
         "materialization": materialization,
         "materialized_decision_count": int(

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -931,6 +931,105 @@ def test_commit_dynamic_next_window_plan_at_configured_notional_writes_when_open
     assert _count_decisions(sqlite_dsn) == 2
 
 
+def test_commit_dynamic_plan_filters_to_confirmed_hpairs_target_before_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    malformed_tsmom_target = {
+        "hypothesis_id": "H-TSMOM-LIQ-01",
+        "candidate_id": "ca4e6e3c7d639e3363dc5860",
+        "runtime_strategy_name": "intraday-tsmom-profit-v3",
+        "strategy_name": "intraday-tsmom-profit-v3",
+        "account_label": "TORGHUT_SIM",
+        "source_manifest_ref": "config/trading/hypotheses/h-tsmom-liq-01.json",
+        "source_plan_ref": "config/trading/hypotheses/h-tsmom-liq-01.json",
+        "target_notional": "75000",
+        "target_quantity": "8",
+        "bounded_collection_stage": "paper",
+        "evidence_collection_stage": "paper",
+        "window_start": "2026-06-01T13:30:00+00:00",
+        "window_end": "2026-06-01T20:00:00+00:00",
+        "paper_route_probe_symbol_actions": {},
+        "paper_route_probe_symbol_quantities": {
+            "AAPL": "1",
+            "AMD": "1",
+            "AMZN": "1",
+            "AVGO": "1",
+            "GOOGL": "1",
+            "INTC": "1",
+            "NVDA": "1",
+            "ORCL": "1",
+        },
+        "evidence_collection_ok": True,
+        "bounded_evidence_collection_authorized": True,
+        "capital_promotion_allowed": False,
+        "promotion_allowed": False,
+        "final_authority_ok": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "live_capital_routing_enabled": False,
+    }
+    payload = {
+        "next_paper_route_runtime_window_targets": _plan(
+            malformed_tsmom_target,
+            _hpairs_target(target_notional="75000"),
+        ),
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "75000",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--require-active-target-window",
+            "--now-utc",
+            "2026-06-01T14:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            HPAIRS_DYNAMIC_SELECTED_PLAN_SOURCE_CONFIRMATION,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "75000",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["materialized"] is True
+    assert report["blocked"] is False
+    assert report["source_target_count"] == 2
+    assert report["target_count"] == 1
+    assert report["dynamic_target_confirmation_filter_applied"] is True
+    assert report["hypothesis_ids"] == ["H-PAIRS-01"]
+    assert report["runtime_strategy_names"] == ["microbar-cross-sectional-pairs-v1"]
+    assert report["source_targets"][0]["hypothesis_id"] == "H-TSMOM-LIQ-01"
+    assert report["source_targets"][0]["symbol_actions"] == {}
+    assert (
+        "paper_route_materialization_target_0_symbol_actions_missing"
+        not in report["blockers"]
+    )
+    assert report["materialized_decision_count"] == 2
+    assert report["route_submission_count"] == 2
+    assert _count_decisions(sqlite_dsn) == 2
+
+
 def test_commit_dynamic_plan_filters_to_active_target_window_subset(
     monkeypatch: pytest.MonkeyPatch,
     sqlite_dsn: str,


### PR DESCRIPTION
## Summary

- Filters dynamic bounded paper-route materialization targets by explicit operator confirmation fields before safety validation.
- Preserves strict validation for static plans and for dynamic plans with no matching confirmed target.
- Adds regression coverage for the live mixed H-TSMOM/H-PAIRS plan shape where only H-PAIRS is materializable and operator-confirmed.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -k 'dynamic_plan_filters_to_confirmed_hpairs_target_before_validation' -q`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen pytest tests/test_paper_route_target_plan.py tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen python -m compileall scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
