### PR TITLE
fix(torghut): read source collection evidence from source dsn

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -7,15 +7,17 @@ of mutating any live submission gate.
 
 from __future__ import annotations
 
+import os
+from contextlib import contextmanager
 import logging
 from collections import Counter
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any, cast
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import func, select, text
+from sqlalchemy import create_engine, func, select, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
@@ -1570,6 +1572,7 @@ def _target_identity(
         "runtime_strategy_name": runtime_strategy_name,
         "strategy_lookup_names": strategy_lookup_names,
         "account_label": _safe_text(target.get("account_label")),
+        "source_account_label": _safe_text(target.get("source_account_label")),
         "source_kind": _safe_text(target.get("source_kind")),
         "source_dsn_env": _safe_text(target.get("source_dsn_env")),
         "target_dsn_env": _safe_text(target.get("target_dsn_env")),
@@ -6765,6 +6768,131 @@ def _evidence_window_contract(
     }
 
 
+@contextmanager
+def _target_source_audit_session(
+    session: Session,
+    *,
+    target: Mapping[str, object],
+) -> Iterator[tuple[Session, dict[str, object]]]:
+    source_dsn_env = _safe_text(target.get("source_dsn_env"))
+    target_dsn_env = _safe_text(target.get("target_dsn_env"))
+    target_account_label = _safe_text(target.get("account_label"))
+    source_account_label = (
+        _safe_text(target.get("source_account_label")) or target_account_label
+    )
+    metadata: dict[str, object] = {
+        "source_session_used": False,
+        "source_session_expected": _target_is_runtime_ledger_source_collection(target)
+        and bool(source_dsn_env),
+        "source_dsn_env": source_dsn_env,
+        "target_dsn_env": target_dsn_env,
+        "source_account_label": source_account_label,
+        "target_account_label": target_account_label,
+    }
+    if not metadata["source_session_expected"]:
+        yield session, metadata
+        return
+    source_dsn = os.getenv(source_dsn_env or "", "").strip()
+    if not source_dsn:
+        yield session, {**metadata, "source_dsn_configured": False}
+        return
+    source_engine = create_engine(source_dsn, future=True, pool_pre_ping=True)
+    try:
+        with Session(source_engine) as source_session:
+            yield (
+                source_session,
+                {
+                    **metadata,
+                    "source_session_used": True,
+                    "source_dsn_configured": True,
+                },
+            )
+    finally:
+        source_engine.dispose()
+
+
+def _source_audit_account_label(
+    target: Mapping[str, object],
+    source_scope: Mapping[str, object],
+) -> str | None:
+    if bool(source_scope.get("source_session_used")):
+        return _safe_text(source_scope.get("source_account_label"))
+    return _safe_text(target.get("account_label"))
+
+
+def _annotate_source_audit_scope(
+    payload: Mapping[str, object],
+    source_scope: Mapping[str, object],
+) -> dict[str, object]:
+    return {**dict(payload), "source_audit_scope": dict(source_scope)}
+
+
+def _database_unavailable_runtime_ledger_summary(
+    *,
+    target: Mapping[str, object],
+    source_scope: Mapping[str, object],
+    strategy_name: str | None,
+    strategy_lookup_names: Sequence[str] | None,
+    account_label: str | None,
+    error_source: str,
+    error: BaseException,
+) -> dict[str, object]:
+    source_blocker = _paper_route_audit_error_source_blocker(error_source)
+    return {
+        "bucket_count": 0,
+        "evidence_grade_bucket_count": 0,
+        "non_evidence_grade_bucket_count": 0,
+        "returned_bucket_count": 0,
+        "query_limit": RUNTIME_LEDGER_SUMMARY_ROW_LIMIT,
+        "truncated": False,
+        "proof_scope": "evidence_grade_runtime_ledger_buckets_only",
+        "fill_count": 0,
+        "decision_count": 0,
+        "submitted_order_count": 0,
+        "closed_trade_count": 0,
+        "open_position_count": 0,
+        "filled_notional": "0",
+        "net_strategy_pnl_after_costs": "0",
+        "post_cost_expectancy_bps": "0",
+        "filters": {
+            "hypothesis_id": _safe_text(target.get("hypothesis_id")),
+            "candidate_id": _safe_text(target.get("candidate_id")),
+            "observed_stage": _safe_text(target.get("observed_stage")),
+            "account_label": account_label,
+            "strategy_name": strategy_name,
+            "strategy_lookup_names": _strategy_lookup_names(
+                strategy_name, strategy_lookup_names
+            ),
+            "strategy_family": _safe_text(target.get("strategy_family")),
+        },
+        "latest_bucket_ended_at": None,
+        "db_row_refs": [],
+        "blockers": [PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER, source_blocker],
+        "non_evidence_grade_diagnostic": {
+            "row_count": 0,
+            "blocker_counts": {},
+            "sample_refs": [],
+        },
+        "db_load_error": _paper_route_audit_error_payload(
+            error_source=error_source,
+            error=error,
+        ),
+        "source_audit_scope": dict(source_scope),
+    }
+
+
+def _target_source_audit_error_source(
+    *,
+    source_scope: Mapping[str, object],
+    fallback: str,
+) -> str:
+    return (
+        "target_source_dsn_audit"
+        if bool(source_scope.get("source_session_used"))
+        else fallback
+    )
+
+
 def _target_audit(
     session: Session,
     *,
@@ -6787,30 +6915,110 @@ def _target_audit(
         for item in _as_sequence(target.get("strategy_lookup_names"))
         if str(item).strip()
     ]
+    source_scope: dict[str, object] = {}
     try:
-        source_activity = _strategy_source_activity(
-            session,
-            strategy_name=cast(str | None, target.get("strategy_name")),
-            strategy_lookup_names=strategy_lookup_names,
-            account_label=cast(str | None, target.get("account_label")),
-            symbols=_target_probe_symbols(target, probe),
-            window_start=window_start,
-            window_end=window_end,
-            candidate_id=candidate_id,
-            hypothesis_id=hypothesis_id,
-            require_source_lineage=_target_requires_source_lineage(target),
-        )
+        with _target_source_audit_session(session, target=target) as (
+            source_session,
+            source_scope,
+        ):
+            source_account_label = _source_audit_account_label(target, source_scope)
+            try:
+                source_activity = _annotate_source_audit_scope(
+                    _strategy_source_activity(
+                        source_session,
+                        strategy_name=cast(str | None, target.get("strategy_name")),
+                        strategy_lookup_names=strategy_lookup_names,
+                        account_label=source_account_label,
+                        symbols=_target_probe_symbols(target, probe),
+                        window_start=window_start,
+                        window_end=window_end,
+                        candidate_id=candidate_id,
+                        hypothesis_id=hypothesis_id,
+                        require_source_lineage=_target_requires_source_lineage(target),
+                    ),
+                    source_scope,
+                )
+            except SQLAlchemyError as exc:
+                source_error = _target_source_audit_error_source(
+                    source_scope=source_scope,
+                    fallback=error_source,
+                )
+                logger.warning(
+                    "Paper-route source activity audit degraded source=%s error=%s",
+                    source_error,
+                    exc,
+                )
+                _rollback_paper_route_audit_session(source_session)
+                source_activity = _database_unavailable_source_activity(
+                    target=target,
+                    probe=probe,
+                    error_source=source_error,
+                    error=exc,
+                )
+                source_activity = _annotate_source_audit_scope(
+                    source_activity, source_scope
+                )
+            try:
+                runtime_ledger = _annotate_source_audit_scope(
+                    _runtime_ledger_summary(
+                        source_session,
+                        hypothesis_id=hypothesis_id,
+                        candidate_id=candidate_id,
+                        observed_stage=cast(str | None, target.get("observed_stage")),
+                        account_label=source_account_label,
+                        strategy_name=cast(str | None, target.get("strategy_name")),
+                        strategy_lookup_names=strategy_lookup_names,
+                        strategy_family=cast(str | None, target.get("strategy_family")),
+                        window_start=window_start,
+                        window_end=window_end,
+                    ),
+                    source_scope,
+                )
+            except SQLAlchemyError as exc:
+                source_error = _target_source_audit_error_source(
+                    source_scope=source_scope,
+                    fallback=error_source,
+                )
+                logger.warning(
+                    "Paper-route runtime-ledger audit degraded source=%s error=%s",
+                    source_error,
+                    exc,
+                )
+                _rollback_paper_route_audit_session(source_session)
+                runtime_ledger = _database_unavailable_runtime_ledger_summary(
+                    target=target,
+                    source_scope=source_scope,
+                    strategy_name=cast(str | None, target.get("strategy_name")),
+                    strategy_lookup_names=strategy_lookup_names,
+                    account_label=source_account_label,
+                    error_source=source_error,
+                    error=exc,
+                )
     except SQLAlchemyError as exc:
+        source_error = _target_source_audit_error_source(
+            source_scope=source_scope,
+            fallback=error_source,
+        )
         logger.warning(
-            "Paper-route source activity audit degraded source=%s error=%s",
-            error_source,
+            "Paper-route source audit session degraded source=%s error=%s",
+            source_error,
             exc,
         )
         _rollback_paper_route_audit_session(session)
         source_activity = _database_unavailable_source_activity(
             target=target,
             probe=probe,
-            error_source=error_source,
+            error_source=source_error,
+            error=exc,
+        )
+        source_activity = _annotate_source_audit_scope(source_activity, source_scope)
+        runtime_ledger = _database_unavailable_runtime_ledger_summary(
+            target=target,
+            source_scope=source_scope,
+            strategy_name=cast(str | None, target.get("strategy_name")),
+            strategy_lookup_names=strategy_lookup_names,
+            account_label=_source_audit_account_label(target, source_scope),
+            error_source=source_error,
             error=exc,
         )
     source_activity_account_diagnostics = _source_activity_account_diagnostics(
@@ -6850,18 +7058,6 @@ def _target_audit(
         session,
         account_label=cast(str | None, target.get("account_label")),
         symbols=_target_probe_symbols(target, probe),
-        window_start=window_start,
-        window_end=window_end,
-    )
-    runtime_ledger = _runtime_ledger_summary(
-        session,
-        hypothesis_id=hypothesis_id,
-        candidate_id=candidate_id,
-        observed_stage=cast(str | None, target.get("observed_stage")),
-        account_label=cast(str | None, target.get("account_label")),
-        strategy_name=cast(str | None, target.get("strategy_name")),
-        strategy_lookup_names=strategy_lookup_names,
-        strategy_family=cast(str | None, target.get("strategy_family")),
         window_start=window_start,
         window_end=window_end,
     )
@@ -8486,14 +8682,32 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
         return {}
     limit = max(0, target_limit)
     source_targets: list[dict[str, object]] = []
-    for target in _as_mapping_items(plan.get("targets")):
+    seen_target_keys: set[tuple[str, str, str, str, str]] = set()
+
+    def append_source_target(target: Mapping[str, Any]) -> None:
         if len(source_targets) >= limit:
-            break
+            return
         if not _target_is_runtime_ledger_source_collection(target):
-            continue
-        source_targets.append(
-            _sanitized_runtime_ledger_source_collection_target(target)
+            return
+        sanitized = _sanitized_runtime_ledger_source_collection_target(target)
+        key = (
+            _safe_text(sanitized.get("hypothesis_id")) or "",
+            _safe_text(sanitized.get("candidate_id")) or "",
+            _safe_text(sanitized.get("runtime_strategy_name")) or "",
+            _safe_text(sanitized.get("window_start")) or "",
+            _safe_text(sanitized.get("window_end")) or "",
         )
+        if key in seen_target_keys:
+            return
+        seen_target_keys.add(key)
+        source_targets.append(sanitized)
+
+    for target in _as_mapping_items(plan.get("targets")):
+        append_source_target(target)
+    for target in _as_mapping_items(
+        live_submission_gate.get("runtime_ledger_source_collection_candidates")
+    ):
+        append_source_target(target)
     if not source_targets:
         return {}
     return {

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tempfile
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
@@ -4841,6 +4842,56 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target_limit=10,
         )
         self.assertEqual(empty_plan, {})
+
+    def test_source_collection_import_plan_uses_direct_gate_candidates(
+        self,
+    ) -> None:
+        live_gate = {
+            "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+            "runtime_ledger_source_collection_candidates": [
+                {
+                    "hypothesis_id": "H-DIRECT",
+                    "candidate_id": "direct-source-collection",
+                    "observed_stage": "paper",
+                    "strategy_family": "intraday_tsmom_consistent",
+                    "strategy_name": "intraday-tsmom-profit-v3",
+                    "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                    "account": "TORGHUT_SIM",
+                    "source_account_label": "TORGHUT_SIM",
+                    "source_dsn_env": "SIM_DB_DSN",
+                    "target_dsn_env": "SIM_DB_DSN",
+                    "window_start": "2026-06-02T13:30:00+00:00",
+                    "window_end": "2026-06-02T20:00:00+00:00",
+                    "source_collection_authorized": True,
+                    "source_collection_reason_codes": [
+                        "runtime_ledger_source_collection_pending"
+                    ],
+                    "fill_count": 1,
+                    "submitted_order_count": 1,
+                    "filled_notional": "100",
+                    "promotion_allowed": True,
+                    "final_promotion_allowed": True,
+                    "max_notional": "25000",
+                }
+            ],
+        }
+
+        plan = paper_route_evidence._runtime_ledger_source_collection_import_plan_for_payload(
+            plan={"targets": []},
+            live_submission_gate=live_gate,
+            target_limit=5,
+        )
+
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["source_collection_target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["candidate_id"], "direct-source-collection")
+        self.assertEqual(target["source_account_label"], "TORGHUT_SIM")
+        self.assertEqual(target["source_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["max_notional"], "0")
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+        self.assertTrue(target["stripped_source_promotion_authority"])
 
     def test_builder_exports_missing_runtime_window_health_gate_as_blockers(
         self,
@@ -10719,3 +10770,261 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "runtime_ledger_evidence_grade_bucket_missing",
             payload["targets"][0]["readiness"]["blockers"],
         )
+
+    def test_source_collection_target_audit_reads_source_dsn_activity(
+        self,
+    ) -> None:
+        source_db = tempfile.NamedTemporaryFile(suffix=".db")
+        self.addCleanup(source_db.close)
+        source_dsn = f"sqlite+pysqlite:///{source_db.name}"
+        source_engine = create_engine(source_dsn, future=True)
+        self.addCleanup(source_engine.dispose)
+        Base.metadata.create_all(source_engine)
+
+        now = datetime(2026, 6, 2, 21, 5, tzinfo=timezone.utc)
+        window_start = datetime(2026, 6, 2, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 2, 20, tzinfo=timezone.utc)
+        event_at = window_start + timedelta(minutes=30)
+        strategy_name = "intraday-tsmom-profit-v3"
+
+        with Session(source_engine) as source_session:
+            strategy = Strategy(
+                name=strategy_name,
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            source_session.add(strategy)
+            source_session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SOURCE",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-source-dsn",
+                    "hypothesis_id": "H-SOURCE-DSN",
+                },
+                rationale="source dsn paper activity fixture",
+                status="executed",
+                created_at=event_at,
+                executed_at=event_at,
+            )
+            source_session.add(decision)
+            source_session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SOURCE",
+                alpaca_order_id="source-dsn-order",
+                client_order_id="source-dsn-client",
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=event_at,
+                updated_at=event_at,
+                last_update_at=event_at,
+            )
+            source_session.add(execution)
+            source_session.flush()
+            source_session.add_all(
+                [
+                    ExecutionOrderEvent(
+                        event_fingerprint="source-dsn-order-event",
+                        source_topic="trade_updates",
+                        source_partition=0,
+                        source_offset=202,
+                        alpaca_account_label="TORGHUT_SOURCE",
+                        event_ts=event_at,
+                        symbol="AAPL",
+                        alpaca_order_id="source-dsn-order",
+                        client_order_id="source-dsn-client",
+                        event_type="fill",
+                        status="filled",
+                        raw_event={},
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        created_at=event_at,
+                    ),
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label="TORGHUT_SOURCE",
+                        symbol="AAPL",
+                        side="buy",
+                        arrival_price=Decimal("99"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=Decimal("1"),
+                        slippage_bps=Decimal("10"),
+                        shortfall_notional=Decimal("1"),
+                        realized_shortfall_bps=Decimal("10"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=event_at,
+                        created_at=event_at,
+                        updated_at=event_at,
+                    ),
+                    StrategyRuntimeLedgerBucket(
+                        run_id="source-dsn-runtime-bucket",
+                        candidate_id="candidate-source-dsn",
+                        hypothesis_id="H-SOURCE-DSN",
+                        observed_stage="paper",
+                        bucket_started_at=window_start,
+                        bucket_ended_at=window_end,
+                        account_label="TORGHUT_SOURCE",
+                        runtime_strategy_name=strategy_name,
+                        strategy_family="intraday_tsmom_consistent",
+                        fill_count=1,
+                        decision_count=1,
+                        submitted_order_count=1,
+                        closed_trade_count=1,
+                        open_position_count=0,
+                        filled_notional=Decimal("100"),
+                        gross_strategy_pnl=Decimal("8"),
+                        cost_amount=Decimal("1"),
+                        net_strategy_pnl_after_costs=Decimal("7"),
+                        post_cost_expectancy_bps=Decimal("700"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy-a": 1},
+                        cost_model_hash_counts={"cost-a": 1},
+                        lineage_hash_counts={"lineage-a": 1},
+                        blockers_json=[],
+                        payload_json={
+                            "source_window_start": window_start.isoformat(),
+                            "source_window_end": window_end.isoformat(),
+                            "source_refs": [
+                                "trade_decisions",
+                                "executions",
+                                "execution_order_events",
+                                "order_feed_source_windows",
+                            ],
+                            "source_row_counts": {
+                                "trade_decisions": 1,
+                                "executions": 1,
+                                "execution_order_events": 1,
+                                "order_feed_source_windows": 1,
+                            },
+                            "source_window_ids": ["source-dsn-window"],
+                            "trade_decision_ids": [str(decision.id)],
+                            "execution_ids": [str(execution.id)],
+                            "execution_order_event_ids": ["source-dsn-order-event"],
+                            "source_offsets": [
+                                {
+                                    "topic": "trade_updates",
+                                    "partition": 0,
+                                    "offset": 202,
+                                }
+                            ],
+                            "order_feed_lifecycle_complete": True,
+                            "execution_economics_complete": True,
+                            "execution_economics_required": True,
+                            "cost_basis": "broker_statement_fee",
+                            "cost_basis_counts": {"broker_statement_fee": 1},
+                            "source_materialization": "execution_order_events",
+                            "authority_class": (
+                                "event_sourced_runtime_ledger_profit_proof"
+                            ),
+                            "authority_reason": (
+                                "event_sourced_runtime_ledger_profit_proof"
+                            ),
+                            "promotion_authority": True,
+                        },
+                    ),
+                ]
+            )
+            source_session.commit()
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"TORGHUT_SOURCE_TEST_DSN": source_dsn},
+                clear=False,
+            ),
+            Session(self.engine) as session,
+        ):
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "source_collection_pending",
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-SOURCE-DSN",
+                                "candidate_id": "candidate-source-dsn",
+                                "observed_stage": "paper",
+                                "strategy_family": "intraday_tsmom_consistent",
+                                "strategy_name": strategy_name,
+                                "runtime_strategy_name": strategy_name,
+                                "account_label": "TORGHUT_SIM",
+                                "source_account_label": "TORGHUT_SOURCE",
+                                "source_dsn_env": "TORGHUT_SOURCE_TEST_DSN",
+                                "target_dsn_env": "SIM_DB_DSN",
+                                "source_kind": (
+                                    "runtime_ledger_source_collection_candidate"
+                                ),
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "source_collection_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_allowed": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": [],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=now,
+            )
+
+        target_audit = payload["targets"][0]
+        source_activity = target_audit["source_activity"]
+        runtime_ledger = target_audit["runtime_ledger"]
+        readback = target_audit["evidence_readback"]
+        self.assertTrue(source_activity["source_audit_scope"]["source_session_used"])
+        self.assertEqual(source_activity["account_label"], "TORGHUT_SOURCE")
+        self.assertEqual(source_activity["decision_count"], 1)
+        self.assertEqual(source_activity["execution_count"], 1)
+        self.assertEqual(source_activity["filled_execution_count"], 1)
+        self.assertEqual(source_activity["tca_sample_count"], 1)
+        self.assertTrue(runtime_ledger["source_audit_scope"]["source_session_used"])
+        self.assertEqual(runtime_ledger["filters"]["account_label"], "TORGHUT_SOURCE")
+        self.assertEqual(runtime_ledger["bucket_count"], 1)
+        self.assertEqual(runtime_ledger["evidence_grade_bucket_count"], 1)
+        self.assertEqual(readback["state"], "evidence_grade_runtime_buckets_present")
+        self.assertTrue(readback["source_decisions_present"])
+        self.assertTrue(readback["submitted_lifecycle_present"])
+        self.assertTrue(readback["fills_or_executions_present"])
+        self.assertTrue(readback["source_refs_present"])
+        self.assertTrue(readback["runtime_buckets_present"])
+        self.assertTrue(readback["evidence_grade_runtime_buckets_present"])
+        self.assertFalse(target_audit["readiness"]["promotion_authority"]["allowed"])


### PR DESCRIPTION
## Summary

- Read source-collection target source activity and runtime-ledger buckets from `source_dsn_env` using `source_account_label`.
- Keep target-account cleanliness checks on the target session while preserving independent runtime-ledger readback when source activity degrades.
- Build sanitized source-collection import targets directly from `runtime_ledger_source_collection_candidates`, deduping targets and stripping promotion authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
