### PR TITLE
fix(torghut): surface quote routeability diagnostics

### DIFF
--- a/services/torghut/app/trading/prices.py
+++ b/services/torghut/app/trading/prices.py
@@ -33,6 +33,7 @@ class MarketSnapshot:
     ask: Optional[Decimal] = None
     quote_as_of: Optional[datetime] = None
     quote_source: Optional[str] = None
+    quote_lookup_diagnostics: Optional[dict[str, object]] = None
 
 
 class PriceFetcher:
@@ -259,9 +260,42 @@ class ClickHousePriceFetcher(PriceFetcher):
             else None
         )
         quote_source = "ta_signals_quote"
+        quote_lookup_diagnostics: dict[str, object] | None = None
+        if self.url:
+            if quote_row is not None:
+                quote_lookup_diagnostics = self._quote_lookup_diagnostics(
+                    symbol=symbol,
+                    target_ts=target_ts,
+                    source=quote_source,
+                    row=quote_row,
+                    accepted=True,
+                )
+            else:
+                quote_lookup_diagnostics = self._quote_lookup_diagnostics(
+                    symbol=symbol,
+                    target_ts=target_ts,
+                    source=quote_source,
+                    row=self._fetch_latest_quote_diagnostic_row(
+                        symbol=symbol,
+                        target_ts=target_ts,
+                    ),
+                    accepted=False,
+                )
         if quote_row is None:
             quote_row = self._fetch_alpaca_latest_quote_row(symbol=symbol)
             quote_source = "alpaca_latest_quote"
+            if quote_row is not None:
+                quote_lookup_diagnostics = self._quote_lookup_diagnostics(
+                    symbol=symbol,
+                    target_ts=target_ts,
+                    source=quote_source,
+                    row=quote_row,
+                    accepted=True,
+                )
+            elif quote_lookup_diagnostics is not None:
+                quote_lookup_diagnostics["alpaca_quote_fallback_attempted"] = (
+                    self.alpaca_quote_fallback_enabled
+                )
         as_of = _snapshot_as_of(row, signal.event_ts)
         price = _select_price(row)
         spread = _optional_decimal(row.get("spread"))
@@ -292,6 +326,7 @@ class ClickHousePriceFetcher(PriceFetcher):
             ask=ask,
             quote_as_of=quote_as_of,
             quote_source=resolved_quote_source,
+            quote_lookup_diagnostics=quote_lookup_diagnostics,
         )
 
     def _fetch_recent_executable_quote_row(
@@ -344,7 +379,95 @@ class ClickHousePriceFetcher(PriceFetcher):
             return None
         if not rows:
             return None
+        for row in rows:
+            if _quote_row_reject_reason(row) is None:
+                return row
+        return None
+
+    def _fetch_latest_quote_diagnostic_row(
+        self,
+        *,
+        symbol: str,
+        target_ts: datetime,
+    ) -> dict[str, Any] | None:
+        lookback = target_ts - timedelta(seconds=self.quote_lookback_seconds)
+        quote_window_end = target_ts
+        if self.quote_forward_seconds > 0:
+            forward_end = target_ts + timedelta(seconds=self.quote_forward_seconds)
+            now = datetime.now(timezone.utc)
+            if target_ts.tzinfo is None:
+                now = now.replace(tzinfo=None)
+            quote_window_end = min(forward_end, now)
+        query = " ".join(
+            [
+                "SELECT event_ts, imbalance_bid_px, imbalance_ask_px, imbalance_spread",
+                "FROM",
+                self.quote_table,
+                "WHERE",
+                f"symbol = {_quote_literal(symbol)}",
+                "AND",
+                f"event_ts >= {to_datetime64(lookback)}",
+                "AND",
+                f"event_ts <= {to_datetime64(quote_window_end)}",
+                "ORDER BY",
+                "event_ts DESC",
+                "LIMIT 1",
+                "FORMAT JSONEachRow",
+            ]
+        )
+        try:
+            rows = self._query_clickhouse(query)
+        except Exception as exc:
+            logger.warning("Failed to fetch recent quote diagnostics: %s", exc)
+            return None
+        if not rows:
+            return None
         return rows[0]
+
+    def _quote_lookup_diagnostics(
+        self,
+        *,
+        symbol: str,
+        target_ts: datetime,
+        source: str,
+        row: Mapping[str, Any] | None,
+        accepted: bool,
+    ) -> dict[str, object]:
+        rejected_reason = None if accepted else "no_recent_quote"
+        bid: Decimal | None = None
+        ask: Decimal | None = None
+        spread: Decimal | None = None
+        spread_bps: Decimal | None = None
+        quote_as_of: datetime | None = None
+        if row is not None:
+            rejected_reason = None if accepted else _quote_row_reject_reason(row)
+            bid = _optional_decimal(row.get("imbalance_bid_px"))
+            ask = _optional_decimal(row.get("imbalance_ask_px"))
+            spread = _select_quote_spread(row, bid=bid, ask=ask)
+            if bid is not None and ask is not None:
+                spread_bps = _quote_spread_bps(bid=bid, ask=ask)
+            quote_as_of = _snapshot_as_of(row, target_ts)
+        return {
+            "schema_version": "torghut.quote-lookup-diagnostics.v1",
+            "symbol": symbol,
+            "target_ts": target_ts.isoformat(),
+            "source": source,
+            "latest_quote_present": row is not None,
+            "latest_quote_accepted": accepted,
+            "latest_quote_rejected_reason": rejected_reason,
+            "latest_quote_as_of": quote_as_of.isoformat()
+            if quote_as_of is not None
+            else None,
+            "latest_quote_bid": str(bid) if bid is not None else None,
+            "latest_quote_ask": str(ask) if ask is not None else None,
+            "latest_quote_spread": str(spread) if spread is not None else None,
+            "latest_quote_spread_bps": str(spread_bps)
+            if spread_bps is not None
+            else None,
+            "max_spread_bps": str(settings.trading_signal_max_executable_spread_bps),
+            "lookback_seconds": self.quote_lookback_seconds,
+            "forward_seconds": self.quote_forward_seconds,
+        }
 
     def _fetch_alpaca_latest_quote_row(self, *, symbol: str) -> dict[str, Any] | None:
         if not self.alpaca_quote_fallback_enabled:
@@ -675,6 +798,29 @@ def _select_quote_spread(
     if bid is None or ask is None:
         return None
     return ask - bid
+
+
+def _quote_row_reject_reason(row: Mapping[str, Any]) -> str | None:
+    bid = _optional_decimal(row.get("imbalance_bid_px"))
+    ask = _optional_decimal(row.get("imbalance_ask_px"))
+    if bid is None and ask is None:
+        return "missing_executable_quote"
+    if bid is None:
+        return "missing_bid"
+    if ask is None:
+        return "missing_ask"
+    if bid <= 0:
+        return "non_positive_bid"
+    if ask <= 0:
+        return "non_positive_ask"
+    if ask < bid:
+        return "crossed_quote"
+    spread_bps = _quote_spread_bps(bid=bid, ask=ask)
+    if spread_bps is None:
+        return "invalid_spread"
+    if spread_bps > settings.trading_signal_max_executable_spread_bps:
+        return "spread_bps_exceeded"
+    return None
 
 
 def _midpoint(*, bid: Decimal | None, ask: Decimal | None) -> Optional[Decimal]:

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -41,6 +41,7 @@ from ..prices import MarketSnapshot
 from ..quote_quality import (
     QuoteQualityPolicy,
     QuoteQualityStatus,
+    _status,
     assess_signal_quote_quality,
 )
 from ..proof_floor import build_profitability_proof_floor_receipt
@@ -3761,6 +3762,13 @@ class SimpleTradingPipeline(TradingPipeline):
                 max_executable_quote_age_seconds=settings.trading_executable_quote_lookback_seconds,
             ),
         )
+        quote_lookup_diagnostics = (
+            snapshot.quote_lookup_diagnostics if snapshot is not None else None
+        )
+        status = self._apply_quote_lookup_diagnostic_reason(
+            status,
+            quote_lookup_diagnostics=quote_lookup_diagnostics,
+        )
         target_mismatch = self._paper_route_target_plan_source_mismatch(decision)
         if target_mismatch is not None:
             status = QuoteQualityStatus(
@@ -3786,9 +3794,45 @@ class SimpleTradingPipeline(TradingPipeline):
             status=status,
             source=source,
             quote_as_of=quote_as_of,
+            quote_lookup_diagnostics=quote_lookup_diagnostics,
             target_mismatch=target_mismatch,
         )
         return status, routeability
+
+    @staticmethod
+    def _apply_quote_lookup_diagnostic_reason(
+        status: QuoteQualityStatus,
+        *,
+        quote_lookup_diagnostics: Mapping[str, object] | None,
+    ) -> QuoteQualityStatus:
+        if status.valid or status.reason != "missing_executable_quote":
+            return status
+        if not isinstance(quote_lookup_diagnostics, Mapping):
+            return status
+        diagnostic_reason = _safe_text(
+            quote_lookup_diagnostics.get("latest_quote_rejected_reason")
+        )
+        if diagnostic_reason not in {
+            "crossed_quote",
+            "non_positive_bid",
+            "non_positive_ask",
+            "spread_bps_exceeded",
+        }:
+            return status
+        return _status(
+            valid=False,
+            reason=diagnostic_reason,
+            spread_bps=_optional_decimal(
+                quote_lookup_diagnostics.get("latest_quote_spread_bps")
+            )
+            or status.spread_bps,
+            jump_bps=status.jump_bps,
+            quote_age_seconds=status.quote_age_seconds,
+            source=status.source,
+            price=status.price,
+            bid=status.bid,
+            ask=status.ask,
+        )
 
     @staticmethod
     def _paper_route_target_plan_source_mismatch(
@@ -3879,6 +3923,7 @@ class SimpleTradingPipeline(TradingPipeline):
         status: QuoteQualityStatus,
         source: str | None,
         quote_as_of: datetime | None,
+        quote_lookup_diagnostics: Mapping[str, object] | None = None,
         target_mismatch: Mapping[str, object] | None = None,
     ) -> dict[str, object]:
         blockers = [] if status.valid else [status.reason or "missing_executable_quote"]
@@ -3925,6 +3970,9 @@ class SimpleTradingPipeline(TradingPipeline):
             },
             "target_plan_source_mismatch": dict(target_mismatch)
             if target_mismatch is not None
+            else None,
+            "quote_lookup_diagnostics": dict(quote_lookup_diagnostics)
+            if isinstance(quote_lookup_diagnostics, Mapping)
             else None,
         }
 

--- a/services/torghut/tests/test_prices.py
+++ b/services/torghut/tests/test_prices.py
@@ -6,7 +6,12 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from app.trading.models import SignalEnvelope
-from app.trading.prices import ClickHousePriceFetcher, _midpoint, _quote_spread_bps
+from app.trading.prices import (
+    ClickHousePriceFetcher,
+    _midpoint,
+    _quote_row_reject_reason,
+    _quote_spread_bps,
+)
 
 
 class FakeClickHousePriceFetcher(ClickHousePriceFetcher):
@@ -257,6 +262,72 @@ class TestClickHousePriceFetcher(TestCase):
         self.assertIn(
             "event_ts <= toDateTime64('2026-01-01 12:01:00", fetcher.queries[1]
         )
+
+    def test_fetch_market_snapshot_records_forward_naive_quote_diagnostics(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30),
+            symbol="NVDA",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[
+                {"event_ts": "2026-01-01T12:00:29", "c": "200.25", "spread": "0.03"}
+            ],
+            quote_rows=[
+                {
+                    "event_ts": "2026-01-01T12:00:45",
+                    "imbalance_bid_px": "100.00",
+                    "imbalance_ask_px": "101.00",
+                }
+            ],
+            quote_forward_seconds=30,
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot.price, Decimal("200.25"))
+        diagnostics = snapshot.quote_lookup_diagnostics or {}
+        self.assertEqual(
+            diagnostics.get("latest_quote_rejected_reason"),
+            "spread_bps_exceeded",
+        )
+        self.assertIn(
+            "event_ts <= toDateTime64('2026-01-01 12:01:00", fetcher.queries[-1]
+        )
+
+    def test_quote_row_reject_reason_records_invalid_quote_shapes(self) -> None:
+        cases = [
+            ({"imbalance_ask_px": "101.00"}, "missing_bid"),
+            ({"imbalance_bid_px": "100.00"}, "missing_ask"),
+            (
+                {"imbalance_bid_px": "0", "imbalance_ask_px": "101.00"},
+                "non_positive_bid",
+            ),
+            (
+                {"imbalance_bid_px": "100.00", "imbalance_ask_px": "0"},
+                "non_positive_ask",
+            ),
+            (
+                {"imbalance_bid_px": "102.00", "imbalance_ask_px": "101.00"},
+                "crossed_quote",
+            ),
+        ]
+
+        for row, expected_reason in cases:
+            with self.subTest(expected_reason=expected_reason):
+                self.assertEqual(_quote_row_reject_reason(row), expected_reason)
+
+        with patch("app.trading.prices._quote_spread_bps", return_value=None):
+            self.assertEqual(
+                _quote_row_reject_reason(
+                    {"imbalance_bid_px": "100.00", "imbalance_ask_px": "101.00"}
+                ),
+                "invalid_spread",
+            )
 
     def test_fetch_market_snapshot_returns_none_without_price_or_quote(
         self,
@@ -672,6 +743,44 @@ class TestClickHousePriceFetcher(TestCase):
         self.assertEqual(snapshot.price, Decimal("200.25"))
         self.assertEqual(snapshot.spread, Decimal("0.03"))
         self.assertEqual(snapshot.source, "ta_microbars")
+
+    def test_fetch_market_snapshot_records_wide_quote_diagnostics(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="NVDA",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[
+                {"event_ts": "2026-01-01T12:00:29Z", "c": "200.25", "spread": "0.03"}
+            ],
+            quote_rows=[
+                {
+                    "event_ts": "2026-01-01T12:00:28Z",
+                    "imbalance_bid_px": "100.00",
+                    "imbalance_ask_px": "101.00",
+                }
+            ],
+        )
+
+        snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNotNone(snapshot)
+        assert snapshot is not None
+        self.assertEqual(snapshot.price, Decimal("200.25"))
+        self.assertIsNone(snapshot.bid)
+        self.assertIsNone(snapshot.ask)
+        diagnostics = snapshot.quote_lookup_diagnostics or {}
+        self.assertEqual(diagnostics.get("latest_quote_present"), True)
+        self.assertEqual(diagnostics.get("latest_quote_accepted"), False)
+        self.assertEqual(
+            diagnostics.get("latest_quote_rejected_reason"),
+            "spread_bps_exceeded",
+        )
+        self.assertEqual(diagnostics.get("latest_quote_bid"), "100.00")
+        self.assertEqual(diagnostics.get("latest_quote_ask"), "101.00")
 
     def test_fetch_market_snapshot_keeps_price_when_quote_lookup_fails(
         self,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -61,6 +61,7 @@ from app.trading.paper_route_target_plan import (
     materialize_bounded_paper_route_target_plan,
     paper_route_target_plan_from_payload,
 )
+from app.trading.quote_quality import QuoteQualityStatus
 from app.trading.reconcile import Reconciler
 from app.trading.runtime_decision_authority import (
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
@@ -761,11 +762,13 @@ class FakePriceFetcher(PriceFetcher):
         spread: Decimal | None = None,
         bid: Decimal | None = None,
         ask: Decimal | None = None,
+        quote_lookup_diagnostics: dict[str, object] | None = None,
     ) -> None:
         self.price = price
         self.spread = spread
         self.bid = bid
         self.ask = ask
+        self.quote_lookup_diagnostics = quote_lookup_diagnostics
         self.snapshot_requests = 0
 
     def fetch_price(self, signal: SignalEnvelope) -> Decimal:
@@ -781,6 +784,7 @@ class FakePriceFetcher(PriceFetcher):
             source="price_fetcher",
             bid=self.bid,
             ask=self.ask,
+            quote_lookup_diagnostics=self.quote_lookup_diagnostics,
         )
 
 
@@ -3610,6 +3614,122 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(
             row_json.get("reject_reason_atomic"), ["missing_executable_quote"]
         )
+
+    def test_paper_route_target_quote_diagnostics_surface_wide_latest_quote(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded target strategy",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="paper-route-target-source",
+            params={
+                "paper_route_target_plan": {"candidate_id": "c88421d619759b2cfaa6f4d0"},
+                "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+            },
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(
+                Decimal("190.12"),
+                quote_lookup_diagnostics={
+                    "schema_version": "torghut.quote-lookup-diagnostics.v1",
+                    "source": "ta_signals_quote",
+                    "latest_quote_present": True,
+                    "latest_quote_accepted": False,
+                    "latest_quote_rejected_reason": "spread_bps_exceeded",
+                    "latest_quote_spread_bps": "105.2631578947368421052631579",
+                },
+            ),
+        )
+        with self.session_local() as session:
+            session.add(strategy)
+            session.commit()
+            row = pipeline.executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "TORGHUT_SIM",
+            )
+
+            prepared = pipeline._prepare_decision_for_submission(
+                session=session,
+                decision=decision,
+                decision_row=row,
+                strategy=strategy,
+                account={
+                    "equity": "100000",
+                    "cash": "100000",
+                    "buying_power": "100000",
+                },
+                positions=[],
+            )
+            session.refresh(row)
+            row_json = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], row_json.get("params"))
+            routeability = cast(dict[str, Any], params.get("quote_routeability"))
+
+        self.assertIsNone(prepared)
+        self.assertEqual(row.status, "rejected")
+        self.assertEqual(routeability.get("status"), "blocked")
+        self.assertEqual(routeability.get("reason"), "spread_bps_exceeded")
+        self.assertEqual(
+            row_json.get("reject_reason_atomic"), ["spread_bps_exceeded"]
+        )
+        diagnostics = cast(dict[str, Any], routeability.get("quote_lookup_diagnostics"))
+        self.assertEqual(
+            diagnostics.get("latest_quote_rejected_reason"),
+            "spread_bps_exceeded",
+        )
+
+    def test_paper_route_quote_lookup_diagnostics_keep_unknown_reason_blocked(
+        self,
+    ) -> None:
+        status = QuoteQualityStatus(
+            valid=False,
+            reason="missing_executable_quote",
+        )
+
+        rewritten = SimpleTradingPipeline._apply_quote_lookup_diagnostic_reason(
+            status,
+            quote_lookup_diagnostics={
+                "latest_quote_rejected_reason": "missing_bid",
+                "latest_quote_spread_bps": "42",
+            },
+        )
+
+        self.assertIs(rewritten, status)
+        self.assertEqual(rewritten.reason, "missing_executable_quote")
 
     def test_paper_route_target_quote_routeability_blocks_stale_and_wide_quotes(
         self,


### PR DESCRIPTION
## Summary

- Adds quote lookup diagnostics to Torghut market snapshots so paper-route readback records whether the latest quote window had no quote, a rejected quote, or an accepted executable quote.
- Validates ClickHouse quote rows in Python before treating them as executable, preserving the safety gate even if a query or fixture returns malformed or wide quotes.
- Surfaces diagnostic wide-quote failures through paper-route routeability as `spread_bps_exceeded` instead of a blind `missing_executable_quote`.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_prices.py -k 'wide_quote_diagnostics or backfills_recent_executable_quote or keeps_price_when_quote_lookup_empty' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'quote_diagnostics_surface_wide_latest_quote or quote_routeability_blocks_missing_quote or quote_routeability_blocks_stale_and_wide_quotes' -q`
- `uv run --frozen ruff check app/trading/prices.py app/trading/scheduler/simple_pipeline.py tests/test_prices.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
