### PR TITLE
fix(torghut): stabilize alpha repair evidence refs

### DIFF
--- a/services/torghut/app/trading/executable_alpha_receipts.py
+++ b/services/torghut/app/trading/executable_alpha_receipts.py
@@ -571,11 +571,22 @@ def build_executable_alpha_repair_receipts(
     source_revenue_repair_ref = "torghut-revenue-repair-digest:" + _stable_hash(
         "torghut-revenue-repair-digest",
         {
-            "generated_at": generated.isoformat(),
-            "top_blocker": dict(top_blocker),
             "business_state": business_state,
+            "top_blocker": dict(top_blocker),
             "repair_bid_settlement_ledger_id": repair_bid_settlement_ledger.get(
                 "ledger_id"
+            ),
+            "selected_lot_ids": _string_list(
+                repair_bid_settlement_ledger.get("selected_lot_ids")
+            ),
+            "dispatchable_lot_ids": _string_list(
+                repair_bid_settlement_ledger.get("dispatchable_lot_ids")
+            ),
+            "held_lot_ids": _string_list(
+                repair_bid_settlement_ledger.get("held_lot_ids")
+            ),
+            "routeable_candidate_count": _int(
+                repair_bid_settlement_ledger.get("routeable_candidate_count")
             ),
         },
     )

--- a/services/torghut/tests/test_executable_alpha_repair_receipts.py
+++ b/services/torghut/tests/test_executable_alpha_repair_receipts.py
@@ -241,9 +241,10 @@ def _build(
     alpha_readiness: Mapping[str, Any] | None = None,
     repair_queue: list[dict[str, object]] | None = None,
     capital: Mapping[str, Any] | None = None,
+    generated_at: datetime = NOW,
 ) -> dict[str, object]:
     return build_executable_alpha_repair_receipts(
-        generated_at=NOW,
+        generated_at=generated_at,
         business_state="repair_only",
         revenue_ready=False,
         repair_queue=repair_queue or _top_alpha_queue(),
@@ -298,6 +299,22 @@ def test_alpha_readiness_top_queue_selects_zero_notional_lineage_receipt() -> No
     assert selected["jangar_reentry"]["max_parallelism"] == 1
     receipts = cast(list[Mapping[str, Any]], payload["receipts"])
     assert "receipt:stale" in cast(list[str], receipts[1]["required_input_refs"])
+
+
+def test_executable_alpha_source_ref_is_stable_across_digest_ticks() -> None:
+    first = _build(generated_at=NOW)
+    second = _build(generated_at=NOW + timedelta(minutes=5))
+
+    assert first["generated_at"] != second["generated_at"]
+    assert first["source_revenue_repair_ref"] == second["source_revenue_repair_ref"]
+    assert (
+        cast(Mapping[str, Any], first["selected_receipt"])["source_revenue_repair_ref"]
+        == first["source_revenue_repair_ref"]
+    )
+    assert (
+        cast(Mapping[str, Any], second["selected_receipt"])["source_revenue_repair_ref"]
+        == first["source_revenue_repair_ref"]
+    )
 
 
 def test_reason_codes_map_to_executable_alpha_repair_classes() -> None:


### PR DESCRIPTION
## Summary

- Stabilizes executable-alpha repair `source_revenue_repair_ref` generation by removing freshness-tick timestamps from the hash inputs.
- Keeps the ref sensitive to real repair evidence changes: queue blocker, settlement ledger, selected/dispatchable/held lots, and routeable candidate count.
- Adds a regression proving identical alpha-readiness repair evidence keeps the same source ref across digest ticks.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py -k source_ref`
- `uv run --frozen pytest tests/test_executable_alpha_repair_receipts.py tests/test_alpha_evidence_foundry.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_dividend_ledger.py tests/test_no_delta_repair_reentry_auction.py tests/test_build_revenue_repair_digest.py`
- `uv run --frozen ruff check app/trading/executable_alpha_receipts.py tests/test_executable_alpha_repair_receipts.py`
- `uv run --frozen ruff format --check app/trading/executable_alpha_receipts.py tests/test_executable_alpha_repair_receipts.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
