### PR TITLE
fix(autotrader): gate recovery trades after losses

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -42,6 +42,9 @@ MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
 MIN_ACTIONABLE_BRACKET_R = Decimal("2.0")
 MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE = 2
 MIN_SCORECARD_ACTIONABLE_AVG_REALIZED_R = Decimal("0.5")
+MIN_POST_LOSS_EXPECTED_R = Decimal("3.0")
+MIN_POST_LOSS_BRACKET_R = Decimal("3.0")
+MIN_POST_LOSS_SCORECARD_AVG_REALIZED_R = Decimal("1.0")
 MAX_SCORECARD_RISK_MULTIPLIER = Decimal("2.0")
 MAX_CURRENT_SESSION_LOSING_ROUND_TRIPS = 2
 BASE_RISK_EQUITY_PCT = Decimal("0.0025")
@@ -1294,11 +1297,7 @@ def current_session_loss_for_result(
 
 
 def current_session_loss_limit(payload: Any) -> dict[str, Any] | None:
-    losses_by_parent: dict[str, dict[str, Any]] = {}
-    for loss in session_losing_round_trip_keys(payload).values():
-        parent_id = optional_text(loss.get("parentClientOrderId"), max_length=240)
-        if parent_id:
-            losses_by_parent[parent_id] = loss
+    losses_by_parent = current_session_losing_round_trips(payload)
     if len(losses_by_parent) < MAX_CURRENT_SESSION_LOSING_ROUND_TRIPS:
         return None
     symbols = sorted(
@@ -1316,6 +1315,53 @@ def current_session_loss_limit(payload: Any) -> dict[str, Any] | None:
     }
 
 
+def current_session_losing_round_trips(payload: Any) -> dict[str, dict[str, Any]]:
+    losses_by_parent: dict[str, dict[str, Any]] = {}
+    for loss in session_losing_round_trip_keys(payload).values():
+        parent_id = optional_text(loss.get("parentClientOrderId"), max_length=240)
+        if parent_id:
+            losses_by_parent[parent_id] = loss
+    return losses_by_parent
+
+
+def post_loss_recovery_gate_no_trade_reason(result: dict[str, Any]) -> str | None:
+    grade = setup_grade(result.get("setup_grade") or result.get("setupGrade"))
+    if grade not in {"A+", "A"}:
+        return "current_session_post_loss_requires_a_grade"
+    expected_r = decimal_value(result.get("expected_r") or result.get("expectedR"))
+    if expected_r is None or expected_r < MIN_POST_LOSS_EXPECTED_R:
+        return "current_session_post_loss_expected_r_below_floor"
+    bracket_r = decimal_value(derived_bracket_for_scan_result(result).get("actualBracketR"))
+    if bracket_r is None or bracket_r < MIN_POST_LOSS_BRACKET_R:
+        return "current_session_post_loss_bracket_r_below_floor"
+    sample_size, avg_realized_r, _confidence = scorecard_edge_values(result)
+    if sample_size < MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE:
+        return "current_session_post_loss_scorecard_repeat_sample_required"
+    if avg_realized_r is None or avg_realized_r < MIN_POST_LOSS_SCORECARD_AVG_REALIZED_R:
+        return "current_session_post_loss_scorecard_avg_r_below_floor"
+    return None
+
+
+def post_loss_recovery_gate(losing_round_trips: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    symbols = sorted(
+        {
+            symbol
+            for loss in losing_round_trips.values()
+            if (symbol := optional_text(loss.get("symbol"), max_length=32))
+        }
+    )
+    return {
+        "reason": "current_session_post_loss_recovery_gate",
+        "losingRoundTripCount": len(losing_round_trips),
+        "symbols": symbols[:20],
+        "minimumExpectedR": str(MIN_POST_LOSS_EXPECTED_R),
+        "minimumBracketR": str(MIN_POST_LOSS_BRACKET_R),
+        "minimumScorecardAvgRealizedR": str(MIN_POST_LOSS_SCORECARD_AVG_REALIZED_R),
+        "minimumScorecardSampleSize": MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE,
+        "allowedSetupGrades": ["A+", "A"],
+    }
+
+
 def overlay_current_session_loss_lockout(scan: dict[str, Any], current_session_payload: Any) -> dict[str, Any]:
     results = scan.get("results")
     if not isinstance(results, list):
@@ -1324,6 +1370,12 @@ def overlay_current_session_loss_lockout(scan: dict[str, Any], current_session_p
     if not losing_keys:
         return scan
     loss_limit = current_session_loss_limit(current_session_payload)
+    losing_round_trips = current_session_losing_round_trips(current_session_payload)
+    recovery_gate = (
+        post_loss_recovery_gate(losing_round_trips)
+        if loss_limit is None and losing_round_trips
+        else None
+    )
     enriched_results: list[Any] = []
     applied_count = 0
     blocked_symbols: list[str] = []
@@ -1349,7 +1401,25 @@ def overlay_current_session_loss_lockout(scan: dict[str, Any], current_session_p
             continue
         lockout = current_session_loss_for_result(result, losing_keys)
         if lockout is None:
-            enriched_results.append(result)
+            recovery_reason = (
+                post_loss_recovery_gate_no_trade_reason(result)
+                if recovery_gate is not None
+                else None
+            )
+            if recovery_reason is None:
+                enriched_results.append(result)
+                continue
+            symbol = optional_text(result.get("symbol"), max_length=32)
+            if symbol and symbol.upper() not in blocked_symbols:
+                blocked_symbols.append(symbol.upper())
+            enriched_results.append(
+                {
+                    **result,
+                    "no_trade_reason": recovery_reason,
+                    "current_session_recovery_gate": recovery_gate,
+                }
+            )
+            applied_count += 1
             continue
         symbol = optional_text(result.get("symbol"), max_length=32)
         if symbol and symbol.upper() not in blocked_symbols:
@@ -1369,6 +1439,7 @@ def overlay_current_session_loss_lockout(scan: dict[str, Any], current_session_p
             "appliedResultCount": applied_count,
             "blockedSymbols": blocked_symbols[:20],
         },
+        **({"currentSessionRecoveryGate": recovery_gate} if recovery_gate is not None else {}),
         **({"currentSessionLossLimit": loss_limit} if loss_limit is not None else {}),
     }
 

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -1389,6 +1389,161 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["bestCandidate"]["symbol"], "AMD")
         self.assertEqual(summary["candidateSymbols"], ["AMD"])
 
+    def test_current_session_post_loss_gate_blocks_weak_different_symbol_recovery(self) -> None:
+        current_session = {
+            "tradeTickets": [
+                {
+                    "id": "ticket-amd",
+                    "symbol": "AMD",
+                    "setupType": "vwap_reclaim",
+                    "setupGrade": "A",
+                }
+            ],
+            "orders": [
+                {
+                    "ticketId": "ticket-amd",
+                    "clientOrderId": "entry-amd",
+                    "symbol": "AMD",
+                    "side": "buy",
+                    "status": "filled",
+                    "brokerPayload": {"filled_avg_price": "533.37"},
+                },
+                {
+                    "ticketId": "ticket-amd",
+                    "clientOrderId": "stop-amd",
+                    "symbol": "AMD",
+                    "side": "sell",
+                    "status": "filled",
+                    "brokerPayload": {
+                        "parentClientOrderId": "entry-amd",
+                        "filled_avg_price": "532.590054",
+                    },
+                },
+            ],
+        }
+        scan = live_scan_cycle.overlay_current_session_loss_lockout(
+            {
+                "results": [
+                    {
+                        "symbol": "AVGO",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A",
+                        "expected_r": "2.5",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "102.50",
+                        "scorecard_sample_size": 2,
+                        "scorecard_avg_realized_r": "0.75",
+                    }
+                ]
+            },
+            current_session,
+        )
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=15,
+            index=1,
+            result=scan["results"][0],
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=15,
+            scan=scan,
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-15-1-AVGO-vwap_reclaim-A",
+                    "ticketId": "ticket-avgo",
+                }
+            ],
+        )
+
+        assert payload is not None
+        self.assertEqual(scan["currentSessionRecoveryGate"]["losingRoundTripCount"], 1)
+        self.assertEqual(scan["currentSessionLossLockout"]["appliedResultCount"], 1)
+        self.assertEqual(scan["currentSessionLossLockout"]["blockedSymbols"], ["AVGO"])
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["noTradeReason"], "current_session_post_loss_expected_r_below_floor")
+        self.assertEqual(
+            payload["brokerOrderPlan"]["raw"]["current_session_recovery_gate"]["minimumExpectedR"],
+            "3.0",
+        )
+        self.assertEqual(summary["action"], "no_actionable_candidate")
+        self.assertEqual(summary["blockedResultCount"], 1)
+
+    def test_current_session_post_loss_gate_allows_strong_different_symbol_recovery(self) -> None:
+        current_session = {
+            "tradeTickets": [
+                {
+                    "id": "ticket-amd",
+                    "symbol": "AMD",
+                    "setupType": "vwap_reclaim",
+                    "setupGrade": "A",
+                }
+            ],
+            "orders": [
+                {
+                    "ticketId": "ticket-amd",
+                    "clientOrderId": "entry-amd",
+                    "symbol": "AMD",
+                    "side": "buy",
+                    "status": "filled",
+                    "brokerPayload": {"filled_avg_price": "533.37"},
+                },
+                {
+                    "ticketId": "ticket-amd",
+                    "clientOrderId": "stop-amd",
+                    "symbol": "AMD",
+                    "side": "sell",
+                    "status": "filled",
+                    "brokerPayload": {
+                        "parentClientOrderId": "entry-amd",
+                        "filled_avg_price": "532.590054",
+                    },
+                },
+            ],
+        }
+        scan = live_scan_cycle.overlay_current_session_loss_lockout(
+            {
+                "results": [
+                    {
+                        "symbol": "NVDA",
+                        "setup_type": "vwap_reclaim",
+                        "setup_grade": "A+",
+                        "expected_r": "3.5",
+                        "last": "100.00",
+                        "support": "99.00",
+                        "resistance": "103.50",
+                        "scorecard_sample_size": 3,
+                        "scorecard_avg_realized_r": "1.25",
+                    }
+                ]
+            },
+            current_session,
+        )
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=15,
+            index=1,
+            result=scan["results"][0],
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=15,
+            scan=scan,
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-15-1-NVDA-vwap_reclaim-A+",
+                    "ticketId": "ticket-nvda",
+                }
+            ],
+        )
+
+        assert payload is not None
+        self.assertEqual(scan["currentSessionRecoveryGate"]["losingRoundTripCount"], 1)
+        self.assertEqual(scan["currentSessionLossLockout"]["appliedResultCount"], 0)
+        self.assertEqual(payload["status"], "candidate")
+        self.assertIsNone(payload["noTradeReason"])
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["bestCandidate"]["symbol"], "NVDA")
+
     def test_current_session_loss_limit_blocks_all_new_entries_after_two_losses(self) -> None:
         current_session = {
             "tradeTickets": [


### PR DESCRIPTION
## Summary

- Add a deterministic post-loss recovery gate after the first realized losing round trip in the current session.
- Require recovery candidates to be A/A+, at least `3.0` expected R, at least `3.0` executable bracket R, repeated scorecard history, and scorecard average realized R at least `1.0`.
- Preserve the existing same-symbol lockout and two-loss full-session lockout, with regression tests for weak recovery blocks and strong recovery pass-through.

## Related Issues

None

## Testing

- `python3 -m py_compile scripts/autotrader/live_scan_cycle.py scripts/autotrader/test_live_scan_cycle.py`
- `python3 -m unittest test_live_scan_cycle.py` from `scripts/autotrader`
- `python3 -m unittest discover -s scripts/autotrader -p 'test_*.py'`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test && python3 scripts/autotrader/market_open_cycle.py --self-test && python3 scripts/autotrader/strategy_order_guard.py --self-test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
