### PR TITLE
fix(torghut): route replay source collection reads to live db

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1642,6 +1642,10 @@ _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND = (
 )
 _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_DSN_ENV = "SIM_DB_DSN"
 _RUNTIME_LEDGER_SOURCE_COLLECTION_TARGET_DSN_ENV = "SIM_DB_DSN"
+_RUNTIME_LEDGER_SOURCE_COLLECTION_BUCKET_SOURCE = "strategy_runtime_ledger_buckets"
+_RUNTIME_LEDGER_SOURCE_COLLECTION_BUCKET_SOURCE_DSN_ENVS = {
+    "TORGHUT_REPLAY": "DB_DSN",
+}
 _RUNTIME_LEDGER_PAPER_PROBATION_TARGET_DSN_ENV = "SIM_DB_DSN"
 _RUNTIME_LEDGER_SOURCE_COLLECTION_TRIGGER_REASONS = frozenset(
     {
@@ -1910,6 +1914,27 @@ def _runtime_ledger_paper_probation_bucket_ref(
     return f"strategy_runtime_ledger_buckets:{run_id}:{started_at}:{ended_at}"
 
 
+def _runtime_ledger_source_collection_source_dsn_env(
+    candidate: Mapping[str, object],
+) -> str:
+    if (
+        _safe_text(candidate.get("source"))
+        != _RUNTIME_LEDGER_SOURCE_COLLECTION_BUCKET_SOURCE
+    ):
+        return _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_DSN_ENV
+    account_label = (
+        _safe_text(candidate.get("account"))
+        or _safe_text(candidate.get("account_label"))
+        or _safe_text(candidate.get("source_account_label"))
+    )
+    if account_label is None:
+        return _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_DSN_ENV
+    return _RUNTIME_LEDGER_SOURCE_COLLECTION_BUCKET_SOURCE_DSN_ENVS.get(
+        account_label,
+        _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_DSN_ENV,
+    )
+
+
 def _runtime_ledger_paper_probation_import_plan(
     candidates: Sequence[Mapping[str, object]],
 ) -> dict[str, object]:
@@ -1993,7 +2018,7 @@ def _runtime_ledger_paper_probation_import_plan(
             else _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_KIND
         )
         source_dsn_env = (
-            _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_DSN_ENV
+            _runtime_ledger_source_collection_source_dsn_env(candidate)
             if source_collection
             else _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_DSN_ENV
         )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -4796,6 +4796,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         "strategy_family": "microbar_cross_sectional_pairs",
                         "strategy_name": "microbar-cross-sectional-pairs-v1",
                         "source_collection_authorized": "true",
+                        "source_account_label": "TORGHUT_REPLAY",
+                        "source_dsn_env": "DB_DSN",
+                        "target_dsn_env": "SIM_DB_DSN",
                         "runtime_ledger_bucket_ref": (
                             "strategy_runtime_ledger_buckets:run-1:start:end"
                         ),
@@ -4819,6 +4822,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(plan["target_count"], 1)
         target = plan["targets"][0]
         self.assertEqual(target["candidate_id"], "keep-source-collection")
+        self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(target["source_dsn_env"], "DB_DSN")
+        self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
         self.assertEqual(
             target["runtime_ledger_bucket_ref"],
             "strategy_runtime_ledger_buckets:run-1:start:end",

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -2099,6 +2099,87 @@ class TestSubmissionCouncil(TestCase):
             target["source_collection_reason_codes"],
         )
 
+    def test_runtime_ledger_source_collection_replay_bucket_reads_from_live_db(
+        self,
+    ) -> None:
+        candidates = _runtime_ledger_source_collection_candidates(
+            [
+                {
+                    "source": "strategy_runtime_ledger_buckets",
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-pairs-vwap-cap-safe",
+                    "account": "TORGHUT_REPLAY",
+                    "observed_stage": "paper",
+                    "bucket_started_at": "2026-05-13T17:00:00+00:00",
+                    "bucket_ended_at": "2026-05-13T17:30:00+00:00",
+                    "submitted_order_count": 8,
+                    "fill_count": 35,
+                    "closed_trade_count": 2,
+                    "open_position_count": 0,
+                    "filled_notional": "127090.02495200",
+                    "net_strategy_pnl_after_costs": "567.44720578",
+                    "reason_codes": [
+                        "runtime_ledger_source_window_missing",
+                        "runtime_ledger_source_refs_missing",
+                        "execution_reconstruction_not_runtime_ledger_proof",
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(len(candidates), 1)
+        plan = _runtime_ledger_paper_probation_import_plan(candidates)
+
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["source_dsn_env"], "DB_DSN")
+        self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(
+            target["source_kind"], "runtime_ledger_source_collection_candidate"
+        )
+        self.assertTrue(target["source_collection_authorized"])
+        self.assertFalse(target["paper_probation_authorized"])
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+        self.assertEqual(target["max_notional"], "0")
+
+    def test_runtime_ledger_source_collection_bucket_without_account_uses_sim_source(
+        self,
+    ) -> None:
+        candidates = _runtime_ledger_source_collection_candidates(
+            [
+                {
+                    "source": "strategy_runtime_ledger_buckets",
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-pairs-vwap-cap-safe",
+                    "observed_stage": "paper",
+                    "bucket_started_at": "2026-05-13T17:00:00+00:00",
+                    "bucket_ended_at": "2026-05-13T17:30:00+00:00",
+                    "submitted_order_count": 8,
+                    "fill_count": 35,
+                    "filled_notional": "127090.02495200",
+                    "reason_codes": [
+                        "runtime_ledger_source_window_missing",
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(len(candidates), 1)
+        plan = _runtime_ledger_paper_probation_import_plan(candidates)
+
+        target = plan["targets"][0]
+        self.assertEqual(target["source_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["source_account_label"], "TORGHUT_SIM")
+
     def test_runtime_ledger_source_collection_allows_unclosed_or_losing_activity(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Route `TORGHUT_REPLAY` runtime-ledger source-collection candidates sourced from `strategy_runtime_ledger_buckets` to read from `DB_DSN`.
- Keep source-collection targets evidence-only with `SIM_DB_DSN` as the materialization target and all promotion/capital authority flags blocked.
- Add regression coverage for replay source reads, default sim fallback, and downstream paper-route preservation of the handoff DSNs.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_submission_council.py -k runtime_ledger_source_collection -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k source_collection_import_plan_sanitizer -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k "source_collection or runtime_window_target_plan_payload_prefers_source_runtime_plan" -q`
- `COVERAGE_FILE=.coverage.local uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml -q tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv lock --check`
- `uv run --frozen python -m compileall app`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python scripts/check_migration_graph.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
