### PR TITLE
fix(torghut): confirm top-level materializer strategy aliases

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -459,6 +459,11 @@ def _target_runtime_strategy_confirmation_names(
         target.get("runtime_strategy_name"),
         target.get("strategy_name"),
     ]
+    target_lookup_names = target.get("strategy_lookup_names")
+    if isinstance(target_lookup_names, Sequence) and not isinstance(
+        target_lookup_names, (str, bytes)
+    ):
+        names.extend(target_lookup_names)
     readiness = target.get("source_decision_readiness")
     if isinstance(readiness, Mapping):
         lookup_names = readiness.get("strategy_lookup_names")

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -955,6 +955,11 @@ def test_commit_dynamic_plan_confirms_strategy_lookup_alias_before_skip(
                 _hpairs_target(
                     runtime_strategy_name="69cf50e3-4815-47c2-b802-1efbaac09ecb",
                     strategy_name="69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                    strategy_lookup_names=[
+                        "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                        "microbar-cross-sectional-pairs-v1",
+                    ],
+                    source_decision_readiness=None,
                 )
             )
         },


### PR DESCRIPTION
## Summary

- Include top-level `strategy_lookup_names` when building materializer runtime strategy confirmation names.
- Match the live target-plan payload shape where H-PAIRS targets carry UUID runtime strategy names plus the human alias in `strategy_lookup_names`.
- Keep the fail-closed confirmation path intact while allowing `microbar-cross-sectional-pairs-v1` to match live UUID-backed targets.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -k 'strategy_lookup_alias or target_summary' -q`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
