### PR TITLE
fix(autotrader): block same-session loss repeats

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -777,6 +777,7 @@ def fetch_scan_inputs(
     feed: str,
     scorecard_limit: int,
     broker_state: dict[str, Any] | None = None,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
     inputs, _ = fetch_scan_inputs_with_metrics(
         alpaca=alpaca,
@@ -787,6 +788,7 @@ def fetch_scan_inputs(
         feed=feed,
         scorecard_limit=scorecard_limit,
         broker_state=broker_state,
+        session_id=session_id,
     )
     return inputs
 
@@ -801,11 +803,13 @@ def fetch_scan_inputs_with_metrics(
     feed: str,
     scorecard_limit: int,
     broker_state: dict[str, Any] | None = None,
+    session_id: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     started_at = time.monotonic()
+    fetch_current_session = bool(optional_text(session_id, max_length=240))
     metrics: dict[str, Any] = {
         "brokerStateSource": "provided" if broker_state is not None else "fetched",
-        "parallelFetchCount": 3,
+        "parallelFetchCount": 4 if fetch_current_session else 3,
     }
     if broker_state is None:
         raw_broker_state, broker_metrics = fetch_broker_state_with_metrics(alpaca)
@@ -856,18 +860,28 @@ def fetch_scan_inputs_with_metrics(
         payload = synthesis.get("/api/autotrader/scorecards", {"limit": str(scorecard_limit)})
         return payload, elapsed_ms(task_started_at)
 
-    with ThreadPoolExecutor(max_workers=3) as executor:
+    def timed_current_session() -> tuple[Any, int]:
+        task_started_at = time.monotonic()
+        payload = synthesis.get(f"/api/autotrader/sessions/{urllib.parse.quote(str(session_id))}", None)
+        return payload, elapsed_ms(task_started_at)
+
+    with ThreadPoolExecutor(max_workers=4 if fetch_current_session else 3) as executor:
         futures = {
             "bars": executor.submit(timed_bars),
             "quotes": executor.submit(timed_quotes),
             "scorecards": executor.submit(timed_scorecards),
         }
+        if fetch_current_session:
+            futures["currentSession"] = executor.submit(timed_current_session)
         bars, metrics["barsMs"] = futures["bars"].result()
         quotes, metrics["quotesMs"] = futures["quotes"].result()
         scorecards, metrics["scorecardsMs"] = futures["scorecards"].result()
+        current_session = None
+        if fetch_current_session:
+            current_session, metrics["currentSessionMs"] = futures["currentSession"].result()
 
     metrics["totalMs"] = elapsed_ms(started_at)
-    return {
+    inputs = {
         "account.json": account,
         "positions.json": {"positions": positions if isinstance(positions, list) else []},
         "open-orders.json": {"orders": orders if isinstance(orders, list) else []},
@@ -875,7 +889,10 @@ def fetch_scan_inputs_with_metrics(
         "quotes.json": quotes,
         "scorecards.json": scorecards,
         "watchlist.json": {"watchlist": symbols},
-    }, metrics
+    }
+    if fetch_current_session:
+        inputs["current-session.json"] = current_session
+    return inputs, metrics
 
 
 def summarize_scan(
@@ -914,6 +931,7 @@ def summarize_scan(
                     "scorecard_sample_size",
                     "scorecard_avg_realized_r",
                     "scorecard_confidence",
+                    "current_session_loss_lockout",
                 )
             }
         )
@@ -928,6 +946,7 @@ def summarize_scan(
         "topResults": top_results,
         "scorecardInfluence": scorecard_usage_summary(scan),
         "scorecardOverlay": scan.get("scorecardOverlay"),
+        "currentSessionLossLockout": scan.get("currentSessionLossLockout"),
     }
 
 
@@ -1164,6 +1183,150 @@ def overlay_scorecards_on_scan(scan: dict[str, Any], scorecard_payload: Any) -> 
         "scorecardOverlay": {
             "sourceScorecardCount": len(scorecards),
             "appliedResultCount": applied_count,
+        },
+    }
+
+
+def session_detail_object(payload: Any) -> dict[str, Any]:
+    return payload if isinstance(payload, dict) else {}
+
+
+def session_detail_collection(payload: Any, key: str) -> list[Any]:
+    detail = session_detail_object(payload)
+    value = detail.get(key)
+    return value if isinstance(value, list) else []
+
+
+def normalized_loss_key(symbol: Any, setup: Any = None) -> tuple[str, str | None] | None:
+    symbol_text = optional_text(symbol, max_length=32)
+    if not symbol_text:
+        return None
+    setup_text = setup_type(setup) if setup is not None else None
+    return symbol_text.upper(), setup_text if setup_text and setup_text != "no_trade" else None
+
+
+def session_ticket_lookup(payload: Any) -> dict[str, dict[str, Any]]:
+    tickets: dict[str, dict[str, Any]] = {}
+    for ticket in session_detail_collection(payload, "tradeTickets"):
+        if not isinstance(ticket, dict):
+            continue
+        ticket_id = optional_text(ticket.get("id") or ticket.get("ticketId"), max_length=240)
+        if ticket_id:
+            tickets[ticket_id] = ticket
+    return tickets
+
+
+def session_losing_round_trip_keys(payload: Any) -> dict[tuple[str, str | None], dict[str, Any]]:
+    orders = [order for order in session_detail_collection(payload, "orders") if isinstance(order, dict)]
+    by_client_order_id = {
+        str(order["clientOrderId"]): order
+        for order in orders
+        if optional_text(order.get("clientOrderId"), max_length=240)
+    }
+    tickets_by_id = session_ticket_lookup(payload)
+    losing: dict[tuple[str, str | None], dict[str, Any]] = {}
+    for exit_order in orders:
+        payload_value = exit_order.get("brokerPayload")
+        broker_payload = payload_value if isinstance(payload_value, dict) else {}
+        parent_client_order_id = optional_text(
+            broker_payload.get("parentClientOrderId") or exit_order.get("parentClientOrderId"),
+            max_length=240,
+        )
+        if not parent_client_order_id:
+            continue
+        parent = by_client_order_id.get(parent_client_order_id)
+        if not isinstance(parent, dict):
+            continue
+        parent_side = optional_text(parent.get("side"), max_length=32)
+        exit_side = optional_text(exit_order.get("side"), max_length=32)
+        if parent_side != "buy" or exit_side != "sell":
+            continue
+        parent_broker_payload = parent.get("brokerPayload") if isinstance(parent.get("brokerPayload"), dict) else {}
+        parent_price = decimal_value(
+            parent.get("filledAvgPrice") or parent.get("filled_avg_price") or parent_broker_payload.get("filled_avg_price")
+        )
+        exit_price = decimal_value(
+            exit_order.get("filledAvgPrice")
+            or exit_order.get("filled_avg_price")
+            or broker_payload.get("filled_avg_price")
+        )
+        if parent_price is None or exit_price is None or exit_price >= parent_price:
+            continue
+        ticket = tickets_by_id.get(str(parent.get("ticketId") or exit_order.get("ticketId") or ""))
+        setup = ticket.get("setupType") if isinstance(ticket, dict) else None
+        symbol = parent.get("symbol") or exit_order.get("symbol")
+        symbol_key = normalized_loss_key(symbol)
+        setup_key = normalized_loss_key(symbol, setup)
+        details = {
+            "symbol": optional_text(symbol, max_length=32).upper() if optional_text(symbol, max_length=32) else None,
+            "setupType": setup_type(setup) if setup is not None else None,
+            "parentClientOrderId": parent_client_order_id,
+            "exitClientOrderId": exit_order.get("clientOrderId"),
+            "entryPrice": str(parent_price),
+            "exitPrice": str(exit_price),
+        }
+        if symbol_key:
+            losing[symbol_key] = details
+        if setup_key:
+            losing[setup_key] = details
+    return losing
+
+
+def current_session_loss_for_result(
+    result: dict[str, Any],
+    losing_keys: dict[tuple[str, str | None], dict[str, Any]],
+) -> dict[str, Any] | None:
+    symbol = optional_text(result.get("symbol"), max_length=32)
+    if not symbol:
+        return None
+    setup = setup_type(result.get("setup_type") or result.get("setupType"))
+    setup_key = normalized_loss_key(symbol, setup)
+    symbol_key = normalized_loss_key(symbol)
+    if setup_key and setup_key in losing_keys:
+        return {**losing_keys[setup_key], "lockoutScope": "symbol_setup"}
+    if symbol_key and symbol_key in losing_keys:
+        return {**losing_keys[symbol_key], "lockoutScope": "symbol"}
+    return None
+
+
+def overlay_current_session_loss_lockout(scan: dict[str, Any], current_session_payload: Any) -> dict[str, Any]:
+    results = scan.get("results")
+    if not isinstance(results, list):
+        return scan
+    losing_keys = session_losing_round_trip_keys(current_session_payload)
+    if not losing_keys:
+        return scan
+    enriched_results: list[Any] = []
+    applied_count = 0
+    blocked_symbols: list[str] = []
+    for result in results:
+        if not isinstance(result, dict):
+            enriched_results.append(result)
+            continue
+        if is_scanner_no_trade_result(result):
+            enriched_results.append(result)
+            continue
+        lockout = current_session_loss_for_result(result, losing_keys)
+        if lockout is None:
+            enriched_results.append(result)
+            continue
+        symbol = optional_text(result.get("symbol"), max_length=32)
+        if symbol and symbol.upper() not in blocked_symbols:
+            blocked_symbols.append(symbol.upper())
+        enriched_results.append(
+            {
+                **result,
+                "no_trade_reason": "current_session_loss_lockout",
+                "current_session_loss_lockout": lockout,
+            }
+        )
+        applied_count += 1
+    return {
+        **scan,
+        "results": enriched_results,
+        "currentSessionLossLockout": {
+            "appliedResultCount": applied_count,
+            "blockedSymbols": blocked_symbols[:20],
         },
     }
 
@@ -1813,6 +1976,7 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
         feed=args.feed,
         scorecard_limit=args.scorecard_limit,
         broker_state=broker_state,
+        session_id=args.session_id,
     )
     stage_timings["inputFetchMs"] = input_fetch_metrics["totalMs"]
     stage_timings["inputFetch"] = input_fetch_metrics
@@ -1840,6 +2004,7 @@ def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
         watchlist=symbols,
     )
     scan = overlay_scorecards_on_scan(scan, inputs.get("scorecards.json"))
+    scan = overlay_current_session_loss_lockout(scan, inputs.get("current-session.json"))
     stage_timings["stockAnalysisScanMs"] = elapsed_ms(scan_started_at)
     prune_started_at = time.monotonic()
     removed_cycle_dirs = prune_old_cycle_dirs(work_dir, args.retain_cycles)

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -1210,6 +1210,102 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["bestCandidate"]["symbol"], "AMD")
         self.assertEqual(summary["candidateSymbols"], ["AMD"])
 
+    def test_current_session_loss_lockout_blocks_same_symbol_setup(self) -> None:
+        current_session = {
+            "tradeTickets": [
+                {
+                    "id": "ticket-avgo",
+                    "symbol": "AVGO",
+                    "setupType": "vwap_reclaim",
+                    "setupGrade": "A",
+                }
+            ],
+            "orders": [
+                {
+                    "ticketId": "ticket-avgo",
+                    "clientOrderId": "entry-avgo",
+                    "symbol": "AVGO",
+                    "side": "buy",
+                    "status": "filled",
+                    "brokerPayload": {"filled_avg_price": "486.14"},
+                },
+                {
+                    "ticketId": "ticket-avgo",
+                    "clientOrderId": "stop-avgo",
+                    "symbol": "AVGO",
+                    "side": "sell",
+                    "status": "filled",
+                    "brokerPayload": {
+                        "parentClientOrderId": "entry-avgo",
+                        "filled_avg_price": "482.90",
+                    },
+                },
+            ],
+        }
+        scan = live_scan_cycle.overlay_current_session_loss_lockout(
+            {
+                "results": [
+                    {
+                        "symbol": "AVGO",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A+",
+                        "expected_r": "3.0",
+                        "last": "486.00",
+                        "support": "484.00",
+                        "resistance": "492.00",
+                        "scorecard_sample_size": 1,
+                        "scorecard_avg_realized_r": "0.3811",
+                    },
+                    {
+                        "symbol": "AMD",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A",
+                        "expected_r": "3.0",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "103.00",
+                        "scorecard_sample_size": 1,
+                        "scorecard_avg_realized_r": "3.042857",
+                    },
+                ]
+            },
+            current_session,
+        )
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=15,
+            index=1,
+            result=scan["results"][0],
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=15,
+            scan=scan,
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-15-1-AVGO-vwap_reclaim-A+",
+                    "ticketId": "ticket-avgo-repeat",
+                },
+                {
+                    "idempotencyKey": "scan-cycle-15-2-AMD-vwap_reclaim-A",
+                    "ticketId": "ticket-amd",
+                },
+            ],
+        )
+
+        assert payload is not None
+        self.assertEqual(scan["currentSessionLossLockout"]["appliedResultCount"], 1)
+        self.assertEqual(scan["currentSessionLossLockout"]["blockedSymbols"], ["AVGO"])
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["noTradeReason"], "current_session_loss_lockout")
+        self.assertEqual(
+            payload["brokerOrderPlan"]["raw"]["current_session_loss_lockout"]["lockoutScope"],
+            "symbol_setup",
+        )
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertEqual(summary["bestCandidate"]["symbol"], "AMD")
+        self.assertEqual(summary["candidateSymbols"], ["AMD"])
+
     def test_decision_summary_reports_no_actionable_candidate(self) -> None:
         summary = live_scan_cycle.decision_summary_for_scan(
             cycle=5,
@@ -1518,6 +1614,9 @@ class LiveScanCycleTest(unittest.TestCase):
                 self.timeout_seconds = timeout_seconds
 
             def get(self, path: str, query: dict[str, str]) -> object:
+                if path == "/api/autotrader/sessions/session-1":
+                    case.assertIsNone(query)
+                    return {"session": {"id": "session-1"}, "orders": [], "tradeTickets": []}
                 case.assertEqual(path, "/api/autotrader/scorecards")
                 case.assertEqual(query, {"limit": "20"})
                 return {
@@ -1588,6 +1687,7 @@ class LiveScanCycleTest(unittest.TestCase):
             self.assertEqual(summary["cycle"], 2)
             self.assertEqual(summary["resultCount"], 1)
             self.assertTrue((cycle_dir / "account.json").exists())
+            self.assertTrue((cycle_dir / "current-session.json").exists())
             self.assertTrue((cycle_dir / "watchlist.json").exists())
             self.assertFalse((cycle_dir / "summary.json").exists())
             self.assertFalse(old_cycle.exists())
@@ -1599,7 +1699,7 @@ class LiveScanCycleTest(unittest.TestCase):
             self.assertEqual(summary["scorecardInfluence"]["scorecardInfluencedResultCount"], 1)
             self.assertEqual(summary["decisionSummary"]["action"], "no_actionable_candidate")
             self.assertGreaterEqual(summary["stageTimingsMs"]["totalMs"], 0)
-            self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["parallelFetchCount"], 3)
+            self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["parallelFetchCount"], 4)
             self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["brokerStateSource"], "fetched")
             self.assertEqual(summary["stageTimingsMs"]["inputFetch"]["brokerState"]["parallelFetchCount"], 3)
             self.assertGreaterEqual(summary["stageTimingsMs"]["stockAnalysisScanMs"], 0)


### PR DESCRIPTION
## Summary

- Fetches the current Synthesis autotrader session during market-open scan input collection when a session id is present.
- Derives same-session losing closed long round trips from filled entry/exit order state and trade-ticket setup metadata.
- Blocks later same-session candidates for the same symbol/setup with `current_session_loss_lockout`, so stale positive scorecards cannot trigger churn after a live stop-out.
- Exposes the lockout in cycle summaries and records blocked trade-ticket state before candidate selection.

## Related Issues

None

## Testing

- `cd scripts/autotrader && python3 -m py_compile live_scan_cycle.py market_open_cycle.py strategy_order_guard.py protective_preflight.py test_live_scan_cycle.py test_market_open_cycle.py test_protective_preflight.py && python3 -m unittest discover -v`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t autonomous`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
