### PR TITLE
fix(torghut): preserve runtime window source collection metadata

### DIFF
--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -809,7 +809,11 @@ def _summarize_runtime_window_import_target(
         "target_dsn_env": _text(target.get("target_dsn_env")),
         "window_start": _text(target.get("window_start")),
         "window_end": _text(target.get("window_end")),
+        "observed_stage": _text(target.get("observed_stage")),
         "source_collection_authorized": _is_source_collection_target(target),
+        "source_collection_authorization_scope": _text(
+            target.get("source_collection_authorization_scope")
+        ),
         "paper_probation_authorized": _bool(target.get("paper_probation_authorized")),
         "evidence_collection_ok": _bool(target.get("evidence_collection_ok")),
         "handoff": _text(target.get("handoff")),

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2106,13 +2106,28 @@ def _runtime_ledger_target_metadata_blockers(
             break
 
     expected_candidate_id = _text_or_none(metadata.get("candidate_id"))
+    artifact_metadata_expected = bool(
+        planned_refs
+        or loaded_refs
+        or any(
+            metadata.get(key) is not None
+            for key in (
+                "runtime_ledger_artifact_row_count",
+                "exact_replay_ledger_artifact_row_count",
+                "runtime_ledger_artifact_fill_count",
+                "exact_replay_ledger_artifact_fill_count",
+                "replay_window_weekday_count",
+                "replay_min_window_weekday_count",
+            )
+        )
+    )
     loaded_candidate_ids = _metadata_text_list(
         runtime_ledger_artifact_metadata.get("runtime_ledger_artifact_candidate_ids")
     )
     loaded_candidate_id = _text_or_none(
         runtime_ledger_artifact_metadata.get("runtime_ledger_artifact_candidate_id")
     )
-    if expected_candidate_id is not None:
+    if expected_candidate_id is not None and artifact_metadata_expected:
         if loaded_candidate_ids:
             if expected_candidate_id not in loaded_candidate_ids:
                 blockers.append("runtime_ledger_artifact_candidate_id_mismatch")

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -782,6 +782,9 @@ class TestBuildRevenueRepairDigest(TestCase):
                     "window_start": "2026-06-02T13:30:00+00:00",
                     "window_end": "2026-06-02T20:00:00+00:00",
                     "source_collection_authorized": True,
+                    "source_collection_authorization_scope": (
+                        "source_window_evidence_collection_only"
+                    ),
                     "source_collection_reason_codes": [
                         "paper_probe_runtime_activity_positive"
                     ],
@@ -848,7 +851,12 @@ class TestBuildRevenueRepairDigest(TestCase):
         self.assertEqual(top_targets[0]["candidate_id"], "cand-source-collection")
         self.assertEqual(top_targets[0]["source_dsn_env"], "SIM_DB_DSN")
         self.assertEqual(top_targets[0]["target_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(top_targets[0]["observed_stage"], "paper")
         self.assertTrue(top_targets[0]["source_collection_authorized"])
+        self.assertEqual(
+            top_targets[0]["source_collection_authorization_scope"],
+            "source_window_evidence_collection_only",
+        )
         self.assertEqual(top_targets[0]["max_notional"], "0")
         self.assertFalse(top_targets[0]["promotion_allowed"])
         self.assertFalse(top_targets[0]["final_promotion_allowed"])

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -2898,6 +2898,37 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ["runtime_ledger_artifact_candidate_id_mismatch"],
         )
 
+    def test_runtime_ledger_target_metadata_does_not_require_artifact_candidate_for_source_dsn(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 13, 17, 0, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 13, 17, 30, tzinfo=timezone.utc)
+
+        self.assertEqual(
+            _runtime_ledger_target_metadata_blockers(
+                target_metadata={
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "source_collection_authorized": True,
+                    "source_collection_authorization_scope": (
+                        "source_window_evidence_collection_only"
+                    ),
+                    "source_kind": "runtime_ledger_source_collection_candidate",
+                    "window_start": "2026-05-13T17:00:00+00:00",
+                    "window_end": "2026-05-13T17:30:00+00:00",
+                },
+                runtime_ledger_artifact_metadata={
+                    "runtime_ledger_artifact_refs": [],
+                    "runtime_ledger_ignored_artifact_refs": [],
+                    "runtime_ledger_artifact_row_count": 0,
+                    "runtime_ledger_artifact_fill_count": 0,
+                    "runtime_ledger_artifact_tca_row_count": 0,
+                },
+                window_start=window_start,
+                window_end=window_end,
+            ),
+            [],
+        )
+
     def test_runtime_window_proof_hygiene_blocks_missing_authoritative_gates(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Expose `observed_stage` and `source_collection_authorization_scope` on `/trading/revenue-repair` runtime-window import targets so the zero-notional source-collection receipt has complete command metadata.
- Keep artifact candidate-id validation tied to actual artifact refs/counts/window constraints, avoiding a false `runtime_ledger_artifact_candidate_id_missing` blocker for source-DSN runtime-window imports.
- Add focused regressions for the revenue repair summary and runtime-window import target metadata blocker behavior.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_build_revenue_repair_digest.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff check app/trading/revenue_repair.py scripts/import_hypothesis_runtime_windows.py tests/test_build_revenue_repair_digest.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check app/trading/revenue_repair.py scripts/import_hypothesis_runtime_windows.py tests/test_build_revenue_repair_digest.py tests/test_import_hypothesis_runtime_windows.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live audit-only readback against `torghut-01013` for `H-PAIRS-01` / `c88421d619759b2cfaa6f4d0` using `scripts/import_hypothesis_runtime_windows.py --audit-only --json`; it produced no writes, found one source runtime-ledger bucket, and confirmed remaining authority blockers.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
