### PR TITLE
feat(torghut): add order book observability stress

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -27,6 +27,9 @@ from app.trading.discovery.microstructure_prefilter import (
     HPAIRS_PREFILTER_PROOF_SOURCE,
     build_hpairs_microstructure_prefilter,
 )
+from app.trading.discovery.order_book_observability_stress import (
+    extract_order_book_observability_stress,
+)
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
@@ -45,6 +48,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "offline_clusterlob_order_flow_feature_lane",
     "hawkes_event_time_excitation_replay_stress",
     "mpc_market_limit_execution_schedule_stress",
+    "order_book_observability_feedback_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -111,6 +115,9 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     execution_schedule_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    order_book_observability_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -201,6 +208,9 @@ class FastReplayPreviewRow:
             "exploration_score": str(self.exploration_score),
             "frontier_bucket": self.frontier_bucket,
             "execution_schedule_stress": dict(self.execution_schedule_stress),
+            "order_book_observability_stress": dict(
+                self.order_book_observability_stress
+            ),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
             "exact_replay_required": True,
@@ -382,6 +392,7 @@ class FastReplayPreviewResult:
                 "clusterlob_order_flow_feature_lane": "offline replay-tape/fixture ClusterLOB and horizon OFI features for preview ranking only",
                 "hawkes_event_time_excitation_replay_stress": "deterministic Hawkes-style event-time burst/self-excitation proxy from arXiv:2510.08085 and arXiv:2604.23961; preview ranking only",
                 "mpc_market_limit_execution_schedule_stress": "deterministic MPC-style schedule deviation/opportunity-cost/market-limit-mix stress from arXiv:2603.28898 and arXiv:2507.06345; preview ranking only",
+                "order_book_observability_feedback_stress": "deterministic order-book feedback/censored-trade and state-dependent spread-cost stress from arXiv:2605.19584 and arXiv:2507.09196; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1032,6 +1043,7 @@ def _score_candidate_spec(
             microstructure_prefilter=dict(microstructure_prefilter),
             clusterlob_order_flow_features=dict(clusterlob_order_flow_features),
             execution_schedule_stress={},
+            order_book_observability_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1091,6 +1103,19 @@ def _score_candidate_spec(
         )
         or 0.0
     )
+    order_book_observability_stress = extract_order_book_observability_stress(
+        matched_source_rows,
+        direction=direction,
+        max_notional=_candidate_notional(spec),
+    ).to_payload()
+    order_book_observability_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(order_book_observability_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
@@ -1136,6 +1161,7 @@ def _score_candidate_spec(
         - impact_liquidity_penalty_bps * 0.18
         - square_root_impact_capacity_penalty_bps * 0.22
         - execution_schedule_rank_penalty_bps * 0.14
+        - order_book_observability_rank_penalty_bps * 0.12
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1166,6 +1192,7 @@ def _score_candidate_spec(
         - conformal_tail_risk_penalty_bps * 0.04
         - square_root_impact_capacity_penalty_bps * 0.08
         - execution_schedule_rank_penalty_bps * 0.05
+        - order_book_observability_rank_penalty_bps * 0.04
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1202,6 +1229,7 @@ def _score_candidate_spec(
         microstructure_prefilter=dict(microstructure_prefilter),
         clusterlob_order_flow_features=dict(clusterlob_order_flow_features),
         execution_schedule_stress=dict(execution_schedule_stress),
+        order_book_observability_stress=dict(order_book_observability_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1237,12 +1265,20 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - float(row.macro_stress_veto_score) * 25.0
         - float(row.square_root_impact_capacity_penalty_bps) * 0.15
         - _execution_schedule_rank_penalty_bps(row) * 0.08
+        - _order_book_observability_rank_penalty_bps(row) * 0.07
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
 
 def _execution_schedule_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
     ranking_features = _mapping(row.execution_schedule_stress.get("ranking_features"))
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _order_book_observability_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
+    ranking_features = _mapping(
+        row.order_book_observability_stress.get("ranking_features")
+    )
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
 
@@ -1433,6 +1469,7 @@ def _row_with_rank_and_selection(
         microstructure_prefilter=dict(row.microstructure_prefilter),
         clusterlob_order_flow_features=dict(row.clusterlob_order_flow_features),
         execution_schedule_stress=dict(row.execution_schedule_stress),
+        order_book_observability_stress=dict(row.order_book_observability_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -1491,6 +1528,7 @@ def _row_with_frontier_dedupe(
         microstructure_prefilter=dict(row.microstructure_prefilter),
         clusterlob_order_flow_features=dict(row.clusterlob_order_flow_features),
         execution_schedule_stress=dict(row.execution_schedule_stress),
+        order_book_observability_stress=dict(row.order_book_observability_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -2286,6 +2324,8 @@ def _risk_flags_for_row(
         flags.add("conformal_tail_risk_penalty_active")
     if row.square_root_impact_capacity_penalty_bps > 0:
         flags.add("square_root_impact_capacity_penalty_active")
+    if _order_book_observability_rank_penalty_bps(row) > 0:
+        flags.add("order_book_observability_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
         flags.add("partial_symbol_coverage")
     if row.trading_day_count <= 0:
@@ -2314,6 +2354,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("conformal_tail_risk_buffer_downranks_only")
     if row.square_root_impact_capacity_penalty_bps > 0:
         reasons.add("square_root_impact_capacity_cap_downranks_only")
+    if _order_book_observability_rank_penalty_bps(row) > 0:
+        reasons.add("order_book_observability_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
         reasons.add("missing_replay_tape_source_data_explicit_blocker")
     if lineage_blockers:
@@ -2335,6 +2377,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("liquidity_regime_unobserved_or_weak")
     if row.square_root_impact_capacity_penalty_bps > 0:
         vetoes.add("square_root_impact_capacity_penalty")
+    if _order_book_observability_rank_penalty_bps(row) > 0:
+        vetoes.add("order_book_observability_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:
         vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
     return tuple(sorted(vetoes))

--- a/services/torghut/app/trading/discovery/order_book_observability_stress.py
+++ b/services/torghut/app/trading/discovery/order_book_observability_stress.py
@@ -1,0 +1,557 @@
+"""Preview-only order-book observability stress for replay candidate ranking.
+
+This module converts recent market-making and stochastic-cost papers into a
+bounded replay harness input. It never simulates fills, writes ledgers, or
+creates promotion authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from math import isfinite
+from typing import Any, cast
+
+from app.trading.models import SignalEnvelope
+
+ORDER_BOOK_OBSERVABILITY_STRESS_SCHEMA_VERSION = (
+    "torghut.order-book-observability-stress.v1"
+)
+ORDER_BOOK_OBSERVABILITY_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.order-book-observability-stress-contract.v1"
+)
+ORDER_BOOK_OBSERVABILITY_STRESS_PROOF_SEMANTICS_LABEL = (
+    "order_book_observability_stress_preview_only_exact_replay_route_tca_"
+    "runtime_ledger_required"
+)
+ORDER_BOOK_OBSERVABILITY_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2605.19584",
+        "url": "https://arxiv.org/abs/2605.19584",
+        "mechanism": "order_book_observation_feedback_vs_trade_censoring",
+    },
+    {
+        "source_id": "arxiv-2507.09196",
+        "url": "https://arxiv.org/abs/2507.09196",
+        "mechanism": "state_dependent_stochastic_transaction_cost_lob_proxy",
+    },
+)
+
+_BID_FIELDS: tuple[str, ...] = ("bid", "best_bid", "bid_price", "best_bid_price")
+_ASK_FIELDS: tuple[str, ...] = ("ask", "best_ask", "ask_price", "best_ask_price")
+_BID_SIZE_FIELDS: tuple[str, ...] = (
+    "bid_size",
+    "bid_qty",
+    "best_bid_size",
+    "best_bid_qty",
+    "bid_depth",
+    "bid_volume",
+)
+_ASK_SIZE_FIELDS: tuple[str, ...] = (
+    "ask_size",
+    "ask_qty",
+    "best_ask_size",
+    "best_ask_qty",
+    "ask_depth",
+    "ask_volume",
+)
+_PRICE_FIELDS: tuple[str, ...] = (
+    "price",
+    "mid_price",
+    "mid",
+    "mark",
+    "last_price",
+    "close",
+)
+_SPREAD_BPS_FIELDS: tuple[str, ...] = (
+    "spread_bps",
+    "quoted_spread_bps",
+    "bid_ask_spread_bps",
+)
+_SPREAD_PRICE_FIELDS: tuple[str, ...] = ("spread", "quoted_spread", "bid_ask_spread")
+_EVENT_FIELDS: tuple[str, ...] = (
+    "lob_event_type",
+    "event_type",
+    "order_event_type",
+    "side",
+    "aggressor_side",
+    "trade_side",
+    "liquidity_side",
+)
+_BOOK_EVENT_TOKENS = frozenset(
+    (
+        "add",
+        "book",
+        "cancel",
+        "depth",
+        "limit",
+        "lob",
+        "modify",
+        "orderbook",
+        "quote",
+        "replace",
+        "update",
+    )
+)
+_TRADE_EVENT_TOKENS = frozenset(("execution", "fill", "market", "trade"))
+_EXECUTABLE_SIDE_DEPTH_SHARE_FLOOR = 0.30
+
+
+@dataclass(frozen=True)
+class OrderBookObservabilityStressSummary:
+    row_count: int
+    observed_quote_count: int
+    observed_depth_count: int
+    observed_spread_count: int
+    book_feedback_event_count: int
+    trade_censored_event_count: int
+    quote_coverage: float
+    depth_coverage: float
+    spread_coverage: float
+    book_feedback_share: float
+    trade_censored_share: float
+    observability_confidence: float
+    median_spread_bps: float
+    spread_cost_bias_bps: float
+    executable_side_depth_shortfall_share: float
+    median_visible_executable_depth_notional: float
+    visible_depth_notional_shortfall_share: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": ORDER_BOOK_OBSERVABILITY_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_order_book_observability_ranking",
+            "source_papers": [
+                dict(item) for item in ORDER_BOOK_OBSERVABILITY_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "observed_quote_count": self.observed_quote_count,
+            "observed_depth_count": self.observed_depth_count,
+            "observed_spread_count": self.observed_spread_count,
+            "book_feedback_event_count": self.book_feedback_event_count,
+            "trade_censored_event_count": self.trade_censored_event_count,
+            "quote_coverage": _stable_float(self.quote_coverage),
+            "depth_coverage": _stable_float(self.depth_coverage),
+            "spread_coverage": _stable_float(self.spread_coverage),
+            "book_feedback_share": _stable_float(self.book_feedback_share),
+            "trade_censored_share": _stable_float(self.trade_censored_share),
+            "observability_confidence": _stable_float(self.observability_confidence),
+            "median_spread_bps": _stable_float(self.median_spread_bps),
+            "spread_cost_bias_bps": _stable_float(self.spread_cost_bias_bps),
+            "executable_side_depth_shortfall_share": _stable_float(
+                self.executable_side_depth_shortfall_share
+            ),
+            "median_visible_executable_depth_notional": _stable_float(
+                self.median_visible_executable_depth_notional
+            ),
+            "visible_depth_notional_shortfall_share": _stable_float(
+                self.visible_depth_notional_shortfall_share
+            ),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "observability_confidence": _stable_float(
+                    self.observability_confidence
+                ),
+                "trade_censored_share": _stable_float(self.trade_censored_share),
+                "spread_cost_bias_bps": _stable_float(self.spread_cost_bias_bps),
+                "executable_side_depth_shortfall_share": _stable_float(
+                    self.executable_side_depth_shortfall_share
+                ),
+                "visible_depth_notional_shortfall_share": _stable_float(
+                    self.visible_depth_notional_shortfall_share
+                ),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "order_book_feedback_preview": True,
+            "stochastic_cost_proxy_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": (
+                ORDER_BOOK_OBSERVABILITY_STRESS_PROOF_SEMANTICS_LABEL
+            ),
+        }
+
+
+def order_book_observability_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": ORDER_BOOK_OBSERVABILITY_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": ORDER_BOOK_OBSERVABILITY_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in ORDER_BOOK_OBSERVABILITY_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": (
+            "quote_depth_observability_vs_trade_censoring_and_state_dependent_"
+            "spread_cost"
+        ),
+        "stress_components": [
+            "observability_confidence",
+            "trade_censored_share",
+            "spread_cost_bias_bps",
+            "executable_side_depth_shortfall_share",
+            "visible_depth_notional_shortfall_share",
+        ],
+        "quote_fields": list(_BID_FIELDS + _ASK_FIELDS),
+        "depth_fields": list(_BID_SIZE_FIELDS + _ASK_SIZE_FIELDS),
+        "spread_fields": list(_SPREAD_BPS_FIELDS + _SPREAD_PRICE_FIELDS),
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_runtime_ledger": True,
+        },
+    }
+
+
+def build_order_book_observability_stress_schema_hash() -> str:
+    return _stable_hash(order_book_observability_stress_contract())
+
+
+def extract_order_book_observability_stress(
+    records: Sequence[SignalEnvelope],
+    *,
+    direction: int | float = 1,
+    max_notional: Decimal | int | float | str | None = None,
+) -> OrderBookObservabilityStressSummary:
+    ordered = tuple(
+        sorted(records, key=lambda item: (item.event_ts, item.symbol, item.seq))
+    )
+    row_count = len(ordered)
+    notional = _nonnegative_float(max_notional)
+    spread_values: list[float] = []
+    side_depth_shares: list[float] = []
+    visible_side_depth_notional_values: list[float] = []
+    observed_quote_count = 0
+    observed_depth_count = 0
+    book_feedback_event_count = 0
+    trade_censored_event_count = 0
+
+    for row in ordered:
+        bid = _first_positive_float(row.payload, _BID_FIELDS)
+        ask = _first_positive_float(row.payload, _ASK_FIELDS)
+        price = _price(row, bid=bid, ask=ask)
+        quote_observed = bid is not None and ask is not None and ask >= bid
+        if quote_observed:
+            observed_quote_count += 1
+
+        spread_bps = _spread_bps(row, bid=bid, ask=ask, price=price)
+        if spread_bps is not None:
+            spread_values.append(spread_bps)
+
+        bid_size = _first_nonnegative_float(row.payload, _BID_SIZE_FIELDS)
+        ask_size = _first_nonnegative_float(row.payload, _ASK_SIZE_FIELDS)
+        depth_observed = (
+            bid_size is not None and ask_size is not None and bid_size + ask_size > 0.0
+        )
+        if depth_observed:
+            observed_depth_count += 1
+            assert bid_size is not None
+            assert ask_size is not None
+            executable_side_depth = ask_size if float(direction) >= 0.0 else bid_size
+            total_depth = bid_size + ask_size
+            side_depth_shares.append(executable_side_depth / total_depth)
+            if price is not None and price > 0.0:
+                visible_side_depth_notional_values.append(executable_side_depth * price)
+
+        if quote_observed or depth_observed or _is_book_feedback_event(row):
+            book_feedback_event_count += 1
+        if _is_trade_censored_event(row) and not quote_observed and not depth_observed:
+            trade_censored_event_count += 1
+
+    observed_spread_count = len(spread_values)
+    quote_coverage = _share(observed_quote_count, row_count)
+    depth_coverage = _share(observed_depth_count, row_count)
+    spread_coverage = _share(observed_spread_count, row_count)
+    book_feedback_share = _share(book_feedback_event_count, row_count)
+    trade_censored_share = _share(trade_censored_event_count, row_count)
+    observability_confidence = _clip(
+        quote_coverage * 0.45
+        + depth_coverage * 0.25
+        + spread_coverage * 0.15
+        + book_feedback_share * 0.15,
+        0.0,
+        1.0,
+    )
+    median_spread_bps = _median(spread_values)
+    executable_side_depth_shortfall_share = _mean(
+        [
+            max(0.0, _EXECUTABLE_SIDE_DEPTH_SHARE_FLOOR - share)
+            / _EXECUTABLE_SIDE_DEPTH_SHARE_FLOOR
+            for share in side_depth_shares
+        ]
+    )
+    if row_count > 0 and not side_depth_shares:
+        executable_side_depth_shortfall_share = 1.0
+    median_visible_depth_notional = _median(visible_side_depth_notional_values)
+    if notional > 0.0:
+        if median_visible_depth_notional <= 0.0:
+            visible_depth_notional_shortfall_share = 1.0
+        else:
+            visible_depth_notional_shortfall_share = _clip(
+                (notional - median_visible_depth_notional) / notional,
+                0.0,
+                1.0,
+            )
+    else:
+        visible_depth_notional_shortfall_share = 0.0
+    spread_cost_bias_bps = median_spread_bps * (
+        1.0 + (1.0 - observability_confidence) * 0.75 + trade_censored_share * 0.50
+    )
+    replay_rank_penalty_bps = (
+        (1.0 - observability_confidence) * 24.0
+        + trade_censored_share * 10.0
+        + executable_side_depth_shortfall_share * 12.0
+        + visible_depth_notional_shortfall_share * 20.0
+        + spread_cost_bias_bps * 0.40
+    )
+    warnings = _warnings(
+        row_count=row_count,
+        observed_quote_count=observed_quote_count,
+        observed_depth_count=observed_depth_count,
+        observed_spread_count=observed_spread_count,
+        trade_censored_share=trade_censored_share,
+        observability_confidence=observability_confidence,
+        executable_side_depth_shortfall_share=executable_side_depth_shortfall_share,
+        visible_depth_notional_shortfall_share=visible_depth_notional_shortfall_share,
+        notional=notional,
+    )
+    return OrderBookObservabilityStressSummary(
+        row_count=row_count,
+        observed_quote_count=observed_quote_count,
+        observed_depth_count=observed_depth_count,
+        observed_spread_count=observed_spread_count,
+        book_feedback_event_count=book_feedback_event_count,
+        trade_censored_event_count=trade_censored_event_count,
+        quote_coverage=quote_coverage,
+        depth_coverage=depth_coverage,
+        spread_coverage=spread_coverage,
+        book_feedback_share=book_feedback_share,
+        trade_censored_share=trade_censored_share,
+        observability_confidence=observability_confidence,
+        median_spread_bps=median_spread_bps,
+        spread_cost_bias_bps=spread_cost_bias_bps,
+        executable_side_depth_shortfall_share=executable_side_depth_shortfall_share,
+        median_visible_executable_depth_notional=median_visible_depth_notional,
+        visible_depth_notional_shortfall_share=visible_depth_notional_shortfall_share,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=warnings,
+        feature_schema_hash=build_order_book_observability_stress_schema_hash(),
+    )
+
+
+def _warnings(
+    *,
+    row_count: int,
+    observed_quote_count: int,
+    observed_depth_count: int,
+    observed_spread_count: int,
+    trade_censored_share: float,
+    observability_confidence: float,
+    executable_side_depth_shortfall_share: float,
+    visible_depth_notional_shortfall_share: float,
+    notional: float,
+) -> tuple[str, ...]:
+    warnings: list[str] = []
+    if row_count <= 0:
+        warnings.append("empty_order_book_observability_rows")
+    if observed_quote_count <= 0:
+        warnings.append("missing_order_book_quotes")
+    if observed_depth_count <= 0:
+        warnings.append("missing_order_book_depth")
+    if observed_spread_count <= 0:
+        warnings.append("missing_order_book_spread")
+    if trade_censored_share > 0.50:
+        warnings.append("high_trade_censored_share")
+    if observability_confidence < 0.50:
+        warnings.append("insufficient_order_book_observability")
+    if executable_side_depth_shortfall_share > 0.50:
+        warnings.append("thin_visible_executable_side_depth")
+    if visible_depth_notional_shortfall_share > 0.50:
+        warnings.append("candidate_notional_exceeds_visible_book_depth")
+    if notional <= 0.0:
+        warnings.append("missing_candidate_notional_for_order_book_stress")
+    return tuple(dict.fromkeys(warnings))
+
+
+def _price(
+    record: SignalEnvelope, *, bid: float | None, ask: float | None
+) -> float | None:
+    price = _first_positive_float(record.payload, _PRICE_FIELDS)
+    if price is not None:
+        return price
+    if bid is not None and ask is not None and bid > 0.0 and ask > 0.0:
+        return (bid + ask) / 2.0
+    return None
+
+
+def _spread_bps(
+    record: SignalEnvelope,
+    *,
+    bid: float | None,
+    ask: float | None,
+    price: float | None,
+) -> float | None:
+    explicit_bps = _first_nonnegative_float(record.payload, _SPREAD_BPS_FIELDS)
+    if explicit_bps is not None:
+        return explicit_bps
+    if bid is not None and ask is not None and bid > 0.0 and ask >= bid:
+        return (ask - bid) / ((ask + bid) / 2.0) * 10_000.0
+    spread = _first_nonnegative_float(record.payload, _SPREAD_PRICE_FIELDS)
+    if spread is not None and price is not None and price > 0.0:
+        return spread / price * 10_000.0
+    return None
+
+
+def _is_book_feedback_event(record: SignalEnvelope) -> bool:
+    label = _event_label(record)
+    tokens = _event_tokens(label)
+    return bool(tokens & _BOOK_EVENT_TOKENS)
+
+
+def _is_trade_censored_event(record: SignalEnvelope) -> bool:
+    label = _event_label(record)
+    tokens = _event_tokens(label)
+    return bool(tokens & _TRADE_EVENT_TOKENS) and not bool(tokens & _BOOK_EVENT_TOKENS)
+
+
+def _event_label(record: SignalEnvelope) -> str:
+    for key in _EVENT_FIELDS:
+        value = str(record.payload.get(key) or "").strip().lower()
+        if value:
+            return value
+    return ""
+
+
+def _event_tokens(label: str) -> frozenset[str]:
+    normalized = (
+        label.lower()
+        .replace("-", "_")
+        .replace("/", "_")
+        .replace(" ", "_")
+        .replace(":", "_")
+    )
+    return frozenset(token for token in normalized.split("_") if token)
+
+
+def _first_positive_float(
+    payload: Mapping[str, Any], keys: Sequence[str]
+) -> float | None:
+    for key in keys:
+        value = _float_or_none(payload.get(key))
+        if value is not None and value > 0.0:
+            return value
+    return None
+
+
+def _first_nonnegative_float(
+    payload: Mapping[str, Any], keys: Sequence[str]
+) -> float | None:
+    for key in keys:
+        value = _float_or_none(payload.get(key))
+        if value is not None and value >= 0.0:
+            return value
+    return None
+
+
+def _nonnegative_float(value: Any) -> float:
+    parsed = _float_or_none(value)
+    if parsed is None:
+        return 0.0
+    return max(0.0, parsed)
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, Decimal):
+        parsed = float(value)
+    elif isinstance(value, (int, float)):
+        parsed = float(value)
+    else:
+        try:
+            parsed = float(str(value).strip())
+        except ValueError:
+            return None
+    return parsed if isfinite(parsed) else None
+
+
+def _share(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return _clip(numerator / denominator, 0.0, 1.0)
+
+
+def _clip(value: float, lower: float, upper: float) -> float:
+    return min(upper, max(lower, value))
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[midpoint]
+    return (ordered[midpoint - 1] + ordered[midpoint]) / 2.0
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _stable_float(value: float) -> str:
+    if not isfinite(value):
+        return "0"
+    return f"{value:.12g}"
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(_json_ready(payload), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[Any, Any], value)
+        return {
+            str(key): _json_ready(mapping[key])
+            for key in sorted(mapping.keys(), key=str)
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        sequence = cast(Sequence[Any], value)
+        return [_json_ready(item) for item in sequence]
+    return value
+
+
+__all__ = [
+    "ORDER_BOOK_OBSERVABILITY_STRESS_PRIMARY_SOURCES",
+    "ORDER_BOOK_OBSERVABILITY_STRESS_PROOF_SEMANTICS_LABEL",
+    "ORDER_BOOK_OBSERVABILITY_STRESS_SCHEMA_VERSION",
+    "OrderBookObservabilityStressSummary",
+    "build_order_book_observability_stress_schema_hash",
+    "extract_order_book_observability_stress",
+    "order_book_observability_stress_contract",
+]

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -69,6 +69,7 @@ class TestFastReplayPreview(TestCase):
         stress: bool = False,
         event_type: str = "trade",
     ) -> SignalEnvelope:
+        mid = Decimal(price)
         return SignalEnvelope(
             event_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc)
             + timedelta(minutes=offset),
@@ -77,7 +78,9 @@ class TestFastReplayPreview(TestCase):
             seq=offset,
             source="test",
             payload={
-                "price": Decimal(price),
+                "price": mid,
+                "bid": mid - Decimal("0.01"),
+                "ask": mid + Decimal("0.01"),
                 "spread_bps": Decimal("2"),
                 "ofi": Decimal(ofi),
                 "microbar_volume": Decimal(volume),
@@ -172,6 +175,10 @@ class TestFastReplayPreview(TestCase):
             "mpc_market_limit_execution_schedule_stress",
             payload["implemented_mechanisms"],
         )
+        self.assertIn(
+            "order_book_observability_feedback_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",
@@ -181,6 +188,22 @@ class TestFastReplayPreview(TestCase):
         self.assertFalse(row_payload["execution_schedule_stress"]["proof_authority"])
         self.assertFalse(
             row_payload["execution_schedule_stress"]["promotion_authority"]
+        )
+        self.assertIn("order_book_observability_stress", row_payload)
+        self.assertFalse(
+            row_payload["order_book_observability_stress"]["proof_authority"]
+        )
+        self.assertFalse(
+            row_payload["order_book_observability_stress"]["promotion_authority"]
+        )
+        self.assertIn(
+            "arxiv-2605.19584",
+            {
+                source["source_id"]
+                for source in row_payload["order_book_observability_stress"][
+                    "source_papers"
+                ]
+            },
         )
         self.assertIn("cost_impact_lineage", row_payload)
         self.assertIn("impact_capacity_lineage", row_payload)

--- a/services/torghut/tests/test_order_book_observability_stress.py
+++ b/services/torghut/tests/test_order_book_observability_stress.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.order_book_observability_stress import (
+    ORDER_BOOK_OBSERVABILITY_STRESS_PRIMARY_SOURCES,
+    extract_order_book_observability_stress,
+    order_book_observability_stress_contract,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestOrderBookObservabilityStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        price: str = "100",
+        event_type: str = "book_update",
+        quote: bool = True,
+        depth: bool = True,
+        bid_size: str = "800",
+        ask_size: str = "800",
+    ) -> SignalEnvelope:
+        mid = Decimal(price)
+        payload: dict[str, object] = {
+            "price": mid,
+            "event_type": event_type,
+            "spread_bps": Decimal("2"),
+        }
+        if quote:
+            payload.update(
+                {
+                    "bid": mid - Decimal("0.01"),
+                    "ask": mid + Decimal("0.01"),
+                }
+            )
+        if depth:
+            payload.update(
+                {
+                    "bid_size": Decimal(bid_size),
+                    "ask_size": Decimal(ask_size),
+                }
+            )
+        return SignalEnvelope(
+            event_ts=datetime(2026, 5, 19, 14, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset),
+            symbol="AAA",
+            timeframe="1S",
+            seq=offset,
+            source="fixture",
+            payload=payload,
+            ingest_ts=datetime(2026, 5, 19, 14, 30, 1, tzinfo=timezone.utc),
+        )
+
+    def test_missing_book_feedback_and_thin_depth_raise_rank_penalty(self) -> None:
+        observable_rows = [
+            self._row(offset=0, event_type="book_update"),
+            self._row(offset=1, event_type="quote_update"),
+            self._row(offset=2, event_type="cancel"),
+        ]
+        censored_trade_rows = [
+            self._row(offset=0, event_type="trade", quote=False, depth=False),
+            self._row(offset=1, event_type="trade", quote=False, depth=False),
+            self._row(offset=2, event_type="fill", quote=False, depth=False),
+        ]
+
+        observable = extract_order_book_observability_stress(
+            observable_rows,
+            direction=1,
+            max_notional=Decimal("25000"),
+        ).to_payload()
+        censored = extract_order_book_observability_stress(
+            censored_trade_rows,
+            direction=1,
+            max_notional=Decimal("25000"),
+        ).to_payload()
+
+        self.assertGreater(
+            float(censored["replay_rank_penalty_bps"]),
+            float(observable["replay_rank_penalty_bps"]) + 40.0,
+        )
+        self.assertEqual(censored["observed_quote_count"], 0)
+        self.assertEqual(censored["observed_depth_count"], 0)
+        self.assertIn("high_trade_censored_share", censored["warnings"])
+        self.assertIn("missing_order_book_quotes", censored["warnings"])
+        self.assertFalse(observable["proof_authority"])
+        self.assertFalse(observable["promotion_authority"])
+        self.assertTrue(observable["order_book_feedback_preview"])
+
+    def test_contract_records_primary_sources_without_promotion_authority(self) -> None:
+        contract = order_book_observability_stress_contract()
+
+        self.assertEqual(
+            [item["source_id"] for item in contract["source_papers"]],
+            [
+                item["source_id"]
+                for item in ORDER_BOOK_OBSERVABILITY_STRESS_PRIMARY_SOURCES
+            ],
+        )
+        self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
+        self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
+        self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertFalse(contract["proof_neutrality"]["promotion_proof"])


### PR DESCRIPTION
## Summary

- Add preview-only order-book observability stress from 2026 order-book feedback and 2025 stochastic transaction-cost papers.
- Wire the stress payload into fast replay ranking, risk flags, and row manifests without granting promotion authority.
- Add focused regression coverage for censored trade rows, missing quote/depth data, primary-source metadata, and fast replay payload wiring.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app/trading/discovery/order_book_observability_stress.py app/trading/discovery/fast_replay.py tests/test_order_book_observability_stress.py tests/test_fast_replay.py`
- `uv run --frozen ruff check app/trading/discovery/order_book_observability_stress.py app/trading/discovery/fast_replay.py tests/test_order_book_observability_stress.py tests/test_fast_replay.py`
- `uv run --frozen pytest tests/test_order_book_observability_stress.py tests/test_fast_replay.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen coverage run -m pytest tests/test_order_book_observability_stress.py tests/test_fast_replay.py -q`
- `uv run --frozen coverage xml --fail-under=0 -o coverage.xml`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
