### PR TITLE
fix(autotrader): complete market runs after close

### DIFF
--- a/argocd/applications/autotrader/autonomous-trader-agentrun-template.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-agentrun-template.yaml
@@ -18,7 +18,7 @@ spec:
   implementationSpecRef:
     name: autonomous-trader-v1
   goal:
-    objective: Reach 500000 USD account equity in the dedicated Synthesis Alpaca paper account through autonomous market-open day trading while recording every decision, risk check, broker action, reconciliation result, and scorecard update in Synthesis.
+    objective: Advance the dedicated Synthesis Alpaca paper account toward 500000 USD equity during this market-open session; after market close, finalize the session, record decisions/risk/broker reconciliation/scorecard feedback in Synthesis, write the report, and complete this AgentRun.
   vcsRef:
     name: github
   vcsPolicy:

--- a/argocd/applications/autotrader/autonomous-trader-green-agentrun-template.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-green-agentrun-template.yaml
@@ -18,7 +18,7 @@ spec:
   implementationSpecRef:
     name: autonomous-trader-v1-green
   goal:
-    objective: Reach 500000 USD account equity in the dedicated Synthesis Alpaca paper account through autonomous market-open day trading while recording every decision, risk check, broker action, reconciliation result, and scorecard update in Synthesis.
+    objective: Advance the dedicated Synthesis Alpaca paper account toward 500000 USD equity during this market-open session; after market close, finalize the session, record decisions/risk/broker reconciliation/scorecard feedback in Synthesis, write the report, and complete this AgentRun.
   vcsRef:
     name: github
   vcsPolicy:

--- a/argocd/applications/autotrader/autonomous-trader-green-implspec.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-green-implspec.yaml
@@ -28,6 +28,7 @@ spec:
     - Bootstrap the analysis repo, read scorecards before grading, and use the live scan-cycle helper for candidate ranking.
     - Submit strategy broker mutations only after Synthesis risk/order records, runner strategy guard approval, and deterministic client order ids.
     - Keep market-open runs cycling until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    - Complete each market-open AgentRun after market-close session finalization; do not keep post-close heartbeats waiting for the next scheduled open.
     - Finalize sessions with realized scorecard observations and write `report.md` as the only operator-facing artifact.
   text: |-
     Run the Synthesis autonomous paper-trader green preview lane using the Agent default system prompt as the durable operating policy.

--- a/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-green-system-prompt-configmap.yaml
@@ -40,11 +40,11 @@ data:
     8. If runner `accountGate.positionManagement.actionRequired=true`, manage the existing broker state before any new entry: repair or flatten unprotected/invalid stops, tighten stops to the runner `recommendedStopPrice` when provided, record the replacement order in Synthesis, then refresh broker state.
     9. The runner records planned/submitted/reconciled new-entry order state in Synthesis. For existing-position repairs, record replacement risk/order in Synthesis before Alpaca mutation.
     10. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
-    11. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    11. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state. When runner `summary.action=market_closed` or `blocker=market_closed`, verify broker state, finalize the session, write the final report, complete this AgentRun, and stop; do not keep post-close heartbeats waiting for the next scheduled open.
 
     Mode behavior:
     - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.
-    - `market-open`: run bootstrap once, then repeat `market_open_cycle.py`. Candidate, no-trade, rejection, account-gated, and protected-position states are cycle outcomes, not terminal outcomes. Do not complete or answer finally until close, target, or hard stop.
+    - `market-open`: run bootstrap once, then repeat `market_open_cycle.py`. Candidate, no-trade, rejection, account-gated, and protected-position states are cycle outcomes, not terminal outcomes. Market close is terminal for this AgentRun even when the 500000 USD account target remains incomplete; the next Schedule-created AgentRun owns the next regular session.
 
     Safety:
     - Route orders only to the Alpaca paper account.
@@ -63,6 +63,6 @@ data:
     - Heartbeat at least every 60 seconds while waiting.
 
     Reporting and finalization:
-    - A `running` report is a checkpoint, not completion. Write Synthesis status/event plus `report.md`, sleep up to 60 seconds, then continue.
+    - A `running` report is a checkpoint, not completion. Write Synthesis status/event plus `report.md`, sleep up to 60 seconds, then continue. After market-close finalization, do not write more waiting heartbeats.
     - Finish only with `target_reached`, `market_closed`, `dry_run_complete`, `scorecard_readback_waiting`, `scorecard_readback_complete`, or `hard_stop`.
     - Before finishing, call `autotrader_finalize_session` with realized scorecard observations, slippage, hold time, MFE/MAE, and mistake tags.

--- a/argocd/applications/autotrader/autonomous-trader-implspec.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-implspec.yaml
@@ -26,6 +26,7 @@ spec:
     - Bootstrap the analysis repo, read scorecards before grading, and use the live scan-cycle helper for candidate ranking.
     - Submit strategy broker mutations only after Synthesis risk/order records, runner strategy guard approval, and deterministic client order ids.
     - Keep market-open runs cycling until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    - Complete each market-open AgentRun after market-close session finalization; do not keep post-close heartbeats waiting for the next scheduled open.
     - Finalize sessions with realized scorecard observations and write `report.md` as the only operator-facing artifact.
   text: |-
     Run the Synthesis autonomous paper-trader using the Agent default system prompt as the durable operating policy.

--- a/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/autotrader/autonomous-trader-system-prompt-configmap.yaml
@@ -40,11 +40,11 @@ data:
     8. If runner `accountGate.positionManagement.actionRequired=true`, manage the existing broker state before any new entry: repair or flatten unprotected/invalid stops, tighten stops to the runner `recommendedStopPrice` when provided, record the replacement order in Synthesis, then refresh broker state.
     9. The runner records planned/submitted/reconciled new-entry order state in Synthesis. For existing-position repairs, record replacement risk/order in Synthesis before Alpaca mutation.
     10. After broker changes, reconcile by broker/client order id, refresh account/positions/orders, and update Synthesis before more risk.
-    11. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state.
+    11. Continue until market close, 500000 USD equity, or hard unrecoverable broker/order/visibility state. When runner `summary.action=market_closed` or `blocker=market_closed`, verify broker state, finalize the session, write the final report, complete this AgentRun, and stop; do not keep post-close heartbeats waiting for the next scheduled open.
 
     Mode behavior:
     - `scorecard-readback`: no Alpaca mutations; bootstrap handles readback/reconcile/finalize/report; after exit 0, complete goal and stop. No grep/tests/clone/scan/logs/web/extra proof.
-    - `market-open`: run bootstrap once, then repeat `market_open_cycle.py`. Candidate, no-trade, rejection, account-gated, and protected-position states are cycle outcomes, not terminal outcomes. Do not complete or answer finally until close, target, or hard stop.
+    - `market-open`: run bootstrap once, then repeat `market_open_cycle.py`. Candidate, no-trade, rejection, account-gated, and protected-position states are cycle outcomes, not terminal outcomes. Market close is terminal for this AgentRun even when the 500000 USD account target remains incomplete; the next Schedule-created AgentRun owns the next regular session.
 
     Safety:
     - Route orders only to the Alpaca paper account.
@@ -63,6 +63,6 @@ data:
     - Heartbeat at least every 60 seconds while waiting.
 
     Reporting and finalization:
-    - A `running` report is a checkpoint, not completion. Write Synthesis status/event plus `report.md`, sleep up to 60 seconds, then continue.
+    - A `running` report is a checkpoint, not completion. Write Synthesis status/event plus `report.md`, sleep up to 60 seconds, then continue. After market-close finalization, do not write more waiting heartbeats.
     - Finish only with `target_reached`, `market_closed`, `dry_run_complete`, `scorecard_readback_waiting`, `scorecard_readback_complete`, or `hard_stop`.
     - Before finishing, call `autotrader_finalize_session` with realized scorecard observations, slippage, hold time, MFE/MAE, and mistake tags.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -781,6 +781,7 @@ describe('autonomous trader provider', () => {
       const scheduleSpec = objectAt(lane.schedule, 'spec')
       const templateSpec = objectAt(lane.template, 'spec')
       const parameters = objectAt(templateSpec, 'parameters')
+      const goalObjective = String(objectAt(objectAt(templateSpec, 'goal'), 'objective') ?? '')
       const role = objectAt(scheduleSpec, 'suspend') === false ? 'active' : 'preview'
       const laneResources = [lane.schedule, lane.template, lane.agent, lane.implementationSpec, lane.systemPrompt]
       const systemPromptText = String(objectAt(objectAt(lane.systemPrompt, 'data'), 'system-prompt.md') ?? '')
@@ -804,10 +805,15 @@ describe('autonomous trader provider', () => {
       expect(objectAt(parameters, 'sessionReconcileEnabled')).toBe(role === 'active' ? 'true' : 'false')
       expect(objectAt(parameters, 'accountType')).toBe('paper')
       expect(objectAt(parameters, 'targetEquityUsd')).toBe('500000')
+      expect(goalObjective).toContain('Advance the dedicated Synthesis Alpaca paper account toward 500000 USD')
+      expect(goalObjective).toContain('complete this AgentRun')
+      expect(goalObjective).not.toContain('Reach 500000 USD account equity')
       expect(systemPromptText).toContain('Ad hoc Python scripts and scratch files are allowed for immediate analysis')
       expect(systemPromptText).toContain('decisionSummary.bestCandidate.riskDirective')
       expect(systemPromptText).toContain('recommendedRiskDollars')
       expect(systemPromptText).toContain('Positive scorecard edge should be acted on aggressively')
+      expect(systemPromptText).toContain('complete this AgentRun, and stop')
+      expect(systemPromptText).toContain('do not keep post-close heartbeats waiting')
     }
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_MODE')).toBe('{{parameters.mode}}')
     expect(objectAt(envTemplate, 'AUTONOMOUS_TRADER_SYNTHESIS_SESSION_MODE')).toBe(


### PR DESCRIPTION
## Summary

- Scope market-open AgentRun objectives to one regular-session run instead of the entire 500000 USD account target.
- Make market close terminal for each scheduled blue/green AgentRun after broker verification, Synthesis finalization, and report writing.
- Add smoke coverage so future autotrader prompt/template changes cannot restore post-close heartbeat waiting.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t 'runs the market-open trader on its dedicated paper account|wires the analysis daytrading bootstrap into the trader provider'`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t 'autonomous trader provider'`
- `kubectl kustomize argocd/applications/autotrader > /tmp/autotrader-render.yaml && rg -n "complete this AgentRun|post-close heartbeats|Advance the dedicated Synthesis Alpaca paper account" /tmp/autotrader-render.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
