### PR TITLE
feat(torghut): add option gamma replay stress

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -45,6 +45,9 @@ from app.trading.discovery.nonlinear_impact_execution_stress import (
 from app.trading.discovery.order_book_observability_stress import (
     extract_order_book_observability_stress,
 )
+from app.trading.discovery.option_gamma_flow_stress import (
+    extract_option_gamma_flow_stress,
+)
 from app.trading.discovery.order_transition_stress import (
     extract_order_transition_stress,
 )
@@ -77,6 +80,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "alpha_decay_predictability_stress",
     "counterfactual_regime_replay_stress",
     "nonlinear_impact_execution_stress",
+    "option_gamma_flow_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -167,6 +171,9 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     nonlinear_impact_execution_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    option_gamma_flow_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -273,6 +280,7 @@ class FastReplayPreviewRow:
             "nonlinear_impact_execution_stress": dict(
                 self.nonlinear_impact_execution_stress
             ),
+            "option_gamma_flow_stress": dict(self.option_gamma_flow_stress),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
             "exact_replay_required": True,
@@ -462,6 +470,7 @@ class FastReplayPreviewResult:
                 "alpha_decay_predictability_stress": "deterministic multi-horizon spread-adjusted alpha decay, cost-crossover, latency-horizon mismatch, and efficiency-regime compression stress from arXiv:2601.02310 and SSRN:6608199; preview ranking only",
                 "counterfactual_regime_replay_stress": "deterministic real-tape regime support, edge concentration, and temporal Wasserstein shift stress from arXiv:2602.03776 and SSRN:6232459; no synthetic PnL; preview ranking only",
                 "nonlinear_impact_execution_stress": "deterministic real-tape participation-rate, square-root impact, and permanent-impact decay stress from arXiv:2603.29086 and arXiv:2502.16246; model costs are not PnL authority; preview ranking only",
+                "option_gamma_flow_stress": "deterministic replay-row option gamma, short-horizon option availability, and dealer-hedging feedback stress from SSRN:4692190 and SSRN:6703098; gamma proxies are not PnL authority; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1120,6 +1129,7 @@ def _score_candidate_spec(
             alpha_decay_predictability_stress={},
             counterfactual_regime_replay_stress={},
             nonlinear_impact_execution_stress={},
+            option_gamma_flow_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1277,6 +1287,18 @@ def _score_candidate_spec(
         )
         or 0.0
     )
+    option_gamma_flow_stress = extract_option_gamma_flow_stress(
+        matched_source_rows,
+        direction=direction,
+    ).to_payload()
+    option_gamma_flow_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(option_gamma_flow_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
@@ -1330,6 +1352,7 @@ def _score_candidate_spec(
         - alpha_decay_predictability_rank_penalty_bps * 0.08
         - counterfactual_regime_rank_penalty_bps * 0.07
         - nonlinear_impact_execution_rank_penalty_bps * 0.06
+        - option_gamma_flow_rank_penalty_bps * 0.05
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1368,6 +1391,7 @@ def _score_candidate_spec(
         - alpha_decay_predictability_rank_penalty_bps * 0.04
         - counterfactual_regime_rank_penalty_bps * 0.03
         - nonlinear_impact_execution_rank_penalty_bps * 0.03
+        - option_gamma_flow_rank_penalty_bps * 0.03
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1412,6 +1436,7 @@ def _score_candidate_spec(
         alpha_decay_predictability_stress=dict(alpha_decay_predictability_stress),
         counterfactual_regime_replay_stress=dict(counterfactual_regime_replay_stress),
         nonlinear_impact_execution_stress=dict(nonlinear_impact_execution_stress),
+        option_gamma_flow_stress=dict(option_gamma_flow_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1455,6 +1480,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - _alpha_decay_predictability_rank_penalty_bps(row) * 0.05
         - _counterfactual_regime_rank_penalty_bps(row) * 0.04
         - _nonlinear_impact_execution_rank_penalty_bps(row) * 0.04
+        - _option_gamma_flow_rank_penalty_bps(row) * 0.04
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
@@ -1511,6 +1537,11 @@ def _nonlinear_impact_execution_rank_penalty_bps(row: FastReplayPreviewRow) -> f
     ranking_features = _mapping(
         row.nonlinear_impact_execution_stress.get("ranking_features")
     )
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _option_gamma_flow_rank_penalty_bps(row: FastReplayPreviewRow) -> float:
+    ranking_features = _mapping(row.option_gamma_flow_stress.get("ranking_features"))
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
 
@@ -1711,6 +1742,7 @@ def _row_with_rank_and_selection(
             row.counterfactual_regime_replay_stress
         ),
         nonlinear_impact_execution_stress=dict(row.nonlinear_impact_execution_stress),
+        option_gamma_flow_stress=dict(row.option_gamma_flow_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -1779,6 +1811,7 @@ def _row_with_frontier_dedupe(
             row.counterfactual_regime_replay_stress
         ),
         nonlinear_impact_execution_stress=dict(row.nonlinear_impact_execution_stress),
+        option_gamma_flow_stress=dict(row.option_gamma_flow_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -2590,6 +2623,8 @@ def _risk_flags_for_row(
         flags.add("counterfactual_regime_replay_stress_penalty_active")
     if _nonlinear_impact_execution_rank_penalty_bps(row) > 0:
         flags.add("nonlinear_impact_execution_stress_penalty_active")
+    if _option_gamma_flow_rank_penalty_bps(row) > 0:
+        flags.add("option_gamma_flow_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
         flags.add("partial_symbol_coverage")
     if row.trading_day_count <= 0:
@@ -2634,6 +2669,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("counterfactual_regime_replay_stress_downranks_only")
     if _nonlinear_impact_execution_rank_penalty_bps(row) > 0:
         reasons.add("nonlinear_impact_execution_stress_downranks_only")
+    if _option_gamma_flow_rank_penalty_bps(row) > 0:
+        reasons.add("option_gamma_flow_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
         reasons.add("missing_replay_tape_source_data_explicit_blocker")
     if lineage_blockers:
@@ -2671,6 +2708,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("counterfactual_regime_replay_stress_penalty")
     if _nonlinear_impact_execution_rank_penalty_bps(row) > 0:
         vetoes.add("nonlinear_impact_execution_stress_penalty")
+    if _option_gamma_flow_rank_penalty_bps(row) > 0:
+        vetoes.add("option_gamma_flow_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:
         vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
     return tuple(sorted(vetoes))

--- a/services/torghut/app/trading/discovery/option_gamma_flow_stress.py
+++ b/services/torghut/app/trading/discovery/option_gamma_flow_stress.py
@@ -1,0 +1,538 @@
+"""Preview-only option gamma flow stress for replay ranking.
+
+This module turns recent 2025-2026 option-market gamma papers into deterministic
+replay-ranking inputs. It only consumes replay rows or fixtures, records explicit
+source gaps when option gamma fields are missing, and never authorizes promotion,
+realized PnL, or live capital.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import isfinite
+from typing import Any, cast
+
+from app.trading.models import SignalEnvelope
+
+OPTION_GAMMA_FLOW_STRESS_SCHEMA_VERSION = "torghut.option-gamma-flow-stress.v1"
+OPTION_GAMMA_FLOW_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.option-gamma-flow-stress-contract.v1"
+)
+OPTION_GAMMA_FLOW_STRESS_PROOF_SEMANTICS_LABEL = "option_gamma_flow_stress_preview_only_exact_replay_options_provider_route_tca_runtime_ledger_required"
+OPTION_GAMMA_FLOW_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "ssrn-4692190",
+        "url": "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4692190",
+        "title": "0DTEs: Trading, Gamma Risk and Volatility Propagation",
+        "date": "2025-06-06",
+        "mechanism": "market_maker_net_gamma_relates_to_intraday_volatility_reversal_and_momentum",
+    },
+    {
+        "source_id": "ssrn-6703098",
+        "url": "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6703098",
+        "title": "Levering Up! Short-Horizon Option Availability and the Gamification of the Stock Market",
+        "date": "2026-05-03",
+        "mechanism": "weekly_option_availability_and_gamma_exposure_amplify_underlying_volume_and_volatility",
+    },
+)
+
+_GAMMA_FIELDS = (
+    "dealer_gamma_exposure",
+    "net_dealer_gamma_exposure",
+    "market_maker_gamma_exposure",
+    "net_gamma_exposure",
+    "gamma_exposure",
+    "gex",
+    "gamma_exposure_usd",
+)
+_OPTION_FLOW_FIELDS = (
+    "option_flow",
+    "options_flow",
+    "option_volume",
+    "options_volume",
+    "short_horizon_option_volume",
+    "weekly_option_volume",
+    "zero_dte_option_volume",
+    "0dte_option_volume",
+)
+_WEEKLY_OPTION_FIELDS = (
+    "weekly_option_availability",
+    "weekly_options_available",
+    "has_weekly_options",
+    "short_horizon_option_available",
+    "option_weekly_available",
+)
+_DTE_FIELDS = (
+    "option_days_to_expiry",
+    "option_days_to_expiration",
+    "days_to_expiry",
+    "days_to_expiration",
+    "dte",
+    "min_option_dte",
+)
+_PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
+_VOLUME_FIELDS = (
+    "microbar_volume",
+    "volume",
+    "share_volume",
+    "trade_volume",
+    "notional_volume",
+)
+
+
+@dataclass(frozen=True)
+class OptionGammaFlowStressSummary:
+    row_count: int
+    observed_gamma_count: int
+    observed_option_flow_count: int
+    observed_weekly_option_count: int
+    observed_short_dte_count: int
+    negative_gamma_row_share: float
+    positive_gamma_row_share: float
+    weekly_or_short_dte_share: float
+    median_abs_gamma_exposure: float
+    option_flow_intensity_score: float
+    intraday_signed_volatility_bps: float
+    positive_gamma_reversal_share: float
+    negative_gamma_momentum_share: float
+    adverse_gamma_feedback_share: float
+    gamma_source_gap_score: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": OPTION_GAMMA_FLOW_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_option_gamma_flow_stress_ranking",
+            "source_papers": [
+                dict(item) for item in OPTION_GAMMA_FLOW_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "observed_gamma_count": self.observed_gamma_count,
+            "observed_option_flow_count": self.observed_option_flow_count,
+            "observed_weekly_option_count": self.observed_weekly_option_count,
+            "observed_short_dte_count": self.observed_short_dte_count,
+            "negative_gamma_row_share": _stable_float(self.negative_gamma_row_share),
+            "positive_gamma_row_share": _stable_float(self.positive_gamma_row_share),
+            "weekly_or_short_dte_share": _stable_float(self.weekly_or_short_dte_share),
+            "median_abs_gamma_exposure": _stable_float(self.median_abs_gamma_exposure),
+            "option_flow_intensity_score": _stable_float(
+                self.option_flow_intensity_score
+            ),
+            "intraday_signed_volatility_bps": _stable_float(
+                self.intraday_signed_volatility_bps
+            ),
+            "positive_gamma_reversal_share": _stable_float(
+                self.positive_gamma_reversal_share
+            ),
+            "negative_gamma_momentum_share": _stable_float(
+                self.negative_gamma_momentum_share
+            ),
+            "adverse_gamma_feedback_share": _stable_float(
+                self.adverse_gamma_feedback_share
+            ),
+            "gamma_source_gap_score": _stable_float(self.gamma_source_gap_score),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "negative_gamma_row_share": _stable_float(
+                    self.negative_gamma_row_share
+                ),
+                "positive_gamma_row_share": _stable_float(
+                    self.positive_gamma_row_share
+                ),
+                "weekly_or_short_dte_share": _stable_float(
+                    self.weekly_or_short_dte_share
+                ),
+                "option_flow_intensity_score": _stable_float(
+                    self.option_flow_intensity_score
+                ),
+                "intraday_signed_volatility_bps": _stable_float(
+                    self.intraday_signed_volatility_bps
+                ),
+                "positive_gamma_reversal_share": _stable_float(
+                    self.positive_gamma_reversal_share
+                ),
+                "negative_gamma_momentum_share": _stable_float(
+                    self.negative_gamma_momentum_share
+                ),
+                "adverse_gamma_feedback_share": _stable_float(
+                    self.adverse_gamma_feedback_share
+                ),
+                "gamma_source_gap_score": _stable_float(self.gamma_source_gap_score),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "option_gamma_exposure_preview": True,
+            "short_horizon_option_availability_preview": True,
+            "requires_options_provider_clock_downstream": True,
+            "requires_option_open_interest_or_dealer_gamma_source_downstream": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": OPTION_GAMMA_FLOW_STRESS_PROOF_SEMANTICS_LABEL,
+        }
+
+
+def option_gamma_flow_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": OPTION_GAMMA_FLOW_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": OPTION_GAMMA_FLOW_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in OPTION_GAMMA_FLOW_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": "short_horizon_option_gamma_flow_feedback_stress",
+        "stress_components": [
+            "negative_gamma_momentum_share",
+            "positive_gamma_reversal_share",
+            "weekly_or_short_dte_share",
+            "option_flow_intensity_score",
+            "gamma_source_gap_score",
+            "adverse_gamma_feedback_share",
+        ],
+        "gamma_fields": list(_GAMMA_FIELDS),
+        "option_flow_fields": list(_OPTION_FLOW_FIELDS),
+        "weekly_option_fields": list(_WEEKLY_OPTION_FIELDS + _DTE_FIELDS),
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_options_provider_clock": True,
+            "requires_option_open_interest_or_dealer_gamma_source": True,
+            "requires_runtime_ledger": True,
+            "rejects_gamma_proxy_as_realized_pnl_authority": True,
+            "rejects_missing_options_source_as_zero_gamma_assumption": True,
+        },
+    }
+
+
+def build_option_gamma_flow_stress_schema_hash() -> str:
+    return _stable_hash(option_gamma_flow_stress_contract())
+
+
+def extract_option_gamma_flow_stress(
+    records: Sequence[SignalEnvelope],
+    *,
+    direction: int | float = 1,
+) -> OptionGammaFlowStressSummary:
+    """Extract deterministic option gamma feedback stress from replay rows."""
+
+    ordered = tuple(
+        sorted(records, key=lambda item: (item.event_ts, item.symbol, item.seq))
+    )
+    signed_direction = 1.0 if float(direction) >= 0.0 else -1.0
+    gammas = tuple(_row_gamma(row) for row in ordered)
+    option_flows = tuple(_row_option_flow(row) for row in ordered)
+    weekly_flags = tuple(_row_weekly_or_short_dte(row) for row in ordered)
+    prices = tuple(_row_price(row) for row in ordered)
+    returns = _returns_bps(prices)
+    signed_returns = tuple(value * signed_direction for value in returns)
+
+    gamma_values = tuple(value for value in gammas if value is not None)
+    option_flow_values = tuple(
+        value for value in option_flows if value is not None and value >= 0.0
+    )
+    weekly_observations = tuple(value for value in weekly_flags if value is not None)
+    short_dte_observations = tuple(
+        value for row in ordered if (value := _row_short_dte(row)) is not None
+    )
+
+    observed_gamma_count = len(gamma_values)
+    observed_option_flow_count = len(option_flow_values)
+    observed_weekly_option_count = len(weekly_observations)
+    observed_short_dte_count = len(short_dte_observations)
+    row_denominator = max(1, len(ordered))
+    negative_gamma_row_share = (
+        sum(1 for value in gamma_values if value < 0.0) / row_denominator
+    )
+    positive_gamma_row_share = (
+        sum(1 for value in gamma_values if value > 0.0) / row_denominator
+    )
+    weekly_or_short_dte_share = (
+        sum(1 for value in weekly_observations if value) / row_denominator
+    )
+    median_abs_gamma_exposure = _median(tuple(abs(value) for value in gamma_values))
+    option_flow_intensity_score = _option_flow_intensity_score(
+        option_flow_values, ordered
+    )
+    intraday_signed_volatility_bps = _median(
+        tuple(abs(value) for value in signed_returns)
+    )
+    positive_gamma_reversal_share, negative_gamma_momentum_share = (
+        _gamma_feedback_shares(
+            gammas=gammas,
+            signed_returns=signed_returns,
+        )
+    )
+    adverse_gamma_feedback_share = _adverse_gamma_feedback_share(
+        gammas=gammas,
+        signed_returns=signed_returns,
+    )
+    gamma_source_gap_score = _gamma_source_gap_score(
+        observed_gamma_count=observed_gamma_count,
+        observed_option_flow_count=observed_option_flow_count,
+        observed_weekly_option_count=observed_weekly_option_count,
+    )
+    replay_rank_penalty_bps = min(
+        250.0,
+        adverse_gamma_feedback_share * 45.0
+        + negative_gamma_momentum_share * 18.0
+        + positive_gamma_reversal_share * 12.0
+        + weekly_or_short_dte_share * 8.0
+        + option_flow_intensity_score * 10.0
+        + gamma_source_gap_score * 20.0
+        + max(0.0, intraday_signed_volatility_bps - 5.0) * 0.10,
+    )
+    warnings: set[str] = set()
+    if not ordered:
+        warnings.add("empty_option_gamma_flow_records")
+    if observed_gamma_count == 0:
+        warnings.add("missing_option_gamma_inputs")
+    if observed_option_flow_count == 0:
+        warnings.add("missing_option_flow_inputs")
+    if observed_weekly_option_count == 0 and observed_short_dte_count == 0:
+        warnings.add("missing_short_horizon_option_availability_inputs")
+    if observed_gamma_count and observed_option_flow_count == 0:
+        warnings.add("gamma_without_option_flow_context")
+    if observed_option_flow_count and observed_gamma_count == 0:
+        warnings.add("option_flow_without_dealer_gamma_source")
+
+    return OptionGammaFlowStressSummary(
+        row_count=len(ordered),
+        observed_gamma_count=observed_gamma_count,
+        observed_option_flow_count=observed_option_flow_count,
+        observed_weekly_option_count=observed_weekly_option_count,
+        observed_short_dte_count=observed_short_dte_count,
+        negative_gamma_row_share=negative_gamma_row_share,
+        positive_gamma_row_share=positive_gamma_row_share,
+        weekly_or_short_dte_share=weekly_or_short_dte_share,
+        median_abs_gamma_exposure=median_abs_gamma_exposure,
+        option_flow_intensity_score=option_flow_intensity_score,
+        intraday_signed_volatility_bps=intraday_signed_volatility_bps,
+        positive_gamma_reversal_share=positive_gamma_reversal_share,
+        negative_gamma_momentum_share=negative_gamma_momentum_share,
+        adverse_gamma_feedback_share=adverse_gamma_feedback_share,
+        gamma_source_gap_score=gamma_source_gap_score,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=tuple(sorted(warnings)),
+        feature_schema_hash=build_option_gamma_flow_stress_schema_hash(),
+    )
+
+
+def _gamma_feedback_shares(
+    *, gammas: Sequence[float | None], signed_returns: Sequence[float]
+) -> tuple[float, float]:
+    positive_reversal = 0
+    positive_count = 0
+    negative_momentum = 0
+    negative_count = 0
+    for index in range(1, min(len(gammas), len(signed_returns))):
+        gamma = gammas[index]
+        previous_return = signed_returns[index - 1]
+        current_return = signed_returns[index]
+        if gamma is None or previous_return == 0.0 or current_return == 0.0:
+            continue
+        same_sign = previous_return * current_return > 0.0
+        if gamma > 0.0:
+            positive_count += 1
+            if not same_sign:
+                positive_reversal += 1
+        elif gamma < 0.0:
+            negative_count += 1
+            if same_sign:
+                negative_momentum += 1
+    return (
+        positive_reversal / max(1, positive_count),
+        negative_momentum / max(1, negative_count),
+    )
+
+
+def _adverse_gamma_feedback_share(
+    *, gammas: Sequence[float | None], signed_returns: Sequence[float]
+) -> float:
+    stressed = 0
+    adverse = 0
+    for index in range(1, min(len(gammas), len(signed_returns))):
+        gamma = gammas[index]
+        current_return = signed_returns[index]
+        previous_return = signed_returns[index - 1]
+        if gamma is None or current_return == 0.0 or previous_return == 0.0:
+            continue
+        stressed += 1
+        if gamma < 0.0 and previous_return < 0.0 and current_return < 0.0:
+            adverse += 1
+        elif gamma > 0.0 and previous_return > 0.0 and current_return < 0.0:
+            adverse += 1
+    return adverse / max(1, stressed)
+
+
+def _gamma_source_gap_score(
+    *,
+    observed_gamma_count: int,
+    observed_option_flow_count: int,
+    observed_weekly_option_count: int,
+) -> float:
+    if observed_gamma_count:
+        return 0.0
+    if observed_option_flow_count or observed_weekly_option_count:
+        return 1.0
+    return 0.25
+
+
+def _option_flow_intensity_score(
+    values: Sequence[float], rows: Sequence[SignalEnvelope]
+) -> float:
+    if not values:
+        return 0.0
+    option_median = _median(values)
+    stock_volumes = tuple(
+        value
+        for row in rows
+        if (value := _coalesce_numeric(row.payload, _VOLUME_FIELDS)) is not None
+        and value > 0.0
+    )
+    stock_median = _median(stock_volumes)
+    if stock_median <= 0.0:
+        return min(1.0, option_median / max(1.0, option_median))
+    return min(1.0, option_median / max(1.0, stock_median))
+
+
+def _row_gamma(row: SignalEnvelope) -> float | None:
+    return _coalesce_numeric(row.payload, _GAMMA_FIELDS)
+
+
+def _row_option_flow(row: SignalEnvelope) -> float | None:
+    return _coalesce_numeric(row.payload, _OPTION_FLOW_FIELDS)
+
+
+def _row_short_dte(row: SignalEnvelope) -> bool | None:
+    dte = _coalesce_numeric(row.payload, _DTE_FIELDS)
+    if dte is None:
+        return None
+    return dte <= 7.0
+
+
+def _row_weekly_or_short_dte(row: SignalEnvelope) -> bool | None:
+    weekly = _coalesce_bool(row.payload, _WEEKLY_OPTION_FIELDS)
+    short_dte = _row_short_dte(row)
+    if weekly is None and short_dte is None:
+        return None
+    return bool(weekly) or bool(short_dte)
+
+
+def _row_price(row: SignalEnvelope) -> float | None:
+    value = _coalesce_numeric(row.payload, _PRICE_FIELDS)
+    if value is None or value <= 0.0:
+        return None
+    return value
+
+
+def _returns_bps(prices: Sequence[float | None]) -> tuple[float, ...]:
+    clean = tuple(value for value in prices if value is not None and value > 0.0)
+    returns: list[float] = []
+    for previous, current in zip(clean, clean[1:]):
+        if previous > 0.0:
+            returns.append((current - previous) / previous * 10_000.0)
+    return tuple(returns)
+
+
+def _coalesce_numeric(
+    payload: Mapping[str, Any], fields: Sequence[str]
+) -> float | None:
+    for field in fields:
+        value = _float_or_none(payload.get(field))
+        if value is not None:
+            return value
+    return None
+
+
+def _coalesce_bool(payload: Mapping[str, Any], fields: Sequence[str]) -> bool | None:
+    for field in fields:
+        if field not in payload:
+            continue
+        value = payload.get(field)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "y", "available"}:
+                return True
+            if normalized in {"0", "false", "no", "n", "unavailable"}:
+                return False
+        number = _float_or_none(value)
+        if number is not None:
+            return number > 0.0
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        converted = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(converted):
+        return None
+    return converted
+
+
+def _median(values: Sequence[float]) -> float:
+    clean = sorted(value for value in values if isfinite(value))
+    if not clean:
+        return 0.0
+    middle = len(clean) // 2
+    if len(clean) % 2:
+        return clean[middle]
+    return (clean[middle - 1] + clean[middle]) / 2.0
+
+
+def _stable_float(value: float) -> float:
+    if not isfinite(value):
+        return 0.0
+    return round(float(value), 6)
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        _json_ready(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[Any, Any], value)
+        return {str(key): _json_ready(item) for key, item in mapping.items()}
+    if isinstance(value, (list, tuple)):
+        sequence = cast(Sequence[Any], value)
+        return [_json_ready(item) for item in sequence]
+    return value
+
+
+__all__ = [
+    "OPTION_GAMMA_FLOW_STRESS_PRIMARY_SOURCES",
+    "OPTION_GAMMA_FLOW_STRESS_PROOF_SEMANTICS_LABEL",
+    "OPTION_GAMMA_FLOW_STRESS_SCHEMA_VERSION",
+    "OptionGammaFlowStressSummary",
+    "build_option_gamma_flow_stress_schema_hash",
+    "extract_option_gamma_flow_stress",
+    "option_gamma_flow_stress_contract",
+]

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -106,6 +106,14 @@ class TestFastReplayPreview(TestCase):
                 "bid_size": Decimal("700"),
                 "ask_size": Decimal("300"),
                 "macro_event_window": stress,
+                "net_dealer_gamma_exposure": Decimal("-9000000")
+                if stress
+                else Decimal("5000000"),
+                "zero_dte_option_volume": Decimal("80000")
+                if stress
+                else Decimal("1000"),
+                "weekly_option_availability": stress,
+                "option_days_to_expiry": Decimal("0") if stress else Decimal("21"),
             },
             ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
         )
@@ -223,6 +231,10 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn(
             "nonlinear_impact_execution_stress",
+            payload["implemented_mechanisms"],
+        )
+        self.assertIn(
+            "option_gamma_flow_stress",
             payload["implemented_mechanisms"],
         )
         self.assertEqual(
@@ -370,6 +382,27 @@ class TestFastReplayPreview(TestCase):
                     "source_papers"
                 ]
             },
+        )
+        self.assertIn("option_gamma_flow_stress", row_payload)
+        self.assertFalse(row_payload["option_gamma_flow_stress"]["proof_authority"])
+        self.assertFalse(row_payload["option_gamma_flow_stress"]["promotion_authority"])
+        self.assertEqual(
+            row_payload["option_gamma_flow_stress"]["status"],
+            "preview_only_option_gamma_flow_stress_ranking",
+        )
+        self.assertIn(
+            "ssrn-4692190",
+            {
+                source["source_id"]
+                for source in row_payload["option_gamma_flow_stress"]["source_papers"]
+            },
+        )
+        self.assertIn(
+            "option_gamma_flow_stress_penalty_active", row_payload["risk_flags"]
+        )
+        self.assertIn(
+            "option_gamma_flow_stress_downranks_only",
+            row_payload["ranking_only_reasons"],
         )
         self.assertIn("cost_impact_lineage", row_payload)
         self.assertIn("impact_capacity_lineage", row_payload)

--- a/services/torghut/tests/test_option_gamma_flow_stress.py
+++ b/services/torghut/tests/test_option_gamma_flow_stress.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.option_gamma_flow_stress import (
+    build_option_gamma_flow_stress_schema_hash,
+    extract_option_gamma_flow_stress,
+    option_gamma_flow_stress_contract,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestOptionGammaFlowStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        price: str,
+        gamma: str | None = None,
+        option_flow: str | None = None,
+        weekly_options: bool | None = None,
+        dte: str | None = None,
+        volume: str = "100000",
+    ) -> SignalEnvelope:
+        payload: dict[str, object] = {
+            "price": Decimal(price),
+            "microbar_volume": Decimal(volume),
+        }
+        if gamma is not None:
+            payload["net_dealer_gamma_exposure"] = Decimal(gamma)
+        if option_flow is not None:
+            payload["zero_dte_option_volume"] = Decimal(option_flow)
+        if weekly_options is not None:
+            payload["weekly_option_availability"] = weekly_options
+        if dte is not None:
+            payload["option_days_to_expiry"] = Decimal(dte)
+        return SignalEnvelope(
+            event_ts=datetime(2026, 5, 4, 14, 30, tzinfo=timezone.utc)
+            + timedelta(minutes=offset),
+            symbol="GAMMA",
+            timeframe="1Min",
+            seq=offset,
+            source="option-gamma-flow-fixture",
+            payload=payload,
+            ingest_ts=datetime(2026, 5, 4, 14, 31, tzinfo=timezone.utc),
+        )
+
+    def test_negative_gamma_weekly_option_flow_penalizes_feedback_risk(self) -> None:
+        benign = extract_option_gamma_flow_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    gamma="5000000",
+                    option_flow="1000",
+                    weekly_options=False,
+                    dte="21",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.04",
+                    gamma="5200000",
+                    option_flow="900",
+                    weekly_options=False,
+                    dte="20",
+                ),
+                self._row(
+                    offset=3,
+                    price="100.08",
+                    gamma="5100000",
+                    option_flow="950",
+                    weekly_options=False,
+                    dte="19",
+                ),
+                self._row(
+                    offset=4,
+                    price="100.12",
+                    gamma="5300000",
+                    option_flow="1000",
+                    weekly_options=False,
+                    dte="18",
+                ),
+            ),
+            direction=1,
+        )
+        stressed = extract_option_gamma_flow_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    gamma="-9000000",
+                    option_flow="80000",
+                    weekly_options=True,
+                    dte="0",
+                ),
+                self._row(
+                    offset=2,
+                    price="99.85",
+                    gamma="-9500000",
+                    option_flow="85000",
+                    weekly_options=True,
+                    dte="0",
+                ),
+                self._row(
+                    offset=3,
+                    price="99.60",
+                    gamma="-10000000",
+                    option_flow="90000",
+                    weekly_options=True,
+                    dte="1",
+                ),
+                self._row(
+                    offset=4,
+                    price="99.25",
+                    gamma="-11000000",
+                    option_flow="95000",
+                    weekly_options=True,
+                    dte="1",
+                ),
+            ),
+            direction=1,
+        )
+
+        self.assertEqual(stressed.observed_gamma_count, 4)
+        self.assertEqual(stressed.observed_option_flow_count, 4)
+        self.assertGreater(
+            stressed.negative_gamma_row_share, benign.negative_gamma_row_share
+        )
+        self.assertGreater(
+            stressed.weekly_or_short_dte_share, benign.weekly_or_short_dte_share
+        )
+        self.assertGreater(
+            stressed.option_flow_intensity_score, benign.option_flow_intensity_score
+        )
+        self.assertGreater(
+            stressed.negative_gamma_momentum_share, benign.negative_gamma_momentum_share
+        )
+        self.assertGreater(
+            stressed.adverse_gamma_feedback_share, benign.adverse_gamma_feedback_share
+        )
+        self.assertGreater(
+            stressed.replay_rank_penalty_bps, benign.replay_rank_penalty_bps
+        )
+        payload = stressed.to_payload()
+        self.assertEqual(
+            payload["status"], "preview_only_option_gamma_flow_stress_ranking"
+        )
+        self.assertTrue(payload["option_gamma_exposure_preview"])
+        self.assertTrue(payload["short_horizon_option_availability_preview"])
+        self.assertTrue(payload["requires_options_provider_clock_downstream"])
+        self.assertTrue(
+            payload["requires_option_open_interest_or_dealer_gamma_source_downstream"]
+        )
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["final_authority_ok"])
+
+    def test_option_flow_without_gamma_fails_closed_as_source_gap(self) -> None:
+        summary = extract_option_gamma_flow_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    option_flow="25000",
+                    weekly_options=True,
+                    dte="0",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.10",
+                    option_flow="30000",
+                    weekly_options=True,
+                    dte="0",
+                ),
+            )
+        )
+        payload = summary.to_payload()
+
+        self.assertEqual(summary.observed_gamma_count, 0)
+        self.assertGreater(summary.gamma_source_gap_score, 0.0)
+        self.assertIn("missing_option_gamma_inputs", summary.warnings)
+        self.assertIn("option_flow_without_dealer_gamma_source", summary.warnings)
+        self.assertFalse(payload["promotion_proof"])
+        self.assertFalse(payload["promotion_allowed"])
+        self.assertFalse(payload["final_promotion_allowed"])
+        self.assertFalse(payload["final_authority_ok"])
+
+    def test_contract_embeds_sources_and_keeps_proof_neutral(self) -> None:
+        contract = option_gamma_flow_stress_contract()
+        payload = extract_option_gamma_flow_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    gamma="-1000000",
+                    option_flow="10000",
+                    weekly_options=True,
+                    dte="0",
+                ),
+                self._row(
+                    offset=2,
+                    price="99.95",
+                    gamma="-1000000",
+                    option_flow="12000",
+                    weekly_options=True,
+                    dte="0",
+                ),
+            )
+        ).to_payload()
+
+        source_ids = {source["source_id"] for source in contract["source_papers"]}
+        self.assertIn("ssrn-4692190", source_ids)
+        self.assertIn("ssrn-6703098", source_ids)
+        proof_neutrality = contract["proof_neutrality"]
+        self.assertTrue(proof_neutrality["requires_exact_replay"])
+        self.assertTrue(proof_neutrality["requires_route_tca"])
+        self.assertTrue(proof_neutrality["requires_options_provider_clock"])
+        self.assertTrue(
+            proof_neutrality["requires_option_open_interest_or_dealer_gamma_source"]
+        )
+        self.assertTrue(proof_neutrality["requires_runtime_ledger"])
+        self.assertTrue(
+            proof_neutrality["rejects_gamma_proxy_as_realized_pnl_authority"]
+        )
+        self.assertTrue(
+            proof_neutrality["rejects_missing_options_source_as_zero_gamma_assumption"]
+        )
+        self.assertFalse(payload["promotion_proof"])
+        self.assertFalse(payload["promotion_allowed"])
+        self.assertEqual(
+            payload["feature_schema_hash"], build_option_gamma_flow_stress_schema_hash()
+        )


### PR DESCRIPTION
## Summary

- Adds preview-only option gamma flow stress extraction for replay rows, sourced from SSRN:4692190 and SSRN:6703098.
- Integrates the stress payload into fast replay scoring, robust ranking, risk flags, and implemented mechanism metadata without granting promotion or PnL authority.
- Adds focused regression tests for negative-gamma/weekly-option feedback risk, missing gamma source gaps, fail-closed contracts, and fast replay manifest payloads.

## Related Issues

None

## Testing

- `cd services/torghut && uvx ruff format --check app/trading/discovery/option_gamma_flow_stress.py app/trading/discovery/fast_replay.py tests/test_option_gamma_flow_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/option_gamma_flow_stress.py app/trading/discovery/fast_replay.py tests/test_option_gamma_flow_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen pytest tests/test_option_gamma_flow_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
