### PR TITLE
fix(autotrader): stop entries after intraday drawdown

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -41,6 +41,9 @@ ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
 MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
 MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE = 2
 MAX_SCORECARD_RISK_MULTIPLIER = Decimal("2.0")
+MAX_INTRADAY_EQUITY_DRAWDOWN_PCT = Decimal("0.015")
+ACCOUNT_MONEY_QUANT = Decimal("0.01")
+ACCOUNT_RATIO_QUANT = Decimal("0.000001")
 PROFIT_PROTECT_BREAKEVEN_TRIGGER_R = Decimal("0.5")
 PROFIT_PROTECT_LOCK_TRIGGER_R = Decimal("1.0")
 PROFIT_LOCK_R = Decimal("0.25")
@@ -188,11 +191,18 @@ def parse_account_int(value: Any) -> int | None:
         return None
 
 
+def quantized_decimal_text(value: Decimal, quantum: Decimal) -> str:
+    return str(value.quantize(quantum))
+
+
 def intraday_equity_entry_eligibility(account: dict[str, Any]) -> dict[str, Any]:
     daytrading_buying_power = account.get("daytrading_buying_power") or account.get("daytrade_buying_power")
     daytrading_buying_power_value = parse_account_decimal(daytrading_buying_power)
     daytrade_count = parse_account_int(account.get("daytrade_count"))
+    equity = parse_account_decimal(account.get("equity"))
+    last_equity = parse_account_decimal(account.get("last_equity") or account.get("lastEquity"))
     reasons: list[str] = []
+    details: dict[str, str] = {}
 
     if account_bool(account.get("account_blocked", False)) or account_bool(account.get("trading_blocked", False)):
         reasons.append("account_or_trading_blocked")
@@ -206,15 +216,30 @@ def intraday_equity_entry_eligibility(account: dict[str, Any]) -> dict[str, Any]
     ):
         reasons.append("pdt_daytrade_count_at_or_above_four_without_dtbp")
 
+    if equity is not None and last_equity is not None and last_equity > 0:
+        drawdown_amount = max(last_equity - equity, Decimal("0"))
+        drawdown_pct = drawdown_amount / last_equity
+        details = {
+            "intradayEquityDrawdownBasis": "equity_vs_last_equity",
+            "intradayEquityDrawdownAmount": quantized_decimal_text(drawdown_amount, ACCOUNT_MONEY_QUANT),
+            "intradayEquityDrawdownPct": quantized_decimal_text(drawdown_pct, ACCOUNT_RATIO_QUANT),
+            "intradayEquityDrawdownLimitPct": quantized_decimal_text(
+                MAX_INTRADAY_EQUITY_DRAWDOWN_PCT, ACCOUNT_RATIO_QUANT
+            ),
+        }
+        if drawdown_pct >= MAX_INTRADAY_EQUITY_DRAWDOWN_PCT:
+            reasons.append("intraday_equity_drawdown_limit_exceeded")
+
     return {
         "status": "blocked" if reasons else "allowed",
         "reasons": reasons,
+        **details,
     }
 
 
 def format_account(account: dict[str, Any]) -> dict[str, Any]:
     daytrading_buying_power = account.get("daytrading_buying_power") or account.get("daytrade_buying_power")
-    return {
+    formatted_account = {
         "account": {
             "id": account.get("id"),
             "equity": account.get("equity"),
@@ -228,6 +253,10 @@ def format_account(account: dict[str, Any]) -> dict[str, Any]:
             "intraday_equity_entry": intraday_equity_entry_eligibility(account),
         }
     }
+    last_equity = account.get("last_equity") or account.get("lastEquity")
+    if last_equity is not None:
+        formatted_account["account"]["last_equity"] = last_equity
+    return formatted_account
 
 
 def list_payload(value: Any) -> list[Any]:

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -215,6 +215,52 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["openOrderCount"], 0)
         self.assertEqual(summary["account"]["intraday_equity_entry"]["status"], "blocked")
 
+    def test_summarizes_account_gate_as_monitor_only_when_intraday_drawdown_breached(self) -> None:
+        summary = live_scan_cycle.summarize_account_gate(
+            raw_account={
+                "id": "paper-account",
+                "equity": "29540.00",
+                "last_equity": "30000.00",
+                "buying_power": "90000",
+                "daytrading_buying_power": "90000",
+                "daytrade_count": 2,
+            },
+            raw_positions=[],
+            raw_orders=[],
+        )
+
+        eligibility = summary["account"]["intraday_equity_entry"]
+        self.assertEqual(summary["action"], "monitor_only")
+        self.assertTrue(summary["skipFullScan"])
+        self.assertEqual(summary["account"]["last_equity"], "30000.00")
+        self.assertEqual(eligibility["status"], "blocked")
+        self.assertEqual(eligibility["reasons"], ["intraday_equity_drawdown_limit_exceeded"])
+        self.assertEqual(eligibility["intradayEquityDrawdownBasis"], "equity_vs_last_equity")
+        self.assertEqual(eligibility["intradayEquityDrawdownAmount"], "460.00")
+        self.assertEqual(eligibility["intradayEquityDrawdownPct"], "0.015333")
+        self.assertEqual(eligibility["intradayEquityDrawdownLimitPct"], "0.015000")
+
+    def test_summarizes_account_gate_as_scan_when_intraday_drawdown_inside_limit(self) -> None:
+        summary = live_scan_cycle.summarize_account_gate(
+            raw_account={
+                "id": "paper-account",
+                "equity": "29600.00",
+                "last_equity": "30000.00",
+                "buying_power": "90000",
+                "daytrading_buying_power": "90000",
+                "daytrade_count": 2,
+            },
+            raw_positions=[],
+            raw_orders=[],
+        )
+
+        eligibility = summary["account"]["intraday_equity_entry"]
+        self.assertEqual(summary["action"], "scan")
+        self.assertFalse(summary["skipFullScan"])
+        self.assertEqual(eligibility["status"], "allowed")
+        self.assertEqual(eligibility["reasons"], [])
+        self.assertEqual(eligibility["intradayEquityDrawdownPct"], "0.013333")
+
     def test_summarizes_account_gate_as_manage_state_when_entry_blocked_with_position(self) -> None:
         summary = live_scan_cycle.summarize_account_gate(
             raw_account={


### PR DESCRIPTION
## Summary

- Adds a deterministic intraday equity drawdown lockout to the Synthesis autotrader account gate.
- Blocks new scans/orders when Alpaca `equity` is down at least 1.5% from `last_equity`, while preserving existing open-position management priority.
- Records the drawdown amount, percentage, limit, and block reason in the existing `intraday_equity_entry` payload.

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/*.py`
- `python3 -m unittest test_live_scan_cycle -v` from `scripts/autotrader`
- `python3 -m unittest discover -v` from `scripts/autotrader`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/market_open_cycle.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t 'autonomous trader|scorecard|trader provider|Synthesis MCP visibility|trader prompt'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
