### PR TITLE
fix(torghut): treat quote-quality source rejects as present for window import

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -3197,6 +3197,77 @@ def _source_decision_rejection_summary(
     }
 
 
+_QUOTE_QUALITY_REJECT_REASON_TOKENS = (
+    "quote",
+    "bid",
+    "ask",
+    "spread",
+    "executable",
+    "routeability",
+    "fillability",
+    "stale",
+    "crossed",
+    "missing",
+)
+
+
+def _is_quote_quality_source_reject_reason(reason: object) -> bool:
+    normalized_text = _safe_text(reason)
+    if not normalized_text:
+        return False
+    normalized = normalized_text.lower()
+    normalized = normalized.removeprefix("source_reject_")
+    if normalized.startswith("missing_"):
+        normalized = normalized.removeprefix("missing_")
+    if normalized in {"quote_quality", "quote_quality_gate"}:
+        return True
+    return any(token in normalized for token in _QUOTE_QUALITY_REJECT_REASON_TOKENS)
+
+
+def _source_reject_blockers_are_quote_quality_only(
+    blockers: Sequence[object],
+) -> bool:
+    reason_blockers: list[str] = []
+    for item in blockers:
+        reason = _safe_text(item)
+        if reason and str(item).strip().lower().startswith("source_reject_"):
+            reason_blockers.append(reason)
+    return bool(reason_blockers) and all(
+        _is_quote_quality_source_reject_reason(reason)
+        for reason in reason_blockers
+    )
+
+
+def _source_activity_missing_reasons_are_quote_quality_only(
+    missing_reasons: Sequence[object],
+) -> bool:
+    reasons: list[str] = []
+    for item in missing_reasons:
+        reason = _safe_text(item)
+        if reason:
+            reasons.append(reason)
+    if not reasons:
+        return False
+    non_source_reject_blockers = [
+        reason
+        for reason in reasons
+        if not reason.startswith("source_reject_")
+    ]
+    if non_source_reject_blockers:
+        return False
+    return _source_reject_blockers_are_quote_quality_only(reasons)
+
+
+def _source_activity_effectively_present_for_runtime_window(
+    source_activity: Mapping[str, object],
+) -> bool:
+    if not bool(source_activity.get("missing")):
+        return True
+    return _source_activity_missing_reasons_are_quote_quality_only(
+        _as_sequence(source_activity.get("missing_reasons"))
+    )
+
+
 def _trade_decision_source_decision_mode(row: TradeDecision) -> str:
     payload = _as_mapping(row.decision_json)
     params = _as_mapping(payload.get("params"))
@@ -4383,13 +4454,24 @@ def _strategy_source_activity(
     decision_reject_blockers = _unique_text_items(
         decision_rejection_summary.get("blockers")
     )
+    quote_quality_only_rejects = (
+        bool(decision_reject_blockers)
+        and _safe_int(decision_rejection_summary.get("rejected_decision_count"))
+        == decision_count
+        and _source_reject_blockers_are_quote_quality_only(decision_reject_blockers)
+    )
     missing_reasons: list[str] = []
     if decision_count <= 0:
         missing_reasons.append("source_decisions_missing")
-    if execution_count <= 0:
+    if execution_count <= 0 and not quote_quality_only_rejects:
         missing_reasons.append("source_executions_missing")
+    if decision_reject_blockers:
         missing_reasons.extend(decision_reject_blockers)
-    if tca_sample_count <= 0 and complete_fill_order_event_count <= 0:
+    if (
+        tca_sample_count <= 0
+        and complete_fill_order_event_count <= 0
+        and not quote_quality_only_rejects
+    ):
         missing_reasons.append("source_tca_missing")
     missing_reasons.extend(lineage_blockers)
     if decision_count <= 0:
@@ -4501,6 +4583,13 @@ def _strategy_source_activity(
         complete_fill_order_event_count=complete_fill_order_event_count,
         tca_sample_count=tca_sample_count,
     )
+    is_effectively_present_for_runtime_window = _source_activity_effectively_present_for_runtime_window(
+        {
+            "missing": bool(missing_reasons),
+            "missing_reasons": missing_reasons,
+        },
+    )
+    missing = not is_effectively_present_for_runtime_window
     return {
         "strategy_name": strategy_name,
         "strategy_lookup_names": strategy_filters,
@@ -4581,7 +4670,7 @@ def _strategy_source_activity(
             _order_event_activity_at(order_event_rows[0]) if order_event_rows else None
         ),
         "last_tca_at": _isoformat(tca_rows[0].computed_at if tca_rows else None),
-        "missing": bool(missing_reasons),
+        "missing": missing,
         "missing_reasons": missing_reasons,
     }
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5987,6 +5987,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         source_activity = target_audit["source_activity"]
         self.assertEqual(source_activity["decision_count"], 1)
         self.assertEqual(source_activity["submitted_order_count"], 0)
+        self.assertFalse(source_activity["missing"])
         self.assertIn(
             "source_reject_missing_executable_quote",
             source_activity["submitted_order_blockers"],
@@ -5995,10 +5996,20 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "source_reject_missing_executable_quote",
             source_activity["missing_reasons"],
         )
+        self.assertNotIn(
+            "source_executions_missing",
+            source_activity["missing_reasons"],
+        )
+        self.assertNotIn("source_tca_missing", source_activity["missing_reasons"])
         self.assertIn(
             "source_reject_missing_executable_quote",
             target_audit["readiness"]["blockers"],
         )
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["state"], "import_due_source_lifecycle_incomplete")
+        self.assertNotIn("paper_route_source_activity_missing", import_audit["blockers"])
+        self.assertNotIn("source_executions_missing", import_audit["blockers"])
+        self.assertNotIn("source_tca_missing", import_audit["blockers"])
 
     def test_hpairs_zero_activity_diagnostics_report_market_window_blocker(
         self,


### PR DESCRIPTION
## Summary

- Added quote-quality-only decision-reject classification helpers so quote route source rejects with `source_reject_*` reasons can be recognized independently from execution/TCA blockers.
- Updated source activity readiness derivation to keep `source_reject_*` blockers visible while skipping `source_executions_missing` and `source_tca_missing` for fully quote-quality-only rejected decision sets.
- Added runtime-window presence reconciliation so source activity is treated as effectively present for runtime-window import when blockers are quote-quality-only, preventing premature `import_due_source_activity_missing` regression.
- Tightened regression assertions in `test_source_activity_readback_exposes_rejected_decision_submit_blocker` to validate the new lifecycle behavior and blocker set.

## Related Issues

None.

## Testing

- `cd services/torghut && uv run --with ruff ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py` (pass)
- `cd services/torghut && uv run --with pyright pyright --project pyrightconfig.json` (pass)
- `cd services/torghut && uv run --with pyright pyright --project pyrightconfig.alpha.json` (pass)
- `cd services/torghut && uv run --with pyright pyright --project pyrightconfig.scripts.json` (pass)
- `cd services/torghut && uv run --with pytest --with pytest-cov --with hypothesis --with pytest-xdist python -m pytest -q tests/test_paper_route_evidence.py -k "source_activity or runtime_window_import or runtime_window_import_audit"` (26 passed)
- `cd services/torghut && uv run --with pytest --with pytest-cov --with hypothesis --with pytest-xdist python -m pytest -q tests/test_verify_trading_readiness.py` (45 passed)
- `cd services/torghut && uv run python -m compileall -q app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py` (pass)

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section is omitted because no UI change occurred.
- [x] Breaking Changes section included (`None`).
- [x] Documentation/release note impact is scoped and tracked in tests/template artifact; no user-facing behavior contract changes.
