### PR TITLE
fix(torghut): allow sim evidence to mirror live targets

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6685,22 +6685,12 @@ def _paper_route_target_plan_url_points_to_self(parsed: Any) -> bool:
     if not hostname:
         return False
 
-    self_hosts = {
-        "localhost",
-        "127.0.0.1",
-        "::1",
-        "torghut",
-        "torghut.torghut",
-        "torghut.torghut.svc",
-        "torghut.torghut.svc.cluster.local",
-        "torghut-sim",
-        "torghut-sim.torghut",
-        "torghut-sim.torghut.svc",
-        "torghut-sim.torghut.svc.cluster.local",
-    }
+    self_hosts = {"localhost", "127.0.0.1", "::1"}
     service_name = os.getenv("K_SERVICE", "").strip().lower()
     namespace = os.getenv("POD_NAMESPACE", os.getenv("NAMESPACE", "")).strip().lower()
     if service_name:
+        if not namespace and service_name in {"torghut", "torghut-sim"}:
+            namespace = "torghut"
         self_hosts.add(service_name)
         if namespace:
             self_hosts.update(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -11683,7 +11683,17 @@ class TestTradingApi(TestCase):
         main_module._paper_route_target_plan_success_cache = None
         try:
             settings.trading_paper_route_target_plan_url = "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan"
-            with patch("app.main.HTTPConnection") as connection:
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "K_SERVICE": "torghut-sim",
+                        "POD_NAMESPACE": "",
+                        "NAMESPACE": "",
+                    },
+                ),
+                patch("app.main.HTTPConnection") as connection,
+            ):
                 plan = _load_external_paper_route_target_plan()
             connection.assert_not_called()
         finally:
@@ -11711,6 +11721,44 @@ class TestTradingApi(TestCase):
             {
                 "K_SERVICE": "route-sim",
                 "POD_NAMESPACE": "proof-ns",
+            },
+        ):
+            self.assertTrue(
+                main_module._paper_route_target_plan_url_points_to_self(parsed)
+            )
+
+    def test_paper_route_target_plan_self_reference_allows_live_from_sim(
+        self,
+    ) -> None:
+        parsed = urlsplit(
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan"
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "K_SERVICE": "torghut-sim",
+                "POD_NAMESPACE": "",
+                "NAMESPACE": "",
+            },
+        ):
+            self.assertFalse(
+                main_module._paper_route_target_plan_url_points_to_self(parsed)
+            )
+
+    def test_paper_route_target_plan_self_reference_defaults_torghut_namespace(
+        self,
+    ) -> None:
+        parsed = urlsplit(
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan"
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "K_SERVICE": "torghut",
+                "POD_NAMESPACE": "",
+                "NAMESPACE": "",
             },
         ):
             self.assertTrue(


### PR DESCRIPTION
## Summary

- Fixes the paper-route target-plan self-reference guard so `torghut-sim` can fetch the live `torghut` target-plan URL.
- Keeps same-service target-plan URLs fail-closed by deriving self hosts from `K_SERVICE` and the service namespace.
- Adds regressions for same-service rejection, sim-to-live allowance, and default Torghut namespace handling.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan_self_reference or load_external_paper_route_target_plan_rejects_self_reference or external_paper_route_target_preserves_live_symbol_envelope' -q`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan' -q`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
