### PR TITLE
fix(autotrader): manage open positions before scanning

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
@@ -37,9 +37,10 @@ data:
     5. Do not manually scan, recreate tickets, run candidate guards, or smoke orders for runner candidates. Use runner `ticketId`, `noTradeReason`, `strategyGuard`, and `blocker` as authoritative.
     6. Only plan new broker risk after the runner returns `strategyGuard.allowed=true` for a candidate.
     7. Size new broker risk from runner `decisionSummary.bestCandidate.riskDirective`: use `recommendedRiskDollars` when present, otherwise honor `riskMultiplier` inside account/day-trade limits. Positive scorecard edge should be acted on aggressively; unproven or negative history must not be enlarged or bypass gates.
-    8. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
-    9. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
-    10. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    8. If runner `accountGate.positionManagement.actionRequired=true`, manage the existing broker state before any new entry: repair or flatten unprotected/invalid stops, tighten stops to the runner `recommendedStopPrice` when provided, record the replacement order in Synthesis, then refresh broker state.
+    9. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
+    10. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
+    11. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 
     Mode behavior:
     - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.

--- a/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
@@ -37,9 +37,10 @@ data:
     5. Do not manually scan, recreate tickets, run candidate guards, or smoke orders for runner candidates. Use runner `ticketId`, `noTradeReason`, `strategyGuard`, and `blocker` as authoritative.
     6. Only plan new broker risk after the runner returns `strategyGuard.allowed=true` for a candidate.
     7. Size new broker risk from runner `decisionSummary.bestCandidate.riskDirective`: use `recommendedRiskDollars` when present, otherwise honor `riskMultiplier` inside account/day-trade limits. Positive scorecard edge should be acted on aggressively; unproven or negative history must not be enlarged or bypass gates.
-    8. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
-    9. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
-    10. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    8. If runner `accountGate.positionManagement.actionRequired=true`, manage the existing broker state before any new entry: repair or flatten unprotected/invalid stops, tighten stops to the runner `recommendedStopPrice` when provided, record the replacement order in Synthesis, then refresh broker state.
+    9. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
+    10. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
+    11. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 
     Mode behavior:
     - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.

--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -41,6 +41,9 @@ ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
 MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
 MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE = 2
 MAX_SCORECARD_RISK_MULTIPLIER = Decimal("2.0")
+PROFIT_PROTECT_BREAKEVEN_TRIGGER_R = Decimal("0.5")
+PROFIT_PROTECT_LOCK_TRIGGER_R = Decimal("1.0")
+PROFIT_LOCK_R = Decimal("0.25")
 
 
 class AlpacaRestClient:
@@ -267,17 +270,214 @@ def summarized_order(value: Any) -> dict[str, Any]:
     }
 
 
+def order_children(value: Any) -> list[Any]:
+    if not isinstance(value, dict):
+        return []
+    children: list[Any] = []
+    legs = value.get("legs")
+    if isinstance(legs, list):
+        for leg in legs:
+            children.append(leg)
+            children.extend(order_children(leg))
+    return children
+
+
+def flat_orders(values: list[Any]) -> list[dict[str, Any]]:
+    flattened: list[dict[str, Any]] = []
+    for value in values:
+        if isinstance(value, dict):
+            flattened.append(value)
+            flattened.extend(child for child in order_children(value) if isinstance(child, dict))
+    return flattened
+
+
+def position_side(value: dict[str, Any]) -> str:
+    side = optional_text(value.get("side"), max_length=32)
+    if side in {"long", "short"}:
+        return side
+    qty = decimal_value(value.get("qty"))
+    if qty is not None and qty < 0:
+        return "short"
+    return "long"
+
+
+def order_is_active(value: dict[str, Any]) -> bool:
+    status = optional_text(value.get("status"), max_length=64)
+    return status not in {"filled", "canceled", "expired", "rejected", "replaced"}
+
+
+def matching_symbol_order(value: dict[str, Any], symbol: str) -> bool:
+    order_symbol = optional_text(value.get("symbol"), max_length=32)
+    return bool(order_symbol and order_symbol.upper() == symbol.upper())
+
+
+def stop_price_for_order(value: dict[str, Any]) -> Decimal | None:
+    return decimal_value(value.get("stop_price") or value.get("stopPrice"))
+
+
+def limit_price_for_order(value: dict[str, Any]) -> Decimal | None:
+    return decimal_value(value.get("limit_price") or value.get("limitPrice"))
+
+
+def protective_orders_for_position(position: dict[str, Any], orders: list[Any]) -> dict[str, Any]:
+    symbol = optional_text(position.get("symbol"), max_length=32)
+    if not symbol:
+        return {"hasStop": False, "hasTakeProfit": False}
+    side = position_side(position)
+    stop_candidates: list[tuple[Decimal, dict[str, Any]]] = []
+    target_candidates: list[tuple[Decimal, dict[str, Any]]] = []
+    for order in flat_orders(orders):
+        if not matching_symbol_order(order, symbol) or not order_is_active(order):
+            continue
+        order_side = optional_text(order.get("side"), max_length=32)
+        if side == "long" and order_side not in {"sell", "sell_to_close"}:
+            continue
+        if side == "short" and order_side not in {"buy", "buy_to_cover", "buy_to_close"}:
+            continue
+        stop_price = stop_price_for_order(order)
+        limit_price = limit_price_for_order(order)
+        if stop_price is not None:
+            stop_candidates.append((stop_price, order))
+        if limit_price is not None and stop_price is None:
+            target_candidates.append((limit_price, order))
+    if side == "long":
+        stop_candidates.sort(key=lambda item: item[0], reverse=True)
+        target_candidates.sort(key=lambda item: item[0])
+    else:
+        stop_candidates.sort(key=lambda item: item[0])
+        target_candidates.sort(key=lambda item: item[0], reverse=True)
+    stop = stop_candidates[0] if stop_candidates else None
+    target = target_candidates[0] if target_candidates else None
+    return {
+        "hasStop": stop is not None,
+        "hasTakeProfit": target is not None,
+        "stopPrice": str(stop[0]) if stop else None,
+        "stopOrderId": stop[1].get("id") if stop else None,
+        "stopClientOrderId": stop[1].get("client_order_id") or stop[1].get("clientOrderId") if stop else None,
+        "takeProfitPrice": str(target[0]) if target else None,
+        "takeProfitOrderId": target[1].get("id") if target else None,
+        "takeProfitClientOrderId": target[1].get("client_order_id") or target[1].get("clientOrderId") if target else None,
+    }
+
+
+def rounded_price(value: Decimal) -> str:
+    return str(value.quantize(Decimal("0.01")))
+
+
+def position_management_for_position(position: dict[str, Any], orders: list[Any]) -> dict[str, Any]:
+    symbol = optional_text(position.get("symbol"), max_length=32) or "UNKNOWN"
+    side = position_side(position)
+    entry = decimal_value(position.get("avg_entry_price") or position.get("avgEntryPrice"))
+    current = decimal_value(position.get("current_price") or position.get("currentPrice"))
+    qty = decimal_value(position.get("qty"))
+    if current is None:
+        market_value = decimal_value(position.get("market_value") or position.get("marketValue"))
+        if market_value is not None and qty is not None and qty != 0:
+            current = abs(market_value / qty)
+    protection = protective_orders_for_position(position, orders)
+    stop = decimal_value(protection.get("stopPrice"))
+    if entry is None or current is None:
+        return {
+            "symbol": symbol.upper(),
+            "side": side,
+            "action": "refresh_broker_state",
+            "reason": "missing_entry_or_current_price",
+            "protection": protection,
+        }
+    if stop is None:
+        return {
+            "symbol": symbol.upper(),
+            "side": side,
+            "action": "repair_or_flatten_unprotected_position",
+            "reason": "missing_protective_stop",
+            "entryPrice": str(entry),
+            "currentPrice": str(current),
+            "protection": protection,
+        }
+    initial_r = abs(entry - stop)
+    if initial_r <= 0:
+        return {
+            "symbol": symbol.upper(),
+            "side": side,
+            "action": "repair_or_flatten_invalid_stop",
+            "reason": "invalid_stop_distance",
+            "entryPrice": str(entry),
+            "currentPrice": str(current),
+            "stopPrice": str(stop),
+            "protection": protection,
+        }
+    if side == "short":
+        open_r = (entry - current) / initial_r
+        stop_r = (entry - stop) / initial_r
+        breakeven_stop = entry
+        locked_stop = entry - (initial_r * PROFIT_LOCK_R)
+    else:
+        open_r = (current - entry) / initial_r
+        stop_r = (stop - entry) / initial_r
+        breakeven_stop = entry
+        locked_stop = entry + (initial_r * PROFIT_LOCK_R)
+    action = "hold_existing_protection"
+    reason = "protected_position_inside_profit_lock_thresholds"
+    recommended_stop: Decimal | None = None
+    if open_r >= PROFIT_PROTECT_LOCK_TRIGGER_R and stop_r < PROFIT_LOCK_R:
+        action = "tighten_stop_lock_profit"
+        reason = "open_profit_at_or_above_1r"
+        recommended_stop = locked_stop
+    elif open_r >= PROFIT_PROTECT_BREAKEVEN_TRIGGER_R and stop_r < 0:
+        action = "tighten_stop_to_breakeven"
+        reason = "open_profit_at_or_above_0_5r"
+        recommended_stop = breakeven_stop
+    return {
+        "symbol": symbol.upper(),
+        "side": side,
+        "action": action,
+        "reason": reason,
+        "entryPrice": str(entry),
+        "currentPrice": str(current),
+        "stopPrice": str(stop),
+        "openR": str(open_r.quantize(Decimal("0.0001"))),
+        "stopR": str(stop_r.quantize(Decimal("0.0001"))),
+        "recommendedStopPrice": rounded_price(recommended_stop) if recommended_stop is not None else None,
+        "protection": protection,
+    }
+
+
+def position_management_summary(positions: list[Any], orders: list[Any]) -> dict[str, Any]:
+    directives = [
+        position_management_for_position(position, orders)
+        for position in positions
+        if isinstance(position, dict)
+    ]
+    action_priority = {
+        "repair_or_flatten_unprotected_position": 5,
+        "repair_or_flatten_invalid_stop": 5,
+        "tighten_stop_lock_profit": 4,
+        "tighten_stop_to_breakeven": 3,
+        "refresh_broker_state": 2,
+        "hold_existing_protection": 1,
+    }
+    primary = max(directives, key=lambda item: action_priority.get(str(item.get("action")), 0), default=None)
+    return {
+        "mode": "serial_position_management",
+        "directiveCount": len(directives),
+        "actionRequired": bool(primary and action_priority.get(str(primary.get("action")), 0) >= 2),
+        "primaryAction": primary.get("action") if isinstance(primary, dict) else None,
+        "primaryReason": primary.get("reason") if isinstance(primary, dict) else None,
+        "positions": directives,
+    }
+
+
 def summarize_records(values: list[Any], summarize: Callable[[Any], dict[str, Any]], limit: int = 20) -> list[dict[str, Any]]:
     return [summarize(value) for value in values[:limit]]
 
 
 def account_gate_action(account: dict[str, Any], positions: list[Any], orders: list[Any]) -> str:
+    if positions or orders:
+        return "manage_existing_broker_state"
     eligibility = account.get("intraday_equity_entry")
     entry_allowed = isinstance(eligibility, dict) and eligibility.get("status") == "allowed"
     if entry_allowed:
         return "scan"
-    if positions or orders:
-        return "manage_existing_broker_state"
     return "monitor_only"
 
 
@@ -299,6 +499,7 @@ def summarize_account_gate(
         "openOrderCount": len(orders),
         "openPositions": summarize_records(positions, summarized_position),
         "openOrders": summarize_records(orders, summarized_order),
+        "positionManagement": position_management_summary(positions, orders) if positions else None,
         "hasOpenBrokerState": bool(positions or orders),
         "action": action,
         "skipFullScan": action != "scan",
@@ -389,7 +590,10 @@ def account_gate_current_action(gate: dict[str, Any]) -> str:
     if action == "scan":
         return "account gate passed; scanning live candidates"
     if action == "manage_existing_broker_state":
-        return "account gate blocked new entries; managing existing broker state"
+        management = gate.get("positionManagement")
+        if isinstance(management, dict) and management.get("primaryAction"):
+            return f"account gate managing existing broker state; {management.get('primaryAction')}"
+        return "account gate managing existing broker state"
     return "account gate blocked new entries; monitoring only"
 
 

--- a/scripts/autotrader/market_open_cycle.py
+++ b/scripts/autotrader/market_open_cycle.py
@@ -135,6 +135,10 @@ def cycle_action(summary: dict[str, Any]) -> str:
             return f"market_open_cycle_waiting_for_open; marketOpenAt={window.get('marketOpenAt')}"
         if action == "market_closed" and isinstance(window, dict):
             return f"market_open_cycle_market_closed; marketCloseAt={window.get('marketCloseAt')}"
+        gate = summary.get("accountGate")
+        management = gate.get("positionManagement") if isinstance(gate, dict) else None
+        if action == "manage_existing_broker_state" and isinstance(management, dict) and management.get("primaryAction"):
+            return f"market_open_cycle_manage_existing; action={management.get('primaryAction')}; reason={management.get('primaryReason')}"
         return f"market_open_cycle_account_gated; action={action}"
     top_results = summary.get("topResults")
     decision = summary.get("decisionSummary")
@@ -301,6 +305,7 @@ def record_cycle_complete(
         "topResults": summary.get("topResults"),
         "decisionSummary": summary.get("decisionSummary"),
         "strategyGuard": summary.get("strategyGuard"),
+        "accountGate": summary.get("accountGate"),
         "marketWindow": summary.get("marketWindow"),
         "windowGate": summary.get("windowGate"),
         "stageTimingsMs": summary.get("stageTimingsMs"),
@@ -387,6 +392,8 @@ def write_report(path: Path, result: dict[str, Any]) -> None:
     if not isinstance(summary, dict):
         summary = {}
     path.parent.mkdir(parents=True, exist_ok=True)
+    gate = summary.get("accountGate")
+    management = gate.get("positionManagement") if isinstance(gate, dict) else None
     lines = [
         "# Autonomous Trader Report",
         "",
@@ -403,10 +410,33 @@ def write_report(path: Path, result: dict[str, Any]) -> None:
         f"recorded_ticket_count: {recorded_ticket_count(summary)}",
         f"scorecard_count: {scorecard_count(summary)}",
         f"strategy_guard: {strategy_guard_report_value(summary)}",
-        "",
-        "Next: continue bounded market-open cycles until close, target, or hard stop.",
-        "",
     ]
+    if isinstance(management, dict) and management.get("primaryAction"):
+        lines.extend(
+            [
+                f"position_management: {management.get('primaryAction')}",
+                f"position_management_reason: {management.get('primaryReason')}",
+                f"position_management_action_required: {str(bool(management.get('actionRequired'))).lower()}",
+            ]
+        )
+        positions = management.get("positions")
+        first_position = positions[0] if isinstance(positions, list) and positions else None
+        if isinstance(first_position, dict):
+            lines.extend(
+                [
+                    f"managed_symbol: {first_position.get('symbol')}",
+                    f"managed_open_r: {first_position.get('openR')}",
+                    f"managed_stop_r: {first_position.get('stopR')}",
+                    f"recommended_stop: {first_position.get('recommendedStopPrice')}",
+                ]
+            )
+    lines.extend(
+        [
+            "",
+            "Next: continue bounded market-open cycles until close, target, or hard stop.",
+            "",
+        ]
+    )
     path.write_text("\n".join(lines), encoding="utf-8")
 
 

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -263,6 +263,99 @@ class LiveScanCycleTest(unittest.TestCase):
         )
         self.assertEqual(summary["openOrders"][0]["clientOrderId"], "agent-AAPL-protect")
 
+    def test_summarizes_account_gate_as_manage_state_when_entry_allowed_with_position(self) -> None:
+        summary = live_scan_cycle.summarize_account_gate(
+            raw_account={
+                "id": "paper-account",
+                "equity": "30000",
+                "buying_power": "120000",
+                "daytrading_buying_power": "120000",
+                "daytrade_count": 1,
+            },
+            raw_positions=[
+                {
+                    "symbol": "AVGO",
+                    "side": "long",
+                    "qty": "43",
+                    "market_value": "4300.00",
+                    "avg_entry_price": "100.00",
+                    "current_price": "102.00",
+                    "unrealized_pl": "86.00",
+                }
+            ],
+            raw_orders=[
+                {
+                    "id": "stop-1",
+                    "client_order_id": "agent-AVGO-stop",
+                    "symbol": "AVGO",
+                    "side": "sell",
+                    "type": "stop",
+                    "status": "held",
+                    "stop_price": "98.00",
+                },
+                {
+                    "id": "target-1",
+                    "client_order_id": "agent-AVGO-target",
+                    "symbol": "AVGO",
+                    "side": "sell",
+                    "type": "limit",
+                    "status": "new",
+                    "limit_price": "106.00",
+                },
+            ],
+        )
+
+        self.assertEqual(summary["action"], "manage_existing_broker_state")
+        self.assertTrue(summary["skipFullScan"])
+        management = summary["positionManagement"]
+        self.assertEqual(management["mode"], "serial_position_management")
+        self.assertEqual(management["primaryAction"], "tighten_stop_lock_profit")
+        self.assertEqual(management["primaryReason"], "open_profit_at_or_above_1r")
+        self.assertTrue(management["actionRequired"])
+        directive = management["positions"][0]
+        self.assertEqual(directive["symbol"], "AVGO")
+        self.assertEqual(directive["openR"], "1.0000")
+        self.assertEqual(directive["stopR"], "-1.0000")
+        self.assertEqual(directive["recommendedStopPrice"], "100.50")
+        self.assertEqual(directive["protection"]["stopClientOrderId"], "agent-AVGO-stop")
+        self.assertEqual(directive["protection"]["takeProfitClientOrderId"], "agent-AVGO-target")
+
+    def test_position_management_tightens_to_breakeven_after_half_r(self) -> None:
+        summary = live_scan_cycle.summarize_account_gate(
+            raw_account={
+                "id": "paper-account",
+                "equity": "30000",
+                "buying_power": "120000",
+                "daytrading_buying_power": "120000",
+            },
+            raw_positions=[
+                {
+                    "symbol": "NVDA",
+                    "side": "long",
+                    "qty": "10",
+                    "avg_entry_price": "100.00",
+                    "current_price": "101.00",
+                }
+            ],
+            raw_orders=[
+                {
+                    "id": "stop-1",
+                    "client_order_id": "agent-NVDA-stop",
+                    "symbol": "NVDA",
+                    "side": "sell",
+                    "type": "stop",
+                    "status": "held",
+                    "stop_price": "98.00",
+                }
+            ],
+        )
+
+        management = summary["positionManagement"]
+        self.assertEqual(management["primaryAction"], "tighten_stop_to_breakeven")
+        directive = management["positions"][0]
+        self.assertEqual(directive["openR"], "0.5000")
+        self.assertEqual(directive["recommendedStopPrice"], "100.00")
+
     def test_run_account_gate_fetches_only_broker_state(self) -> None:
         case = self
 

--- a/scripts/autotrader/test_market_open_cycle.py
+++ b/scripts/autotrader/test_market_open_cycle.py
@@ -300,6 +300,77 @@ class MarketOpenCycleTest(unittest.TestCase):
         self.assertEqual(status_payload["blocker"], "daytrading_buying_power_not_positive")
         self.assertEqual(status_payload["currentAction"], "market_open_cycle_account_gated; action=monitor_only")
 
+    def test_reports_position_management_directive_without_new_scan(self) -> None:
+        synthesis = FakeSynthesis()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "session.json").write_text('{"sessionId":"session-market-open"}\n', encoding="utf-8")
+            report_path = root / "report.md"
+
+            def fake_run_cycle(args: Any) -> dict[str, Any]:
+                return {
+                    "ok": True,
+                    "mode": "cycle",
+                    "cycle": 5,
+                    "cycleDir": str(root / "cycle-5"),
+                    "skipFullScan": True,
+                    "action": "manage_existing_broker_state",
+                    "resultCount": 0,
+                    "topResults": [],
+                    "recordedTickets": [],
+                    "accountGate": {
+                        "action": "manage_existing_broker_state",
+                        "skipFullScan": True,
+                        "account": {
+                            "equity": "30000",
+                            "buying_power": "120000",
+                            "daytrading_buying_power": "120000",
+                        },
+                        "positionManagement": {
+                            "mode": "serial_position_management",
+                            "actionRequired": True,
+                            "primaryAction": "tighten_stop_to_breakeven",
+                            "primaryReason": "open_profit_at_or_above_0_5r",
+                            "positions": [
+                                {
+                                    "symbol": "AVGO",
+                                    "openR": "0.7500",
+                                    "stopR": "-1.0000",
+                                    "recommendedStopPrice": "486.14",
+                                }
+                            ],
+                        },
+                    },
+                }
+
+            args = market_open_cycle.build_parser().parse_args(
+                [
+                    "--work-dir",
+                    str(root),
+                    "--report-path",
+                    str(report_path),
+                    "--now",
+                    "2026-06-03T14:00:00Z",
+                ]
+            )
+            with patch.object(market_open_cycle.live_scan_cycle, "run_cycle", fake_run_cycle):
+                result = market_open_cycle.run_market_open_cycle(args=args, synthesis=synthesis)  # type: ignore[arg-type]
+
+            self.assertTrue(result["summary"]["skipFullScan"])
+            report = report_path.read_text(encoding="utf-8")
+            self.assertIn("phase: manage", report)
+            self.assertIn("position_management: tighten_stop_to_breakeven", report)
+            self.assertIn("recommended_stop: 486.14", report)
+
+        status_payload = synthesis.posts[0][1]
+        self.assertEqual(status_payload["phase"], "manage")
+        self.assertEqual(
+            status_payload["currentAction"],
+            "market_open_cycle_manage_existing; action=tighten_stop_to_breakeven; reason=open_profit_at_or_above_0_5r",
+        )
+        self.assertEqual(status_payload["payload"]["accountGate"]["positionManagement"]["primaryAction"], "tighten_stop_to_breakeven")
+
     def test_waits_before_regular_market_open_without_scanning(self) -> None:
         synthesis = FakeSynthesis()
 


### PR DESCRIPTION
## Summary

- Make open broker state take precedence over new scanning so the market-open runner manages the active position before adding new risk.
- Add deterministic R-based `positionManagement` directives that recommend breakeven stop tightening after +0.5R and profit-lock stop tightening after +1R.
- Surface the directive through Synthesis status payloads, `report.md`, and the blue/green autonomous-trader prompts.
- Add regression coverage for serial open-position management, stop-tightening recommendations, and market-open report/status output.

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/market_open_cycle.py scripts/autotrader/test_live_scan_cycle.py scripts/autotrader/test_market_open_cycle.py`
- `python3 -m unittest discover -v` from `scripts/autotrader`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/market_open_cycle.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`
- `git diff --check HEAD~1..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
