### PR TITLE
fix(torghut): prefer paper-route evidence targets

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -830,42 +830,41 @@ def _runtime_window_target_plan_with_live_gate_source_collection(
 def _runtime_window_target_plan_from_payload(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
+    paper_route_plan = _as_dict(payload.get("next_paper_route_runtime_window_targets"))
+    paper_route_evidence_payload = (
+        str(payload.get("schema_version") or "").strip()
+        == "torghut.paper-route-evidence.v1"
+    )
+    if paper_route_evidence_payload and paper_route_plan:
+        plan = paper_route_plan
+    else:
+        plan = {}
     source_runtime_window_plan = _as_dict(
         payload.get("source_runtime_window_import_plan")
     )
-    if _runtime_window_plan_target_items(source_runtime_window_plan):
+    if not plan and _runtime_window_plan_target_items(source_runtime_window_plan):
         plan = source_runtime_window_plan
-    else:
+    if not plan:
         direct_plan = _as_dict(payload.get("runtime_window_import_plan"))
         if direct_plan:
             plan = direct_plan
         else:
-            paper_route_plan = _as_dict(
-                payload.get("next_paper_route_runtime_window_targets")
+            gate = _as_dict(payload.get("live_submission_gate"))
+            gate_plan = _as_dict(
+                gate.get("runtime_ledger_paper_probation_import_plan")
             )
-            if (
-                str(payload.get("schema_version") or "").strip()
-                == "torghut.paper-route-evidence.v1"
-                and paper_route_plan
-            ):
-                plan = paper_route_plan
+            if gate_plan:
+                plan = gate_plan
             else:
-                gate = _as_dict(payload.get("live_submission_gate"))
-                gate_plan = _as_dict(
-                    gate.get("runtime_ledger_paper_probation_import_plan")
+                top_level_gate_plan = _as_dict(
+                    payload.get("runtime_ledger_paper_probation_import_plan")
                 )
-                if gate_plan:
-                    plan = gate_plan
+                if top_level_gate_plan:
+                    plan = top_level_gate_plan
+                elif paper_route_plan:
+                    plan = paper_route_plan
                 else:
-                    top_level_gate_plan = _as_dict(
-                        payload.get("runtime_ledger_paper_probation_import_plan")
-                    )
-                    if top_level_gate_plan:
-                        plan = top_level_gate_plan
-                    elif paper_route_plan:
-                        plan = paper_route_plan
-                    else:
-                        plan = _as_dict(payload)
+                    plan = _as_dict(payload)
     plan = _runtime_window_target_plan_with_live_gate_source_collection(
         payload=payload,
         plan=plan,

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1072,6 +1072,20 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         plan = renewal._runtime_window_target_plan_from_payload(
             {
                 "schema_version": "torghut.paper-route-evidence.v1",
+                "source_runtime_window_import_plan": {
+                    "schema_version": (
+                        "torghut.source-runtime-window-import-plan.v1"
+                    ),
+                    "target_count": 5,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-source-superset",
+                            "hypothesis_id": "H-SOURCE-SUPERSET",
+                            "window_start": "2026-05-20T13:30:00+00:00",
+                            "window_end": "2026-05-20T20:00:00+00:00",
+                        }
+                    ],
+                },
                 "live_submission_gate": {
                     "runtime_ledger_paper_probation_import_plan": {
                         "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",


### PR DESCRIPTION
## Summary

- Prefer `next_paper_route_runtime_window_targets` when a `torghut.paper-route-evidence.v1` payload also carries a broader `source_runtime_window_import_plan`.
- Preserve the older fallback chain for non-paper-route-evidence payloads and targetless fallbacks.
- Add a regression covering the live shape that was expanding a 2-target paper-route plan into a source-runtime superset.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'prefers_next_paper_route_plan or accepts_paper_route_evidence_plan or transient_empty_paper_route' -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen python -m compileall app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
