### PR TITLE
fix(autotrader): fail closed on june three replay

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -2162,6 +2162,180 @@ def decision_summary_for_scan(
     }
 
 
+def june3_losing_round_trip_session(*, include_avgo: bool) -> dict[str, Any]:
+    tickets: list[dict[str, Any]] = [
+        {
+            "id": "ticket-amd-june3",
+            "symbol": "AMD",
+            "setupType": "vwap_reclaim",
+            "setupGrade": "A",
+        }
+    ]
+    orders: list[dict[str, Any]] = [
+        {
+            "ticketId": "ticket-amd-june3",
+            "clientOrderId": "autonomous-trader-market-open-28hn6-c131-AMD-entry",
+            "symbol": "AMD",
+            "side": "buy",
+            "status": "filled",
+            "brokerPayload": {"filled_avg_price": "533.37"},
+        },
+        {
+            "ticketId": "ticket-amd-june3",
+            "clientOrderId": "amd-june3-stop",
+            "symbol": "AMD",
+            "side": "sell",
+            "status": "filled",
+            "brokerPayload": {
+                "parentClientOrderId": "autonomous-trader-market-open-28hn6-c131-AMD-entry",
+                "filled_avg_price": "532.590054",
+            },
+        },
+    ]
+    if include_avgo:
+        tickets.append(
+            {
+                "id": "ticket-avgo-june3",
+                "symbol": "AVGO",
+                "setupType": "vwap_reclaim",
+                "setupGrade": "B",
+            }
+        )
+        orders.extend(
+            [
+                {
+                    "ticketId": "ticket-avgo-june3",
+                    "clientOrderId": "autonomous-trader-market-open-28hn6-c147-AVGO-entry",
+                    "symbol": "AVGO",
+                    "side": "buy",
+                    "status": "filled",
+                    "brokerPayload": {"filled_avg_price": "486.14"},
+                },
+                {
+                    "ticketId": "ticket-avgo-june3",
+                    "clientOrderId": "avgo-june3-stop",
+                    "symbol": "AVGO",
+                    "side": "sell",
+                    "status": "filled",
+                    "brokerPayload": {
+                        "parentClientOrderId": "autonomous-trader-market-open-28hn6-c147-AVGO-entry",
+                        "filled_avg_price": "482.90",
+                    },
+                },
+            ]
+        )
+    return {"tradeTickets": tickets, "orders": orders}
+
+
+def june3_failure_replay_cases() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "amd_cycle_131_one_sample_positive_scorecard",
+            "cycle": 131,
+            "index": 1,
+            "currentSession": {"tradeTickets": [], "orders": []},
+            "expectedNoTradeReason": "positive_scorecard_repeat_sample_required",
+            "result": {
+                "symbol": "AMD",
+                "setup_type": "vwap_reclaim",
+                "setup_grade": "A",
+                "expected_r": "5.9481",
+                "last": "534.345",
+                "support": "532.74",
+                "resistance": "543.88",
+                "scorecard_sample_size": 1,
+                "scorecard_avg_realized_r": "3.0429",
+                "scorecard_confidence": "0.0909",
+            },
+        },
+        {
+            "name": "avgo_cycle_147_post_amd_loss_b_grade_single_sample",
+            "cycle": 147,
+            "index": 1,
+            "currentSession": june3_losing_round_trip_session(include_avgo=False),
+            "expectedNoTradeReason": "current_session_post_loss_requires_a_grade",
+            "result": {
+                "symbol": "AVGO",
+                "setup_type": "vwap_reclaim",
+                "setup_grade": "B",
+                "expected_r": "2.5058",
+                "last": "486.395",
+                "support": "482.96",
+                "resistance": "495.00",
+                "scorecard_sample_size": 1,
+                "scorecard_avg_realized_r": "0.3811",
+                "scorecard_confidence": "0.0909",
+            },
+        },
+        {
+            "name": "avgo_cycle_309_after_two_losing_round_trips",
+            "cycle": 309,
+            "index": 1,
+            "currentSession": june3_losing_round_trip_session(include_avgo=True),
+            "expectedNoTradeReason": "current_session_loss_limit_reached",
+            "result": {
+                "symbol": "AVGO",
+                "setup_type": "vwap_reclaim",
+                "setup_grade": "B",
+                "expected_r": "2.1719",
+                "last": "487.645",
+                "support": "484.26",
+                "resistance": "495.00",
+                "scorecard_sample_size": 1,
+                "scorecard_avg_realized_r": "0.3811",
+                "scorecard_confidence": "0.0909",
+            },
+        },
+    ]
+
+
+def run_june3_failure_path_replay() -> dict[str, Any]:
+    cases: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for case in june3_failure_replay_cases():
+        scan = overlay_current_session_loss_lockout(
+            {"results": [dict(case["result"])]},
+            case["currentSession"],
+        )
+        result = scan["results"][0]
+        payload = ticket_payload_for_scan_result(
+            session_id="june3-replay",
+            cycle=case["cycle"],
+            index=case["index"],
+            result=result,
+        )
+        summary = decision_summary_for_scan(
+            cycle=case["cycle"],
+            scan=scan,
+            recorded_tickets=[],
+        )
+        no_trade_reason = payload.get("noTradeReason") if isinstance(payload, dict) else None
+        blocked = isinstance(payload, dict) and payload.get("status") == "blocked"
+        summary_blocked = summary.get("action") == "no_actionable_candidate"
+        ok = blocked and summary_blocked and no_trade_reason == case["expectedNoTradeReason"]
+        case_result = {
+            "name": case["name"],
+            "cycle": case["cycle"],
+            "symbol": case["result"]["symbol"],
+            "expectedNoTradeReason": case["expectedNoTradeReason"],
+            "actualNoTradeReason": no_trade_reason,
+            "ticketStatus": payload.get("status") if isinstance(payload, dict) else None,
+            "decisionAction": summary.get("action"),
+            "ok": ok,
+        }
+        cases.append(case_result)
+        if not ok:
+            failures.append(case_result)
+    return {
+        "ok": not failures,
+        "name": "june3_failure_path_replay",
+        "caseCount": len(cases),
+        "blockedCaseCount": len([case for case in cases if case.get("ok")]),
+        "failures": failures,
+        "cases": cases,
+    }
+
+
 def run_cycle(args: argparse.Namespace) -> dict[str, Any]:
     cycle_started_at = time.monotonic()
     stage_timings: dict[str, Any] = {}

--- a/scripts/autotrader/market_open_bootstrap.py
+++ b/scripts/autotrader/market_open_bootstrap.py
@@ -90,6 +90,12 @@ def run_bootstrap(
     analysis_dir: Path,
     analysis_context_path: Path,
 ) -> dict[str, Any]:
+    june3_replay_gate = live_scan_cycle.run_june3_failure_path_replay()
+    if not june3_replay_gate.get("ok"):
+        raise RuntimeError(
+            "market-open safety regression failed: "
+            + json.dumps(june3_replay_gate.get("failures", []), sort_keys=True)
+        )
     broker_state = live_scan_cycle.fetch_broker_state(alpaca)
     account = broker_state.get("account")
     if not isinstance(account, dict):
@@ -125,6 +131,7 @@ def run_bootstrap(
             "accountGate": account_gate,
             "analysisHead": analysis_head,
             "analysisContextHash": analysis_context_hash,
+            "june3FailurePathReplayGate": june3_replay_gate,
         },
     }
     synthesis.post("/api/autotrader/status", status_payload)
@@ -148,6 +155,7 @@ def run_bootstrap(
         "accountGate": account_gate,
         "analysisHead": analysis_head,
         "analysisContextHash": analysis_context_hash,
+        "june3FailurePathReplayGate": june3_replay_gate,
         "nextCommand": (
             "python3 /workspace/lab/scripts/autotrader/market_open_cycle.py"
         ),
@@ -179,6 +187,12 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.self_test:
+        june3_replay_gate = live_scan_cycle.run_june3_failure_path_replay()
+        if not june3_replay_gate.get("ok"):
+            raise RuntimeError(
+                "market-open safety regression failed: "
+                + json.dumps(june3_replay_gate.get("failures", []), sort_keys=True)
+            )
         print(
             json.dumps(
                 {
@@ -187,6 +201,7 @@ def main(argv: list[str] | None = None) -> int:
                     "sessionMode": args.session_mode,
                     "workDir": args.work_dir,
                     "analysisContext": args.analysis_context,
+                    "june3FailurePathReplayGate": june3_replay_gate,
                 },
                 sort_keys=True,
                 indent=2,

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -1769,6 +1769,22 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["blockedResultCount"], 1)
         self.assertIsNone(summary["bestCandidate"])
 
+    def test_june3_failure_path_replay_blocks_losing_decisions(self) -> None:
+        replay = live_scan_cycle.run_june3_failure_path_replay()
+
+        self.assertTrue(replay["ok"], replay["failures"])
+        self.assertEqual(replay["caseCount"], 3)
+        self.assertEqual(replay["blockedCaseCount"], 3)
+        reasons = {case["name"]: case["actualNoTradeReason"] for case in replay["cases"]}
+        self.assertEqual(
+            reasons,
+            {
+                "amd_cycle_131_one_sample_positive_scorecard": "positive_scorecard_repeat_sample_required",
+                "avgo_cycle_147_post_amd_loss_b_grade_single_sample": "current_session_post_loss_requires_a_grade",
+                "avgo_cycle_309_after_two_losing_round_trips": "current_session_loss_limit_reached",
+            },
+        )
+
     def test_decision_summary_reports_no_actionable_candidate(self) -> None:
         summary = live_scan_cycle.decision_summary_for_scan(
             cycle=5,

--- a/scripts/autotrader/test_market_open_bootstrap.py
+++ b/scripts/autotrader/test_market_open_bootstrap.py
@@ -6,6 +6,7 @@ import unittest
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import market_open_bootstrap
 
@@ -73,6 +74,7 @@ class MarketOpenBootstrapTest(unittest.TestCase):
             self.assertEqual(result["sessionId"], "session-market-open")
             self.assertEqual(result["accountGate"]["action"], "scan")
             self.assertEqual(len(result["analysisContextHash"]), 64)
+            self.assertTrue(result["june3FailurePathReplayGate"]["ok"])
             self.assertTrue((root / "session.json").exists())
             self.assertIn("session-market-open", (root / "session.json").read_text(encoding="utf-8"))
             self.assertIn("status: running", report_path.read_text(encoding="utf-8"))
@@ -87,7 +89,42 @@ class MarketOpenBootstrapTest(unittest.TestCase):
         self.assertEqual(start_payload["analysisContextHash"], result["analysisContextHash"])
         self.assertEqual(status_payload["phase"], "scan")
         self.assertEqual(status_payload["payload"]["bootstrap"], "market_open_session")
+        self.assertTrue(status_payload["payload"]["june3FailurePathReplayGate"]["ok"])
         self.assertEqual(event_payload["eventType"], "market_open_bootstrap_complete")
+
+    def test_fails_closed_when_june3_replay_gate_fails(self) -> None:
+        synthesis = FakeSynthesis()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            analysis_dir = root / "analysis"
+            analysis_dir.mkdir()
+            analysis_context = root / "analysis-context.json"
+            analysis_context.write_text('{"ok":true}\n', encoding="utf-8")
+
+            with patch.object(
+                market_open_bootstrap.live_scan_cycle,
+                "run_june3_failure_path_replay",
+                return_value={
+                    "ok": False,
+                    "name": "june3_failure_path_replay",
+                    "failures": [{"name": "avgo_cycle_147_post_amd_loss_b_grade_single_sample"}],
+                },
+            ):
+                with self.assertRaisesRegex(RuntimeError, "market-open safety regression failed"):
+                    market_open_bootstrap.run_bootstrap(
+                        synthesis=synthesis,  # type: ignore[arg-type]
+                        alpaca=FakeAlpaca(),  # type: ignore[arg-type]
+                        now=datetime(2026, 6, 3, 13, 15, tzinfo=UTC),
+                        agent_run_name="autonomous-trader-market-open-test",
+                        session_mode="market_open",
+                        goal_equity="500000",
+                        work_dir=root,
+                        report_path=root / "report.md",
+                        analysis_dir=analysis_dir,
+                        analysis_context_path=analysis_context,
+                    )
+
+        self.assertEqual(synthesis.posts, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds a deterministic June 3 failure-path replay covering AMD cycle 131, AVGO cycle 147, and AVGO cycle 309.
- Wires the replay into market-open bootstrap so the runner fails closed before starting a session if those bad entries become actionable again.
- Records the replay gate in bootstrap status/event payloads and covers both pass and fail-closed behavior with regression tests.

## Related Issues

None

## Testing

- `python3 -m py_compile live_scan_cycle.py market_open_bootstrap.py market_open_cycle.py strategy_order_guard.py protective_preflight.py test_live_scan_cycle.py test_market_open_bootstrap.py test_market_open_cycle.py`
- `python3 -m unittest test_live_scan_cycle.LiveScanCycleTest.test_june3_failure_path_replay_blocks_losing_decisions -v`
- `python3 -m unittest test_market_open_bootstrap -v`
- `python3 live_scan_cycle.py --self-test && python3 market_open_bootstrap.py --self-test`
- `python3 -m unittest discover -v`
- `python3 live_scan_cycle.py --self-test && python3 market_open_bootstrap.py --self-test && python3 market_open_cycle.py --self-test && python3 strategy_order_guard.py --self-test`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t autonomous`
- `bun run lint:argocd`
- `git diff --check HEAD~1..HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
