### PR TITLE
feat(torghut): add responsive LOB replay stress

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -532,7 +532,7 @@ class FastReplayPreviewResult:
                 "dynamic_lead_lag_cross_asset_stress": "deterministic event-grid dynamic pair-specific lead-lag, cross-market LOB/order-flow predictability, and one-second OFI endogeneity stress from arXiv:2511.00390, SSRN:5523878, and arXiv:2508.06788; lead-lag is not alpha proof; preview ranking only",
                 "queue_position_survival_fill_stress": "deterministic queue-position survival fill probability, depth-delay, and nonfill opportunity-cost stress from arXiv:2512.05734, SSRN:6440898, and SSRN:6730443; preview ranking only",
                 "public_feed_lag_quoted_liquidity_stress": "deterministic public-feed delay, quoted-liquidity reliability, stale-quote, and authoritative trade-direction join stress from SSRN:6675338, arXiv:2604.24366, and arXiv:2511.20606; preview ranking only",
-                "lob_simulation_reality_gap_execution_stress": "deterministic spread-volume imbalance, latency-race mode, power-law signed-flow impact, and odd-lot liquidity reliability stress from arXiv:2603.24137, OFR WP 25-01, and arXiv:2507.06345; preview ranking only",
+                "lob_simulation_reality_gap_execution_stress": "deterministic spread-volume imbalance, latency-race mode, power-law signed-flow impact, odd-lot liquidity reliability, and responsive exchange event-mix stress from arXiv:2603.24137, OFR WP 25-01, arXiv:2507.06345, and arXiv:2502.07071; preview ranking only",
                 "alpha_decay_predictability_stress": "deterministic multi-horizon spread-adjusted alpha decay, cost-crossover, latency-horizon mismatch, and efficiency-regime compression stress from arXiv:2601.02310 and SSRN:6608199; preview ranking only",
                 "counterfactual_regime_replay_stress": "deterministic real-tape regime support, edge concentration, and temporal Wasserstein shift stress from arXiv:2602.03776 and SSRN:6232459; no synthetic PnL; preview ranking only",
                 "nonlinear_impact_execution_stress": "deterministic real-tape participation-rate, square-root impact, and permanent-impact decay stress from arXiv:2603.29086 and arXiv:2502.16246; model costs are not PnL authority; preview ranking only",
@@ -1413,12 +1413,10 @@ def _score_candidate_spec(
         )
         or 0.0
     )
-    intraday_price_path_asymmetry_stress = (
-        extract_intraday_price_path_asymmetry_stress(
-            matched_source_rows,
-            direction=direction,
-        ).to_payload()
-    )
+    intraday_price_path_asymmetry_stress = extract_intraday_price_path_asymmetry_stress(
+        matched_source_rows,
+        direction=direction,
+    ).to_payload()
     intraday_price_path_asymmetry_rank_penalty_bps = (
         _float_or_none(
             _mapping(intraday_price_path_asymmetry_stress.get("ranking_features")).get(
@@ -1620,9 +1618,7 @@ def _score_candidate_spec(
         nonlinear_impact_execution_stress=dict(nonlinear_impact_execution_stress),
         option_gamma_flow_stress=dict(option_gamma_flow_stress),
         intraday_jump_burst_stress=dict(intraday_jump_burst_stress),
-        intraday_price_path_asymmetry_stress=dict(
-            intraday_price_path_asymmetry_stress
-        ),
+        intraday_price_path_asymmetry_stress=dict(intraday_price_path_asymmetry_stress),
         rough_flow_volatility_stress=dict(rough_flow_volatility_stress),
         institutional_mechanism_fidelity_stress=dict(
             institutional_mechanism_fidelity_stress

--- a/services/torghut/app/trading/discovery/lob_reality_gap_stress.py
+++ b/services/torghut/app/trading/discovery/lob_reality_gap_stress.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 
 from app.trading.models import SignalEnvelope
 
-LOB_REALITY_GAP_STRESS_SCHEMA_VERSION = "torghut.lob-reality-gap-stress.v1"
+LOB_REALITY_GAP_STRESS_SCHEMA_VERSION = "torghut.lob-reality-gap-stress.v2"
 LOB_REALITY_GAP_STRESS_CONTRACT_SCHEMA_VERSION = (
     "torghut.lob-reality-gap-stress-contract.v1"
 )
@@ -42,6 +42,13 @@ LOB_REALITY_GAP_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
         "title": "Reinforcement Learning for Trade Execution with Market and Limit Orders",
         "date": "2026-01-26",
         "mechanism": "market_limit_allocation_sensitivity_to_order_book_imbalance_tactical_response",
+    },
+    {
+        "source_id": "arxiv-2502.07071",
+        "url": "https://arxiv.org/abs/2502.07071",
+        "title": "TRADES: Tool for Responsive Agent-Based Modeling of Digital Exchange Simulator",
+        "date": "2025-02-11",
+        "mechanism": "responsive_exchange_event_mix_and_state_conditioned_order_response_gap",
     },
 )
 
@@ -89,6 +96,9 @@ _OFF_EXCHANGE_FIELDS = (
     "dark_trade",
 )
 _EVENT_TYPE_FIELDS = ("event_type", "lob_event_type", "order_event_type")
+_MARKET_EVENT_TOKENS = ("trade", "market", "fill", "execute")
+_LIMIT_EVENT_TOKENS = ("add", "insert", "new", "quote", "limit")
+_CANCEL_EVENT_TOKENS = ("cancel", "delete", "remove", "replace")
 _POWER_LAW_DECAY_EXPONENT = 0.60
 _HIGH_IMBALANCE_FLOOR = 0.65
 _ODD_LOT_VANISH_FLOOR = 0.50
@@ -102,10 +112,14 @@ class LobRealityGapStressSummary:
     observed_latency_count: int
     observed_signed_flow_count: int
     observed_odd_lot_count: int
+    observed_responsive_event_count: int
     off_exchange_event_count: int
     median_spread_bps: float
     median_abs_volume_imbalance: float
     high_imbalance_share: float
+    responsive_event_concentration_share: float
+    state_conditioned_response_gap_share: float
+    responsive_simulation_gap_score: float
     latency_mode_ms: float
     latency_mode_share: float
     power_law_signed_flow_impact_bps: float
@@ -131,12 +145,22 @@ class LobRealityGapStressSummary:
             "observed_latency_count": self.observed_latency_count,
             "observed_signed_flow_count": self.observed_signed_flow_count,
             "observed_odd_lot_count": self.observed_odd_lot_count,
+            "observed_responsive_event_count": self.observed_responsive_event_count,
             "off_exchange_event_count": self.off_exchange_event_count,
             "median_spread_bps": _stable_float(self.median_spread_bps),
             "median_abs_volume_imbalance": _stable_float(
                 self.median_abs_volume_imbalance
             ),
             "high_imbalance_share": _stable_float(self.high_imbalance_share),
+            "responsive_event_concentration_share": _stable_float(
+                self.responsive_event_concentration_share
+            ),
+            "state_conditioned_response_gap_share": _stable_float(
+                self.state_conditioned_response_gap_share
+            ),
+            "responsive_simulation_gap_score": _stable_float(
+                self.responsive_simulation_gap_score
+            ),
             "latency_mode_ms": _stable_float(self.latency_mode_ms),
             "latency_mode_share": _stable_float(self.latency_mode_share),
             "power_law_signed_flow_impact_bps": _stable_float(
@@ -157,6 +181,15 @@ class LobRealityGapStressSummary:
                     self.median_abs_volume_imbalance
                 ),
                 "high_imbalance_share": _stable_float(self.high_imbalance_share),
+                "responsive_event_concentration_share": _stable_float(
+                    self.responsive_event_concentration_share
+                ),
+                "state_conditioned_response_gap_share": _stable_float(
+                    self.state_conditioned_response_gap_share
+                ),
+                "responsive_simulation_gap_score": _stable_float(
+                    self.responsive_simulation_gap_score
+                ),
                 "latency_mode_share": _stable_float(self.latency_mode_share),
                 "power_law_signed_flow_impact_bps": _stable_float(
                     self.power_law_signed_flow_impact_bps
@@ -178,6 +211,7 @@ class LobRealityGapStressSummary:
             "latency_race_mode_preview": True,
             "power_law_signed_flow_impact_preview": True,
             "odd_lot_liquidity_reliability_preview": True,
+            "responsive_exchange_simulation_preview": True,
             "research_ranking_only": True,
             "prefilter_only": True,
             "promotion_proof": False,
@@ -205,6 +239,8 @@ def lob_reality_gap_stress_contract() -> dict[str, Any]:
             "impact_reversion_failure_share",
             "odd_lot_vanish_share",
             "off_exchange_cancellation_share",
+            "responsive_event_concentration_share",
+            "state_conditioned_response_gap_share",
         ],
         "output_scope": "preview_replay_ranking_only",
         "proof_neutrality": {
@@ -219,6 +255,7 @@ def lob_reality_gap_stress_contract() -> dict[str, Any]:
             "requires_runtime_ledger": True,
             "rejects_simulator_only_pnl_authority": True,
             "rejects_hidden_or_odd_lot_liquidity_as_fill_authority": True,
+            "rejects_responsive_simulator_only_pnl_authority": True,
         },
     }
 
@@ -244,12 +281,25 @@ def extract_lob_reality_gap_stress(
         value for value in depths if value is not None and value > 0
     )
     depth_median = _median(observed_depths) or 1.0
-    imbalances: list[float] = []
-    for row in ordered:
-        value = _volume_imbalance(row)
-        if value is not None:
-            imbalances.append(value)
+    volume_imbalances = tuple(_volume_imbalance(row) for row in ordered)
+    imbalances = tuple(value for value in volume_imbalances if value is not None)
     abs_imbalances = tuple(abs(value) for value in imbalances)
+    responsive_event_categories = tuple(
+        category for row in ordered if (category := _event_category(row)) is not None
+    )
+    responsive_event_concentration_share = _event_category_concentration(
+        responsive_event_categories
+    )
+    event_mix_gap_score = max(
+        0.0, (responsive_event_concentration_share - (1.0 / 3.0)) / (2.0 / 3.0)
+    )
+    state_conditioned_response_gap_share = _state_conditioned_response_gap_share(
+        ordered,
+        volume_imbalances=volume_imbalances,
+    )
+    responsive_simulation_gap_score = min(
+        1.0, event_mix_gap_score * 0.55 + state_conditioned_response_gap_share * 0.45
+    )
     latency_values: list[float] = []
     for row in ordered:
         value = _latency_ms(row)
@@ -308,6 +358,7 @@ def extract_lob_reality_gap_stress(
         + min(1.0, power_law_signed_flow_impact_bps / 25.0) * 0.18
         + impact_reversion_failure_share * 0.10
         + odd_lot_vanish_share * 0.12
+        + responsive_simulation_gap_score * 0.12
         + off_exchange_cancellation_share * 0.08,
     )
     replay_rank_penalty_bps = (
@@ -319,6 +370,7 @@ def extract_lob_reality_gap_stress(
         + impact_reversion_failure_share * 6.0
         + odd_lot_vanish_share * 5.0
         + off_exchange_cancellation_share * 3.0
+        + responsive_simulation_gap_score * 4.0
     )
     warnings: list[str] = []
     if not spreads:
@@ -331,6 +383,8 @@ def extract_lob_reality_gap_stress(
         warnings.append("missing_signed_flow_inputs")
     if not observed_odd_lots:
         warnings.append("missing_odd_lot_liquidity_inputs")
+    if not responsive_event_categories:
+        warnings.append("missing_responsive_event_type_inputs")
 
     return LobRealityGapStressSummary(
         row_count=len(ordered),
@@ -339,10 +393,14 @@ def extract_lob_reality_gap_stress(
         observed_latency_count=len(latency_values),
         observed_signed_flow_count=len(observed_signed_flow),
         observed_odd_lot_count=len(observed_odd_lots),
+        observed_responsive_event_count=len(responsive_event_categories),
         off_exchange_event_count=off_exchange_count,
         median_spread_bps=median_spread_bps,
         median_abs_volume_imbalance=median_abs_imbalance,
         high_imbalance_share=high_imbalance_share,
+        responsive_event_concentration_share=responsive_event_concentration_share,
+        state_conditioned_response_gap_share=state_conditioned_response_gap_share,
+        responsive_simulation_gap_score=responsive_simulation_gap_score,
         latency_mode_ms=latency_mode_ms,
         latency_mode_share=latency_mode_share,
         power_law_signed_flow_impact_bps=power_law_signed_flow_impact_bps,
@@ -538,6 +596,59 @@ def _event_type_contains(row: SignalEnvelope, needles: Sequence[str]) -> bool:
         str(payload.get(field) or "").strip().lower() for field in _EVENT_TYPE_FIELDS
     )
     return any(needle in token for token in tokens for needle in needles)
+
+
+def _event_category(row: SignalEnvelope) -> str | None:
+    payload = _payload(row)
+    tokens = tuple(
+        str(payload.get(field) or "").strip().lower()
+        for field in _EVENT_TYPE_FIELDS
+        if str(payload.get(field) or "").strip()
+    )
+    for token in tokens:
+        if any(item in token for item in _CANCEL_EVENT_TOKENS):
+            return "cancel"
+        if any(item in token for item in _LIMIT_EVENT_TOKENS):
+            return "limit"
+        if any(item in token for item in _MARKET_EVENT_TOKENS):
+            return "market"
+    return None
+
+
+def _event_category_concentration(categories: Sequence[str]) -> float:
+    if not categories:
+        return 0.0
+    counts: dict[str, int] = {}
+    for category in categories:
+        counts[category] = counts.get(category, 0) + 1
+    return max(counts.values()) / max(1, len(categories))
+
+
+def _state_conditioned_response_gap_share(
+    rows: Sequence[SignalEnvelope],
+    *,
+    volume_imbalances: Sequence[float | None],
+) -> float:
+    gaps = 0
+    observations = 0
+    for index in range(1, min(len(rows), len(volume_imbalances))):
+        previous_imbalance = volume_imbalances[index - 1]
+        current_imbalance = volume_imbalances[index]
+        if previous_imbalance is None or current_imbalance is None:
+            continue
+        if abs(previous_imbalance) < _HIGH_IMBALANCE_FLOOR:
+            continue
+        previous_category = _event_category(rows[index - 1])
+        current_category = _event_category(rows[index])
+        if previous_category is None or current_category is None:
+            continue
+        observations += 1
+        if (
+            previous_category == current_category
+            and abs(current_imbalance) >= abs(previous_imbalance) * 0.90
+        ):
+            gaps += 1
+    return gaps / max(1, observations)
 
 
 def _truthy(value: Any) -> bool:

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -401,6 +401,18 @@ class TestFastReplayPreview(TestCase):
                 for source in row_payload["lob_reality_gap_stress"]["source_papers"]
             },
         )
+        self.assertIn(
+            "arxiv-2502.07071",
+            {
+                source["source_id"]
+                for source in row_payload["lob_reality_gap_stress"]["source_papers"]
+            },
+        )
+        self.assertTrue(
+            row_payload["lob_reality_gap_stress"][
+                "responsive_exchange_simulation_preview"
+            ]
+        )
         self.assertIn("alpha_decay_predictability_stress", row_payload)
         self.assertFalse(
             row_payload["alpha_decay_predictability_stress"]["proof_authority"]
@@ -604,9 +616,7 @@ class TestFastReplayPreview(TestCase):
             row_payload["intraday_price_path_asymmetry_stress"]["proof_authority"]
         )
         self.assertFalse(
-            row_payload["intraday_price_path_asymmetry_stress"][
-                "promotion_authority"
-            ]
+            row_payload["intraday_price_path_asymmetry_stress"]["promotion_authority"]
         )
         self.assertIn(
             "intraday_price_path_asymmetry_stress_penalty_active",

--- a/services/torghut/tests/test_lob_reality_gap_stress.py
+++ b/services/torghut/tests/test_lob_reality_gap_stress.py
@@ -66,6 +66,7 @@ class TestLobRealityGapStress(TestCase):
                     trade_size="5",
                     odd_lot_bid_size="40",
                     odd_lot_ask_size="42",
+                    event_type="add",
                 ),
                 self._row(
                     offset=2,
@@ -77,6 +78,7 @@ class TestLobRealityGapStress(TestCase):
                     trade_size="4",
                     odd_lot_bid_size="41",
                     odd_lot_ask_size="43",
+                    event_type="cancel",
                 ),
                 self._row(
                     offset=3,
@@ -157,6 +159,10 @@ class TestLobRealityGapStress(TestCase):
         )
         self.assertGreater(fragile.odd_lot_vanish_share, stable.odd_lot_vanish_share)
         self.assertGreater(
+            fragile.responsive_simulation_gap_score,
+            stable.responsive_simulation_gap_score,
+        )
+        self.assertGreater(
             fragile.replay_rank_penalty_bps, stable.replay_rank_penalty_bps
         )
         payload = fragile.to_payload()
@@ -165,6 +171,10 @@ class TestLobRealityGapStress(TestCase):
         )
         self.assertTrue(payload["power_law_signed_flow_impact_preview"])
         self.assertTrue(payload["odd_lot_liquidity_reliability_preview"])
+        self.assertTrue(payload["responsive_exchange_simulation_preview"])
+        self.assertGreater(
+            payload["ranking_features"]["responsive_simulation_gap_score"], 0
+        )
         self.assertFalse(payload["proof_authority"])
         self.assertFalse(payload["promotion_allowed"])
         self.assertFalse(payload["final_authority_ok"])
@@ -205,11 +215,20 @@ class TestLobRealityGapStress(TestCase):
         self.assertIn("arxiv-2603.24137", source_ids)
         self.assertIn("ofr-25-01", source_ids)
         self.assertIn("arxiv-2507.06345", source_ids)
+        self.assertIn("arxiv-2502.07071", source_ids)
+        self.assertIn(
+            "responsive_event_concentration_share", contract["stress_components"]
+        )
         self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
         self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
         self.assertTrue(
             contract["proof_neutrality"]["requires_order_lifecycle_fill_evidence"]
         )
         self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertTrue(
+            contract["proof_neutrality"][
+                "rejects_responsive_simulator_only_pnl_authority"
+            ]
+        )
         self.assertFalse(contract["proof_neutrality"]["promotion_proof"])
         self.assertFalse(payload["promotion_authority"])


### PR DESCRIPTION
## Summary

- Adds responsive exchange event-mix and state-conditioned response-gap scoring to the preview-only LOB reality-gap stress, sourced to arXiv:2502.07071.
- Carries the new ranking feature and source provenance through fast replay manifests while keeping proof and promotion authority disabled.
- Extends focused LOB stress and fast replay tests for the new source, ranking payload, and proof boundary.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/discovery/lob_reality_gap_stress.py app/trading/discovery/fast_replay.py tests/test_lob_reality_gap_stress.py tests/test_fast_replay.py`
- `uv run --frozen ruff format --check app/trading/discovery/lob_reality_gap_stress.py app/trading/discovery/fast_replay.py tests/test_lob_reality_gap_stress.py tests/test_fast_replay.py`
- `uv run --frozen pytest tests/test_lob_reality_gap_stress.py tests/test_fast_replay.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
