### PR TITLE
fix(torghut): serve cached health during refresh

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -1618,6 +1618,13 @@ def _evaluate_trading_health_payload_bounded(
                 cached_result = (payload, status_code)
             else:
                 future = None
+        elif future is not None:
+            cache_entry = _TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.get(cache_key)
+            if cache_entry is not None:
+                payload = deepcopy(cast(dict[str, object], cache_entry["payload"]))
+                status_value = cache_entry.get("status_code")
+                status_code = status_value if isinstance(status_value, int) else 503
+                cached_result = (payload, status_code)
         if future is None and cached_result is None:
             future = _TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR.submit(
                 _evaluate_trading_health_payload,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -5551,6 +5551,71 @@ class TestTradingApi(TestCase):
         self.assertEqual(payload["reason"], "cached_health_payload")
         self.assertNotEqual(payload["reason"], "trading_health_evaluation_timeout")
 
+    def test_trading_health_serves_cached_payload_during_inflight_refresh(
+        self,
+    ) -> None:
+        cache_key = main_module._trading_health_surface_cache_key(
+            include_database_contract=False,
+            allow_stale_dependency_cache=False,
+        )
+        cached_payload: dict[str, object] = {
+            "status": "degraded",
+            "reason": "cached_health_payload",
+            "reason_codes": ["cached_health_payload"],
+            "dependencies": {"postgres": {"ok": True, "detail": "ok"}},
+            "live_submission_gate": {
+                "allowed": False,
+                "promotion_authority": False,
+                "final_authority_ok": False,
+                "final_promotion_allowed": False,
+            },
+        }
+        refresh_started = Event()
+        release_refresh = Event()
+
+        def _refresh_health_payload() -> tuple[dict[str, object], int]:
+            refresh_started.set()
+            release_refresh.wait(1.0)
+            return (
+                {
+                    **cached_payload,
+                    "reason": "refreshed_health_payload",
+                    "reason_codes": ["refreshed_health_payload"],
+                },
+                503,
+            )
+
+        refresh_future = main_module._TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR.submit(
+            _refresh_health_payload,
+        )
+        self.assertTrue(refresh_started.wait(1.0))
+        with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS[cache_key] = refresh_future
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE[cache_key] = {
+                "payload": cached_payload,
+                "status_code": 503,
+                "checked_at": datetime.now(timezone.utc),
+            }
+
+        try:
+            started_at = time.monotonic()
+            response = self.client.get("/trading/health")
+            elapsed = time.monotonic() - started_at
+        finally:
+            release_refresh.set()
+            refresh_future.result(timeout=1.0)
+            with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+                main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+                main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+
+        self.assertLess(elapsed, 0.5)
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["reason"], "cached_health_payload")
+        self.assertNotEqual(payload["reason"], "trading_health_evaluation_timeout")
+
     def test_trading_health_starts_fresh_eval_when_completed_future_has_no_cache(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Serve the last completed `/trading/health` payload immediately when a slow refresh is already in flight.
- Keep the background refresh running while preserving the existing fail-closed cached health semantics.
- Add a regression test for the in-flight refresh case so timeout fallback does not mask real health blockers.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_trading_api.py -k 'trading_health_serves_cached_payload_during_inflight_refresh or trading_health_serves_completed_health_cache_while_refreshing or trading_health_evaluation_timeout or trading_health_timeout_uses_cached_dependency_shape or trading_health_timeout_uses_cached_blockers_fail_closed' -q`
- `uv run --frozen pytest tests/test_trading_api.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
