### PR TITLE
fix(torghut): confirm materializer strategy aliases

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -448,6 +448,31 @@ def _load_plan(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]
     )
 
 
+def _unique_texts(values: Sequence[object]) -> list[str]:
+    return sorted({text for value in values if (text := _safe_text(value))})
+
+
+def _target_runtime_strategy_confirmation_names(
+    target: Mapping[str, Any],
+) -> list[str]:
+    names: list[object] = [
+        target.get("runtime_strategy_name"),
+        target.get("strategy_name"),
+    ]
+    readiness = target.get("source_decision_readiness")
+    if isinstance(readiness, Mapping):
+        lookup_names = readiness.get("strategy_lookup_names")
+        if isinstance(lookup_names, Sequence) and not isinstance(
+            lookup_names, (str, bytes)
+        ):
+            names.extend(lookup_names)
+        matched_strategy = readiness.get("matched_strategy")
+        if isinstance(matched_strategy, Mapping):
+            names.append(matched_strategy.get("strategy_name"))
+            names.append(matched_strategy.get("name"))
+    return _unique_texts(names)
+
+
 def _target_summaries(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
     summaries: list[dict[str, Any]] = []
     for index, target in enumerate(paper_route_target_plan_targets(plan)):
@@ -461,6 +486,9 @@ def _target_summaries(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
                 "candidate_id": _safe_text(target.get("candidate_id")),
                 "runtime_strategy_name": _safe_text(target.get("runtime_strategy_name"))
                 or _safe_text(target.get("strategy_name")),
+                "runtime_strategy_confirmation_names": (
+                    _target_runtime_strategy_confirmation_names(target)
+                ),
                 "strategy_name": _safe_text(target.get("strategy_name")),
                 "account_label": _safe_text(target.get("account_label")),
                 "target_plan_ref": _target_plan_ref(target),
@@ -560,10 +588,6 @@ def _plan_with_target_indexes(
     }
 
 
-def _unique_texts(values: Sequence[object]) -> list[str]:
-    return sorted({text for value in values if (text := _safe_text(value))})
-
-
 def _confirmed_selected_plan_sources(value: object) -> set[str]:
     text = _safe_text(value)
     if text is None:
@@ -591,10 +615,23 @@ def _confirmed_dynamic_target_indexes(
         return []
     indexes: list[int] = []
     for summary in summaries:
-        if all(
-            _safe_text(summary.get(field)) == expected
-            for field, expected in filters.items()
-        ):
+        matched = True
+        for field, expected in filters.items():
+            if field == "runtime_strategy_name":
+                confirmation_names = summary.get("runtime_strategy_confirmation_names")
+                if not isinstance(confirmation_names, Sequence) or isinstance(
+                    confirmation_names, (str, bytes)
+                ):
+                    confirmation_names = []
+                allowed_names = {_safe_text(summary.get(field))}
+                allowed_names.update(_safe_text(value) for value in confirmation_names)
+                if expected not in {value for value in allowed_names if value}:
+                    matched = False
+                    break
+            elif _safe_text(summary.get(field)) != expected:
+                matched = False
+                break
+        if matched:
             indexes.append(int(summary.get("target_index", 0)))
     return indexes
 
@@ -635,12 +672,6 @@ def _confirmation_blockers(
             _safe_text(args.confirm_hypothesis_id),
             ",".join(_unique_texts([item.get("hypothesis_id") for item in summaries])),
         ),
-        "runtime_strategy_name": (
-            _safe_text(args.confirm_runtime_strategy_name),
-            ",".join(
-                _unique_texts([item.get("runtime_strategy_name") for item in summaries])
-            ),
-        ),
         "max_notional": (
             _safe_text(args.confirm_max_notional),
             _safe_text(args.max_notional),
@@ -651,6 +682,25 @@ def _confirmation_blockers(
             blockers.append(
                 f"paper_route_materialization_commit_confirm_{name}_missing"
             )
+    runtime_strategy_confirmation = _safe_text(args.confirm_runtime_strategy_name)
+    runtime_strategy_confirmed = bool(summaries) and bool(runtime_strategy_confirmation)
+    for item in summaries:
+        confirmation_names = item.get("runtime_strategy_confirmation_names")
+        if not isinstance(confirmation_names, Sequence) or isinstance(
+            confirmation_names, (str, bytes)
+        ):
+            confirmation_names = []
+        allowed_names = {_safe_text(item.get("runtime_strategy_name"))}
+        allowed_names.update(_safe_text(value) for value in confirmation_names)
+        if runtime_strategy_confirmation not in {
+            value for value in allowed_names if value
+        }:
+            runtime_strategy_confirmed = False
+            break
+    if not runtime_strategy_confirmed:
+        blockers.append(
+            "paper_route_materialization_commit_confirm_runtime_strategy_name_missing"
+        )
 
     if not dynamic_target_plan:
         exact_confirmations = {

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -593,6 +593,9 @@ def test_paper_route_target_plan_target_summary_accepts_explicit_quantity_and_sy
             "hypothesis_id": "H-PAIRS-01",
             "candidate_id": "c88421d619759b2cfaa6f4d0",
             "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "runtime_strategy_confirmation_names": [
+                "microbar-cross-sectional-pairs-v1"
+            ],
             "strategy_name": "microbar-cross-sectional-pairs-v1",
             "account_label": "TORGHUT_SIM",
             "target_plan_ref": "paper-route-plan:c88421d619759b2cfaa6f4d0",
@@ -938,6 +941,70 @@ def test_commit_dynamic_source_collection_plan_skips_without_target_window(
     assert report["source_targets"][0]["target_notional"] == "0"
     assert report["materialized_decision_count"] == 0
     assert report["route_submission_count"] == 0
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_commit_dynamic_plan_confirms_strategy_lookup_alias_before_skip(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "live_submission_gate": {
+            "runtime_ledger_paper_probation_import_plan": _plan(
+                _hpairs_target(
+                    runtime_strategy_name="69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                    strategy_name="69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                )
+            )
+        },
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "25",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--skip-unless-active-target-window",
+            "--now-utc",
+            "2026-06-01T13:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            cli.DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "25",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["skipped"] is True
+    assert report["skip_reason"] == cli.ACTIVE_TARGET_WINDOW_SKIP_REASON
+    assert report["blocked"] is False
+    assert report["source_target_count"] == 1
+    assert report["target_count"] == 1
+    assert report["runtime_strategy_names"] == ["69cf50e3-4815-47c2-b802-1efbaac09ecb"]
+    assert (
+        "microbar-cross-sectional-pairs-v1"
+        in report["targets"][0]["runtime_strategy_confirmation_names"]
+    )
     assert _count_decisions(sqlite_dsn) == 0
 
 


### PR DESCRIPTION
## Summary

 - Allows bounded paper-route target materialization to confirm the configured strategy name through source-decision readiness aliases when live target plans carry opaque runtime strategy IDs.
- Keeps materialization fail-closed for UUID-only source-collection targets without matching aliases, so target-count confirmation is not weakened.
- Adds regression coverage for the live H-PAIRS UUID strategy payload so closed-window runs skip cleanly instead of failing before the window gate.

## Related Issues

None

## Testing

 - `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
