### PR TITLE
fix(autotrader): emit guarded broker order intent

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
@@ -35,10 +35,10 @@ data:
     3. Do not call `autotrader_start_session` unless `${AUTONOMOUS_TRADER_WORK_DIR}/session.json` is missing or invalid; otherwise reuse the recorded session.
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/market_open_cycle.py`; runner owns session loading, market-hour waiting, account gate, scan, scorecard/tickets, best-candidate guard, `last-cycle.json`, and checkpoint.
     5. Do not manually scan, recreate tickets, run candidate guards, or smoke orders for runner candidates. Use runner `ticketId`, `noTradeReason`, `strategyGuard`, and `blocker` as authoritative.
-    6. Only plan new broker risk after the runner returns `strategyGuard.allowed=true` for a candidate.
-    7. Size new broker risk from runner `decisionSummary.bestCandidate.riskDirective`: use `recommendedRiskDollars` when present, otherwise honor `riskMultiplier` inside account/day-trade limits. Positive scorecard edge should be acted on aggressively; unproven or negative history must not be enlarged or bypass gates.
+    6. Only create new broker orders from runner `brokerOrderIntent.state=ready`. If it is absent or blocked, record/report that runner state and stand down from new entries until runner output changes.
+    7. Use runner `brokerOrderIntent.clientOrderId`, `alpacaBracketPayload`, and `synthesisRecordOrderInput` exactly. The runner already sized risk from `decisionSummary.bestCandidate.riskDirective` and `recommendedRiskDollars`. Positive scorecard edge should be acted on aggressively only through that ready intent; do not rebuild sizing, bracket prices, or client order ids in the prompt.
     8. If runner `accountGate.positionManagement.actionRequired=true`, manage the existing broker state before any new entry: repair or flatten unprotected/invalid stops, tighten stops to the runner `recommendedStopPrice` when provided, record the replacement order in Synthesis, then refresh broker state.
-    9. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
+    9. Before Alpaca mutation, record planned risk/order in Synthesis from `brokerOrderIntent.synthesisRecordOrderInput`.
     10. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
     11. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 

--- a/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
@@ -35,10 +35,10 @@ data:
     3. Do not call `autotrader_start_session` unless `${AUTONOMOUS_TRADER_WORK_DIR}/session.json` is missing or invalid; otherwise reuse the recorded session.
     4. Each cycle: run `python3 /workspace/lab/scripts/autotrader/market_open_cycle.py`; runner owns session loading, market-hour waiting, account gate, scan, scorecard/tickets, best-candidate guard, `last-cycle.json`, and checkpoint.
     5. Do not manually scan, recreate tickets, run candidate guards, or smoke orders for runner candidates. Use runner `ticketId`, `noTradeReason`, `strategyGuard`, and `blocker` as authoritative.
-    6. Only plan new broker risk after the runner returns `strategyGuard.allowed=true` for a candidate.
-    7. Size new broker risk from runner `decisionSummary.bestCandidate.riskDirective`: use `recommendedRiskDollars` when present, otherwise honor `riskMultiplier` inside account/day-trade limits. Positive scorecard edge should be acted on aggressively; unproven or negative history must not be enlarged or bypass gates.
+    6. Only create new broker orders from runner `brokerOrderIntent.state=ready`. If it is absent or blocked, record/report that runner state and stand down from new entries until runner output changes.
+    7. Use runner `brokerOrderIntent.clientOrderId`, `alpacaBracketPayload`, and `synthesisRecordOrderInput` exactly. The runner already sized risk from `decisionSummary.bestCandidate.riskDirective` and `recommendedRiskDollars`. Positive scorecard edge should be acted on aggressively only through that ready intent; do not rebuild sizing, bracket prices, or client order ids in the prompt.
     8. If runner `accountGate.positionManagement.actionRequired=true`, manage the existing broker state before any new entry: repair or flatten unprotected/invalid stops, tighten stops to the runner `recommendedStopPrice` when provided, record the replacement order in Synthesis, then refresh broker state.
-    9. Before Alpaca mutation, record planned risk/order in Synthesis and use an AgentRun-prefixed deterministic `client_order_id` when supported.
+    9. Before Alpaca mutation, record planned risk/order in Synthesis from `brokerOrderIntent.synthesisRecordOrderInput`.
     10. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
     11. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
 

--- a/scripts/autotrader/market_open_cycle.py
+++ b/scripts/autotrader/market_open_cycle.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import re
 from datetime import UTC, datetime, time
 from pathlib import Path
 from typing import Any
@@ -11,6 +13,8 @@ from typing import Any
 import live_scan_cycle
 import strategy_order_guard
 from synthesis_autotrader_client import SynthesisClient
+
+MAX_CLIENT_ORDER_ID_LENGTH = 128
 
 
 def parse_datetime(value: str | None) -> datetime:
@@ -147,6 +151,21 @@ def cycle_action(summary: dict[str, Any]) -> str:
         candidate = guard.get("candidate")
         if not isinstance(candidate, dict):
             candidate = {}
+        intent = summary.get("brokerOrderIntent")
+        if guard.get("allowed") is True and isinstance(intent, dict):
+            if intent.get("state") == "ready":
+                return (
+                    "market_open_cycle_order_intent_ready; "
+                    f"ticketId={intent.get('ticketId')}; "
+                    f"symbol={intent.get('symbol')}; "
+                    f"clientOrderId={intent.get('clientOrderId')}"
+                )
+            return (
+                "market_open_cycle_order_intent_blocked; "
+                f"ticketId={intent.get('ticketId')}; "
+                f"symbol={intent.get('symbol')}; "
+                f"reason={intent.get('reason')}"
+            )
         state = "allowed" if guard.get("allowed") is True else "blocked"
         return (
             f"market_open_cycle_guard_{state}; "
@@ -169,6 +188,11 @@ def cycle_blocker(summary: dict[str, Any]) -> str | None:
     blocker = summary.get("blocker")
     if isinstance(blocker, str) and blocker.strip():
         return blocker.strip()
+    intent = summary.get("brokerOrderIntent")
+    if isinstance(intent, dict) and intent.get("state") == "blocked":
+        reason = live_scan_cycle.optional_text(intent.get("reason"), max_length=240)
+        if reason:
+            return reason
     guard = summary.get("strategyGuard")
     if isinstance(guard, dict) and guard.get("allowed") is not True:
         reason = live_scan_cycle.optional_text(guard.get("reason"), max_length=240)
@@ -284,6 +308,134 @@ def run_strategy_guard_for_summary(args: argparse.Namespace, summary: dict[str, 
     }
 
 
+def broker_order_client_id(
+    *,
+    agent_run_name: str,
+    session_id: str,
+    cycle: int,
+    ticket_id: str,
+    symbol: str,
+) -> str:
+    prefix = re.sub(r"[^A-Za-z0-9_-]+", "-", agent_run_name.strip()) or "autonomous-trader"
+    symbol_part = re.sub(r"[^A-Za-z0-9_-]+", "-", symbol.strip().upper()) or "UNKNOWN"
+    digest = hashlib.sha256(f"{session_id}:{cycle}:{ticket_id}:{symbol_part}".encode("utf-8")).hexdigest()[:10]
+    suffix = f"c{cycle}-{symbol_part}-{digest}"
+    max_prefix_length = MAX_CLIENT_ORDER_ID_LENGTH - len(suffix) - 1
+    safe_prefix = prefix[: max(1, max_prefix_length)].rstrip("-_") or "autonomous-trader"
+    return f"{safe_prefix}-{suffix}"
+
+
+def broker_order_intent_for_summary(
+    *,
+    args: argparse.Namespace,
+    session_id: str,
+    summary: dict[str, Any],
+) -> dict[str, Any] | None:
+    guard = summary.get("strategyGuard")
+    if not isinstance(guard, dict) or guard.get("allowed") is not True:
+        return None
+    decision = summary.get("decisionSummary")
+    candidate = decision.get("bestCandidate") if isinstance(decision, dict) else None
+    if not isinstance(candidate, dict):
+        return {
+            "source": "market_open_cycle",
+            "state": "blocked",
+            "reason": "broker_order_intent_missing_candidate",
+            "missingFields": ["candidate"],
+        }
+    risk_directive = candidate.get("riskDirective")
+    quantity = live_scan_cycle.numeric_text(
+        candidate.get("plannedQuantity")
+        or (risk_directive.get("plannedQuantity") if isinstance(risk_directive, dict) else None)
+    )
+    risk_dollars = live_scan_cycle.numeric_text(
+        candidate.get("riskDollars")
+        or (risk_directive.get("recommendedRiskDollars") if isinstance(risk_directive, dict) else None)
+    )
+    values = {
+        "ticketId": live_scan_cycle.optional_text(candidate.get("ticketId"), max_length=240),
+        "symbol": live_scan_cycle.optional_text(candidate.get("symbol"), max_length=32),
+        "side": live_scan_cycle.optional_text(candidate.get("side"), max_length=32),
+        "quantity": quantity,
+        "entryLimitPrice": live_scan_cycle.numeric_text(candidate.get("entryLimitPrice")),
+        "takeProfitLimitPrice": live_scan_cycle.numeric_text(candidate.get("targetPrice")),
+        "stopLossStopPrice": live_scan_cycle.numeric_text(candidate.get("stopPrice")),
+        "riskDollars": risk_dollars,
+        "actualBracketR": live_scan_cycle.numeric_text(candidate.get("actualBracketR")),
+    }
+    missing = [key for key, value in values.items() if not value]
+    if not isinstance(risk_directive, dict):
+        missing.append("riskDirective")
+    if values.get("side") not in {"buy", "sell"} and "side" not in missing:
+        missing.append("side")
+    cycle = live_scan_cycle.int_text_value(summary.get("cycle"))
+    common = {
+        "source": "market_open_cycle",
+        "cycle": cycle,
+        "strategyGuardReason": guard.get("reason"),
+        "ticketId": values.get("ticketId"),
+        "symbol": values.get("symbol"),
+        "side": values.get("side"),
+        "quantity": values.get("quantity"),
+        "entryLimitPrice": values.get("entryLimitPrice"),
+        "takeProfitLimitPrice": values.get("takeProfitLimitPrice"),
+        "stopLossStopPrice": values.get("stopLossStopPrice"),
+        "riskDollars": values.get("riskDollars"),
+        "actualBracketR": values.get("actualBracketR"),
+        "riskDirective": risk_directive if isinstance(risk_directive, dict) else None,
+    }
+    if missing:
+        return {
+            **common,
+            "state": "blocked",
+            "reason": "broker_order_intent_missing_fields",
+            "missingFields": missing,
+        }
+    client_order_id = broker_order_client_id(
+        agent_run_name=args.agent_run_name,
+        session_id=session_id,
+        cycle=cycle,
+        ticket_id=str(values["ticketId"]),
+        symbol=str(values["symbol"]),
+    )
+    alpaca_payload = {
+        "symbol": str(values["symbol"]).upper(),
+        "qty": str(values["quantity"]),
+        "side": values["side"],
+        "type": "limit",
+        "time_in_force": "day",
+        "limit_price": values["entryLimitPrice"],
+        "order_class": "bracket",
+        "client_order_id": client_order_id,
+        "take_profit": {"limit_price": values["takeProfitLimitPrice"]},
+        "stop_loss": {"stop_price": values["stopLossStopPrice"]},
+    }
+    synthesis_order = {
+        "sessionId": session_id,
+        "ticketId": values["ticketId"],
+        "clientOrderId": client_order_id,
+        "symbol": str(values["symbol"]).upper(),
+        "instrument": "stock",
+        "side": values["side"],
+        "quantity": values["quantity"],
+        "orderType": "limit",
+        "orderClass": "bracket",
+        "limitPrice": values["entryLimitPrice"],
+        "takeProfitLimitPrice": values["takeProfitLimitPrice"],
+        "stopLossStopPrice": values["stopLossStopPrice"],
+        "status": "planned",
+        "brokerPayload": alpaca_payload,
+    }
+    return {
+        **common,
+        "state": "ready",
+        "reason": "strategy_guard_allowed_broker_intent_ready",
+        "clientOrderId": client_order_id,
+        "alpacaBracketPayload": alpaca_payload,
+        "synthesisRecordOrderInput": synthesis_order,
+    }
+
+
 def record_cycle_complete(
     *,
     synthesis: SynthesisClient,
@@ -305,6 +457,7 @@ def record_cycle_complete(
         "topResults": summary.get("topResults"),
         "decisionSummary": summary.get("decisionSummary"),
         "strategyGuard": summary.get("strategyGuard"),
+        "brokerOrderIntent": summary.get("brokerOrderIntent"),
         "accountGate": summary.get("accountGate"),
         "marketWindow": summary.get("marketWindow"),
         "windowGate": summary.get("windowGate"),
@@ -347,6 +500,15 @@ def strategy_guard_report_value(summary: dict[str, Any]) -> str:
     if guard.get("allowed") is True:
         return f"allowed:{guard.get('reason')}"
     return f"blocked:{guard.get('reason')}"
+
+
+def broker_order_intent_report_value(summary: dict[str, Any]) -> str:
+    intent = summary.get("brokerOrderIntent")
+    if not isinstance(intent, dict):
+        return "not_ready"
+    if intent.get("state") == "ready":
+        return f"ready:{intent.get('clientOrderId')}"
+    return f"blocked:{intent.get('reason')}"
 
 
 def scan_args_for(args: argparse.Namespace, *, session_id: str, work_dir: Path) -> argparse.Namespace:
@@ -410,6 +572,7 @@ def write_report(path: Path, result: dict[str, Any]) -> None:
         f"recorded_ticket_count: {recorded_ticket_count(summary)}",
         f"scorecard_count: {scorecard_count(summary)}",
         f"strategy_guard: {strategy_guard_report_value(summary)}",
+        f"broker_order_intent: {broker_order_intent_report_value(summary)}",
     ]
     if isinstance(management, dict) and management.get("primaryAction"):
         lines.extend(
@@ -455,6 +618,9 @@ def run_market_open_cycle(
         strategy_guard = run_strategy_guard_for_summary(args, summary)
         if strategy_guard is not None:
             summary["strategyGuard"] = strategy_guard
+            broker_order_intent = broker_order_intent_for_summary(args=args, session_id=session_id, summary=summary)
+            if broker_order_intent is not None:
+                summary["brokerOrderIntent"] = broker_order_intent
     else:
         summary = market_window_skip_summary(args=args, work_dir=work_dir, window=window)
     output = {
@@ -487,6 +653,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--retain-cycles", type=int, default=5)
     parser.add_argument("--max-recorded-tickets", type=int, default=10)
     parser.add_argument("--report-path", default="/workspace/.agentrun/autonomous-trader/report.md")
+    parser.add_argument("--agent-run-name", default=os.environ.get("AGENT_RUN_NAME", "autonomous-trader-market-open"))
     parser.add_argument("--now")
     parser.add_argument("--self-test", action="store_true")
     return parser

--- a/scripts/autotrader/test_market_open_cycle.py
+++ b/scripts/autotrader/test_market_open_cycle.py
@@ -73,6 +73,15 @@ class MarketOpenCycleTest(unittest.TestCase):
                             "entryLimitPrice": "100.25",
                             "targetPrice": "103.00",
                             "stopPrice": "99.00",
+                            "riskDollars": "75.00",
+                            "plannedQuantity": "60",
+                            "actualBracketR": "2.2000",
+                            "riskDirective": {
+                                "source": "account_equity_stop_distance",
+                                "recommendedRiskDollars": "75.00",
+                                "plannedQuantity": "60",
+                                "plannedMaxLossDollars": "75.00",
+                            },
                             "ticketId": "ticket-1",
                         },
                     },
@@ -108,6 +117,8 @@ class MarketOpenCycleTest(unittest.TestCase):
                     str(report_path),
                     "--watchlist",
                     "NVDA",
+                    "--agent-run-name",
+                    "autonomous-trader-market-open-test",
                     "--now",
                     "2026-06-03T14:00:00Z",
                 ]
@@ -145,6 +156,20 @@ class MarketOpenCycleTest(unittest.TestCase):
             self.assertEqual(guard_calls[0].entry_limit, "100.25")
             self.assertEqual(guard_calls[0].take_profit_limit, "103.00")
             self.assertEqual(guard_calls[0].stop_loss_stop, "99.00")
+            intent = result["summary"]["brokerOrderIntent"]
+            self.assertEqual(intent["state"], "ready")
+            self.assertEqual(intent["ticketId"], "ticket-1")
+            self.assertEqual(intent["symbol"], "NVDA")
+            self.assertEqual(intent["quantity"], "60")
+            self.assertEqual(intent["riskDollars"], "75.00")
+            self.assertLessEqual(len(intent["clientOrderId"]), 128)
+            self.assertTrue(intent["clientOrderId"].startswith("autonomous-trader-market-open-test-c3-NVDA-"))
+            self.assertEqual(intent["alpacaBracketPayload"]["client_order_id"], intent["clientOrderId"])
+            self.assertEqual(intent["alpacaBracketPayload"]["qty"], "60")
+            self.assertEqual(intent["alpacaBracketPayload"]["take_profit"]["limit_price"], "103.00")
+            self.assertEqual(intent["alpacaBracketPayload"]["stop_loss"]["stop_price"], "99.00")
+            self.assertEqual(intent["synthesisRecordOrderInput"]["clientOrderId"], intent["clientOrderId"])
+            self.assertEqual(intent["synthesisRecordOrderInput"]["status"], "planned")
             self.assertTrue(captured_args[0].record_tickets)
             self.assertTrue(captured_args[0].respect_account_gate)
             self.assertEqual(captured_args[0].watchlist, ["NVDA"])
@@ -153,6 +178,7 @@ class MarketOpenCycleTest(unittest.TestCase):
             report = report_path.read_text(encoding="utf-8")
             self.assertIn("cycle_runner: deterministic_market_open_cycle", report)
             self.assertIn("strategy_guard: allowed:fresh_strategy_order", report)
+            self.assertIn("broker_order_intent: ready:", report)
 
         paths = [path for path, _ in synthesis.posts]
         self.assertEqual(paths, ["/api/autotrader/status", "/api/autotrader/events"])
@@ -162,13 +188,104 @@ class MarketOpenCycleTest(unittest.TestCase):
         self.assertEqual(status_payload["phase"], "scan")
         self.assertEqual(
             status_payload["currentAction"],
-            "market_open_cycle_guard_allowed; ticketId=ticket-1; symbol=NVDA; reason=fresh_strategy_order",
+            f"market_open_cycle_order_intent_ready; ticketId=ticket-1; symbol=NVDA; clientOrderId={intent['clientOrderId']}",
         )
         self.assertEqual(status_payload["payload"]["recordedTicketCount"], 1)
         self.assertEqual(status_payload["payload"]["stageTimingsMs"]["totalMs"], 88)
         self.assertEqual(status_payload["payload"]["decisionSummary"]["action"], "run_strategy_order_guard")
         self.assertEqual(status_payload["payload"]["strategyGuard"]["result"]["allowed"], True)
+        self.assertEqual(status_payload["payload"]["brokerOrderIntent"]["clientOrderId"], intent["clientOrderId"])
         self.assertEqual(event_payload["eventType"], "market_open_cycle_complete")
+
+    def test_blocks_allowed_guard_when_order_intent_fields_are_missing(self) -> None:
+        synthesis = FakeSynthesis()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "session.json").write_text('{"sessionId":"session-market-open"}\n', encoding="utf-8")
+            report_path = root / "report.md"
+
+            def fake_run_cycle(args: Any) -> dict[str, Any]:
+                return {
+                    "ok": True,
+                    "mode": "cycle",
+                    "cycle": 4,
+                    "cycleDir": str(root / "cycle-4"),
+                    "resultCount": 1,
+                    "topResults": [],
+                    "recordedTickets": [
+                        {
+                            "symbol": "AMD",
+                            "ticketId": "ticket-amd-1",
+                            "idempotencyKey": "scan-cycle-4-1-AMD-vwap_reclaim-A",
+                        }
+                    ],
+                    "decisionSummary": {
+                        "action": "run_strategy_order_guard",
+                        "bestCandidate": {
+                            "symbol": "AMD",
+                            "side": "buy",
+                            "setupType": "vwap_reclaim",
+                            "setupGrade": "A",
+                            "expectedR": "2.2",
+                            "entryLimitPrice": "140.00",
+                            "targetPrice": "144.00",
+                            "stopPrice": "138.00",
+                            "ticketId": "ticket-amd-1",
+                        },
+                    },
+                    "accountGate": {
+                        "action": "scan",
+                        "skipFullScan": False,
+                        "account": {
+                            "equity": "30000",
+                            "buying_power": "60000",
+                            "daytrading_buying_power": "60000",
+                        },
+                    },
+                    "skipFullScan": False,
+                    "action": "scan",
+                }
+
+            def fake_evaluate_order(args: Any) -> dict[str, Any]:
+                return {
+                    "ok": True,
+                    "allowed": True,
+                    "reason": "fresh_strategy_order",
+                }
+
+            args = market_open_cycle.build_parser().parse_args(
+                [
+                    "--work-dir",
+                    str(root),
+                    "--report-path",
+                    str(report_path),
+                    "--now",
+                    "2026-06-03T14:00:00Z",
+                ]
+            )
+            with (
+                patch.object(market_open_cycle.live_scan_cycle, "run_cycle", fake_run_cycle),
+                patch.object(market_open_cycle.strategy_order_guard, "evaluate_order", fake_evaluate_order),
+            ):
+                result = market_open_cycle.run_market_open_cycle(args=args, synthesis=synthesis)  # type: ignore[arg-type]
+
+            intent = result["summary"]["brokerOrderIntent"]
+            self.assertEqual(intent["state"], "blocked")
+            self.assertEqual(intent["reason"], "broker_order_intent_missing_fields")
+            self.assertEqual(
+                intent["missingFields"],
+                ["quantity", "riskDollars", "actualBracketR", "riskDirective"],
+            )
+            report = report_path.read_text(encoding="utf-8")
+            self.assertIn("broker_order_intent: blocked:broker_order_intent_missing_fields", report)
+
+        status_payload = synthesis.posts[0][1]
+        self.assertEqual(status_payload["blocker"], "broker_order_intent_missing_fields")
+        self.assertEqual(
+            status_payload["currentAction"],
+            "market_open_cycle_order_intent_blocked; ticketId=ticket-amd-1; symbol=AMD; reason=broker_order_intent_missing_fields",
+        )
 
     def test_records_missing_strategy_guard_inputs_without_calling_guard(self) -> None:
         synthesis = FakeSynthesis()


### PR DESCRIPTION
## Summary

- Adds deterministic `brokerOrderIntent` output after `strategyGuard.allowed=true`, including the AgentRun-prefixed client order id, Alpaca bracket payload, Synthesis planned-order input, bracket R, and risk sizing.
- Blocks an otherwise allowed candidate when required handoff fields are missing, so the prompt cannot improvise sizing, bracket prices, or client ids.
- Updates active and green autotrader prompts to place new broker orders only from `brokerOrderIntent.state=ready`.

## Related Issues

None

## Testing

- `python3 -m py_compile live_scan_cycle.py market_open_cycle.py strategy_order_guard.py test_live_scan_cycle.py test_market_open_cycle.py`
- `python3 -m unittest discover -v` in `scripts/autotrader` (69 tests)
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t autonomous`
- `bun run lint:argocd`
- `git diff --check HEAD~1..HEAD`

## Screenshots (if applicable)

N/A - no UI changes.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
