### PR TITLE
perf(torghut): raise tigerbeetle journal throughput

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -57,7 +57,10 @@ spec:
                   cd /app
                   exec /opt/venv/bin/python scripts/run_tigerbeetle_journal_cron.py \
                     --preset live \
-                    --execution-batch-size 5 \
+                    --execution-batch-size 250 \
+                    --tca-metric-batch-size 250 \
+                    --order-event-batch-size 50 \
+                    --runtime-ledger-batch-size 100 \
                     --supervise-timeout-seconds 45 \
                     --json
               env:
@@ -146,6 +149,8 @@ spec:
                   cd /app
                   exec /opt/venv/bin/python scripts/run_tigerbeetle_journal_cron.py \
                     --preset sim \
+                    --sim-batch-size 250 \
+                    --runtime-ledger-batch-size 100 \
                     --supervise-timeout-seconds 45 \
                     --json
               env:

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -24,14 +24,20 @@ from app.trading.tigerbeetle_journal import (  # noqa: E402
 )
 from scripts import journal_tigerbeetle_order_events as journal_script  # noqa: E402
 
-LIVE_ORDER_EVENT_BATCH_SIZE = 1
+MAX_TIGERBEETLE_BATCH_SIZE = 5000
+LIVE_ORDER_EVENT_BATCH_SIZE = 50
 LIVE_ORDER_EVENT_MAX_BATCHES = 1
-LIVE_ORDER_EVENT_SCAN_LIMIT = 250
-LIVE_EXECUTION_BATCH_SIZE = 5
-LIVE_EXECUTION_SLICE_COUNT = 5
-LIVE_TCA_METRIC_BATCH_SIZE = 5
+LIVE_ORDER_EVENT_SCAN_LIMIT = 5000
+LIVE_EXECUTION_BATCH_SIZE = 250
+LIVE_EXECUTION_SLICE_COUNT = 1
+LIVE_EXECUTION_PROGRESS_INTERVAL = 25
+LIVE_TCA_METRIC_BATCH_SIZE = 250
 LIVE_TCA_METRIC_MAX_BATCHES = 1
+LIVE_RUNTIME_LEDGER_BATCH_SIZE = 100
 LIVE_RECONCILE_LIMIT = 500
+SIM_SOURCE_BATCH_SIZE = 250
+SIM_RUNTIME_LEDGER_BATCH_SIZE = 100
+SIM_ORDER_EVENT_SCAN_LIMIT = 5000
 RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS = 120.0
 
 
@@ -64,12 +70,38 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--execution-batch-size", type=int, default=LIVE_EXECUTION_BATCH_SIZE
     )
+    parser.add_argument(
+        "--tca-metric-batch-size",
+        type=int,
+        default=LIVE_TCA_METRIC_BATCH_SIZE,
+    )
+    parser.add_argument(
+        "--order-event-batch-size",
+        type=int,
+        default=LIVE_ORDER_EVENT_BATCH_SIZE,
+    )
+    parser.add_argument(
+        "--runtime-ledger-batch-size",
+        type=int,
+        default=LIVE_RUNTIME_LEDGER_BATCH_SIZE,
+    )
+    parser.add_argument("--sim-batch-size", type=int, default=SIM_SOURCE_BATCH_SIZE)
     parser.add_argument("--supervise-timeout-seconds", type=float, default=45.0)
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
 
-def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
+def _bounded_batch_size(value: object) -> int:
+    return max(1, min(int(value), MAX_TIGERBEETLE_BATCH_SIZE))
+
+
+def _live_commands(
+    *,
+    execution_batch_size: int,
+    tca_metric_batch_size: int = LIVE_TCA_METRIC_BATCH_SIZE,
+    order_event_batch_size: int = LIVE_ORDER_EVENT_BATCH_SIZE,
+    runtime_ledger_batch_size: int = LIVE_RUNTIME_LEDGER_BATCH_SIZE,
+) -> list[JournalCronCommand]:
     return [
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION,
@@ -80,13 +112,13 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
             skip_reconcile=True,
             allow_data_quality_degraded=True,
             commit_each_row=True,
-            progress_interval=1,
+            progress_interval=LIVE_EXECUTION_PROGRESS_INTERVAL,
             repeat_count=LIVE_EXECUTION_SLICE_COUNT,
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_TCA_METRIC,
             dsn_env="DB_DSN",
-            batch_size=LIVE_TCA_METRIC_BATCH_SIZE,
+            batch_size=tca_metric_batch_size,
             max_batches=LIVE_TCA_METRIC_MAX_BATCHES,
             reconcile_limit=1000,
             skip_reconcile=True,
@@ -94,7 +126,7 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
             dsn_env="DB_DSN",
-            batch_size=LIVE_ORDER_EVENT_BATCH_SIZE,
+            batch_size=order_event_batch_size,
             max_batches=LIVE_ORDER_EVENT_MAX_BATCHES,
             reconcile_limit=1000,
             event_scan_limit=LIVE_ORDER_EVENT_SCAN_LIMIT,
@@ -104,7 +136,7 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
         JournalCronCommand(
             source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             dsn_env="DB_DSN",
-            batch_size=5,
+            batch_size=runtime_ledger_batch_size,
             max_batches=1,
             reconcile_limit=LIVE_RECONCILE_LIMIT,
             reconcile_empty_selection=True,
@@ -114,39 +146,56 @@ def _live_commands(*, execution_batch_size: int) -> list[JournalCronCommand]:
     ]
 
 
-def _sim_commands() -> list[JournalCronCommand]:
-    common = {
-        "dsn_env": "SIM_DB_DSN",
-        "batch_size": 5,
-        "max_batches": 1,
-        "reconcile_limit": 500,
-        "account_label": "TORGHUT_SIM",
-    }
+def _sim_commands(
+    *,
+    batch_size: int = SIM_SOURCE_BATCH_SIZE,
+    runtime_ledger_batch_size: int = SIM_RUNTIME_LEDGER_BATCH_SIZE,
+) -> list[JournalCronCommand]:
+    dsn_env = "SIM_DB_DSN"
+    max_batches = 1
+    reconcile_limit = 500
+    account_label = "TORGHUT_SIM"
     return [
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION,
+            dsn_env=dsn_env,
+            batch_size=batch_size,
+            max_batches=max_batches,
+            reconcile_limit=reconcile_limit,
+            account_label=account_label,
             skip_reconcile=True,
             allow_data_quality_degraded=True,
-            **common,
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_TCA_METRIC,
+            dsn_env=dsn_env,
+            batch_size=batch_size,
+            max_batches=max_batches,
+            reconcile_limit=reconcile_limit,
+            account_label=account_label,
             skip_reconcile=True,
-            **common,
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
-            event_scan_limit=300,
+            dsn_env=dsn_env,
+            batch_size=batch_size,
+            max_batches=max_batches,
+            reconcile_limit=reconcile_limit,
+            account_label=account_label,
+            event_scan_limit=SIM_ORDER_EVENT_SCAN_LIMIT,
             skip_reconcile=True,
             allow_data_quality_degraded=True,
-            **common,
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            dsn_env=dsn_env,
+            batch_size=runtime_ledger_batch_size,
+            max_batches=max_batches,
+            reconcile_limit=reconcile_limit,
+            account_label=account_label,
             reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
             supervise_timeout_seconds=RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
-            **common,
         ),
     ]
 
@@ -154,9 +203,31 @@ def _sim_commands() -> list[JournalCronCommand]:
 def _commands_for_preset(args: argparse.Namespace) -> list[JournalCronCommand]:
     if args.preset == "live":
         return _live_commands(
-            execution_batch_size=max(1, min(int(args.execution_batch_size), 5000))
+            execution_batch_size=_bounded_batch_size(
+                getattr(args, "execution_batch_size", LIVE_EXECUTION_BATCH_SIZE)
+            ),
+            tca_metric_batch_size=_bounded_batch_size(
+                getattr(args, "tca_metric_batch_size", LIVE_TCA_METRIC_BATCH_SIZE)
+            ),
+            order_event_batch_size=_bounded_batch_size(
+                getattr(args, "order_event_batch_size", LIVE_ORDER_EVENT_BATCH_SIZE)
+            ),
+            runtime_ledger_batch_size=_bounded_batch_size(
+                getattr(
+                    args,
+                    "runtime_ledger_batch_size",
+                    LIVE_RUNTIME_LEDGER_BATCH_SIZE,
+                )
+            ),
         )
-    return _sim_commands()
+    return _sim_commands(
+        batch_size=_bounded_batch_size(
+            getattr(args, "sim_batch_size", SIM_SOURCE_BATCH_SIZE)
+        ),
+        runtime_ledger_batch_size=_bounded_batch_size(
+            getattr(args, "runtime_ledger_batch_size", SIM_RUNTIME_LEDGER_BATCH_SIZE)
+        ),
+    )
 
 
 def _journal_script_path() -> str:

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -754,7 +754,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 order_event_argv = command_argvs[2]
                 self.assertEqual(
                     order_event_argv[order_event_argv.index("--batch-size") + 1],
-                    "1",
+                    str(cron_runner.LIVE_ORDER_EVENT_BATCH_SIZE),
                 )
                 self.assertEqual(
                     order_event_argv[order_event_argv.index("--max-batches") + 1],

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1662,7 +1662,10 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("SIM_DB_DSN", live_env)
         live_args = "\n".join(str(item) for item in live_container.get("args", []))
         self.assertIn("--preset live", live_args)
-        self.assertIn("--execution-batch-size 5", live_args)
+        self.assertIn("--execution-batch-size 250", live_args)
+        self.assertIn("--tca-metric-batch-size 250", live_args)
+        self.assertIn("--order-event-batch-size 50", live_args)
+        self.assertIn("--runtime-ledger-batch-size 100", live_args)
         self.assertIn("--supervise-timeout-seconds 45", live_args)
         self.assertNotIn("--dsn-env DB_DSN", live_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)
@@ -1684,7 +1687,10 @@ class TestLiveConfigManifestContract(TestCase):
             tigerbeetle_journal_runner.LIVE_EXECUTION_SLICE_COUNT,
         )
         self.assertTrue(live_execution_command.commit_each_row)
-        self.assertEqual(live_execution_command.progress_interval, 1)
+        self.assertEqual(
+            live_execution_command.progress_interval,
+            tigerbeetle_journal_runner.LIVE_EXECUTION_PROGRESS_INTERVAL,
+        )
         live_order_event_commands = [
             command
             for command in tigerbeetle_journal_runner._live_commands(
@@ -1698,7 +1704,7 @@ class TestLiveConfigManifestContract(TestCase):
             live_order_event_command.batch_size,
             tigerbeetle_journal_runner.LIVE_ORDER_EVENT_BATCH_SIZE,
         )
-        self.assertEqual(live_order_event_command.batch_size, 1)
+        self.assertEqual(live_order_event_command.batch_size, 50)
         self.assertEqual(
             live_order_event_command.event_scan_limit,
             tigerbeetle_journal_runner.LIVE_ORDER_EVENT_SCAN_LIMIT,
@@ -1715,8 +1721,8 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertLessEqual(
             live_order_event_command.batch_size * live_order_event_command.max_batches,
-            1,
-            "live order-event slices must stay to one selected row after the 2-batch image still timed out",
+            tigerbeetle_journal_runner.LIVE_ORDER_EVENT_BATCH_SIZE,
+            "live order-event slices must stay to one bounded batch under the 45s watchdog",
         )
         self.assertTrue(live_order_event_command.skip_reconcile)
         self.assertTrue(live_order_event_command.allow_data_quality_degraded)
@@ -1760,6 +1766,8 @@ class TestLiveConfigManifestContract(TestCase):
             )
         sim_args = "\n".join(str(item) for item in sim_container.get("args", []))
         self.assertIn("--preset sim", sim_args)
+        self.assertIn("--sim-batch-size 250", sim_args)
+        self.assertIn("--runtime-ledger-batch-size 100", sim_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", sim_args)
         self.assertNotIn("--account-label TORGHUT_SIM", sim_args)
         self.assertNotIn("--batch-size", sim_args)
@@ -1898,7 +1906,7 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertNotIn("--runtime-window-hypothesis-id H-TSMOM-01", args)
-        self.assertNotIn("--runtime-window-target '{\"hypothesis_id\"", args)
+        self.assertNotIn('--runtime-window-target \'{"hypothesis_id"', args)
         self.assertNotIn("PA3SX7FYNUTF", args)
         self.assertIn("--runtime-window-account-label TORGHUT_SIM", args)
         self.assertIn("--runtime-window-observed-stage paper", args)

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -27,6 +27,14 @@ class RunTigerBeetleJournalCronTest(TestCase):
                 "live",
                 "--execution-batch-size",
                 "0",
+                "--tca-metric-batch-size",
+                "0",
+                "--order-event-batch-size",
+                "50000",
+                "--runtime-ledger-batch-size",
+                "0",
+                "--sim-batch-size",
+                "0",
                 "--supervise-timeout-seconds",
                 "3.5",
                 "--json",
@@ -41,9 +49,38 @@ class RunTigerBeetleJournalCronTest(TestCase):
             runner._commands_for_preset(args)[0].batch_size,
             1,
         )
+        self.assertEqual(runner._commands_for_preset(args)[1].batch_size, 1)
+        self.assertEqual(runner._commands_for_preset(args)[2].batch_size, 5000)
+        self.assertEqual(runner._commands_for_preset(args)[3].batch_size, 1)
         self.assertEqual(
-            runner._commands_for_preset(argparse.Namespace(preset="sim"))[0].dsn_env,
+            runner._commands_for_preset(
+                argparse.Namespace(
+                    preset="sim",
+                    sim_batch_size=0,
+                    runtime_ledger_batch_size=50_000,
+                )
+            )[0].dsn_env,
             "SIM_DB_DSN",
+        )
+        self.assertEqual(
+            runner._commands_for_preset(
+                argparse.Namespace(
+                    preset="sim",
+                    sim_batch_size=0,
+                    runtime_ledger_batch_size=50_000,
+                )
+            )[0].batch_size,
+            1,
+        )
+        self.assertEqual(
+            runner._commands_for_preset(
+                argparse.Namespace(
+                    preset="sim",
+                    sim_batch_size=0,
+                    runtime_ledger_batch_size=50_000,
+                )
+            )[-1].batch_size,
+            5000,
         )
 
     def test_default_live_execution_slices_drain_source_ref_backlog(self) -> None:
@@ -63,36 +100,43 @@ class RunTigerBeetleJournalCronTest(TestCase):
             if item.source == SOURCE_TYPE_EXECUTION
         ]
 
-        self.assertEqual(runner.LIVE_EXECUTION_BATCH_SIZE, 5)
-        self.assertEqual(runner.LIVE_EXECUTION_SLICE_COUNT, 5)
+        self.assertEqual(runner.LIVE_EXECUTION_BATCH_SIZE, 250)
+        self.assertEqual(runner.LIVE_EXECUTION_SLICE_COUNT, 1)
         self.assertEqual(command.batch_size, runner.LIVE_EXECUTION_BATCH_SIZE)
         self.assertEqual(command.max_batches, 1)
         self.assertEqual(command.repeat_count, runner.LIVE_EXECUTION_SLICE_COUNT)
         self.assertTrue(command.commit_each_row)
-        self.assertEqual(command.progress_interval, 1)
+        self.assertEqual(
+            command.progress_interval, runner.LIVE_EXECUTION_PROGRESS_INTERVAL
+        )
         self.assertTrue(command.skip_reconcile)
         self.assertTrue(command.allow_data_quality_degraded)
 
-    def test_live_preset_raises_only_execution_batch_size(self) -> None:
-        commands = runner._live_commands(execution_batch_size=10)
+    def test_live_preset_can_tune_source_batch_sizes_independently(self) -> None:
+        commands = runner._live_commands(
+            execution_batch_size=10,
+            tca_metric_batch_size=20,
+            order_event_batch_size=30,
+            runtime_ledger_batch_size=40,
+        )
 
         self.assertEqual(commands[0].source, SOURCE_TYPE_EXECUTION)
         self.assertEqual(commands[0].batch_size, 10)
         self.assertEqual(commands[0].max_batches, 1)
         self.assertEqual(commands[0].repeat_count, runner.LIVE_EXECUTION_SLICE_COUNT)
         self.assertTrue(commands[0].commit_each_row)
-        self.assertEqual(commands[0].progress_interval, 1)
+        self.assertEqual(
+            commands[0].progress_interval, runner.LIVE_EXECUTION_PROGRESS_INTERVAL
+        )
         self.assertTrue(commands[0].skip_reconcile)
         self.assertTrue(commands[0].allow_data_quality_degraded)
         self.assertEqual(commands[1].source, SOURCE_TYPE_EXECUTION_TCA_METRIC)
-        self.assertEqual(commands[1].batch_size, runner.LIVE_TCA_METRIC_BATCH_SIZE)
-        self.assertEqual(commands[1].batch_size, 5)
+        self.assertEqual(commands[1].batch_size, 20)
         self.assertEqual(commands[1].max_batches, runner.LIVE_TCA_METRIC_MAX_BATCHES)
         self.assertEqual(commands[1].max_batches, 1)
         self.assertTrue(commands[1].skip_reconcile)
         self.assertEqual(commands[2].source, SOURCE_TYPE_EXECUTION_ORDER_EVENT)
-        self.assertEqual(commands[2].batch_size, runner.LIVE_ORDER_EVENT_BATCH_SIZE)
-        self.assertEqual(commands[2].batch_size, 1)
+        self.assertEqual(commands[2].batch_size, 30)
         self.assertEqual(commands[2].max_batches, runner.LIVE_ORDER_EVENT_MAX_BATCHES)
         self.assertEqual(commands[2].max_batches, 1)
         self.assertLessEqual(commands[2].max_batches, 2)
@@ -101,6 +145,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
             runner.LIVE_ORDER_EVENT_SCAN_LIMIT,
         )
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
+        self.assertEqual(commands[3].batch_size, 40)
         self.assertFalse(commands[3].skip_reconcile)
         self.assertTrue(commands[3].reconcile_empty_selection)
         self.assertEqual(commands[3].reconcile_limit, runner.LIVE_RECONCILE_LIMIT)
@@ -181,8 +226,11 @@ class RunTigerBeetleJournalCronTest(TestCase):
             str(runner.LIVE_ORDER_EVENT_MAX_BATCHES),
         )
         self.assertLessEqual(int(argv[argv.index("--max-batches") + 1]), 2)
-        self.assertEqual(int(argv[argv.index("--batch-size") + 1]), 1)
         self.assertEqual(int(argv[argv.index("--max-batches") + 1]), 1)
+        self.assertEqual(
+            int(argv[argv.index("--batch-size") + 1]),
+            runner.LIVE_ORDER_EVENT_BATCH_SIZE,
+        )
         self.assertEqual(
             argv[argv.index("--event-scan-limit") + 1],
             str(runner.LIVE_ORDER_EVENT_SCAN_LIMIT),
@@ -393,11 +441,14 @@ class RunTigerBeetleJournalCronTest(TestCase):
             exit_code = runner.main()
 
         self.assertEqual(exit_code, 1)
-        self.assertEqual(len(observed), 8)
+        self.assertEqual(len(observed), 4)
         first_argv = observed[0][0]
         self.assertEqual(first_argv[first_argv.index("--batch-size") + 1], "5000")
         self.assertIn("--commit-each-row", first_argv)
-        self.assertEqual(first_argv[first_argv.index("--progress-interval") + 1], "1")
+        self.assertEqual(
+            first_argv[first_argv.index("--progress-interval") + 1],
+            str(runner.LIVE_EXECUTION_PROGRESS_INTERVAL),
+        )
         self.assertEqual(
             first_argv[first_argv.index("--supervise-timeout-seconds") + 1],
             "0.001",


### PR DESCRIPTION
## Summary

- Added per-source TigerBeetle journal cron batch-size controls, clamped to `1..5000`.
- Raised live journal defaults to process more execution, TCA, order-event, and runtime-ledger rows per scheduled run while keeping split sources, one batch per source, watchdog supervision, and degraded-payload normalization.
- Raised sim journal source/runtime-ledger defaults and updated the manifest contract tests that guard the CronJob shape.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim tests/test_journal_tigerbeetle_order_events.py::TestJournalTigerBeetleOrderEventsScript::test_torghut_cronjob_keeps_live_sources_split_and_honest`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py tests/test_journal_tigerbeetle_order_events.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `uv run --frozen python -m compileall scripts/run_tigerbeetle_journal_cron.py`
- `uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `git diff --check`

## Screenshots (if applicable)

N/A - non-UI cron runner and manifest change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
