### PR TITLE
feat(torghut): add lob reality gap stress preview

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -25,6 +25,9 @@ from app.trading.discovery.execution_schedule_stress import (
 from app.trading.discovery.feed_lag_liquidity_stress import (
     extract_feed_lag_liquidity_stress,
 )
+from app.trading.discovery.lob_reality_gap_stress import (
+    extract_lob_reality_gap_stress,
+)
 from app.trading.discovery.microstructure_prefilter import (
     HPAIRS_PREFILTER_PROOF_SEMANTICS_LABEL,
     HPAIRS_PREFILTER_PROOF_SOURCE,
@@ -61,6 +64,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "markov_order_transition_latent_regime_stress",
     "queue_position_survival_fill_stress",
     "public_feed_lag_quoted_liquidity_stress",
+    "lob_simulation_reality_gap_execution_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -139,6 +143,9 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     feed_lag_liquidity_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    lob_reality_gap_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -235,6 +242,7 @@ class FastReplayPreviewRow:
             "order_transition_stress": dict(self.order_transition_stress),
             "queue_survival_fill_stress": dict(self.queue_survival_fill_stress),
             "feed_lag_liquidity_stress": dict(self.feed_lag_liquidity_stress),
+            "lob_reality_gap_stress": dict(self.lob_reality_gap_stress),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
             "exact_replay_required": True,
@@ -420,6 +428,7 @@ class FastReplayPreviewResult:
                 "markov_order_transition_latent_regime_stress": "deterministic Markov transition entropy/inertia plus latent rising-edge stress from arXiv:2502.07625 and arXiv:2604.20949; preview ranking only",
                 "queue_position_survival_fill_stress": "deterministic queue-position survival fill probability, depth-delay, and nonfill opportunity-cost stress from arXiv:2512.05734, SSRN:6440898, and SSRN:6730443; preview ranking only",
                 "public_feed_lag_quoted_liquidity_stress": "deterministic public-feed delay, quoted-liquidity reliability, stale-quote, and authoritative trade-direction join stress from SSRN:6675338, arXiv:2604.24366, and arXiv:2511.20606; preview ranking only",
+                "lob_simulation_reality_gap_execution_stress": "deterministic spread-volume imbalance, latency-race mode, power-law signed-flow impact, and odd-lot liquidity reliability stress from arXiv:2603.24137, OFR WP 25-01, and arXiv:2507.06345; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1074,6 +1083,7 @@ def _score_candidate_spec(
             order_transition_stress={},
             queue_survival_fill_stress={},
             feed_lag_liquidity_stress={},
+            lob_reality_gap_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1182,6 +1192,18 @@ def _score_candidate_spec(
         )
         or 0.0
     )
+    lob_reality_gap_stress = extract_lob_reality_gap_stress(
+        matched_source_rows,
+        direction=direction,
+    ).to_payload()
+    lob_reality_gap_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(lob_reality_gap_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
@@ -1231,6 +1253,7 @@ def _score_candidate_spec(
         - order_transition_rank_penalty_bps * 0.11
         - queue_survival_fill_rank_penalty_bps * 0.13
         - feed_lag_liquidity_rank_penalty_bps * 0.10
+        - lob_reality_gap_rank_penalty_bps * 0.09
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1265,6 +1288,7 @@ def _score_candidate_spec(
         - order_transition_rank_penalty_bps * 0.04
         - queue_survival_fill_rank_penalty_bps * 0.05
         - feed_lag_liquidity_rank_penalty_bps * 0.04
+        - lob_reality_gap_rank_penalty_bps * 0.04
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1305,6 +1329,7 @@ def _score_candidate_spec(
         order_transition_stress=dict(order_transition_stress),
         queue_survival_fill_stress=dict(queue_survival_fill_stress),
         feed_lag_liquidity_stress=dict(feed_lag_liquidity_stress),
+        lob_reality_gap_stress=dict(lob_reality_gap_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1344,6 +1369,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - _order_transition_rank_penalty_bps(row) * 0.06
         - _queue_survival_fill_rank_penalty_bps(row) * 0.07
         - _feed_lag_liquidity_rank_penalty_bps(row) * 0.06
+        - _lob_reality_gap_rank_penalty_bps(row) * 0.05
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
@@ -1372,6 +1398,11 @@ def _queue_survival_fill_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
 
 def _feed_lag_liquidity_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
     ranking_features = _mapping(row.feed_lag_liquidity_stress.get("ranking_features"))
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _lob_reality_gap_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
+    ranking_features = _mapping(row.lob_reality_gap_stress.get("ranking_features"))
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
 
@@ -1566,6 +1597,7 @@ def _row_with_rank_and_selection(
         order_transition_stress=dict(row.order_transition_stress),
         queue_survival_fill_stress=dict(row.queue_survival_fill_stress),
         feed_lag_liquidity_stress=dict(row.feed_lag_liquidity_stress),
+        lob_reality_gap_stress=dict(row.lob_reality_gap_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -1628,6 +1660,7 @@ def _row_with_frontier_dedupe(
         order_transition_stress=dict(row.order_transition_stress),
         queue_survival_fill_stress=dict(row.queue_survival_fill_stress),
         feed_lag_liquidity_stress=dict(row.feed_lag_liquidity_stress),
+        lob_reality_gap_stress=dict(row.lob_reality_gap_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -2431,6 +2464,8 @@ def _risk_flags_for_row(
         flags.add("queue_survival_fill_stress_penalty_active")
     if _feed_lag_liquidity_rank_penalty_bps(row) > 0:
         flags.add("feed_lag_liquidity_stress_penalty_active")
+    if _lob_reality_gap_rank_penalty_bps(row) > 0:
+        flags.add("lob_reality_gap_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
         flags.add("partial_symbol_coverage")
     if row.trading_day_count <= 0:
@@ -2467,6 +2502,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("queue_survival_fill_stress_downranks_only")
     if _feed_lag_liquidity_rank_penalty_bps(row) > 0:
         reasons.add("feed_lag_liquidity_stress_downranks_only")
+    if _lob_reality_gap_rank_penalty_bps(row) > 0:
+        reasons.add("lob_reality_gap_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
         reasons.add("missing_replay_tape_source_data_explicit_blocker")
     if lineage_blockers:
@@ -2496,6 +2533,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("queue_survival_fill_stress_penalty")
     if _feed_lag_liquidity_rank_penalty_bps(row) > 0:
         vetoes.add("feed_lag_liquidity_stress_penalty")
+    if _lob_reality_gap_rank_penalty_bps(row) > 0:
+        vetoes.add("lob_reality_gap_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:
         vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
     return tuple(sorted(vetoes))

--- a/services/torghut/app/trading/discovery/lob_reality_gap_stress.py
+++ b/services/torghut/app/trading/discovery/lob_reality_gap_stress.py
@@ -1,0 +1,582 @@
+"""Preview-only LOB reality-gap stress for replay candidate ranking.
+
+This module converts recent limit-order-book simulation and liquidity reliability
+papers into deterministic replay-ranking inputs. It never simulates fills, writes
+ledgers, authorizes promotion, or enables live capital.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import isfinite
+from typing import Any, cast
+
+from app.trading.models import SignalEnvelope
+
+LOB_REALITY_GAP_STRESS_SCHEMA_VERSION = "torghut.lob-reality-gap-stress.v1"
+LOB_REALITY_GAP_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.lob-reality-gap-stress-contract.v1"
+)
+LOB_REALITY_GAP_STRESS_PROOF_SEMANTICS_LABEL = "lob_reality_gap_stress_preview_only_exact_replay_route_tca_order_lifecycle_runtime_ledger_required"
+LOB_REALITY_GAP_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2603.24137",
+        "url": "https://arxiv.org/abs/2603.24137",
+        "title": "Bridging the Reality Gap in Limit Order Book Simulation",
+        "date": "2026-03-25",
+        "mechanism": "spread_volume_imbalance_projection_latency_mode_and_power_law_signed_flow_impact",
+    },
+    {
+        "source_id": "ofr-25-01",
+        "url": "https://www.financialresearch.gov/working-papers/2025/06/05/the-reliability-of-odd-lot-liquidity/",
+        "title": "The Reliability of Odd-Lot Liquidity",
+        "date": "2025-06-05",
+        "mechanism": "off_exchange_trade_correlated_odd_lot_liquidity_vanish_and_cancellation_stress",
+    },
+    {
+        "source_id": "arxiv-2507.06345",
+        "url": "https://arxiv.org/abs/2507.06345",
+        "title": "Reinforcement Learning for Trade Execution with Market and Limit Orders",
+        "date": "2026-01-26",
+        "mechanism": "market_limit_allocation_sensitivity_to_order_book_imbalance_tactical_response",
+    },
+)
+
+_BID_FIELDS = ("bid", "best_bid", "bid_price", "best_bid_price")
+_ASK_FIELDS = ("ask", "best_ask", "ask_price", "best_ask_price")
+_BID_SIZE_FIELDS = (
+    "bid_size",
+    "bid_qty",
+    "best_bid_size",
+    "best_bid_qty",
+    "bid_depth",
+    "bid_volume",
+)
+_ASK_SIZE_FIELDS = (
+    "ask_size",
+    "ask_qty",
+    "best_ask_size",
+    "best_ask_qty",
+    "ask_depth",
+    "ask_volume",
+)
+_PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
+_SPREAD_BPS_FIELDS = ("spread_bps", "quoted_spread_bps", "effective_spread_bps")
+_TRADE_SIZE_FIELDS = ("trade_size", "trade_qty", "last_size", "volume", "qty")
+_NOTIONAL_FIELDS = ("trade_notional", "notional", "dollar_volume", "signed_notional")
+_DIRECTION_FIELDS = (
+    "trade_direction",
+    "aggressor_side",
+    "trade_side",
+    "side",
+    "execution_side",
+)
+_LATENCY_MS_FIELDS = (
+    "round_trip_latency_ms",
+    "exchange_round_trip_latency_ms",
+    "latency_ms",
+    "event_latency_ms",
+)
+_ODD_LOT_BID_FIELDS = ("odd_lot_bid_size", "odd_lot_bid_qty", "hidden_odd_lot_bid_size")
+_ODD_LOT_ASK_FIELDS = ("odd_lot_ask_size", "odd_lot_ask_qty", "hidden_odd_lot_ask_size")
+_OFF_EXCHANGE_FIELDS = (
+    "off_exchange_trade",
+    "off_exchange_print",
+    "trf_trade",
+    "dark_trade",
+)
+_EVENT_TYPE_FIELDS = ("event_type", "lob_event_type", "order_event_type")
+_POWER_LAW_DECAY_EXPONENT = 0.60
+_HIGH_IMBALANCE_FLOOR = 0.65
+_ODD_LOT_VANISH_FLOOR = 0.50
+
+
+@dataclass(frozen=True)
+class LobRealityGapStressSummary:
+    row_count: int
+    observed_spread_count: int
+    observed_depth_count: int
+    observed_latency_count: int
+    observed_signed_flow_count: int
+    observed_odd_lot_count: int
+    off_exchange_event_count: int
+    median_spread_bps: float
+    median_abs_volume_imbalance: float
+    high_imbalance_share: float
+    latency_mode_ms: float
+    latency_mode_share: float
+    power_law_signed_flow_impact_bps: float
+    impact_reversion_failure_share: float
+    odd_lot_vanish_share: float
+    off_exchange_cancellation_share: float
+    replay_reality_gap_score: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": LOB_REALITY_GAP_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_lob_reality_gap_stress_ranking",
+            "source_papers": [
+                dict(item) for item in LOB_REALITY_GAP_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "observed_spread_count": self.observed_spread_count,
+            "observed_depth_count": self.observed_depth_count,
+            "observed_latency_count": self.observed_latency_count,
+            "observed_signed_flow_count": self.observed_signed_flow_count,
+            "observed_odd_lot_count": self.observed_odd_lot_count,
+            "off_exchange_event_count": self.off_exchange_event_count,
+            "median_spread_bps": _stable_float(self.median_spread_bps),
+            "median_abs_volume_imbalance": _stable_float(
+                self.median_abs_volume_imbalance
+            ),
+            "high_imbalance_share": _stable_float(self.high_imbalance_share),
+            "latency_mode_ms": _stable_float(self.latency_mode_ms),
+            "latency_mode_share": _stable_float(self.latency_mode_share),
+            "power_law_signed_flow_impact_bps": _stable_float(
+                self.power_law_signed_flow_impact_bps
+            ),
+            "impact_reversion_failure_share": _stable_float(
+                self.impact_reversion_failure_share
+            ),
+            "odd_lot_vanish_share": _stable_float(self.odd_lot_vanish_share),
+            "off_exchange_cancellation_share": _stable_float(
+                self.off_exchange_cancellation_share
+            ),
+            "replay_reality_gap_score": _stable_float(self.replay_reality_gap_score),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "median_abs_volume_imbalance": _stable_float(
+                    self.median_abs_volume_imbalance
+                ),
+                "high_imbalance_share": _stable_float(self.high_imbalance_share),
+                "latency_mode_share": _stable_float(self.latency_mode_share),
+                "power_law_signed_flow_impact_bps": _stable_float(
+                    self.power_law_signed_flow_impact_bps
+                ),
+                "impact_reversion_failure_share": _stable_float(
+                    self.impact_reversion_failure_share
+                ),
+                "odd_lot_vanish_share": _stable_float(self.odd_lot_vanish_share),
+                "off_exchange_cancellation_share": _stable_float(
+                    self.off_exchange_cancellation_share
+                ),
+                "replay_reality_gap_score": _stable_float(
+                    self.replay_reality_gap_score
+                ),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "spread_volume_imbalance_projection_preview": True,
+            "latency_race_mode_preview": True,
+            "power_law_signed_flow_impact_preview": True,
+            "odd_lot_liquidity_reliability_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": LOB_REALITY_GAP_STRESS_PROOF_SEMANTICS_LABEL,
+        }
+
+
+def lob_reality_gap_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": LOB_REALITY_GAP_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": LOB_REALITY_GAP_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in LOB_REALITY_GAP_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": "lob_simulation_reality_gap_latency_impact_odd_lot_reliability_stress",
+        "stress_components": [
+            "spread_volume_imbalance_projection",
+            "latency_mode_share",
+            "power_law_signed_flow_impact_bps",
+            "impact_reversion_failure_share",
+            "odd_lot_vanish_share",
+            "off_exchange_cancellation_share",
+        ],
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_order_lifecycle_fill_evidence": True,
+            "requires_runtime_ledger": True,
+            "rejects_simulator_only_pnl_authority": True,
+            "rejects_hidden_or_odd_lot_liquidity_as_fill_authority": True,
+        },
+    }
+
+
+def build_lob_reality_gap_stress_schema_hash() -> str:
+    return _stable_hash(lob_reality_gap_stress_contract())
+
+
+def extract_lob_reality_gap_stress(
+    records: Sequence[SignalEnvelope],
+    *,
+    direction: int | float = 1,
+) -> LobRealityGapStressSummary:
+    """Extract deterministic LOB simulation reality-gap stress from replay rows."""
+
+    ordered = tuple(
+        sorted(records, key=lambda item: (item.event_ts, item.symbol, item.seq))
+    )
+    signed_direction = 1.0 if float(direction) >= 0.0 else -1.0
+    spreads = tuple(value for row in ordered if (value := _spread_bps(row)) is not None)
+    depths = tuple(_depth_notional(row) for row in ordered)
+    observed_depths = tuple(
+        value for value in depths if value is not None and value > 0
+    )
+    depth_median = _median(observed_depths) or 1.0
+    imbalances: list[float] = []
+    for row in ordered:
+        value = _volume_imbalance(row)
+        if value is not None:
+            imbalances.append(value)
+    abs_imbalances = tuple(abs(value) for value in imbalances)
+    latency_values: list[float] = []
+    for row in ordered:
+        value = _latency_ms(row)
+        if value is not None:
+            latency_values.append(value)
+    latency_mode_ms, latency_mode_share = _latency_mode(latency_values)
+    signed_flow = tuple(
+        _signed_flow_notional(row, direction=signed_direction) for row in ordered
+    )
+    observed_signed_flow = tuple(value for value in signed_flow if value is not None)
+    decayed_flow = _power_law_decayed_signed_flow(
+        ordered,
+        signed_flow=signed_flow,
+        depth_median=depth_median,
+    )
+    impact_bps = _signed_flow_impact_bps(ordered, decayed_flow=decayed_flow)
+    odd_lot_values = tuple(_odd_lot_notional(row) for row in ordered)
+    observed_odd_lots = tuple(value for value in odd_lot_values if value is not None)
+    odd_lot_median = _median(observed_odd_lots) or 0.0
+    off_exchange_count = sum(1 for row in ordered if _is_off_exchange(row))
+    odd_lot_vanish_count = sum(
+        1
+        for row, value in zip(ordered, odd_lot_values, strict=False)
+        if _is_off_exchange(row)
+        and value is not None
+        and odd_lot_median > 0.0
+        and value < odd_lot_median * _ODD_LOT_VANISH_FLOOR
+    )
+    off_exchange_cancel_count = sum(
+        1
+        for row in ordered
+        if _is_off_exchange(row) and _event_type_contains(row, ("cancel", "delete"))
+    )
+    impact_reversion_failure_share = _impact_reversion_failure_share(
+        ordered,
+        decayed_flow=decayed_flow,
+        direction=signed_direction,
+    )
+    high_imbalance_share = _share(
+        1 for value in abs_imbalances if value >= _HIGH_IMBALANCE_FLOOR
+    ) / max(1, len(abs_imbalances))
+    odd_lot_vanish_share = odd_lot_vanish_count / max(1, off_exchange_count)
+    off_exchange_cancellation_share = off_exchange_cancel_count / max(
+        1, off_exchange_count
+    )
+    median_abs_imbalance = _median(abs_imbalances) or 0.0
+    median_spread_bps = _median(spreads) or 0.0
+    power_law_signed_flow_impact_bps = max(
+        (abs(value) for value in impact_bps), default=0.0
+    )
+    replay_reality_gap_score = min(
+        1.0,
+        median_abs_imbalance * 0.35
+        + high_imbalance_share * 0.20
+        + min(1.0, latency_mode_share) * 0.12
+        + min(1.0, power_law_signed_flow_impact_bps / 25.0) * 0.18
+        + impact_reversion_failure_share * 0.10
+        + odd_lot_vanish_share * 0.12
+        + off_exchange_cancellation_share * 0.08,
+    )
+    replay_rank_penalty_bps = (
+        median_spread_bps * 0.10
+        + median_abs_imbalance * 8.0
+        + high_imbalance_share * 4.0
+        + latency_mode_share * 2.0
+        + power_law_signed_flow_impact_bps * 0.18
+        + impact_reversion_failure_share * 6.0
+        + odd_lot_vanish_share * 5.0
+        + off_exchange_cancellation_share * 3.0
+    )
+    warnings: list[str] = []
+    if not spreads:
+        warnings.append("missing_spread_inputs")
+    if not observed_depths:
+        warnings.append("missing_depth_inputs")
+    if not latency_values:
+        warnings.append("missing_latency_inputs")
+    if not observed_signed_flow:
+        warnings.append("missing_signed_flow_inputs")
+    if not observed_odd_lots:
+        warnings.append("missing_odd_lot_liquidity_inputs")
+
+    return LobRealityGapStressSummary(
+        row_count=len(ordered),
+        observed_spread_count=len(spreads),
+        observed_depth_count=len(observed_depths),
+        observed_latency_count=len(latency_values),
+        observed_signed_flow_count=len(observed_signed_flow),
+        observed_odd_lot_count=len(observed_odd_lots),
+        off_exchange_event_count=off_exchange_count,
+        median_spread_bps=median_spread_bps,
+        median_abs_volume_imbalance=median_abs_imbalance,
+        high_imbalance_share=high_imbalance_share,
+        latency_mode_ms=latency_mode_ms,
+        latency_mode_share=latency_mode_share,
+        power_law_signed_flow_impact_bps=power_law_signed_flow_impact_bps,
+        impact_reversion_failure_share=impact_reversion_failure_share,
+        odd_lot_vanish_share=odd_lot_vanish_share,
+        off_exchange_cancellation_share=off_exchange_cancellation_share,
+        replay_reality_gap_score=replay_reality_gap_score,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=tuple(warnings),
+        feature_schema_hash=build_lob_reality_gap_stress_schema_hash(),
+    )
+
+
+def _payload(row: SignalEnvelope) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], row.payload)
+
+
+def _number(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if isfinite(result) else None
+
+
+def _first_number(payload: Mapping[str, Any], fields: Sequence[str]) -> float | None:
+    for field in fields:
+        value = _number(payload.get(field))
+        if value is not None:
+            return value
+    return None
+
+
+def _spread_bps(row: SignalEnvelope) -> float | None:
+    payload = _payload(row)
+    explicit = _first_number(payload, _SPREAD_BPS_FIELDS)
+    if explicit is not None:
+        return max(0.0, explicit)
+    bid = _first_number(payload, _BID_FIELDS)
+    ask = _first_number(payload, _ASK_FIELDS)
+    if bid is None or ask is None or bid <= 0.0 or ask <= bid:
+        return None
+    mid = (bid + ask) / 2.0
+    return ((ask - bid) / mid) * 10_000.0 if mid > 0.0 else None
+
+
+def _price(row: SignalEnvelope) -> float | None:
+    payload = _payload(row)
+    price = _first_number(payload, _PRICE_FIELDS)
+    if price is not None and price > 0.0:
+        return price
+    bid = _first_number(payload, _BID_FIELDS)
+    ask = _first_number(payload, _ASK_FIELDS)
+    if bid is not None and ask is not None and bid > 0.0 and ask > 0.0:
+        return (bid + ask) / 2.0
+    return None
+
+
+def _depth_notional(row: SignalEnvelope) -> float | None:
+    payload = _payload(row)
+    bid_size = _first_number(payload, _BID_SIZE_FIELDS)
+    ask_size = _first_number(payload, _ASK_SIZE_FIELDS)
+    price = _price(row)
+    if bid_size is None or ask_size is None or price is None:
+        return None
+    return max(0.0, bid_size + ask_size) * price
+
+
+def _volume_imbalance(row: SignalEnvelope) -> float | None:
+    payload = _payload(row)
+    bid_size = _first_number(payload, _BID_SIZE_FIELDS)
+    ask_size = _first_number(payload, _ASK_SIZE_FIELDS)
+    if bid_size is None or ask_size is None:
+        return None
+    total = bid_size + ask_size
+    if total <= 0.0:
+        return None
+    return (bid_size - ask_size) / total
+
+
+def _latency_ms(row: SignalEnvelope) -> float | None:
+    value = _first_number(_payload(row), _LATENCY_MS_FIELDS)
+    return max(0.0, value) if value is not None else None
+
+
+def _signed_flow_notional(row: SignalEnvelope, *, direction: float) -> float | None:
+    payload = _payload(row)
+    explicit = _first_number(payload, _NOTIONAL_FIELDS)
+    price = _price(row) or 1.0
+    size = _first_number(payload, _TRADE_SIZE_FIELDS)
+    magnitude = abs(explicit) if explicit is not None else None
+    if magnitude is None and size is not None:
+        magnitude = abs(size) * price
+    if magnitude is None or magnitude == 0.0:
+        return None
+    sign = _direction_sign(payload) or direction
+    return sign * magnitude
+
+
+def _direction_sign(payload: Mapping[str, Any]) -> float | None:
+    for field in _DIRECTION_FIELDS:
+        value = payload.get(field)
+        if value is None:
+            continue
+        token = str(value).strip().lower()
+        if token in {"buy", "bid", "b", "1", "+1", "long"}:
+            return 1.0
+        if token in {"sell", "ask", "offer", "s", "-1", "short"}:
+            return -1.0
+    return None
+
+
+def _power_law_decayed_signed_flow(
+    rows: Sequence[SignalEnvelope],
+    *,
+    signed_flow: Sequence[float | None],
+    depth_median: float,
+) -> tuple[float, ...]:
+    values: list[float] = []
+    state = 0.0
+    previous_ts = None
+    for row, flow in zip(rows, signed_flow, strict=False):
+        if previous_ts is not None:
+            dt_seconds = max(0.0, (row.event_ts - previous_ts).total_seconds())
+            state *= (1.0 + dt_seconds) ** (-_POWER_LAW_DECAY_EXPONENT)
+        if flow is not None:
+            state += flow / max(1.0, depth_median)
+        values.append(state)
+        previous_ts = row.event_ts
+    return tuple(values)
+
+
+def _signed_flow_impact_bps(
+    rows: Sequence[SignalEnvelope], *, decayed_flow: Sequence[float]
+) -> tuple[float, ...]:
+    prices = tuple(_price(row) for row in rows)
+    impacts: list[float] = []
+    for index, state in enumerate(decayed_flow[:-1]):
+        current_price = prices[index]
+        next_price = prices[index + 1]
+        if current_price is None or next_price is None or current_price <= 0.0:
+            continue
+        move_bps = ((next_price - current_price) / current_price) * 10_000.0
+        impacts.append(move_bps * (1.0 if state >= 0.0 else -1.0))
+    return tuple(value for value in impacts if value > 0.0)
+
+
+def _impact_reversion_failure_share(
+    rows: Sequence[SignalEnvelope], *, decayed_flow: Sequence[float], direction: float
+) -> float:
+    prices = tuple(_price(row) for row in rows)
+    failures = 0
+    observations = 0
+    for index, state in enumerate(decayed_flow[:-1]):
+        current_price = prices[index]
+        next_price = prices[index + 1]
+        if (
+            abs(state) < 0.05
+            or current_price is None
+            or next_price is None
+            or current_price <= 0.0
+        ):
+            continue
+        observations += 1
+        signed_move = (
+            ((next_price - current_price) / current_price)
+            * (1.0 if state >= 0.0 else -1.0)
+            * direction
+        )
+        if signed_move >= 0.0:
+            failures += 1
+    return failures / max(1, observations)
+
+
+def _odd_lot_notional(row: SignalEnvelope) -> float | None:
+    payload = _payload(row)
+    bid = _first_number(payload, _ODD_LOT_BID_FIELDS)
+    ask = _first_number(payload, _ODD_LOT_ASK_FIELDS)
+    price = _price(row)
+    if bid is None or ask is None or price is None:
+        return None
+    return max(0.0, bid + ask) * price
+
+
+def _is_off_exchange(row: SignalEnvelope) -> bool:
+    payload = _payload(row)
+    return any(_truthy(payload.get(field)) for field in _OFF_EXCHANGE_FIELDS)
+
+
+def _event_type_contains(row: SignalEnvelope, needles: Sequence[str]) -> bool:
+    payload = _payload(row)
+    tokens = tuple(
+        str(payload.get(field) or "").strip().lower() for field in _EVENT_TYPE_FIELDS
+    )
+    return any(needle in token for token in tokens for needle in needles)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _latency_mode(values: Sequence[float]) -> tuple[float, float]:
+    if not values:
+        return 0.0, 0.0
+    buckets: dict[float, int] = {}
+    for value in values:
+        bucket = round(value, 1)
+        buckets[bucket] = buckets.get(bucket, 0) + 1
+    mode, count = max(buckets.items(), key=lambda item: (item[1], -item[0]))
+    return mode, count / max(1, len(values))
+
+
+def _median(values: Sequence[float]) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def _share(items: Any) -> float:
+    return float(sum(1 for _ in items))
+
+
+def _stable_float(value: float) -> float:
+    return round(float(value), 8) if isfinite(float(value)) else 0.0
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -93,6 +93,12 @@ class TestFastReplayPreview(TestCase):
                 "feed_delay_ms": Decimal(feed_delay_ms),
                 "feed_trade_direction": "buy",
                 "authoritative_trade_direction": "buy",
+                "trade_direction": "buy",
+                "trade_size": Decimal("100"),
+                "round_trip_latency_ms": Decimal("2.0"),
+                "odd_lot_bid_size": Decimal("20"),
+                "odd_lot_ask_size": Decimal("18"),
+                "off_exchange_trade": stress,
                 "bid_size": Decimal("700"),
                 "ask_size": Decimal("300"),
                 "macro_event_window": stress,
@@ -199,6 +205,10 @@ class TestFastReplayPreview(TestCase):
             "public_feed_lag_quoted_liquidity_stress",
             payload["implemented_mechanisms"],
         )
+        self.assertIn(
+            "lob_simulation_reality_gap_execution_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",
@@ -269,6 +279,20 @@ class TestFastReplayPreview(TestCase):
             {
                 source["source_id"]
                 for source in row_payload["feed_lag_liquidity_stress"]["source_papers"]
+            },
+        )
+        self.assertIn("lob_reality_gap_stress", row_payload)
+        self.assertFalse(row_payload["lob_reality_gap_stress"]["proof_authority"])
+        self.assertFalse(row_payload["lob_reality_gap_stress"]["promotion_authority"])
+        self.assertEqual(
+            row_payload["lob_reality_gap_stress"]["status"],
+            "preview_only_lob_reality_gap_stress_ranking",
+        )
+        self.assertIn(
+            "arxiv-2603.24137",
+            {
+                source["source_id"]
+                for source in row_payload["lob_reality_gap_stress"]["source_papers"]
             },
         )
         self.assertIn("cost_impact_lineage", row_payload)

--- a/services/torghut/tests/test_lob_reality_gap_stress.py
+++ b/services/torghut/tests/test_lob_reality_gap_stress.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.lob_reality_gap_stress import (
+    build_lob_reality_gap_stress_schema_hash,
+    extract_lob_reality_gap_stress,
+    lob_reality_gap_stress_contract,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestLobRealityGapStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        price: str,
+        bid_size: str,
+        ask_size: str,
+        latency_ms: str,
+        trade_direction: str,
+        trade_size: str,
+        odd_lot_bid_size: str,
+        odd_lot_ask_size: str,
+        off_exchange_trade: bool = False,
+        event_type: str = "trade",
+    ) -> SignalEnvelope:
+        mid = Decimal(price)
+        return SignalEnvelope(
+            event_ts=datetime(2026, 3, 25, 14, 30, tzinfo=timezone.utc)
+            + timedelta(milliseconds=offset),
+            symbol="LBG",
+            timeframe="1ms",
+            seq=offset,
+            source="lob-reality-gap-fixture",
+            payload={
+                "price": mid,
+                "bid": mid - Decimal("0.01"),
+                "ask": mid + Decimal("0.01"),
+                "bid_size": Decimal(bid_size),
+                "ask_size": Decimal(ask_size),
+                "round_trip_latency_ms": Decimal(latency_ms),
+                "trade_direction": trade_direction,
+                "trade_size": Decimal(trade_size),
+                "odd_lot_bid_size": Decimal(odd_lot_bid_size),
+                "odd_lot_ask_size": Decimal(odd_lot_ask_size),
+                "off_exchange_trade": off_exchange_trade,
+                "event_type": event_type,
+            },
+            ingest_ts=datetime(2026, 3, 25, 14, 31, tzinfo=timezone.utc),
+        )
+
+    def test_reality_gap_stress_penalizes_latency_flow_and_odd_lot_vanish(self) -> None:
+        stable = extract_lob_reality_gap_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    bid_size="500",
+                    ask_size="480",
+                    latency_ms="1.2",
+                    trade_direction="buy",
+                    trade_size="5",
+                    odd_lot_bid_size="40",
+                    odd_lot_ask_size="42",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.01",
+                    bid_size="510",
+                    ask_size="500",
+                    latency_ms="2.7",
+                    trade_direction="sell",
+                    trade_size="4",
+                    odd_lot_bid_size="41",
+                    odd_lot_ask_size="43",
+                ),
+                self._row(
+                    offset=3,
+                    price="100.00",
+                    bid_size="505",
+                    ask_size="495",
+                    latency_ms="3.5",
+                    trade_direction="buy",
+                    trade_size="4",
+                    odd_lot_bid_size="40",
+                    odd_lot_ask_size="44",
+                ),
+            ),
+            direction=1,
+        )
+        fragile = extract_lob_reality_gap_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    bid_size="950",
+                    ask_size="50",
+                    latency_ms="2.0",
+                    trade_direction="buy",
+                    trade_size="900",
+                    odd_lot_bid_size="80",
+                    odd_lot_ask_size="82",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.28",
+                    bid_size="930",
+                    ask_size="45",
+                    latency_ms="2.0",
+                    trade_direction="buy",
+                    trade_size="850",
+                    odd_lot_bid_size="5",
+                    odd_lot_ask_size="4",
+                    off_exchange_trade=True,
+                    event_type="cancel",
+                ),
+                self._row(
+                    offset=3,
+                    price="100.62",
+                    bid_size="920",
+                    ask_size="40",
+                    latency_ms="2.0",
+                    trade_direction="buy",
+                    trade_size="800",
+                    odd_lot_bid_size="4",
+                    odd_lot_ask_size="3",
+                    off_exchange_trade=True,
+                    event_type="cancel_replace",
+                ),
+                self._row(
+                    offset=4,
+                    price="100.91",
+                    bid_size="900",
+                    ask_size="35",
+                    latency_ms="2.0",
+                    trade_direction="buy",
+                    trade_size="780",
+                    odd_lot_bid_size="70",
+                    odd_lot_ask_size="72",
+                ),
+            ),
+            direction=1,
+        )
+
+        self.assertGreater(
+            fragile.median_abs_volume_imbalance, stable.median_abs_volume_imbalance
+        )
+        self.assertGreater(fragile.high_imbalance_share, stable.high_imbalance_share)
+        self.assertGreater(fragile.latency_mode_share, stable.latency_mode_share)
+        self.assertGreater(
+            fragile.power_law_signed_flow_impact_bps,
+            stable.power_law_signed_flow_impact_bps,
+        )
+        self.assertGreater(fragile.odd_lot_vanish_share, stable.odd_lot_vanish_share)
+        self.assertGreater(
+            fragile.replay_rank_penalty_bps, stable.replay_rank_penalty_bps
+        )
+        payload = fragile.to_payload()
+        self.assertEqual(
+            payload["status"], "preview_only_lob_reality_gap_stress_ranking"
+        )
+        self.assertTrue(payload["power_law_signed_flow_impact_preview"])
+        self.assertTrue(payload["odd_lot_liquidity_reliability_preview"])
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["promotion_allowed"])
+        self.assertFalse(payload["final_authority_ok"])
+
+    def test_contract_embeds_sources_and_keeps_proof_fail_closed(self) -> None:
+        contract = lob_reality_gap_stress_contract()
+        payload = extract_lob_reality_gap_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100",
+                    bid_size="100",
+                    ask_size="100",
+                    latency_ms="1",
+                    trade_direction="buy",
+                    trade_size="10",
+                    odd_lot_bid_size="10",
+                    odd_lot_ask_size="10",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.01",
+                    bid_size="100",
+                    ask_size="100",
+                    latency_ms="1.5",
+                    trade_direction="sell",
+                    trade_size="8",
+                    odd_lot_bid_size="10",
+                    odd_lot_ask_size="10",
+                ),
+            )
+        ).to_payload()
+        source_ids = {source["source_id"] for source in payload["source_papers"]}
+
+        self.assertEqual(
+            payload["feature_schema_hash"], build_lob_reality_gap_stress_schema_hash()
+        )
+        self.assertIn("arxiv-2603.24137", source_ids)
+        self.assertIn("ofr-25-01", source_ids)
+        self.assertIn("arxiv-2507.06345", source_ids)
+        self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
+        self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
+        self.assertTrue(
+            contract["proof_neutrality"]["requires_order_lifecycle_fill_evidence"]
+        )
+        self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertFalse(contract["proof_neutrality"]["promotion_proof"])
+        self.assertFalse(payload["promotion_authority"])


### PR DESCRIPTION
## Summary

- Adds preview-only LOB reality-gap stress extraction for replay candidate ranking, sourced from recent LOB simulation, odd-lot liquidity, and market/limit execution papers.
- Wires the stress into fast replay payloads, implemented-mechanism metadata, robust ranking penalties, and risk/ranking-only veto reasons.
- Adds regression tests proving fragile LOB fixtures receive higher latency/flow/odd-lot penalties while all proof and promotion authority remains fail-closed.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uvx ruff format --check app/trading/discovery/lob_reality_gap_stress.py app/trading/discovery/fast_replay.py tests/test_lob_reality_gap_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/lob_reality_gap_stress.py app/trading/discovery/fast_replay.py tests/test_lob_reality_gap_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen pytest tests/test_lob_reality_gap_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
