### PR TITLE
fix(cloudflare): route apex domain through tunnel

### DIFF
--- a/argocd/applications/cloudflare/configmap.yaml
+++ b/argocd/applications/cloudflare/configmap.yaml
@@ -8,6 +8,10 @@ data:
     ingress:
       - hostname: olden.proompteng.ai
         service: http://olden.olden.svc.cluster.local:80
+      - hostname: proompteng.ai
+        service: https://traefik.traefik.svc.cluster.local:443
+        originRequest:
+          noTLSVerify: true
       - hostname: "*.proompteng.ai"
         service: https://traefik.traefik.svc.cluster.local:443
         originRequest:


### PR DESCRIPTION
## Summary

- Route the `proompteng.ai` apex hostname explicitly through the Cloudflare Tunnel to in-cluster Traefik.
- Keep the existing `*.proompteng.ai` wildcard tunnel route and `http_status:404` fallback unchanged.
- Preserve the same Traefik TLS origin behavior with `originRequest.noTLSVerify: true`.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=client -f argocd/applications/cloudflare/configmap.yaml`
- `cloudflared tunnel --config <extracted config.yaml> ingress validate`
- `kubectl -n cloudflare exec deploy/cloudflared-deployment -- cloudflared tunnel --config /etc/cloudflared/config.yaml ingress validate`
- `bun run lint:argocd`
- `git diff --check -- argocd/applications/cloudflare/configmap.yaml`
- `curl -sSIL --max-time 20 https://proompteng.ai/` returned `HTTP/2 200`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
