### PR TITLE
feat(torghut): add signal adaptive execution stress

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -69,6 +69,9 @@ from app.trading.discovery.queue_survival_fill_stress import (
 from app.trading.discovery.rough_flow_volatility_stress import (
     extract_rough_flow_volatility_stress,
 )
+from app.trading.discovery.signal_adaptive_execution_resilience_stress import (
+    extract_signal_adaptive_execution_resilience_stress,
+)
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
@@ -101,6 +104,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "intraday_jump_burst_stress",
     "rough_flow_volatility_impact_stress",
     "institutional_mechanism_fidelity_stress",
+    "signal_adaptive_execution_resilience_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -209,6 +213,9 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     institutional_mechanism_fidelity_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    signal_adaptive_execution_resilience_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -324,6 +331,9 @@ class FastReplayPreviewRow:
             "rough_flow_volatility_stress": dict(self.rough_flow_volatility_stress),
             "institutional_mechanism_fidelity_stress": dict(
                 self.institutional_mechanism_fidelity_stress
+            ),
+            "signal_adaptive_execution_resilience_stress": dict(
+                self.signal_adaptive_execution_resilience_stress
             ),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
@@ -520,6 +530,7 @@ class FastReplayPreviewResult:
                 "intraday_jump_burst_stress": "deterministic replay-row intraday jump, volatility burst, and spurious-jump source-gap stress from SSRN:5223127, SSRN:5199540, and arXiv:2602.10925; jump proxies are not PnL authority; preview ranking only",
                 "rough_flow_volatility_impact_stress": "deterministic persistent signed-flow, rough traded-volume/volatility, Poisson-arrival, and power-law impact consistency stress from arXiv:2601.23172 and arXiv:2603.13170; roughness proxies are not PnL authority; preview ranking only",
                 "institutional_mechanism_fidelity_stress": "deterministic market-calendar, auction/session-boundary, price-limit, tick-size, latency, and asynchronous cross-asset mechanism-fidelity stress from arXiv:2604.18046 and arXiv:2511.02016; simulator realism proxies are not PnL authority; preview ranking only",
+                "signal_adaptive_execution_resilience_stress": "deterministic signal-adaptive quote, fill-intensity, inventory-risk, stochastic liquidity-resilience, and regime-switch stress from arXiv:2605.24242 and arXiv:2506.11813; signal drift and modeled fill intensity are not PnL authority; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1184,6 +1195,7 @@ def _score_candidate_spec(
             intraday_jump_burst_stress={},
             rough_flow_volatility_stress={},
             institutional_mechanism_fidelity_stress={},
+            signal_adaptive_execution_resilience_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1413,6 +1425,20 @@ def _score_candidate_spec(
         )
         or 0.0
     )
+    signal_adaptive_execution_resilience_stress = (
+        extract_signal_adaptive_execution_resilience_stress(
+            matched_source_rows,
+            direction=direction,
+        ).to_payload()
+    )
+    signal_adaptive_execution_resilience_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(
+                signal_adaptive_execution_resilience_stress.get("ranking_features")
+            ).get("replay_rank_penalty_bps")
+        )
+        or 0.0
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
@@ -1472,6 +1498,7 @@ def _score_candidate_spec(
         - intraday_jump_burst_rank_penalty_bps * 0.05
         - rough_flow_volatility_rank_penalty_bps * 0.06
         - institutional_mechanism_fidelity_rank_penalty_bps * 0.05
+        - signal_adaptive_execution_resilience_rank_penalty_bps * 0.05
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1516,6 +1543,7 @@ def _score_candidate_spec(
         - intraday_jump_burst_rank_penalty_bps * 0.03
         - rough_flow_volatility_rank_penalty_bps * 0.03
         - institutional_mechanism_fidelity_rank_penalty_bps * 0.03
+        - signal_adaptive_execution_resilience_rank_penalty_bps * 0.03
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1568,6 +1596,9 @@ def _score_candidate_spec(
         institutional_mechanism_fidelity_stress=dict(
             institutional_mechanism_fidelity_stress
         ),
+        signal_adaptive_execution_resilience_stress=dict(
+            signal_adaptive_execution_resilience_stress
+        ),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1617,6 +1648,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - _intraday_jump_burst_rank_penalty_bps(row) * 0.04
         - _rough_flow_volatility_rank_penalty_bps(row) * 0.04
         - _institutional_mechanism_fidelity_rank_penalty_bps(row) * 0.04
+        - _signal_adaptive_execution_resilience_rank_penalty_bps(row) * 0.04
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
@@ -1712,6 +1744,15 @@ def _institutional_mechanism_fidelity_rank_penalty_bps(
 ) -> float:
     ranking_features = _mapping(
         row.institutional_mechanism_fidelity_stress.get("ranking_features")
+    )
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _signal_adaptive_execution_resilience_rank_penalty_bps(
+    row: FastReplayPreviewRow,
+) -> float:
+    ranking_features = _mapping(
+        row.signal_adaptive_execution_resilience_stress.get("ranking_features")
     )
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
@@ -1921,6 +1962,9 @@ def _row_with_rank_and_selection(
         institutional_mechanism_fidelity_stress=dict(
             row.institutional_mechanism_fidelity_stress
         ),
+        signal_adaptive_execution_resilience_stress=dict(
+            row.signal_adaptive_execution_resilience_stress
+        ),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -1996,6 +2040,9 @@ def _row_with_frontier_dedupe(
         rough_flow_volatility_stress=dict(row.rough_flow_volatility_stress),
         institutional_mechanism_fidelity_stress=dict(
             row.institutional_mechanism_fidelity_stress
+        ),
+        signal_adaptive_execution_resilience_stress=dict(
+            row.signal_adaptive_execution_resilience_stress
         ),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
@@ -2820,6 +2867,8 @@ def _risk_flags_for_row(
         flags.add("rough_flow_volatility_stress_penalty_active")
     if _institutional_mechanism_fidelity_rank_penalty_bps(row) > 0:
         flags.add("institutional_mechanism_fidelity_stress_penalty_active")
+    if _signal_adaptive_execution_resilience_rank_penalty_bps(row) > 0:
+        flags.add("signal_adaptive_execution_resilience_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
         flags.add("partial_symbol_coverage")
     if row.trading_day_count <= 0:
@@ -2876,6 +2925,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("rough_flow_volatility_stress_downranks_only")
     if _institutional_mechanism_fidelity_rank_penalty_bps(row) > 0:
         reasons.add("institutional_mechanism_fidelity_stress_downranks_only")
+    if _signal_adaptive_execution_resilience_rank_penalty_bps(row) > 0:
+        reasons.add("signal_adaptive_execution_resilience_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
         reasons.add("missing_replay_tape_source_data_explicit_blocker")
     if lineage_blockers:
@@ -2925,6 +2976,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("rough_flow_volatility_stress_penalty")
     if _institutional_mechanism_fidelity_rank_penalty_bps(row) > 0:
         vetoes.add("institutional_mechanism_fidelity_stress_penalty")
+    if _signal_adaptive_execution_resilience_rank_penalty_bps(row) > 0:
+        vetoes.add("signal_adaptive_execution_resilience_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:
         vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
     return tuple(sorted(vetoes))

--- a/services/torghut/app/trading/discovery/signal_adaptive_execution_resilience_stress.py
+++ b/services/torghut/app/trading/discovery/signal_adaptive_execution_resilience_stress.py
@@ -1,0 +1,575 @@
+"""Preview-only signal-adaptive execution and liquidity-resilience stress.
+
+This module converts recent optimal-execution papers into deterministic replay
+ranking inputs. It tests whether a candidate's replay edge is robust after
+accounting for signal-adaptive limit-order quoting, execution risk, inventory
+risk, market impact, and stochastic liquidity resilience/regime shifts.
+
+The output is a local offline replay prefilter only. It never models broker
+fills as proof, writes runtime ledgers, relaxes promotion gates, or enables live
+capital.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import isfinite, log1p
+from statistics import median
+from typing import Any, cast
+
+from app.trading.models import SignalEnvelope
+
+SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_SCHEMA_VERSION = (
+    "torghut.signal-adaptive-execution-resilience-stress.v1"
+)
+SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.signal-adaptive-execution-resilience-stress-contract.v1"
+)
+SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_PROOF_SEMANTICS_LABEL = (
+    "signal_adaptive_execution_resilience_stress_preview_only_"
+    "exact_replay_route_tca_order_lifecycle_runtime_ledger_required"
+)
+SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_PRIMARY_SOURCES: tuple[
+    Mapping[str, str], ...
+] = (
+    {
+        "source_id": "arxiv-2605.24242",
+        "url": "https://arxiv.org/abs/2605.24242",
+        "title": "Explicit Signal-Adaptive Sequential Optimal Execution Quotes",
+        "date": "2026-05-22",
+        "mechanism": (
+            "signal_dependent_drift_limit_order_quotes_fill_intensity_"
+            "inventory_risk_execution_risk_price_impact"
+        ),
+    },
+    {
+        "source_id": "arxiv-2506.11813",
+        "url": "https://arxiv.org/abs/2506.11813",
+        "title": "Optimal Execution under Liquidity Uncertainty",
+        "date": "2025-06-13",
+        "mechanism": (
+            "general_lob_shape_market_impact_resilience_volume_effect_"
+            "regime_switching_liquidity"
+        ),
+    },
+)
+
+_PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
+_SIGNAL_FIELDS = (
+    "signal_bps",
+    "alpha_bps",
+    "expected_return_bps",
+    "predicted_return_bps",
+    "drift_bps",
+    "forecast_return_bps",
+    "microprice_bias_bps",
+)
+_OFI_FIELDS = ("ofi", "order_flow_imbalance", "ofi_score", "signed_ofi")
+_SPREAD_FIELDS = ("spread_bps", "quoted_spread_bps", "effective_spread_bps")
+_QUOTE_OFFSET_FIELDS = (
+    "quote_offset_bps",
+    "limit_quote_offset_bps",
+    "passive_quote_offset_bps",
+    "limit_offset_bps",
+    "reservation_price_offset_bps",
+)
+_FILL_INTENSITY_FIELDS = (
+    "fill_intensity",
+    "fill_probability",
+    "limit_fill_probability",
+    "fill_rate",
+    "arrival_intensity",
+)
+_INVENTORY_FIELDS = ("inventory", "position", "current_inventory", "net_position")
+_TARGET_INVENTORY_FIELDS = ("target_inventory", "desired_inventory", "inventory_target")
+_MAX_INVENTORY_FIELDS = (
+    "max_inventory",
+    "inventory_limit",
+    "position_limit",
+    "max_position",
+)
+_DEPTH_FIELDS = (
+    "bid_size",
+    "ask_size",
+    "best_bid_size",
+    "best_ask_size",
+    "bid_depth",
+    "ask_depth",
+    "visible_depth",
+    "book_depth",
+)
+_VOLUME_FIELDS = (
+    "microbar_volume",
+    "volume",
+    "qty",
+    "quantity",
+    "trade_size",
+    "last_size",
+)
+_IMPACT_FIELDS = ("impact_bps", "estimated_impact_bps", "market_impact_bps")
+_EVENT_FIELDS = ("event_type", "order_event_type", "lob_event_type", "action", "type")
+_SHOCK_TOKENS = frozenset(("trade", "fill", "execution", "market", "sweep"))
+_MIN_FILL_PROBABILITY = 0.15
+_DEPTH_SWITCH_LOG_THRESHOLD = 0.60
+_SIGNAL_COST_BUFFER_BPS = 0.25
+
+
+@dataclass(frozen=True)
+class SignalAdaptiveExecutionResilienceStressSummary:
+    row_count: int
+    observed_signal_count: int
+    observed_quote_offset_count: int
+    observed_fill_intensity_count: int
+    observed_inventory_count: int
+    observed_depth_count: int
+    median_signal_edge_bps: float
+    median_quote_offset_bps: float
+    median_fill_intensity: float
+    signal_cost_mismatch_share: float
+    quote_adaptation_gap_share: float
+    fill_intensity_shortfall_share: float
+    inventory_risk_pressure_score: float
+    liquidity_regime_switch_share: float
+    resilience_recovery_failure_share: float
+    impact_resilience_mismatch_share: float
+    missing_execution_metadata_score: float
+    execution_resilience_gap_score: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_signal_adaptive_execution_resilience_stress_ranking",
+            "source_papers": [
+                dict(item)
+                for item in SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "observed_signal_count": self.observed_signal_count,
+            "observed_quote_offset_count": self.observed_quote_offset_count,
+            "observed_fill_intensity_count": self.observed_fill_intensity_count,
+            "observed_inventory_count": self.observed_inventory_count,
+            "observed_depth_count": self.observed_depth_count,
+            "median_signal_edge_bps": _stable_float(self.median_signal_edge_bps),
+            "median_quote_offset_bps": _stable_float(self.median_quote_offset_bps),
+            "median_fill_intensity": _stable_float(self.median_fill_intensity),
+            "signal_cost_mismatch_share": _stable_float(
+                self.signal_cost_mismatch_share
+            ),
+            "quote_adaptation_gap_share": _stable_float(
+                self.quote_adaptation_gap_share
+            ),
+            "fill_intensity_shortfall_share": _stable_float(
+                self.fill_intensity_shortfall_share
+            ),
+            "inventory_risk_pressure_score": _stable_float(
+                self.inventory_risk_pressure_score
+            ),
+            "liquidity_regime_switch_share": _stable_float(
+                self.liquidity_regime_switch_share
+            ),
+            "resilience_recovery_failure_share": _stable_float(
+                self.resilience_recovery_failure_share
+            ),
+            "impact_resilience_mismatch_share": _stable_float(
+                self.impact_resilience_mismatch_share
+            ),
+            "missing_execution_metadata_score": _stable_float(
+                self.missing_execution_metadata_score
+            ),
+            "execution_resilience_gap_score": _stable_float(
+                self.execution_resilience_gap_score
+            ),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "signal_cost_mismatch_share": _stable_float(
+                    self.signal_cost_mismatch_share
+                ),
+                "quote_adaptation_gap_share": _stable_float(
+                    self.quote_adaptation_gap_share
+                ),
+                "fill_intensity_shortfall_share": _stable_float(
+                    self.fill_intensity_shortfall_share
+                ),
+                "inventory_risk_pressure_score": _stable_float(
+                    self.inventory_risk_pressure_score
+                ),
+                "liquidity_regime_switch_share": _stable_float(
+                    self.liquidity_regime_switch_share
+                ),
+                "resilience_recovery_failure_share": _stable_float(
+                    self.resilience_recovery_failure_share
+                ),
+                "impact_resilience_mismatch_share": _stable_float(
+                    self.impact_resilience_mismatch_share
+                ),
+                "missing_execution_metadata_score": _stable_float(
+                    self.missing_execution_metadata_score
+                ),
+                "execution_resilience_gap_score": _stable_float(
+                    self.execution_resilience_gap_score
+                ),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "signal_adaptive_quote_preview": True,
+            "fill_intensity_execution_risk_preview": True,
+            "inventory_risk_preview": True,
+            "liquidity_resilience_regime_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": (
+                SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_PROOF_SEMANTICS_LABEL
+            ),
+        }
+
+
+def signal_adaptive_execution_resilience_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item)
+            for item in SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": "signal_adaptive_quote_and_liquidity_resilience_replay_stress",
+        "stress_components": [
+            "signal_cost_mismatch_share",
+            "quote_adaptation_gap_share",
+            "fill_intensity_shortfall_share",
+            "inventory_risk_pressure_score",
+            "liquidity_regime_switch_share",
+            "resilience_recovery_failure_share",
+            "impact_resilience_mismatch_share",
+            "missing_execution_metadata_score",
+        ],
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_order_lifecycle_fill_evidence": True,
+            "requires_runtime_ledger": True,
+            "rejects_signal_drift_as_fill_or_pnl_authority": True,
+            "rejects_modeled_fill_intensity_as_runtime_ledger_authority": True,
+            "rejects_liquidity_resilience_proxy_as_cost_proof": True,
+        },
+    }
+
+
+def build_signal_adaptive_execution_resilience_stress_schema_hash() -> str:
+    return _stable_hash(signal_adaptive_execution_resilience_stress_contract())
+
+
+def extract_signal_adaptive_execution_resilience_stress(
+    records: Sequence[SignalEnvelope],
+    *,
+    direction: int | float = 1,
+) -> SignalAdaptiveExecutionResilienceStressSummary:
+    """Extract deterministic signal-adaptive execution stress from replay rows."""
+
+    ordered = tuple(
+        sorted(records, key=lambda item: (item.event_ts, item.symbol, item.seq or 0))
+    )
+    schema_hash = build_signal_adaptive_execution_resilience_stress_schema_hash()
+    if not ordered:
+        return SignalAdaptiveExecutionResilienceStressSummary(
+            row_count=0,
+            observed_signal_count=0,
+            observed_quote_offset_count=0,
+            observed_fill_intensity_count=0,
+            observed_inventory_count=0,
+            observed_depth_count=0,
+            median_signal_edge_bps=0.0,
+            median_quote_offset_bps=0.0,
+            median_fill_intensity=0.0,
+            signal_cost_mismatch_share=0.0,
+            quote_adaptation_gap_share=0.0,
+            fill_intensity_shortfall_share=0.0,
+            inventory_risk_pressure_score=0.0,
+            liquidity_regime_switch_share=0.0,
+            resilience_recovery_failure_share=0.0,
+            impact_resilience_mismatch_share=0.0,
+            missing_execution_metadata_score=1.0,
+            execution_resilience_gap_score=1.0,
+            replay_rank_penalty_bps=35.0,
+            warnings=(
+                "empty_replay_rows_for_signal_adaptive_execution_resilience_stress",
+            ),
+            feature_schema_hash=schema_hash,
+        )
+
+    signed_direction = 1.0 if float(direction) >= 0.0 else -1.0
+    warnings: set[str] = set()
+    signal_edges: list[float] = []
+    quote_offsets: list[float] = []
+    fill_intensities: list[float] = []
+    inventory_pressures: list[float] = []
+    depths: list[float] = []
+    impact_rows = 0
+    mismatch_count = 0
+    quote_gap_count = 0
+    short_fill_count = 0
+    impact_resilience_mismatch_count = 0
+    prior_depth_by_symbol: dict[str, float] = {}
+    prior_event_shock_by_symbol: dict[str, tuple[float, float]] = {}
+    depth_switch_count = 0
+    resilience_failure_count = 0
+    depth_transition_count = 0
+
+    for row in ordered:
+        payload = row.payload
+        signal_edge = _signal_edge_bps(payload, signed_direction)
+        spread = _first_number(payload, _SPREAD_FIELDS)
+        quote_offset = _first_number(payload, _QUOTE_OFFSET_FIELDS)
+        fill_intensity = _first_number(payload, _FILL_INTENSITY_FIELDS)
+        inventory_pressure = _inventory_pressure(payload)
+        depth = _depth_proxy(payload)
+        impact = _first_number(payload, _IMPACT_FIELDS)
+
+        if signal_edge is not None:
+            signal_edges.append(signal_edge)
+        if quote_offset is not None:
+            quote_offsets.append(abs(quote_offset))
+        if fill_intensity is not None:
+            fill_intensities.append(max(0.0, fill_intensity))
+        if inventory_pressure is not None:
+            inventory_pressures.append(inventory_pressure)
+        if depth is not None and depth > 0.0:
+            depths.append(depth)
+            prior_depth = prior_depth_by_symbol.get(row.symbol)
+            if prior_depth is not None and prior_depth > 0.0:
+                depth_transition_count += 1
+                if (
+                    abs(log1p(depth) - log1p(prior_depth))
+                    >= _DEPTH_SWITCH_LOG_THRESHOLD
+                ):
+                    depth_switch_count += 1
+            shock = prior_event_shock_by_symbol.get(row.symbol)
+            if shock is not None:
+                shock_depth, shock_impact = shock
+                if shock_depth > 0.0 and depth < shock_depth * 0.75:
+                    resilience_failure_count += 1
+                if shock_impact > 0.0 and depth < shock_depth * 0.75:
+                    impact_resilience_mismatch_count += 1
+            prior_depth_by_symbol[row.symbol] = depth
+
+        if signal_edge is not None:
+            cost_floor = (spread or 0.0) * 0.5 + abs(quote_offset or 0.0)
+            if signal_edge <= cost_floor + _SIGNAL_COST_BUFFER_BPS:
+                mismatch_count += 1
+            if quote_offset is not None and abs(quote_offset) > max(
+                0.5, abs(signal_edge) * 0.8
+            ):
+                quote_gap_count += 1
+        if fill_intensity is not None and fill_intensity < _MIN_FILL_PROBABILITY:
+            short_fill_count += 1
+        if impact is not None:
+            impact_rows += 1
+        if depth is not None and impact is not None and _is_shock_event(payload):
+            prior_event_shock_by_symbol[row.symbol] = (depth, abs(impact))
+
+    signal_count = len(signal_edges)
+    quote_count = len(quote_offsets)
+    fill_count = len(fill_intensities)
+    inventory_count = len(inventory_pressures)
+    depth_count = len(depths)
+
+    if signal_count == 0:
+        warnings.add("missing_signal_drift_or_alpha_fields")
+    if quote_count == 0:
+        warnings.add("missing_limit_quote_offset_fields")
+    if fill_count == 0:
+        warnings.add("missing_fill_intensity_or_probability_fields")
+    if inventory_count == 0:
+        warnings.add("missing_inventory_risk_fields")
+    if depth_count < 2:
+        warnings.add("insufficient_depth_rows_for_liquidity_resilience_stress")
+    if impact_rows == 0:
+        warnings.add("missing_price_impact_fields_for_resilience_mismatch")
+
+    observed_components = sum(
+        1
+        for count in (
+            signal_count,
+            quote_count,
+            fill_count,
+            inventory_count,
+            depth_count,
+            impact_rows,
+        )
+        if count > 0
+    )
+    missing_execution_metadata_score = 1.0 - observed_components / 6.0
+    signal_cost_mismatch_share = mismatch_count / max(1, signal_count)
+    quote_adaptation_gap_share = quote_gap_count / max(
+        1, min(signal_count, quote_count)
+    )
+    fill_intensity_shortfall_share = short_fill_count / max(1, fill_count)
+    liquidity_regime_switch_share = depth_switch_count / max(1, depth_transition_count)
+    resilience_recovery_failure_share = resilience_failure_count / max(
+        1, depth_transition_count
+    )
+    impact_resilience_mismatch_share = impact_resilience_mismatch_count / max(
+        1, impact_rows
+    )
+    inventory_risk_pressure_score = (
+        median(inventory_pressures) if inventory_pressures else 0.0
+    )
+
+    execution_resilience_gap_score = min(
+        1.0,
+        missing_execution_metadata_score * 0.20
+        + signal_cost_mismatch_share * 0.18
+        + quote_adaptation_gap_share * 0.14
+        + fill_intensity_shortfall_share * 0.14
+        + inventory_risk_pressure_score * 0.12
+        + liquidity_regime_switch_share * 0.10
+        + resilience_recovery_failure_share * 0.08
+        + impact_resilience_mismatch_share * 0.04,
+    )
+    replay_rank_penalty_bps = min(95.0, 7.0 + execution_resilience_gap_score * 88.0)
+
+    return SignalAdaptiveExecutionResilienceStressSummary(
+        row_count=len(ordered),
+        observed_signal_count=signal_count,
+        observed_quote_offset_count=quote_count,
+        observed_fill_intensity_count=fill_count,
+        observed_inventory_count=inventory_count,
+        observed_depth_count=depth_count,
+        median_signal_edge_bps=median(signal_edges) if signal_edges else 0.0,
+        median_quote_offset_bps=median(quote_offsets) if quote_offsets else 0.0,
+        median_fill_intensity=median(fill_intensities) if fill_intensities else 0.0,
+        signal_cost_mismatch_share=signal_cost_mismatch_share,
+        quote_adaptation_gap_share=quote_adaptation_gap_share,
+        fill_intensity_shortfall_share=fill_intensity_shortfall_share,
+        inventory_risk_pressure_score=inventory_risk_pressure_score,
+        liquidity_regime_switch_share=liquidity_regime_switch_share,
+        resilience_recovery_failure_share=resilience_recovery_failure_share,
+        impact_resilience_mismatch_share=impact_resilience_mismatch_share,
+        missing_execution_metadata_score=missing_execution_metadata_score,
+        execution_resilience_gap_score=execution_resilience_gap_score,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=tuple(sorted(warnings)),
+        feature_schema_hash=schema_hash,
+    )
+
+
+def _signal_edge_bps(payload: Mapping[str, Any], direction: float) -> float | None:
+    signal = _first_number(payload, _SIGNAL_FIELDS)
+    if signal is not None:
+        return direction * signal
+    ofi = _first_number(payload, _OFI_FIELDS)
+    if ofi is None:
+        return None
+    return direction * max(-10.0, min(10.0, ofi * 8.0))
+
+
+def _inventory_pressure(payload: Mapping[str, Any]) -> float | None:
+    inventory = _first_number(payload, _INVENTORY_FIELDS)
+    if inventory is None:
+        return None
+    target = _first_number(payload, _TARGET_INVENTORY_FIELDS) or 0.0
+    limit = _first_number(payload, _MAX_INVENTORY_FIELDS)
+    denominator = max(
+        1.0,
+        abs(limit)
+        if limit is not None and limit != 0.0
+        else abs(inventory) + abs(target),
+    )
+    return min(1.0, abs(inventory - target) / denominator)
+
+
+def _depth_proxy(payload: Mapping[str, Any]) -> float | None:
+    explicit = _first_number(payload, _DEPTH_FIELDS)
+    if explicit is not None:
+        return explicit
+    bid = _first_number(payload, ("bid_size", "bid_qty", "best_bid_size", "bid_depth"))
+    ask = _first_number(payload, ("ask_size", "ask_qty", "best_ask_size", "ask_depth"))
+    if bid is not None or ask is not None:
+        return max(0.0, (bid or 0.0) + (ask or 0.0))
+    return _first_number(payload, _VOLUME_FIELDS)
+
+
+def _is_shock_event(payload: Mapping[str, Any]) -> bool:
+    value = str(_first_value(payload, _EVENT_FIELDS) or "").lower()
+    if any(token in value for token in _SHOCK_TOKENS):
+        return True
+    volume = _first_number(payload, _VOLUME_FIELDS)
+    depth = _depth_proxy(payload)
+    return volume is not None and depth is not None and volume > depth * 0.5
+
+
+def _first_value(payload: Mapping[str, Any], fields: Sequence[str]) -> Any | None:
+    for field in fields:
+        if field in payload and payload[field] is not None:
+            return payload[field]
+    return None
+
+
+def _first_number(payload: Mapping[str, Any], fields: Sequence[str]) -> float | None:
+    value = _first_value(payload, fields)
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(number):
+        return None
+    return number
+
+
+def _stable_float(value: float) -> float:
+    if not isfinite(value):
+        return 0.0
+    return round(float(value), 6)
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        _json_ready(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[Any, Any], value)
+        return {
+            str(key): _json_ready(mapping[key])
+            for key in sorted(mapping.keys(), key=str)
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_ready(item) for item in cast(Sequence[Any], value)]
+    return value
+
+
+__all__ = [
+    "SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_PRIMARY_SOURCES",
+    "SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_PROOF_SEMANTICS_LABEL",
+    "SIGNAL_ADAPTIVE_EXECUTION_RESILIENCE_STRESS_SCHEMA_VERSION",
+    "SignalAdaptiveExecutionResilienceStressSummary",
+    "build_signal_adaptive_execution_resilience_stress_schema_hash",
+    "extract_signal_adaptive_execution_resilience_stress",
+    "signal_adaptive_execution_resilience_stress_contract",
+]

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -261,6 +261,10 @@ class TestFastReplayPreview(TestCase):
             "institutional_mechanism_fidelity_stress",
             payload["implemented_mechanisms"],
         )
+        self.assertIn(
+            "signal_adaptive_execution_resilience_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",
@@ -536,6 +540,38 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn(
             "institutional_mechanism_fidelity_stress_downranks_only",
+            row_payload["ranking_only_reasons"],
+        )
+        self.assertIn("signal_adaptive_execution_resilience_stress", row_payload)
+        self.assertEqual(
+            row_payload["signal_adaptive_execution_resilience_stress"]["status"],
+            "preview_only_signal_adaptive_execution_resilience_stress_ranking",
+        )
+        self.assertIn(
+            "arxiv-2605.24242",
+            {
+                source["source_id"]
+                for source in row_payload[
+                    "signal_adaptive_execution_resilience_stress"
+                ]["source_papers"]
+            },
+        )
+        self.assertFalse(
+            row_payload["signal_adaptive_execution_resilience_stress"][
+                "proof_authority"
+            ]
+        )
+        self.assertFalse(
+            row_payload["signal_adaptive_execution_resilience_stress"][
+                "promotion_authority"
+            ]
+        )
+        self.assertIn(
+            "signal_adaptive_execution_resilience_stress_penalty_active",
+            row_payload["risk_flags"],
+        )
+        self.assertIn(
+            "signal_adaptive_execution_resilience_stress_downranks_only",
             row_payload["ranking_only_reasons"],
         )
         self.assertIn(

--- a/services/torghut/tests/test_signal_adaptive_execution_resilience_stress.py
+++ b/services/torghut/tests/test_signal_adaptive_execution_resilience_stress.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.signal_adaptive_execution_resilience_stress import (
+    extract_signal_adaptive_execution_resilience_stress,
+    signal_adaptive_execution_resilience_stress_contract,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestSignalAdaptiveExecutionResilienceStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        price: str,
+        signal_bps: str,
+        spread_bps: str,
+        quote_offset_bps: str,
+        fill_probability: str,
+        inventory: str,
+        visible_depth: str,
+        impact_bps: str,
+        event_type: str = "trade",
+    ) -> SignalEnvelope:
+        return SignalEnvelope(
+            event_ts=datetime(2026, 5, 22, 14, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset),
+            symbol="SAE",
+            timeframe="1s",
+            seq=offset,
+            source="signal-adaptive-execution-fixture",
+            payload={
+                "price": Decimal(price),
+                "signal_bps": Decimal(signal_bps),
+                "spread_bps": Decimal(spread_bps),
+                "quote_offset_bps": Decimal(quote_offset_bps),
+                "fill_probability": Decimal(fill_probability),
+                "inventory": Decimal(inventory),
+                "target_inventory": Decimal("0"),
+                "max_inventory": Decimal("1000"),
+                "visible_depth": Decimal(visible_depth),
+                "impact_bps": Decimal(impact_bps),
+                "event_type": event_type,
+            },
+            ingest_ts=datetime(2026, 5, 22, 14, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset + 1),
+        )
+
+    def test_weak_signal_low_fill_and_depth_collapse_downrank_more(self) -> None:
+        resilient_rows = [
+            self._row(
+                offset=0,
+                price="100.00",
+                signal_bps="9.0",
+                spread_bps="1.0",
+                quote_offset_bps="1.0",
+                fill_probability="0.85",
+                inventory="25",
+                visible_depth="12000",
+                impact_bps="0.5",
+                event_type="limit",
+            ),
+            self._row(
+                offset=1,
+                price="100.03",
+                signal_bps="8.5",
+                spread_bps="1.1",
+                quote_offset_bps="1.2",
+                fill_probability="0.82",
+                inventory="30",
+                visible_depth="11800",
+                impact_bps="0.6",
+            ),
+            self._row(
+                offset=2,
+                price="100.05",
+                signal_bps="8.0",
+                spread_bps="1.0",
+                quote_offset_bps="1.0",
+                fill_probability="0.80",
+                inventory="20",
+                visible_depth="12100",
+                impact_bps="0.5",
+                event_type="cancel",
+            ),
+        ]
+        fragile_rows = [
+            self._row(
+                offset=0,
+                price="100.00",
+                signal_bps="0.2",
+                spread_bps="8.0",
+                quote_offset_bps="7.0",
+                fill_probability="0.05",
+                inventory="950",
+                visible_depth="16000",
+                impact_bps="9.0",
+            ),
+            self._row(
+                offset=1,
+                price="99.92",
+                signal_bps="-0.1",
+                spread_bps="9.0",
+                quote_offset_bps="8.0",
+                fill_probability="0.03",
+                inventory="980",
+                visible_depth="3500",
+                impact_bps="12.0",
+            ),
+            self._row(
+                offset=2,
+                price="99.86",
+                signal_bps="0.0",
+                spread_bps="10.0",
+                quote_offset_bps="9.0",
+                fill_probability="0.02",
+                inventory="990",
+                visible_depth="2500",
+                impact_bps="15.0",
+            ),
+        ]
+
+        resilient = extract_signal_adaptive_execution_resilience_stress(
+            resilient_rows
+        ).to_payload()
+        fragile = extract_signal_adaptive_execution_resilience_stress(
+            fragile_rows
+        ).to_payload()
+
+        self.assertEqual(
+            fragile["status"],
+            "preview_only_signal_adaptive_execution_resilience_stress_ranking",
+        )
+        self.assertGreater(
+            fragile["ranking_features"]["replay_rank_penalty_bps"],
+            resilient["ranking_features"]["replay_rank_penalty_bps"],
+        )
+        self.assertGreater(fragile["ranking_features"]["signal_cost_mismatch_share"], 0)
+        self.assertGreater(
+            fragile["ranking_features"]["fill_intensity_shortfall_share"], 0
+        )
+        self.assertGreater(
+            fragile["ranking_features"]["liquidity_regime_switch_share"], 0
+        )
+        self.assertIn(
+            "arxiv-2605.24242",
+            {source["source_id"] for source in fragile["source_papers"]},
+        )
+        self.assertFalse(fragile["promotion_authority"])
+        self.assertFalse(fragile["final_promotion_allowed"])
+
+    def test_missing_execution_inputs_fail_closed(self) -> None:
+        row = SignalEnvelope(
+            event_ts=datetime(2026, 5, 22, 14, 30, tzinfo=timezone.utc),
+            symbol="SAE",
+            timeframe="1Min",
+            seq=1,
+            source="missing-execution-fixture",
+            payload={"price": Decimal("100")},
+            ingest_ts=datetime(2026, 5, 22, 14, 31, tzinfo=timezone.utc),
+        )
+
+        payload = extract_signal_adaptive_execution_resilience_stress(
+            (row,)
+        ).to_payload()
+
+        self.assertGreater(payload["ranking_features"]["replay_rank_penalty_bps"], 0)
+        self.assertEqual(
+            payload["ranking_features"]["missing_execution_metadata_score"], 1
+        )
+        self.assertIn("missing_signal_drift_or_alpha_fields", payload["warnings"])
+        self.assertFalse(payload["promotion_proof"])
+
+    def test_contract_keeps_route_tca_and_runtime_ledger_authoritative(self) -> None:
+        contract = signal_adaptive_execution_resilience_stress_contract()
+
+        self.assertEqual(
+            {source["source_id"] for source in contract["source_papers"]},
+            {"arxiv-2605.24242", "arxiv-2506.11813"},
+        )
+        neutrality = contract["proof_neutrality"]
+        self.assertFalse(neutrality["promotion_proof"])
+        self.assertTrue(neutrality["requires_exact_replay"])
+        self.assertTrue(neutrality["requires_route_tca"])
+        self.assertTrue(neutrality["requires_order_lifecycle_fill_evidence"])
+        self.assertTrue(neutrality["requires_runtime_ledger"])
+        self.assertTrue(neutrality["rejects_signal_drift_as_fill_or_pnl_authority"])
+        self.assertTrue(
+            neutrality["rejects_modeled_fill_intensity_as_runtime_ledger_authority"]
+        )


### PR DESCRIPTION
## Summary

- Adds a signal-adaptive execution/liquidity-resilience replay stress from 2026 signal-adaptive quote execution and 2025 liquidity-uncertainty optimal execution papers.
- Computes preview-only downrank inputs for signal-vs-cost mismatch, quote adaptation gaps, fill-intensity shortfall, inventory pressure, liquidity regime switches, resilience recovery failures, and impact/resilience mismatches.
- Wires the stress into fast replay payloads, implemented mechanism metadata, rank penalties, risk flags, ranking-only reasons, and veto reporting while keeping all proof/promotion authority false.
- Adds focused regression coverage for the standalone stress contract and fast replay integration.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_signal_adaptive_execution_resilience_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uvx ruff format --check app/trading/discovery/signal_adaptive_execution_resilience_stress.py app/trading/discovery/fast_replay.py tests/test_signal_adaptive_execution_resilience_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/signal_adaptive_execution_resilience_stress.py app/trading/discovery/fast_replay.py tests/test_signal_adaptive_execution_resilience_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend replay-ranking and test-only change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
