### PR TITLE
fix(torghut): reopen materialized route retries

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -6147,6 +6147,8 @@ class SimpleTradingPipeline(TradingPipeline):
         if self._proof_floor_submission_block_reason(proof_floor) is None:
             return None
 
+        self.executor.update_decision_params(session, decision_row, decision.params)
+        self.executor.sync_decision_state(session, decision_row, decision)
         decision_row.status = "planned"
         decision_row.created_at = trading_now(account_label=self.account_label)
         decision_json = dict(cast(Mapping[str, Any], decision_row.decision_json))
@@ -6198,7 +6200,13 @@ class SimpleTradingPipeline(TradingPipeline):
             return None
         if decision_row.alpaca_account_label != self.account_label:
             return None
-        if decision_row.status != "planned":
+        retryable_status = decision_row.status in {"blocked", "rejected"} and (
+            self._paper_route_quote_routeability_retry_metadata(decision_row)
+            is not None
+            or self._paper_route_target_price_retry_metadata(decision_row) is not None
+            or self._paper_route_probe_retry_metadata(decision_row) is not None
+        )
+        if decision_row.status != "planned" and not retryable_status:
             return None
         if self.executor.execution_exists(session, decision_row):
             return None
@@ -6206,10 +6214,11 @@ class SimpleTradingPipeline(TradingPipeline):
         decision_row.strategy_id = strategy.id
         decision_row.symbol = decision.symbol
         decision_row.timeframe = decision.timeframe
-        decision_row.decision_json = coerce_json_payload(
-            decision.model_dump(mode="json")
-        )
         decision_row.rationale = decision.rationale
+        if decision_row.status == "planned":
+            decision_row.decision_json = coerce_json_payload(
+                decision.model_dump(mode="json")
+            )
         session.add(decision_row)
         session.commit()
         session.refresh(decision_row)
@@ -6249,9 +6258,6 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         if reopened_quote_routeability is not None:
             return reopened_quote_routeability
-        if "paper_route_target_plan" in decision.params:
-            self.executor.update_decision_params(session, decision_row, decision.params)
-            self.executor.sync_decision_state(session, decision_row, decision)
         reopened_exit = self._reopen_rejected_paper_route_probe_exit_decision(
             session=session,
             decision=decision,
@@ -6266,6 +6272,16 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         if reopened_price_retry is not None:
             return reopened_price_retry
+        reopened_bounded_collection = self._reopen_bounded_sim_collection_decision(
+            session=session,
+            decision=decision,
+            decision_row=decision_row,
+        )
+        if reopened_bounded_collection is not None:
+            return reopened_bounded_collection
+        if "paper_route_target_plan" in decision.params:
+            self.executor.update_decision_params(session, decision_row, decision.params)
+            self.executor.sync_decision_state(session, decision_row, decision)
         if (
             decision_row.status == "planned"
             and self._paper_route_target_source_cap(decision.params) is not None
@@ -6274,13 +6290,6 @@ class SimpleTradingPipeline(TradingPipeline):
             session.add(decision_row)
             session.commit()
             session.refresh(decision_row)
-        reopened_bounded_collection = self._reopen_bounded_sim_collection_decision(
-            session=session,
-            decision=decision,
-            decision_row=decision_row,
-        )
-        if reopened_bounded_collection is not None:
-            return reopened_bounded_collection
         if (
             _safe_text(
                 decision.params.get("paper_route_materialized_trade_decision_id")

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -7953,6 +7953,121 @@ class TestTradingPipeline(TestCase):
                 )
             )
 
+    def test_materialized_target_plan_quote_routeability_retry_reopens_row(
+        self,
+    ) -> None:
+        from app import config
+
+        event_ts = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 2
+        config.settings.trading_simple_paper_route_probe_retry_batch_limit = 4
+        config.settings.trading_simple_paper_route_probe_retry_scan_limit = 16
+
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                description="bounded H-PAIRS materialized target",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            row = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"params": {}},
+                decision_hash="materialized-quote-retry",
+                status="planned",
+                created_at=event_ts,
+            )
+            session.add(row)
+            session.commit()
+            session.refresh(row)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=event_ts,
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("1"),
+                rationale="materialized target",
+                params={
+                    "paper_route_materialized_trade_decision_id": str(row.id),
+                    "paper_route_target_plan": {
+                        "candidate_id": "cand-materialized-retry",
+                        "hypothesis_id": "H-PAIRS-01",
+                    },
+                    "paper_route_target_plan_source_decision": {
+                        "candidate_id": "cand-materialized-retry",
+                        "hypothesis_id": "H-PAIRS-01",
+                    },
+                    "quote_routeability": {
+                        "schema_version": "torghut.paper-route-quote-routeability.v1",
+                        "status": "blocked",
+                        "reason": "spread_bps_exceeded",
+                    },
+                },
+            )
+            decision_json = decision.model_dump(mode="json")
+            decision_json["submission_stage"] = "rejected_pre_submit"
+            decision_json["reject_reason_atomic"] = ["spread_bps_exceeded"]
+            row.status = "rejected"
+            row.decision_json = decision_json
+            session.add(row)
+            session.commit()
+
+            with patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=event_ts,
+            ):
+                retries = pipeline._paper_route_probe_retry_decisions(session=session)
+                self.assertEqual([retry.symbol for retry in retries], ["AAPL"])
+                reopened = pipeline._ensure_pending_decision_row(
+                    session=session,
+                    decision=retries[0],
+                    strategy=strategy,
+                )
+
+            self.assertIsNotNone(reopened)
+            session.refresh(row)
+            row_json = cast(dict[str, Any], row.decision_json)
+            row_params = cast(dict[str, Any], row_json.get("params"))
+
+            self.assertEqual(row.status, "planned")
+            self.assertEqual(
+                row_json.get("submission_stage"),
+                "paper_route_quote_routeability_retry_pending",
+            )
+            self.assertNotIn("quote_routeability", row_params)
+            self.assertEqual(
+                row_json.get("paper_route_quote_routeability_retry_attempts"),
+                1,
+            )
+
     def test_simple_pipeline_signal_cycle_still_generates_target_plan_source_decision(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Allow retry-eligible rejected or blocked materialized paper-route decisions to be claimed so existing retry reopen logic can run.
- Preserve prior retry metadata while merging current decision params for bounded collection retries.
- Add regression coverage for a rejected materialized target-plan row blocked by transient quote routeability.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/test_trading_pipeline.py`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
