### PR TITLE
fix(torghut): preserve local readiness source

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -4279,8 +4279,14 @@ class SimpleTradingPipeline(TradingPipeline):
             blockers.append("paper_route_probe_symbol_missing")
         elif not scoped_probe_symbols:
             blockers.append("source_strategy_universe_excludes_probe_symbols")
+        source = (
+            "local_strategy_universe_target_plan_fallback"
+            if target.get("paper_route_probe_strategy_universe_fallback") is True
+            else "local_paper_route_target_plan"
+        )
         return {
             "schema_version": "torghut.paper-route-source-decision-readiness.v1",
+            "source": source,
             "ready": not blockers,
             "blockers": blockers,
             "strategy_lookup_names": lookup_names,


### PR DESCRIPTION
## Summary

- Adds explicit source provenance to generated paper-route source-decision readiness contracts.
- Marks strategy-universe fallback readiness as `local_strategy_universe_target_plan_fallback` so local target-plan consumers can audit fallback scope.
- Unblocks the Torghut source CI failure in `TestTradingPipeline.test_local_paper_route_target_plan_falls_back_to_strategy_symbols`.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py::TestTradingPipeline::test_local_paper_route_target_plan_falls_back_to_strategy_symbols`
- `uv run --frozen pytest tests/test_simple_pipeline.py::test_local_target_plan_enriches_probe_contract_before_bounded_gate`
- `uv run --frozen pytest tests/test_simple_pipeline.py tests/test_trading_pipeline.py -k "local_paper_route_target_plan or paper_route_target_source_decisions or target_plan_source or bounded_sim_collection"`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
