### PR TITLE
feat(torghut): add order transition stress preview

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -30,6 +30,9 @@ from app.trading.discovery.microstructure_prefilter import (
 from app.trading.discovery.order_book_observability_stress import (
     extract_order_book_observability_stress,
 )
+from app.trading.discovery.order_transition_stress import (
+    extract_order_transition_stress,
+)
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
@@ -49,6 +52,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "hawkes_event_time_excitation_replay_stress",
     "mpc_market_limit_execution_schedule_stress",
     "order_book_observability_feedback_stress",
+    "markov_order_transition_latent_regime_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -118,6 +122,9 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     order_book_observability_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    order_transition_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -211,6 +218,7 @@ class FastReplayPreviewRow:
             "order_book_observability_stress": dict(
                 self.order_book_observability_stress
             ),
+            "order_transition_stress": dict(self.order_transition_stress),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
             "exact_replay_required": True,
@@ -393,6 +401,7 @@ class FastReplayPreviewResult:
                 "hawkes_event_time_excitation_replay_stress": "deterministic Hawkes-style event-time burst/self-excitation proxy from arXiv:2510.08085 and arXiv:2604.23961; preview ranking only",
                 "mpc_market_limit_execution_schedule_stress": "deterministic MPC-style schedule deviation/opportunity-cost/market-limit-mix stress from arXiv:2603.28898 and arXiv:2507.06345; preview ranking only",
                 "order_book_observability_feedback_stress": "deterministic order-book feedback/censored-trade and state-dependent spread-cost stress from arXiv:2605.19584 and arXiv:2507.09196; preview ranking only",
+                "markov_order_transition_latent_regime_stress": "deterministic Markov transition entropy/inertia plus latent rising-edge stress from arXiv:2502.07625 and arXiv:2604.20949; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1044,6 +1053,7 @@ def _score_candidate_spec(
             clusterlob_order_flow_features=dict(clusterlob_order_flow_features),
             execution_schedule_stress={},
             order_book_observability_stress={},
+            order_transition_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1116,6 +1126,17 @@ def _score_candidate_spec(
         )
         or 0.0
     )
+    order_transition_stress = extract_order_transition_stress(
+        matched_source_rows
+    ).to_payload()
+    order_transition_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(order_transition_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
@@ -1162,6 +1183,7 @@ def _score_candidate_spec(
         - square_root_impact_capacity_penalty_bps * 0.22
         - execution_schedule_rank_penalty_bps * 0.14
         - order_book_observability_rank_penalty_bps * 0.12
+        - order_transition_rank_penalty_bps * 0.11
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1193,6 +1215,7 @@ def _score_candidate_spec(
         - square_root_impact_capacity_penalty_bps * 0.08
         - execution_schedule_rank_penalty_bps * 0.05
         - order_book_observability_rank_penalty_bps * 0.04
+        - order_transition_rank_penalty_bps * 0.04
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1230,6 +1253,7 @@ def _score_candidate_spec(
         clusterlob_order_flow_features=dict(clusterlob_order_flow_features),
         execution_schedule_stress=dict(execution_schedule_stress),
         order_book_observability_stress=dict(order_book_observability_stress),
+        order_transition_stress=dict(order_transition_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1266,6 +1290,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - float(row.square_root_impact_capacity_penalty_bps) * 0.15
         - _execution_schedule_rank_penalty_bps(row) * 0.08
         - _order_book_observability_rank_penalty_bps(row) * 0.07
+        - _order_transition_rank_penalty_bps(row) * 0.06
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
@@ -1279,6 +1304,11 @@ def _order_book_observability_rank_penalty_bps(row: FastReplayPreviewRow) -> flo
     ranking_features = _mapping(
         row.order_book_observability_stress.get("ranking_features")
     )
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _order_transition_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
+    ranking_features = _mapping(row.order_transition_stress.get("ranking_features"))
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
 
@@ -1470,6 +1500,7 @@ def _row_with_rank_and_selection(
         clusterlob_order_flow_features=dict(row.clusterlob_order_flow_features),
         execution_schedule_stress=dict(row.execution_schedule_stress),
         order_book_observability_stress=dict(row.order_book_observability_stress),
+        order_transition_stress=dict(row.order_transition_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -1529,6 +1560,7 @@ def _row_with_frontier_dedupe(
         clusterlob_order_flow_features=dict(row.clusterlob_order_flow_features),
         execution_schedule_stress=dict(row.execution_schedule_stress),
         order_book_observability_stress=dict(row.order_book_observability_stress),
+        order_transition_stress=dict(row.order_transition_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -2326,6 +2358,8 @@ def _risk_flags_for_row(
         flags.add("square_root_impact_capacity_penalty_active")
     if _order_book_observability_rank_penalty_bps(row) > 0:
         flags.add("order_book_observability_stress_penalty_active")
+    if _order_transition_rank_penalty_bps(row) > 0:
+        flags.add("order_transition_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
         flags.add("partial_symbol_coverage")
     if row.trading_day_count <= 0:
@@ -2356,6 +2390,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("square_root_impact_capacity_cap_downranks_only")
     if _order_book_observability_rank_penalty_bps(row) > 0:
         reasons.add("order_book_observability_stress_downranks_only")
+    if _order_transition_rank_penalty_bps(row) > 0:
+        reasons.add("order_transition_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
         reasons.add("missing_replay_tape_source_data_explicit_blocker")
     if lineage_blockers:
@@ -2379,6 +2415,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("square_root_impact_capacity_penalty")
     if _order_book_observability_rank_penalty_bps(row) > 0:
         vetoes.add("order_book_observability_stress_penalty")
+    if _order_transition_rank_penalty_bps(row) > 0:
+        vetoes.add("order_transition_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:
         vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
     return tuple(sorted(vetoes))

--- a/services/torghut/app/trading/discovery/order_transition_stress.py
+++ b/services/torghut/app/trading/discovery/order_transition_stress.py
@@ -1,0 +1,435 @@
+"""Preview-only order-transition and latent-regime stress for replay rows.
+
+This module actualizes recent order-transition and latent microstructure-regime
+papers into deterministic replay harness inputs.  It does not simulate broker
+fills, write ledgers, or carry promotion authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import isfinite, log2
+from typing import Any, cast
+
+from app.trading.models import SignalEnvelope
+
+ORDER_TRANSITION_STRESS_SCHEMA_VERSION = "torghut.order-transition-stress.v1"
+ORDER_TRANSITION_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.order-transition-stress-contract.v1"
+)
+ORDER_TRANSITION_STRESS_PROOF_SEMANTICS_LABEL = "order_transition_stress_preview_only_exact_replay_route_tca_runtime_ledger_required"
+ORDER_TRANSITION_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2502.07625",
+        "url": "https://arxiv.org/abs/2502.07625",
+        "mechanism": "first_order_markov_order_transition_dynamics_degree_of_inertia",
+    },
+    {
+        "source_id": "arxiv-2604.20949",
+        "url": "https://arxiv.org/abs/2604.20949",
+        "mechanism": "latent_microstructure_build_up_rising_edge_detector",
+    },
+)
+
+_KNOWN_STATES: tuple[str, ...] = (
+    "limit_add",
+    "limit_cancel",
+    "limit_modify",
+    "buy_execution",
+    "sell_execution",
+    "unknown",
+)
+_EXECUTION_STATES = frozenset(("buy_execution", "sell_execution"))
+_LIMIT_MODIFICATION_STATES = frozenset(("limit_cancel", "limit_modify"))
+_SPREAD_FIELDS = ("spread_bps", "quoted_spread_bps", "effective_spread_bps")
+_OFI_FIELDS = (
+    "ofi",
+    "order_flow_imbalance",
+    "ofi_pressure_score",
+    "signed_order_flow_imbalance",
+    "queue_imbalance",
+    "book_imbalance",
+)
+_VOLUME_FIELDS = (
+    "microbar_volume",
+    "volume",
+    "qty",
+    "quantity",
+    "size",
+    "trade_size",
+    "last_size",
+)
+_BID_SIZE_FIELDS = ("bid_size", "bid_qty", "best_bid_size")
+_ASK_SIZE_FIELDS = ("ask_size", "ask_qty", "best_ask_size")
+
+
+@dataclass(frozen=True)
+class OrderTransitionStressSummary:
+    row_count: int
+    observed_state_count: int
+    transition_count: int
+    state_counts: Mapping[str, int]
+    transition_counts: Mapping[str, int]
+    normalized_transition_entropy: float
+    degree_of_inertia: float
+    execution_cluster_share: float
+    limit_modification_share: float
+    latent_build_up_score: float
+    rising_edge_trigger_count: int
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": ORDER_TRANSITION_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_order_transition_stress_ranking",
+            "source_papers": [
+                dict(item) for item in ORDER_TRANSITION_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "observed_state_count": self.observed_state_count,
+            "transition_count": self.transition_count,
+            "state_counts": dict(self.state_counts),
+            "transition_counts": dict(self.transition_counts),
+            "normalized_transition_entropy": _stable_float(
+                self.normalized_transition_entropy
+            ),
+            "degree_of_inertia": _stable_float(self.degree_of_inertia),
+            "execution_cluster_share": _stable_float(self.execution_cluster_share),
+            "limit_modification_share": _stable_float(self.limit_modification_share),
+            "latent_build_up_score": _stable_float(self.latent_build_up_score),
+            "rising_edge_trigger_count": self.rising_edge_trigger_count,
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "normalized_transition_entropy": _stable_float(
+                    self.normalized_transition_entropy
+                ),
+                "degree_of_inertia": _stable_float(self.degree_of_inertia),
+                "execution_cluster_share": _stable_float(self.execution_cluster_share),
+                "limit_modification_share": _stable_float(
+                    self.limit_modification_share
+                ),
+                "latent_build_up_score": _stable_float(self.latent_build_up_score),
+                "rising_edge_trigger_count": self.rising_edge_trigger_count,
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "markov_transition_matrix_preview": True,
+            "latent_regime_rising_edge_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": ORDER_TRANSITION_STRESS_PROOF_SEMANTICS_LABEL,
+        }
+
+
+def order_transition_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": ORDER_TRANSITION_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": ORDER_TRANSITION_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in ORDER_TRANSITION_STRESS_PRIMARY_SOURCES
+        ],
+        "transition_policy": "first_order_markov_state_counts_over_replay_event_order",
+        "latent_regime_policy": "adaptive_threshold_rising_edge_max_channel_detector",
+        "state_space": list(_KNOWN_STATES),
+        "stress_components": [
+            "normalized_transition_entropy",
+            "degree_of_inertia",
+            "execution_cluster_share",
+            "limit_modification_share",
+            "latent_build_up_score",
+        ],
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_runtime_ledger": True,
+        },
+    }
+
+
+def build_order_transition_stress_schema_hash() -> str:
+    return _stable_hash(order_transition_stress_contract())
+
+
+def extract_order_transition_stress(
+    records: Sequence[SignalEnvelope],
+) -> OrderTransitionStressSummary:
+    """Extract deterministic order-transition and latent-regime stress.
+
+    The returned score is only a cheap replay-ranking stress input. Exact
+    replay, route TCA, and runtime-ledger proof remain authoritative.
+    """
+
+    ordered = tuple(
+        sorted(records, key=lambda item: (item.event_ts, item.symbol, item.seq))
+    )
+    states = tuple(_event_state(row) for row in ordered)
+    observed_state_count = sum(1 for state in states if state != "unknown")
+    transition_pairs = tuple(
+        (left, right)
+        for left, right in zip(states, states[1:])
+        if left != "unknown" and right != "unknown"
+    )
+    state_counts = Counter(states)
+    transition_counts = Counter(f"{left}->{right}" for left, right in transition_pairs)
+    transition_count = len(transition_pairs)
+    normalized_transition_entropy = _normalized_transition_entropy(transition_counts)
+    degree_of_inertia = _degree_of_inertia(transition_pairs)
+    execution_cluster_share = _execution_cluster_share(transition_pairs)
+    limit_modification_share = _limit_modification_share(states)
+    latent_channel = tuple(_latent_stress_channel(row) for row in ordered)
+    latent_build_up_score, rising_edge_trigger_count = _latent_build_up_score(
+        latent_channel
+    )
+
+    warnings: list[str] = []
+    if len(ordered) < 3:
+        warnings.append("insufficient_order_transition_rows")
+    if observed_state_count < 2:
+        warnings.append("insufficient_observed_order_transition_states")
+    if transition_count < 1:
+        warnings.append("missing_order_transition_pairs")
+    if not any(item > 0.0 for item in latent_channel):
+        warnings.append("missing_latent_regime_channels")
+
+    missing_penalty_bps = 5.0 * len(warnings)
+    replay_rank_penalty_bps = (
+        normalized_transition_entropy * 8.0
+        + max(0.0, 0.45 - degree_of_inertia) * 10.0
+        + execution_cluster_share * 9.0
+        + limit_modification_share * 7.0
+        + latent_build_up_score * 14.0
+        + missing_penalty_bps
+    )
+    return OrderTransitionStressSummary(
+        row_count=len(ordered),
+        observed_state_count=observed_state_count,
+        transition_count=transition_count,
+        state_counts={
+            state: int(state_counts.get(state, 0)) for state in _KNOWN_STATES
+        },
+        transition_counts=dict(sorted(transition_counts.items())),
+        normalized_transition_entropy=normalized_transition_entropy,
+        degree_of_inertia=degree_of_inertia,
+        execution_cluster_share=execution_cluster_share,
+        limit_modification_share=limit_modification_share,
+        latent_build_up_score=latent_build_up_score,
+        rising_edge_trigger_count=rising_edge_trigger_count,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=tuple(dict.fromkeys(warnings)),
+        feature_schema_hash=build_order_transition_stress_schema_hash(),
+    )
+
+
+def _event_state(row: SignalEnvelope) -> str:
+    payload = row.payload
+    raw_type = str(
+        _first_payload_value(
+            payload,
+            (
+                "event_type",
+                "order_event_type",
+                "lob_event_type",
+                "order_action",
+                "action",
+                "type",
+            ),
+        )
+        or ""
+    ).lower()
+    side = str(
+        _first_payload_value(payload, ("side", "trade_side", "aggressor_side")) or ""
+    ).lower()
+    signed_volume = _float_or_none(
+        _first_payload_value(
+            payload,
+            (
+                "signed_volume",
+                "signed_qty",
+                "signed_quantity",
+                "signed_size",
+                "aggressor_signed_volume",
+            ),
+        )
+    )
+    if any(token in raw_type for token in ("cancel", "delete", "remove")):
+        return "limit_cancel"
+    if any(token in raw_type for token in ("modify", "replace", "update")):
+        return "limit_modify"
+    if any(
+        token in raw_type
+        for token in ("execute", "execution", "trade", "fill", "market")
+    ):
+        return _execution_state(side=side, signed_volume=signed_volume)
+    if any(token in raw_type for token in ("add", "place", "submit", "limit")):
+        return "limit_add"
+    if signed_volume is not None and signed_volume != 0.0:
+        return _execution_state(side=side, signed_volume=signed_volume)
+    return "unknown"
+
+
+def _execution_state(*, side: str, signed_volume: float | None) -> str:
+    if side in {"buy", "bid", "b"}:
+        return "buy_execution"
+    if side in {"sell", "ask", "s"}:
+        return "sell_execution"
+    if signed_volume is not None:
+        return "buy_execution" if signed_volume > 0.0 else "sell_execution"
+    return "buy_execution"
+
+
+def _normalized_transition_entropy(transition_counts: Mapping[str, int]) -> float:
+    total = sum(transition_counts.values())
+    if total <= 0:
+        return 0.0
+    probabilities = [count / total for count in transition_counts.values() if count > 0]
+    entropy = -sum(probability * log2(probability) for probability in probabilities)
+    max_entropy = log2(max(2, min(len(_KNOWN_STATES) ** 2, total)))
+    if max_entropy <= 0.0:
+        return 0.0
+    return min(1.0, max(0.0, entropy / max_entropy))
+
+
+def _degree_of_inertia(transition_pairs: Sequence[tuple[str, str]]) -> float:
+    if not transition_pairs:
+        return 0.0
+    same_count = sum(1 for left, right in transition_pairs if left == right)
+    return same_count / len(transition_pairs)
+
+
+def _execution_cluster_share(transition_pairs: Sequence[tuple[str, str]]) -> float:
+    if not transition_pairs:
+        return 0.0
+    clustered = sum(
+        1
+        for left, right in transition_pairs
+        if left in _EXECUTION_STATES and right in _EXECUTION_STATES
+    )
+    return clustered / len(transition_pairs)
+
+
+def _limit_modification_share(states: Sequence[str]) -> float:
+    observed = [state for state in states if state != "unknown"]
+    if not observed:
+        return 0.0
+    return sum(1 for state in observed if state in _LIMIT_MODIFICATION_STATES) / len(
+        observed
+    )
+
+
+def _latent_stress_channel(row: SignalEnvelope) -> float:
+    payload = row.payload
+    spread = _nonnegative_float(_first_payload_value(payload, _SPREAD_FIELDS))
+    ofi = abs(_float_or_none(_first_payload_value(payload, _OFI_FIELDS)) or 0.0)
+    volume = _nonnegative_float(_first_payload_value(payload, _VOLUME_FIELDS))
+    bid_size = _nonnegative_float(_first_payload_value(payload, _BID_SIZE_FIELDS))
+    ask_size = _nonnegative_float(_first_payload_value(payload, _ASK_SIZE_FIELDS))
+    displayed_depth = bid_size + ask_size
+    depth_fragility = (
+        1.0 / (1.0 + displayed_depth / 1_000.0) if displayed_depth > 0.0 else 0.0
+    )
+    low_volume_fragility = 1.0 / (1.0 + volume / 10_000.0) if volume > 0.0 else 0.0
+    spread_channel = min(1.0, spread / 20.0) if spread > 0.0 else 0.0
+    ofi_channel = min(1.0, ofi)
+    return min(
+        1.0,
+        spread_channel * 0.35
+        + depth_fragility * 0.25
+        + ofi_channel * 0.25
+        + low_volume_fragility * 0.15,
+    )
+
+
+def _latent_build_up_score(channel: Sequence[float]) -> tuple[float, int]:
+    if len(channel) < 3:
+        return 0.0, 0
+    baseline = _median(channel)
+    deviations = [abs(item - baseline) for item in channel]
+    threshold = min(1.0, baseline + _median(deviations) + 0.04)
+    rising_edges = [
+        max(0.0, current - previous)
+        for previous, current in zip(channel, channel[1:])
+        if current >= threshold and current > previous
+    ]
+    if not rising_edges:
+        return 0.0, 0
+    tail_mean = _mean(channel[max(0, len(channel) - 3) :])
+    head_mean = _mean(channel[: min(3, len(channel))])
+    build_up = max(0.0, tail_mean - head_mean)
+    score = min(1.0, build_up + max(rising_edges))
+    return score, len(rising_edges)
+
+
+def _first_payload_value(
+    payload: Mapping[str, Any], fields: Sequence[str]
+) -> Any | None:
+    for field in fields:
+        value = payload.get(field)
+        if value is not None:
+            return value
+    return None
+
+
+def _nonnegative_float(value: object) -> float:
+    parsed = _float_or_none(value)
+    if parsed is None or parsed < 0.0:
+        return 0.0
+    return parsed
+
+
+def _float_or_none(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(cast(Any, value))
+    except (TypeError, ValueError):
+        return None
+    return parsed if isfinite(parsed) else None
+
+
+def _median(values: Sequence[float]) -> float:
+    clean = sorted(value for value in values if isfinite(value))
+    if not clean:
+        return 0.0
+    midpoint = len(clean) // 2
+    if len(clean) % 2:
+        return clean[midpoint]
+    return (clean[midpoint - 1] + clean[midpoint]) / 2.0
+
+
+def _mean(values: Sequence[float]) -> float:
+    clean = [value for value in values if isfinite(value)]
+    return sum(clean) / len(clean) if clean else 0.0
+
+
+def _stable_float(value: float) -> str:
+    return f"{value:.10f}".rstrip("0").rstrip(".") or "0"
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        cast(dict[str, Any], payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -179,6 +179,10 @@ class TestFastReplayPreview(TestCase):
             "order_book_observability_feedback_stress",
             payload["implemented_mechanisms"],
         )
+        self.assertIn(
+            "markov_order_transition_latent_regime_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",
@@ -203,6 +207,20 @@ class TestFastReplayPreview(TestCase):
                 for source in row_payload["order_book_observability_stress"][
                     "source_papers"
                 ]
+            },
+        )
+        self.assertIn("order_transition_stress", row_payload)
+        self.assertFalse(row_payload["order_transition_stress"]["proof_authority"])
+        self.assertFalse(row_payload["order_transition_stress"]["promotion_authority"])
+        self.assertEqual(
+            row_payload["order_transition_stress"]["status"],
+            "preview_only_order_transition_stress_ranking",
+        )
+        self.assertIn(
+            "arxiv-2502.07625",
+            {
+                source["source_id"]
+                for source in row_payload["order_transition_stress"]["source_papers"]
             },
         )
         self.assertIn("cost_impact_lineage", row_payload)

--- a/services/torghut/tests/test_order_transition_stress.py
+++ b/services/torghut/tests/test_order_transition_stress.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.order_transition_stress import (
+    ORDER_TRANSITION_STRESS_PRIMARY_SOURCES,
+    extract_order_transition_stress,
+    order_transition_stress_contract,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestOrderTransitionStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        event_type: str,
+        side: str = "buy",
+        spread_bps: str = "2",
+        bid_size: str = "1000",
+        ask_size: str = "1000",
+        ofi: str = "0.10",
+        volume: str = "10000",
+    ) -> SignalEnvelope:
+        return SignalEnvelope(
+            event_ts=datetime(2026, 4, 24, 13, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset),
+            symbol="AAA",
+            timeframe="1S",
+            seq=offset,
+            source="fixture",
+            payload={
+                "event_type": event_type,
+                "side": side,
+                "spread_bps": Decimal(spread_bps),
+                "bid_size": Decimal(bid_size),
+                "ask_size": Decimal(ask_size),
+                "ofi": Decimal(ofi),
+                "microbar_volume": Decimal(volume),
+            },
+            ingest_ts=datetime(2026, 4, 24, 13, 30, 1, tzinfo=timezone.utc),
+        )
+
+    def test_transition_entropy_and_latent_buildup_raise_replay_penalty(self) -> None:
+        stable_rows = [
+            self._row(offset=index, event_type="add", ofi="0.05") for index in range(6)
+        ]
+        stressed_rows = [
+            self._row(offset=0, event_type="add", spread_bps="2", ofi="0.05"),
+            self._row(offset=1, event_type="cancel", spread_bps="3", ofi="0.20"),
+            self._row(
+                offset=2, event_type="trade", side="buy", spread_bps="6", ofi="0.55"
+            ),
+            self._row(
+                offset=3,
+                event_type="trade",
+                side="sell",
+                spread_bps="9",
+                bid_size="200",
+                ask_size="250",
+                ofi="-0.70",
+                volume="2500",
+            ),
+            self._row(
+                offset=4,
+                event_type="modify",
+                spread_bps="12",
+                bid_size="100",
+                ask_size="120",
+                ofi="0.85",
+                volume="1000",
+            ),
+            self._row(
+                offset=5,
+                event_type="trade",
+                side="sell",
+                spread_bps="15",
+                bid_size="60",
+                ask_size="80",
+                ofi="-0.95",
+                volume="500",
+            ),
+        ]
+
+        stable = extract_order_transition_stress(stable_rows).to_payload()
+        stressed = extract_order_transition_stress(stressed_rows).to_payload()
+
+        self.assertGreater(
+            float(stressed["normalized_transition_entropy"]),
+            float(stable["normalized_transition_entropy"]),
+        )
+        self.assertGreater(
+            float(stressed["latent_build_up_score"]),
+            float(stable["latent_build_up_score"]),
+        )
+        self.assertGreater(
+            float(stressed["replay_rank_penalty_bps"]),
+            float(stable["replay_rank_penalty_bps"]),
+        )
+        self.assertTrue(stressed["markov_transition_matrix_preview"])
+        self.assertTrue(stressed["latent_regime_rising_edge_preview"])
+        self.assertFalse(stressed["proof_authority"])
+        self.assertFalse(stressed["promotion_authority"])
+
+    def test_contract_records_primary_sources_without_promotion_authority(self) -> None:
+        contract = order_transition_stress_contract()
+
+        self.assertEqual(
+            [item["source_id"] for item in contract["source_papers"]],
+            [item["source_id"] for item in ORDER_TRANSITION_STRESS_PRIMARY_SOURCES],
+        )
+        self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
+        self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
+        self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertFalse(contract["proof_neutrality"]["promotion_proof"])


### PR DESCRIPTION
## Summary

- Adds a preview-only Markov order-transition and latent-regime rising-edge stress extractor for Torghut replay rows.
- Records primary-source paper metadata for arXiv:2502.07625 and arXiv:2604.20949 in executable stress payloads and contracts.
- Wires the stress into fast replay ranking/exploration risk penalties while preserving exact replay, route TCA, and runtime-ledger authority boundaries.
- Adds regression coverage for standalone stress extraction and fast replay payload/proof-neutrality integration.

## Related Issues

None

## Testing

- PASS: `uvx ruff format --check app/trading/discovery/order_transition_stress.py app/trading/discovery/fast_replay.py tests/test_order_transition_stress.py tests/test_fast_replay.py`
- PASS: `uvx ruff check app/trading/discovery/order_transition_stress.py app/trading/discovery/fast_replay.py tests/test_order_transition_stress.py tests/test_fast_replay.py`
- PASS: `uv run --frozen pytest tests/test_order_transition_stress.py tests/test_fast_replay.py -q`
- PASS: `uv sync --frozen --extra dev`
- PASS: `uv run --frozen pyright --project pyrightconfig.json`
- PASS: `uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
