### PR TITLE
feat(torghut): add cost-aware forecast replay stress

### DIFF
--- a/services/torghut/app/trading/discovery/cost_aware_forecast_filter_stress.py
+++ b/services/torghut/app/trading/discovery/cost_aware_forecast_filter_stress.py
@@ -1,0 +1,572 @@
+"""Preview-only cost-aware forecast filter stress for replay ranking.
+
+This module converts recent 2025-2026 walk-forward forecasting and
+transaction-cost/slippage papers into deterministic replay-ranking inputs.  It
+never rewrites realized PnL, simulates fills, authorizes promotion, or enables
+live capital.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import isfinite
+from statistics import median
+from typing import Any, cast
+
+from app.trading.models import SignalEnvelope
+
+COST_AWARE_FORECAST_FILTER_STRESS_SCHEMA_VERSION = (
+    "torghut.cost-aware-forecast-filter-stress.v1"
+)
+COST_AWARE_FORECAST_FILTER_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.cost-aware-forecast-filter-stress-contract.v1"
+)
+COST_AWARE_FORECAST_FILTER_STRESS_PROOF_SEMANTICS_LABEL = (
+    "cost_aware_forecast_filter_stress_preview_only_exact_replay_route_tca_"
+    "order_lifecycle_runtime_ledger_required"
+)
+COST_AWARE_FORECAST_FILTER_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2606.00060",
+        "url": "https://arxiv.org/abs/2606.00060",
+        "title": "Machine Learning-Based Bitcoin Trading Under Transaction Costs: Evidence From Walk-Forward Forecasting",
+        "date": "2026-05-19",
+        "mechanism": "walk_forward_forecasts_require_cost_threshold_trade_filter_to_avoid_turnover_destroying_gross_alpha",
+    },
+    {
+        "source_id": "arxiv-2512.12727",
+        "url": "https://arxiv.org/abs/2512.12727",
+        "title": "EXFormer: A Multi-Scale Trend-Aware Transformer with Dynamic Variable Selection for Foreign Exchange Returns Prediction",
+        "date": "2026-01-19",
+        "mechanism": "multi_scale_trend_forecasts_need_out_of_sample_slippage_cost_survival_and_variable_selection_coverage",
+    },
+)
+
+_FORECAST_BPS_FIELDS = (
+    "forecast_return_bps",
+    "predicted_return_bps",
+    "expected_return_bps",
+    "alpha_forecast_bps",
+    "signal_return_bps",
+    "model_prediction_bps",
+    "edge_bps",
+    "forecast_edge_bps",
+    "expected_edge_bps",
+)
+_TOTAL_COST_BPS_FIELDS = (
+    "total_cost_bps",
+    "transaction_cost_bps",
+    "estimated_total_cost_bps",
+    "execution_cost_bps",
+    "round_trip_cost_bps",
+    "cost_threshold_bps",
+)
+_COST_COMPONENT_BPS_FIELDS = (
+    "fee_bps",
+    "commission_bps",
+    "slippage_bps",
+    "impact_cost_bps",
+    "market_impact_cost_bps",
+    "borrow_cost_bps",
+)
+_SPREAD_BPS_FIELDS = (
+    "spread_bps",
+    "quoted_spread_bps",
+    "effective_spread_bps",
+    "nbbo_spread_bps",
+)
+_ACTION_FIELDS = (
+    "cost_filtered_action",
+    "trade_action",
+    "action",
+    "decision",
+    "side",
+    "signal_side",
+    "target_side",
+)
+_POSITION_FIELDS = (
+    "target_position",
+    "position_target",
+    "desired_position",
+    "target_weight",
+    "order_qty",
+    "trade_qty",
+)
+_FOLD_FIELDS = (
+    "walk_forward_fold",
+    "walk_forward_fold_id",
+    "oos_fold_id",
+    "validation_fold",
+    "fold_id",
+    "test_fold_id",
+    "sliding_window_id",
+)
+_MULTI_SCALE_FIELDS = (
+    "multi_scale_trend_score",
+    "multi_scale_features",
+    "trend_scales",
+    "short_horizon_trend_bps",
+    "medium_horizon_trend_bps",
+    "long_horizon_trend_bps",
+)
+_VARIABLE_SELECTION_FIELDS = (
+    "dynamic_variable_weights",
+    "variable_selection_weights",
+    "selected_variable_count",
+    "exogenous_feature_weight_count",
+    "feature_importance_snapshot",
+)
+
+
+@dataclass(frozen=True)
+class CostAwareForecastFilterStressSummary:
+    row_count: int
+    forecast_observation_count: int
+    cost_observation_count: int
+    action_observation_count: int
+    fold_observation_count: int
+    distinct_walk_forward_fold_count: int
+    multi_scale_feature_count: int
+    variable_selection_feature_count: int
+    median_abs_forecast_bps: float
+    median_total_cost_bps: float
+    median_cost_clearance_bps: float
+    cost_clearance_share: float
+    weak_forecast_trade_share: float
+    cost_filtered_action_agreement_share: float
+    turnover_churn_score: float
+    walk_forward_coverage_score: float
+    multi_scale_feature_coverage: float
+    dynamic_variable_selection_coverage: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": COST_AWARE_FORECAST_FILTER_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_cost_aware_forecast_filter_stress_ranking",
+            "source_papers": [
+                dict(item) for item in COST_AWARE_FORECAST_FILTER_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "forecast_observation_count": self.forecast_observation_count,
+            "cost_observation_count": self.cost_observation_count,
+            "action_observation_count": self.action_observation_count,
+            "fold_observation_count": self.fold_observation_count,
+            "distinct_walk_forward_fold_count": self.distinct_walk_forward_fold_count,
+            "multi_scale_feature_count": self.multi_scale_feature_count,
+            "variable_selection_feature_count": self.variable_selection_feature_count,
+            "median_abs_forecast_bps": _stable_float(self.median_abs_forecast_bps),
+            "median_total_cost_bps": _stable_float(self.median_total_cost_bps),
+            "median_cost_clearance_bps": _stable_float(self.median_cost_clearance_bps),
+            "cost_clearance_share": _stable_float(self.cost_clearance_share),
+            "weak_forecast_trade_share": _stable_float(self.weak_forecast_trade_share),
+            "cost_filtered_action_agreement_share": _stable_float(
+                self.cost_filtered_action_agreement_share
+            ),
+            "turnover_churn_score": _stable_float(self.turnover_churn_score),
+            "walk_forward_coverage_score": _stable_float(
+                self.walk_forward_coverage_score
+            ),
+            "multi_scale_feature_coverage": _stable_float(
+                self.multi_scale_feature_coverage
+            ),
+            "dynamic_variable_selection_coverage": _stable_float(
+                self.dynamic_variable_selection_coverage
+            ),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "cost_clearance_share": _stable_float(self.cost_clearance_share),
+                "weak_forecast_trade_share": _stable_float(
+                    self.weak_forecast_trade_share
+                ),
+                "cost_filtered_action_agreement_share": _stable_float(
+                    self.cost_filtered_action_agreement_share
+                ),
+                "turnover_churn_score": _stable_float(self.turnover_churn_score),
+                "walk_forward_coverage_score": _stable_float(
+                    self.walk_forward_coverage_score
+                ),
+                "multi_scale_feature_coverage": _stable_float(
+                    self.multi_scale_feature_coverage
+                ),
+                "dynamic_variable_selection_coverage": _stable_float(
+                    self.dynamic_variable_selection_coverage
+                ),
+                "median_cost_clearance_bps": _stable_float(
+                    self.median_cost_clearance_bps
+                ),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "walk_forward_cost_filter_preview": True,
+            "cost_threshold_trade_filter_preview": True,
+            "turnover_churn_preview": True,
+            "multi_scale_trend_feature_coverage_preview": True,
+            "dynamic_variable_selection_coverage_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": (
+                COST_AWARE_FORECAST_FILTER_STRESS_PROOF_SEMANTICS_LABEL
+            ),
+        }
+
+
+def cost_aware_forecast_filter_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": COST_AWARE_FORECAST_FILTER_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": COST_AWARE_FORECAST_FILTER_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in COST_AWARE_FORECAST_FILTER_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": "walk_forward_cost_threshold_forecast_to_trade_filter_stress",
+        "stress_components": [
+            "cost_clearance_share",
+            "weak_forecast_trade_share",
+            "cost_filtered_action_agreement_share",
+            "turnover_churn_score",
+            "walk_forward_coverage_score",
+            "multi_scale_feature_coverage",
+            "dynamic_variable_selection_coverage",
+        ],
+        "forecast_fields": list(_FORECAST_BPS_FIELDS),
+        "cost_fields": list(_TOTAL_COST_BPS_FIELDS),
+        "cost_component_fields": list(_COST_COMPONENT_BPS_FIELDS),
+        "spread_fields": list(_SPREAD_BPS_FIELDS),
+        "action_fields": list(_ACTION_FIELDS),
+        "fold_fields": list(_FOLD_FIELDS),
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_order_lifecycle_fill_evidence": True,
+            "requires_runtime_ledger": True,
+            "rejects_gross_forecast_return_as_pnl_proof": True,
+            "rejects_cost_filtered_preview_as_promotion_authority": True,
+            "rejects_walk_forward_backtest_without_runtime_ledger": True,
+        },
+    }
+
+
+def build_cost_aware_forecast_filter_stress_schema_hash() -> str:
+    return _stable_hash(cost_aware_forecast_filter_stress_contract())
+
+
+def extract_cost_aware_forecast_filter_stress(
+    records: Sequence[SignalEnvelope],
+    *,
+    cost_multiplier: float = 1.0,
+) -> CostAwareForecastFilterStressSummary:
+    """Extract deterministic cost-threshold forecast-to-trade stress."""
+
+    row_count = len(records)
+    forecasts: list[float] = []
+    costs: list[float] = []
+    clearances: list[float] = []
+    fold_ids: set[str] = set()
+    action_signs: list[int] = []
+    multi_scale_count = 0
+    variable_selection_count = 0
+    comparable_count = 0
+    cost_clear_count = 0
+    weak_forecast_trade_count = 0
+    action_agreement_count = 0
+    warnings: list[str] = []
+
+    for row in records:
+        forecast = _forecast_bps(row)
+        cost = _total_cost_bps(row)
+        action = _action_sign(row)
+        fold_id = _fold_id(row)
+        has_multi_scale = _has_any_payload_field(row, _MULTI_SCALE_FIELDS)
+        has_variable_selection = _has_any_payload_field(row, _VARIABLE_SELECTION_FIELDS)
+
+        if forecast is not None:
+            forecasts.append(forecast)
+        if cost is not None:
+            costs.append(cost)
+        if action is not None:
+            action_signs.append(action)
+        if fold_id is not None:
+            fold_ids.add(fold_id)
+        if has_multi_scale:
+            multi_scale_count += 1
+        if has_variable_selection:
+            variable_selection_count += 1
+
+        if forecast is None or cost is None:
+            continue
+
+        threshold = max(0.0, cost * cost_multiplier)
+        clearance = abs(forecast) - threshold
+        clearances.append(clearance)
+        comparable_count += 1
+        expected_trade = clearance > 0.0
+        if expected_trade:
+            cost_clear_count += 1
+        if action is not None:
+            actual_trade = action != 0
+            if actual_trade and not expected_trade:
+                weak_forecast_trade_count += 1
+            if actual_trade == expected_trade:
+                action_agreement_count += 1
+
+    if not forecasts:
+        warnings.append("missing_forecast_magnitude_inputs")
+    if not costs:
+        warnings.append("missing_transaction_cost_or_spread_inputs")
+    if not action_signs:
+        warnings.append("missing_trade_action_inputs")
+    if not fold_ids:
+        warnings.append("missing_walk_forward_fold_inputs")
+    if multi_scale_count == 0:
+        warnings.append("missing_multi_scale_trend_feature_inputs")
+    if variable_selection_count == 0:
+        warnings.append("missing_dynamic_variable_selection_inputs")
+
+    forecast_count = len(forecasts)
+    cost_count = len(costs)
+    action_count = len(action_signs)
+    fold_count = sum(1 for row in records if _fold_id(row) is not None)
+    distinct_fold_count = len(fold_ids)
+    median_abs_forecast = (
+        median(abs(value) for value in forecasts) if forecasts else 0.0
+    )
+    median_cost = median(costs) if costs else 0.0
+    median_clearance = median(clearances) if clearances else 0.0
+    cost_clearance_share = _safe_ratio(cost_clear_count, comparable_count)
+    weak_forecast_trade_share = _safe_ratio(weak_forecast_trade_count, action_count)
+    cost_filtered_action_agreement_share = _safe_ratio(
+        action_agreement_count,
+        sum(
+            1
+            for row in records
+            if _forecast_bps(row) is not None
+            and _total_cost_bps(row) is not None
+            and _action_sign(row) is not None
+        ),
+        default=0.0 if action_count else 1.0,
+    )
+    turnover_churn = _turnover_churn_score(action_signs)
+    walk_forward_coverage = min(1.0, distinct_fold_count / 3.0) if row_count else 0.0
+    multi_scale_coverage = _safe_ratio(multi_scale_count, row_count)
+    variable_selection_coverage = _safe_ratio(variable_selection_count, row_count)
+    missing_input_penalty = 0.0
+    if not forecasts:
+        missing_input_penalty += 4.0
+    if not costs:
+        missing_input_penalty += 3.0
+    if not action_signs:
+        missing_input_penalty += 1.5
+    if not fold_ids:
+        missing_input_penalty += 1.5
+
+    replay_rank_penalty_bps = max(
+        0.0,
+        (1.0 - cost_clearance_share) * 4.0
+        + weak_forecast_trade_share * 5.0
+        + (1.0 - cost_filtered_action_agreement_share) * 3.0
+        + turnover_churn * 2.0
+        + (1.0 - walk_forward_coverage) * 2.0
+        + (1.0 - multi_scale_coverage) * 1.0
+        + (1.0 - variable_selection_coverage) * 1.0
+        + max(0.0, -median_clearance) * 0.15
+        + missing_input_penalty,
+    )
+
+    return CostAwareForecastFilterStressSummary(
+        row_count=row_count,
+        forecast_observation_count=forecast_count,
+        cost_observation_count=cost_count,
+        action_observation_count=action_count,
+        fold_observation_count=fold_count,
+        distinct_walk_forward_fold_count=distinct_fold_count,
+        multi_scale_feature_count=multi_scale_count,
+        variable_selection_feature_count=variable_selection_count,
+        median_abs_forecast_bps=median_abs_forecast,
+        median_total_cost_bps=median_cost,
+        median_cost_clearance_bps=median_clearance,
+        cost_clearance_share=cost_clearance_share,
+        weak_forecast_trade_share=weak_forecast_trade_share,
+        cost_filtered_action_agreement_share=cost_filtered_action_agreement_share,
+        turnover_churn_score=turnover_churn,
+        walk_forward_coverage_score=walk_forward_coverage,
+        multi_scale_feature_coverage=multi_scale_coverage,
+        dynamic_variable_selection_coverage=variable_selection_coverage,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=tuple(sorted(set(warnings))),
+        feature_schema_hash=build_cost_aware_forecast_filter_stress_schema_hash(),
+    )
+
+
+def _forecast_bps(row: SignalEnvelope) -> float | None:
+    return _first_float(row.payload, _FORECAST_BPS_FIELDS)
+
+
+def _total_cost_bps(row: SignalEnvelope) -> float | None:
+    explicit = _first_float(row.payload, _TOTAL_COST_BPS_FIELDS)
+    if explicit is not None:
+        return max(0.0, explicit)
+
+    component_values = [
+        value
+        for field in _COST_COMPONENT_BPS_FIELDS
+        if (value := _float_or_none(row.payload.get(field))) is not None
+    ]
+    spread = _first_float(row.payload, _SPREAD_BPS_FIELDS)
+    if component_values or spread is not None:
+        return max(0.0, sum(component_values) + max(0.0, spread or 0.0) * 0.5)
+    return None
+
+
+def _action_sign(row: SignalEnvelope) -> int | None:
+    for field in _ACTION_FIELDS:
+        value = row.payload.get(field)
+        if value is None:
+            continue
+        sign = _action_value_sign(value)
+        if sign is not None:
+            return sign
+    for field in _POSITION_FIELDS:
+        value = _float_or_none(row.payload.get(field))
+        if value is None:
+            continue
+        if value > 0.0:
+            return 1
+        if value < 0.0:
+            return -1
+        return 0
+    return None
+
+
+def _action_value_sign(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return 1 if value else 0
+    numeric = _float_or_none(value)
+    if numeric is not None:
+        if numeric > 0.0:
+            return 1
+        if numeric < 0.0:
+            return -1
+        return 0
+    text = str(value).strip().lower()
+    if text in {"buy", "long", "bid", "enter_long", "cover"}:
+        return 1
+    if text in {"sell", "short", "ask", "enter_short"}:
+        return -1
+    if text in {"hold", "none", "flat", "wait", "skip", "no_trade", "0"}:
+        return 0
+    return None
+
+
+def _fold_id(row: SignalEnvelope) -> str | None:
+    for field in _FOLD_FIELDS:
+        value = row.payload.get(field)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return None
+
+
+def _has_any_payload_field(row: SignalEnvelope, fields: Sequence[str]) -> bool:
+    for field in fields:
+        value = row.payload.get(field)
+        if value is None:
+            continue
+        if isinstance(value, Mapping):
+            if len(cast(Mapping[Any, Any], value)) > 0:
+                return True
+            continue
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            if len(cast(Sequence[Any], value)) > 0:
+                return True
+            continue
+        return True
+    return False
+
+
+def _turnover_churn_score(action_signs: Sequence[int]) -> float:
+    trade_signs = [sign for sign in action_signs if sign != 0]
+    if not action_signs:
+        return 0.0
+    trade_rate = len(trade_signs) / len(action_signs)
+    if len(trade_signs) <= 1:
+        flip_rate = 0.0
+    else:
+        flips = sum(
+            1
+            for previous, current in zip(trade_signs, trade_signs[1:])
+            if previous != current
+        )
+        flip_rate = flips / (len(trade_signs) - 1)
+    return min(1.0, trade_rate * 0.6 + flip_rate * 0.4)
+
+
+def _first_float(payload: Mapping[str, Any], fields: Sequence[str]) -> float | None:
+    for field in fields:
+        value = _float_or_none(payload.get(field))
+        if value is not None:
+            return value
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(result):
+        return None
+    return result
+
+
+def _safe_ratio(
+    numerator: int | float, denominator: int | float, *, default: float = 0.0
+) -> float:
+    if denominator <= 0:
+        return default
+    return max(0.0, min(1.0, float(numerator) / float(denominator)))
+
+
+def _stable_float(value: float) -> float:
+    if not isfinite(value):
+        return 0.0
+    return round(float(value), 10)
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+
+
+__all__ = [
+    "COST_AWARE_FORECAST_FILTER_STRESS_PRIMARY_SOURCES",
+    "COST_AWARE_FORECAST_FILTER_STRESS_SCHEMA_VERSION",
+    "CostAwareForecastFilterStressSummary",
+    "build_cost_aware_forecast_filter_stress_schema_hash",
+    "cost_aware_forecast_filter_stress_contract",
+    "extract_cost_aware_forecast_filter_stress",
+]

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -20,6 +20,9 @@ from app.trading.discovery.alpha_decay_predictability_stress import (
 from app.trading.discovery.counterfactual_regime_replay_stress import (
     extract_counterfactual_regime_replay_stress,
 )
+from app.trading.discovery.cost_aware_forecast_filter_stress import (
+    extract_cost_aware_forecast_filter_stress,
+)
 from app.trading.discovery.cluster_lob_features import (
     HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION,
     extract_cluster_lob_features,
@@ -81,8 +84,8 @@ from app.trading.discovery.signal_adaptive_execution_resilience_stress import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v8"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v9"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v9"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v10"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -113,6 +116,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "institutional_mechanism_fidelity_stress",
     "signal_adaptive_execution_resilience_stress",
     "microstructure_regime_tokenization_stress",
+    "cost_aware_forecast_filter_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -230,6 +234,9 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     microstructure_regime_tokenization_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    cost_aware_forecast_filter_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -354,6 +361,9 @@ class FastReplayPreviewRow:
             ),
             "microstructure_regime_tokenization_stress": dict(
                 self.microstructure_regime_tokenization_stress
+            ),
+            "cost_aware_forecast_filter_stress": dict(
+                self.cost_aware_forecast_filter_stress
             ),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
@@ -553,6 +563,7 @@ class FastReplayPreviewResult:
                 "institutional_mechanism_fidelity_stress": "deterministic market-calendar, auction/session-boundary, price-limit, tick-size, latency, and asynchronous cross-asset mechanism-fidelity stress from arXiv:2604.18046 and arXiv:2511.02016; simulator realism proxies are not PnL authority; preview ranking only",
                 "signal_adaptive_execution_resilience_stress": "deterministic signal-adaptive quote, fill-intensity, inventory-risk, stochastic liquidity-resilience, and regime-switch stress from arXiv:2605.24242 and arXiv:2506.11813; signal drift and modeled fill intensity are not PnL authority; preview ranking only",
                 "microstructure_regime_tokenization_stress": "deterministic latent-regime early-warning, scale-invariant trade-flow token coverage, raw event precision, and stylized-fact replay stress from arXiv:2604.20949, arXiv:2602.23784, and arXiv:2508.02247; latent triggers and tokenized trade-flow are not PnL authority; preview ranking only",
+                "cost_aware_forecast_filter_stress": "deterministic walk-forward forecast-magnitude, transaction-cost threshold, turnover churn, multi-scale trend coverage, and dynamic-variable-selection stress from arXiv:2606.00060 and arXiv:2512.12727; cost-filtered forecasts are not PnL authority; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1220,6 +1231,7 @@ def _score_candidate_spec(
             institutional_mechanism_fidelity_stress={},
             signal_adaptive_execution_resilience_stress={},
             microstructure_regime_tokenization_stress={},
+            cost_aware_forecast_filter_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1489,6 +1501,17 @@ def _score_candidate_spec(
         )
         or 0.0
     )
+    cost_aware_forecast_filter_stress = extract_cost_aware_forecast_filter_stress(
+        matched_source_rows
+    ).to_payload()
+    cost_aware_forecast_filter_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(cost_aware_forecast_filter_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
@@ -1551,6 +1574,7 @@ def _score_candidate_spec(
         - institutional_mechanism_fidelity_rank_penalty_bps * 0.05
         - signal_adaptive_execution_resilience_rank_penalty_bps * 0.05
         - microstructure_regime_tokenization_rank_penalty_bps * 0.05
+        - cost_aware_forecast_filter_rank_penalty_bps * 0.05
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1598,6 +1622,7 @@ def _score_candidate_spec(
         - institutional_mechanism_fidelity_rank_penalty_bps * 0.03
         - signal_adaptive_execution_resilience_rank_penalty_bps * 0.03
         - microstructure_regime_tokenization_rank_penalty_bps * 0.03
+        - cost_aware_forecast_filter_rank_penalty_bps * 0.03
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1657,6 +1682,7 @@ def _score_candidate_spec(
         microstructure_regime_tokenization_stress=dict(
             microstructure_regime_tokenization_stress
         ),
+        cost_aware_forecast_filter_stress=dict(cost_aware_forecast_filter_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1709,6 +1735,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - _institutional_mechanism_fidelity_rank_penalty_bps(row) * 0.04
         - _signal_adaptive_execution_resilience_rank_penalty_bps(row) * 0.04
         - _microstructure_regime_tokenization_rank_penalty_bps(row) * 0.04
+        - _cost_aware_forecast_filter_rank_penalty_bps(row) * 0.04
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
@@ -1831,6 +1858,15 @@ def _microstructure_regime_tokenization_rank_penalty_bps(
 ) -> float:
     ranking_features = _mapping(
         row.microstructure_regime_tokenization_stress.get("ranking_features")
+    )
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _cost_aware_forecast_filter_rank_penalty_bps(
+    row: FastReplayPreviewRow,
+) -> float:
+    ranking_features = _mapping(
+        row.cost_aware_forecast_filter_stress.get("ranking_features")
     )
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
@@ -2049,6 +2085,7 @@ def _row_with_rank_and_selection(
         microstructure_regime_tokenization_stress=dict(
             row.microstructure_regime_tokenization_stress
         ),
+        cost_aware_forecast_filter_stress=dict(row.cost_aware_forecast_filter_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -2134,6 +2171,7 @@ def _row_with_frontier_dedupe(
         microstructure_regime_tokenization_stress=dict(
             row.microstructure_regime_tokenization_stress
         ),
+        cost_aware_forecast_filter_stress=dict(row.cost_aware_forecast_filter_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -2963,6 +3001,8 @@ def _risk_flags_for_row(
         flags.add("signal_adaptive_execution_resilience_stress_penalty_active")
     if _microstructure_regime_tokenization_rank_penalty_bps(row) > 0:
         flags.add("microstructure_regime_tokenization_stress_penalty_active")
+    if _cost_aware_forecast_filter_rank_penalty_bps(row) > 0:
+        flags.add("cost_aware_forecast_filter_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
         flags.add("partial_symbol_coverage")
     if row.trading_day_count <= 0:
@@ -3025,6 +3065,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("signal_adaptive_execution_resilience_stress_downranks_only")
     if _microstructure_regime_tokenization_rank_penalty_bps(row) > 0:
         reasons.add("microstructure_regime_tokenization_stress_downranks_only")
+    if _cost_aware_forecast_filter_rank_penalty_bps(row) > 0:
+        reasons.add("cost_aware_forecast_filter_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
         reasons.add("missing_replay_tape_source_data_explicit_blocker")
     if lineage_blockers:
@@ -3080,6 +3122,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("signal_adaptive_execution_resilience_stress_penalty")
     if _microstructure_regime_tokenization_rank_penalty_bps(row) > 0:
         vetoes.add("microstructure_regime_tokenization_stress_penalty")
+    if _cost_aware_forecast_filter_rank_penalty_bps(row) > 0:
+        vetoes.add("cost_aware_forecast_filter_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:
         vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
     return tuple(sorted(vetoes))

--- a/services/torghut/tests/test_cost_aware_forecast_filter_stress.py
+++ b/services/torghut/tests/test_cost_aware_forecast_filter_stress.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.cost_aware_forecast_filter_stress import (
+    build_cost_aware_forecast_filter_stress_schema_hash,
+    cost_aware_forecast_filter_stress_contract,
+    extract_cost_aware_forecast_filter_stress,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestCostAwareForecastFilterStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        forecast_bps: str | None,
+        cost_bps: str = "4",
+        action: str = "hold",
+        fold: str | None = "wf-1",
+        multi_scale: bool = True,
+        variable_selection: bool = True,
+    ) -> SignalEnvelope:
+        payload: dict[str, object] = {
+            "transaction_cost_bps": Decimal(cost_bps),
+            "trade_action": action,
+            "spread_bps": Decimal("2"),
+        }
+        if forecast_bps is not None:
+            payload["forecast_return_bps"] = Decimal(forecast_bps)
+        if fold is not None:
+            payload["walk_forward_fold_id"] = fold
+        if multi_scale:
+            payload["multi_scale_trend_score"] = Decimal("0.72")
+            payload["trend_scales"] = {"short": "up", "medium": "up", "long": "flat"}
+        if variable_selection:
+            payload["dynamic_variable_weights"] = {
+                "dxy": "0.31",
+                "rates": "0.22",
+                "vol": "0.18",
+            }
+        return SignalEnvelope(
+            event_ts=datetime(2026, 5, 19, 14, 30, tzinfo=timezone.utc)
+            + timedelta(minutes=offset),
+            symbol="COST",
+            timeframe="1Min",
+            seq=offset,
+            source="cost-aware-forecast-filter-fixture",
+            payload=payload,
+            ingest_ts=datetime(2026, 5, 19, 14, 31, tzinfo=timezone.utc),
+        )
+
+    def test_cost_filter_downranks_weak_forecast_churn(self) -> None:
+        filtered = extract_cost_aware_forecast_filter_stress(
+            (
+                self._row(offset=1, forecast_bps="12", action="buy", fold="wf-1"),
+                self._row(offset=2, forecast_bps="10", action="buy", fold="wf-2"),
+                self._row(offset=3, forecast_bps="8", action="buy", fold="wf-3"),
+                self._row(offset=4, forecast_bps="3", action="hold", fold="wf-3"),
+            )
+        )
+        churny = extract_cost_aware_forecast_filter_stress(
+            (
+                self._row(
+                    offset=1,
+                    forecast_bps="1.0",
+                    action="buy",
+                    fold=None,
+                    multi_scale=False,
+                    variable_selection=False,
+                ),
+                self._row(
+                    offset=2,
+                    forecast_bps="1.2",
+                    action="sell",
+                    fold=None,
+                    multi_scale=False,
+                    variable_selection=False,
+                ),
+                self._row(
+                    offset=3,
+                    forecast_bps="0.8",
+                    action="buy",
+                    fold=None,
+                    multi_scale=False,
+                    variable_selection=False,
+                ),
+                self._row(
+                    offset=4,
+                    forecast_bps="0.5",
+                    action="sell",
+                    fold=None,
+                    multi_scale=False,
+                    variable_selection=False,
+                ),
+            )
+        )
+
+        self.assertGreater(filtered.cost_clearance_share, churny.cost_clearance_share)
+        self.assertLess(
+            filtered.weak_forecast_trade_share, churny.weak_forecast_trade_share
+        )
+        self.assertGreater(
+            filtered.cost_filtered_action_agreement_share,
+            churny.cost_filtered_action_agreement_share,
+        )
+        self.assertLess(filtered.turnover_churn_score, churny.turnover_churn_score)
+        self.assertGreater(
+            filtered.walk_forward_coverage_score,
+            churny.walk_forward_coverage_score,
+        )
+        self.assertGreater(
+            filtered.multi_scale_feature_coverage,
+            churny.multi_scale_feature_coverage,
+        )
+        self.assertGreater(
+            filtered.dynamic_variable_selection_coverage,
+            churny.dynamic_variable_selection_coverage,
+        )
+        self.assertGreater(
+            churny.replay_rank_penalty_bps,
+            filtered.replay_rank_penalty_bps,
+        )
+        payload = churny.to_payload()
+        self.assertEqual(
+            payload["status"],
+            "preview_only_cost_aware_forecast_filter_stress_ranking",
+        )
+        self.assertTrue(payload["cost_threshold_trade_filter_preview"])
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["final_authority_ok"])
+
+    def test_missing_inputs_fail_closed_and_contract_rejects_pnl_authority(
+        self,
+    ) -> None:
+        summary = extract_cost_aware_forecast_filter_stress(
+            (
+                self._row(
+                    offset=1,
+                    forecast_bps=None,
+                    action="hold",
+                    fold=None,
+                    multi_scale=False,
+                    variable_selection=False,
+                ),
+            )
+        )
+        payload = summary.to_payload()
+        contract = cost_aware_forecast_filter_stress_contract()
+        source_ids = {source["source_id"] for source in payload["source_papers"]}
+
+        self.assertEqual(
+            payload["feature_schema_hash"],
+            build_cost_aware_forecast_filter_stress_schema_hash(),
+        )
+        self.assertIn("arxiv-2606.00060", source_ids)
+        self.assertIn("arxiv-2512.12727", source_ids)
+        self.assertIn("missing_forecast_magnitude_inputs", payload["warnings"])
+        self.assertIn("missing_walk_forward_fold_inputs", payload["warnings"])
+        self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
+        self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
+        self.assertTrue(
+            contract["proof_neutrality"]["requires_order_lifecycle_fill_evidence"]
+        )
+        self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertTrue(
+            contract["proof_neutrality"]["rejects_gross_forecast_return_as_pnl_proof"]
+        )
+        self.assertTrue(
+            contract["proof_neutrality"][
+                "rejects_cost_filtered_preview_as_promotion_authority"
+            ]
+        )
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(contract["proof_neutrality"]["promotion_proof"])

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -117,6 +117,18 @@ class TestFastReplayPreview(TestCase):
                 "jump_bps": Decimal("120") if stress else Decimal("2"),
                 "news_event_window": stress,
                 "session_open_window": stress,
+                "forecast_return_bps": Decimal("1.0") if stress else Decimal("12.0"),
+                "transaction_cost_bps": Decimal("4.0"),
+                "cost_filtered_action": "buy",
+                "walk_forward_fold_id": f"wf-{offset}",
+                "multi_scale_trend_score": Decimal("0.60")
+                if stress
+                else Decimal("0.85"),
+                "dynamic_variable_weights": {
+                    "ofi": "0.35",
+                    "spread": "0.20",
+                    "volume": "0.15",
+                },
             },
             ingest_ts=datetime(2026, 2, 23, 14, 31, tzinfo=timezone.utc),
         )
@@ -271,6 +283,10 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn(
             "microstructure_regime_tokenization_stress",
+            payload["implemented_mechanisms"],
+        )
+        self.assertIn(
+            "cost_aware_forecast_filter_stress",
             payload["implemented_mechanisms"],
         )
         self.assertEqual(
@@ -631,6 +647,43 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn(
             "microstructure_regime_tokenization_stress_downranks_only",
+            row_payload["ranking_only_reasons"],
+        )
+        self.assertIn("cost_aware_forecast_filter_stress", row_payload)
+        self.assertEqual(
+            row_payload["cost_aware_forecast_filter_stress"]["status"],
+            "preview_only_cost_aware_forecast_filter_stress_ranking",
+        )
+        self.assertIn(
+            "arxiv-2606.00060",
+            {
+                source["source_id"]
+                for source in row_payload["cost_aware_forecast_filter_stress"][
+                    "source_papers"
+                ]
+            },
+        )
+        self.assertIn(
+            "arxiv-2512.12727",
+            {
+                source["source_id"]
+                for source in row_payload["cost_aware_forecast_filter_stress"][
+                    "source_papers"
+                ]
+            },
+        )
+        self.assertFalse(
+            row_payload["cost_aware_forecast_filter_stress"]["proof_authority"]
+        )
+        self.assertFalse(
+            row_payload["cost_aware_forecast_filter_stress"]["promotion_authority"]
+        )
+        self.assertIn(
+            "cost_aware_forecast_filter_stress_penalty_active",
+            row_payload["risk_flags"],
+        )
+        self.assertIn(
+            "cost_aware_forecast_filter_stress_downranks_only",
             row_payload["ranking_only_reasons"],
         )
         self.assertIn(


### PR DESCRIPTION
## Summary

- Adds a preview-only `cost_aware_forecast_filter_stress` extractor that turns 2026 walk-forward transaction-cost filtering and 2025/2026 multi-scale forecast/slippage papers into deterministic replay-ranking inputs.
- Integrates the stress into `fast_replay` manifest/row payloads, preview scoring, robust ranking, risk flags, ranking-only reasons, and veto metadata without granting promotion authority.
- Adds regression coverage proving weak forecasts traded below costs are downranked, missing proof inputs fail closed, and cost-filtered forecasts remain non-authoritative.

## Related Issues

None

## Testing

- `cd services/torghut && uvx ruff format --check app/trading/discovery/cost_aware_forecast_filter_stress.py app/trading/discovery/fast_replay.py tests/test_cost_aware_forecast_filter_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/cost_aware_forecast_filter_stress.py app/trading/discovery/fast_replay.py tests/test_cost_aware_forecast_filter_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen pytest tests/test_cost_aware_forecast_filter_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
