### PR TITLE
fix(autotrader): use main for scheduled templates

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-agentrun-template.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-agentrun-template.yaml
@@ -34,7 +34,7 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/synthesis-autonomous-trader-session
+    head: main
     mode: market-open
     synthesisSessionMode: market_open
     brokerMutationEnabled: "true"

--- a/argocd/applications/autotrader/autonomous-trader-green-agentrun-template.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-green-agentrun-template.yaml
@@ -34,7 +34,7 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/synthesis-autonomous-trader-session-green
+    head: main
     mode: market-open
     synthesisSessionMode: market_open
     brokerMutationEnabled: "false"

--- a/argocd/applications/autotrader/autonomous-trader-scorecard-readback-template.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-scorecard-readback-template.yaml
@@ -34,7 +34,7 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/synthesis-autonomous-trader-scorecard-readback
+    head: main
     mode: scorecard-readback
     synthesisSessionMode: scorecard_readback
     brokerMutationEnabled: "false"


### PR DESCRIPTION
## Summary

- Updates the reusable active market-open AgentRun template to resolve `head: main`.
- Updates the green preview and scorecard-readback templates to resolve `head: main`.
- Leaves dated one-off recovery/proof AgentRuns unchanged so historical objects are not mutated.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/autotrader >/tmp/autotrader-kustomize-render.yaml`
- `rg -n "head: (codex/synthesis-autonomous-trader-session|codex/synthesis-autonomous-trader-scorecard-readback|codex/synthesis-autonomous-trader-session-green)|head: main" /tmp/autotrader-kustomize-render.yaml`
- `sed -n '1088,1106p;1228,1244p;1368,1382p;1438,1452p' /tmp/autotrader-kustomize-render.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
