### PR TITLE
fix(torghut): use psycopg for source audit dsn

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -6850,6 +6850,17 @@ def _evidence_window_contract(
     }
 
 
+def _source_audit_sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
+
+
 @contextmanager
 def _target_source_audit_session(
     session: Session,
@@ -6878,7 +6889,11 @@ def _target_source_audit_session(
     if not source_dsn:
         yield session, {**metadata, "source_dsn_configured": False}
         return
-    source_engine = create_engine(source_dsn, future=True, pool_pre_ping=True)
+    source_engine = create_engine(
+        _source_audit_sqlalchemy_dsn(source_dsn),
+        future=True,
+        pool_pre_ping=True,
+    )
     try:
         with Session(source_engine) as source_session:
             yield (

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -11173,3 +11173,31 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertTrue(readback["runtime_buckets_present"])
         self.assertTrue(readback["evidence_grade_runtime_buckets_present"])
         self.assertFalse(target_audit["readiness"]["promotion_authority"]["allowed"])
+
+    def test_source_audit_sqlalchemy_dsn_uses_installed_psycopg_driver(
+        self,
+    ) -> None:
+        self.assertEqual(
+            paper_route_evidence._source_audit_sqlalchemy_dsn(
+                "postgres://user:pass@postgres/torghut"
+            ),
+            "postgresql+psycopg://user:pass@postgres/torghut",
+        )
+        self.assertEqual(
+            paper_route_evidence._source_audit_sqlalchemy_dsn(
+                "postgresql://user:pass@postgres/torghut"
+            ),
+            "postgresql+psycopg://user:pass@postgres/torghut",
+        )
+        self.assertEqual(
+            paper_route_evidence._source_audit_sqlalchemy_dsn(
+                "postgresql+psycopg://user:pass@postgres/torghut"
+            ),
+            "postgresql+psycopg://user:pass@postgres/torghut",
+        )
+        self.assertEqual(
+            paper_route_evidence._source_audit_sqlalchemy_dsn(
+                "sqlite+pysqlite:///:memory:"
+            ),
+            "sqlite+pysqlite:///:memory:",
+        )


### PR DESCRIPTION
## Summary

- Normalize Torghut paper-route source audit Postgres DSNs to `postgresql+psycopg://`.
- Prevent live source audit reads from falling back to SQLAlchemy's default `psycopg2` driver.
- Add regression coverage for source audit DSN normalization while preserving SQLite audit fixtures.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "source_audit_sqlalchemy_dsn or source_collection_target_audit_reads_source_dsn_activity"`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.alpha.json`
- `NODE_OPTIONS=--max-old-space-size=4096 uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
