### PR TITLE
fix(torghut): prefer executable paper route target plans

### DIFF
--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -57,6 +57,121 @@ def paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, A
     return mapping_items(plan.get("targets"))
 
 
+def _target_probe_symbol_values(target: Mapping[str, Any]) -> set[str]:
+    symbols: set[str] = set()
+    for field in (
+        "paper_route_probe_symbols",
+        "paper_route_probe_raw_target_symbols",
+        "symbols",
+        "target_symbols",
+    ):
+        raw_symbols = target.get(field)
+        if isinstance(raw_symbols, str):
+            values: Sequence[object] = raw_symbols.split(",")
+        elif isinstance(raw_symbols, Sequence) and not isinstance(
+            raw_symbols, (bytes, bytearray)
+        ):
+            values = cast(Sequence[object], raw_symbols)
+        else:
+            values = ()
+        for raw_symbol in values:
+            symbol = str(raw_symbol).strip().upper()
+            if symbol:
+                symbols.add(symbol)
+
+    for field in (
+        "paper_route_probe_symbol_actions",
+        "symbol_actions",
+        "target_symbol_actions",
+    ):
+        raw_actions = target.get(field)
+        if not isinstance(raw_actions, Mapping):
+            continue
+        for raw_symbol in cast(Mapping[object, object], raw_actions):
+            symbol = str(raw_symbol).strip().upper()
+            if symbol:
+                symbols.add(symbol)
+    return symbols
+
+
+def _target_source_decision_ready(target: Mapping[str, Any]) -> bool:
+    readiness = target.get("source_decision_readiness")
+    if not isinstance(readiness, Mapping):
+        return False
+    value = cast(Mapping[object, object], readiness).get("ready")
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _target_identity_value(target: Mapping[str, Any], field: str) -> str:
+    return str(target.get(field) or "").strip()
+
+
+def _target_identity_keys(target: Mapping[str, Any]) -> set[tuple[str, str]]:
+    candidate_id = _target_identity_value(target, "candidate_id")
+    if candidate_id:
+        return {("candidate_id", candidate_id)}
+
+    source_plan_ref = _target_identity_value(target, "source_plan_ref")
+    if source_plan_ref:
+        return {("source_plan_ref", source_plan_ref)}
+
+    hypothesis_id = _target_identity_value(target, "hypothesis_id")
+    strategy_name = _target_identity_value(
+        target,
+        "runtime_strategy_name",
+    ) or _target_identity_value(target, "strategy_name")
+    if hypothesis_id and strategy_name:
+        return {("hypothesis_strategy", f"{hypothesis_id}:{strategy_name}")}
+    if hypothesis_id:
+        return {("hypothesis_id", hypothesis_id)}
+    if strategy_name:
+        return {("strategy_name", strategy_name)}
+    return set()
+
+
+def _target_plan_selected_identity_match(
+    plan: Mapping[str, Any],
+    *,
+    selected_identity_keys: set[tuple[str, str]],
+) -> bool:
+    if not selected_identity_keys:
+        return True
+    return any(
+        bool(_target_identity_keys(target) & selected_identity_keys)
+        for target in paper_route_target_plan_targets(plan)
+    )
+
+
+def _target_plan_selection_score(
+    plan: Mapping[str, Any],
+    *,
+    source_rank: int,
+    selected_identity_keys: set[tuple[str, str]],
+) -> tuple[int, int, int, int, int, int]:
+    targets = paper_route_target_plan_targets(plan)
+    if not targets:
+        return (-1, 0, 0, 0, 0, -source_rank)
+    probe_symbol_count = sum(
+        len(_target_probe_symbol_values(target)) for target in targets
+    )
+    ready_count = sum(1 for target in targets if _target_source_decision_ready(target))
+    return (
+        1
+        if _target_plan_selected_identity_match(
+            plan,
+            selected_identity_keys=selected_identity_keys,
+        )
+        else 0,
+        1 if probe_symbol_count else 0,
+        ready_count,
+        probe_symbol_count,
+        len(targets),
+        -source_rank,
+    )
+
+
 def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     live_gate = _to_str_map(payload.get("live_submission_gate"))
     top_level_target_plan = (
@@ -79,6 +194,11 @@ def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str
     next_paper_route_plan = _to_str_map(
         payload.get("next_paper_route_runtime_window_targets")
     )
+    selected_identity_keys = {
+        key
+        for target in paper_route_target_plan_targets(top_level_target_plan)
+        for key in _target_identity_keys(target)
+    }
     candidate_plans = [
         top_level_target_plan,
         next_clean_after_discard_plan,
@@ -90,10 +210,21 @@ def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str
         _to_str_map(payload.get("runtime_ledger_paper_probation_import_plan")),
         dict(payload) if paper_route_target_plan_targets(payload) else {},
     ]
-    for plan in candidate_plans:
-        if paper_route_target_plan_targets(plan):
-            return plan
-    return {}
+    scored_plans = [
+        (
+            _target_plan_selection_score(
+                plan,
+                source_rank=source_rank,
+                selected_identity_keys=selected_identity_keys,
+            ),
+            plan,
+        )
+        for source_rank, plan in enumerate(candidate_plans)
+        if paper_route_target_plan_targets(plan)
+    ]
+    if not scored_plans:
+        return {}
+    return dict(max(scored_plans, key=lambda item: item[0])[1])
 
 
 def fetch_paper_route_target_plan_url(
@@ -188,19 +319,7 @@ def _fetch_paper_route_target_plan_url_once(
 def paper_route_target_plan_probe_symbols(plan: Mapping[str, Any]) -> set[str]:
     symbols: set[str] = set()
     for target in paper_route_target_plan_targets(plan):
-        raw_symbols = target.get("paper_route_probe_symbols")
-        if isinstance(raw_symbols, str):
-            values: Sequence[object] = raw_symbols.split(",")
-        elif isinstance(raw_symbols, Sequence) and not isinstance(
-            raw_symbols, (bytes, bytearray)
-        ):
-            values = cast(Sequence[object], raw_symbols)
-        else:
-            values = ()
-        for raw_symbol in values:
-            symbol = str(raw_symbol).strip().upper()
-            if symbol:
-                symbols.add(symbol)
+        symbols.update(_target_probe_symbol_values(target))
     return symbols
 
 

--- a/services/torghut/tests/test_paper_route_target_plan.py
+++ b/services/torghut/tests/test_paper_route_target_plan.py
@@ -22,8 +22,13 @@ from app.trading.models import StrategyDecision, decision_hash
 from app.trading.paper_route_target_plan import (
     _paper_route_source_decision_needs_refresh,
     _paper_route_source_materialization_blockers,
+    _target_identity_keys,
+    _target_plan_selection_score,
+    _target_source_decision_ready,
     _truthy,
     materialize_bounded_paper_route_target_plan,
+    paper_route_target_plan_from_payload,
+    paper_route_target_plan_probe_symbols,
 )
 from app.trading.runtime_decision_authority import (
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
@@ -131,6 +136,165 @@ def test_materialization_truthy_helper_accepts_numeric_and_text_readiness() -> N
     assert _truthy(0) is False
     assert _truthy("true") is True
     assert _truthy("false") is False
+
+
+def test_target_source_decision_readiness_accepts_text_truth() -> None:
+    assert _target_source_decision_ready(
+        {"source_decision_readiness": {"ready": "yes"}}
+    )
+    assert not _target_source_decision_ready(
+        {"source_decision_readiness": {"ready": "no"}}
+    )
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        (
+            {"source_plan_ref": "paper-route-plan:abc"},
+            {("source_plan_ref", "paper-route-plan:abc")},
+        ),
+        (
+            {
+                "hypothesis_id": "H-TSMOM-LIQ-01",
+                "runtime_strategy_name": "intraday-tsmom-profit-v3",
+            },
+            {("hypothesis_strategy", "H-TSMOM-LIQ-01:intraday-tsmom-profit-v3")},
+        ),
+        (
+            {
+                "hypothesis_id": "H-PAIRS-01",
+                "strategy_name": "microbar-cross-sectional-pairs-v1",
+            },
+            {("hypothesis_strategy", "H-PAIRS-01:microbar-cross-sectional-pairs-v1")},
+        ),
+        ({"hypothesis_id": "H-PAIRS-01"}, {("hypothesis_id", "H-PAIRS-01")}),
+        (
+            {"strategy_name": "microbar-cross-sectional-pairs-v1"},
+            {("strategy_name", "microbar-cross-sectional-pairs-v1")},
+        ),
+        ({}, set()),
+    ],
+)
+def test_target_identity_keys_fall_back_by_available_specificity(
+    target: dict[str, Any],
+    expected: set[tuple[str, str]],
+) -> None:
+    assert _target_identity_keys(target) == expected
+
+
+def test_target_plan_selection_score_rejects_empty_plans() -> None:
+    assert _target_plan_selection_score(
+        {},
+        source_rank=3,
+        selected_identity_keys=set(),
+    ) == (-1, 0, 0, 0, 0, -3)
+
+
+def test_target_plan_payload_prefers_nested_plan_with_probe_symbols() -> None:
+    payload = {
+        "schema_version": "torghut.paper-route-target-plan.v1",
+        "target_count": 1,
+        "targets": [
+            {
+                "hypothesis_id": "H-TSMOM-LIQ-01",
+                "candidate_id": "ca4e6e3c7d639e3363dc5860",
+                "runtime_strategy_name": "intraday-tsmom-profit-v3",
+            }
+        ],
+        "next_paper_route_runtime_window_targets": {
+            "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+            "source": "paper_route_evidence_audit",
+            "target_count": 1,
+            "targets": [
+                {
+                    "hypothesis_id": "H-TSMOM-LIQ-01",
+                    "candidate_id": "ca4e6e3c7d639e3363dc5860",
+                    "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                    "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                    "paper_route_probe_symbol_actions": {},
+                    "source_decision_readiness": {"ready": True, "blockers": []},
+                }
+            ],
+        },
+    }
+
+    plan = paper_route_target_plan_from_payload(payload)
+
+    assert plan["source"] == "paper_route_evidence_audit"
+    assert plan["targets"][0]["paper_route_probe_symbols"] == ["AAPL", "AMZN"]
+    assert paper_route_target_plan_probe_symbols(plan) == {"AAPL", "AMZN"}
+
+
+def test_target_plan_payload_keeps_selected_target_over_unrelated_nested_plan() -> None:
+    payload = {
+        "schema_version": "torghut.paper-route-target-plan.v1",
+        "target_count": 1,
+        "targets": [
+            {
+                "hypothesis_id": "H-TSMOM-LIQ-01",
+                "candidate_id": "ca4e6e3c7d639e3363dc5860",
+                "runtime_strategy_name": "intraday-tsmom-profit-v3",
+            }
+        ],
+        "next_paper_route_runtime_window_targets": {
+            "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+            "source": "paper_route_evidence_audit",
+            "target_count": 1,
+            "targets": [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                    "source_decision_readiness": {"ready": True, "blockers": []},
+                }
+            ],
+        },
+    }
+
+    plan = paper_route_target_plan_from_payload(payload)
+
+    assert plan["schema_version"] == "torghut.paper-route-target-plan.v1"
+    assert plan["targets"][0]["hypothesis_id"] == "H-TSMOM-LIQ-01"
+    assert plan["targets"][0]["candidate_id"] == "ca4e6e3c7d639e3363dc5860"
+    assert paper_route_target_plan_probe_symbols(plan) == set()
+
+
+def test_target_plan_payload_keeps_top_level_plan_when_it_has_probe_symbols() -> None:
+    payload = {
+        "schema_version": "torghut.paper-route-target-plan.v1",
+        "target_count": 1,
+        "targets": [
+            {
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "paper_route_probe_symbol_actions": {
+                    "AAPL": "buy",
+                    "AMZN": "sell",
+                },
+            }
+        ],
+        "next_paper_route_runtime_window_targets": {
+            "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+            "source": "paper_route_evidence_audit",
+            "targets": [
+                {
+                    "hypothesis_id": "H-TSMOM-LIQ-01",
+                    "candidate_id": "ca4e6e3c7d639e3363dc5860",
+                    "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                    "paper_route_probe_symbols": ["NVDA"],
+                }
+            ],
+        },
+    }
+
+    plan = paper_route_target_plan_from_payload(payload)
+
+    assert plan["schema_version"] == "torghut.paper-route-target-plan.v1"
+    assert plan["targets"][0]["hypothesis_id"] == "H-PAIRS-01"
+    assert paper_route_target_plan_probe_symbols(plan) == {"AAPL", "AMZN"}
 
 
 def test_fresh_hpairs_target_materializes_bounded_collection_source_decisions(


### PR DESCRIPTION
## Summary

- Prefer executable bounded paper-route target plans only when they match the selected top-level target identity.
- Keep explicitly selected top-level targets from being replaced by unrelated nested plans with richer probe-symbol metadata.
- Teach target-plan symbol extraction to read explicit symbol lists, target-symbol lists, and symbol-action maps.
- Add regression coverage for skeletal selected targets, unrelated nested plans, helper fallback scoring, and action-key-only H-PAIRS targets.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_target_plan.py -q`
- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_payload_prefers_selected_top_level_targets -q`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_target or bounded_paper_route' -q`
- `uv run --frozen ruff check app/trading/paper_route_target_plan.py tests/test_paper_route_target_plan.py tests/test_trading_api.py tests/test_materialize_bounded_paper_route_targets.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/paper_route_target_plan.py tests/test_paper_route_target_plan.py tests/test_trading_api.py tests/test_materialize_bounded_paper_route_targets.py tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
