### PR TITLE
fix(torghut): normalize paper route source audit dsn

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -6878,7 +6878,11 @@ def _target_source_audit_session(
     if not source_dsn:
         yield session, {**metadata, "source_dsn_configured": False}
         return
-    source_engine = create_engine(source_dsn, future=True, pool_pre_ping=True)
+    source_engine = create_engine(
+        _sqlalchemy_dsn(source_dsn),
+        future=True,
+        pool_pre_ping=True,
+    )
     try:
         with Session(source_engine) as source_session:
             yield (
@@ -6891,6 +6895,17 @@ def _target_source_audit_session(
             )
     finally:
         source_engine.dispose()
+
+
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
 
 
 def _source_audit_account_label(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -11173,3 +11173,27 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertTrue(readback["runtime_buckets_present"])
         self.assertTrue(readback["evidence_grade_runtime_buckets_present"])
         self.assertFalse(target_audit["readiness"]["promotion_authority"]["allowed"])
+
+    def test_source_audit_sqlalchemy_dsn_uses_installed_psycopg_driver(self) -> None:
+        self.assertEqual(
+            paper_route_evidence._sqlalchemy_dsn(
+                "postgres://user:pass@postgres/torghut"
+            ),
+            "postgresql+psycopg://user:pass@postgres/torghut",
+        )
+        self.assertEqual(
+            paper_route_evidence._sqlalchemy_dsn(
+                "postgresql://user:pass@postgres/torghut"
+            ),
+            "postgresql+psycopg://user:pass@postgres/torghut",
+        )
+        self.assertEqual(
+            paper_route_evidence._sqlalchemy_dsn(
+                "postgresql+psycopg://user:pass@postgres/torghut"
+            ),
+            "postgresql+psycopg://user:pass@postgres/torghut",
+        )
+        self.assertEqual(
+            paper_route_evidence._sqlalchemy_dsn("sqlite+pysqlite:///:memory:"),
+            "sqlite+pysqlite:///:memory:",
+        )


### PR DESCRIPTION
## Summary

- Normalize paper-route source-audit Postgres DSNs to `postgresql+psycopg://` before creating SQLAlchemy engines.
- Prevent live `/trading/paper-route-evidence` from defaulting to missing `psycopg2` when source collection reads use `DB_DSN`.
- Add regression coverage for Postgres and SQLite DSN normalization.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'source_audit_sqlalchemy_dsn or source_collection_target_audit_reads_source_dsn_activity' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen python -m compileall app/trading/paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv lock --check`
- `uv run --frozen pytest tests/test_paper_route_evidence.py --cov=app --cov-report=xml --cov-fail-under=0 -q`
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- Live readback before fix: `torghut-01008` returned HTTP 500 for `/trading/paper-route-evidence?target_limit=1` with `ModuleNotFoundError: No module named 'psycopg2'`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
