### PR TITLE
fix(torghut): clear stale profit proof exposure

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -5610,6 +5610,7 @@ class SimpleTradingPipeline(TradingPipeline):
                     Execution.side,
                     Execution.filled_qty,
                     TradeDecision.decision_json,
+                    Execution.created_at,
                 )
                 .join(TradeDecision, Execution.trade_decision_id == TradeDecision.id)
                 .where(
@@ -5634,7 +5635,12 @@ class SimpleTradingPipeline(TradingPipeline):
             return True
 
         signed_qty = Decimal("0")
-        for side, filled_qty, raw_decision_json in rows:
+        latest_fill_at: datetime | None = None
+        for row in rows:
+            side = row[0]
+            filled_qty = row[1]
+            raw_decision_json = row[2]
+            created_at = row[3] if len(row) > 3 else None
             if not isinstance(raw_decision_json, Mapping):
                 continue
             decision_json = cast(Mapping[str, Any], raw_decision_json)
@@ -5660,7 +5666,22 @@ class SimpleTradingPipeline(TradingPipeline):
                 signed_qty -= qty
             else:
                 signed_qty += qty
-        return abs(signed_qty) > _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON
+            if isinstance(created_at, datetime):
+                latest_fill_at = (
+                    created_at
+                    if latest_fill_at is None or created_at > latest_fill_at
+                    else latest_fill_at
+                )
+        if abs(signed_qty) <= _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON:
+            return False
+        if SimpleTradingPipeline._paper_route_target_symbol_has_flat_repair_snapshot(
+            session=session,
+            account_label=account_label,
+            symbol=normalized_symbol,
+            after=latest_fill_at,
+        ):
+            return False
+        return True
 
     @staticmethod
     def _paper_route_target_symbol_has_open_position(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8994,6 +8994,46 @@ class TestTradingPipeline(TestCase):
             )
         )
 
+    def test_paper_route_target_profit_proof_exposure_accepts_flat_snapshot(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid4(),
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        fill_result = Mock()
+        fill_result.all.return_value = [
+            (
+                "buy",
+                Decimal("3"),
+                {"params": {"profit_proof_eligible": True}},
+                datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc),
+            )
+        ]
+        snapshot_result = Mock()
+        snapshot_result.first.return_value = (
+            [{"symbol": "AAPL", "qty": "0", "market_value": "0"}],
+            datetime(2026, 5, 26, 14, 5, tzinfo=timezone.utc),
+        )
+        mock_session = Mock(spec=Session)
+        mock_session.execute.side_effect = [fill_result, snapshot_result]
+
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_profit_proof_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol="aapl",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+
     def test_paper_route_target_profit_proof_exposure_helper_returns_false_without_key(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Let the paper-route profit-proof exposure guard honor later flat repair snapshots.
- Preserve fail-closed behavior when old profit-proof fills still imply open exposure.
- Add a regression test covering stale historical fills followed by a flat snapshot.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k "profit_proof_exposure" -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen python -m compileall app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
