### PR TITLE
fix(torghut): label local target source readiness

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -4251,6 +4251,11 @@ class SimpleTradingPipeline(TradingPipeline):
         raw_probe_symbols: set[str],
         scoped_probe_symbols: set[str],
     ) -> dict[str, object]:
+        source = (
+            "local_strategy_universe_target_plan_fallback"
+            if bool(target.get("paper_route_probe_strategy_universe_fallback"))
+            else "local_target_plan_probe_symbols"
+        )
         lookup_names = [
             name for name in _target_lookup_names(target) if str(name).strip()
         ]
@@ -4281,6 +4286,7 @@ class SimpleTradingPipeline(TradingPipeline):
             blockers.append("source_strategy_universe_excludes_probe_symbols")
         return {
             "schema_version": "torghut.paper-route-source-decision-readiness.v1",
+            "source": source,
             "ready": not blockers,
             "blockers": blockers,
             "strategy_lookup_names": lookup_names,


### PR DESCRIPTION
## Summary

- Restores the local paper-route target-plan source-readiness contract by labeling strategy-universe fallback readiness with its explicit source.
- Keeps the readiness payload fail-closed and metadata-only; no promotion gate, live-capital path, ledger authority, or PnL proof semantics are changed.
- Unblocks the Torghut CI regression that failed after the feed-lag replay harness source merge and prevented safe image promotion.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py::TestTradingPipeline::test_local_paper_route_target_plan_falls_back_to_strategy_symbols tests/test_trading_pipeline.py::TestTradingPipeline::test_local_paper_route_target_plan_strategy_fallback_satisfies_source_collection_gate -q`
- `cd services/torghut && uvx ruff format --check app/trading/scheduler/simple_pipeline.py`
- `cd services/torghut && uvx ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A — backend scheduler contract fix.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
