### PR TITLE
feat(torghut): add metaorder adverse selection stress

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -49,6 +49,9 @@ from app.trading.discovery.institutional_mechanism_fidelity_stress import (
 from app.trading.discovery.lead_lag_cross_asset_stress import (
     extract_lead_lag_cross_asset_stress,
 )
+from app.trading.discovery.metaorder_adverse_selection_stress import (
+    extract_metaorder_adverse_selection_stress,
+)
 from app.trading.discovery.lob_reality_gap_stress import (
     extract_lob_reality_gap_stress,
 )
@@ -87,8 +90,8 @@ from app.trading.discovery.signal_adaptive_execution_resilience_stress import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v10"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v11"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v11"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v12"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -121,6 +124,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "microstructure_regime_tokenization_stress",
     "cost_aware_forecast_filter_stress",
     "adaptive_market_limit_allocation_stress",
+    "metaorder_adverse_selection_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -244,6 +248,9 @@ class FastReplayPreviewRow:
         default_factory=lambda: cast(dict[str, Any], {})
     )
     adaptive_market_limit_allocation_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
+    metaorder_adverse_selection_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
@@ -374,6 +381,9 @@ class FastReplayPreviewRow:
             ),
             "adaptive_market_limit_allocation_stress": dict(
                 self.adaptive_market_limit_allocation_stress
+            ),
+            "metaorder_adverse_selection_stress": dict(
+                self.metaorder_adverse_selection_stress
             ),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
@@ -575,6 +585,7 @@ class FastReplayPreviewResult:
                 "microstructure_regime_tokenization_stress": "deterministic latent-regime early-warning, scale-invariant trade-flow token coverage, raw event precision, and stylized-fact replay stress from arXiv:2604.20949, arXiv:2602.23784, and arXiv:2508.02247; latent triggers and tokenized trade-flow are not PnL authority; preview ranking only",
                 "cost_aware_forecast_filter_stress": "deterministic walk-forward forecast-magnitude, transaction-cost threshold, turnover churn, multi-scale trend coverage, and dynamic-variable-selection stress from arXiv:2606.00060 and arXiv:2512.12727; cost-filtered forecasts are not PnL authority; preview ranking only",
                 "adaptive_market_limit_allocation_stress": "deterministic observed market/limit allocation, fill-uncertainty, tactical-imbalance, and trade-level cost logging stress from arXiv:2507.06345 and arXiv:2603.29086; allocation models are not fill or PnL authority; preview ranking only",
+                "metaorder_adverse_selection_stress": "deterministic Hawkes-style event clustering, same-direction metaorder footprint, adverse-selection drift, and liquidity-replenishment gap stress from arXiv:2510.27334 and DOI:10.1007/s10203-026-00570-z; metaorder footprints and Hawkes intensity are not fill or PnL authority; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1244,6 +1255,7 @@ def _score_candidate_spec(
             microstructure_regime_tokenization_stress={},
             cost_aware_forecast_filter_stress={},
             adaptive_market_limit_allocation_stress={},
+            metaorder_adverse_selection_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1538,6 +1550,18 @@ def _score_candidate_spec(
         )
         or 0.0
     )
+    metaorder_adverse_selection_stress = extract_metaorder_adverse_selection_stress(
+        matched_source_rows,
+        direction=direction,
+    ).to_payload()
+    metaorder_adverse_selection_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(metaorder_adverse_selection_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
     impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
         median_spread_bps=median_spread_bps,
         spread_tail_bps=spread_tail_bps,
@@ -1602,6 +1626,7 @@ def _score_candidate_spec(
         - microstructure_regime_tokenization_rank_penalty_bps * 0.05
         - cost_aware_forecast_filter_rank_penalty_bps * 0.05
         - adaptive_market_limit_allocation_rank_penalty_bps * 0.05
+        - metaorder_adverse_selection_rank_penalty_bps * 0.05
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1651,6 +1676,7 @@ def _score_candidate_spec(
         - microstructure_regime_tokenization_rank_penalty_bps * 0.03
         - cost_aware_forecast_filter_rank_penalty_bps * 0.03
         - adaptive_market_limit_allocation_rank_penalty_bps * 0.03
+        - metaorder_adverse_selection_rank_penalty_bps * 0.03
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1714,6 +1740,7 @@ def _score_candidate_spec(
         adaptive_market_limit_allocation_stress=dict(
             adaptive_market_limit_allocation_stress
         ),
+        metaorder_adverse_selection_stress=dict(metaorder_adverse_selection_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1768,6 +1795,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - _microstructure_regime_tokenization_rank_penalty_bps(row) * 0.04
         - _cost_aware_forecast_filter_rank_penalty_bps(row) * 0.04
         - _adaptive_market_limit_allocation_rank_penalty_bps(row) * 0.04
+        - _metaorder_adverse_selection_rank_penalty_bps(row) * 0.04
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
@@ -1908,6 +1936,15 @@ def _adaptive_market_limit_allocation_rank_penalty_bps(
 ) -> float:
     ranking_features = _mapping(
         row.adaptive_market_limit_allocation_stress.get("ranking_features")
+    )
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _metaorder_adverse_selection_rank_penalty_bps(
+    row: FastReplayPreviewRow,
+) -> float:
+    ranking_features = _mapping(
+        row.metaorder_adverse_selection_stress.get("ranking_features")
     )
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
@@ -2130,6 +2167,7 @@ def _row_with_rank_and_selection(
         adaptive_market_limit_allocation_stress=dict(
             row.adaptive_market_limit_allocation_stress
         ),
+        metaorder_adverse_selection_stress=dict(row.metaorder_adverse_selection_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -2219,6 +2257,7 @@ def _row_with_frontier_dedupe(
         adaptive_market_limit_allocation_stress=dict(
             row.adaptive_market_limit_allocation_stress
         ),
+        metaorder_adverse_selection_stress=dict(row.metaorder_adverse_selection_stress),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -3052,6 +3091,8 @@ def _risk_flags_for_row(
         flags.add("cost_aware_forecast_filter_stress_penalty_active")
     if _adaptive_market_limit_allocation_rank_penalty_bps(row) > 0:
         flags.add("adaptive_market_limit_allocation_stress_penalty_active")
+    if _metaorder_adverse_selection_rank_penalty_bps(row) > 0:
+        flags.add("metaorder_adverse_selection_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
         flags.add("partial_symbol_coverage")
     if row.trading_day_count <= 0:
@@ -3118,6 +3159,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("cost_aware_forecast_filter_stress_downranks_only")
     if _adaptive_market_limit_allocation_rank_penalty_bps(row) > 0:
         reasons.add("adaptive_market_limit_allocation_stress_downranks_only")
+    if _metaorder_adverse_selection_rank_penalty_bps(row) > 0:
+        reasons.add("metaorder_adverse_selection_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
         reasons.add("missing_replay_tape_source_data_explicit_blocker")
     if lineage_blockers:
@@ -3177,6 +3220,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("cost_aware_forecast_filter_stress_penalty")
     if _adaptive_market_limit_allocation_rank_penalty_bps(row) > 0:
         vetoes.add("adaptive_market_limit_allocation_stress_penalty")
+    if _metaorder_adverse_selection_rank_penalty_bps(row) > 0:
+        vetoes.add("metaorder_adverse_selection_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:
         vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
     return tuple(sorted(vetoes))

--- a/services/torghut/app/trading/discovery/metaorder_adverse_selection_stress.py
+++ b/services/torghut/app/trading/discovery/metaorder_adverse_selection_stress.py
@@ -1,0 +1,613 @@
+"""Preview-only metaorder adverse-selection stress for replay ranking.
+
+This module turns recent 2025-2026 market-microstructure research into
+executable replay inputs.  It detects Hawkes-style clustered LOB event flow,
+same-direction aggressive trade runs, and liquidity-replenishment gaps that can
+make Torghut's intraday candidates vulnerable to opportunistic market makers
+when they chase visible metaorder drift.
+
+The output is a deterministic offline ranking stress only.  It never creates
+broker fills, writes runtime ledgers, relaxes proof gates, or enables live
+capital.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import exp, isfinite
+from statistics import median
+from typing import Any
+
+from app.trading.models import SignalEnvelope
+
+METAORDER_ADVERSE_SELECTION_STRESS_SCHEMA_VERSION = (
+    "torghut.metaorder-adverse-selection-stress.v1"
+)
+METAORDER_ADVERSE_SELECTION_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.metaorder-adverse-selection-stress-contract.v1"
+)
+METAORDER_ADVERSE_SELECTION_STRESS_PROOF_SEMANTICS_LABEL = (
+    "metaorder_adverse_selection_preview_only_exact_replay_route_tca_"
+    "order_lifecycle_runtime_ledger_required"
+)
+METAORDER_ADVERSE_SELECTION_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2510.27334",
+        "url": "https://arxiv.org/abs/2510.27334",
+        "title": "When AI Trading Agents Compete: Adverse Selection of Meta-Orders by Reinforcement Learning-Based Market Making",
+        "date": "2025-10-31",
+        "mechanism": "rl_market_makers_exploit_metaorder_induced_price_drift_and_hawkes_lob_endogeneity",
+    },
+    {
+        "source_id": "doi-10.1007/s10203-026-00570-z",
+        "url": "https://link.springer.com/article/10.1007/s10203-026-00570-z",
+        "title": "Forecasting Bitcoin price movements using multivariate Hawkes processes and limit order book data",
+        "date": "2026-04-17",
+        "mechanism": "multivariate_hawkes_lob_event_timing_cross_excitation_base_imbalance_and_return_sign_forecasting",
+    },
+)
+
+_EVENT_TYPE_FIELDS = (
+    "event_type",
+    "order_event_type",
+    "lob_event_type",
+    "action",
+    "type",
+)
+_ORDER_TYPE_FIELDS = (
+    "order_type",
+    "order_kind",
+    "execution_order_type",
+    "execution_type",
+    "route_order_type",
+)
+_TRADE_DIRECTION_FIELDS = (
+    "trade_direction",
+    "authoritative_trade_direction",
+    "feed_trade_direction",
+    "aggressive_side",
+    "initiator_side",
+    "side",
+    "signed_trade_direction",
+)
+_PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
+_SPREAD_BPS_FIELDS = ("spread_bps", "quoted_spread_bps", "effective_spread_bps")
+_IMBALANCE_FIELDS = (
+    "base_imbalance",
+    "order_book_imbalance",
+    "book_imbalance",
+    "bid_ask_imbalance",
+    "depth_imbalance",
+    "ofi",
+    "order_flow_imbalance",
+)
+_BID_DEPTH_FIELDS = (
+    "bid_size",
+    "best_bid_size",
+    "bid_depth",
+    "bid_volume",
+    "visible_bid_depth",
+)
+_ASK_DEPTH_FIELDS = (
+    "ask_size",
+    "best_ask_size",
+    "ask_depth",
+    "ask_volume",
+    "visible_ask_depth",
+)
+_SIZE_FIELDS = (
+    "trade_size",
+    "last_size",
+    "fill_qty",
+    "filled_qty",
+    "quantity",
+    "qty",
+    "order_qty",
+)
+_AGGRESSIVE_EVENT_TOKENS = frozenset(
+    ("trade", "fill", "execution", "market", "sweep", "take", "taker")
+)
+_PASSIVE_OR_CANCEL_EVENT_TOKENS = frozenset(
+    ("add", "limit", "cancel", "replace", "modify", "delete")
+)
+_HAWKES_DECAY_SECONDS = 30.0
+_METAORDER_STREAK_LENGTH = 3
+_HIGH_SPREAD_BPS = 8.0
+_LIQUIDITY_DROP_THRESHOLD = 0.35
+
+
+@dataclass(frozen=True)
+class MetaorderAdverseSelectionStressSummary:
+    row_count: int
+    observed_event_type_count: int
+    observed_trade_direction_count: int
+    observed_price_count: int
+    observed_imbalance_count: int
+    aggressive_event_share: float
+    event_time_clustering_score: float
+    same_direction_aggressive_run_share: float
+    metaorder_footprint_share: float
+    candidate_chasing_drift_share: float
+    adverse_selection_alignment_share: float
+    liquidity_replenishment_gap_share: float
+    wide_spread_toxic_flow_share: float
+    median_metaorder_size: float
+    median_adverse_drift_bps: float
+    metaorder_adverse_selection_score: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": METAORDER_ADVERSE_SELECTION_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_metaorder_adverse_selection_stress_ranking",
+            "source_papers": [
+                dict(item)
+                for item in METAORDER_ADVERSE_SELECTION_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "observed_event_type_count": self.observed_event_type_count,
+            "observed_trade_direction_count": self.observed_trade_direction_count,
+            "observed_price_count": self.observed_price_count,
+            "observed_imbalance_count": self.observed_imbalance_count,
+            "aggressive_event_share": _stable_float(self.aggressive_event_share),
+            "event_time_clustering_score": _stable_float(
+                self.event_time_clustering_score
+            ),
+            "same_direction_aggressive_run_share": _stable_float(
+                self.same_direction_aggressive_run_share
+            ),
+            "metaorder_footprint_share": _stable_float(self.metaorder_footprint_share),
+            "candidate_chasing_drift_share": _stable_float(
+                self.candidate_chasing_drift_share
+            ),
+            "adverse_selection_alignment_share": _stable_float(
+                self.adverse_selection_alignment_share
+            ),
+            "liquidity_replenishment_gap_share": _stable_float(
+                self.liquidity_replenishment_gap_share
+            ),
+            "wide_spread_toxic_flow_share": _stable_float(
+                self.wide_spread_toxic_flow_share
+            ),
+            "median_metaorder_size": _stable_float(self.median_metaorder_size),
+            "median_adverse_drift_bps": _stable_float(self.median_adverse_drift_bps),
+            "metaorder_adverse_selection_score": _stable_float(
+                self.metaorder_adverse_selection_score
+            ),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "aggressive_event_share": _stable_float(self.aggressive_event_share),
+                "event_time_clustering_score": _stable_float(
+                    self.event_time_clustering_score
+                ),
+                "same_direction_aggressive_run_share": _stable_float(
+                    self.same_direction_aggressive_run_share
+                ),
+                "metaorder_footprint_share": _stable_float(
+                    self.metaorder_footprint_share
+                ),
+                "candidate_chasing_drift_share": _stable_float(
+                    self.candidate_chasing_drift_share
+                ),
+                "adverse_selection_alignment_share": _stable_float(
+                    self.adverse_selection_alignment_share
+                ),
+                "liquidity_replenishment_gap_share": _stable_float(
+                    self.liquidity_replenishment_gap_share
+                ),
+                "wide_spread_toxic_flow_share": _stable_float(
+                    self.wide_spread_toxic_flow_share
+                ),
+                "median_adverse_drift_bps": _stable_float(
+                    self.median_adverse_drift_bps
+                ),
+                "metaorder_adverse_selection_score": _stable_float(
+                    self.metaorder_adverse_selection_score
+                ),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "hawkes_event_clustering_preview": True,
+            "metaorder_footprint_preview": True,
+            "adverse_selection_execution_stress_preview": True,
+            "liquidity_replenishment_gap_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": METAORDER_ADVERSE_SELECTION_STRESS_PROOF_SEMANTICS_LABEL,
+        }
+
+
+def metaorder_adverse_selection_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": METAORDER_ADVERSE_SELECTION_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": METAORDER_ADVERSE_SELECTION_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in METAORDER_ADVERSE_SELECTION_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": "hawkes_metaorder_adverse_selection_and_liquidity_replenishment_replay_stress",
+        "stress_components": [
+            "event_time_clustering_score",
+            "same_direction_aggressive_run_share",
+            "metaorder_footprint_share",
+            "candidate_chasing_drift_share",
+            "adverse_selection_alignment_share",
+            "liquidity_replenishment_gap_share",
+            "wide_spread_toxic_flow_share",
+            "median_adverse_drift_bps",
+        ],
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_order_lifecycle_fill_evidence": True,
+            "requires_runtime_ledger": True,
+            "requires_real_fill_slippage_observations": True,
+            "rejects_metaorder_footprint_as_pnl_authority": True,
+            "rejects_hawkes_intensity_as_fill_authority": True,
+            "rejects_simulated_market_maker_profit_as_torghut_profit_proof": True,
+        },
+    }
+
+
+def build_metaorder_adverse_selection_stress_schema_hash() -> str:
+    return _stable_hash(metaorder_adverse_selection_stress_contract())
+
+
+def extract_metaorder_adverse_selection_stress(
+    records: Sequence[SignalEnvelope],
+    *,
+    direction: int | float = 1,
+) -> MetaorderAdverseSelectionStressSummary:
+    """Extract Hawkes/metaorder adverse-selection stress from replay rows."""
+
+    ordered = tuple(
+        sorted(records, key=lambda item: (item.event_ts, item.symbol, item.seq or 0))
+    )
+    signed_direction = 1.0 if float(direction) >= 0.0 else -1.0
+    warnings: list[str] = []
+    event_type_count = 0
+    trade_direction_count = 0
+    price_count = 0
+    imbalance_count = 0
+    aggressive_count = 0
+    same_direction_run_count = 0
+    metaorder_row_count = 0
+    chasing_drift_count = 0
+    adverse_alignment_count = 0
+    liquidity_gap_count = 0
+    wide_spread_toxic_count = 0
+    candidate_alignment_observation_count = 0
+    clustering_weights: list[float] = []
+    metaorder_sizes: list[float] = []
+    adverse_drifts: list[float] = []
+
+    prices = tuple(_first_float(row.payload, _PRICE_FIELDS) for row in ordered)
+    event_signs = tuple(_extract_trade_direction(row.payload) for row in ordered)
+    aggressive_flags = tuple(_is_aggressive_event(row.payload) for row in ordered)
+    spreads = tuple(_first_float(row.payload, _SPREAD_BPS_FIELDS) for row in ordered)
+    imbalances = tuple(_first_float(row.payload, _IMBALANCE_FIELDS) for row in ordered)
+    bid_depths = tuple(_first_float(row.payload, _BID_DEPTH_FIELDS) for row in ordered)
+    ask_depths = tuple(_first_float(row.payload, _ASK_DEPTH_FIELDS) for row in ordered)
+
+    current_streak_sign = 0.0
+    current_streak_length = 0
+    previous_aggressive_index: int | None = None
+    previous_aggressive_sign = 0.0
+
+    for index, row in enumerate(ordered):
+        event_type = _first_text(row.payload, _EVENT_TYPE_FIELDS) or _first_text(
+            row.payload, _ORDER_TYPE_FIELDS
+        )
+        if event_type is not None:
+            event_type_count += 1
+        price = prices[index]
+        if price is not None:
+            price_count += 1
+        imbalance = imbalances[index]
+        if imbalance is not None:
+            imbalance_count += 1
+
+        aggressive = aggressive_flags[index]
+        sign = event_signs[index]
+        if sign is not None:
+            trade_direction_count += 1
+
+        if not aggressive:
+            if _is_passive_or_cancel_event(row.payload):
+                current_streak_sign = 0.0
+                current_streak_length = 0
+            continue
+
+        aggressive_count += 1
+        if sign is None:
+            current_streak_sign = 0.0
+            current_streak_length = 0
+            continue
+
+        if previous_aggressive_index is not None:
+            dt_seconds = max(
+                0.0,
+                (
+                    row.event_ts - ordered[previous_aggressive_index].event_ts
+                ).total_seconds(),
+            )
+            clustering_weights.append(exp(-dt_seconds / _HAWKES_DECAY_SECONDS))
+            if sign == previous_aggressive_sign:
+                same_direction_run_count += 1
+
+        if sign == current_streak_sign:
+            current_streak_length += 1
+        else:
+            current_streak_sign = sign
+            current_streak_length = 1
+        if current_streak_length >= _METAORDER_STREAK_LENGTH:
+            metaorder_row_count += 1
+            size = _first_float(row.payload, _SIZE_FIELDS)
+            if size is not None and size > 0.0:
+                metaorder_sizes.append(size)
+
+        if sign == signed_direction:
+            candidate_alignment_observation_count += 1
+            drift_bps = _next_return_bps(
+                prices, index=index, direction=signed_direction
+            )
+            signed_imbalance = (
+                signed_direction * imbalance if imbalance is not None else None
+            )
+            if drift_bps is not None and drift_bps > 0.0:
+                chasing_drift_count += 1
+                adverse_drifts.append(drift_bps)
+            if (
+                current_streak_length >= _METAORDER_STREAK_LENGTH
+                or (signed_imbalance is not None and signed_imbalance > 0.15)
+            ) and (drift_bps is not None and drift_bps >= 0.50):
+                adverse_alignment_count += 1
+            spread = spreads[index]
+            if spread is not None and spread >= _HIGH_SPREAD_BPS:
+                wide_spread_toxic_count += 1
+
+        if _liquidity_replenishment_gap(
+            bid_depths,
+            ask_depths,
+            index=index,
+            trade_sign=sign,
+        ):
+            liquidity_gap_count += 1
+
+        previous_aggressive_index = index
+        previous_aggressive_sign = sign
+
+    row_count = len(ordered)
+    if row_count < 2:
+        warnings.append("insufficient_metaorder_adverse_selection_rows")
+    if event_type_count == 0:
+        warnings.append("missing_lob_event_type_evidence")
+    if trade_direction_count == 0:
+        warnings.append("missing_trade_direction_evidence")
+    if price_count < 2:
+        warnings.append("missing_price_path_for_adverse_drift")
+    if imbalance_count == 0:
+        warnings.append("missing_base_imbalance_or_ofi_evidence")
+
+    aggressive_event_share = _share(aggressive_count, row_count)
+    event_time_clustering_score = (
+        median(clustering_weights) if clustering_weights else 0.0
+    )
+    same_direction_aggressive_run_share = _share(
+        same_direction_run_count, aggressive_count
+    )
+    metaorder_footprint_share = _share(metaorder_row_count, aggressive_count)
+    candidate_chasing_drift_share = _share(
+        chasing_drift_count, candidate_alignment_observation_count
+    )
+    adverse_selection_alignment_share = _share(
+        adverse_alignment_count, candidate_alignment_observation_count
+    )
+    liquidity_replenishment_gap_share = _share(liquidity_gap_count, aggressive_count)
+    wide_spread_toxic_flow_share = _share(
+        wide_spread_toxic_count, candidate_alignment_observation_count
+    )
+    median_metaorder_size = median(metaorder_sizes) if metaorder_sizes else 0.0
+    median_adverse_drift_bps = median(adverse_drifts) if adverse_drifts else 0.0
+
+    evidence_gap_score = (
+        (0.0 if event_type_count > 0 else 1.0)
+        + (0.0 if trade_direction_count > 0 else 1.0)
+        + (0.0 if price_count >= 2 else 1.0)
+        + (0.0 if imbalance_count > 0 else 0.5)
+    ) / 3.5
+    metaorder_adverse_selection_score = min(
+        1.0,
+        evidence_gap_score * 0.35
+        + event_time_clustering_score * 0.15
+        + same_direction_aggressive_run_share * 0.15
+        + metaorder_footprint_share * 0.20
+        + candidate_chasing_drift_share * 0.15
+        + adverse_selection_alignment_share * 0.25
+        + liquidity_replenishment_gap_share * 0.15
+        + wide_spread_toxic_flow_share * 0.15,
+    )
+    missing_penalty_bps = 6.0 * len(warnings)
+    replay_rank_penalty_bps = (
+        missing_penalty_bps
+        + metaorder_adverse_selection_score * 12.0
+        + median_adverse_drift_bps * 0.50
+        + wide_spread_toxic_flow_share * _HIGH_SPREAD_BPS
+        + liquidity_replenishment_gap_share * 6.0
+        + metaorder_footprint_share * 5.0
+    )
+
+    return MetaorderAdverseSelectionStressSummary(
+        row_count=row_count,
+        observed_event_type_count=event_type_count,
+        observed_trade_direction_count=trade_direction_count,
+        observed_price_count=price_count,
+        observed_imbalance_count=imbalance_count,
+        aggressive_event_share=aggressive_event_share,
+        event_time_clustering_score=event_time_clustering_score,
+        same_direction_aggressive_run_share=same_direction_aggressive_run_share,
+        metaorder_footprint_share=metaorder_footprint_share,
+        candidate_chasing_drift_share=candidate_chasing_drift_share,
+        adverse_selection_alignment_share=adverse_selection_alignment_share,
+        liquidity_replenishment_gap_share=liquidity_replenishment_gap_share,
+        wide_spread_toxic_flow_share=wide_spread_toxic_flow_share,
+        median_metaorder_size=median_metaorder_size,
+        median_adverse_drift_bps=median_adverse_drift_bps,
+        metaorder_adverse_selection_score=metaorder_adverse_selection_score,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=tuple(dict.fromkeys(warnings)),
+        feature_schema_hash=build_metaorder_adverse_selection_stress_schema_hash(),
+    )
+
+
+def _is_aggressive_event(payload: Mapping[str, Any]) -> bool:
+    values = tuple(
+        item.lower().replace("-", "_").replace(" ", "_")
+        for item in (
+            _first_text(payload, _EVENT_TYPE_FIELDS),
+            _first_text(payload, _ORDER_TYPE_FIELDS),
+        )
+        if item is not None
+    )
+    return any(
+        any(token in value for token in _AGGRESSIVE_EVENT_TOKENS) for value in values
+    )
+
+
+def _is_passive_or_cancel_event(payload: Mapping[str, Any]) -> bool:
+    values = tuple(
+        item.lower().replace("-", "_").replace(" ", "_")
+        for item in (
+            _first_text(payload, _EVENT_TYPE_FIELDS),
+            _first_text(payload, _ORDER_TYPE_FIELDS),
+        )
+        if item is not None
+    )
+    return any(
+        any(token in value for token in _PASSIVE_OR_CANCEL_EVENT_TOKENS)
+        for value in values
+    )
+
+
+def _extract_trade_direction(payload: Mapping[str, Any]) -> float | None:
+    raw = _first_text(payload, _TRADE_DIRECTION_FIELDS)
+    if raw is not None:
+        normalized = raw.lower().replace("-", "_").replace(" ", "_")
+        if normalized in {"buy", "buyer", "bid", "b", "long", "aggressive_buy"}:
+            return 1.0
+        if normalized in {
+            "sell",
+            "seller",
+            "ask",
+            "offer",
+            "s",
+            "short",
+            "aggressive_sell",
+        }:
+            return -1.0
+        if "buy" in normalized:
+            return 1.0
+        if "sell" in normalized:
+            return -1.0
+    for field in _TRADE_DIRECTION_FIELDS:
+        numeric = _float_or_none(payload.get(field))
+        if numeric is not None and numeric != 0.0:
+            return 1.0 if numeric > 0.0 else -1.0
+    return None
+
+
+def _next_return_bps(
+    prices: Sequence[float | None],
+    *,
+    index: int,
+    direction: float,
+) -> float | None:
+    current = prices[index]
+    if current is None or current <= 0.0:
+        return None
+    for next_price in prices[index + 1 :]:
+        if next_price is not None and next_price > 0.0:
+            return direction * (next_price - current) / current * 10_000.0
+    return None
+
+
+def _liquidity_replenishment_gap(
+    bid_depths: Sequence[float | None],
+    ask_depths: Sequence[float | None],
+    *,
+    index: int,
+    trade_sign: float,
+) -> bool:
+    if index + 1 >= len(bid_depths):
+        return False
+    depth_series = ask_depths if trade_sign > 0 else bid_depths
+    current = depth_series[index]
+    next_depth = depth_series[index + 1]
+    if current is None or next_depth is None or current <= 0.0:
+        return False
+    retained_share = next_depth / current
+    return retained_share <= (1.0 - _LIQUIDITY_DROP_THRESHOLD)
+
+
+def _share(numerator: int | float, denominator: int | float) -> float:
+    if denominator <= 0:
+        return 0.0
+    return min(1.0, max(0.0, float(numerator) / float(denominator)))
+
+
+def _first_text(payload: Mapping[str, Any], fields: Sequence[str]) -> str | None:
+    for field in fields:
+        value = payload.get(field)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _first_float(payload: Mapping[str, Any], fields: Sequence[str]) -> float | None:
+    for field in fields:
+        value = payload.get(field)
+        parsed = _float_or_none(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(parsed):
+        return None
+    return parsed
+
+
+def _stable_float(value: float) -> float:
+    if not isfinite(value):
+        return 0.0
+    return float(f"{value:.10f}")
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    stable_payload = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(stable_payload.encode("utf-8")).hexdigest()

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -299,6 +299,10 @@ class TestFastReplayPreview(TestCase):
             "adaptive_market_limit_allocation_stress",
             payload["implemented_mechanisms"],
         )
+        self.assertIn(
+            "metaorder_adverse_selection_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",
@@ -733,6 +737,43 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn(
             "adaptive_market_limit_allocation_stress_downranks_only",
+            row_payload["ranking_only_reasons"],
+        )
+        self.assertIn("metaorder_adverse_selection_stress", row_payload)
+        self.assertEqual(
+            row_payload["metaorder_adverse_selection_stress"]["status"],
+            "preview_only_metaorder_adverse_selection_stress_ranking",
+        )
+        self.assertIn(
+            "arxiv-2510.27334",
+            {
+                source["source_id"]
+                for source in row_payload["metaorder_adverse_selection_stress"][
+                    "source_papers"
+                ]
+            },
+        )
+        self.assertIn(
+            "doi-10.1007/s10203-026-00570-z",
+            {
+                source["source_id"]
+                for source in row_payload["metaorder_adverse_selection_stress"][
+                    "source_papers"
+                ]
+            },
+        )
+        self.assertFalse(
+            row_payload["metaorder_adverse_selection_stress"]["proof_authority"]
+        )
+        self.assertFalse(
+            row_payload["metaorder_adverse_selection_stress"]["promotion_authority"]
+        )
+        self.assertIn(
+            "metaorder_adverse_selection_stress_penalty_active",
+            row_payload["risk_flags"],
+        )
+        self.assertIn(
+            "metaorder_adverse_selection_stress_downranks_only",
             row_payload["ranking_only_reasons"],
         )
         self.assertIn(

--- a/services/torghut/tests/test_metaorder_adverse_selection_stress.py
+++ b/services/torghut/tests/test_metaorder_adverse_selection_stress.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.metaorder_adverse_selection_stress import (
+    extract_metaorder_adverse_selection_stress,
+    metaorder_adverse_selection_stress_contract,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestMetaorderAdverseSelectionStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        price: str,
+        event_type: str,
+        trade_direction: str,
+        spread_bps: str,
+        imbalance: str,
+        bid_size: str,
+        ask_size: str,
+        trade_size: str = "100",
+    ) -> SignalEnvelope:
+        return SignalEnvelope(
+            event_ts=datetime(2026, 4, 17, 14, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset),
+            symbol="META",
+            timeframe="1s",
+            seq=offset,
+            source="metaorder-adverse-selection-fixture",
+            payload={
+                "price": Decimal(price),
+                "event_type": event_type,
+                "order_type": "market" if event_type == "trade" else "limit",
+                "trade_direction": trade_direction,
+                "base_imbalance": Decimal(imbalance),
+                "spread_bps": Decimal(spread_bps),
+                "bid_size": Decimal(bid_size),
+                "ask_size": Decimal(ask_size),
+                "trade_size": Decimal(trade_size),
+            },
+            ingest_ts=datetime(2026, 4, 17, 14, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset + 1),
+        )
+
+    def test_clustered_buy_metaorder_drift_downranks_more_than_balanced_flow(
+        self,
+    ) -> None:
+        balanced_rows = [
+            self._row(
+                offset=0,
+                price="100.00",
+                event_type="trade",
+                trade_direction="buy",
+                spread_bps="1.0",
+                imbalance="0.05",
+                bid_size="1000",
+                ask_size="1000",
+            ),
+            self._row(
+                offset=20,
+                price="100.01",
+                event_type="add",
+                trade_direction="sell",
+                spread_bps="1.1",
+                imbalance="0.00",
+                bid_size="1100",
+                ask_size="1050",
+            ),
+            self._row(
+                offset=45,
+                price="100.00",
+                event_type="trade",
+                trade_direction="sell",
+                spread_bps="1.0",
+                imbalance="-0.04",
+                bid_size="1080",
+                ask_size="1060",
+            ),
+            self._row(
+                offset=90,
+                price="100.01",
+                event_type="cancel",
+                trade_direction="buy",
+                spread_bps="1.0",
+                imbalance="0.02",
+                bid_size="1070",
+                ask_size="1080",
+            ),
+        ]
+        toxic_rows = [
+            self._row(
+                offset=0,
+                price="100.00",
+                event_type="trade",
+                trade_direction="buy",
+                spread_bps="9.0",
+                imbalance="0.45",
+                bid_size="1200",
+                ask_size="1000",
+                trade_size="600",
+            ),
+            self._row(
+                offset=2,
+                price="100.06",
+                event_type="trade",
+                trade_direction="buy",
+                spread_bps="9.5",
+                imbalance="0.50",
+                bid_size="1250",
+                ask_size="520",
+                trade_size="650",
+            ),
+            self._row(
+                offset=4,
+                price="100.14",
+                event_type="trade",
+                trade_direction="buy",
+                spread_bps="10.0",
+                imbalance="0.55",
+                bid_size="1300",
+                ask_size="300",
+                trade_size="700",
+            ),
+            self._row(
+                offset=6,
+                price="100.22",
+                event_type="trade",
+                trade_direction="buy",
+                spread_bps="11.0",
+                imbalance="0.58",
+                bid_size="1350",
+                ask_size="180",
+                trade_size="750",
+            ),
+        ]
+
+        balanced = extract_metaorder_adverse_selection_stress(
+            balanced_rows,
+            direction=1,
+        ).to_payload()
+        toxic = extract_metaorder_adverse_selection_stress(
+            toxic_rows,
+            direction=1,
+        ).to_payload()
+
+        self.assertEqual(
+            toxic["status"],
+            "preview_only_metaorder_adverse_selection_stress_ranking",
+        )
+        self.assertGreater(
+            toxic["ranking_features"]["replay_rank_penalty_bps"],
+            balanced["ranking_features"]["replay_rank_penalty_bps"],
+        )
+        self.assertGreater(toxic["ranking_features"]["metaorder_footprint_share"], 0)
+        self.assertGreater(
+            toxic["ranking_features"]["adverse_selection_alignment_share"],
+            0,
+        )
+        self.assertGreater(
+            toxic["ranking_features"]["liquidity_replenishment_gap_share"],
+            0,
+        )
+        self.assertIn(
+            "arxiv-2510.27334",
+            {source["source_id"] for source in toxic["source_papers"]},
+        )
+        self.assertIn(
+            "doi-10.1007/s10203-026-00570-z",
+            {source["source_id"] for source in toxic["source_papers"]},
+        )
+        self.assertFalse(toxic["promotion_proof"])
+        self.assertFalse(toxic["promotion_authority"])
+
+    def test_missing_inputs_fail_closed_and_contract_preserves_authority(self) -> None:
+        payload = extract_metaorder_adverse_selection_stress(
+            (
+                SignalEnvelope(
+                    event_ts=datetime(2026, 4, 17, 14, 30, tzinfo=timezone.utc),
+                    symbol="META",
+                    timeframe="1Min",
+                    seq=1,
+                    source="missing-metaorder-inputs",
+                    payload={"price": Decimal("100")},
+                    ingest_ts=datetime(2026, 4, 17, 14, 31, tzinfo=timezone.utc),
+                ),
+            )
+        ).to_payload()
+
+        self.assertGreater(payload["ranking_features"]["replay_rank_penalty_bps"], 0)
+        self.assertIn("missing_lob_event_type_evidence", payload["warnings"])
+        self.assertIn("missing_trade_direction_evidence", payload["warnings"])
+        self.assertIn("missing_price_path_for_adverse_drift", payload["warnings"])
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["final_promotion_allowed"])
+
+        contract = metaorder_adverse_selection_stress_contract()
+        neutrality = contract["proof_neutrality"]
+        self.assertFalse(neutrality["promotion_proof"])
+        self.assertTrue(neutrality["requires_exact_replay"])
+        self.assertTrue(neutrality["requires_route_tca"])
+        self.assertTrue(neutrality["requires_order_lifecycle_fill_evidence"])
+        self.assertTrue(neutrality["requires_runtime_ledger"])
+        self.assertTrue(neutrality["rejects_metaorder_footprint_as_pnl_authority"])
+        self.assertTrue(neutrality["rejects_hawkes_intensity_as_fill_authority"])


### PR DESCRIPTION
## Summary

- Adds `metaorder_adverse_selection_stress`, a deterministic replay-ranking feature that detects clustered aggressive flow, same-direction metaorder footprints, candidate-chasing drift, wide-spread toxic flow, and liquidity-replenishment gaps.
- Wires the stress into fast replay preview scoring, robust ranking, row payloads, manifest metadata, risk flags, ranking-only reasons, and veto metadata.
- Records 2025-2026 primary sources in executable payload metadata while preserving proof neutrality: no synthetic fills, no modeled PnL authority, no promotion gate relaxation, and no live capital.

## Related Issues

None

## Testing

- `cd services/torghut && uvx ruff format --check app/trading/discovery/metaorder_adverse_selection_stress.py app/trading/discovery/fast_replay.py tests/test_metaorder_adverse_selection_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/metaorder_adverse_selection_stress.py app/trading/discovery/fast_replay.py tests/test_metaorder_adverse_selection_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen pytest tests/test_metaorder_adverse_selection_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A — replay/candidate-ranking backend change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
