### PR TITLE
feat(torghut): add alpha decay replay stress

### DIFF
--- a/services/torghut/app/trading/discovery/alpha_decay_predictability_stress.py
+++ b/services/torghut/app/trading/discovery/alpha_decay_predictability_stress.py
@@ -1,0 +1,540 @@
+"""Preview-only alpha-decay predictability stress for replay candidate ranking.
+
+This module converts recent high-frequency LOB alpha-decay and short-run market
+efficiency papers into deterministic replay-ranking inputs. It never simulates
+fills, writes ledgers, authorizes promotion, or enables live capital.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from math import isfinite
+from statistics import median
+from typing import Any, cast
+
+from app.trading.models import SignalEnvelope
+
+ALPHA_DECAY_PREDICTABILITY_STRESS_SCHEMA_VERSION = (
+    "torghut.alpha-decay-predictability-stress.v1"
+)
+ALPHA_DECAY_PREDICTABILITY_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.alpha-decay-predictability-stress-contract.v1"
+)
+ALPHA_DECAY_PREDICTABILITY_STRESS_PROOF_SEMANTICS_LABEL = (
+    "alpha_decay_predictability_stress_preview_only_exact_replay_route_tca_"
+    "order_lifecycle_runtime_ledger_required"
+)
+ALPHA_DECAY_PREDICTABILITY_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2601.02310",
+        "url": "https://arxiv.org/abs/2601.02310",
+        "title": "Temporal Kolmogorov-Arnold Networks (T-KAN) for High-Frequency Limit Order Book Forecasting: Efficiency, Interpretability, and Alpha Decay",
+        "date": "2026-01-05",
+        "mechanism": "multi_horizon_lob_alpha_decay_curve_with_spread_adjusted_cost_crossover",
+    },
+    {
+        "source_id": "ssrn-6608199",
+        "url": "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6608199",
+        "title": "Learning from the Book: AI Evidence on Short-Run Market Efficiency",
+        "date": "2026-05-01",
+        "mechanism": "tight_spread_heavy_trading_algorithmic_activity_predictability_compression",
+    },
+)
+
+_PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
+_BID_FIELDS = ("bid", "best_bid", "bid_price", "best_bid_price")
+_ASK_FIELDS = ("ask", "best_ask", "ask_price", "best_ask_price")
+_SPREAD_BPS_FIELDS = ("spread_bps", "quoted_spread_bps", "effective_spread_bps")
+_VOLUME_FIELDS = (
+    "microbar_volume",
+    "volume",
+    "trade_volume",
+    "dollar_volume",
+    "notional",
+    "trade_notional",
+)
+_ALGO_ACTIVITY_FIELDS = (
+    "algo_activity_score",
+    "algorithmic_activity_score",
+    "hft_activity_score",
+    "message_to_trade_ratio",
+    "quote_update_rate",
+    "order_update_rate",
+)
+_INFERENCE_LATENCY_MS_FIELDS = (
+    "model_inference_latency_ms",
+    "inference_latency_ms",
+    "feature_latency_ms",
+    "decision_latency_ms",
+)
+_DEFAULT_HORIZON_STEPS = (1, 2, 3, 5, 8)
+_MIN_OBSERVED_HORIZON_COUNT = 2
+
+
+@dataclass(frozen=True)
+class AlphaDecayPredictabilityStressSummary:
+    row_count: int
+    observed_price_count: int
+    observed_spread_count: int
+    observed_volume_count: int
+    observed_horizon_count: int
+    horizon_observation_count: int
+    horizon_curve: tuple[Mapping[str, Any], ...]
+    first_horizon_steps: int
+    best_horizon_steps: int
+    first_horizon_spread_adjusted_net_bps: float
+    longest_horizon_spread_adjusted_net_bps: float
+    best_horizon_spread_adjusted_net_bps: float
+    net_positive_horizon_share: float
+    alpha_decay_bps: float
+    cost_crossover_share: float
+    tight_spread_heavy_volume_share: float
+    algorithmic_activity_intensity: float
+    inference_latency_ms: float
+    latency_horizon_mismatch_share: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": ALPHA_DECAY_PREDICTABILITY_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_alpha_decay_predictability_ranking",
+            "source_papers": [
+                dict(item) for item in ALPHA_DECAY_PREDICTABILITY_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "observed_price_count": self.observed_price_count,
+            "observed_spread_count": self.observed_spread_count,
+            "observed_volume_count": self.observed_volume_count,
+            "observed_horizon_count": self.observed_horizon_count,
+            "horizon_observation_count": self.horizon_observation_count,
+            "horizon_curve": [dict(item) for item in self.horizon_curve],
+            "first_horizon_steps": self.first_horizon_steps,
+            "best_horizon_steps": self.best_horizon_steps,
+            "first_horizon_spread_adjusted_net_bps": _stable_float(
+                self.first_horizon_spread_adjusted_net_bps
+            ),
+            "longest_horizon_spread_adjusted_net_bps": _stable_float(
+                self.longest_horizon_spread_adjusted_net_bps
+            ),
+            "best_horizon_spread_adjusted_net_bps": _stable_float(
+                self.best_horizon_spread_adjusted_net_bps
+            ),
+            "net_positive_horizon_share": _stable_float(
+                self.net_positive_horizon_share
+            ),
+            "alpha_decay_bps": _stable_float(self.alpha_decay_bps),
+            "cost_crossover_share": _stable_float(self.cost_crossover_share),
+            "tight_spread_heavy_volume_share": _stable_float(
+                self.tight_spread_heavy_volume_share
+            ),
+            "algorithmic_activity_intensity": _stable_float(
+                self.algorithmic_activity_intensity
+            ),
+            "inference_latency_ms": _stable_float(self.inference_latency_ms),
+            "latency_horizon_mismatch_share": _stable_float(
+                self.latency_horizon_mismatch_share
+            ),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "observed_horizon_count": self.observed_horizon_count,
+                "best_horizon_steps": self.best_horizon_steps,
+                "first_horizon_spread_adjusted_net_bps": _stable_float(
+                    self.first_horizon_spread_adjusted_net_bps
+                ),
+                "longest_horizon_spread_adjusted_net_bps": _stable_float(
+                    self.longest_horizon_spread_adjusted_net_bps
+                ),
+                "best_horizon_spread_adjusted_net_bps": _stable_float(
+                    self.best_horizon_spread_adjusted_net_bps
+                ),
+                "net_positive_horizon_share": _stable_float(
+                    self.net_positive_horizon_share
+                ),
+                "alpha_decay_bps": _stable_float(self.alpha_decay_bps),
+                "cost_crossover_share": _stable_float(self.cost_crossover_share),
+                "tight_spread_heavy_volume_share": _stable_float(
+                    self.tight_spread_heavy_volume_share
+                ),
+                "algorithmic_activity_intensity": _stable_float(
+                    self.algorithmic_activity_intensity
+                ),
+                "latency_horizon_mismatch_share": _stable_float(
+                    self.latency_horizon_mismatch_share
+                ),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "multi_horizon_alpha_decay_preview": True,
+            "spread_adjusted_label_preview": True,
+            "efficiency_regime_compression_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": (
+                ALPHA_DECAY_PREDICTABILITY_STRESS_PROOF_SEMANTICS_LABEL
+            ),
+        }
+
+
+def alpha_decay_predictability_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": ALPHA_DECAY_PREDICTABILITY_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": ALPHA_DECAY_PREDICTABILITY_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in ALPHA_DECAY_PREDICTABILITY_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": "multi_horizon_alpha_decay_spread_adjusted_efficiency_regime_stress",
+        "stress_components": [
+            "horizon_curve",
+            "alpha_decay_bps",
+            "cost_crossover_share",
+            "tight_spread_heavy_volume_share",
+            "algorithmic_activity_intensity",
+            "latency_horizon_mismatch_share",
+        ],
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_order_lifecycle_fill_evidence": True,
+            "requires_runtime_ledger": True,
+            "rejects_single_horizon_lob_alpha_promotion": True,
+            "rejects_classification_accuracy_without_costs": True,
+            "rejects_preview_decay_curve_as_profit_proof": True,
+        },
+    }
+
+
+def build_alpha_decay_predictability_stress_schema_hash() -> str:
+    return _stable_hash(alpha_decay_predictability_stress_contract())
+
+
+def extract_alpha_decay_predictability_stress(
+    records: Sequence[SignalEnvelope],
+    *,
+    direction: int | float = 1,
+    horizon_steps: Sequence[int] = _DEFAULT_HORIZON_STEPS,
+) -> AlphaDecayPredictabilityStressSummary:
+    """Extract deterministic multi-horizon alpha-decay stress from replay rows."""
+
+    signed_direction = 1.0 if float(direction) >= 0.0 else -1.0
+    horizons = tuple(sorted({int(value) for value in horizon_steps if int(value) > 0}))
+    rows_by_symbol = _rows_by_symbol(records)
+    prices = tuple(
+        price
+        for rows in rows_by_symbol.values()
+        for row in rows
+        if (price := _price(row)) is not None
+    )
+    spreads = tuple(
+        spread
+        for rows in rows_by_symbol.values()
+        for row in rows
+        if (spread := _spread_bps(row)) is not None
+    )
+    volumes = tuple(
+        volume
+        for rows in rows_by_symbol.values()
+        for row in rows
+        if (volume := _volume(row)) is not None
+    )
+    median_spread = median(spreads) if spreads else 0.0
+    median_volume = median(volumes) if volumes else 0.0
+
+    horizon_curve: list[Mapping[str, Any]] = []
+    for horizon in horizons:
+        observations = _horizon_observations(
+            rows_by_symbol.values(), horizon=horizon, direction=signed_direction
+        )
+        if not observations:
+            continue
+        spread_adjusted = tuple(item[1] for item in observations)
+        signed_returns = tuple(item[0] for item in observations)
+        horizon_curve.append(
+            {
+                "horizon_steps": horizon,
+                "observation_count": len(observations),
+                "median_signed_return_bps": _stable_float(median(signed_returns)),
+                "median_spread_adjusted_net_bps": _stable_float(
+                    median(spread_adjusted)
+                ),
+                "net_positive_share": _stable_float(
+                    sum(1 for value in spread_adjusted if value > 0.0)
+                    / max(1, len(spread_adjusted))
+                ),
+            }
+        )
+
+    observed_horizon_count = len(horizon_curve)
+    horizon_observation_count = sum(
+        int(item.get("observation_count") or 0) for item in horizon_curve
+    )
+    net_values = tuple(
+        float(item["median_spread_adjusted_net_bps"]) for item in horizon_curve
+    )
+    first_horizon_steps = int(horizon_curve[0]["horizon_steps"]) if horizon_curve else 0
+    first_net = net_values[0] if net_values else 0.0
+    longest_net = net_values[-1] if net_values else 0.0
+    best_index = _best_index(net_values)
+    best_horizon_steps = (
+        int(horizon_curve[best_index]["horizon_steps"]) if horizon_curve else 0
+    )
+    best_net = net_values[best_index] if net_values else 0.0
+    alpha_decay_bps = max(0.0, best_net - longest_net)
+    cost_crossover_share = sum(1 for value in net_values if value <= 0.0) / max(
+        1, len(net_values)
+    )
+    net_positive_horizon_share = sum(1 for value in net_values if value > 0.0) / max(
+        1, len(net_values)
+    )
+    tight_heavy_share = _tight_spread_heavy_volume_share(
+        rows_by_symbol.values(),
+        median_spread=median_spread,
+        median_volume=median_volume,
+    )
+    algorithmic_activity_intensity = _algorithmic_activity_intensity(
+        row for rows in rows_by_symbol.values() for row in rows
+    )
+    inference_latency_ms = _median_latency_ms(
+        row for rows in rows_by_symbol.values() for row in rows
+    )
+    latency_mismatch_share = _latency_horizon_mismatch_share(
+        rows_by_symbol.values(),
+        inference_latency_ms=inference_latency_ms,
+        best_horizon_steps=best_horizon_steps,
+    )
+
+    replay_rank_penalty_bps = (
+        alpha_decay_bps * 0.40
+        + cost_crossover_share * 5.0
+        + max(0.0, -longest_net) * 0.35
+        + tight_heavy_share * 2.0
+        + algorithmic_activity_intensity * 2.0
+        + latency_mismatch_share * 3.0
+    )
+    if observed_horizon_count < _MIN_OBSERVED_HORIZON_COUNT:
+        replay_rank_penalty_bps += 4.0
+
+    warnings: list[str] = []
+    if not prices:
+        warnings.append("missing_price_inputs")
+    if not spreads:
+        warnings.append("missing_spread_inputs")
+    if not volumes:
+        warnings.append("missing_volume_inputs")
+    if observed_horizon_count < _MIN_OBSERVED_HORIZON_COUNT:
+        warnings.append("insufficient_multi_horizon_alpha_decay_curve")
+
+    return AlphaDecayPredictabilityStressSummary(
+        row_count=sum(len(rows) for rows in rows_by_symbol.values()),
+        observed_price_count=len(prices),
+        observed_spread_count=len(spreads),
+        observed_volume_count=len(volumes),
+        observed_horizon_count=observed_horizon_count,
+        horizon_observation_count=horizon_observation_count,
+        horizon_curve=tuple(horizon_curve),
+        first_horizon_steps=first_horizon_steps,
+        best_horizon_steps=best_horizon_steps,
+        first_horizon_spread_adjusted_net_bps=first_net,
+        longest_horizon_spread_adjusted_net_bps=longest_net,
+        best_horizon_spread_adjusted_net_bps=best_net,
+        net_positive_horizon_share=net_positive_horizon_share,
+        alpha_decay_bps=alpha_decay_bps,
+        cost_crossover_share=cost_crossover_share,
+        tight_spread_heavy_volume_share=tight_heavy_share,
+        algorithmic_activity_intensity=algorithmic_activity_intensity,
+        inference_latency_ms=inference_latency_ms,
+        latency_horizon_mismatch_share=latency_mismatch_share,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=tuple(warnings),
+        feature_schema_hash=build_alpha_decay_predictability_stress_schema_hash(),
+    )
+
+
+def _rows_by_symbol(
+    records: Sequence[SignalEnvelope],
+) -> dict[str, tuple[SignalEnvelope, ...]]:
+    grouped: dict[str, list[SignalEnvelope]] = {}
+    for row in records:
+        grouped.setdefault(row.symbol, []).append(row)
+    return {
+        symbol: tuple(sorted(rows, key=lambda item: (item.event_ts, item.seq)))
+        for symbol, rows in grouped.items()
+    }
+
+
+def _horizon_observations(
+    grouped_rows: Iterable[Sequence[SignalEnvelope]], *, horizon: int, direction: float
+) -> tuple[tuple[float, float], ...]:
+    observations: list[tuple[float, float]] = []
+    for rows in grouped_rows:
+        for index, row in enumerate(rows[:-horizon]):
+            current = _price(row)
+            future = _price(rows[index + horizon])
+            if current is None or future is None or current <= 0.0:
+                continue
+            signed_return_bps = direction * ((future - current) / current) * 10_000.0
+            spread_adjusted = signed_return_bps - (_spread_bps(row) or 0.0)
+            observations.append((signed_return_bps, spread_adjusted))
+    return tuple(observations)
+
+
+def _payload(row: SignalEnvelope) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], row.payload)
+
+
+def _number(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isfinite(parsed) else None
+
+
+def _first_number(payload: Mapping[str, Any], fields: Sequence[str]) -> float | None:
+    for field in fields:
+        value = _number(payload.get(field))
+        if value is not None:
+            return value
+    return None
+
+
+def _price(row: SignalEnvelope) -> float | None:
+    payload = _payload(row)
+    price = _first_number(payload, _PRICE_FIELDS)
+    if price is not None and price > 0.0:
+        return price
+    bid = _first_number(payload, _BID_FIELDS)
+    ask = _first_number(payload, _ASK_FIELDS)
+    if bid is not None and ask is not None and bid > 0.0 and ask > 0.0:
+        return (bid + ask) / 2.0
+    return None
+
+
+def _spread_bps(row: SignalEnvelope) -> float | None:
+    payload = _payload(row)
+    explicit = _first_number(payload, _SPREAD_BPS_FIELDS)
+    if explicit is not None:
+        return max(0.0, explicit)
+    bid = _first_number(payload, _BID_FIELDS)
+    ask = _first_number(payload, _ASK_FIELDS)
+    if bid is None or ask is None or bid <= 0.0 or ask <= bid:
+        return None
+    mid = (bid + ask) / 2.0
+    return ((ask - bid) / mid) * 10_000.0 if mid > 0.0 else None
+
+
+def _volume(row: SignalEnvelope) -> float | None:
+    return _first_number(_payload(row), _VOLUME_FIELDS)
+
+
+def _algo_activity(row: SignalEnvelope) -> float | None:
+    value = _first_number(_payload(row), _ALGO_ACTIVITY_FIELDS)
+    if value is None:
+        return None
+    if value > 1.0:
+        return min(1.0, value / 100.0)
+    return max(0.0, min(1.0, value))
+
+
+def _inference_latency_ms(row: SignalEnvelope) -> float | None:
+    value = _first_number(_payload(row), _INFERENCE_LATENCY_MS_FIELDS)
+    return max(0.0, value) if value is not None else None
+
+
+def _tight_spread_heavy_volume_share(
+    grouped_rows: Iterable[Sequence[SignalEnvelope]],
+    *,
+    median_spread: float,
+    median_volume: float,
+) -> float:
+    observations = 0
+    hits = 0
+    for rows in grouped_rows:
+        for row in rows:
+            spread = _spread_bps(row)
+            volume = _volume(row)
+            if spread is None or volume is None:
+                continue
+            observations += 1
+            if spread <= median_spread and volume >= median_volume:
+                hits += 1
+    return hits / max(1, observations)
+
+
+def _algorithmic_activity_intensity(rows: Iterable[SignalEnvelope]) -> float:
+    values = tuple(value for row in rows if (value := _algo_activity(row)) is not None)
+    return median(values) if values else 0.0
+
+
+def _median_latency_ms(rows: Iterable[SignalEnvelope]) -> float:
+    values = tuple(
+        value for row in rows if (value := _inference_latency_ms(row)) is not None
+    )
+    return median(values) if values else 0.0
+
+
+def _latency_horizon_mismatch_share(
+    grouped_rows: Iterable[Sequence[SignalEnvelope]],
+    *,
+    inference_latency_ms: float,
+    best_horizon_steps: int,
+) -> float:
+    if inference_latency_ms <= 0.0 or best_horizon_steps <= 0:
+        return 0.0
+    observations = 0
+    mismatches = 0
+    for rows in grouped_rows:
+        if len(rows) < 2:
+            continue
+        deltas = [
+            max(
+                0.0,
+                (rows[index + 1].event_ts - rows[index].event_ts).total_seconds()
+                * 1000.0,
+            )
+            for index in range(len(rows) - 1)
+        ]
+        if not deltas:
+            continue
+        estimated_horizon_ms = median(deltas) * best_horizon_steps
+        observations += 1
+        if estimated_horizon_ms > 0.0 and inference_latency_ms > estimated_horizon_ms:
+            mismatches += 1
+    return mismatches / max(1, observations)
+
+
+def _best_index(values: Sequence[float]) -> int:
+    if not values:
+        return 0
+    best = 0
+    for index, value in enumerate(values):
+        if value > values[best]:
+            best = index
+    return best
+
+
+def _stable_float(value: float) -> float:
+    return round(float(value), 8) if isfinite(float(value)) else 0.0
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -14,6 +14,9 @@ import numpy as np
 from numpy.typing import NDArray
 
 from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.discovery.alpha_decay_predictability_stress import (
+    extract_alpha_decay_predictability_stress,
+)
 from app.trading.discovery.cluster_lob_features import (
     HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION,
     extract_cluster_lob_features,
@@ -65,6 +68,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "queue_position_survival_fill_stress",
     "public_feed_lag_quoted_liquidity_stress",
     "lob_simulation_reality_gap_execution_stress",
+    "alpha_decay_predictability_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -146,6 +150,9 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     lob_reality_gap_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    alpha_decay_predictability_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -243,6 +250,9 @@ class FastReplayPreviewRow:
             "queue_survival_fill_stress": dict(self.queue_survival_fill_stress),
             "feed_lag_liquidity_stress": dict(self.feed_lag_liquidity_stress),
             "lob_reality_gap_stress": dict(self.lob_reality_gap_stress),
+            "alpha_decay_predictability_stress": dict(
+                self.alpha_decay_predictability_stress
+            ),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
             "exact_replay_required": True,
@@ -429,6 +439,7 @@ class FastReplayPreviewResult:
                 "queue_position_survival_fill_stress": "deterministic queue-position survival fill probability, depth-delay, and nonfill opportunity-cost stress from arXiv:2512.05734, SSRN:6440898, and SSRN:6730443; preview ranking only",
                 "public_feed_lag_quoted_liquidity_stress": "deterministic public-feed delay, quoted-liquidity reliability, stale-quote, and authoritative trade-direction join stress from SSRN:6675338, arXiv:2604.24366, and arXiv:2511.20606; preview ranking only",
                 "lob_simulation_reality_gap_execution_stress": "deterministic spread-volume imbalance, latency-race mode, power-law signed-flow impact, and odd-lot liquidity reliability stress from arXiv:2603.24137, OFR WP 25-01, and arXiv:2507.06345; preview ranking only",
+                "alpha_decay_predictability_stress": "deterministic multi-horizon spread-adjusted alpha decay, cost-crossover, latency-horizon mismatch, and efficiency-regime compression stress from arXiv:2601.02310 and SSRN:6608199; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1084,6 +1095,7 @@ def _score_candidate_spec(
             queue_survival_fill_stress={},
             feed_lag_liquidity_stress={},
             lob_reality_gap_stress={},
+            alpha_decay_predictability_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1204,6 +1216,18 @@ def _score_candidate_spec(
         )
         or 0.0
     )
+    alpha_decay_predictability_stress = extract_alpha_decay_predictability_stress(
+        matched_source_rows,
+        direction=direction,
+    ).to_payload()
+    alpha_decay_predictability_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(alpha_decay_predictability_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
@@ -1254,6 +1278,7 @@ def _score_candidate_spec(
         - queue_survival_fill_rank_penalty_bps * 0.13
         - feed_lag_liquidity_rank_penalty_bps * 0.10
         - lob_reality_gap_rank_penalty_bps * 0.09
+        - alpha_decay_predictability_rank_penalty_bps * 0.08
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1289,6 +1314,7 @@ def _score_candidate_spec(
         - queue_survival_fill_rank_penalty_bps * 0.05
         - feed_lag_liquidity_rank_penalty_bps * 0.04
         - lob_reality_gap_rank_penalty_bps * 0.04
+        - alpha_decay_predictability_rank_penalty_bps * 0.04
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1330,6 +1356,7 @@ def _score_candidate_spec(
         queue_survival_fill_stress=dict(queue_survival_fill_stress),
         feed_lag_liquidity_stress=dict(feed_lag_liquidity_stress),
         lob_reality_gap_stress=dict(lob_reality_gap_stress),
+        alpha_decay_predictability_stress=dict(alpha_decay_predictability_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1370,6 +1397,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - _queue_survival_fill_rank_penalty_bps(row) * 0.07
         - _feed_lag_liquidity_rank_penalty_bps(row) * 0.06
         - _lob_reality_gap_rank_penalty_bps(row) * 0.05
+        - _alpha_decay_predictability_rank_penalty_bps(row) * 0.05
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
@@ -1403,6 +1431,15 @@ def _feed_lag_liquidity_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
 
 def _lob_reality_gap_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
     ranking_features = _mapping(row.lob_reality_gap_stress.get("ranking_features"))
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _alpha_decay_predictability_rank_penalty_bps(
+    row: FastReplayPreviewRow,
+) -> float:
+    ranking_features = _mapping(
+        row.alpha_decay_predictability_stress.get("ranking_features")
+    )
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
 
@@ -1598,6 +1635,7 @@ def _row_with_rank_and_selection(
         queue_survival_fill_stress=dict(row.queue_survival_fill_stress),
         feed_lag_liquidity_stress=dict(row.feed_lag_liquidity_stress),
         lob_reality_gap_stress=dict(row.lob_reality_gap_stress),
+        alpha_decay_predictability_stress=dict(row.alpha_decay_predictability_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -1661,6 +1699,7 @@ def _row_with_frontier_dedupe(
         queue_survival_fill_stress=dict(row.queue_survival_fill_stress),
         feed_lag_liquidity_stress=dict(row.feed_lag_liquidity_stress),
         lob_reality_gap_stress=dict(row.lob_reality_gap_stress),
+        alpha_decay_predictability_stress=dict(row.alpha_decay_predictability_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -2466,6 +2505,8 @@ def _risk_flags_for_row(
         flags.add("feed_lag_liquidity_stress_penalty_active")
     if _lob_reality_gap_rank_penalty_bps(row) > 0:
         flags.add("lob_reality_gap_stress_penalty_active")
+    if _alpha_decay_predictability_rank_penalty_bps(row) > 0:
+        flags.add("alpha_decay_predictability_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
         flags.add("partial_symbol_coverage")
     if row.trading_day_count <= 0:
@@ -2504,6 +2545,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("feed_lag_liquidity_stress_downranks_only")
     if _lob_reality_gap_rank_penalty_bps(row) > 0:
         reasons.add("lob_reality_gap_stress_downranks_only")
+    if _alpha_decay_predictability_rank_penalty_bps(row) > 0:
+        reasons.add("alpha_decay_predictability_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
         reasons.add("missing_replay_tape_source_data_explicit_blocker")
     if lineage_blockers:
@@ -2535,6 +2578,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("feed_lag_liquidity_stress_penalty")
     if _lob_reality_gap_rank_penalty_bps(row) > 0:
         vetoes.add("lob_reality_gap_stress_penalty")
+    if _alpha_decay_predictability_rank_penalty_bps(row) > 0:
+        vetoes.add("alpha_decay_predictability_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:
         vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
     return tuple(sorted(vetoes))

--- a/services/torghut/tests/test_alpha_decay_predictability_stress.py
+++ b/services/torghut/tests/test_alpha_decay_predictability_stress.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.alpha_decay_predictability_stress import (
+    build_alpha_decay_predictability_stress_schema_hash,
+    alpha_decay_predictability_stress_contract,
+    extract_alpha_decay_predictability_stress,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestAlphaDecayPredictabilityStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        price: str,
+        spread_bps: str,
+        volume: str,
+        algo_activity_score: str = "0.10",
+        inference_latency_ms: str = "10",
+    ) -> SignalEnvelope:
+        mid = Decimal(price)
+        return SignalEnvelope(
+            event_ts=datetime(2026, 1, 5, 14, 30, tzinfo=timezone.utc)
+            + timedelta(milliseconds=offset * 100),
+            symbol="ADX",
+            timeframe="100ms",
+            seq=offset,
+            source="alpha-decay-fixture",
+            payload={
+                "price": mid,
+                "bid": mid - Decimal("0.01"),
+                "ask": mid + Decimal("0.01"),
+                "spread_bps": Decimal(spread_bps),
+                "microbar_volume": Decimal(volume),
+                "algo_activity_score": Decimal(algo_activity_score),
+                "model_inference_latency_ms": Decimal(inference_latency_ms),
+            },
+            ingest_ts=datetime(2026, 1, 5, 14, 31, tzinfo=timezone.utc),
+        )
+
+    def test_alpha_decay_stress_penalizes_cost_crossover_and_latency_mismatch(
+        self,
+    ) -> None:
+        durable = extract_alpha_decay_predictability_stress(
+            (
+                self._row(offset=1, price="100.00", spread_bps="0.5", volume="100"),
+                self._row(offset=2, price="100.08", spread_bps="0.5", volume="105"),
+                self._row(offset=3, price="100.16", spread_bps="0.5", volume="110"),
+                self._row(offset=4, price="100.24", spread_bps="0.5", volume="115"),
+                self._row(offset=5, price="100.32", spread_bps="0.5", volume="120"),
+                self._row(offset=6, price="100.40", spread_bps="0.5", volume="125"),
+            ),
+            direction=1,
+        )
+        decayed = extract_alpha_decay_predictability_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    spread_bps="3.0",
+                    volume="900",
+                    algo_activity_score="0.95",
+                    inference_latency_ms="350",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.06",
+                    spread_bps="3.0",
+                    volume="950",
+                    algo_activity_score="0.95",
+                    inference_latency_ms="350",
+                ),
+                self._row(
+                    offset=3,
+                    price="99.98",
+                    spread_bps="3.0",
+                    volume="980",
+                    algo_activity_score="0.95",
+                    inference_latency_ms="350",
+                ),
+                self._row(
+                    offset=4,
+                    price="99.90",
+                    spread_bps="3.0",
+                    volume="990",
+                    algo_activity_score="0.95",
+                    inference_latency_ms="350",
+                ),
+                self._row(
+                    offset=5,
+                    price="99.84",
+                    spread_bps="3.0",
+                    volume="1000",
+                    algo_activity_score="0.95",
+                    inference_latency_ms="350",
+                ),
+                self._row(
+                    offset=6,
+                    price="99.80",
+                    spread_bps="3.0",
+                    volume="1020",
+                    algo_activity_score="0.95",
+                    inference_latency_ms="350",
+                ),
+            ),
+            direction=1,
+        )
+
+        self.assertGreater(decayed.alpha_decay_bps, durable.alpha_decay_bps)
+        self.assertGreater(decayed.cost_crossover_share, durable.cost_crossover_share)
+        self.assertGreater(
+            decayed.algorithmic_activity_intensity,
+            durable.algorithmic_activity_intensity,
+        )
+        self.assertGreater(
+            decayed.latency_horizon_mismatch_share,
+            durable.latency_horizon_mismatch_share,
+        )
+        self.assertGreater(
+            decayed.replay_rank_penalty_bps, durable.replay_rank_penalty_bps
+        )
+        payload = decayed.to_payload()
+        self.assertEqual(
+            payload["status"], "preview_only_alpha_decay_predictability_ranking"
+        )
+        self.assertTrue(payload["multi_horizon_alpha_decay_preview"])
+        self.assertTrue(payload["spread_adjusted_label_preview"])
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["final_authority_ok"])
+
+    def test_contract_embeds_sources_and_keeps_proof_fail_closed(self) -> None:
+        contract = alpha_decay_predictability_stress_contract()
+        payload = extract_alpha_decay_predictability_stress(
+            (
+                self._row(offset=1, price="100.00", spread_bps="1", volume="100"),
+                self._row(offset=2, price="100.01", spread_bps="1", volume="110"),
+                self._row(offset=3, price="100.02", spread_bps="1", volume="120"),
+            )
+        ).to_payload()
+        source_ids = {source["source_id"] for source in payload["source_papers"]}
+
+        self.assertEqual(
+            payload["feature_schema_hash"],
+            build_alpha_decay_predictability_stress_schema_hash(),
+        )
+        self.assertIn("arxiv-2601.02310", source_ids)
+        self.assertIn("ssrn-6608199", source_ids)
+        self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
+        self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
+        self.assertTrue(
+            contract["proof_neutrality"]["requires_order_lifecycle_fill_evidence"]
+        )
+        self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertTrue(
+            contract["proof_neutrality"]["rejects_single_horizon_lob_alpha_promotion"]
+        )
+        self.assertFalse(contract["proof_neutrality"]["promotion_proof"])
+        self.assertFalse(payload["promotion_authority"])

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -99,6 +99,10 @@ class TestFastReplayPreview(TestCase):
                 "odd_lot_bid_size": Decimal("20"),
                 "odd_lot_ask_size": Decimal("18"),
                 "off_exchange_trade": stress,
+                "algo_activity_score": Decimal("0.80") if stress else Decimal("0.20"),
+                "model_inference_latency_ms": Decimal("120")
+                if stress
+                else Decimal("5"),
                 "bid_size": Decimal("700"),
                 "ask_size": Decimal("300"),
                 "macro_event_window": stress,
@@ -209,6 +213,10 @@ class TestFastReplayPreview(TestCase):
             "lob_simulation_reality_gap_execution_stress",
             payload["implemented_mechanisms"],
         )
+        self.assertIn(
+            "alpha_decay_predictability_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",
@@ -293,6 +301,26 @@ class TestFastReplayPreview(TestCase):
             {
                 source["source_id"]
                 for source in row_payload["lob_reality_gap_stress"]["source_papers"]
+            },
+        )
+        self.assertIn("alpha_decay_predictability_stress", row_payload)
+        self.assertFalse(
+            row_payload["alpha_decay_predictability_stress"]["proof_authority"]
+        )
+        self.assertFalse(
+            row_payload["alpha_decay_predictability_stress"]["promotion_authority"]
+        )
+        self.assertEqual(
+            row_payload["alpha_decay_predictability_stress"]["status"],
+            "preview_only_alpha_decay_predictability_ranking",
+        )
+        self.assertIn(
+            "arxiv-2601.02310",
+            {
+                source["source_id"]
+                for source in row_payload["alpha_decay_predictability_stress"][
+                    "source_papers"
+                ]
             },
         )
         self.assertIn("cost_impact_lineage", row_payload)


### PR DESCRIPTION
## Summary

- Adds preview-only alpha-decay predictability stress extraction for replay candidate ranking, sourced from recent LOB alpha-decay and short-run market-efficiency preprints.
- Wires the stress into fast replay payloads, implemented-mechanism metadata, robust ranking penalties, and ranking-only risk/veto reasons.
- Adds regression tests proving decayed/cost-crossed/latency-mismatched fixtures receive higher penalties while proof and promotion authority remain fail-closed.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uvx ruff format --check app/trading/discovery/alpha_decay_predictability_stress.py app/trading/discovery/fast_replay.py tests/test_alpha_decay_predictability_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/alpha_decay_predictability_stress.py app/trading/discovery/fast_replay.py tests/test_alpha_decay_predictability_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen pytest tests/test_alpha_decay_predictability_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
