### PR TITLE
fix(autotrader): stop entries after session loss limit

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -42,6 +42,7 @@ MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
 MIN_ACTIONABLE_BRACKET_R = Decimal("2.0")
 MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE = 2
 MAX_SCORECARD_RISK_MULTIPLIER = Decimal("2.0")
+MAX_CURRENT_SESSION_LOSING_ROUND_TRIPS = 2
 BASE_RISK_EQUITY_PCT = Decimal("0.0025")
 MAX_RISK_EQUITY_PCT = Decimal("0.005")
 MAX_POSITION_NOTIONAL_EQUITY_PCT = Decimal("0.50")
@@ -932,6 +933,7 @@ def summarize_scan(
                     "scorecard_avg_realized_r",
                     "scorecard_confidence",
                     "current_session_loss_lockout",
+                    "current_session_loss_limit",
                 )
             }
         )
@@ -947,6 +949,7 @@ def summarize_scan(
         "scorecardInfluence": scorecard_usage_summary(scan),
         "scorecardOverlay": scan.get("scorecardOverlay"),
         "currentSessionLossLockout": scan.get("currentSessionLossLockout"),
+        "currentSessionLossLimit": scan.get("currentSessionLossLimit"),
     }
 
 
@@ -1289,6 +1292,29 @@ def current_session_loss_for_result(
     return None
 
 
+def current_session_loss_limit(payload: Any) -> dict[str, Any] | None:
+    losses_by_parent: dict[str, dict[str, Any]] = {}
+    for loss in session_losing_round_trip_keys(payload).values():
+        parent_id = optional_text(loss.get("parentClientOrderId"), max_length=240)
+        if parent_id:
+            losses_by_parent[parent_id] = loss
+    if len(losses_by_parent) < MAX_CURRENT_SESSION_LOSING_ROUND_TRIPS:
+        return None
+    symbols = sorted(
+        {
+            symbol
+            for loss in losses_by_parent.values()
+            if (symbol := optional_text(loss.get("symbol"), max_length=32))
+        }
+    )
+    return {
+        "reason": "current_session_loss_limit_reached",
+        "losingRoundTripCount": len(losses_by_parent),
+        "maxLosingRoundTrips": MAX_CURRENT_SESSION_LOSING_ROUND_TRIPS,
+        "symbols": symbols[:20],
+    }
+
+
 def overlay_current_session_loss_lockout(scan: dict[str, Any], current_session_payload: Any) -> dict[str, Any]:
     results = scan.get("results")
     if not isinstance(results, list):
@@ -1296,6 +1322,7 @@ def overlay_current_session_loss_lockout(scan: dict[str, Any], current_session_p
     losing_keys = session_losing_round_trip_keys(current_session_payload)
     if not losing_keys:
         return scan
+    loss_limit = current_session_loss_limit(current_session_payload)
     enriched_results: list[Any] = []
     applied_count = 0
     blocked_symbols: list[str] = []
@@ -1305,6 +1332,19 @@ def overlay_current_session_loss_lockout(scan: dict[str, Any], current_session_p
             continue
         if is_scanner_no_trade_result(result):
             enriched_results.append(result)
+            continue
+        if loss_limit is not None:
+            symbol = optional_text(result.get("symbol"), max_length=32)
+            if symbol and symbol.upper() not in blocked_symbols:
+                blocked_symbols.append(symbol.upper())
+            enriched_results.append(
+                {
+                    **result,
+                    "no_trade_reason": "current_session_loss_limit_reached",
+                    "current_session_loss_limit": loss_limit,
+                }
+            )
+            applied_count += 1
             continue
         lockout = current_session_loss_for_result(result, losing_keys)
         if lockout is None:
@@ -1328,6 +1368,7 @@ def overlay_current_session_loss_lockout(scan: dict[str, Any], current_session_p
             "appliedResultCount": applied_count,
             "blockedSymbols": blocked_symbols[:20],
         },
+        **({"currentSessionLossLimit": loss_limit} if loss_limit is not None else {}),
     }
 
 

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -1350,6 +1350,117 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["bestCandidate"]["symbol"], "AMD")
         self.assertEqual(summary["candidateSymbols"], ["AMD"])
 
+    def test_current_session_loss_limit_blocks_all_new_entries_after_two_losses(self) -> None:
+        current_session = {
+            "tradeTickets": [
+                {
+                    "id": "ticket-amd",
+                    "symbol": "AMD",
+                    "setupType": "vwap_reclaim",
+                    "setupGrade": "A",
+                },
+                {
+                    "id": "ticket-avgo",
+                    "symbol": "AVGO",
+                    "setupType": "vwap_reclaim",
+                    "setupGrade": "B",
+                },
+            ],
+            "orders": [
+                {
+                    "ticketId": "ticket-amd",
+                    "clientOrderId": "entry-amd",
+                    "symbol": "AMD",
+                    "side": "buy",
+                    "status": "filled",
+                    "brokerPayload": {"filled_avg_price": "533.37"},
+                },
+                {
+                    "ticketId": "ticket-amd",
+                    "clientOrderId": "stop-amd",
+                    "symbol": "AMD",
+                    "side": "sell",
+                    "status": "filled",
+                    "brokerPayload": {
+                        "parentClientOrderId": "entry-amd",
+                        "filled_avg_price": "532.590054",
+                    },
+                },
+                {
+                    "ticketId": "ticket-avgo",
+                    "clientOrderId": "entry-avgo",
+                    "symbol": "AVGO",
+                    "side": "buy",
+                    "status": "filled",
+                    "brokerPayload": {"filled_avg_price": "486.14"},
+                },
+                {
+                    "ticketId": "ticket-avgo",
+                    "clientOrderId": "stop-avgo",
+                    "symbol": "AVGO",
+                    "side": "sell",
+                    "status": "filled",
+                    "brokerPayload": {
+                        "parentClientOrderId": "entry-avgo",
+                        "filled_avg_price": "482.90",
+                    },
+                },
+            ],
+        }
+        scan = live_scan_cycle.overlay_current_session_loss_lockout(
+            {
+                "results": [
+                    {
+                        "symbol": "NVDA",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A+",
+                        "expected_r": "4.0",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "104.00",
+                        "scorecard_sample_size": 3,
+                        "scorecard_avg_realized_r": "1.5",
+                    },
+                    {
+                        "symbol": "GOOGL",
+                        "setup_type": "no_trade",
+                        "setup_grade": "C",
+                        "no_trade_reason": "no_confirmed_setup",
+                    },
+                ]
+            },
+            current_session,
+        )
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=16,
+            index=1,
+            result=scan["results"][0],
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=16,
+            scan=scan,
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-16-1-NVDA-vwap_reclaim-A+",
+                    "ticketId": "ticket-nvda",
+                }
+            ],
+        )
+
+        assert payload is not None
+        self.assertEqual(scan["currentSessionLossLimit"]["losingRoundTripCount"], 2)
+        self.assertEqual(scan["currentSessionLossLimit"]["symbols"], ["AMD", "AVGO"])
+        self.assertEqual(scan["currentSessionLossLockout"]["appliedResultCount"], 1)
+        self.assertEqual(scan["currentSessionLossLockout"]["blockedSymbols"], ["NVDA"])
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["noTradeReason"], "current_session_loss_limit_reached")
+        self.assertEqual(payload["brokerOrderPlan"]["raw"]["current_session_loss_limit"]["maxLosingRoundTrips"], 2)
+        self.assertEqual(summary["action"], "no_actionable_candidate")
+        self.assertEqual(summary["actionableCandidateCount"], 0)
+        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertIsNone(summary["bestCandidate"])
+
     def test_decision_summary_reports_no_actionable_candidate(self) -> None:
         summary = live_scan_cycle.decision_summary_for_scan(
             cycle=5,


### PR DESCRIPTION
## Summary

- Stops new broker-executable entries for the rest of a session after two closed losing round trips are detected in current Synthesis session detail.
- Reuses the existing current-session order/ticket readback path and records `current_session_loss_limit_reached` in scan results, top results, and trade-ticket raw payloads.
- Leaves scanner no-trade rows untouched and preserves the existing same-symbol loss lockout for sessions with only one realized loss.

## Related Issues

None

## Testing

- `cd scripts/autotrader && python3 -m py_compile live_scan_cycle.py market_open_cycle.py strategy_order_guard.py protective_preflight.py test_live_scan_cycle.py test_market_open_cycle.py test_protective_preflight.py && python3 -m unittest discover -v`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t autonomous`
- `bun run lint:argocd`
- `git diff --check`
- Manual Synthesis readback of session `0b1077ec-2eb0-4f8d-8cf0-bd5be211f307`: AMD and AVGO both closed as losses, while the running old job remained flat afterward with no new orders.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
