### PR TITLE
fix(autotrader): expand scorecard readback coverage

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -38,6 +38,7 @@ SYNTHESIS_SIDES = {
     "sell_to_close",
 }
 ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
+DEFAULT_SCORECARD_LIMIT = 100
 MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
 MIN_ACTIONABLE_BRACKET_R = Decimal("2.0")
 MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE = 2
@@ -2317,7 +2318,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--start")
     parser.add_argument("--end")
     parser.add_argument("--feed", default="iex")
-    parser.add_argument("--scorecard-limit", type=int, default=20)
+    parser.add_argument("--scorecard-limit", type=int, default=DEFAULT_SCORECARD_LIMIT)
     parser.add_argument("--timeout-seconds", type=float, default=10.0)
     parser.add_argument("--synthesis-base-url")
     parser.add_argument("--analysis-context")

--- a/scripts/autotrader/market_open_cycle.py
+++ b/scripts/autotrader/market_open_cycle.py
@@ -942,7 +942,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--start")
     parser.add_argument("--end")
     parser.add_argument("--feed", default="iex")
-    parser.add_argument("--scorecard-limit", type=int, default=20)
+    parser.add_argument("--scorecard-limit", type=int, default=live_scan_cycle.DEFAULT_SCORECARD_LIMIT)
     parser.add_argument("--timeout-seconds", type=float, default=10.0)
     parser.add_argument("--synthesis-base-url")
     parser.add_argument("--analysis-context")

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -15,6 +15,11 @@ class LiveScanCycleTest(unittest.TestCase):
     def test_normalizes_watchlist(self) -> None:
         self.assertEqual(live_scan_cycle.normalize_watchlist([" spy ", "SPY", "nvda"]), ["SPY", "NVDA"])
 
+    def test_parser_defaults_to_full_scorecard_api_window(self) -> None:
+        args = live_scan_cycle.build_parser().parse_args([])
+
+        self.assertEqual(args.scorecard_limit, 100)
+
     def test_picks_next_cycle_number(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -2076,7 +2081,7 @@ class LiveScanCycleTest(unittest.TestCase):
                     case.assertIsNone(query)
                     return {"session": {"id": "session-1"}, "orders": [], "tradeTickets": []}
                 case.assertEqual(path, "/api/autotrader/scorecards")
-                case.assertEqual(query, {"limit": "20"})
+                case.assertEqual(query, {"limit": "100"})
                 return {
                     "scorecards": [
                         {

--- a/scripts/autotrader/test_market_open_cycle.py
+++ b/scripts/autotrader/test_market_open_cycle.py
@@ -20,6 +20,11 @@ class FakeSynthesis:
 
 
 class MarketOpenCycleTest(unittest.TestCase):
+    def test_parser_defaults_to_full_scorecard_api_window(self) -> None:
+        args = market_open_cycle.build_parser().parse_args([])
+
+        self.assertEqual(args.scorecard_limit, 100)
+
     def test_loads_session_runs_guarded_scan_records_checkpoint_and_report(self) -> None:
         synthesis = FakeSynthesis()
 
@@ -172,6 +177,7 @@ class MarketOpenCycleTest(unittest.TestCase):
             self.assertEqual(intent["synthesisRecordOrderInput"]["status"], "planned")
             self.assertTrue(captured_args[0].record_tickets)
             self.assertTrue(captured_args[0].respect_account_gate)
+            self.assertEqual(captured_args[0].scorecard_limit, 100)
             self.assertEqual(captured_args[0].watchlist, ["NVDA"])
             self.assertEqual(captured_args[0].analysis_context, str(root / "analysis-context.json"))
             self.assertTrue((root / "last-cycle.json").exists())


### PR DESCRIPTION
## Summary

- Increases the deterministic autotrader scorecard readback default from `20` to the Synthesis API window of `100`.
- Keeps `market_open_cycle.py` and `live_scan_cycle.py` on the same named default so scheduled market-open runs fetch the wider scorecard corpus.
- Adds parser/default propagation tests so the runner keeps seeing older still-relevant winners, not only the most recently updated scorecards.

## Related Issues

None

## Testing

- `cd scripts/autotrader && python3 -m py_compile live_scan_cycle.py market_open_cycle.py test_live_scan_cycle.py test_market_open_cycle.py strategy_order_guard.py protective_preflight.py && python3 -m unittest discover -v`
- `python3 scripts/autotrader/live_scan_cycle.py --self-test && python3 scripts/autotrader/market_open_cycle.py --self-test && python3 scripts/autotrader/strategy_order_guard.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t autonomous`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
