### PR TITLE
fix(autotrader): require meaningful scorecard edge

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -41,6 +41,7 @@ ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
 MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
 MIN_ACTIONABLE_BRACKET_R = Decimal("2.0")
 MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE = 2
+MIN_SCORECARD_ACTIONABLE_AVG_REALIZED_R = Decimal("0.5")
 MAX_SCORECARD_RISK_MULTIPLIER = Decimal("2.0")
 MAX_CURRENT_SESSION_LOSING_ROUND_TRIPS = 2
 BASE_RISK_EQUITY_PCT = Decimal("0.0025")
@@ -1614,6 +1615,8 @@ def result_no_trade_reason(
         return bracket_reason
     if scorecard_sample_size <= 0 or scorecard_avg_r is None or scorecard_avg_r <= 0:
         return "positive_scorecard_edge_required"
+    if scorecard_avg_r < MIN_SCORECARD_ACTIONABLE_AVG_REALIZED_R:
+        return "scorecard_avg_realized_r_below_actionable_floor"
     if scorecard_sample_size < MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE:
         return "positive_scorecard_repeat_sample_required"
     risk_directive = scorecard_risk_directive(result, account=account)
@@ -1770,6 +1773,8 @@ def scorecard_edge_weight(sample_size: int) -> Decimal:
 def scorecard_risk_directive(result: dict[str, Any], account: dict[str, Any] | None = None) -> dict[str, Any] | None:
     sample_size, avg_realized_r, confidence = scorecard_edge_values(result)
     if sample_size <= 0 or avg_realized_r is None or avg_realized_r <= 0:
+        return None
+    if avg_realized_r < MIN_SCORECARD_ACTIONABLE_AVG_REALIZED_R:
         return None
     risk_multiplier = (
         min(MAX_SCORECARD_RISK_MULTIPLIER, max(Decimal("1.0"), avg_realized_r))

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -693,7 +693,7 @@ class LiveScanCycleTest(unittest.TestCase):
                         "support": "99.00",
                         "resistance": "102.50",
                         "scorecard_sample_size": 2,
-                        "scorecard_avg_realized_r": "0.2",
+                        "scorecard_avg_realized_r": "0.75",
                     },
                     {
                         "symbol": "NVDA",
@@ -747,7 +747,7 @@ class LiveScanCycleTest(unittest.TestCase):
                         "support": "99.00",
                         "resistance": "102.10",
                         "scorecard_sample_size": 2,
-                        "scorecard_avg_realized_r": "0.1",
+                        "scorecard_avg_realized_r": "0.75",
                     },
                     {
                         "symbol": "AMD",
@@ -758,7 +758,7 @@ class LiveScanCycleTest(unittest.TestCase):
                         "support": "99.00",
                         "resistance": "104.00",
                         "scorecard_sample_size": 2,
-                        "scorecard_avg_realized_r": "0.1",
+                        "scorecard_avg_realized_r": "0.75",
                     },
                 ]
             },
@@ -1004,6 +1004,45 @@ class LiveScanCycleTest(unittest.TestCase):
             payload["brokerOrderPlan"]["riskDirective"]["reason"],
             "positive_scorecard_edge_pending_repeat_sample",
         )
+        self.assertEqual(summary["action"], "no_actionable_candidate")
+        self.assertEqual(summary["actionableCandidateCount"], 0)
+        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertIsNone(summary["bestCandidate"])
+
+    def test_decision_summary_blocks_weak_positive_scorecard_edge(self) -> None:
+        result = {
+            "symbol": "AMD",
+            "setup_type": "vwap_reclaim",
+            "setup_grade": "A",
+            "expected_r": "4.0",
+            "last": "100.00",
+            "support": "99.00",
+            "resistance": "104.00",
+            "scorecard_sample_size": 5,
+            "scorecard_avg_realized_r": "0.25",
+            "scorecard_confidence": "0.75",
+        }
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=10,
+            index=1,
+            result=result,
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=10,
+            scan={"results": [result]},
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-10-1-AMD-vwap_reclaim-A",
+                    "ticketId": "ticket-amd",
+                }
+            ],
+        )
+
+        assert payload is not None
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["noTradeReason"], "scorecard_avg_realized_r_below_actionable_floor")
+        self.assertIsNone(payload["brokerOrderPlan"]["riskDirective"])
         self.assertEqual(summary["action"], "no_actionable_candidate")
         self.assertEqual(summary["actionableCandidateCount"], 0)
         self.assertEqual(summary["blockedResultCount"], 1)


### PR DESCRIPTION
## Summary

- Require scorecard average realized R to be at least `0.5` before a scan result can become an actionable market-open candidate.
- Suppress risk scaling directives for weak positive scorecard history so tiny above-zero averages cannot trigger broker order planning.
- Add regression coverage proving weak positive history is blocked while stronger repeated scorecard edge still ranks and sizes through the existing deterministic runner gates.

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/test_live_scan_cycle.py`
- `python3 -m unittest test_live_scan_cycle.py` from `scripts/autotrader`
- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test && python3 scripts/autotrader/market_open_cycle.py --self-test && python3 scripts/autotrader/strategy_order_guard.py --self-test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
