### PR TITLE
fix(torghut): prioritize ready paper probation candidates

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -4602,8 +4602,7 @@ def _candidate_exact_replay_ledger_artifact_refs(item: Mapping[str, Any]) -> lis
         ref = str(raw_ref).strip()
         ref_lower = ref.lower()
         if ref and (
-            "exact-replay-ledger" in ref_lower
-            or "exact_replay_ledger" in ref_lower
+            "exact-replay-ledger" in ref_lower or "exact_replay_ledger" in ref_lower
         ):
             refs.append(ref)
     return list(dict.fromkeys(refs))
@@ -5018,28 +5017,11 @@ def _build_paper_probation_shortlist(
         )
         > Decimal("0")
     ]
-    visible_items.sort(
-        key=lambda item: (
-            -_safe_decimal(
-                _candidate_metric_value(
-                    item,
-                    scorecard_key="net_pnl_per_day",
-                    full_window_key="net_per_day",
-                )
-            ),
-            -_safe_decimal(
-                _candidate_metric_value(
-                    item,
-                    scorecard_key="net_pnl",
-                    full_window_key="net_pnl",
-                )
-            ),
-            str(item.get("candidate_id") or ""),
-        )
-    )
 
-    shortlist: list[dict[str, Any]] = []
-    for item in visible_items[: max(1, int(top_n))]:
+    shortlist_candidates: list[
+        tuple[bool, bool, Decimal, Decimal, str, dict[str, Any]]
+    ] = []
+    for item in visible_items:
         hard_vetoes = [
             str(reason) for reason in cast(Sequence[Any], item.get("hard_vetoes") or ())
         ]
@@ -5111,99 +5093,115 @@ def _build_paper_probation_shortlist(
             exact_replay_parity_ok=exact_replay_parity_ok,
             diagnostics=handoff_diagnostics,
         )
-        shortlist.append(
-            {
-                "candidate_id": str(item.get("candidate_id") or ""),
-                "strategy_name": str(item.get("strategy_name") or ""),
-                "family": str(item.get("family") or ""),
-                "stage": "paper_evidence_collection_only",
-                "paper_probation_allowed": paper_probation_allowed,
-                "evidence_collection_ok": bounded_sim_handoff["evidence_collection_ok"],
-                "promotion_allowed": False,
-                "final_promotion_allowed": False,
-                "final_promotion_authorized": False,
-                "probation_blockers": blockers,
-                "handoff_diagnostics": handoff_diagnostics,
-                "bounded_sim_handoff": bounded_sim_handoff,
-                "required_actions_before_or_during_probation": (
-                    _paper_probation_required_actions(hard_vetoes)
-                ),
-                "recommended_notional_scale": _paper_probation_notional_scale(
-                    item=item,
-                    objective_veto_policy=objective_veto_policy,
-                    hard_vetoes=hard_vetoes,
-                ),
-                "exact_replay_ledger_artifact_refs": artifact_refs,
-                "exact_replay_ledger_artifact_row_count": (
-                    exact_replay_ledger_row_count
-                ),
-                "exact_replay_ledger_artifact_fill_count": (
-                    exact_replay_ledger_fill_count
-                ),
-                "net_pnl_per_day": str(
-                    _candidate_metric_value(
-                        item,
-                        scorecard_key="net_pnl_per_day",
-                        full_window_key="net_per_day",
-                    )
-                ),
-                "net_pnl": str(
-                    _candidate_metric_value(
-                        item,
-                        scorecard_key="net_pnl",
-                        full_window_key="net_pnl",
-                    )
-                ),
-                "active_day_ratio": str(
-                    _candidate_metric_value(
-                        item,
-                        scorecard_key="active_day_ratio",
-                        full_window_key="active_ratio",
-                    )
-                ),
-                "positive_day_ratio": str(
-                    _candidate_metric_value(
-                        item,
-                        scorecard_key="positive_day_ratio",
-                        full_window_key="positive_day_ratio",
-                    )
-                ),
-                "max_drawdown": str(
-                    _candidate_metric_value(
-                        item,
-                        scorecard_key="max_drawdown",
-                        full_window_key="max_drawdown",
-                    )
-                ),
-                "worst_day_loss": str(
-                    _candidate_metric_value(
-                        item,
-                        scorecard_key="worst_day_loss",
-                        full_window_key="worst_day_loss",
-                    )
-                ),
-                "max_gross_exposure_pct_equity": str(
-                    _candidate_metric_value(
-                        item,
-                        scorecard_key="max_gross_exposure_pct_equity",
-                        full_window_key="max_gross_exposure_pct_equity",
-                    )
-                ),
-                "min_cash": str(
-                    _candidate_metric_value(
-                        item,
-                        scorecard_key="min_cash",
-                        full_window_key="min_cash",
-                    )
-                ),
-                "exact_replay_ledger_artifact_ref": str(
-                    item.get("exact_replay_ledger_artifact_ref") or ""
-                ),
-                "replay_artifact_refs": artifact_refs,
-                "hard_vetoes": hard_vetoes,
-            }
+        entry = {
+            "candidate_id": str(item.get("candidate_id") or ""),
+            "strategy_name": str(item.get("strategy_name") or ""),
+            "family": str(item.get("family") or ""),
+            "stage": "paper_evidence_collection_only",
+            "paper_probation_allowed": paper_probation_allowed,
+            "evidence_collection_ok": bounded_sim_handoff["evidence_collection_ok"],
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "probation_blockers": blockers,
+            "handoff_diagnostics": handoff_diagnostics,
+            "bounded_sim_handoff": bounded_sim_handoff,
+            "required_actions_before_or_during_probation": (
+                _paper_probation_required_actions(hard_vetoes)
+            ),
+            "recommended_notional_scale": _paper_probation_notional_scale(
+                item=item,
+                objective_veto_policy=objective_veto_policy,
+                hard_vetoes=hard_vetoes,
+            ),
+            "exact_replay_ledger_artifact_refs": artifact_refs,
+            "exact_replay_ledger_artifact_row_count": (exact_replay_ledger_row_count),
+            "exact_replay_ledger_artifact_fill_count": (exact_replay_ledger_fill_count),
+            "net_pnl_per_day": str(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="net_pnl_per_day",
+                    full_window_key="net_per_day",
+                )
+            ),
+            "net_pnl": str(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="net_pnl",
+                    full_window_key="net_pnl",
+                )
+            ),
+            "active_day_ratio": str(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="active_day_ratio",
+                    full_window_key="active_ratio",
+                )
+            ),
+            "positive_day_ratio": str(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="positive_day_ratio",
+                    full_window_key="positive_day_ratio",
+                )
+            ),
+            "max_drawdown": str(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="max_drawdown",
+                    full_window_key="max_drawdown",
+                )
+            ),
+            "worst_day_loss": str(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="worst_day_loss",
+                    full_window_key="worst_day_loss",
+                )
+            ),
+            "max_gross_exposure_pct_equity": str(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="max_gross_exposure_pct_equity",
+                    full_window_key="max_gross_exposure_pct_equity",
+                )
+            ),
+            "min_cash": str(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="min_cash",
+                    full_window_key="min_cash",
+                )
+            ),
+            "exact_replay_ledger_artifact_ref": str(
+                item.get("exact_replay_ledger_artifact_ref") or ""
+            ),
+            "replay_artifact_refs": artifact_refs,
+            "hard_vetoes": hard_vetoes,
+        }
+        net_pnl_per_day = _safe_decimal(entry["net_pnl_per_day"])
+        net_pnl = _safe_decimal(entry["net_pnl"])
+        shortlist_candidates.append(
+            (
+                paper_probation_allowed,
+                bool(bounded_sim_handoff["evidence_collection_ok"]),
+                net_pnl_per_day,
+                net_pnl,
+                entry["candidate_id"],
+                entry,
+            )
         )
-    return shortlist
+
+    shortlist_candidates.sort(
+        key=lambda candidate: (
+            0 if candidate[0] else 1,
+            0 if candidate[1] else 1,
+            -candidate[2],
+            -candidate[3],
+            candidate[4],
+        )
+    )
+    return [candidate[5] for candidate in shortlist_candidates[: max(1, int(top_n))]]
 
 
 def _frontier_state_item(item: Mapping[str, Any]) -> dict[str, Any]:

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2740,6 +2740,92 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             item["required_actions_before_or_during_probation"],
         )
 
+    def test_paper_probation_shortlist_prioritizes_handoff_ready_candidate(
+        self,
+    ) -> None:
+        items = [
+            {
+                "candidate_id": "higher-profit-unproved",
+                "strategy_name": "blocked",
+                "family": "microbar",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "900",
+                    "net_pnl": "1800",
+                    "max_gross_exposure_pct_equity": "0.5",
+                    "min_cash": "100",
+                },
+                "full_window": {"net_per_day": "900", "net_pnl": "1800"},
+                "hard_vetoes": [],
+            },
+            {
+                "candidate_id": "lower-profit-handoff-ready",
+                "strategy_name": "ready",
+                "family": "hpairs",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "275",
+                    "net_pnl": "550",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "1",
+                    "max_drawdown": "50",
+                    "worst_day_loss": "25",
+                    "max_gross_exposure_pct_equity": "0.5",
+                    "min_cash": "100",
+                },
+                "full_window": {"net_per_day": "275", "net_pnl": "550"},
+                "exact_replay_ledger_artifact_ref": (
+                    "/tmp/lower-profit-handoff-ready-exact-replay-ledger.json"
+                ),
+                "exact_replay_ledger_artifact_row_count": 10,
+                "exact_replay_ledger_artifact_fill_count": 4,
+                "runtime_ledger_cost_basis_count": 4,
+                "runtime_ledger_post_cost_expectancy_bps": "18",
+                "runtime_ledger_pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+                "runtime_ledger_open_position_count": 0,
+                "replay_artifact_refs": [
+                    "/tmp/lower-profit-handoff-ready-exact-replay-ledger.json"
+                ],
+                "dataset_snapshot_id": "snapshot-handoff-ready",
+                "replay_lineage": {"lineage_hash": "lineage-handoff-ready"},
+                "candidate_evaluation_key": "eval-handoff-ready",
+                "candidate_evaluation_key_payload": {
+                    "candidate_evaluation_key": "eval-handoff-ready",
+                    "replay_tape": {
+                        "content_sha256": "tape-sha",
+                        "dataset_snapshot_ref": "snapshot-handoff-ready",
+                        "source_query_digest": "query-sha",
+                        "feature_schema_hash": "feature-sha",
+                        "cost_model_hash": "cost-sha",
+                        "strategy_family": "hpairs",
+                        "replay_cache_key": "cache-key",
+                        "selected_symbols": ["NVDA"],
+                        "selected_row_count": 10,
+                        "validation_status": "valid",
+                    },
+                },
+                "hard_vetoes": [],
+            },
+        ]
+
+        shortlist = frontier._build_paper_probation_shortlist(
+            items,
+            top_n=1,
+            objective_veto_policy=frontier.ObjectiveVetoPolicy(
+                required_max_gross_exposure_pct_equity=Decimal("1"),
+                required_min_cash=Decimal("0"),
+            ),
+        )
+
+        item = shortlist[0]
+        self.assertEqual(item["candidate_id"], "lower-profit-handoff-ready")
+        self.assertTrue(item["paper_probation_allowed"])
+        self.assertTrue(item["evidence_collection_ok"])
+        self.assertFalse(item["promotion_allowed"])
+        self.assertFalse(item["final_promotion_allowed"])
+        self.assertFalse(item["final_promotion_authorized"])
+        self.assertFalse(item["bounded_sim_handoff"]["promotion_allowed"])
+        self.assertFalse(item["bounded_sim_handoff"]["final_promotion_allowed"])
+        self.assertEqual(item["probation_blockers"], [])
+
     def test_paper_probation_shortlist_blocks_missing_ledger_artifact(self) -> None:
         shortlist = frontier._build_paper_probation_shortlist(
             [


### PR DESCRIPTION
## Summary

- Evaluates every positive paper-probation candidate for source, exact replay, ledger, and post-cost handoff readiness before truncating the shortlist.
- Prioritizes candidates that can actually enter bounded paper evidence collection over higher-PnL candidates missing required proof preconditions.
- Adds a regression test covering the blocked-high-PnL versus ready-lower-PnL selection case while keeping promotion and final authority gates disabled.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -q`
- `uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A; backend harness selection change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
