### PR TITLE
fix(torghut): compact tigerbeetle status readback

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -186,6 +186,7 @@ from .trading.tigerbeetle_client import check_tigerbeetle_health
 from .trading.tigerbeetle_reconcile import (
     BLOCKER_RECONCILIATION_STALE,
     latest_tigerbeetle_reconciliation_payload,
+    latest_tigerbeetle_reconciliation_status_payload,
     tigerbeetle_ref_counts,
 )
 from .trading.zero_notional_repair_executor import run_zero_notional_repair
@@ -7118,10 +7119,15 @@ def _build_tigerbeetle_ledger_status(session: Session) -> dict[str, object]:
     reconciliation_status_available = True
     try:
         _apply_status_read_statement_timeout(session, milliseconds=750)
-        latest_reconciliation = latest_tigerbeetle_reconciliation_payload(
+        latest_reconciliation = latest_tigerbeetle_reconciliation_status_payload(
             session,
             cluster_id=settings.tigerbeetle_cluster_id,
         )
+        if latest_reconciliation is None:
+            latest_reconciliation = latest_tigerbeetle_reconciliation_payload(
+                session,
+                cluster_id=settings.tigerbeetle_cluster_id,
+            )
     except SQLAlchemyError as exc:
         logger.warning("TigerBeetle reconciliation status unavailable: %s", exc)
         session.rollback()

--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -644,6 +644,35 @@ class TigerBeetleReconciliationRun(Base, TimestampMixin):
     source_missing_count: Mapped[int] = mapped_column(
         BigInteger(), nullable=False, server_default=text("0")
     )
+    account_ref_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    transfer_ref_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    runtime_ledger_ref_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    runtime_ledger_signed_ref_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    runtime_ledger_missing_signed_ref_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    runtime_ledger_missing_account_ref_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    stable_ref_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    stable_ref_missing_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    stable_ref_mismatch_count: Mapped[int] = mapped_column(
+        BigInteger(), nullable=False, server_default=text("0")
+    )
+    blockers_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
+    ref_counts_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
     payload_json: Mapped[Optional[Any]] = mapped_column(JSONType, nullable=True)
 
     __table_args__ = (

--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -75,6 +75,31 @@ BLOCKER_STABLE_REF_PAYLOAD_MISMATCH = "tigerbeetle_stable_ref_payload_mismatch"
 BLOCKER_CLIENT_UNAVAILABLE = "tigerbeetle_client_unavailable"
 BLOCKER_RECONCILIATION_STALE = "tigerbeetle_reconciliation_stale"
 SAMPLE_LIMIT = 50
+REF_COUNT_FIELD_NAMES = (
+    "account_ref_count",
+    "transfer_ref_count",
+    "runtime_ledger_ref_count",
+    "runtime_ledger_signed_ref_count",
+    "runtime_ledger_missing_signed_ref_count",
+    "runtime_ledger_missing_account_ref_count",
+    "stable_ref_count",
+    "stable_ref_missing_count",
+    "stable_ref_mismatch_count",
+)
+COMPACT_REF_COUNT_KEYS = (
+    *REF_COUNT_FIELD_NAMES,
+    "order_event_ref_count",
+    "execution_ref_count",
+    "cost_ref_count",
+    "runtime_ledger_required_bucket_count",
+    "runtime_ledger_account_ref_count",
+    "stable_ref_sample_size",
+    "runtime_ledger_ref_sample_size",
+)
+COMPACT_REF_COUNT_FLAG_KEYS = (
+    "stable_ref_diagnostic_bounded",
+    "runtime_ledger_ref_coverage_bounded",
+)
 
 
 def _attr(value: object, name: str) -> Any:
@@ -358,6 +383,62 @@ def _payload_string_list(payload: Mapping[str, object], key: str) -> list[str]:
     if value is None:
         return []
     return [str(value)]
+
+
+def _source_materialization_payload() -> dict[str, object]:
+    return {
+        "account_ref_table": "tigerbeetle_account_refs",
+        "transfer_ref_table": "tigerbeetle_transfer_refs",
+        "reconciliation_run_table": "tigerbeetle_reconciliation_runs",
+        "runtime_ledger_source_table": "strategy_runtime_ledger_buckets",
+        "runtime_ledger_source_type": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+        "runtime_ledger_transfer_kind": TRANSFER_KIND_RUNTIME_NET_PNL,
+    }
+
+
+def _compact_reconciliation_ref_counts(
+    ref_counts: Mapping[str, object],
+    *,
+    cluster_id: int,
+) -> dict[str, object]:
+    raw_by_source = ref_counts.get("by_source_type")
+    by_source: dict[str, int] = {}
+    if isinstance(raw_by_source, Mapping):
+        for source_type, count in cast(Mapping[object, object], raw_by_source).items():
+            by_source[str(source_type)] = _payload_int({"count": count}, "count")
+
+    runtime_ledger_ref_count = _payload_int(ref_counts, "runtime_ledger_ref_count")
+    if runtime_ledger_ref_count and SOURCE_TYPE_RUNTIME_LEDGER_BUCKET not in by_source:
+        by_source[SOURCE_TYPE_RUNTIME_LEDGER_BUCKET] = runtime_ledger_ref_count
+
+    raw_source_materialization = ref_counts.get("source_materialization")
+    source_materialization = (
+        dict(cast(Mapping[str, object], raw_source_materialization))
+        if isinstance(raw_source_materialization, Mapping)
+        else _source_materialization_payload()
+    )
+    compact: dict[str, object] = {
+        "schema_version": "torghut.tigerbeetle-ref-counts.v1",
+        "cluster_id": cluster_id,
+        "by_source_type": by_source,
+        "source_materialization": source_materialization,
+    }
+    for key in COMPACT_REF_COUNT_KEYS:
+        if key in REF_COUNT_FIELD_NAMES or key in ref_counts:
+            compact[key] = _payload_int(ref_counts, key)
+    for key in COMPACT_REF_COUNT_FLAG_KEYS:
+        if key in ref_counts:
+            compact[key] = bool(ref_counts[key])
+    compact.setdefault(
+        "order_event_ref_count",
+        by_source.get(SOURCE_TYPE_EXECUTION_ORDER_EVENT, 0),
+    )
+    compact.setdefault("execution_ref_count", by_source.get(SOURCE_TYPE_EXECUTION, 0))
+    compact.setdefault(
+        "cost_ref_count",
+        by_source.get(SOURCE_TYPE_EXECUTION_TCA_METRIC, 0),
+    )
+    return compact
 
 
 def _as_aware_utc(value: datetime) -> datetime:
@@ -902,17 +983,7 @@ def _latest_run_payload(
     ref_count_field_names = sorted(
         {
             key
-            for key in (
-                "account_ref_count",
-                "transfer_ref_count",
-                "runtime_ledger_ref_count",
-                "runtime_ledger_signed_ref_count",
-                "runtime_ledger_missing_signed_ref_count",
-                "runtime_ledger_missing_account_ref_count",
-                "stable_ref_count",
-                "stable_ref_missing_count",
-                "stable_ref_mismatch_count",
-            )
+            for key in REF_COUNT_FIELD_NAMES
             if key in payload or key in ref_counts
         }
     )
@@ -1055,6 +1126,171 @@ def _latest_run_payload(
         "finished_at": row.finished_at.isoformat() if row.finished_at else None,
         "blockers": blockers,
     }
+
+
+def _latest_run_compact_status_payload(
+    row: Mapping[str, object] | None,
+) -> dict[str, object] | None:
+    if row is None:
+        return None
+    raw_blockers_json = row.get("blockers_json")
+    raw_ref_counts_json = row.get("ref_counts_json")
+    if raw_blockers_json is None and raw_ref_counts_json is None:
+        return None
+
+    blockers = _payload_string_list({"blockers": raw_blockers_json}, "blockers")
+    raw_ref_counts = (
+        cast(Mapping[str, object], raw_ref_counts_json)
+        if isinstance(raw_ref_counts_json, Mapping)
+        else cast(Mapping[str, object], {})
+    )
+    ref_count_source = dict(raw_ref_counts)
+    for key in REF_COUNT_FIELD_NAMES:
+        ref_count_source[key] = _payload_int(row, key)
+
+    cluster_id = _payload_int(row, "cluster_id")
+    ref_counts = _compact_reconciliation_ref_counts(
+        ref_count_source,
+        cluster_id=cluster_id,
+    )
+
+    raw_started_at = row.get("started_at")
+    started_at = (
+        _as_aware_utc(raw_started_at)
+        if isinstance(raw_started_at, datetime)
+        else datetime.now(timezone.utc)
+    )
+    raw_finished_at = row.get("finished_at")
+    finished_at = (
+        _as_aware_utc(raw_finished_at)
+        if isinstance(raw_finished_at, datetime)
+        else None
+    )
+    observed_at = finished_at or started_at
+    age_seconds = max(
+        0,
+        int((datetime.now(timezone.utc) - observed_at).total_seconds()),
+    )
+    max_age_seconds = max(1, int(settings.tigerbeetle_reconcile_max_age_seconds))
+    stale = age_seconds > max_age_seconds
+    status = str(row.get("status") or "unknown")
+    source_missing_count = _payload_int(row, "source_missing_count")
+    mismatched_transfer_count = _payload_int(row, "mismatched_transfer_count")
+    client_lookup_ok = status == "ok" and BLOCKER_CLIENT_UNAVAILABLE not in blockers
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": status == "ok" and not blockers,
+        "cluster_id": cluster_id,
+        "status": status,
+        "age_seconds": age_seconds,
+        "reconciliation_max_age_seconds": max_age_seconds,
+        "reconciliation_stale": stale,
+        "reconciliation_freshness": {
+            "observed_at": observed_at.isoformat(),
+            "age_seconds": age_seconds,
+            "max_age_seconds": max_age_seconds,
+            "stale": stale,
+        },
+        "authority": "accounting_parity_only",
+        "promotion_authority": False,
+        "overrides_runtime_ledger_authority": False,
+        "client_lookup_ok": client_lookup_ok,
+        "client_error": None,
+        "account_ref_count": _payload_int(row, "account_ref_count"),
+        "transfer_ref_count": _payload_int(row, "transfer_ref_count"),
+        "checked_transfer_count": _payload_int(row, "checked_transfer_count"),
+        "missing_transfer_count": _payload_int(row, "missing_transfer_count"),
+        "mismatched_transfer_count": mismatched_transfer_count,
+        "mismatched_ref_count": mismatched_transfer_count,
+        "source_missing_count": source_missing_count,
+        "source_row_missing_count": source_missing_count,
+        "missing_source_row_count": source_missing_count,
+        "source_amount_mismatch_count": 0,
+        "legacy_source_amount_unverifiable_count": 0,
+        "runtime_ledger_checked_transfer_count": 0,
+        "runtime_ledger_signed_transfer_count": 0,
+        "runtime_ledger_ref_count": _payload_int(row, "runtime_ledger_ref_count"),
+        "runtime_ledger_signed_ref_count": _payload_int(
+            row,
+            "runtime_ledger_signed_ref_count",
+        ),
+        "runtime_ledger_missing_signed_ref_count": _payload_int(
+            row,
+            "runtime_ledger_missing_signed_ref_count",
+        ),
+        "runtime_ledger_missing_account_ref_count": _payload_int(
+            row,
+            "runtime_ledger_missing_account_ref_count",
+        ),
+        "stable_ref_count": _payload_int(row, "stable_ref_count"),
+        "stable_ref_missing_count": _payload_int(row, "stable_ref_missing_count"),
+        "stable_ref_mismatch_count": _payload_int(row, "stable_ref_mismatch_count"),
+        "archived_runtime_ledger_source_missing_count": 0,
+        "runtime_ledger_direction_mismatch_count": 0,
+        "runtime_ledger_metadata_mismatch_count": 0,
+        "unlinked_event_count": 0,
+        "unlinked_order_event_ref_count": 0,
+        "unlinked_execution_count": 0,
+        "unlinked_execution_ref_count": 0,
+        "unlinked_cost_count": 0,
+        "unlinked_cost_ref_count": 0,
+        "unlinked_runtime_ledger_count": 0,
+        "unlinked_runtime_ledger_ref_count": 0,
+        "missing_transfer_refs": [],
+        "mismatched_refs": [],
+        "missing_source_rows": [],
+        "unlinked_refs": [],
+        "legacy_source_amount_unverifiable_refs": [],
+        "blocker_details": {},
+        "ref_counts": ref_counts,
+        "ref_count_field_names": list(REF_COUNT_FIELD_NAMES),
+        "started_at": started_at.isoformat(),
+        "finished_at": finished_at.isoformat() if finished_at else None,
+        "blockers": blockers,
+        "compact_status": True,
+        "payload_json_skipped": True,
+    }
+
+
+def latest_tigerbeetle_reconciliation_status_payload(
+    session: Session,
+    *,
+    cluster_id: int,
+) -> dict[str, object] | None:
+    row = (
+        session.execute(
+            select(
+                TigerBeetleReconciliationRun.id,
+                TigerBeetleReconciliationRun.cluster_id,
+                TigerBeetleReconciliationRun.started_at,
+                TigerBeetleReconciliationRun.finished_at,
+                TigerBeetleReconciliationRun.status,
+                TigerBeetleReconciliationRun.checked_transfer_count,
+                TigerBeetleReconciliationRun.missing_transfer_count,
+                TigerBeetleReconciliationRun.mismatched_transfer_count,
+                TigerBeetleReconciliationRun.source_missing_count,
+                TigerBeetleReconciliationRun.account_ref_count,
+                TigerBeetleReconciliationRun.transfer_ref_count,
+                TigerBeetleReconciliationRun.runtime_ledger_ref_count,
+                TigerBeetleReconciliationRun.runtime_ledger_signed_ref_count,
+                TigerBeetleReconciliationRun.runtime_ledger_missing_signed_ref_count,
+                TigerBeetleReconciliationRun.runtime_ledger_missing_account_ref_count,
+                TigerBeetleReconciliationRun.stable_ref_count,
+                TigerBeetleReconciliationRun.stable_ref_missing_count,
+                TigerBeetleReconciliationRun.stable_ref_mismatch_count,
+                TigerBeetleReconciliationRun.blockers_json,
+                TigerBeetleReconciliationRun.ref_counts_json,
+            )
+            .where(TigerBeetleReconciliationRun.cluster_id == cluster_id)
+            .order_by(TigerBeetleReconciliationRun.started_at.desc())
+            .limit(1)
+        )
+        .mappings()
+        .first()
+    )
+    return _latest_run_compact_status_payload(
+        None if row is None else cast(Mapping[str, object], row)
+    )
 
 
 def latest_tigerbeetle_reconciliation_payload(
@@ -1499,6 +1735,10 @@ def reconcile_tigerbeetle_transfers(
         session,
         cluster_id=settings_obj.tigerbeetle_cluster_id,
     )
+    compact_ref_counts = _compact_reconciliation_ref_counts(
+        ref_counts,
+        cluster_id=settings_obj.tigerbeetle_cluster_id,
+    )
     runtime_ledger_missing_signed_ref_count = _payload_int(
         ref_counts,
         "runtime_ledger_missing_signed_ref_count",
@@ -1623,6 +1863,33 @@ def reconcile_tigerbeetle_transfers(
                 missing_transfer_count=missing_transfer_count,
                 mismatched_transfer_count=mismatched_transfer_count,
                 source_missing_count=source_missing_count,
+                account_ref_count=_payload_int(compact_ref_counts, "account_ref_count"),
+                transfer_ref_count=_payload_int(compact_ref_counts, "transfer_ref_count"),
+                runtime_ledger_ref_count=_payload_int(
+                    compact_ref_counts,
+                    "runtime_ledger_ref_count",
+                ),
+                runtime_ledger_signed_ref_count=_payload_int(
+                    compact_ref_counts,
+                    "runtime_ledger_signed_ref_count",
+                ),
+                runtime_ledger_missing_signed_ref_count=(
+                    runtime_ledger_missing_signed_ref_count
+                ),
+                runtime_ledger_missing_account_ref_count=(
+                    runtime_ledger_missing_account_ref_count
+                ),
+                stable_ref_count=_payload_int(compact_ref_counts, "stable_ref_count"),
+                stable_ref_missing_count=_payload_int(
+                    compact_ref_counts,
+                    "stable_ref_missing_count",
+                ),
+                stable_ref_mismatch_count=max(
+                    stable_ref_mismatch_count,
+                    ref_count_stable_ref_mismatch_count,
+                ),
+                blockers_json=coerce_json_payload(unique_blockers),
+                ref_counts_json=coerce_json_payload(compact_ref_counts),
                 payload_json=coerce_json_payload(payload),
             )
         )

--- a/services/torghut/migrations/versions/0050_tigerbeetle_reconciliation_compact_status.py
+++ b/services/torghut/migrations/versions/0050_tigerbeetle_reconciliation_compact_status.py
@@ -1,0 +1,73 @@
+"""Add compact TigerBeetle reconciliation status columns.
+
+Revision ID: 0050_tigerbeetle_reconciliation_compact_status
+Revises: 0049_tigerbeetle_reconciliation_status_lookup
+Create Date: 2026-06-03 16:40:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0050_tigerbeetle_reconciliation_compact_status"
+down_revision = "0049_tigerbeetle_reconciliation_status_lookup"
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = "tigerbeetle_reconciliation_runs"
+COMPACT_COUNT_COLUMNS = (
+    "account_ref_count",
+    "transfer_ref_count",
+    "runtime_ledger_ref_count",
+    "runtime_ledger_signed_ref_count",
+    "runtime_ledger_missing_signed_ref_count",
+    "runtime_ledger_missing_account_ref_count",
+    "stable_ref_count",
+    "stable_ref_missing_count",
+    "stable_ref_mismatch_count",
+)
+COMPACT_JSON_COLUMNS = (
+    "blockers_json",
+    "ref_counts_json",
+)
+
+
+def _column_names() -> set[str]:
+    inspector = inspect(op.get_bind())
+    if not inspector.has_table(TABLE_NAME):
+        return set()
+    return {column["name"] for column in inspector.get_columns(TABLE_NAME)}
+
+
+def upgrade() -> None:
+    columns = _column_names()
+    if not columns:
+        return
+    for column_name in COMPACT_COUNT_COLUMNS:
+        if column_name in columns:
+            continue
+        op.add_column(
+            TABLE_NAME,
+            sa.Column(
+                column_name,
+                sa.BigInteger(),
+                server_default=sa.text("0"),
+                nullable=False,
+            ),
+        )
+    for column_name in COMPACT_JSON_COLUMNS:
+        if column_name in columns:
+            continue
+        op.add_column(TABLE_NAME, sa.Column(column_name, sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    columns = _column_names()
+    if not columns:
+        return
+    for column_name in reversed((*COMPACT_JSON_COLUMNS, *COMPACT_COUNT_COLUMNS)):
+        if column_name in columns:
+            op.drop_column(TABLE_NAME, column_name)

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -75,6 +75,7 @@ from app.trading.tigerbeetle_reconcile import (
     _usd_to_micros,
     _uuid_or_none,
     latest_tigerbeetle_reconciliation_payload,
+    latest_tigerbeetle_reconciliation_status_payload,
     reconcile_tigerbeetle_transfers,
     tigerbeetle_ref_counts,
 )
@@ -217,6 +218,18 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertTrue(payload["ok"])
             self.assertEqual(payload["blockers"], [])
             self.assertEqual(payload["checked_transfer_count"], 1)
+            run = session.execute(select(TigerBeetleReconciliationRun)).scalar_one()
+            self.assertEqual(run.blockers_json, [])
+            self.assertEqual(run.transfer_ref_count, 1)
+            self.assertIsInstance(run.ref_counts_json, dict)
+            compact_payload = latest_tigerbeetle_reconciliation_status_payload(
+                session,
+                cluster_id=2001,
+            )
+            self.assertIsNotNone(compact_payload)
+            assert compact_payload is not None
+            self.assertTrue(compact_payload["compact_status"])
+            self.assertEqual(compact_payload["transfer_ref_count"], 1)
 
     def test_reconciliation_closes_owned_tigerbeetle_client(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_tigerbeetle_reconciliation_compact_status_migration.py
+++ b/services/torghut/tests/test_tigerbeetle_reconciliation_compact_status_migration.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0050_tigerbeetle_reconciliation_compact_status.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0050", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0050")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestTigerBeetleReconciliationCompactStatusMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(
+            module.revision,
+            "0050_tigerbeetle_reconciliation_compact_status",
+        )
+        self.assertEqual(
+            module.down_revision,
+            "0049_tigerbeetle_reconciliation_status_lookup",
+        )
+
+    def test_upgrade_adds_compact_status_columns(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_columns.return_value = [{"name": "id"}]
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "add_column") as add_column,
+        ):
+            module.upgrade()
+
+        column_names = [call.args[1].name for call in add_column.call_args_list]
+        self.assertEqual(
+            column_names,
+            [
+                *module.COMPACT_COUNT_COLUMNS,
+                *module.COMPACT_JSON_COLUMNS,
+            ],
+        )
+
+    def test_upgrade_skips_existing_compact_status_columns(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_columns.return_value = [
+            {"name": column_name}
+            for column_name in (
+                "id",
+                *module.COMPACT_COUNT_COLUMNS,
+                *module.COMPACT_JSON_COLUMNS,
+            )
+        ]
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "add_column") as add_column,
+        ):
+            module.upgrade()
+
+        add_column.assert_not_called()
+
+    def test_downgrade_drops_compact_status_columns(self) -> None:
+        module = _load_migration_module()
+        bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_columns.return_value = [
+            {"name": column_name}
+            for column_name in (
+                "id",
+                *module.COMPACT_COUNT_COLUMNS,
+                *module.COMPACT_JSON_COLUMNS,
+            )
+        ]
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "drop_column") as drop_column,
+        ):
+            module.downgrade()
+
+        column_names = [call.args[1] for call in drop_column.call_args_list]
+        self.assertEqual(
+            column_names,
+            list(reversed((*module.COMPACT_JSON_COLUMNS, *module.COMPACT_COUNT_COLUMNS))),
+        )

--- a/services/torghut/tests/test_tigerbeetle_status.py
+++ b/services/torghut/tests/test_tigerbeetle_status.py
@@ -180,6 +180,128 @@ class TestTigerBeetleStatus(TestCase):
         self.assertTrue(ref_counts["bounded_status_live_query_skipped"])
         self.assertNotIn("tigerbeetle_ref_counts_unavailable", payload["blockers"])
 
+    def test_status_uses_compact_reconciliation_without_payload_or_ref_scan(
+        self,
+    ) -> None:
+        observed_at = datetime.now(timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                TigerBeetleReconciliationRun(
+                    cluster_id=2001,
+                    started_at=observed_at,
+                    finished_at=observed_at,
+                    status="ok",
+                    checked_transfer_count=7,
+                    missing_transfer_count=0,
+                    mismatched_transfer_count=0,
+                    source_missing_count=0,
+                    account_ref_count=54_129,
+                    transfer_ref_count=28_993,
+                    runtime_ledger_ref_count=26,
+                    runtime_ledger_signed_ref_count=26,
+                    runtime_ledger_missing_signed_ref_count=0,
+                    runtime_ledger_missing_account_ref_count=0,
+                    stable_ref_count=28_993,
+                    stable_ref_missing_count=0,
+                    stable_ref_mismatch_count=0,
+                    blockers_json=[],
+                    ref_counts_json={
+                        "by_source_type": {"strategy_runtime_ledger_bucket": 26},
+                        "source_materialization": {},
+                    },
+                    payload_json={
+                        "blockers": ["legacy_payload_should_not_be_read"],
+                        "ref_counts": {
+                            "runtime_ledger_missing_signed_ref_count": 99,
+                        },
+                    },
+                )
+            )
+            session.flush()
+            with (
+                patch(
+                    "app.main.latest_tigerbeetle_reconciliation_payload",
+                    side_effect=AssertionError("legacy payload query was called"),
+                ),
+                patch(
+                    "app.main.tigerbeetle_ref_counts",
+                    side_effect=AssertionError("live ref-count scan was called"),
+                ),
+            ):
+                payload = _build_tigerbeetle_ledger_status(session)
+
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["claimed_by_runtime_evidence"])
+        self.assertEqual(payload["blockers"], [])
+        self.assertEqual(payload["runtime_ledger_ref_count"], 26)
+        self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 0)
+        latest_reconciliation = payload["latest_reconciliation"]
+        self.assertIsInstance(latest_reconciliation, dict)
+        assert isinstance(latest_reconciliation, dict)
+        self.assertTrue(latest_reconciliation["compact_status"])
+        self.assertTrue(latest_reconciliation["payload_json_skipped"])
+        self.assertEqual(latest_reconciliation["transfer_ref_count"], 28_993)
+        ref_counts = payload["ref_counts"]
+        self.assertIsInstance(ref_counts, dict)
+        assert isinstance(ref_counts, dict)
+        self.assertTrue(ref_counts["bounded_status_live_query_skipped"])
+        self.assertEqual(ref_counts["transfer_ref_count"], 28_993)
+
+    def test_compact_reconciliation_status_keeps_persisted_blockers_fail_closed(
+        self,
+    ) -> None:
+        settings.tigerbeetle_reconcile_required = True
+        observed_at = datetime.now(timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                TigerBeetleReconciliationRun(
+                    cluster_id=2001,
+                    started_at=observed_at,
+                    finished_at=observed_at,
+                    status="degraded",
+                    checked_transfer_count=2,
+                    missing_transfer_count=0,
+                    mismatched_transfer_count=1,
+                    source_missing_count=0,
+                    account_ref_count=1,
+                    transfer_ref_count=2,
+                    runtime_ledger_ref_count=0,
+                    runtime_ledger_signed_ref_count=0,
+                    runtime_ledger_missing_signed_ref_count=0,
+                    runtime_ledger_missing_account_ref_count=0,
+                    stable_ref_count=2,
+                    stable_ref_missing_count=0,
+                    stable_ref_mismatch_count=1,
+                    blockers_json=["tigerbeetle_transfer_code_mismatch"],
+                    ref_counts_json={"by_source_type": {}},
+                    payload_json={
+                        "blockers": [],
+                        "ref_counts": {"transfer_ref_count": 0},
+                    },
+                )
+            )
+            session.flush()
+            with (
+                patch(
+                    "app.main.latest_tigerbeetle_reconciliation_payload",
+                    side_effect=AssertionError("legacy payload query was called"),
+                ),
+                patch(
+                    "app.main.tigerbeetle_ref_counts",
+                    side_effect=AssertionError("live ref-count scan was called"),
+                ),
+            ):
+                payload = _build_tigerbeetle_ledger_status(session)
+
+        self.assertFalse(payload["ok"])
+        self.assertFalse(payload["reconciliation_ok"])
+        self.assertIn("tigerbeetle_transfer_code_mismatch", payload["blockers"])
+        latest_reconciliation = payload["latest_reconciliation"]
+        self.assertIsInstance(latest_reconciliation, dict)
+        assert isinstance(latest_reconciliation, dict)
+        self.assertTrue(latest_reconciliation["compact_status"])
+        self.assertEqual(latest_reconciliation["blockers"], ["tigerbeetle_transfer_code_mismatch"])
+
     def test_ref_count_failure_degrades_without_status_exception(self) -> None:
         with Session(self.engine) as session:
             with patch(


### PR DESCRIPTION
## Summary

- Adds compact TigerBeetle reconciliation status columns so status readback can use scalar authority fields instead of loading full reconciliation payload JSON.
- Persists compact blockers/ref-count summaries from reconciliation runs and makes `/readyz` prefer the compact status projection before legacy fallback.
- Adds regression coverage for compact status readback, persisted blocker fail-closed behavior, writer persistence, and the new migration.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_tigerbeetle_status.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_reconciliation_compact_status_migration.py tests/test_tigerbeetle_reconciliation_status_lookup_migration.py -q`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall app tests migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen pytest tests/test_tigerbeetle_status.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_reconciliation_compact_status_migration.py tests/test_tigerbeetle_reconciliation_status_lookup_migration.py --cov=app --cov-branch --cov-fail-under=0 --cov-report=xml --cov-report= -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds Alembic migration `0050_tigerbeetle_reconciliation_compact_status` for new compact status columns on `tigerbeetle_reconciliation_runs`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
