### PR TITLE
fix(torghut): serve idle cached health immediately

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -1326,8 +1326,9 @@ def _record_trading_health_surface_completion(
 ) -> None:
     with _TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
         current = _TRADING_HEALTH_SURFACE_EVALUATIONS.get(cache_key)
-        if current is future:
-            _TRADING_HEALTH_SURFACE_EVALUATIONS.pop(cache_key, None)
+        if current is not future:
+            return
+        _TRADING_HEALTH_SURFACE_EVALUATIONS.pop(cache_key, None)
 
     try:
         payload, status_code = future.result()
@@ -1599,39 +1600,92 @@ def _evaluate_trading_health_payload_bounded(
     )
     callback_future: Future[tuple[dict[str, object], int]] | None = None
     cached_result: tuple[dict[str, object], int] | None = None
+
+    def _cached_result_from_entry(
+        cache_entry: Mapping[str, object] | None,
+    ) -> tuple[dict[str, object], int] | None:
+        if cache_entry is None:
+            return None
+        payload = deepcopy(cast(dict[str, object], cache_entry["payload"]))
+        dependencies = payload.get("dependencies")
+        if isinstance(dependencies, Mapping):
+            readiness_dependency_reasons = (
+                _readiness_dependency_degradation_reason_codes(
+                    cast(Mapping[str, object], dependencies),
+                    scheduler_ok=True,
+                )
+            )
+            live_submission_gate = payload.get("live_submission_gate")
+            if isinstance(live_submission_gate, Mapping):
+                guarded_live_submission_gate = (
+                    _guard_live_submission_gate_for_readiness(
+                        cast(Mapping[str, object], live_submission_gate),
+                        readiness_dependency_reasons=readiness_dependency_reasons,
+                    )
+                )
+                payload["live_submission_gate"] = guarded_live_submission_gate
+                if bool(
+                    guarded_live_submission_gate.get(
+                        "readiness_dependency_guard_active"
+                    )
+                ):
+                    dependencies_payload = deepcopy(
+                        dict(cast(Mapping[str, object], dependencies))
+                    )
+                    dependencies_payload["live_submission_gate"] = {
+                        "ok": False,
+                        "detail": str(
+                            guarded_live_submission_gate.get("reason")
+                            or "readiness_dependency_degraded"
+                        ),
+                        "capital_stage": guarded_live_submission_gate.get(
+                            "capital_stage"
+                        ),
+                        "readiness_dependency_guard_active": True,
+                        "readiness_dependency_guard_reasons": (
+                            readiness_dependency_reasons
+                        ),
+                    }
+                    payload["dependencies"] = dependencies_payload
+        status_value = cache_entry.get("status_code")
+        status_code = status_value if isinstance(status_value, int) else 503
+        return (
+            cast(
+                dict[str, object],
+                _strip_promotion_authority_claims_for_readiness(payload),
+            ),
+            status_code,
+        )
+
+    def _start_refresh_locked() -> Future[tuple[dict[str, object], int]]:
+        refresh_future = _TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR.submit(
+            _evaluate_trading_health_payload,
+            include_database_contract=include_database_contract,
+            allow_stale_dependency_cache=allow_stale_dependency_cache,
+        )
+        _TRADING_HEALTH_SURFACE_EVALUATIONS[cache_key] = refresh_future
+        return refresh_future
+
     with _TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
         future = _TRADING_HEALTH_SURFACE_EVALUATIONS.get(cache_key)
         if future is not None and future.done():
-            cache_entry = _TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.get(cache_key)
             _TRADING_HEALTH_SURFACE_EVALUATIONS.pop(cache_key, None)
-            if cache_entry is not None:
-                payload = deepcopy(cast(dict[str, object], cache_entry["payload"]))
-                status_value = cache_entry.get("status_code")
-                status_code = status_value if isinstance(status_value, int) else 503
-                refresh_future = _TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR.submit(
-                    _evaluate_trading_health_payload,
-                    include_database_contract=include_database_contract,
-                    allow_stale_dependency_cache=allow_stale_dependency_cache,
-                )
-                _TRADING_HEALTH_SURFACE_EVALUATIONS[cache_key] = refresh_future
-                callback_future = refresh_future
-                cached_result = (payload, status_code)
+            cached_result = _cached_result_from_entry(
+                _TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.get(cache_key)
+            )
+            if cached_result is not None:
+                callback_future = _start_refresh_locked()
             else:
                 future = None
         elif future is not None:
-            cache_entry = _TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.get(cache_key)
-            if cache_entry is not None:
-                payload = deepcopy(cast(dict[str, object], cache_entry["payload"]))
-                status_value = cache_entry.get("status_code")
-                status_code = status_value if isinstance(status_value, int) else 503
-                cached_result = (payload, status_code)
-        if future is None and cached_result is None:
-            future = _TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR.submit(
-                _evaluate_trading_health_payload,
-                include_database_contract=include_database_contract,
-                allow_stale_dependency_cache=allow_stale_dependency_cache,
+            cached_result = _cached_result_from_entry(
+                _TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.get(cache_key)
             )
-            _TRADING_HEALTH_SURFACE_EVALUATIONS[cache_key] = future
+        if future is None and cached_result is None:
+            cached_result = _cached_result_from_entry(
+                _TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.get(cache_key)
+            )
+            future = _start_refresh_locked()
             callback_future = future
 
     if callback_future is not None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -491,6 +491,7 @@ class _PostgresRuntimeLedgerPortfolioSummarySession:
 
 class TestTradingApi(TestCase):
     def setUp(self) -> None:
+        self._clear_trading_health_surface_cache()
         _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
         _ALPACA_HEALTH_STATE.clear()
         _OPTIONS_CATALOG_FRESHNESS_CACHE.clear()
@@ -620,6 +621,16 @@ class TestTradingApi(TestCase):
             )
             session.commit()
 
+    def _clear_trading_health_surface_cache(self) -> None:
+        with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+            refresh_futures = list(
+                main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.values()
+            )
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+        for refresh_future in refresh_futures:
+            refresh_future.cancel()
+
     def _enable_exact_options_catalog_route_scope(self) -> None:
         original_exact_scope = (
             settings.trading_options_catalog_freshness_exact_route_scope_enabled
@@ -670,6 +681,7 @@ class TestTradingApi(TestCase):
         self.assertEqual(status["source"], "empirical_jobs")
 
     def tearDown(self) -> None:
+        self._clear_trading_health_surface_cache()
         _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
         _ALPACA_HEALTH_STATE.clear()
         app.dependency_overrides.clear()
@@ -5616,6 +5628,84 @@ class TestTradingApi(TestCase):
         self.assertEqual(payload["reason"], "cached_health_payload")
         self.assertNotEqual(payload["reason"], "trading_health_evaluation_timeout")
 
+    def test_trading_health_serves_cached_payload_when_idle_and_refreshes(
+        self,
+    ) -> None:
+        original_timeout = main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS
+        main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = 0.01
+        cache_key = main_module._trading_health_surface_cache_key(
+            include_database_contract=False,
+            allow_stale_dependency_cache=False,
+        )
+        cached_payload: dict[str, object] = {
+            "status": "degraded",
+            "reason": "cached_health_payload",
+            "reason_codes": ["cached_health_payload"],
+            "dependencies": {"postgres": {"ok": True, "detail": "ok"}},
+            "live_submission_gate": {
+                "allowed": False,
+                "promotion_authority": False,
+                "final_authority_ok": False,
+                "final_promotion_allowed": False,
+            },
+        }
+        refresh_started = Event()
+        release_refresh = Event()
+        refresh_calls: list[object] = []
+
+        def _refresh_health_payload(
+            **_kwargs: object,
+        ) -> tuple[dict[str, object], int]:
+            refresh_calls.append(_kwargs)
+            refresh_started.set()
+            release_refresh.wait(1.0)
+            return (
+                {
+                    **cached_payload,
+                    "reason": "refreshed_health_payload",
+                    "reason_codes": ["refreshed_health_payload"],
+                },
+                503,
+            )
+
+        with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+            main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+            main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE[cache_key] = {
+                "payload": cached_payload,
+                "status_code": 503,
+                "checked_at": datetime.now(timezone.utc),
+            }
+
+        try:
+            with patch(
+                "app.main._evaluate_trading_health_payload",
+                side_effect=_refresh_health_payload,
+            ):
+                started_at = time.monotonic()
+                response = self.client.get("/trading/health")
+                elapsed = time.monotonic() - started_at
+                self.assertTrue(refresh_started.wait(1.0))
+                self.assertEqual(len(refresh_calls), 1)
+        finally:
+            release_refresh.set()
+            main_module._TRADING_HEALTH_SURFACE_TIMEOUT_SECONDS = original_timeout
+            with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+                refresh_futures = list(
+                    main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.values()
+                )
+            for refresh_future in refresh_futures:
+                refresh_future.result(timeout=1.0)
+            with main_module._TRADING_HEALTH_SURFACE_EVALUATION_LOCK:
+                main_module._TRADING_HEALTH_SURFACE_EVALUATIONS.clear()
+                main_module._TRADING_HEALTH_SURFACE_PAYLOAD_CACHE.clear()
+
+        self.assertLess(elapsed, 0.5)
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["reason"], "cached_health_payload")
+        self.assertNotEqual(payload["reason"], "trading_health_evaluation_timeout")
+
     def test_trading_health_starts_fresh_eval_when_completed_future_has_no_cache(
         self,
     ) -> None:
@@ -5763,7 +5853,7 @@ class TestTradingApi(TestCase):
         self.assertEqual(response.status_code, 503)
         payload = response.json()
         self.assertEqual(payload["status"], "degraded")
-        self.assertEqual(payload["reason"], "trading_health_evaluation_timeout")
+        self.assertNotEqual(payload.get("reason"), "trading_health_evaluation_timeout")
         self.assertIn(
             "source_amount_mismatch",
             payload["dependencies"]["tigerbeetle"]["blockers"],


### PR DESCRIPTION
## Summary

- Serve a completed cached `/trading/health` payload immediately even when no refresh is currently active, while starting a background refresh.
- Reapply readiness dependency guards to cached health responses so dependency blockers cannot leak live submission authority.
- Ignore orphaned async health completions and clear health-surface cache state between API tests.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/main.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_trading_api.py -k 'trading_health_serves_cached_payload_when_idle_and_refreshes or trading_health_serves_cached_payload_during_inflight_refresh or trading_health_serves_completed_health_cache_while_refreshing or trading_health_evaluation_timeout or trading_health_timeout_uses_cached_dependency_shape or trading_health_timeout_uses_cached_blockers_fail_closed' -q`
- `uv run --frozen pytest tests/test_trading_api.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
