### PR TITLE
fix(torghut): allow sim target plan provider fetch

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6689,14 +6689,6 @@ def _paper_route_target_plan_url_points_to_self(parsed: Any) -> bool:
         "localhost",
         "127.0.0.1",
         "::1",
-        "torghut",
-        "torghut.torghut",
-        "torghut.torghut.svc",
-        "torghut.torghut.svc.cluster.local",
-        "torghut-sim",
-        "torghut-sim.torghut",
-        "torghut-sim.torghut.svc",
-        "torghut-sim.torghut.svc.cluster.local",
     }
     service_name = os.getenv("K_SERVICE", "").strip().lower()
     namespace = os.getenv("POD_NAMESPACE", os.getenv("NAMESPACE", "")).strip().lower()
@@ -6710,6 +6702,19 @@ def _paper_route_target_plan_url_points_to_self(parsed: Any) -> bool:
                     f"{service_name}.{namespace}.svc.cluster.local",
                 }
             )
+    else:
+        self_hosts.update(
+            {
+                "torghut",
+                "torghut.torghut",
+                "torghut.torghut.svc",
+                "torghut.torghut.svc.cluster.local",
+                "torghut-sim",
+                "torghut-sim.torghut",
+                "torghut-sim.torghut.svc",
+                "torghut-sim.torghut.svc.cluster.local",
+            }
+        )
     return hostname in self_hosts
 
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -11692,6 +11692,25 @@ class TestTradingApi(TestCase):
 
         self.assertEqual(plan["load_error"], "paper_route_target_plan_self_reference")
 
+    def test_paper_route_target_plan_self_reference_defaults_conservative(
+        self,
+    ) -> None:
+        parsed = urlsplit(
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan"
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "K_SERVICE": "",
+                "POD_NAMESPACE": "",
+                "NAMESPACE": "",
+            },
+        ):
+            self.assertTrue(
+                main_module._paper_route_target_plan_url_points_to_self(parsed)
+            )
+
     def test_paper_route_target_plan_self_reference_requires_host(self) -> None:
         parsed = urlsplit("/trading/paper-route-target-plan")
 
@@ -11715,6 +11734,30 @@ class TestTradingApi(TestCase):
         ):
             self.assertTrue(
                 main_module._paper_route_target_plan_url_points_to_self(parsed)
+            )
+
+    def test_paper_route_target_plan_self_reference_allows_provider_from_sim(
+        self,
+    ) -> None:
+        provider = urlsplit(
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan"
+        )
+        current_service = urlsplit(
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan"
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "K_SERVICE": "torghut-sim",
+                "POD_NAMESPACE": "torghut",
+            },
+        ):
+            self.assertFalse(
+                main_module._paper_route_target_plan_url_points_to_self(provider)
+            )
+            self.assertTrue(
+                main_module._paper_route_target_plan_url_points_to_self(current_service)
             )
 
     def test_load_external_paper_route_target_plan_uses_recent_success_after_timeout(


### PR DESCRIPTION
## Summary

- Allows `torghut-sim` to fetch the provider target plan from `torghut.torghut.svc.cluster.local` instead of treating that provider URL as a self-reference.
- Keeps self-reference protection for localhost, the current `K_SERVICE` host, and conservative no-service-identity defaults.
- Adds regression coverage for the live sim/provider topology and the fallback self-reference path.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k "paper_route_target_plan_self_reference or trading_paper_route_evidence_uses_external_plan_when_url_configured" -q`
- `uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_trading_api.py -k "paper_route_target_plan_self_reference" --cov=app --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
