### PR TITLE
fix(torghut): centralize paper route retry transitions

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_DOWN
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, Optional, TypeAlias, cast
 from urllib.parse import urlsplit
 from uuid import UUID
 
@@ -88,6 +89,14 @@ _PAPER_ROUTE_PROBE_REASONS = {
     "route_tca_passed_but_dependency_receipts_block_capital",
     "tca_evidence_stale",
 }
+_PaperRouteRetryKind: TypeAlias = Literal[
+    "bounded_probe",
+    "quote_routeability",
+    "target_price",
+]
+_PAPER_ROUTE_RETRY_KINDS: frozenset[_PaperRouteRetryKind] = frozenset(
+    {"bounded_probe", "quote_routeability", "target_price"}
+)
 _PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS = 86_400
 _SIMPLE_MARKET_CONTEXT_RETRY_INTERVAL = timedelta(seconds=30)
 _PAPER_ROUTE_PROBE_QTY_STEP = Decimal("0.0001")
@@ -174,6 +183,12 @@ _BOUNDED_SIM_COLLECTION_SOURCE_AUTHORIZATION_SCOPES = frozenset(
         "source_window_evidence_collection_only",
     }
 )
+
+
+@dataclass(frozen=True)
+class _PaperRouteRetryTransition:
+    kind: _PaperRouteRetryKind
+    metadata: dict[str, object]
 
 
 def _safe_int(value: object) -> int:
@@ -2044,11 +2059,7 @@ class SimpleTradingPipeline(TradingPipeline):
         for decision_row in rows:
             if len(decisions) >= batch_limit:
                 break
-            if (
-                self._paper_route_probe_retry_metadata(decision_row) is None
-                and self._paper_route_quote_routeability_retry_metadata(decision_row)
-                is None
-            ):
+            if self._paper_route_retry_transition(decision_row) is None:
                 continue
             if self.executor.execution_exists(session, decision_row):
                 continue
@@ -2550,6 +2561,45 @@ class SimpleTradingPipeline(TradingPipeline):
             "previous_retry_attempts": retry_attempts,
         }
 
+    @staticmethod
+    def _paper_route_retry_transition(
+        decision_row: TradeDecision,
+        *,
+        allowed_kinds: frozenset[_PaperRouteRetryKind] = _PAPER_ROUTE_RETRY_KINDS,
+    ) -> _PaperRouteRetryTransition | None:
+        if "quote_routeability" in allowed_kinds:
+            quote_routeability_metadata = (
+                SimpleTradingPipeline._paper_route_quote_routeability_retry_metadata(
+                    decision_row
+                )
+            )
+            if quote_routeability_metadata is not None:
+                return _PaperRouteRetryTransition(
+                    kind="quote_routeability",
+                    metadata=quote_routeability_metadata,
+                )
+        if "target_price" in allowed_kinds:
+            target_price_metadata = (
+                SimpleTradingPipeline._paper_route_target_price_retry_metadata(
+                    decision_row
+                )
+            )
+            if target_price_metadata is not None:
+                return _PaperRouteRetryTransition(
+                    kind="target_price",
+                    metadata=target_price_metadata,
+                )
+        if "bounded_probe" in allowed_kinds:
+            probe_metadata = SimpleTradingPipeline._paper_route_probe_retry_metadata(
+                decision_row
+            )
+            if probe_metadata is not None:
+                return _PaperRouteRetryTransition(
+                    kind="bounded_probe",
+                    metadata=probe_metadata,
+                )
+        return None
+
     def _reopen_rejected_paper_route_target_price_decision(
         self,
         *,
@@ -2557,9 +2607,13 @@ class SimpleTradingPipeline(TradingPipeline):
         decision: StrategyDecision,
         decision_row: TradeDecision,
     ) -> TradeDecision | None:
-        retry_metadata = self._paper_route_target_price_retry_metadata(decision_row)
-        if retry_metadata is None:
+        retry_transition = self._paper_route_retry_transition(
+            decision_row,
+            allowed_kinds=frozenset({"target_price"}),
+        )
+        if retry_transition is None:
             return None
+        retry_metadata = retry_transition.metadata
         if self.executor.execution_exists(session, decision_row):
             return None
 
@@ -3914,11 +3968,13 @@ class SimpleTradingPipeline(TradingPipeline):
         decision: StrategyDecision,
         decision_row: TradeDecision,
     ) -> TradeDecision | None:
-        retry_metadata = self._paper_route_quote_routeability_retry_metadata(
-            decision_row
+        retry_transition = self._paper_route_retry_transition(
+            decision_row,
+            allowed_kinds=frozenset({"quote_routeability"}),
         )
-        if retry_metadata is None:
+        if retry_transition is None:
             return None
+        retry_metadata = retry_transition.metadata
         if self.executor.execution_exists(session, decision_row):
             return None
 
@@ -6131,9 +6187,13 @@ class SimpleTradingPipeline(TradingPipeline):
         decision: StrategyDecision,
         decision_row: TradeDecision,
     ) -> TradeDecision | None:
-        retry_metadata = self._paper_route_probe_retry_metadata(decision_row)
-        if retry_metadata is None:
+        retry_transition = self._paper_route_retry_transition(
+            decision_row,
+            allowed_kinds=frozenset({"bounded_probe"}),
+        )
+        if retry_transition is None:
             return None
+        retry_metadata = retry_transition.metadata
         if self.executor.execution_exists(session, decision_row):
             return None
         collection_metadata = _bounded_sim_collection_metadata_from_decision(
@@ -6200,11 +6260,9 @@ class SimpleTradingPipeline(TradingPipeline):
             return None
         if decision_row.alpaca_account_label != self.account_label:
             return None
-        retryable_status = decision_row.status in {"blocked", "rejected"} and (
-            self._paper_route_quote_routeability_retry_metadata(decision_row)
-            is not None
-            or self._paper_route_target_price_retry_metadata(decision_row) is not None
-            or self._paper_route_probe_retry_metadata(decision_row) is not None
+        retryable_status = (
+            decision_row.status in {"blocked", "rejected"}
+            and self._paper_route_retry_transition(decision_row) is not None
         )
         if decision_row.status != "planned" and not retryable_status:
             return None
@@ -6297,13 +6355,17 @@ class SimpleTradingPipeline(TradingPipeline):
             is not None
         ):
             return decision_row
-        retry_metadata = self._paper_route_probe_retry_metadata(decision_row)
-        if retry_metadata is None:
+        retry_transition = self._paper_route_retry_transition(
+            decision_row,
+            allowed_kinds=frozenset({"bounded_probe"}),
+        )
+        if retry_transition is None:
             return super()._ensure_pending_decision_row(
                 session=session,
                 decision=decision,
                 strategy=strategy,
             )
+        retry_metadata = retry_transition.metadata
         if self.executor.execution_exists(session, decision_row):
             return None
 

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4809,6 +4809,111 @@ class TestTradingPipeline(TestCase):
                 "paper_route_target_price_retry_pending",
             )
 
+    def test_simple_pipeline_scans_target_price_retry_without_new_signal(self) -> None:
+        from app import config
+
+        event_ts = datetime(2026, 5, 29, 14, 0, tzinfo=timezone.utc)
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 2
+        config.settings.trading_simple_paper_route_probe_retry_batch_limit = 4
+        config.settings.trading_simple_paper_route_probe_retry_scan_limit = 16
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-paper-target-price-retry-scan",
+                description="simple paper target source price retry scan",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=event_ts,
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("1"),
+                rationale="paper-route-target-source",
+                params={
+                    "paper_route_target_plan": {
+                        "candidate_id": "candidate-1",
+                        "hypothesis_id": "H-PAIRS-01",
+                    },
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "paper",
+            )
+            decision_json = dict(cast(Mapping[str, Any], decision_row.decision_json))
+            params = dict(cast(Mapping[str, Any], decision_json.get("params") or {}))
+            params["simple_lane_precheck"] = {
+                "price": None,
+                "requested_qty": "1",
+            }
+            decision_json.update(
+                {
+                    "params": params,
+                    "submission_stage": "rejected_pre_submit",
+                    "risk_reasons": ["broker_precheck_failed"],
+                    "reject_reason_atomic": ["broker_precheck_failed"],
+                }
+            )
+            decision_row.status = "rejected"
+            decision_row.decision_json = decision_json
+            session.add(decision_row)
+            session.commit()
+
+            pipeline = SimpleTradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=executor,
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+
+            with patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=datetime(2026, 5, 29, 14, 5, tzinfo=timezone.utc),
+            ):
+                retries = pipeline._paper_route_probe_retry_decisions(session=session)
+                self.assertEqual([retry.symbol for retry in retries], ["AAPL"])
+                pending = pipeline._ensure_pending_decision_row(
+                    session=session,
+                    decision=retries[0],
+                    strategy=strategy,
+                )
+
+            self.assertIsNotNone(pending)
+            session.refresh(decision_row)
+            refreshed_json = cast(dict[str, Any], decision_row.decision_json)
+            self.assertEqual(decision_row.status, "planned")
+            self.assertEqual(
+                refreshed_json.get("submission_stage"),
+                "paper_route_target_price_retry_pending",
+            )
+            self.assertEqual(
+                refreshed_json.get("paper_route_target_price_retry_attempts"),
+                1,
+            )
+
     def test_simple_pipeline_retry_helpers_filter_invalid_rows_and_limits(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Centralizes paper-route retry eligibility behind a typed retry transition classifier.
- Uses the classifier in retry scanning, materialized-row claiming, and individual reopen paths.
- Adds no-new-signal scanner recovery for transient target-price precheck rejects, matching quote-routeability recovery behavior.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k "target_price_retry or quote_routeability_retry or materialized_target_plan_quote_routeability_retry"`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app tests scripts migrations`
- `git diff --check`
- Direct `coverage.xml` inspection of changed lines in `app/trading/scheduler/simple_pipeline.py`: `100.00%`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
