### PR TITLE
fix(torghut): carry local target readiness

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -99,6 +99,12 @@ _SIGNAL_INGEST_UNAVAILABLE_REASONS = frozenset(
 )
 _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL = "TORGHUT_SIM"
 _BOUNDED_SIM_COLLECTION_SOURCE_KIND = "paper_route_probe_runtime_observed"
+_BOUNDED_SIM_COLLECTION_SOURCE_KINDS = frozenset(
+    {
+        _BOUNDED_SIM_COLLECTION_SOURCE_KIND,
+        "runtime_ledger_source_collection_candidate",
+    }
+)
 _BOUNDED_SIM_COLLECTION_SCOPE = "paper_route_probe_next_session_only"
 _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS = (
     "bounded_evidence_collection_blockers",
@@ -262,7 +268,7 @@ def _target_has_bounded_source_collection_authorization(
     scope = _safe_text(target.get("source_collection_authorization_scope"))
     return (
         _target_truthy(target.get("source_collection_authorized"))
-        and _safe_text(target.get("source_kind")) == _BOUNDED_SIM_COLLECTION_SOURCE_KIND
+        and _target_has_bounded_sim_collection_source_kind(target)
         and _safe_text(target.get("account_label"))
         == _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL
         and scope in _BOUNDED_SIM_COLLECTION_SOURCE_AUTHORIZATION_SCOPES
@@ -276,6 +282,12 @@ def _target_bounded_collection_authorized(target: Mapping[str, Any]) -> bool:
         or _target_truthy(target.get("canary_collection_authorized"))
         or _target_has_bounded_source_collection_authorization(target)
     )
+
+
+def _target_has_bounded_sim_collection_source_kind(
+    target: Mapping[str, Any],
+) -> bool:
+    return _safe_text(target.get("source_kind")) in _BOUNDED_SIM_COLLECTION_SOURCE_KINDS
 
 
 def _bounded_sim_collection_blockers(
@@ -293,7 +305,7 @@ def _bounded_sim_collection_blockers(
         blockers.append("bounded_sim_collection_target_account_not_torghut_sim")
     if _safe_text(target.get("observed_stage")) != "paper":
         blockers.append("bounded_sim_collection_paper_stage_required")
-    if _safe_text(target.get("source_kind")) != _BOUNDED_SIM_COLLECTION_SOURCE_KIND:
+    if not _target_has_bounded_sim_collection_source_kind(target):
         blockers.append("bounded_sim_collection_source_kind_required")
     if not (
         _safe_text(target.get("candidate_id"))
@@ -752,9 +764,7 @@ def _target_probe_exit_minute_after_open(
         )
         if exit_minute is not None:
             return exit_minute, False
-    if _safe_text(
-        target.get("source_kind")
-    ) == "paper_route_probe_runtime_observed" and (
+    if _target_has_bounded_sim_collection_source_kind(target) and (
         _target_truthy(target.get("bounded_evidence_collection_authorized"))
         or _target_truthy(target.get("paper_probation_authorized"))
         or _target_truthy(target.get("source_collection_authorized"))
@@ -3982,26 +3992,82 @@ class SimpleTradingPipeline(TradingPipeline):
         if not targets:
             return set(), "paper_route_target_plan_missing", []
 
-        symbols = set(paper_route_target_plan_probe_symbols(plan))
-        if not symbols:
-            for target in targets:
-                symbols.update(_target_symbols(target))
-                if strategies is None:
-                    continue
-                strategy = self._paper_route_target_strategy(target, strategies)
-                if strategy is not None:
-                    symbols.update(self._paper_route_target_strategy_symbols(strategy))
-
-        resolved_targets = [
-            {
+        resolved_targets: list[dict[str, Any]] = []
+        for target in targets:
+            resolved_target = {
                 **dict(target),
                 "paper_route_target_plan_source": _safe_text(
                     target.get("paper_route_target_plan_source")
                 )
                 or "local_live_submission_gate",
             }
-            for target in targets
-        ]
+            target_symbols = _target_symbols(resolved_target)
+            strategy = (
+                self._paper_route_target_strategy(resolved_target, strategies)
+                if strategies is not None
+                else None
+            )
+            strategy_symbols = (
+                sorted(self._paper_route_target_strategy_symbols(strategy))
+                if strategy is not None
+                else []
+            )
+            if not target_symbols and strategy_symbols:
+                resolved_target["paper_route_probe_symbols"] = strategy_symbols
+                resolved_target["paper_route_probe_raw_target_symbols"] = []
+                resolved_target["paper_route_probe_strategy_scope_applied"] = True
+                resolved_target["paper_route_probe_strategy_universe_fallback"] = True
+                resolved_target["paper_route_probe_strategy_universe_symbols"] = (
+                    strategy_symbols
+                )
+                target_symbols = set(strategy_symbols)
+            if (
+                target_symbols
+                and strategy is not None
+                and not isinstance(
+                    resolved_target.get("source_decision_readiness"), Mapping
+                )
+            ):
+                readiness_blockers = (
+                    [] if bool(strategy.enabled) else ["source_strategy_disabled"]
+                )
+                resolved_target["source_decision_readiness"] = {
+                    "schema_version": (
+                        "torghut.paper-route-source-decision-readiness.v1"
+                    ),
+                    "ready": not readiness_blockers,
+                    "blockers": readiness_blockers,
+                    "strategy_lookup_names": [
+                        item
+                        for item in (
+                            _safe_text(strategy.name),
+                            _safe_text(resolved_target.get("strategy_name")),
+                            _safe_text(resolved_target.get("runtime_strategy_name")),
+                            _safe_text(resolved_target.get("strategy_id")),
+                        )
+                        if item
+                    ],
+                    "matched_strategy": {
+                        "strategy_id": str(strategy.id or ""),
+                        "strategy_name": strategy.name,
+                        "enabled": bool(strategy.enabled),
+                        "base_timeframe": strategy.base_timeframe,
+                        "universe_symbols": strategy_symbols,
+                        "max_notional_per_trade": (
+                            str(strategy.max_notional_per_trade)
+                            if strategy.max_notional_per_trade is not None
+                            else "0"
+                        ),
+                    },
+                    "raw_probe_symbols": sorted(target_symbols),
+                    "scoped_probe_symbols": sorted(target_symbols),
+                    "source": "local_strategy_universe_target_plan_fallback",
+                }
+            resolved_targets.append(resolved_target)
+
+        symbols = set(
+            paper_route_target_plan_probe_symbols({"targets": resolved_targets})
+        )
         if not symbols:
             return (
                 set(),
@@ -5126,10 +5192,7 @@ class SimpleTradingPipeline(TradingPipeline):
                 continue
             if str(target.get("observed_stage") or "").strip().lower() != "paper":
                 continue
-            if (
-                _safe_text(target.get("source_kind"))
-                != "paper_route_probe_runtime_observed"
-            ):
+            if not _target_has_bounded_sim_collection_source_kind(target):
                 continue
             if _target_requires_bounded_sim_collection_gate(target):
                 blockers = _bounded_sim_collection_blockers(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -9085,6 +9085,16 @@ class TestTradingPipeline(TestCase):
             targets[0]["paper_route_target_plan_source"],
             "local_live_submission_gate",
         )
+        self.assertEqual(targets[0]["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(
+            targets[0]["source_decision_readiness"]["schema_version"],
+            "torghut.paper-route-source-decision-readiness.v1",
+        )
+        self.assertTrue(targets[0]["source_decision_readiness"]["ready"])
+        self.assertEqual(
+            targets[0]["source_decision_readiness"]["scoped_probe_symbols"],
+            ["AAPL", "AMZN"],
+        )
 
     def test_local_paper_route_target_plan_reports_missing_targets(self) -> None:
         pipeline = object.__new__(SimpleTradingPipeline)
@@ -9143,6 +9153,80 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(
             targets[0]["paper_route_target_plan_source"], "local_live_submission_gate"
         )
+        self.assertEqual(targets[0]["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+        self.assertTrue(targets[0]["source_decision_readiness"]["ready"])
+        self.assertEqual(
+            targets[0]["source_decision_readiness"]["source"],
+            "local_strategy_universe_target_plan_fallback",
+        )
+        self.assertEqual(
+            targets[0]["source_decision_readiness"]["scoped_probe_symbols"],
+            ["AAPL", "AMZN"],
+        )
+
+    def test_local_paper_route_target_plan_strategy_fallback_satisfies_source_collection_gate(
+        self,
+    ) -> None:
+        pipeline = object.__new__(SimpleTradingPipeline)
+        strategy = Strategy(
+            name="intraday-tsmom-profit-v3",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "NVDA"],
+        )
+        local_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "targets": [
+                    {
+                        "candidate_id": "candidate-local-source-collection",
+                        "hypothesis_id": "H-TSMOM-LIQ-01",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                        "account_label": "TORGHUT_SIM",
+                        "source_account_label": "TORGHUT_SIM",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_manifest_ref": (
+                            "config/trading/hypotheses/h-tsmom-liq-01.json"
+                        ),
+                        "source_collection_authorized": True,
+                        "source_collection_authorization_scope": (
+                            "source_window_evidence_collection_only"
+                        ),
+                        "evidence_collection_ok": True,
+                        "observed_stage": "paper",
+                        "paper_route_probe_window_start": ("2026-06-01T13:30:00+00:00"),
+                        "paper_route_probe_window_end": "2026-06-01T20:00:00+00:00",
+                        "paper_route_probe_next_session_max_notional": "75000",
+                    }
+                ],
+            }
+        }
+
+        with patch.object(pipeline, "_live_submission_gate", return_value=local_gate):
+            symbols, error, targets = pipeline._local_paper_route_target_probe_symbols(
+                session=None,
+                strategies=[strategy],
+            )
+
+        self.assertEqual(symbols, {"AAPL", "NVDA"})
+        self.assertIsNone(error)
+        target = _bounded_sim_collection_target_with_runtime_account_audit(
+            targets[0],
+            positions=[],
+            account_label="TORGHUT_SIM",
+        )
+        blockers = _bounded_sim_collection_blockers(
+            target,
+            account_label="TORGHUT_SIM",
+        )
+        self.assertNotIn("bounded_sim_collection_probe_symbols_missing", blockers)
+        self.assertNotIn(
+            "bounded_sim_collection_source_decision_readiness_missing",
+            blockers,
+        )
+        self.assertEqual(blockers, [])
 
     def test_local_paper_route_target_plan_requires_probe_symbols(self) -> None:
         pipeline = object.__new__(SimpleTradingPipeline)


### PR DESCRIPTION
## Summary

- Carries locally derived strategy-universe probe symbols onto self-referenced paper-route target-plan targets.
- Adds explicit source-decision readiness metadata for local target-plan fallback targets without weakening promotion authority.
- Accepts runtime-ledger source-collection candidates in the bounded SIM source-collection gate while preserving account, scope, readiness, symbol, and non-promotion checks.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_target or bounded_source_collection or source_collection' -q`
- `uv run --frozen pytest tests/test_simple_pipeline.py -k 'bounded_source_collection_authorizes_after_runtime_account_audit_readback or source_collection_authorization_emits_bounded_lineage_decisions_without_candidate_hardcode or target_account_audit_unavailable_still_scopes_signal_ingest' -q`
- `uv run --frozen pytest tests/test_trading_scheduler_safety.py -k 'hpairs_target_strategy_matches_declared_catalog_strategy_id or paper_route_source_decisions_skip_balanced_pair_when_shorts_disabled or paper_route_source_decisions_skip_imbalanced_pair_targets' -q`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
