### PR TITLE
fix(torghut): prioritize profit-target source collection

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1670,6 +1670,13 @@ _RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS = (
     "runtime_ledger_source_window_evidence_pending",
     "live_runtime_ledger_required",
 )
+_RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_NET_PNL_AFTER_COSTS = Decimal("500")
+_RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_BLOCKER = (
+    "runtime_ledger_profit_target_source_collection_pending"
+)
+_RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_SELECTION_REASON = (
+    "profit_target_source_window_evidence_pending"
+)
 _HPAIRS_BOUNDED_COLLECTION_HYPOTHESIS_ID = "H-PAIRS-01"
 _HPAIRS_BOUNDED_COLLECTION_CANDIDATE_ID = "c88421d619759b2cfaa6f4d0"
 _BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_KIND = "paper_route_probe_runtime_observed"
@@ -1831,12 +1838,71 @@ def _runtime_ledger_source_collection_candidate(
     )
 
 
+def _runtime_ledger_source_collection_profit_target_candidate(
+    candidate: Mapping[str, object],
+) -> bool:
+    payload = _runtime_ledger_paper_probation_payload(candidate)
+    net_pnl = _safe_decimal(payload.get("net_strategy_pnl_after_costs")) or Decimal("0")
+    expectancy_bps = _safe_decimal(payload.get("post_cost_expectancy_bps")) or Decimal(
+        "0"
+    )
+    return (
+        _runtime_ledger_source_collection_candidate(candidate)
+        and _safe_text(payload.get("pnl_basis")) == POST_COST_PNL_BASIS
+        and net_pnl
+        >= _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_NET_PNL_AFTER_COSTS
+        and expectancy_bps > 0
+        and _safe_int(payload.get("closed_trade_count"))
+        >= _RUNTIME_LEDGER_PAPER_PROBATION_MIN_CLOSED_ROUND_TRIPS
+        and _safe_int(payload.get("open_position_count")) <= 0
+        and _safe_decimal(payload.get("cost_amount")) is not None
+    )
+
+
+def _runtime_ledger_source_collection_profit_target_metadata(
+    candidate: Mapping[str, object],
+) -> dict[str, object]:
+    payload = _runtime_ledger_paper_probation_payload(candidate)
+    profit_target_candidate = _runtime_ledger_source_collection_profit_target_candidate(
+        candidate
+    )
+    metadata: dict[str, object] = {
+        "source_collection_profit_target_candidate": profit_target_candidate,
+        "source_collection_profit_target_net_pnl_after_costs": str(
+            _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_NET_PNL_AFTER_COSTS
+        ),
+        "source_collection_priority": "source_window_evidence_collection",
+    }
+    if profit_target_candidate:
+        metadata.update(
+            {
+                "source_collection_priority": "profit_target_source_materialization",
+                "source_collection_net_strategy_pnl_after_costs": str(
+                    _safe_decimal(payload.get("net_strategy_pnl_after_costs"))
+                    or Decimal("0")
+                ),
+                "source_collection_post_cost_expectancy_bps": str(
+                    _safe_decimal(payload.get("post_cost_expectancy_bps"))
+                    or Decimal("0")
+                ),
+                "source_collection_filled_notional": str(
+                    _safe_decimal(payload.get("filled_notional")) or Decimal("0")
+                ),
+                "source_collection_next_action": (
+                    "materialize_runtime_ledger_source_window_refs"
+                ),
+            }
+        )
+    return metadata
+
+
 def _runtime_ledger_source_collection_candidates(
     candidates: Sequence[Mapping[str, object]],
 ) -> list[dict[str, object]]:
     return [
         {
             **dict(candidate),
+            **_runtime_ledger_source_collection_profit_target_metadata(candidate),
             "source_collection_candidate": True,
             "source_collection_authorized": True,
             "source_collection_scope": "source_window_evidence_collection_only",
@@ -2032,6 +2098,16 @@ def _runtime_ledger_paper_probation_import_plan(
             if source_collection
             else _RUNTIME_LEDGER_PAPER_PROBATION_PROMOTION_BLOCKERS
         )
+        profit_target_source_collection = bool(
+            candidate.get("source_collection_profit_target_candidate")
+        )
+        selection_reason = "positive_post_cost_runtime_ledger_bucket"
+        if source_collection:
+            selection_reason = "positive_activity_needs_source_window_runtime_evidence"
+            if profit_target_source_collection:
+                selection_reason = (
+                    _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_SELECTION_REASON
+                )
         target_key = (
             hypothesis_id or "",
             candidate_id or "",
@@ -2146,13 +2222,46 @@ def _runtime_ledger_paper_probation_import_plan(
                 if source_collection
                 else "runtime_ledger_paper_probation"
             ),
-            "selection_reason": (
-                "positive_activity_needs_source_window_runtime_evidence"
-                if source_collection
-                else "positive_post_cost_runtime_ledger_bucket"
-            ),
+            "selection_reason": selection_reason,
             "max_notional": "0",
         }
+        if source_collection:
+            target.update(
+                {
+                    "source_collection_priority": (
+                        _safe_text(candidate.get("source_collection_priority"))
+                        or "source_window_evidence_collection"
+                    ),
+                    "source_collection_profit_target_candidate": (
+                        profit_target_source_collection
+                    ),
+                    "source_collection_profit_target_net_pnl_after_costs": str(
+                        _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_NET_PNL_AFTER_COSTS
+                    ),
+                    "source_collection_net_strategy_pnl_after_costs": (
+                        _safe_text(
+                            candidate.get(
+                                "source_collection_net_strategy_pnl_after_costs"
+                            )
+                        )
+                        or ""
+                    ),
+                    "source_collection_post_cost_expectancy_bps": (
+                        _safe_text(
+                            candidate.get("source_collection_post_cost_expectancy_bps")
+                        )
+                        or ""
+                    ),
+                    "source_collection_filled_notional": (
+                        _safe_text(candidate.get("source_collection_filled_notional"))
+                        or ""
+                    ),
+                    "source_collection_next_action": (
+                        _safe_text(candidate.get("source_collection_next_action"))
+                        or "materialize_runtime_ledger_source_window_refs"
+                    ),
+                }
+            )
         if bucket_ref:
             target["runtime_ledger_bucket_ref"] = bucket_ref
         targets.append(target)
@@ -2189,6 +2298,11 @@ def _runtime_ledger_paper_probation_import_plan(
         ),
         "source_collection_target_count": sum(
             1 for target in targets if bool(target.get("source_collection_authorized"))
+        ),
+        "source_collection_profit_target_count": sum(
+            1
+            for target in targets
+            if bool(target.get("source_collection_profit_target_candidate"))
         ),
         "skipped_target_count": len(skipped_targets),
         "targets": targets,
@@ -4128,6 +4242,11 @@ def build_live_submission_gate_payload(
     runtime_ledger_source_collection_candidates = (
         _runtime_ledger_source_collection_candidates(runtime_ledger_repair_candidates)
     )
+    runtime_ledger_source_collection_profit_target_candidates = [
+        candidate
+        for candidate in runtime_ledger_source_collection_candidates
+        if bool(candidate.get("source_collection_profit_target_candidate"))
+    ]
     runtime_ledger_paper_probation_import_plan = (
         _runtime_ledger_paper_probation_import_plan(
             [
@@ -4295,6 +4414,9 @@ def build_live_submission_gate_payload(
             "runtime_ledger_source_collection_candidate_total": len(
                 runtime_ledger_source_collection_candidates
             ),
+            "runtime_ledger_source_collection_profit_target_candidate_total": len(
+                runtime_ledger_source_collection_profit_target_candidates
+            ),
             "runtime_ledger_paper_probation_eligible_total": len(
                 runtime_ledger_paper_probation_candidates
             ),
@@ -4317,6 +4439,10 @@ def build_live_submission_gate_payload(
                 "manifest_bounded_collection_target_count"
             )
         ):
+            if runtime_ledger_source_collection_profit_target_candidates:
+                blocked_reasons.append(
+                    _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_BLOCKER
+                )
             blocked_reasons.append("runtime_ledger_source_collection_pending")
     if empirical_ready is False:
         blocked_reasons.append("empirical_jobs_not_ready")
@@ -4517,6 +4643,9 @@ def build_live_submission_gate_payload(
         ),
         "runtime_ledger_source_collection_candidate_total": len(
             runtime_ledger_source_collection_candidates
+        ),
+        "runtime_ledger_source_collection_profit_target_candidate_total": len(
+            runtime_ledger_source_collection_profit_target_candidates
         ),
         "runtime_ledger_paper_probation_eligible_total": len(
             runtime_ledger_paper_probation_candidates

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -2120,7 +2120,10 @@ class TestSubmissionCouncil(TestCase):
                     "closed_trade_count": 2,
                     "open_position_count": 0,
                     "filled_notional": "127090.02495200",
+                    "cost_amount": "12.42289104",
                     "net_strategy_pnl_after_costs": "567.44720578",
+                    "post_cost_expectancy_bps": "44.64923238",
+                    "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
                     "reason_codes": [
                         "runtime_ledger_source_window_missing",
                         "runtime_ledger_source_refs_missing",
@@ -2131,9 +2134,15 @@ class TestSubmissionCouncil(TestCase):
         )
 
         self.assertEqual(len(candidates), 1)
+        self.assertTrue(candidates[0]["source_collection_profit_target_candidate"])
+        self.assertEqual(
+            candidates[0]["source_collection_priority"],
+            "profit_target_source_materialization",
+        )
         plan = _runtime_ledger_paper_probation_import_plan(candidates)
 
         self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["source_collection_profit_target_count"], 1)
         target = plan["targets"][0]
         self.assertEqual(target["source_dsn_env"], "DB_DSN")
         self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
@@ -2146,6 +2155,13 @@ class TestSubmissionCouncil(TestCase):
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_allowed"])
         self.assertEqual(target["max_notional"], "0")
+        self.assertEqual(
+            target["selection_reason"], "profit_target_source_window_evidence_pending"
+        )
+        self.assertEqual(
+            target["source_collection_next_action"],
+            "materialize_runtime_ledger_source_window_refs",
+        )
 
     def test_runtime_ledger_source_collection_bucket_without_account_uses_sim_source(
         self,
@@ -2329,14 +2345,14 @@ class TestSubmissionCouncil(TestCase):
                     rejected_order_count=0,
                     unfilled_order_count=0,
                     closed_trade_count=12,
-                    open_position_count=4,
+                    open_position_count=0,
                     filled_notional=Decimal("157941.50000000"),
                     gross_strategy_pnl=Decimal("5530.86354020"),
                     cost_amount=Decimal("16"),
                     net_strategy_pnl_after_costs=Decimal("5514.86354020"),
-                    post_cost_expectancy_bps=None,
+                    post_cost_expectancy_bps=Decimal("349.15976763"),
                     ledger_schema_version="torghut.runtime-ledger-bucket.v1",
-                    pnl_basis="runtime_reconstructed_pnl",
+                    pnl_basis="realized_strategy_pnl_after_explicit_costs",
                     execution_policy_hash_counts={},
                     cost_model_hash_counts={},
                     lineage_hash_counts={},
@@ -2388,20 +2404,39 @@ class TestSubmissionCouncil(TestCase):
         self.assertIn(
             "runtime_ledger_source_collection_pending", gate["blocked_reasons"]
         )
+        self.assertIn(
+            "runtime_ledger_profit_target_source_collection_pending",
+            gate["blocked_reasons"],
+        )
         self.assertEqual(gate["runtime_ledger_source_collection_candidate_total"], 1)
+        self.assertEqual(
+            gate["runtime_ledger_source_collection_profit_target_candidate_total"], 1
+        )
         source_candidates = gate["runtime_ledger_source_collection_candidates"]
         self.assertEqual(len(source_candidates), 1)
         self.assertEqual(
             source_candidates[0]["source_collection_scope"],
             "source_window_evidence_collection_only",
         )
+        self.assertTrue(
+            source_candidates[0]["source_collection_profit_target_candidate"]
+        )
+        self.assertEqual(
+            source_candidates[0]["source_collection_priority"],
+            "profit_target_source_materialization",
+        )
         import_plan = gate["runtime_ledger_paper_probation_import_plan"]
         self.assertEqual(import_plan["paper_probation_target_count"], 0)
         self.assertEqual(import_plan["source_collection_target_count"], 1)
+        self.assertEqual(import_plan["source_collection_profit_target_count"], 1)
         target = import_plan["targets"][0]
         self.assertFalse(target["paper_probation_authorized"])
         self.assertTrue(target["source_collection_authorized"])
         self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+        self.assertEqual(
+            target["selection_reason"], "profit_target_source_window_evidence_pending"
+        )
 
     def test_live_gate_seeds_hpairs_bounded_collection_target_without_source_rows(
         self,


### PR DESCRIPTION
## Summary

- Marks runtime-ledger source-collection candidates that already exceed `$500` net PnL after explicit costs as profit-target source-materialization targets.
- Surfaces `runtime_ledger_profit_target_source_collection_pending` and target metadata so the next source-window evidence step is explicit.
- Preserves current safety semantics: source-collection targets still have `max_notional=0`, no paper probation, no promotion authority, and final promotion blocked.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
