### PR TITLE
fix(torghut): avoid scheduler target plan self-fetch

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_DOWN
 from typing import Any, Literal, Optional, cast
+from urllib.parse import urlsplit
 from uuid import UUID
 
 from sqlalchemy import desc, select  # pyright: ignore[reportUnknownVariableType]
@@ -24,6 +26,7 @@ from ..ingest import SignalBatch
 from ..models import SignalEnvelope, StrategyDecision
 from ..paper_route_target_plan import (
     fetch_paper_route_target_plan_url,
+    paper_route_target_plan_from_payload,
     paper_route_target_plan_probe_symbols,
     paper_route_target_plan_targets,
 )
@@ -1287,7 +1290,10 @@ class SimpleTradingPipeline(TradingPipeline):
             self._capture_runtime_window_account_snapshot_if_due(session)
             self._warm_session_context_from_open(session, strategies=strategies)
 
-            signal_scope = self._bounded_paper_route_signal_scope(strategies)
+            signal_scope = self._bounded_paper_route_signal_scope(
+                strategies,
+                session=session,
+            )
             batch = self._fetch_signal_batch(session, signal_scope=signal_scope)
             self._record_ingest_window(batch)
             if self._signal_ingest_unavailable(batch):
@@ -1494,6 +1500,8 @@ class SimpleTradingPipeline(TradingPipeline):
     def _bounded_paper_route_signal_scope(
         self,
         strategies: Sequence[Strategy],
+        *,
+        session: Session | None = None,
     ) -> tuple[set[str], set[str]] | None:
         if settings.trading_mode != "paper":
             return None
@@ -1503,7 +1511,10 @@ class SimpleTradingPipeline(TradingPipeline):
         if not self._is_market_session_open(now):
             return None
         target_symbols, target_plan_error, targets = (
-            self._external_paper_route_target_probe_symbols_cached()
+            self._external_paper_route_target_probe_symbols_cached(
+                session=session,
+                strategies=strategies,
+            )
         )
         if target_plan_error:
             self._record_bounded_target_plan_blocker(
@@ -3465,6 +3476,8 @@ class SimpleTradingPipeline(TradingPipeline):
                 proof_floor=proof_floor,
                 decision=decision,
                 strategy=strategy,
+                session=session,
+                strategies=[strategy],
             )
             capped_decision = self._paper_route_probe_capped_decision(
                 decision=decision,
@@ -3923,7 +3936,86 @@ class SimpleTradingPipeline(TradingPipeline):
         return True
 
     @staticmethod
-    def _external_paper_route_target_probe_symbols() -> tuple[
+    def _paper_route_target_plan_url_points_to_current_service(url: str) -> bool:
+        parsed = urlsplit(url)
+        path = (parsed.path or "").rstrip("/")
+        if path != "/trading/paper-route-target-plan":
+            return False
+        hostname = (parsed.hostname or "").strip().lower()
+        service_name = os.getenv("K_SERVICE", "").strip().lower()
+        if not hostname or not service_name:
+            return False
+        namespace = (
+            os.getenv("POD_NAMESPACE", os.getenv("NAMESPACE", "")).strip().lower()
+        )
+        service_hosts = {service_name}
+        if namespace:
+            service_hosts.update(
+                {
+                    f"{service_name}.{namespace}",
+                    f"{service_name}.{namespace}.svc",
+                    f"{service_name}.{namespace}.svc.cluster.local",
+                }
+            )
+        return hostname in service_hosts or hostname.startswith(f"{service_name}.")
+
+    def _local_paper_route_target_probe_symbols(
+        self,
+        *,
+        session: Session | None,
+        strategies: Sequence[Strategy] | None = None,
+    ) -> tuple[set[str], str | None, list[dict[str, Any]]]:
+        try:
+            gate = self._live_submission_gate(session=session)
+        except Exception as exc:  # pragma: no cover - defensive runtime fallback
+            logger.exception(
+                "Local paper-route target plan unavailable for bounded probe"
+            )
+            return (
+                set(),
+                f"paper_route_target_plan_local_gate_failed:{type(exc).__name__}",
+                [],
+            )
+
+        plan = paper_route_target_plan_from_payload(gate)
+        targets = paper_route_target_plan_targets(plan)
+        if not targets:
+            return set(), "paper_route_target_plan_missing", []
+
+        symbols = set(paper_route_target_plan_probe_symbols(plan))
+        if not symbols:
+            for target in targets:
+                symbols.update(_target_symbols(target))
+                if strategies is None:
+                    continue
+                strategy = self._paper_route_target_strategy(target, strategies)
+                if strategy is not None:
+                    symbols.update(self._paper_route_target_strategy_symbols(strategy))
+
+        resolved_targets = [
+            {
+                **dict(target),
+                "paper_route_target_plan_source": _safe_text(
+                    target.get("paper_route_target_plan_source")
+                )
+                or "local_live_submission_gate",
+            }
+            for target in targets
+        ]
+        if not symbols:
+            return (
+                set(),
+                "paper_route_target_plan_probe_symbols_missing",
+                resolved_targets,
+            )
+        return symbols, None, resolved_targets
+
+    def _external_paper_route_target_probe_symbols(
+        self,
+        *,
+        session: Session | None = None,
+        strategies: Sequence[Strategy] | None = None,
+    ) -> tuple[
         set[str],
         str | None,
         list[dict[str, Any]],
@@ -3931,6 +4023,11 @@ class SimpleTradingPipeline(TradingPipeline):
         url = str(settings.trading_paper_route_target_plan_url or "").strip()
         if not url:
             return set(), None, []
+        if self._paper_route_target_plan_url_points_to_current_service(url):
+            return self._local_paper_route_target_probe_symbols(
+                session=session,
+                strategies=strategies,
+            )
         plan = fetch_paper_route_target_plan_url(
             url,
             timeout_seconds=settings.trading_paper_route_target_plan_timeout_seconds,
@@ -3953,6 +4050,9 @@ class SimpleTradingPipeline(TradingPipeline):
 
     def _external_paper_route_target_probe_symbols_cached(
         self,
+        *,
+        session: Session | None = None,
+        strategies: Sequence[Strategy] | None = None,
     ) -> tuple[set[str], str | None, list[dict[str, Any]]]:
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
         cached = self._paper_route_target_plan_cache
@@ -3962,7 +4062,10 @@ class SimpleTradingPipeline(TradingPipeline):
                 now - cached_at.astimezone(timezone.utc)
             ).total_seconds() < _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS:
                 return set(symbols), load_error, [dict(target) for target in targets]
-        symbols, load_error, targets = self._external_paper_route_target_probe_symbols()
+        symbols, load_error, targets = self._external_paper_route_target_probe_symbols(
+            session=session,
+            strategies=strategies,
+        )
         used_stale_success = False
         if load_error:
             success_cached = self._paper_route_target_plan_success_cache
@@ -4318,7 +4421,10 @@ class SimpleTradingPipeline(TradingPipeline):
             )
             return []
         target_symbols, target_plan_error, target_plan_targets = (
-            self._external_paper_route_target_probe_symbols_cached()
+            self._external_paper_route_target_probe_symbols_cached(
+                session=session,
+                strategies=strategies,
+            )
         )
         if target_plan_error:
             self._record_bounded_target_plan_blocker(
@@ -5183,6 +5289,8 @@ class SimpleTradingPipeline(TradingPipeline):
         proof_floor: Mapping[str, object],
         decision: StrategyDecision,
         strategy: Strategy | None = None,
+        session: Session | None = None,
+        strategies: Sequence[Strategy] | None = None,
     ) -> dict[str, object] | None:
         if settings.trading_mode != "paper":
             return None
@@ -5196,10 +5304,13 @@ class SimpleTradingPipeline(TradingPipeline):
             return None
         if decision.action not in {"buy", "sell"}:
             return None
-        cap = _min_optional_decimal(
-            _optional_decimal(settings.trading_simple_paper_route_probe_max_notional),
-            self._paper_route_target_source_cap(decision.params),
-        )
+        target_source_cap = self._paper_route_target_source_cap(decision.params)
+        if target_source_cap is not None:
+            cap = target_source_cap
+        else:
+            cap = _optional_decimal(
+                settings.trading_simple_paper_route_probe_max_notional
+            )
         if cap is None or cap <= 0:
             return None
         if not self._proof_floor_market_session_open(proof_floor):
@@ -5230,7 +5341,10 @@ class SimpleTradingPipeline(TradingPipeline):
         }
         symbol = decision.symbol.strip().upper()
         target_plan_symbols, target_plan_error, target_plan_targets = (
-            self._external_paper_route_target_probe_symbols()
+            self._external_paper_route_target_probe_symbols_cached(
+                session=session,
+                strategies=strategies,
+            )
         )
         if target_plan_error:
             return None
@@ -5486,6 +5600,8 @@ class SimpleTradingPipeline(TradingPipeline):
             proof_floor=proof_floor,
             decision=decision,
             strategy=strategy,
+            session=session,
+            strategies=[strategy],
         )
         if probe_context is None:
             return None

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -954,7 +954,7 @@ def test_bounded_source_collection_authorizes_after_runtime_account_audit_readba
         pipeline = object.__new__(SimpleTradingPipeline)
         pipeline.account_label = "TORGHUT_SIM"
         pipeline._is_market_session_open = lambda _now: True
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
             {"AAPL", "AMZN"},
             None,
             [target],
@@ -1057,7 +1057,7 @@ def test_source_collection_authorization_emits_bounded_lineage_decisions_without
         pipeline = object.__new__(SimpleTradingPipeline)
         pipeline.account_label = "TORGHUT_SIM"
         pipeline._is_market_session_open = lambda _now: True
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
             {"AAPL", "AMZN"},
             None,
             [target],
@@ -1307,7 +1307,7 @@ def test_bounded_source_collection_blocks_closed_session_with_explicit_reason(
         pipeline.account_label = "TORGHUT_SIM"
         pipeline.state = SimpleNamespace()
         pipeline._is_market_session_open = lambda _now: False
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
             {"AAPL", "AMZN"},
             None,
             [_bounded_hpairs_target()],
@@ -1478,7 +1478,7 @@ def test_contaminated_bounded_window_still_reserves_paper_account(monkeypatch) -
         pipeline = object.__new__(SimpleTradingPipeline)
         pipeline.account_label = "TORGHUT_SIM"
         pipeline._is_market_session_open = lambda _now: True
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
             {"AAPL", "AMZN"},
             None,
             [target],
@@ -1529,7 +1529,7 @@ def test_target_account_audit_unavailable_still_reserves_paper_account(
         pipeline = object.__new__(SimpleTradingPipeline)
         pipeline.account_label = "TORGHUT_SIM"
         pipeline._is_market_session_open = lambda _now: True
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
             {"AAPL", "AMZN"},
             None,
             [target],
@@ -1571,7 +1571,7 @@ def test_target_plan_fetch_error_reserves_configured_paper_account(
         pipeline.account_label = "TORGHUT_SIM"
         pipeline.state = SimpleNamespace()
         pipeline._is_market_session_open = lambda _now: True
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
             set(),
             "paper_route_target_plan_fetch_failed:timeout",
             [],
@@ -1608,7 +1608,7 @@ def test_target_plan_fetch_error_without_config_does_not_reserve_paper_account(
         pipeline = object.__new__(SimpleTradingPipeline)
         pipeline.account_label = "TORGHUT_SIM"
         pipeline._is_market_session_open = lambda _now: True
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
             set(),
             "paper_route_target_plan_fetch_failed:timeout",
             [],
@@ -1639,7 +1639,7 @@ def test_empty_target_plan_symbols_do_not_reserve_account(
         pipeline = object.__new__(SimpleTradingPipeline)
         pipeline.account_label = "TORGHUT_SIM"
         pipeline._is_market_session_open = lambda _now: True
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
             set(),
             None,
             [],
@@ -1691,7 +1691,7 @@ def test_target_account_audit_unavailable_still_scopes_signal_ingest(
         pipeline = object.__new__(SimpleTradingPipeline)
         pipeline.account_label = "TORGHUT_SIM"
         pipeline._is_market_session_open = lambda _now: True
-        pipeline._external_paper_route_target_probe_symbols_cached = lambda: (
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
             {"AAPL", "AMZN", "MSFT"},
             None,
             [target],

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -8980,6 +8981,199 @@ class TestTradingPipeline(TestCase):
         )
         self.assertEqual(fetch_plan.call_count, 2)
 
+    def test_self_referential_paper_route_target_plan_uses_local_gate_without_http(
+        self,
+    ) -> None:
+        from app import config
+
+        original_target_plan_url = config.settings.trading_paper_route_target_plan_url
+        original_target_plan_timeout = (
+            config.settings.trading_paper_route_target_plan_timeout_seconds
+        )
+        original_mode = config.settings.trading_mode
+        original_probe_enabled = (
+            config.settings.trading_simple_paper_route_probe_enabled
+        )
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan"
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+        pipeline._paper_route_target_plan_cache = None
+        pipeline._paper_route_target_plan_success_cache = None
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        local_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "targets": [
+                    {
+                        "candidate_id": "candidate-local-gate",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_window_start": ("2026-06-01T13:30:00+00:00"),
+                        "paper_route_probe_window_end": ("2026-06-01T20:00:00+00:00"),
+                        "paper_route_probe_next_session_max_notional": "75000",
+                    }
+                ],
+            }
+        }
+        try:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"K_SERVICE": "torghut-sim", "POD_NAMESPACE": "torghut"},
+                    clear=False,
+                ),
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=datetime(2026, 6, 1, 14, 30, tzinfo=timezone.utc),
+                ),
+                patch.object(
+                    pipeline, "_live_submission_gate", return_value=local_gate
+                ),
+                patch(
+                    "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+                    side_effect=AssertionError(
+                        "scheduler must not self-fetch target plan"
+                    ),
+                ),
+            ):
+                symbols, error, targets = (
+                    pipeline._external_paper_route_target_probe_symbols_cached(
+                        session=None,
+                        strategies=[strategy],
+                    )
+                )
+        finally:
+            config.settings.trading_mode = original_mode
+            config.settings.trading_simple_paper_route_probe_enabled = (
+                original_probe_enabled
+            )
+            config.settings.trading_paper_route_target_plan_url = (
+                original_target_plan_url
+            )
+            config.settings.trading_paper_route_target_plan_timeout_seconds = (
+                original_target_plan_timeout
+            )
+
+        self.assertEqual(symbols, {"AAPL", "AMZN"})
+        self.assertIsNone(error)
+        self.assertEqual(targets[0]["candidate_id"], "candidate-local-gate")
+        self.assertEqual(
+            targets[0]["paper_route_target_plan_source"],
+            "local_live_submission_gate",
+        )
+
+    def test_local_paper_route_target_plan_reports_missing_targets(self) -> None:
+        pipeline = object.__new__(SimpleTradingPipeline)
+        local_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "targets": [],
+            }
+        }
+
+        with patch.object(pipeline, "_live_submission_gate", return_value=local_gate):
+            symbols, error, targets = pipeline._local_paper_route_target_probe_symbols(
+                session=None,
+                strategies=None,
+            )
+
+        self.assertEqual(symbols, set())
+        self.assertEqual(error, "paper_route_target_plan_missing")
+        self.assertEqual(targets, [])
+
+    def test_local_paper_route_target_plan_falls_back_to_strategy_symbols(self) -> None:
+        pipeline = object.__new__(SimpleTradingPipeline)
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        local_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "targets": [
+                    {
+                        "candidate_id": "candidate-local-gate",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_probe_window_start": ("2026-06-01T13:30:00+00:00"),
+                        "paper_route_probe_window_end": "2026-06-01T20:00:00+00:00",
+                        "paper_route_probe_next_session_max_notional": "75000",
+                    }
+                ],
+            }
+        }
+
+        with patch.object(pipeline, "_live_submission_gate", return_value=local_gate):
+            symbols, error, targets = pipeline._local_paper_route_target_probe_symbols(
+                session=None,
+                strategies=[strategy],
+            )
+
+        self.assertEqual(symbols, {"AAPL", "AMZN"})
+        self.assertIsNone(error)
+        self.assertEqual(
+            targets[0]["paper_route_target_plan_source"], "local_live_submission_gate"
+        )
+
+    def test_local_paper_route_target_plan_requires_probe_symbols(self) -> None:
+        pipeline = object.__new__(SimpleTradingPipeline)
+        local_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "targets": [
+                    {
+                        "candidate_id": "candidate-local-gate",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_probe_window_start": ("2026-06-01T13:30:00+00:00"),
+                        "paper_route_probe_window_end": "2026-06-01T20:00:00+00:00",
+                        "paper_route_probe_next_session_max_notional": "75000",
+                    }
+                ],
+            }
+        }
+
+        with patch.object(pipeline, "_live_submission_gate", return_value=local_gate):
+            symbols, error, targets = pipeline._local_paper_route_target_probe_symbols(
+                session=None,
+                strategies=None,
+            )
+
+        self.assertEqual(symbols, set())
+        self.assertEqual(error, "paper_route_target_plan_probe_symbols_missing")
+        self.assertEqual(
+            targets[0]["paper_route_target_plan_source"], "local_live_submission_gate"
+        )
+
     def test_bounded_signal_scope_records_target_plan_fetch_failure(
         self,
     ) -> None:
@@ -9857,7 +10051,7 @@ class TestTradingPipeline(TestCase):
             setattr(
                 pipeline,
                 "_external_paper_route_target_probe_symbols_cached",
-                lambda: ({"AAPL", "AMZN"}, None, [target]),
+                lambda **_kwargs: ({"AAPL", "AMZN"}, None, [target]),
             )
             with patch(
                 "app.trading.scheduler.simple_pipeline.trading_now",
@@ -9983,7 +10177,7 @@ class TestTradingPipeline(TestCase):
             setattr(
                 pipeline,
                 "_external_paper_route_target_probe_symbols_cached",
-                lambda: ({"AAPL", "AMZN"}, None, [target]),
+                lambda **_kwargs: ({"AAPL", "AMZN"}, None, [target]),
             )
             with patch(
                 "app.trading.scheduler.simple_pipeline.trading_now",
@@ -10229,7 +10423,7 @@ class TestTradingPipeline(TestCase):
             setattr(
                 pipeline,
                 "_external_paper_route_target_probe_symbols_cached",
-                lambda: ({"AAPL", "AMZN"}, None, [target]),
+                lambda **_kwargs: ({"AAPL", "AMZN"}, None, [target]),
             )
             with patch(
                 "app.trading.scheduler.simple_pipeline.trading_now",
@@ -10276,7 +10470,7 @@ class TestTradingPipeline(TestCase):
         setattr(
             pipeline,
             "_external_paper_route_target_probe_symbols_cached",
-            lambda: ({"AAPL", "AMZN"}, None, [target]),
+            lambda **_kwargs: ({"AAPL", "AMZN"}, None, [target]),
         )
 
         with patch(
@@ -10798,7 +10992,7 @@ class TestTradingPipeline(TestCase):
         setattr(
             pipeline,
             "_external_paper_route_target_probe_symbols_cached",
-            lambda: ({"AAPL", "AMZN"}, None, targets),
+            lambda **_kwargs: ({"AAPL", "AMZN"}, None, targets),
         )
 
         with patch(

--- a/services/torghut/tests/test_trading_scheduler_safety.py
+++ b/services/torghut/tests/test_trading_scheduler_safety.py
@@ -328,7 +328,7 @@ class TestTradingSchedulerSafety(TestCase):
         setattr(
             pipeline,
             "_external_paper_route_target_probe_symbols_cached",
-            lambda: ({"AAPL", "AMZN", "MSFT"}, None, [target]),
+            lambda **_kwargs: ({"AAPL", "AMZN", "MSFT"}, None, [target]),
         )
         setattr(
             pipeline,
@@ -382,7 +382,7 @@ class TestTradingSchedulerSafety(TestCase):
         setattr(
             pipeline,
             "_external_paper_route_target_probe_symbols_cached",
-            lambda: ({"AAPL", "AMZN"}, None, [target]),
+            lambda **_kwargs: ({"AAPL", "AMZN"}, None, [target]),
         )
         setattr(
             pipeline,
@@ -455,7 +455,7 @@ class TestTradingSchedulerSafety(TestCase):
         setattr(
             pipeline,
             "_external_paper_route_target_probe_symbols_cached",
-            lambda: ({"AAPL", "AMZN"}, None, [target]),
+            lambda **_kwargs: ({"AAPL", "AMZN"}, None, [target]),
         )
         config.settings.trading_mode = "paper"
         config.settings.trading_simple_paper_route_probe_enabled = True


### PR DESCRIPTION
## Summary

- Prevent the simple scheduler from HTTP self-fetching `/trading/paper-route-target-plan` when the configured URL points at the current Knative service.
- Derive self-referential bounded paper-route targets from the scheduler's local live submission gate and keep the existing target-plan cache/stale-success behavior.
- Add regression coverage proving the scheduler does not call the HTTP fetch helper for a self-referential Torghut SIM target-plan URL.
- Add focused local-gate coverage for missing targets, strategy-symbol fallback, and missing-symbol blocker reporting.
- Update existing target-plan mocks to accept the new cached probe-symbol helper context arguments.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k self_referential_paper_route_target_plan_uses_local_gate_without_http -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'self_referential_paper_route_target_plan or local_paper_route_target_plan' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'external_paper_route_target_plan_cache or bounded_signal_scope_records_target_plan_fetch_failure or bounded_signal_scope_records_configured_target_plan_missing_symbols or paper_route_target_source_decisions_record_target_plan_unavailable or paper_route_probe_context_honors_external_target_plan_scope or paper_decision_persists_external_target_lineage_without_gate_bypass' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_target' -q`
- `uv run --frozen pytest tests/test_simple_pipeline.py::test_bounded_source_collection_authorizes_after_runtime_account_audit_readback tests/test_simple_pipeline.py::test_source_collection_authorization_emits_bounded_lineage_decisions_without_candidate_hardcode tests/test_simple_pipeline.py::test_target_account_audit_unavailable_still_scopes_signal_ingest tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_hpairs_target_strategy_matches_declared_catalog_strategy_id tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_paper_route_source_decisions_skip_balanced_pair_when_shorts_disabled tests/test_trading_scheduler_safety.py::TestTradingSchedulerSafety::test_paper_route_source_decisions_skip_imbalanced_pair_targets -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py tests/test_simple_pipeline.py tests/test_trading_scheduler_safety.py`
- `uv run --frozen ruff check tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py tests/test_simple_pipeline.py tests/test_trading_scheduler_safety.py`
- `uv run --frozen ruff format --check tests/test_trading_pipeline.py`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
