### PR TITLE
fix(torghut): preserve source collection profit metadata

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -8917,6 +8917,9 @@ def _sanitized_runtime_ledger_source_collection_target(
         "source_collection_reason_codes": _unique_text_items(
             target.get("source_collection_reason_codes")
         ),
+        "source_collection_profit_target_candidate": _truthy_plan_value(
+            target.get("source_collection_profit_target_candidate")
+        ),
         "proof_mode": "probation",
         "evidence_collection_ok": True,
         "canary_collection_authorized": False,
@@ -8951,6 +8954,16 @@ def _sanitized_runtime_ledger_source_collection_target(
             or target.get("final_promotion_authorized")
         ),
     }
+    for key in (
+        "source_collection_priority",
+        "source_collection_profit_target_net_pnl_after_costs",
+        "source_collection_filled_notional",
+        "source_collection_net_strategy_pnl_after_costs",
+        "source_collection_post_cost_expectancy_bps",
+        "source_collection_next_action",
+    ):
+        if value := _safe_text(target.get(key)):
+            sanitized[key] = value
     sanitized.update(_runtime_window_import_target_metadata(target))
     if runtime_ledger_bucket_ref := _safe_text(target.get("runtime_ledger_bucket_ref")):
         sanitized["runtime_ledger_bucket_ref"] = runtime_ledger_bucket_ref

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -88,6 +88,13 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "source_collection_authorized",
     "source_collection_authorization_scope",
     "source_collection_reason_codes",
+    "source_collection_priority",
+    "source_collection_profit_target_candidate",
+    "source_collection_profit_target_net_pnl_after_costs",
+    "source_collection_filled_notional",
+    "source_collection_net_strategy_pnl_after_costs",
+    "source_collection_post_cost_expectancy_bps",
+    "source_collection_next_action",
     "bounded_evidence_collection_authorized",
     "bounded_evidence_collection_scope",
     "bounded_evidence_collection_max_notional",
@@ -850,9 +857,7 @@ def _runtime_window_target_plan_from_payload(
             plan = direct_plan
         else:
             gate = _as_dict(payload.get("live_submission_gate"))
-            gate_plan = _as_dict(
-                gate.get("runtime_ledger_paper_probation_import_plan")
-            )
+            gate_plan = _as_dict(gate.get("runtime_ledger_paper_probation_import_plan"))
             if gate_plan:
                 plan = gate_plan
             else:

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5140,6 +5140,21 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         "strategy_family": "microbar_cross_sectional_pairs",
                         "strategy_name": "microbar-cross-sectional-pairs-v1",
                         "source_collection_authorized": "true",
+                        "source_collection_priority": (
+                            "profit_target_source_materialization"
+                        ),
+                        "source_collection_profit_target_candidate": "true",
+                        "source_collection_profit_target_net_pnl_after_costs": (
+                            "567.44720578"
+                        ),
+                        "source_collection_filled_notional": "127090.02495200",
+                        "source_collection_net_strategy_pnl_after_costs": (
+                            "567.44720578"
+                        ),
+                        "source_collection_post_cost_expectancy_bps": "44.64923238",
+                        "source_collection_next_action": (
+                            "materialize_runtime_ledger_source_window_refs"
+                        ),
                         "source_account_label": "TORGHUT_REPLAY",
                         "source_dsn_env": "DB_DSN",
                         "target_dsn_env": "SIM_DB_DSN",
@@ -5174,6 +5189,28 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "strategy_runtime_ledger_buckets:run-1:start:end",
         )
         self.assertEqual(target["artifact_refs"], ["runtime-ledger/proof.json"])
+        self.assertEqual(
+            target["source_collection_priority"],
+            "profit_target_source_materialization",
+        )
+        self.assertTrue(target["source_collection_profit_target_candidate"])
+        self.assertEqual(
+            target["source_collection_profit_target_net_pnl_after_costs"],
+            "567.44720578",
+        )
+        self.assertEqual(target["source_collection_filled_notional"], "127090.02495200")
+        self.assertEqual(
+            target["source_collection_net_strategy_pnl_after_costs"],
+            "567.44720578",
+        )
+        self.assertEqual(
+            target["source_collection_post_cost_expectancy_bps"],
+            "44.64923238",
+        )
+        self.assertEqual(
+            target["source_collection_next_action"],
+            "materialize_runtime_ledger_source_window_refs",
+        )
         self.assertEqual(target["max_notional"], "0")
         self.assertFalse(target["promotion_allowed"])
 

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1073,9 +1073,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             {
                 "schema_version": "torghut.paper-route-evidence.v1",
                 "source_runtime_window_import_plan": {
-                    "schema_version": (
-                        "torghut.source-runtime-window-import-plan.v1"
-                    ),
+                    "schema_version": ("torghut.source-runtime-window-import-plan.v1"),
                     "target_count": 5,
                     "targets": [
                         {
@@ -2589,6 +2587,15 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 "source_collection_reason_codes": [
                     "source_window_evidence_collection_pending"
                 ],
+                "source_collection_priority": "profit_target_source_materialization",
+                "source_collection_profit_target_candidate": True,
+                "source_collection_profit_target_net_pnl_after_costs": "567.44720578",
+                "source_collection_filled_notional": "127090.02495200",
+                "source_collection_net_strategy_pnl_after_costs": "567.44720578",
+                "source_collection_post_cost_expectancy_bps": "44.64923238",
+                "source_collection_next_action": (
+                    "materialize_runtime_ledger_source_window_refs"
+                ),
                 "bounded_evidence_collection_authorized": True,
                 "bounded_evidence_collection_scope": (
                     "paper_route_probe_next_session_only"
@@ -2609,6 +2616,30 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(
             metadata["source_collection_reason_codes"],
             ["source_window_evidence_collection_pending"],
+        )
+        self.assertEqual(
+            metadata["source_collection_priority"],
+            "profit_target_source_materialization",
+        )
+        self.assertTrue(metadata["source_collection_profit_target_candidate"])
+        self.assertEqual(
+            metadata["source_collection_profit_target_net_pnl_after_costs"],
+            "567.44720578",
+        )
+        self.assertEqual(
+            metadata["source_collection_filled_notional"], "127090.02495200"
+        )
+        self.assertEqual(
+            metadata["source_collection_net_strategy_pnl_after_costs"],
+            "567.44720578",
+        )
+        self.assertEqual(
+            metadata["source_collection_post_cost_expectancy_bps"],
+            "44.64923238",
+        )
+        self.assertEqual(
+            metadata["source_collection_next_action"],
+            "materialize_runtime_ledger_source_window_refs",
         )
         self.assertTrue(metadata["bounded_evidence_collection_authorized"])
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Preserve runtime-ledger source-collection profit-target metadata in paper-route evidence import plans.
- Carry source-collection notional, post-cost PnL, expectancy, priority, and next-action fields through empirical renewal target metadata.
- Add regressions for endpoint sanitization and renewal metadata preservation while keeping promotion authority disabled.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k source_collection_import_plan_sanitizer_filters_and_preserves_refs -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k runtime_window_target_metadata_defaults_source_collection_blockers -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
