### PR TITLE
fix(torghut): expire stale materialized paper-route rows

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -3310,6 +3310,52 @@ def _trade_decision_is_target_plan_source_decision(row: TradeDecision) -> bool:
     return _safe_text(metadata.get("mode")) == "paper_route_target_plan_source_decision"
 
 
+def _trade_decision_materialized_unsubmitted_reason(
+    row: TradeDecision,
+    *,
+    window_end: datetime,
+) -> str | None:
+    payload = _as_mapping(row.decision_json)
+    params = _as_mapping(payload.get("params"))
+    metadata = _as_mapping(params.get("paper_route_target_plan_source_decision"))
+    if not metadata:
+        metadata = _as_mapping(params.get("paper_route_target_plan"))
+    expiry = _as_mapping(payload.get("paper_route_materialized_unsubmitted"))
+    if not expiry:
+        expiry = _as_mapping(params.get("paper_route_materialized_unsubmitted"))
+    expired_reason = _safe_text(expiry.get("reason"))
+    if expired_reason:
+        if expired_reason == "paper_route_materialized_window_expired_unsubmitted":
+            return "source_materialized_window_expired_unsubmitted"
+        return expired_reason
+
+    materialized = (
+        _safe_text(payload.get("submission_stage"))
+        == "bounded_paper_route_materialized"
+        or _safe_text(metadata.get("source")) == "paper_route_target_plan_materializer"
+        or str(params.get("paper_route_target_plan_materialized") or "").strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+    if not materialized or _safe_text(row.status) != "planned":
+        return None
+    raw_window_end = (
+        metadata.get("paper_route_probe_window_end")
+        or metadata.get("window_end")
+        or payload.get("window_end")
+    )
+    materialized_window_end = _parse_datetime(raw_window_end)
+    if materialized_window_end is None:
+        return None
+    normalized_audit_end = (
+        window_end
+        if window_end.tzinfo is not None
+        else window_end.replace(tzinfo=timezone.utc)
+    ).astimezone(timezone.utc)
+    if materialized_window_end.astimezone(timezone.utc) <= normalized_audit_end:
+        return "source_materialized_window_expired_unsubmitted"
+    return None
+
+
 def _trade_decision_is_paper_route_closeout(row: TradeDecision) -> bool:
     payload = _as_mapping(row.decision_json)
     params = _as_mapping(payload.get("params"))
@@ -4469,6 +4515,28 @@ def _strategy_source_activity(
         int(_trade_decision_is_target_plan_source_decision(row))
         for row in decision_rows
     )
+    materialized_unsubmitted_reasons = _unique_text_items(
+        [
+            reason
+            for row in decision_rows
+            if (
+                reason := _trade_decision_materialized_unsubmitted_reason(
+                    row,
+                    window_end=window_end,
+                )
+            )
+        ]
+    )
+    materialized_unsubmitted_decision_count = sum(
+        int(
+            _trade_decision_materialized_unsubmitted_reason(
+                row,
+                window_end=window_end,
+            )
+            is not None
+        )
+        for row in decision_rows
+    )
     decision_rejection_summary = _source_decision_rejection_summary(decision_rows)
     decision_reject_blockers = _unique_text_items(
         decision_rejection_summary.get("blockers")
@@ -4484,6 +4552,7 @@ def _strategy_source_activity(
         missing_reasons.append("source_decisions_missing")
     if execution_count <= 0 and not quote_quality_only_rejects:
         missing_reasons.append("source_executions_missing")
+    missing_reasons.extend(materialized_unsubmitted_reasons)
     if decision_reject_blockers:
         missing_reasons.extend(decision_reject_blockers)
     if (
@@ -4557,6 +4626,7 @@ def _strategy_source_activity(
         [
             *_unique_text_items(lifecycle_summary.get("submitted_order_blockers")),
             *(["source_execution_refs_missing"] if not execution_refs else []),
+            *materialized_unsubmitted_reasons,
             *(
                 decision_reject_blockers
                 if execution_count <= 0 and decision_reject_blockers
@@ -4569,6 +4639,7 @@ def _strategy_source_activity(
             *_unique_text_items(lifecycle_summary.get("blockers")),
             *_unique_text_items(closeout_fillability.get("blockers")),
             *source_reference_blockers,
+            *materialized_unsubmitted_reasons,
             *(
                 decision_reject_blockers
                 if execution_count <= 0 and decision_reject_blockers
@@ -4637,6 +4708,10 @@ def _strategy_source_activity(
         "decision_count": decision_count,
         "source_decision_count": decision_count,
         "target_plan_source_decision_count": target_plan_source_decision_count,
+        "materialized_unsubmitted_decision_count": (
+            materialized_unsubmitted_decision_count
+        ),
+        "materialized_unsubmitted_reasons": materialized_unsubmitted_reasons,
         "source_decision_mode_counts": _source_decision_mode_counts(decision_rows),
         "execution_count": execution_count,
         "linked_execution_count": execution_count,

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -3131,6 +3131,41 @@ class SimpleTradingPipeline(TradingPipeline):
             params=params,
         )
 
+    @staticmethod
+    def _expire_stale_materialized_paper_route_decision(
+        *,
+        decision_row: TradeDecision,
+        payload: Mapping[str, Any],
+        window_end: datetime,
+        now: datetime,
+        reason: str = "paper_route_materialized_window_expired_unsubmitted",
+    ) -> bool:
+        if decision_row.status != "planned":
+            return False
+        if now < window_end.astimezone(timezone.utc):
+            return False
+        decision_json = dict(payload)
+        params = dict(cast(Mapping[str, Any], decision_json.get("params") or {}))
+        expiry_payload = {
+            "schema_version": "torghut.paper-route-materialized-expiry.v1",
+            "reason": reason,
+            "window_end": window_end.astimezone(timezone.utc).isoformat(),
+            "expired_at": now.astimezone(timezone.utc).isoformat(),
+            "previous_submission_stage": _safe_text(
+                decision_json.get("submission_stage")
+            )
+            or "bounded_paper_route_materialized",
+        }
+        params["paper_route_materialized_unsubmitted"] = expiry_payload
+        decision_json["params"] = params
+        decision_json["submission_stage"] = "expired_paper_route_materialized_window"
+        decision_json["submission_block_reason"] = reason
+        decision_json["reject_reason_atomic"] = [reason]
+        decision_json["paper_route_materialized_unsubmitted"] = expiry_payload
+        decision_row.status = "rejected"
+        decision_row.decision_json = decision_json
+        return True
+
     def _paper_route_materialized_planned_decisions(
         self,
         *,
@@ -3144,8 +3179,6 @@ class SimpleTradingPipeline(TradingPipeline):
         if not settings.trading_simple_paper_route_probe_enabled:
             return []
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
-        if not self._is_market_session_open(now):
-            return []
 
         rows = (
             session.execute(
@@ -3165,6 +3198,7 @@ class SimpleTradingPipeline(TradingPipeline):
         }
         decisions: list[StrategyDecision] = []
         seen: set[str] = set()
+        expired_count = 0
         for decision_row in rows:
             if str(decision_row.id) in seen:
                 continue
@@ -3202,7 +3236,19 @@ class SimpleTradingPipeline(TradingPipeline):
             if window is None:
                 continue
             window_start, window_end = window
+            if self._expire_stale_materialized_paper_route_decision(
+                decision_row=decision_row,
+                payload=payload,
+                window_end=window_end,
+                now=now,
+            ):
+                session.add(decision_row)
+                expired_count += 1
+                seen.add(str(decision_row.id))
+                continue
             if now < window_start or now >= window_end:
+                continue
+            if not self._is_market_session_open(now):
                 continue
             target_cap = _target_probe_cap(target)
             if target_cap is None or target_cap <= 0:
@@ -3273,6 +3319,13 @@ class SimpleTradingPipeline(TradingPipeline):
                 continue
             decisions.append(decision)
             seen.add(str(decision_row.id))
+        if expired_count:
+            session.commit()
+            logger.warning(
+                "Expired stale materialized paper-route target source decisions account_label=%s count=%s",
+                self.account_label,
+                expired_count,
+            )
         return decisions
 
     def _process_paper_route_materialized_decisions(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1074,6 +1074,166 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(activity["raw_decision_count"], 1)
         self.assertEqual(activity["lineage_matched_decision_count"], 1)
 
+    def test_source_activity_surfaces_expired_materialized_target_row(self) -> None:
+        window_start = datetime(2026, 6, 3, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 3, 20, 0, tzinfo=timezone.utc)
+        candidate_id = "c88421d619759b2cfaa6f4d0"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+            )
+            session.add(strategy)
+            session.flush()
+            session.add(
+                TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    timeframe="1Sec",
+                    decision_json={
+                        "submission_stage": "bounded_paper_route_materialized",
+                        "action": "buy",
+                        "qty": "1",
+                        "candidate_id": candidate_id,
+                        "hypothesis_id": "H-PAIRS-01",
+                        "params": {
+                            "paper_route_target_plan_materialized": True,
+                            "source_decision_mode": ("bounded_paper_route_collection"),
+                            "candidate_id": candidate_id,
+                            "hypothesis_id": "H-PAIRS-01",
+                            "paper_route_target_plan_source_decision": {
+                                "mode": "paper_route_target_plan_source_decision",
+                                "source": "paper_route_target_plan_materializer",
+                                "source_decision_mode": (
+                                    "bounded_paper_route_collection"
+                                ),
+                                "candidate_id": candidate_id,
+                                "hypothesis_id": "H-PAIRS-01",
+                                "runtime_strategy_name": (
+                                    "microbar-cross-sectional-pairs-v1"
+                                ),
+                                "paper_route_probe_window_start": (
+                                    window_start.isoformat()
+                                ),
+                                "paper_route_probe_window_end": (
+                                    window_end.isoformat()
+                                ),
+                            },
+                        },
+                    },
+                    rationale="expired materialized H-PAIRS source row",
+                    status="planned",
+                    created_at=window_start + timedelta(minutes=5),
+                )
+            )
+            session.commit()
+
+            source_activity = _strategy_source_activity(
+                session,
+                strategy_name="microbar-cross-sectional-pairs-v1",
+                account_label="TORGHUT_SIM",
+                symbols=["AAPL", "AMZN"],
+                window_start=window_start,
+                window_end=window_end,
+                candidate_id=candidate_id,
+                hypothesis_id="H-PAIRS-01",
+                require_source_lineage=True,
+            )
+
+        self.assertTrue(source_activity["missing"])
+        self.assertEqual(source_activity["decision_count"], 1)
+        self.assertEqual(
+            source_activity["materialized_unsubmitted_decision_count"],
+            1,
+        )
+        self.assertIn(
+            "source_materialized_window_expired_unsubmitted",
+            source_activity["missing_reasons"],
+        )
+        self.assertIn(
+            "source_materialized_window_expired_unsubmitted",
+            source_activity["submitted_order_blockers"],
+        )
+        self.assertIn(
+            "source_materialized_window_expired_unsubmitted",
+            source_activity["source_lifecycle_blockers"],
+        )
+
+    def test_materialized_unsubmitted_reason_classifies_expiry_payloads(self) -> None:
+        window_end = datetime(2026, 6, 3, 20, 0, tzinfo=timezone.utc)
+
+        explicit_expired = TradeDecision(
+            status="rejected",
+            decision_json={
+                "paper_route_materialized_unsubmitted": {
+                    "reason": "paper_route_materialized_window_expired_unsubmitted"
+                }
+            },
+        )
+        self.assertEqual(
+            paper_route_evidence._trade_decision_materialized_unsubmitted_reason(
+                explicit_expired,
+                window_end=window_end,
+            ),
+            "source_materialized_window_expired_unsubmitted",
+        )
+
+        custom_expired = TradeDecision(
+            status="rejected",
+            decision_json={
+                "params": {
+                    "paper_route_materialized_unsubmitted": {
+                        "reason": "paper_route_submit_blocked"
+                    }
+                }
+            },
+        )
+        self.assertEqual(
+            paper_route_evidence._trade_decision_materialized_unsubmitted_reason(
+                custom_expired,
+                window_end=window_end,
+            ),
+            "paper_route_submit_blocked",
+        )
+
+        missing_window = TradeDecision(
+            status="planned",
+            decision_json={
+                "submission_stage": "bounded_paper_route_materialized",
+                "params": {"paper_route_target_plan_materialized": True},
+            },
+        )
+        self.assertIsNone(
+            paper_route_evidence._trade_decision_materialized_unsubmitted_reason(
+                missing_window,
+                window_end=window_end,
+            )
+        )
+
+        future_window = TradeDecision(
+            status="planned",
+            decision_json={
+                "submission_stage": "bounded_paper_route_materialized",
+                "params": {
+                    "paper_route_target_plan_source_decision": {
+                        "paper_route_probe_window_end": (
+                            window_end + timedelta(minutes=1)
+                        ).isoformat()
+                    }
+                },
+            },
+        )
+        self.assertIsNone(
+            paper_route_evidence._trade_decision_materialized_unsubmitted_reason(
+                future_window,
+                window_end=window_end,
+            )
+        )
+
     def test_source_activity_order_event_query_timeout_fails_closed(self) -> None:
         activity, rollback_count = self._source_activity_with_failing_query(
             failure_call=3

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3703,9 +3703,7 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(row.status, "rejected")
         self.assertEqual(routeability.get("status"), "blocked")
         self.assertEqual(routeability.get("reason"), "spread_bps_exceeded")
-        self.assertEqual(
-            row_json.get("reject_reason_atomic"), ["spread_bps_exceeded"]
-        )
+        self.assertEqual(row_json.get("reject_reason_atomic"), ["spread_bps_exceeded"])
         diagnostics = cast(dict[str, Any], routeability.get("quote_lookup_diagnostics"))
         self.assertEqual(
             diagnostics.get("latest_quote_rejected_reason"),
@@ -7584,6 +7582,185 @@ class TestTradingPipeline(TestCase):
                 self.assertFalse(params["promotion_allowed"])
                 self.assertFalse(params["final_promotion_authorized"])
 
+    def test_materialized_target_plan_expired_rows_fail_closed(self) -> None:
+        from app import config
+
+        generated_at = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc)
+        now = window_end + timedelta(minutes=5)
+        already_submitted = TradeDecision(
+            status="submitted",
+            decision_json={"submission_stage": "bounded_paper_route_materialized"},
+        )
+        self.assertFalse(
+            SimpleTradingPipeline._expire_stale_materialized_paper_route_decision(
+                decision_row=already_submitted,
+                payload=cast(Mapping[str, Any], already_submitted.decision_json),
+                window_end=window_end,
+                now=now,
+            )
+        )
+        original = {
+            "trading_mode": config.settings.trading_mode,
+            "trading_simple_paper_route_probe_enabled": (
+                config.settings.trading_simple_paper_route_probe_enabled
+            ),
+            "trading_allow_shorts": config.settings.trading_allow_shorts,
+        }
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = True
+
+        try:
+            with self.session_local() as session:
+                strategy = Strategy(
+                    name="microbar-cross-sectional-pairs-v1",
+                    description="expired bounded H-PAIRS target",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_notional_per_trade=Decimal("1000"),
+                )
+                session.add(strategy)
+                session.commit()
+
+                materialized = materialize_bounded_paper_route_target_plan(
+                    session,
+                    {
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                                "runtime_strategy_name": (
+                                    "microbar-cross-sectional-pairs-v1"
+                                ),
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "account_label": "TORGHUT_SIM",
+                                "source_account_label": "TORGHUT_REPLAY",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_plan_ref": (
+                                    "s3://torghut-proof/hpairs/current-window.json"
+                                ),
+                                "source_manifest_ref": (
+                                    "config/trading/hypotheses/h-pairs.json"
+                                ),
+                                "observed_stage": "paper",
+                                "bounded_collection_stage": (
+                                    "bounded_paper_collection"
+                                ),
+                                "target_notional": "200",
+                                "target_quantity": "2",
+                                "paper_route_probe_next_session_max_notional": "200",
+                                "paper_route_probe_window_start": (
+                                    window_start.isoformat()
+                                ),
+                                "paper_route_probe_window_end": (
+                                    window_end.isoformat()
+                                ),
+                                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                                "paper_route_probe_symbol_actions": {
+                                    "AAPL": "buy",
+                                    "AMZN": "sell",
+                                },
+                                "paper_route_probe_symbol_quantities": {
+                                    "AAPL": "1",
+                                    "AMZN": "1",
+                                },
+                                "paper_route_probe_pair_balance_state": "balanced",
+                                "paper_route_clean_window_baseline_state": {
+                                    "state": "clean",
+                                    "blockers": [],
+                                },
+                                "paper_route_clean_window_state": "clean",
+                                "source_decision_readiness": {
+                                    "ready": True,
+                                    "blockers": [],
+                                },
+                                "bounded_evidence_collection_authorized": True,
+                                "bounded_live_paper_collection_authorized": True,
+                                "canary_collection_authorized": True,
+                                "evidence_collection_ok": True,
+                                "bounded_evidence_collection_blockers": [],
+                                "runtime_window_import_health_gate_blockers": [],
+                                "paper_route_target_account_audit_state": {
+                                    "state": "available",
+                                    "audit_available": True,
+                                    "blockers": [],
+                                },
+                                "paper_route_target_account_audit_blockers": [],
+                                "paper_route_account_pre_session_blockers": [],
+                                "paper_route_hpairs_symbol_blockers": [],
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "final_promotion_allowed": False,
+                            },
+                        ],
+                    },
+                    generated_at=generated_at,
+                    bounded_notional_limit=Decimal("500"),
+                )
+                self.assertEqual(materialized["materialized_decision_count"], 2)
+                session.commit()
+
+                pipeline = SimpleTradingPipeline(
+                    alpaca_client=FakeAlpacaClient(),
+                    order_firewall=OrderFirewall(FakeAlpacaClient()),
+                    ingestor=FakeIngestor([]),
+                    decision_engine=DecisionEngine(),
+                    risk_engine=RiskEngine(),
+                    executor=OrderExecutor(),
+                    execution_adapter=FakeAlpacaClient(),
+                    reconciler=Reconciler(),
+                    universe_resolver=UniverseResolver(),
+                    state=TradingState(),
+                    account_label="TORGHUT_SIM",
+                    session_factory=self.session_local,
+                )
+                pipeline._is_market_session_open = lambda _now=None: False  # type: ignore[method-assign]
+                with patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=now,
+                ):
+                    decisions = pipeline._paper_route_materialized_planned_decisions(
+                        session=session,
+                        strategies=[strategy],
+                        allowed_symbols={"AAPL", "AMZN"},
+                        positions=[],
+                    )
+
+                self.assertEqual(decisions, [])
+                rows = list(
+                    session.execute(
+                        select(TradeDecision).order_by(TradeDecision.symbol)
+                    )
+                    .scalars()
+                    .all()
+                )
+                self.assertEqual([row.status for row in rows], ["rejected", "rejected"])
+                for row in rows:
+                    payload = cast(dict[str, Any], row.decision_json)
+                    params = cast(dict[str, Any], payload["params"])
+                    self.assertEqual(
+                        payload["submission_stage"],
+                        "expired_paper_route_materialized_window",
+                    )
+                    self.assertEqual(
+                        payload["submission_block_reason"],
+                        "paper_route_materialized_window_expired_unsubmitted",
+                    )
+                    self.assertEqual(
+                        params["paper_route_materialized_unsubmitted"]["reason"],
+                        "paper_route_materialized_window_expired_unsubmitted",
+                    )
+        finally:
+            config.settings.trading_mode = original["trading_mode"]
+            config.settings.trading_simple_paper_route_probe_enabled = original[
+                "trading_simple_paper_route_probe_enabled"
+            ]
+            config.settings.trading_allow_shorts = original["trading_allow_shorts"]
+
     def test_simple_pipeline_processes_materialized_target_plan_when_signal_ingest_unavailable(
         self,
     ) -> None:
@@ -7716,9 +7893,7 @@ class TestTradingPipeline(TestCase):
                 session.commit()
 
             alpaca_client = FakeAlpacaClient()
-            ingestor = NoSignalReasonIngestor(
-                no_signal_reason="clickhouse_url_missing"
-            )
+            ingestor = NoSignalReasonIngestor(no_signal_reason="clickhouse_url_missing")
             pipeline = SimpleTradingPipeline(
                 alpaca_client=alpaca_client,
                 order_firewall=OrderFirewall(alpaca_client),
@@ -8197,10 +8372,20 @@ class TestTradingPipeline(TestCase):
                 account_label="TORGHUT_SIM",
                 session_factory=self.session_local,
             )
+            pipeline._is_market_session_open = lambda _now=None: False  # type: ignore[method-assign]
             with patch(
                 "app.trading.scheduler.simple_pipeline.trading_now",
                 return_value=now,
             ):
+                closed_market_decisions = (
+                    pipeline._paper_route_materialized_planned_decisions(
+                        session=session,
+                        strategies=[strategy],
+                        allowed_symbols={"AAPL"},
+                        positions=[],
+                    )
+                )
+                pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
                 decisions = pipeline._paper_route_materialized_planned_decisions(
                     session=session,
                     strategies=[strategy],
@@ -8216,6 +8401,7 @@ class TestTradingPipeline(TestCase):
                     )
                 )
 
+        self.assertEqual(closed_market_decisions, [])
         self.assertEqual(len(decisions), 1)
         self.assertEqual(decisions[0].action, "buy")
         self.assertEqual(blocked_by_exposure, [])


### PR DESCRIPTION
## Summary

- Expire stale planned materialized paper-route target rows once their evidence window closes.
- Preserve fail-closed metadata on expired rows so the previous materialized stage and expiry reason remain auditable.
- Surface expired unsubmitted materialized rows in paper-route source activity as `source_materialized_window_expired_unsubmitted`.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py tests/test_trading_pipeline.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py tests/test_trading_pipeline.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'materialized_target_plan_expired_rows_fail_closed or simple_pipeline_submits_materialized_target_plan_source_decisions'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'source_activity_surfaces_expired_materialized_target_row'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
