### PR TITLE
fix(autotrader): classify no-trade scan summaries

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -1223,6 +1223,10 @@ def result_no_trade_reason(result: dict[str, Any], grade: str, type_: str) -> st
     return None
 
 
+def is_scanner_no_trade_result(result: dict[str, Any]) -> bool:
+    return setup_type(result.get("setup_type") or result.get("setupType")) == "no_trade"
+
+
 def ticket_payload_for_scan_result(
     *,
     session_id: str,
@@ -1462,7 +1466,9 @@ def decision_summary_for_scan(
             setup_grade(result.get("setup_grade") or result.get("setupGrade")),
             setup_type(result.get("setup_type") or result.get("setupType")),
         )
-        if reason:
+        if is_scanner_no_trade_result(result):
+            no_trade_count += 1
+        elif reason:
             blocked_count += 1
         else:
             no_trade_count += 1

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -715,7 +715,8 @@ class LiveScanCycleTest(unittest.TestCase):
 
         self.assertEqual(summary["action"], "run_strategy_order_guard")
         self.assertEqual(summary["actionableCandidateCount"], 2)
-        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertEqual(summary["blockedResultCount"], 0)
+        self.assertEqual(summary["noTradeResultCount"], 1)
         self.assertEqual(summary["bestCandidate"]["symbol"], "NVDA")
         self.assertEqual(summary["bestCandidate"]["side"], "buy")
         self.assertEqual(summary["bestCandidate"]["ticketId"], "ticket-nvda")
@@ -928,6 +929,7 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["action"], "no_actionable_candidate")
         self.assertEqual(summary["actionableCandidateCount"], 0)
         self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertEqual(summary["noTradeResultCount"], 0)
         self.assertIsNone(summary["bestCandidate"])
 
     def test_decision_summary_blocks_sub_two_r_candidates(self) -> None:
@@ -961,6 +963,7 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["action"], "no_actionable_candidate")
         self.assertEqual(summary["actionableCandidateCount"], 0)
         self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertEqual(summary["noTradeResultCount"], 0)
         self.assertIsNone(summary["bestCandidate"])
 
     def test_decision_summary_blocks_negative_scorecard_history(self) -> None:
@@ -1030,7 +1033,8 @@ class LiveScanCycleTest(unittest.TestCase):
 
         self.assertEqual(summary["action"], "no_actionable_candidate")
         self.assertEqual(summary["actionableCandidateCount"], 0)
-        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertEqual(summary["blockedResultCount"], 0)
+        self.assertEqual(summary["noTradeResultCount"], 1)
         self.assertIsNone(summary["bestCandidate"])
 
     def test_records_scan_tickets_to_synthesis_with_ticket_ids(self) -> None:


### PR DESCRIPTION
## Summary

- Classifies literal scanner `setup_type: no_trade` rows as no-trade outcomes in `decisionSummary`.
- Keeps weak expected-R, negative scorecard history, and unproven positive-edge candidates counted as blocked outcomes.
- Adds regression expectations so live scan feedback separates “no confirmed setup” from “blocked actionable setup.”

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/test_live_scan_cycle.py`
- `python3 -m unittest test_live_scan_cycle.LiveScanCycleTest.test_decision_summary_blocks_sub_two_r_candidates test_live_scan_cycle.LiveScanCycleTest.test_decision_summary_reports_no_actionable_candidate -v`
- `python3 -m unittest test_live_scan_cycle -v`
- `python3 -m unittest discover -v`
- `git diff --check`
- Manual live-shape simulation from `scripts/autotrader`: five `setup_type: no_trade` rows now produce `blockedResultCount=0` and `noTradeResultCount=5`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
