### PR TITLE
fix(torghut): bypass H-PAIRS drift blockers for market-closed staleness

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -11,7 +11,7 @@ import os
 from contextlib import contextmanager
 import logging
 from collections import Counter
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Generator, Mapping, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any, cast
@@ -172,6 +172,11 @@ HPAIRS_CURRENT_COLLECTION_PREREQUISITE_BLOCKERS = frozenset(
     {
         "drift_checks_missing",
         "signal_lag_exceeded",
+    }
+)
+_HPAIRS_EXPECTED_MARKET_CLOSED_DRIFT_CHECK_BYPASS_REASONS = frozenset(
+    {
+        "expected_market_closed_staleness",
     }
 )
 PAPER_ROUTE_ACCOUNT_STATE_DISCARD_BLOCKERS = frozenset(
@@ -1858,6 +1863,10 @@ def _hpairs_current_collection_prerequisite_blockers(
     current_blockers: set[str] = set()
     continuity_reason = _safe_text(health_gate.get("continuity_reason"))
     drift_reason = _safe_text(health_gate.get("drift_reason"))
+    bypass_drift_checks_for_closed_market = (
+        continuity_reason in _HPAIRS_EXPECTED_MARKET_CLOSED_DRIFT_CHECK_BYPASS_REASONS
+        and _safe_text(health_gate.get("continuity_ok")) == "true"
+    )
 
     signal_currently_stale = not _health_gate_ready_bool(
         health_gate,
@@ -1876,9 +1885,13 @@ def _hpairs_current_collection_prerequisite_blockers(
         source_key="drift_source",
     )
     if (
-        "drift_checks_missing" in raw_blockers
-        or (drift_reason is not None and "missing" in drift_reason)
-    ) and drift_currently_missing:
+        not bypass_drift_checks_for_closed_market
+        and (
+            "drift_checks_missing" in raw_blockers
+            or (drift_reason is not None and "missing" in drift_reason)
+        )
+        and drift_currently_missing
+    ):
         current_blockers.add("drift_checks_missing")
 
     return sorted(current_blockers)
@@ -1905,11 +1918,20 @@ def _hpairs_stale_collection_blockers_cleared_by_current_inputs(
         )
         & HPAIRS_CURRENT_COLLECTION_PREREQUISITE_BLOCKERS
     )
+    continuity_reason = _safe_text(health_gate.get("continuity_reason"))
+    bypass_drift_checks_for_closed_market = (
+        continuity_reason in _HPAIRS_EXPECTED_MARKET_CLOSED_DRIFT_CHECK_BYPASS_REASONS
+        and _safe_text(health_gate.get("continuity_ok")) == "true"
+    )
     cleared: list[str] = []
     if "drift_checks_missing" in raw_blockers and _health_gate_ready_bool(
         health_gate,
         ok_key="drift_ok",
         source_key="drift_source",
+    ):
+        cleared.append("drift_checks_missing")
+    elif (
+        bypass_drift_checks_for_closed_market and "drift_checks_missing" in raw_blockers
     ):
         cleared.append("drift_checks_missing")
     if "signal_lag_exceeded" in raw_blockers and _health_gate_ready_bool(
@@ -3233,8 +3255,7 @@ def _source_reject_blockers_are_quote_quality_only(
         if reason and str(item).strip().lower().startswith("source_reject_"):
             reason_blockers.append(reason)
     return bool(reason_blockers) and all(
-        _is_quote_quality_source_reject_reason(reason)
-        for reason in reason_blockers
+        _is_quote_quality_source_reject_reason(reason) for reason in reason_blockers
     )
 
 
@@ -3249,9 +3270,7 @@ def _source_activity_missing_reasons_are_quote_quality_only(
     if not reasons:
         return False
     non_source_reject_blockers = [
-        reason
-        for reason in reasons
-        if not reason.startswith("source_reject_")
+        reason for reason in reasons if not reason.startswith("source_reject_")
     ]
     if non_source_reject_blockers:
         return False
@@ -4583,11 +4602,13 @@ def _strategy_source_activity(
         complete_fill_order_event_count=complete_fill_order_event_count,
         tca_sample_count=tca_sample_count,
     )
-    is_effectively_present_for_runtime_window = _source_activity_effectively_present_for_runtime_window(
-        {
-            "missing": bool(missing_reasons),
-            "missing_reasons": missing_reasons,
-        },
+    is_effectively_present_for_runtime_window = (
+        _source_activity_effectively_present_for_runtime_window(
+            {
+                "missing": bool(missing_reasons),
+                "missing_reasons": missing_reasons,
+            },
+        )
     )
     missing = not is_effectively_present_for_runtime_window
     return {
@@ -6955,7 +6976,7 @@ def _target_source_audit_session(
     session: Session,
     *,
     target: Mapping[str, object],
-) -> Iterator[tuple[Session, dict[str, object]]]:
+) -> Generator[tuple[Session, dict[str, object]], None, None]:
     source_dsn_env = _safe_text(target.get("source_dsn_env"))
     target_dsn_env = _safe_text(target.get("target_dsn_env"))
     target_account_label = _safe_text(target.get("account_label"))

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -586,6 +586,50 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_allowed"])
 
+    def test_hpairs_expected_market_closed_staleness_bypasses_current_drift_blocks(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 6, 2, 15, tzinfo=timezone.utc)
+        window_start, _window_end = _next_regular_equities_session_window(generated_at)
+        with Session(self.engine) as session:
+            self._seed_hpairs_strategy_and_flat_snapshot(
+                session,
+                window_start=window_start,
+            )
+
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate=self._hpairs_live_submission_gate(
+                    candidate_blockers=[
+                        "drift_checks_missing",
+                        "paper_route_runtime_ledger_import_pending",
+                    ],
+                    continuity_ok=True,
+                    continuity_reason="expected_market_closed_staleness",
+                    drift_ok=False,
+                    drift_reason="drift_live_promotion_ineligible",
+                ),
+                route_reacquisition_book=self._hpairs_route_reacquisition_book(),
+                generated_at=generated_at,
+                include_runtime_window_import_audit=False,
+            )
+
+        target = payload["targets"][0]
+        self.assertTrue(target["evidence_collection_ok"])
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertNotIn("drift_checks_missing", target["candidate_blockers"])
+        self.assertIn(
+            "drift_checks_missing",
+            target["stale_collection_blockers_cleared_by_current_inputs"],
+        )
+        self.assertEqual(target["runtime_window_import_health_gate_blockers"], [])
+        self.assertEqual(
+            target["runtime_window_import_promotion_blockers"],
+            ["drift_checks_not_ok"],
+        )
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+
     def test_hpairs_after_hours_market_session_closed_is_not_bypassed(self) -> None:
         generated_at = datetime(2026, 6, 2, 21, tzinfo=timezone.utc)
         window_start, _window_end = _next_regular_equities_session_window(generated_at)
@@ -6006,8 +6050,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target_audit["readiness"]["blockers"],
         )
         import_audit = payload["runtime_window_import_audit"]
-        self.assertEqual(import_audit["state"], "import_due_source_lifecycle_incomplete")
-        self.assertNotIn("paper_route_source_activity_missing", import_audit["blockers"])
+        self.assertEqual(
+            import_audit["state"], "import_due_source_lifecycle_incomplete"
+        )
+        self.assertNotIn(
+            "paper_route_source_activity_missing", import_audit["blockers"]
+        )
         self.assertNotIn("source_executions_missing", import_audit["blockers"])
         self.assertNotIn("source_tca_missing", import_audit["blockers"])
 


### PR DESCRIPTION
## Summary

- Allows H-PAIRS bounded paper-route collection to clear stale `drift_checks_missing` only when continuity explicitly reports `expected_market_closed_staleness`.
- Keeps promotion authority blocked: the target still surfaces `drift_checks_not_ok`, `promotion_allowed=false`, and `final_promotion_allowed=false`.
- Adds regression coverage for the market-closed drift-bypass path and the existing stale-signal/missing-drift negative path.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen python -m pytest -q tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_hpairs_expected_market_closed_staleness_bypasses_current_drift_blocks tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_hpairs_stale_signal_and_missing_drift_block_collection_when_current`
- `uv run --frozen python -m compileall -q app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A; backend gate and runtime metadata change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
