### PR TITLE
fix(torghut): source sim target plans from live service

### DIFF
--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -52,7 +52,7 @@ spec:
                     exit 0
                   fi
                   /opt/venv/bin/python scripts/materialize_bounded_paper_route_targets.py \
-                    --plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan \
+                    --plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan \
                     --plan-url-timeout-seconds 45 \
                     --plan-url-attempts 3 \
                     --database-dsn-env SIM_DB_DSN \

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -130,7 +130,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
               value: "75000"
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
-              value: http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan
+              value: http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS
               value: "10"
             - name: TRADING_KILL_SWITCH_ENABLED

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -689,7 +689,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_URL"),
-            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS"),
@@ -1472,7 +1472,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertIn(
             "--plan-url "
-            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
             args,
         )
         self.assertIn("--plan-url-timeout-seconds 45", args)


### PR DESCRIPTION
## Summary

- Point `torghut-sim` at the live Torghut `/trading/paper-route-target-plan` endpoint instead of self-referencing its own empty mirror.
- Source bounded paper-route target materialization from the live target plan so the sim DB can bootstrap the mirror.
- Update the Torghut manifest contract test to prevent this self-reference regression.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv lock --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
