### PR TITLE
fix(autotrader): require executable bracket R

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -39,11 +39,13 @@ SYNTHESIS_SIDES = {
 }
 ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
 MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
+MIN_ACTIONABLE_BRACKET_R = Decimal("2.0")
 MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE = 2
 MAX_SCORECARD_RISK_MULTIPLIER = Decimal("2.0")
 MAX_INTRADAY_EQUITY_DRAWDOWN_PCT = Decimal("0.015")
 ACCOUNT_MONEY_QUANT = Decimal("0.01")
 ACCOUNT_RATIO_QUANT = Decimal("0.000001")
+R_MULTIPLE_QUANT = Decimal("0.000001")
 PROFIT_PROTECT_BREAKEVEN_TRIGGER_R = Decimal("0.5")
 PROFIT_PROTECT_LOCK_TRIGGER_R = Decimal("1.0")
 PROFIT_LOCK_R = Decimal("0.25")
@@ -193,6 +195,10 @@ def parse_account_int(value: Any) -> int | None:
 
 def quantized_decimal_text(value: Decimal, quantum: Decimal) -> str:
     return str(value.quantize(quantum))
+
+
+def normalized_quantized_decimal_text(value: Decimal, quantum: Decimal) -> str:
+    return format(value.quantize(quantum).normalize(), "f")
 
 
 def intraday_equity_entry_eligibility(account: dict[str, Any]) -> dict[str, Any]:
@@ -1201,6 +1207,100 @@ def schema_enum(value: Any, allowed: set[str], default: str) -> str:
     return default
 
 
+def first_decimal_value(result: dict[str, Any], *keys: str) -> Decimal | None:
+    for key in keys:
+        value = decimal_value(result.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def result_side(result: dict[str, Any]) -> str:
+    return schema_enum(result.get("side"), SYNTHESIS_SIDES, "buy")
+
+
+def order_side_direction(side: str) -> str:
+    return "sell" if side.startswith("sell") else "buy"
+
+
+def bracket_r_value(*, side: str, entry: Decimal, stop: Decimal, target: Decimal) -> Decimal | None:
+    direction = order_side_direction(side)
+    if direction == "buy":
+        risk = entry - stop
+        reward = target - entry
+    else:
+        risk = stop - entry
+        reward = entry - target
+    if risk <= 0 or reward <= 0:
+        return None
+    return reward / risk
+
+
+def derived_bracket_for_scan_result(result: dict[str, Any]) -> dict[str, Any]:
+    side = result_side(result)
+    direction = order_side_direction(side)
+    entry = first_decimal_value(result, "entry_limit_price", "entryLimitPrice", "last")
+    explicit_stop = first_decimal_value(result, "stop_price", "stopPrice")
+    explicit_target = first_decimal_value(result, "target_price", "targetPrice")
+    support = first_decimal_value(result, "support")
+    resistance = first_decimal_value(result, "resistance")
+    stop = explicit_stop
+    target = explicit_target
+    stop_source = "explicit" if stop is not None else None
+    target_source = "explicit" if target is not None else None
+
+    if entry is not None and stop is None:
+        if direction == "buy" and support is not None and support < entry:
+            stop = support
+            stop_source = "support"
+        elif direction == "sell" and resistance is not None and resistance > entry:
+            stop = resistance
+            stop_source = "resistance"
+
+    if entry is not None and target is None:
+        if direction == "buy" and resistance is not None and resistance > entry:
+            target = resistance
+            target_source = "resistance"
+        elif direction == "sell" and support is not None and support < entry:
+            target = support
+            target_source = "support"
+
+    missing = []
+    if entry is None:
+        missing.append("entryLimitPrice")
+    if stop is None:
+        missing.append("stopPrice")
+    if target is None:
+        missing.append("targetPrice")
+
+    actual_r = bracket_r_value(side=side, entry=entry, stop=stop, target=target) if not missing else None
+    return {
+        "side": side,
+        "entryLimitPrice": str(entry) if entry is not None else None,
+        "stopPrice": str(stop) if stop is not None else None,
+        "targetPrice": str(target) if target is not None else None,
+        "actualBracketR": (
+            normalized_quantized_decimal_text(actual_r, R_MULTIPLE_QUANT) if actual_r is not None else None
+        ),
+        "entrySource": "explicit_or_last" if entry is not None else None,
+        "stopSource": stop_source,
+        "targetSource": target_source,
+        "missingFields": missing,
+    }
+
+
+def executable_bracket_no_trade_reason(result: dict[str, Any]) -> str | None:
+    bracket = derived_bracket_for_scan_result(result)
+    if bracket["missingFields"]:
+        return "missing_executable_bracket_prices"
+    actual_r = decimal_value(bracket.get("actualBracketR"))
+    if actual_r is None:
+        return "invalid_executable_bracket_prices"
+    if actual_r < MIN_ACTIONABLE_BRACKET_R:
+        return "actual_bracket_r_below_threshold"
+    return None
+
+
 def result_no_trade_reason(result: dict[str, Any], grade: str, type_: str) -> str | None:
     reason = optional_text(result.get("no_trade_reason") or result.get("noTradeReason"), max_length=1000)
     if reason:
@@ -1218,6 +1318,9 @@ def result_no_trade_reason(result: dict[str, Any], grade: str, type_: str) -> st
         return "missing_expected_r"
     if expected_r < MIN_ACTIONABLE_EXPECTED_R:
         return "expected_r_below_threshold"
+    bracket_reason = executable_bracket_no_trade_reason(result)
+    if bracket_reason:
+        return bracket_reason
     if scorecard_sample_size <= 0 or scorecard_avg_r is None or scorecard_avg_r <= 0:
         return "positive_scorecard_edge_required"
     return None
@@ -1239,6 +1342,8 @@ def ticket_payload_for_scan_result(
         return None
     grade = setup_grade(result.get("setup_grade") or result.get("setupGrade"))
     type_ = setup_type(result.get("setup_type") or result.get("setupType"))
+    side = result_side(result)
+    bracket = derived_bracket_for_scan_result(result)
     no_trade_reason = result_no_trade_reason(result, grade, type_)
     expected_r = numeric_text(result.get("expected_r") or result.get("expectedR"))
     blocked = no_trade_reason is not None
@@ -1257,7 +1362,7 @@ def ticket_payload_for_scan_result(
         "idempotencyKey": idempotency_key,
         "symbol": symbol.upper(),
         "instrument": schema_enum(result.get("instrument"), SYNTHESIS_INSTRUMENTS, "stock"),
-        "side": schema_enum(result.get("side"), SYNTHESIS_SIDES, "buy"),
+        "side": side,
         "setupType": type_,
         "setupGrade": grade,
         "fatPitch": bool(result.get("fat_pitch") or result.get("fatPitch") or False),
@@ -1267,10 +1372,11 @@ def ticket_payload_for_scan_result(
         "thesis": thesis,
         "entryTrigger": entry_trigger or ("blocked_by_scanner" if blocked else "scanner_candidate_requires_guard"),
         "invalidation": invalidation or ("no broker order" if blocked else "strategy guard must approve before broker order"),
-        "entryLimitPrice": numeric_text(result.get("entry_limit_price") or result.get("entryLimitPrice") or result.get("last")),
-        "stopPrice": numeric_text(result.get("stop_price") or result.get("stopPrice")),
-        "targetPrice": numeric_text(result.get("target_price") or result.get("targetPrice")),
+        "entryLimitPrice": bracket["entryLimitPrice"],
+        "stopPrice": bracket["stopPrice"],
+        "targetPrice": bracket["targetPrice"],
         "expectedR": expected_r,
+        "actualBracketR": bracket["actualBracketR"],
         "riskDollars": numeric_text(result.get("risk_dollars") or result.get("riskDollars")),
         "plannedQuantity": numeric_text(result.get("planned_quantity") or result.get("plannedQuantity")),
         "protectionType": optional_text(result.get("protection_type") or result.get("protectionType"), max_length=80)
@@ -1280,6 +1386,7 @@ def ticket_payload_for_scan_result(
             "cycle": cycle,
             "resultIndex": index,
             "riskDirective": risk_directive,
+            "executableBracket": bracket,
             "raw": result,
         },
         "status": "blocked" if blocked else "candidate",
@@ -1380,13 +1487,15 @@ def candidate_score(result: dict[str, Any]) -> tuple[Decimal, Decimal, int, int,
     grade = setup_grade(result.get("setup_grade") or result.get("setupGrade"))
     grade_score = {"A+": 3, "A": 2, "B": 1}.get(grade, 0)
     expected_r = decimal_value(result.get("expected_r") or result.get("expectedR")) or Decimal("0")
+    bracket_r = decimal_value(derived_bracket_for_scan_result(result).get("actualBracketR"))
+    executable_r = min(expected_r, bracket_r) if bracket_r is not None else expected_r
     sample_size, avg_realized_r, confidence = scorecard_edge_values(result)
     scorecard_edge = (
         avg_realized_r * scorecard_edge_weight(sample_size)
         if sample_size > 0 and avg_realized_r is not None and avg_realized_r > 0
         else Decimal("0")
     )
-    return expected_r + scorecard_edge, expected_r, grade_score, sample_size, confidence
+    return executable_r + scorecard_edge, executable_r, grade_score, sample_size, confidence
 
 
 def actionable_candidate_for_result(
@@ -1418,6 +1527,7 @@ def actionable_candidate_for_result(
         "targetPrice": payload.get("targetPrice"),
         "riskDollars": payload.get("riskDollars"),
         "plannedQuantity": payload.get("plannedQuantity"),
+        "actualBracketR": payload.get("actualBracketR"),
         "riskDirective": scorecard_risk_directive(result),
         "scorecardSampleSize": int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize")),
         "scorecardAvgRealizedR": numeric_text(

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -524,6 +524,8 @@ class LiveScanCycleTest(unittest.TestCase):
                         "setup_grade": "A",
                         "expected_r": "3.0",
                         "last": "180.25",
+                        "support": "179.25",
+                        "resistance": "183.25",
                     }
                 ]
             },
@@ -630,6 +632,8 @@ class LiveScanCycleTest(unittest.TestCase):
                 "setup_grade": "A",
                 "expected_r": "2.50",
                 "last": "100.25",
+                "support": "99.25",
+                "resistance": "102.75",
                 "fat_pitch": True,
                 "regime": "trend_up",
                 "instrument": "equity",
@@ -685,6 +689,9 @@ class LiveScanCycleTest(unittest.TestCase):
                         "setup_type": "vwap_reclaim",
                         "setup_grade": "B",
                         "expected_r": "2.5",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "102.50",
                         "scorecard_sample_size": 2,
                         "scorecard_avg_realized_r": "0.2",
                     },
@@ -693,6 +700,9 @@ class LiveScanCycleTest(unittest.TestCase):
                         "setup_type": "opening_range_breakout",
                         "setup_grade": "A",
                         "expected_r": "2.6",
+                        "last": "200.00",
+                        "support": "198.00",
+                        "resistance": "205.20",
                         "scorecard_sample_size": 7,
                         "scorecard_avg_realized_r": "0.9",
                         "scorecard_confidence": "0.75",
@@ -733,6 +743,9 @@ class LiveScanCycleTest(unittest.TestCase):
                         "setup_type": "vwap_reclaim",
                         "setup_grade": "A+",
                         "expected_r": "2.1",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "102.10",
                         "scorecard_sample_size": 1,
                         "scorecard_avg_realized_r": "0.1",
                     },
@@ -741,6 +754,9 @@ class LiveScanCycleTest(unittest.TestCase):
                         "setup_type": "vwap_reclaim",
                         "setup_grade": "A",
                         "expected_r": "4.0",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "104.00",
                         "scorecard_sample_size": 1,
                         "scorecard_avg_realized_r": "0.1",
                     },
@@ -774,12 +790,18 @@ class LiveScanCycleTest(unittest.TestCase):
                         "setup_type": "vwap_reclaim",
                         "setup_grade": "A+",
                         "expected_r": "5.0",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "105.00",
                     },
                     {
                         "symbol": "AMD",
                         "setup_type": "vwap_reclaim",
                         "setup_grade": "A",
                         "expected_r": "3.0",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "103.00",
                         "risk_dollars": "100",
                         "scorecard_sample_size": 1,
                         "scorecard_avg_realized_r": "3.042857",
@@ -832,6 +854,9 @@ class LiveScanCycleTest(unittest.TestCase):
                         "setup_type": "vwap_reclaim",
                         "setup_grade": "A",
                         "expected_r": "3.0",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "103.00",
                         "scorecard_sample_size": 1,
                         "scorecard_avg_realized_r": "3.0",
                         "scorecard_confidence": "0.0909",
@@ -841,6 +866,9 @@ class LiveScanCycleTest(unittest.TestCase):
                         "setup_type": "vwap_reclaim",
                         "setup_grade": "A",
                         "expected_r": "3.0",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "103.00",
                         "scorecard_sample_size": 2,
                         "scorecard_avg_realized_r": "2.0",
                         "scorecard_confidence": "0.1667",
@@ -873,6 +901,9 @@ class LiveScanCycleTest(unittest.TestCase):
                 "setup_type": "vwap_reclaim",
                 "setup_grade": "A",
                 "expected_r": "3.0",
+                "last": "100.00",
+                "support": "99.00",
+                "resistance": "103.00",
                 "risk_dollars": "125",
                 "scorecard_sample_size": 2,
                 "scorecard_avg_realized_r": "1.4",
@@ -905,6 +936,8 @@ class LiveScanCycleTest(unittest.TestCase):
             "setup_grade": "A+",
             "expected_r": "5.0",
             "last": "280.00",
+            "support": "278.00",
+            "resistance": "290.00",
         }
         payload = live_scan_cycle.ticket_payload_for_scan_result(
             session_id="session-1",
@@ -931,6 +964,70 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["blockedResultCount"], 1)
         self.assertEqual(summary["noTradeResultCount"], 0)
         self.assertIsNone(summary["bestCandidate"])
+
+    def test_ticket_payload_derives_executable_buy_bracket_from_support_resistance(self) -> None:
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=12,
+            index=1,
+            result={
+                "symbol": "AMD",
+                "setup_type": "vwap_reclaim",
+                "setup_grade": "A",
+                "expected_r": "3.0",
+                "last": "100.00",
+                "support": "99.00",
+                "resistance": "103.00",
+                "scorecard_sample_size": 2,
+                "scorecard_avg_realized_r": "1.2",
+            },
+        )
+
+        assert payload is not None
+        self.assertEqual(payload["status"], "candidate")
+        self.assertEqual(payload["entryLimitPrice"], "100.00")
+        self.assertEqual(payload["stopPrice"], "99.00")
+        self.assertEqual(payload["targetPrice"], "103.00")
+        self.assertEqual(payload["actualBracketR"], "3")
+        self.assertEqual(payload["brokerOrderPlan"]["executableBracket"]["stopSource"], "support")
+        self.assertEqual(payload["brokerOrderPlan"]["executableBracket"]["targetSource"], "resistance")
+
+    def test_decision_summary_blocks_weak_derived_bracket_r(self) -> None:
+        result = {
+            "symbol": "AMD",
+            "setup_type": "vwap_reclaim",
+            "setup_grade": "A",
+            "expected_r": "3.5595",
+            "last": "534.83",
+            "support": "524.64",
+            "resistance": "543.88",
+            "scorecard_sample_size": 1,
+            "scorecard_avg_realized_r": "3.0429",
+            "scorecard_confidence": "0.0909",
+        }
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=38,
+            index=1,
+            result=result,
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=38,
+            scan={"results": [result]},
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-38-1-AMD-vwap_reclaim-A",
+                    "ticketId": "ticket-amd",
+                }
+            ],
+        )
+
+        assert payload is not None
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["noTradeReason"], "actual_bracket_r_below_threshold")
+        self.assertEqual(payload["actualBracketR"], "0.888126")
+        self.assertEqual(summary["action"], "no_actionable_candidate")
+        self.assertEqual(summary["blockedResultCount"], 1)
 
     def test_decision_summary_blocks_sub_two_r_candidates(self) -> None:
         result = {
@@ -981,6 +1078,9 @@ class LiveScanCycleTest(unittest.TestCase):
             "setup_type": "vwap_reclaim",
             "setup_grade": "A",
             "expected_r": "3.0",
+            "last": "100.00",
+            "support": "99.00",
+            "resistance": "103.00",
             "scorecard_sample_size": 1,
             "scorecard_avg_realized_r": "3.042857",
             "scorecard_confidence": "0.0909",


### PR DESCRIPTION
## Summary

- Derive executable bracket prices from scanner `last`/`support`/`resistance` when explicit stop/target fields are absent.
- Require actual executable bracket R to meet the same 2R floor before a scan result can reach strategy guard.
- Record `actualBracketR` and the derived bracket source on trade tickets so post-run readback can prove why a candidate was accepted or blocked.
- Add regression coverage for the live AMD-style candidate that had positive scorecard edge but an under-2R executable bracket.

## Related Issues

None

## Testing

- `python3 -m py_compile live_scan_cycle.py market_open_cycle.py strategy_order_guard.py test_live_scan_cycle.py test_market_open_cycle.py`
- `python3 -m unittest discover -v`
- Manual `python3 -` live-shape simulation for the AMD cycle 38 candidate verified `actual_bracket_r_below_threshold`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
