### PR TITLE
fix(torghut): label local target readiness source

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -4279,8 +4279,16 @@ class SimpleTradingPipeline(TradingPipeline):
             blockers.append("paper_route_probe_symbol_missing")
         elif not scoped_probe_symbols:
             blockers.append("source_strategy_universe_excludes_probe_symbols")
+        source = (
+            "local_strategy_universe_target_plan_fallback"
+            if _target_truthy(
+                target.get("paper_route_probe_strategy_universe_fallback")
+            )
+            else "local_target_plan"
+        )
         return {
             "schema_version": "torghut.paper-route-source-decision-readiness.v1",
+            "source": source,
             "ready": not blockers,
             "blockers": blockers,
             "strategy_lookup_names": lookup_names,


### PR DESCRIPTION
## Summary

- Preserve local paper-route source-decision provenance when the scheduler falls back to a matched strategy universe for probe symbols.
- Adds the missing `source` label expected by the existing local target-plan readiness contract.
- Unblocks the failed source CI shard that was blocking Torghut image promotion.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_pipeline.py::TestTradingPipeline::test_local_paper_route_target_plan_falls_back_to_strategy_symbols -q`
- `SHARD_INDEX=0 SHARD_TOTAL=4 COVERAGE_FILE=.coverage.0 sh -c 'set -eu; files=$(find tests -name "test_*.py" ! -path "tests/test_run_whitepaper_autoresearch_profit_target.py" -print | sort | awk -v shard="$SHARD_INDEX" -v total="$SHARD_TOTAL" "((NR - 1) % total) == shard"); count=$(printf "%s\n" "$files" | sed "/^$/d" | wc -l | tr -d " "); printf "Running %s test files in shard %s/%s\n" "$count" "$SHARD_INDEX" "$SHARD_TOTAL"; test "$count" -gt 0; uv run --frozen pytest -n auto --dist=worksteal --cov --cov-branch --cov-fail-under=0 --cov-report= $files'`
- `uv run --frozen ruff format app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
