### PR TITLE
fix(synthesis): derive running autotrader realized R

### DIFF
--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -7,6 +7,7 @@ import {
   handleAutotraderGetScorecard,
   handleAutotraderGetSession,
   handleAutotraderListSessions,
+  handleAutotraderRecordFill,
   handleAutotraderRecordOrder,
   handleAutotraderRecordPositionSnapshot,
   handleAutotraderStartSession,
@@ -650,6 +651,130 @@ describe('synthesis REST auth', () => {
     })
     expect(detailPayload.performance).toEqual(listPayload.sessions[0].performance)
     expect(detailPayload.session.finalizedAt).toBeNull()
+  })
+
+  test('reports running-session realized R from completed fills when ticket risk dollars are missing', async () => {
+    const authedHeaders = {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    }
+    const startResponse = await handleAutotraderStartSession(
+      new Request('http://synthesis.test/api/autotrader/sessions', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          agentRunName: 'autonomous-trader-running-r-api-test',
+          mode: 'market_open',
+          tradingDate: '2026-06-03',
+          accountId: 'paper-account',
+          goalEquity: '500000',
+          openingEquity: '30000',
+          marketOpenAt: '2026-06-03T13:30:00Z',
+          marketCloseAt: '2026-06-03T20:00:00Z',
+        }),
+      }),
+    )
+    const startPayload = await startResponse.json()
+    const sessionId = startPayload.session.id
+
+    const ticketResponse = await handleAutotraderCreateTradeTicket(
+      new Request('http://synthesis.test/api/autotrader/trade-tickets', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId,
+          idempotencyKey: 'amd-running-r',
+          symbol: 'AMD',
+          instrument: 'stock',
+          side: 'buy',
+          setupType: 'vwap_reclaim',
+          setupGrade: 'A',
+          regime: 'intraday_live_scan',
+          timeBucket: 'market_session',
+          thesis: 'Running R regression fixture.',
+          entryTrigger: 'entry filled',
+          invalidation: 'stop loss',
+          entryLimitPrice: '100',
+          stopPrice: '99',
+          targetPrice: '103',
+          expectedR: '3',
+          protectionType: 'bracket',
+          status: 'candidate',
+        }),
+      }),
+    )
+    const ticketPayload = await ticketResponse.json()
+    expect(ticketResponse.status).toBe(201)
+    const ticketId = ticketPayload.ticket.id
+
+    for (const order of [
+      { clientOrderId: 'amd-entry', side: 'buy', brokerOrderId: 'broker-entry' },
+      { clientOrderId: 'amd-stop', side: 'sell', brokerOrderId: 'broker-stop' },
+    ] as const) {
+      const orderResponse = await handleAutotraderRecordOrder(
+        new Request('http://synthesis.test/api/autotrader/orders', {
+          method: 'POST',
+          headers: authedHeaders,
+          body: JSON.stringify({
+            sessionId,
+            ticketId,
+            clientOrderId: order.clientOrderId,
+            brokerOrderId: order.brokerOrderId,
+            symbol: 'AMD',
+            instrument: 'stock',
+            side: order.side,
+            quantity: '10',
+            orderType: 'limit',
+            orderClass: 'bracket',
+            status: 'filled',
+            brokerPayload: {},
+          }),
+        }),
+      )
+      expect(orderResponse.status).toBe(201)
+    }
+
+    for (const fill of [
+      { clientOrderId: 'amd-entry', brokerFillId: 'fill-entry', side: 'buy', price: '100' },
+      { clientOrderId: 'amd-stop', brokerFillId: 'fill-stop', side: 'sell', price: '99.5' },
+    ] as const) {
+      const fillResponse = await handleAutotraderRecordFill(
+        new Request('http://synthesis.test/api/autotrader/fills', {
+          method: 'POST',
+          headers: authedHeaders,
+          body: JSON.stringify({
+            sessionId,
+            clientOrderId: fill.clientOrderId,
+            brokerFillId: fill.brokerFillId,
+            symbol: 'AMD',
+            side: fill.side,
+            quantity: '10',
+            price: fill.price,
+            filledAt: '2026-06-03T15:30:00Z',
+            brokerPayload: {},
+          }),
+        }),
+      )
+      expect(fillResponse.status).toBe(201)
+    }
+
+    const listResponse = await handleAutotraderListSessions(
+      new Request('http://synthesis.test/api/autotrader/sessions?limit=5'),
+    )
+    const detailResponse = await handleAutotraderGetSession(
+      new Request(`http://synthesis.test/api/autotrader/sessions/${sessionId}`),
+      sessionId,
+    )
+    const listPayload = await listResponse.json()
+    const detailPayload = await detailResponse.json()
+
+    expect(listPayload.sessions[0].performance).toMatchObject({
+      totalRealizedR: '-0.5',
+      avgRealizedR: '-0.5',
+      realizedRObservationCount: 1,
+      filledOrderCount: 2,
+    })
+    expect(detailPayload.performance).toEqual(listPayload.sessions[0].performance)
   })
 
   test('clamps future autotrader position snapshot timestamps at ingestion', async () => {

--- a/apps/synthesis/src/server/autotrader-store.ts
+++ b/apps/synthesis/src/server/autotrader-store.ts
@@ -302,6 +302,101 @@ const sumLatestPositionSnapshotRealizedPnl = (snapshots: AutotraderPositionSnaps
   return String(realizedValues.reduce((total, value) => total + value, 0))
 }
 
+const BUY_FILL_SIDES = new Set(['buy', 'buy_to_cover', 'buy_to_open', 'buy_to_close'])
+const SELL_FILL_SIDES = new Set(['sell', 'sell_short', 'sell_to_open', 'sell_to_close'])
+const ROUND_TRIP_EPSILON = 0.000001
+
+const completedRoundTripRealizedRValues = ({
+  tickets,
+  orders,
+  fills,
+  excludedTicketIds,
+}: {
+  tickets: AutotraderTradeTicket[]
+  orders: AutotraderOrder[]
+  fills: AutotraderFill[]
+  excludedTicketIds: Set<string>
+}) => {
+  const ticketById = new Map(tickets.map((ticket) => [ticket.id, ticket]))
+  const orderByClientId = new Map(orders.map((order) => [order.clientOrderId, order]))
+  const fillsByTicketId = new Map<string, AutotraderFill[]>()
+
+  for (const fill of fills) {
+    const order = orderByClientId.get(fill.clientOrderId)
+    const ticketId = order?.ticketId
+    if (!ticketId || excludedTicketIds.has(ticketId) || !ticketById.has(ticketId)) continue
+    const ticketFills = fillsByTicketId.get(ticketId) ?? []
+    ticketFills.push(fill)
+    fillsByTicketId.set(ticketId, ticketFills)
+  }
+
+  const realizedRValues: number[] = []
+  for (const [ticketId, ticketFills] of fillsByTicketId) {
+    const ticket = ticketById.get(ticketId)
+    if (!ticket) continue
+    const entrySide = String(ticket.side).trim().toLowerCase()
+    const entryIsBuy = BUY_FILL_SIDES.has(entrySide)
+    const entryIsSell = SELL_FILL_SIDES.has(entrySide)
+    if (!entryIsBuy && !entryIsSell) continue
+
+    let pnl = 0
+    let netQuantity = 0
+    let buyQuantity = 0
+    let sellQuantity = 0
+    let entryQuantity = 0
+    let entryCost = 0
+    let invalid = false
+
+    for (const fill of ticketFills) {
+      const side = String(fill.side).trim().toLowerCase()
+      const quantity = finiteNumber(fill.quantity)
+      const price = finiteNumber(fill.price)
+      if (quantity == null || price == null || quantity <= 0 || price <= 0) {
+        invalid = true
+        break
+      }
+      if (BUY_FILL_SIDES.has(side)) {
+        buyQuantity += quantity
+        netQuantity += quantity
+        pnl -= quantity * price
+        if (entryIsBuy) {
+          entryQuantity += quantity
+          entryCost += quantity * price
+        }
+      } else if (SELL_FILL_SIDES.has(side)) {
+        sellQuantity += quantity
+        netQuantity -= quantity
+        pnl += quantity * price
+        if (entryIsSell) {
+          entryQuantity += quantity
+          entryCost += quantity * price
+        }
+      } else {
+        invalid = true
+        break
+      }
+    }
+
+    if (invalid || buyQuantity <= 0 || sellQuantity <= 0 || Math.abs(netQuantity) > ROUND_TRIP_EPSILON) continue
+
+    const explicitRiskDollars = finiteNumber(ticket.riskDollars)
+    const stopPrice = finiteNumber(ticket.stopPrice)
+    const entryAveragePrice = entryQuantity > 0 ? entryCost / entryQuantity : null
+    const derivedRiskDollars =
+      stopPrice == null || entryAveragePrice == null ? null : Math.abs(entryAveragePrice - stopPrice) * entryQuantity
+    let riskDollars: number | null = null
+    if (explicitRiskDollars != null && explicitRiskDollars > 0) {
+      riskDollars = explicitRiskDollars
+    } else if (derivedRiskDollars != null && derivedRiskDollars > 0) {
+      riskDollars = derivedRiskDollars
+    }
+    if (riskDollars == null) continue
+    realizedRValues.push(pnl / riskDollars)
+  }
+
+  return realizedRValues
+}
+
 const sessionPerformanceCountsForRecords = ({
   tickets,
   orders,
@@ -317,9 +412,15 @@ const sessionPerformanceCountsForRecords = ({
   status?: AutotraderStatus | null
   positions?: AutotraderPositionSnapshot[]
 }): AutotraderSessionPerformanceCounts => {
+  const exampleTicketIds = new Set(
+    examples.map((example) => example.ticketId).filter((ticketId): ticketId is string => Boolean(ticketId)),
+  )
   const realizedRValues = examples
     .map((example) => (example.realizedR == null ? null : Number(example.realizedR)))
     .filter((value): value is number => value != null && Number.isFinite(value))
+  realizedRValues.push(
+    ...completedRoundTripRealizedRValues({ tickets, orders, fills, excludedTicketIds: exampleTicketIds }),
+  )
   const currentRealizedPnl = status?.realizedPnl ?? sumLatestPositionSnapshotRealizedPnl(positions ?? [])
   return {
     tradeTicketCount: tickets.length,
@@ -863,6 +964,12 @@ type SessionSummaryRow = SessionRow & {
   current_equity: number | string | null
   current_status_realized_pnl: number | string | null
   current_snapshot_realized_pnl: number | string | null
+}
+
+type RealizedRCountRow = {
+  session_id: string
+  realized_r_observation_count: number | string | null
+  total_realized_r: number | string | null
 }
 
 type StatusRow = {
@@ -1742,6 +1849,112 @@ class PostgresAutotraderStore implements AutotraderStore {
     return { scorecards, setupExamples }
   }
 
+  private async realizedRCountsBySessionIds(sessionIds: string[]) {
+    if (!sessionIds.length) return new Map<string, RealizedRCountRow>()
+    const result = await this.pool.query<RealizedRCountRow>(
+      `WITH linked_fills AS (
+         SELECT
+           t.session_id,
+           t.id AS ticket_id,
+           t.risk_dollars,
+           t.stop_price,
+           lower(t.side) AS ticket_side,
+           lower(f.side) AS fill_side,
+           f.quantity,
+           f.price
+         FROM autotrader.fills f
+         JOIN autotrader.orders o
+           ON o.session_id = f.session_id AND o.client_order_id = f.client_order_id
+         JOIN autotrader.trade_tickets t
+           ON t.session_id = f.session_id AND t.id = o.ticket_id
+         WHERE t.session_id = ANY($1::text[])
+           AND NOT EXISTS (
+             SELECT 1
+             FROM autotrader.setup_examples se
+             WHERE se.session_id = t.session_id AND se.ticket_id = t.id
+           )
+       ),
+       round_trips AS (
+         SELECT
+           session_id,
+           ticket_id,
+           bool_or(fill_side IN ('buy', 'buy_to_cover', 'buy_to_open', 'buy_to_close')) AS saw_buy,
+           bool_or(fill_side IN ('sell', 'sell_short', 'sell_to_open', 'sell_to_close')) AS saw_sell,
+           sum(
+             CASE
+               WHEN fill_side IN ('buy', 'buy_to_cover', 'buy_to_open', 'buy_to_close') THEN quantity
+               WHEN fill_side IN ('sell', 'sell_short', 'sell_to_open', 'sell_to_close') THEN -quantity
+               ELSE 0
+             END
+           ) AS net_quantity,
+           sum(
+             CASE
+               WHEN fill_side IN ('buy', 'buy_to_cover', 'buy_to_open', 'buy_to_close') THEN -quantity * price
+               WHEN fill_side IN ('sell', 'sell_short', 'sell_to_open', 'sell_to_close') THEN quantity * price
+               ELSE 0
+             END
+           ) AS pnl,
+           max(risk_dollars) AS risk_dollars,
+           max(stop_price) AS stop_price,
+           sum(
+             CASE
+               WHEN ticket_side IN ('buy', 'buy_to_cover', 'buy_to_open', 'buy_to_close')
+                 AND fill_side IN ('buy', 'buy_to_cover', 'buy_to_open', 'buy_to_close') THEN quantity
+               WHEN ticket_side IN ('sell', 'sell_short', 'sell_to_open', 'sell_to_close')
+                 AND fill_side IN ('sell', 'sell_short', 'sell_to_open', 'sell_to_close') THEN quantity
+               ELSE 0
+             END
+           ) AS entry_quantity,
+           sum(
+             CASE
+               WHEN ticket_side IN ('buy', 'buy_to_cover', 'buy_to_open', 'buy_to_close')
+                 AND fill_side IN ('buy', 'buy_to_cover', 'buy_to_open', 'buy_to_close') THEN quantity * price
+               WHEN ticket_side IN ('sell', 'sell_short', 'sell_to_open', 'sell_to_close')
+                 AND fill_side IN ('sell', 'sell_short', 'sell_to_open', 'sell_to_close') THEN quantity * price
+               ELSE 0
+             END
+           ) AS entry_cost
+         FROM linked_fills
+         GROUP BY session_id, ticket_id
+       ),
+       completed_round_trips AS (
+         SELECT
+           session_id,
+           pnl / COALESCE(
+             NULLIF(risk_dollars, 0),
+             CASE
+               WHEN stop_price IS NOT NULL
+                 AND entry_quantity > 0
+                 AND abs((entry_cost / entry_quantity) - stop_price) > 0
+                 THEN abs((entry_cost / entry_quantity) - stop_price) * entry_quantity
+               ELSE NULL
+             END
+           ) AS realized_r
+         FROM round_trips
+         WHERE saw_buy IS TRUE
+           AND saw_sell IS TRUE
+           AND abs(net_quantity) < 0.000001
+       ),
+       realized_values AS (
+         SELECT se.session_id, se.realized_r
+         FROM autotrader.setup_examples se
+         WHERE se.session_id = ANY($1::text[]) AND se.realized_r IS NOT NULL
+         UNION ALL
+         SELECT session_id, realized_r
+         FROM completed_round_trips
+         WHERE realized_r IS NOT NULL
+       )
+       SELECT
+         session_id,
+         COUNT(*)::int AS realized_r_observation_count,
+         SUM(realized_r) AS total_realized_r
+       FROM realized_values
+       GROUP BY session_id`,
+      [sessionIds],
+    )
+    return new Map(result.rows.map((row) => [row.session_id, row]))
+  }
+
   async listSessions(limit: number): Promise<AutotraderSessionSummary[]> {
     await this.ensureSchema()
     const result = await this.pool.query<SessionSummaryRow>(
@@ -1813,10 +2026,18 @@ class PostgresAutotraderStore implements AutotraderStore {
          ) AS current_snapshot_realized_pnl
        FROM autotrader.sessions s
        ORDER BY s.started_at DESC
-       LIMIT $1`,
+      LIMIT $1`,
       [limit],
     )
-    return result.rows.map(mapSessionSummary)
+    const realizedRCounts = await this.realizedRCountsBySessionIds(result.rows.map((row) => row.id))
+    return result.rows.map((row) => {
+      const realizedRCount = realizedRCounts.get(row.id)
+      return mapSessionSummary({
+        ...row,
+        realized_r_observation_count: realizedRCount?.realized_r_observation_count ?? row.realized_r_observation_count,
+        total_realized_r: realizedRCount?.total_realized_r ?? row.total_realized_r,
+      })
+    })
   }
 
   async getSessionDetail(sessionId: string): Promise<AutotraderSessionDetail | null> {

--- a/scripts/autotrader/session_reconciler.py
+++ b/scripts/autotrader/session_reconciler.py
@@ -94,6 +94,41 @@ def as_list(value: Any) -> list[dict[str, Any]]:
     return [entry for entry in value if isinstance(entry, dict)]
 
 
+def fill_side(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def derived_round_trip_risk_dollars(ticket: dict[str, Any], ticket_fills: list[dict[str, Any]]) -> Decimal | None:
+    entry_side = fill_side(ticket.get("side"))
+    entry_is_buy = entry_side in BUY_SIDES
+    entry_is_sell = entry_side in SELL_SIDES
+    if not entry_is_buy and not entry_is_sell:
+        return None
+    stop_price = decimal_value(ticket.get("stopPrice") or ticket.get("stop_price"))
+    if stop_price is None:
+        return None
+    entry_quantity = Decimal("0")
+    entry_cost = Decimal("0")
+    for fill in ticket_fills:
+        side = fill_side(fill.get("side"))
+        quantity = decimal_value(fill.get("quantity"))
+        price = decimal_value(fill.get("price"))
+        if quantity is None or price is None or quantity <= 0 or price <= 0:
+            return None
+        if entry_is_buy and side in BUY_SIDES:
+            entry_quantity += quantity
+            entry_cost += quantity * price
+        elif entry_is_sell and side in SELL_SIDES:
+            entry_quantity += quantity
+            entry_cost += quantity * price
+    if entry_quantity <= 0:
+        return None
+    per_share_risk = abs((entry_cost / entry_quantity) - stop_price)
+    if per_share_risk <= 0:
+        return None
+    return per_share_risk * entry_quantity
+
+
 def is_stale_market_session(
     session: dict[str, Any], *, now: datetime, grace: timedelta, current_agent_run: str
 ) -> bool:
@@ -222,7 +257,7 @@ def scorecard_observations(detail: dict[str, Any]) -> tuple[list[dict[str, Any]]
         fill_times: list[datetime] = []
         client_order_ids: list[str] = []
         for fill in ticket_fills:
-            side = str(fill.get("side") or "").strip().lower()
+            side = fill_side(fill.get("side"))
             quantity = decimal_value(fill.get("quantity"))
             price = decimal_value(fill.get("price"))
             if quantity is None or price is None or quantity <= 0:
@@ -256,7 +291,17 @@ def scorecard_observations(detail: dict[str, Any]) -> tuple[list[dict[str, Any]]
             skipped["incompleteRoundTrips"] += 1
             continue
 
-        risk_dollars = decimal_value(ticket.get("riskDollars"))
+        explicit_risk_dollars = decimal_value(ticket.get("riskDollars"))
+        derived_risk_dollars = derived_round_trip_risk_dollars(ticket, ticket_fills)
+        risk_dollars_source = None
+        if explicit_risk_dollars is not None and explicit_risk_dollars > 0:
+            risk_dollars = explicit_risk_dollars
+            risk_dollars_source = "ticket_risk_dollars"
+        elif derived_risk_dollars is not None and derived_risk_dollars > 0:
+            risk_dollars = derived_risk_dollars
+            risk_dollars_source = "entry_stop_fill_risk"
+        else:
+            risk_dollars = None
         realized_r = pnl / risk_dollars if risk_dollars and risk_dollars > 0 else None
         if realized_r is not None:
             if realized_r > SCRATCH_R_THRESHOLD:
@@ -300,6 +345,7 @@ def scorecard_observations(detail: dict[str, Any]) -> tuple[list[dict[str, Any]]
                 "pnlDollars": format_decimal(pnl),
                 "netQuantity": format_decimal(net_quantity),
                 "riskDollars": format_decimal(risk_dollars) if risk_dollars is not None else None,
+                "riskDollarsSource": risk_dollars_source,
                 "clientOrderIds": client_order_ids,
             },
         }

--- a/scripts/autotrader/test_session_reconciler.py
+++ b/scripts/autotrader/test_session_reconciler.py
@@ -132,6 +132,20 @@ def completed_round_trip_detail() -> dict[str, Any]:
     }
 
 
+def completed_round_trip_detail_without_ticket_risk() -> dict[str, Any]:
+    detail = completed_round_trip_detail()
+    ticket = detail["tradeTickets"][0]
+    ticket["side"] = "buy"
+    ticket["entryLimitPrice"] = "100"
+    ticket["stopPrice"] = "99"
+    ticket["targetPrice"] = "103"
+    ticket["riskDollars"] = None
+    detail["fills"][1]["price"] = "99.5"
+    detail["session"]["realizedPnl"] = "-5"
+    detail["status"]["realizedPnl"] = "-5"
+    return detail
+
+
 class SessionReconcilerTest(unittest.TestCase):
     def test_finalizes_stale_market_session_when_broker_is_flat(self) -> None:
         synthesis = FakeSynthesis(
@@ -286,6 +300,27 @@ class SessionReconcilerTest(unittest.TestCase):
         summary = payload["summary"]["scorecardObservationSummary"]
         self.assertEqual(summary["generated"], 1)
         self.assertEqual(summary["skipped"]["missingRoundTripSides"], 1)
+
+    def test_derives_scorecard_realized_r_from_entry_stop_risk_when_ticket_risk_is_missing(self) -> None:
+        synthesis = FakeSynthesis([stale_session()], {"session-1": completed_round_trip_detail_without_ticket_risk()})
+
+        session_reconciler.reconcile_sessions(
+            synthesis=synthesis,  # type: ignore[arg-type]
+            alpaca=FakeAlpaca(account={"equity": "29995.00"}),  # type: ignore[arg-type]
+            now=datetime(2026, 6, 2, 20, 10, tzinfo=UTC),
+            limit=50,
+            grace_minutes=5,
+            finalize_stale_flat=True,
+            backfill_finalized_flat=False,
+            current_agent_run="",
+        )
+
+        observation = synthesis.finalized[0]["scorecardObservations"][0]
+        self.assertEqual(observation["outcome"], "loss")
+        self.assertEqual(observation["realizedR"], "-0.5")
+        self.assertEqual(observation["payload"]["pnlDollars"], "-5")
+        self.assertEqual(observation["payload"]["riskDollars"], "10")
+        self.assertEqual(observation["payload"]["riskDollarsSource"], "entry_stop_fill_risk")
 
     def test_backfills_finalized_flat_market_session_without_examples(self) -> None:
         session = stale_session(


### PR DESCRIPTION
## Summary

- Derives running-session realized R from completed recorded round trips when `riskDollars` is missing by falling back to entry-fill-to-stop risk.
- Keeps Synthesis list and detail performance aligned by adding a batched Postgres realized-R aggregation for running sessions.
- Updates the post-close session reconciler so scorecard observations receive the same derived realized R and risk source metadata.

## Related Issues

None

## Testing

- `bun run --filter synthesis test -- src/server/__tests__/autotrader-performance.test.ts src/server/__tests__/api.test.ts src/server/__tests__/mcp.test.ts src/routes/-autotrader-alerts.test.ts -t 'autotrader|Autotrader|runtime|performance|scorecard|canonical|running-session'`
- `python3 -m unittest discover -v` from `scripts/autotrader`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test`
- `python3 scripts/autotrader/market_open_cycle.py --self-test`
- `bunx oxfmt --check apps/synthesis/src/server/autotrader-store.ts apps/synthesis/src/server/__tests__/api.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
