### PR TITLE
fix(torghut): narrow renewal runtime targets

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -61,9 +61,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
-                    --runtime-window-target '{"hypothesis_id":"H-PAIRS-01","candidate_id":"c88421d619759b2cfaa6f4d0","observed_stage":"live","strategy_family":"microbar_cross_sectional_pairs","strategy_name":"microbar-cross-sectional-pairs-v1","account_label":"PA3SX7FYNUTF","source_account_label":"PA3SX7FYNUTF","source_dsn_env":"DB_DSN","target_dsn_env":"DB_DSN","source_kind":"live_runtime_observed","source_manifest_ref":"config/trading/hypotheses/h-pairs-01.json","dependency_quorum_decision":"allow","continuity_ok":"true","drift_ok":"false","runtime_window_import_health_gate":{"schema_version":"torghut.runtime-window-import-health-gate-summary.v1","dependency_quorum_decision":"allow","continuity_ok":"true","continuity_reason":"signals_present","drift_ok":"false","drift_reason":"drift_live_promotion_ineligible","blockers":[],"promotion_blockers":["drift_checks_not_ok"]},"runtime_window_import_promotion_blockers":["drift_checks_not_ok"],"evidence_collection_stage":"live","promotion_gate":"runtime_ledger_live_or_live_paper_required","promotion_allowed":false,"final_promotion_authorized":false,"final_promotion_allowed":false}' \
-                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan \
-                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/status \
+                    --runtime-window-target-plan-url 'http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5' \
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1848,10 +1848,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
-            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "'http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5'",
             args,
         )
-        self.assertIn(
+        self.assertNotIn(
             "--runtime-window-target-plan-url "
             "http://torghut.torghut.svc.cluster.local/trading/status",
             args,
@@ -1869,12 +1869,12 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertNotIn(
             "--runtime-window-target-plan-url "
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
             args,
         )
         self.assertNotIn(
             "--runtime-window-target-plan-url "
-            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertIn("--runtime-window-target-plan-exclusive", args)
@@ -1898,24 +1898,21 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertNotIn("--runtime-window-hypothesis-id H-TSMOM-01", args)
-        self.assertIn('--runtime-window-target \'{"hypothesis_id":"H-PAIRS-01"', args)
+        self.assertNotIn("--runtime-window-target '{\"hypothesis_id\"", args)
+        self.assertNotIn("PA3SX7FYNUTF", args)
         self.assertIn("--runtime-window-account-label TORGHUT_SIM", args)
         self.assertIn("--runtime-window-observed-stage paper", args)
         self.assertIn("--runtime-window-source-dsn-env SIM_DB_DSN", args)
         self.assertIn("--runtime-window-target-dsn-env SIM_DB_DSN", args)
-        self.assertIn(
+        self.assertNotIn(
             '"source_kind":"live_runtime_observed"',
             args,
         )
-        self.assertIn('"dependency_quorum_decision":"allow"', args)
-        self.assertIn('"continuity_ok":"true"', args)
-        self.assertIn('"drift_ok":"false"', args)
-        self.assertIn(
+        self.assertNotIn('"evidence_collection_stage":"live"', args)
+        self.assertNotIn(
             '"runtime_window_import_promotion_blockers":["drift_checks_not_ok"]',
             args,
         )
-        self.assertIn('"evidence_collection_stage":"live"', args)
-        self.assertIn('"promotion_allowed":false', args)
         self.assertIn(
             "RENEWAL_OUTPUT=/tmp/torghut-empirical-renewal/runtime-window-renewal.json",
             args,


### PR DESCRIPTION
## Summary

- Narrow `torghut-empirical-promotion-renewal` runtime-window imports to the sim paper-route evidence handoff endpoint.
- Remove the hardcoded live H-PAIRS import target from the renewal job so it no longer injects a guaranteed blocked live target into every proof run.
- Stop feeding `/trading/status` source-collection candidates into the runtime-window import target list; the proof packet still reads status separately as a gate.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall app tests scripts migrations`
- `bun run lint:argocd`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
