### PR TITLE
perf(torghut): batch tigerbeetle journal writes

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -119,6 +119,35 @@ def _result_status(result: object) -> str:
     return _normalize_result_status(getattr(result, "status", ""))
 
 
+def _result_index(result: object, fallback: int) -> int:
+    if isinstance(result, Mapping):
+        result_mapping = cast(Mapping[str, object], result)
+        raw_index = result_mapping.get("index")
+    else:
+        raw_index = getattr(result, "index", None)
+    if raw_index is None:
+        return fallback
+    try:
+        return raw_index if isinstance(raw_index, int) else int(str(raw_index))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"tigerbeetle_result_index_invalid:{raw_index}") from exc
+
+
+def _result_statuses_by_index(
+    results: Sequence[object],
+    *,
+    count: int,
+    default_status: str,
+) -> dict[int, str]:
+    statuses = {index: default_status for index in range(count)}
+    for fallback_index, result in enumerate(results):
+        index = _result_index(result, fallback_index)
+        if index < 0 or index >= count:
+            raise RuntimeError(f"tigerbeetle_result_index_out_of_range:{index}")
+        statuses[index] = _result_status(result)
+    return statuses
+
+
 def _transfer_attr(transfer: object, name: str) -> Any:
     if isinstance(transfer, Mapping):
         transfer_mapping = cast(Mapping[str, Any], transfer)
@@ -585,6 +614,21 @@ class TigerBeetleSourceTransferPlan:
     account_specs: tuple[TigerBeetleAccountSpec, ...]
     transfer_spec: TigerBeetleTransferSpec
     amount_source: Decimal
+
+
+@dataclass(frozen=True)
+class _PreparedTigerBeetleTransferWrite:
+    account_specs: tuple[TigerBeetleAccountSpec, ...]
+    transfer_spec: TigerBeetleTransferSpec
+    trade_decision_id: object | None
+    execution_id: object | None
+    execution_order_event_id: object | None
+    execution_tca_metric_id: object | None
+    runtime_ledger_bucket_id: object | None
+    event_fingerprint: str | None
+    source_type: str
+    source_id: str
+    payload_json: Mapping[str, object]
 
 
 def _submitted_pending_key(event: ExecutionOrderEvent) -> str:
@@ -1079,6 +1123,30 @@ def _persist_account_refs(
                 raise RuntimeError("tigerbeetle_account_ref_conflict") from None
 
 
+def _dedupe_account_specs(
+    account_specs: Sequence[TigerBeetleAccountSpec],
+) -> list[TigerBeetleAccountSpec]:
+    by_key: dict[str, TigerBeetleAccountSpec] = {}
+    by_id: dict[str, TigerBeetleAccountSpec] = {}
+    ordered: list[TigerBeetleAccountSpec] = []
+    for spec in account_specs:
+        account_id = u128_decimal(spec.account_id)
+        existing = by_key.get(spec.account_key) or by_id.get(account_id)
+        if existing is not None:
+            if (
+                existing.account_id != spec.account_id
+                or existing.account_key != spec.account_key
+                or existing.ledger != spec.ledger
+                or existing.code != spec.code
+            ):
+                raise RuntimeError("tigerbeetle_account_spec_conflict")
+            continue
+        by_key[spec.account_key] = spec
+        by_id[account_id] = spec
+        ordered.append(spec)
+    return ordered
+
+
 def _transfer_matches(
     actual: object,
     expected: TigerBeetleTransferSpec,
@@ -1397,6 +1465,180 @@ class TigerBeetleLedgerJournal:
             close()
         self._client = None
 
+    def _payload_with_stable_ref(
+        self,
+        prepared: _PreparedTigerBeetleTransferWrite,
+    ) -> dict[str, object]:
+        cluster_id = self._settings.tigerbeetle_cluster_id
+        return {
+            **prepared.payload_json,
+            **tigerbeetle_stable_ref_payload(
+                cluster_id=cluster_id,
+                account_specs=prepared.account_specs,
+                transfer_spec=prepared.transfer_spec,
+                source_type=prepared.source_type,
+                source_id=prepared.source_id,
+                payload_json=prepared.payload_json,
+                event_fingerprint=prepared.event_fingerprint,
+            ),
+        }
+
+    def _persist_written_transfer_ref(
+        self,
+        session: Session,
+        *,
+        prepared: _PreparedTigerBeetleTransferWrite,
+        payload_json: Mapping[str, object],
+        status: str,
+    ) -> TigerBeetleTransferRef:
+        cluster_id = self._settings.tigerbeetle_cluster_id
+        transfer_spec = prepared.transfer_spec
+        transfer_id_text = u128_decimal(transfer_spec.transfer_id)
+        ref = TigerBeetleTransferRef(
+            cluster_id=cluster_id,
+            transfer_id=transfer_id_text,
+            transfer_kind=transfer_spec.transfer_kind,
+            ledger=transfer_spec.ledger,
+            code=transfer_spec.code,
+            amount=Decimal(transfer_spec.amount),
+            status=status,
+            result_code=status,
+            trade_decision_id=cast(Any, prepared.trade_decision_id),
+            execution_id=cast(Any, prepared.execution_id),
+            execution_order_event_id=cast(Any, prepared.execution_order_event_id),
+            execution_tca_metric_id=cast(Any, prepared.execution_tca_metric_id),
+            runtime_ledger_bucket_id=cast(Any, prepared.runtime_ledger_bucket_id),
+            source_type=prepared.source_type,
+            source_id=prepared.source_id,
+            event_fingerprint=prepared.event_fingerprint,
+            payload_json=coerce_json_payload(payload_json),
+        )
+        try:
+            with session.begin_nested():
+                session.add(ref)
+                session.flush()
+        except IntegrityError:
+            existing = _find_transfer_ref(
+                session,
+                cluster_id=cluster_id,
+                transfer_id_text=transfer_id_text,
+                source_type=prepared.source_type,
+                source_id=prepared.source_id,
+                transfer_kind=transfer_spec.transfer_kind,
+            )
+            if existing is None:
+                raise
+            return _merge_existing_transfer_ref(
+                session,
+                existing,
+                transfer_spec=transfer_spec,
+                trade_decision_id=prepared.trade_decision_id,
+                execution_id=prepared.execution_id,
+                execution_order_event_id=prepared.execution_order_event_id,
+                execution_tca_metric_id=prepared.execution_tca_metric_id,
+                runtime_ledger_bucket_id=prepared.runtime_ledger_bucket_id,
+                event_fingerprint=prepared.event_fingerprint,
+                source_type=prepared.source_type,
+                source_id=prepared.source_id,
+                payload_json=payload_json,
+            )
+        return ref
+
+    def _persist_transfer_batch(
+        self,
+        session: Session,
+        prepared_writes: Sequence[_PreparedTigerBeetleTransferWrite],
+    ) -> list[TigerBeetleTransferRef]:
+        cluster_id = self._settings.tigerbeetle_cluster_id
+        refs: list[TigerBeetleTransferRef | None] = [None] * len(prepared_writes)
+        new_writes: list[
+            tuple[int, _PreparedTigerBeetleTransferWrite, dict[str, object]]
+        ] = []
+
+        for index, prepared in enumerate(prepared_writes):
+            transfer_spec = prepared.transfer_spec
+            transfer_id_text = u128_decimal(transfer_spec.transfer_id)
+            payload_json = self._payload_with_stable_ref(prepared)
+            existing = _find_transfer_ref(
+                session,
+                cluster_id=cluster_id,
+                transfer_id_text=transfer_id_text,
+                source_type=prepared.source_type,
+                source_id=prepared.source_id,
+                transfer_kind=transfer_spec.transfer_kind,
+            )
+            if existing is not None:
+                refs[index] = _merge_existing_transfer_ref(
+                    session,
+                    existing,
+                    transfer_spec=transfer_spec,
+                    trade_decision_id=prepared.trade_decision_id,
+                    execution_id=prepared.execution_id,
+                    execution_order_event_id=prepared.execution_order_event_id,
+                    execution_tca_metric_id=prepared.execution_tca_metric_id,
+                    runtime_ledger_bucket_id=prepared.runtime_ledger_bucket_id,
+                    event_fingerprint=prepared.event_fingerprint,
+                    source_type=prepared.source_type,
+                    source_id=prepared.source_id,
+                    payload_json=payload_json,
+                )
+                continue
+            new_writes.append((index, prepared, payload_json))
+
+        if not new_writes:
+            return [cast(TigerBeetleTransferRef, ref) for ref in refs]
+
+        account_specs = _dedupe_account_specs(
+            [spec for _, prepared, _ in new_writes for spec in prepared.account_specs]
+        )
+        _persist_account_refs(
+            session,
+            cluster_id=cluster_id,
+            account_specs=account_specs,
+        )
+        client = self._client_for_write()
+        account_statuses = _result_statuses_by_index(
+            client.create_accounts(account_specs),
+            count=len(account_specs),
+            default_status="created",
+        )
+        for index, status in account_statuses.items():
+            if status not in {"created", "exists"}:
+                account_id = u128_decimal(account_specs[index].account_id)
+                raise RuntimeError(
+                    f"tigerbeetle_create_account_failed:{account_id}:{status}"
+                )
+
+        transfer_specs = [prepared.transfer_spec for _, prepared, _ in new_writes]
+        transfer_statuses = _result_statuses_by_index(
+            client.create_transfers(transfer_specs),
+            count=len(transfer_specs),
+            default_status="created",
+        )
+        for batch_index, (original_index, prepared, payload_json) in enumerate(
+            new_writes
+        ):
+            transfer_spec = prepared.transfer_spec
+            status = transfer_statuses[batch_index]
+            if status not in {"created", "exists"}:
+                raise RuntimeError(f"tigerbeetle_create_transfer_failed:{status}")
+            if status == "exists":
+                matches = [
+                    item
+                    for item in client.lookup_transfers([transfer_spec.transfer_id])
+                    if _transfer_matches(item, transfer_spec)
+                ]
+                if not matches:
+                    raise RuntimeError("tigerbeetle_duplicate_transfer_conflict")
+            refs[original_index] = self._persist_written_transfer_ref(
+                session,
+                prepared=prepared,
+                payload_json=payload_json,
+                status=status,
+            )
+
+        return [cast(TigerBeetleTransferRef, ref) for ref in refs]
+
     def _persist_transfer(
         self,
         session: Session,
@@ -1413,113 +1655,24 @@ class TigerBeetleLedgerJournal:
         source_id: str,
         payload_json: Mapping[str, object],
     ) -> TigerBeetleTransferRef:
-        cluster_id = self._settings.tigerbeetle_cluster_id
-        transfer_id_text = u128_decimal(transfer_spec.transfer_id)
-        payload_json = {
-            **payload_json,
-            **tigerbeetle_stable_ref_payload(
-                cluster_id=cluster_id,
-                account_specs=account_specs,
-                transfer_spec=transfer_spec,
-                source_type=source_type,
-                source_id=source_id,
-                payload_json=payload_json,
-                event_fingerprint=event_fingerprint,
-            ),
-        }
-        existing = _find_transfer_ref(
+        return self._persist_transfer_batch(
             session,
-            cluster_id=cluster_id,
-            transfer_id_text=transfer_id_text,
-            source_type=source_type,
-            source_id=source_id,
-            transfer_kind=transfer_spec.transfer_kind,
-        )
-        if existing is not None:
-            return _merge_existing_transfer_ref(
-                session,
-                existing,
-                transfer_spec=transfer_spec,
-                trade_decision_id=trade_decision_id,
-                execution_id=execution_id,
-                execution_order_event_id=execution_order_event_id,
-                execution_tca_metric_id=execution_tca_metric_id,
-                runtime_ledger_bucket_id=runtime_ledger_bucket_id,
-                event_fingerprint=event_fingerprint,
-                source_type=source_type,
-                source_id=source_id,
-                payload_json=payload_json,
-            )
-
-        _persist_account_refs(
-            session,
-            cluster_id=cluster_id,
-            account_specs=account_specs,
-        )
-        client = self._client_for_write()
-        client.create_accounts(account_specs)
-        transfer_results = client.create_transfers([transfer_spec])
-        status = _result_status(transfer_results[0]) if transfer_results else "created"
-        if status not in {"created", "exists"}:
-            raise RuntimeError(f"tigerbeetle_create_transfer_failed:{status}")
-        if status == "exists":
-            matches = [
-                item
-                for item in client.lookup_transfers([transfer_spec.transfer_id])
-                if _transfer_matches(item, transfer_spec)
-            ]
-            if not matches:
-                raise RuntimeError("tigerbeetle_duplicate_transfer_conflict")
-
-        ref = TigerBeetleTransferRef(
-            cluster_id=cluster_id,
-            transfer_id=transfer_id_text,
-            transfer_kind=transfer_spec.transfer_kind,
-            ledger=transfer_spec.ledger,
-            code=transfer_spec.code,
-            amount=Decimal(transfer_spec.amount),
-            status=status,
-            result_code=status,
-            trade_decision_id=trade_decision_id,
-            execution_id=execution_id,
-            execution_order_event_id=execution_order_event_id,
-            execution_tca_metric_id=execution_tca_metric_id,
-            runtime_ledger_bucket_id=runtime_ledger_bucket_id,
-            source_type=source_type,
-            source_id=source_id,
-            event_fingerprint=event_fingerprint,
-            payload_json=coerce_json_payload(payload_json),
-        )
-        try:
-            with session.begin_nested():
-                session.add(ref)
-                session.flush()
-        except IntegrityError:
-            existing = _find_transfer_ref(
-                session,
-                cluster_id=cluster_id,
-                transfer_id_text=transfer_id_text,
-                source_type=source_type,
-                source_id=source_id,
-                transfer_kind=transfer_spec.transfer_kind,
-            )
-            if existing is None:
-                raise
-            return _merge_existing_transfer_ref(
-                session,
-                existing,
-                transfer_spec=transfer_spec,
-                trade_decision_id=trade_decision_id,
-                execution_id=execution_id,
-                execution_order_event_id=execution_order_event_id,
-                execution_tca_metric_id=execution_tca_metric_id,
-                runtime_ledger_bucket_id=runtime_ledger_bucket_id,
-                event_fingerprint=event_fingerprint,
-                source_type=source_type,
-                source_id=source_id,
-                payload_json=payload_json,
-            )
-        return ref
+            [
+                _PreparedTigerBeetleTransferWrite(
+                    account_specs=tuple(account_specs),
+                    transfer_spec=transfer_spec,
+                    trade_decision_id=trade_decision_id,
+                    execution_id=execution_id,
+                    execution_order_event_id=execution_order_event_id,
+                    execution_tca_metric_id=execution_tca_metric_id,
+                    runtime_ledger_bucket_id=runtime_ledger_bucket_id,
+                    event_fingerprint=event_fingerprint,
+                    source_type=source_type,
+                    source_id=source_id,
+                    payload_json=payload_json,
+                )
+            ],
+        )[0]
 
     def backfill_stable_ref_payloads(
         self,
@@ -1590,6 +1743,271 @@ class TigerBeetleLedgerJournal:
         if updated:
             session.flush()
         return {"selected": len(refs), "updated": updated, "skipped": skipped}
+
+    def journal_order_events(
+        self,
+        session: Session,
+        events: Sequence[ExecutionOrderEvent],
+    ) -> list[TigerBeetleTransferRef | None]:
+        if (
+            not self._settings.tigerbeetle_enabled
+            or not self._settings.tigerbeetle_journal_enabled
+        ):
+            return [None for _ in events]
+
+        indexes: list[int] = []
+        prepared: list[_PreparedTigerBeetleTransferWrite] = []
+        refs: list[TigerBeetleTransferRef | None] = [None for _ in events]
+        for index, event in enumerate(events):
+            plan = build_order_event_transfer_plan(
+                session,
+                event,
+                settings_obj=self._settings,
+            )
+            if plan is None:
+                continue
+            transfer_spec = plan.transfer_spec
+            indexes.append(index)
+            prepared.append(
+                _PreparedTigerBeetleTransferWrite(
+                    account_specs=plan.account_specs,
+                    transfer_spec=transfer_spec,
+                    trade_decision_id=event.trade_decision_id,
+                    execution_id=event.execution_id,
+                    execution_order_event_id=event.id,
+                    execution_tca_metric_id=None,
+                    runtime_ledger_bucket_id=None,
+                    event_fingerprint=event.event_fingerprint,
+                    source_type=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                    source_id=str(event.id),
+                    payload_json={
+                        "debit_account_id": u128_decimal(
+                            transfer_spec.debit_account_id
+                        ),
+                        "credit_account_id": u128_decimal(
+                            transfer_spec.credit_account_id
+                        ),
+                        "pending_id": u128_decimal(transfer_spec.pending_id)
+                        if transfer_spec.pending_id
+                        else None,
+                        "pending_mode": plan.pending_mode,
+                        "source": SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                    },
+                )
+            )
+        for index, ref in zip(indexes, self._persist_transfer_batch(session, prepared)):
+            refs[index] = ref
+        return refs
+
+    def journal_executions(
+        self,
+        session: Session,
+        executions: Sequence[Execution],
+    ) -> list[TigerBeetleTransferRef | None]:
+        if (
+            not self._settings.tigerbeetle_enabled
+            or not self._settings.tigerbeetle_journal_enabled
+        ):
+            return [None for _ in executions]
+
+        indexes: list[int] = []
+        prepared: list[_PreparedTigerBeetleTransferWrite] = []
+        refs: list[TigerBeetleTransferRef | None] = [None for _ in executions]
+        for index, execution in enumerate(executions):
+            plan = build_execution_transfer_plan(execution)
+            if plan is None:
+                continue
+            transfer_spec = plan.transfer_spec
+            indexes.append(index)
+            prepared.append(
+                _PreparedTigerBeetleTransferWrite(
+                    account_specs=plan.account_specs,
+                    transfer_spec=transfer_spec,
+                    trade_decision_id=execution.trade_decision_id,
+                    execution_id=execution.id,
+                    execution_order_event_id=None,
+                    execution_tca_metric_id=None,
+                    runtime_ledger_bucket_id=None,
+                    event_fingerprint=None,
+                    source_type=SOURCE_TYPE_EXECUTION,
+                    source_id=str(execution.id),
+                    payload_json={
+                        "source": SOURCE_TYPE_EXECUTION,
+                        "source_refs": [
+                            f"postgres:executions:{execution.id}",
+                        ],
+                        "source_row_id": str(execution.id),
+                        "source_economic_fingerprint": execution_source_id(
+                            execution
+                        ).split(":", 1)[1],
+                        "economic_event_key": execution_economic_event_key(execution),
+                        "alpaca_order_id": execution.alpaca_order_id,
+                        "client_order_id": execution.client_order_id,
+                        "filled_qty": str(execution.filled_qty),
+                        "avg_fill_price": str(execution.avg_fill_price),
+                        "amount_source": str(plan.amount_source),
+                        "notional_micros": transfer_spec.amount,
+                        "transfer_id": u128_decimal(transfer_spec.transfer_id),
+                        "ledger": transfer_spec.ledger,
+                        "code": transfer_spec.code,
+                        "debit_account_id": u128_decimal(
+                            transfer_spec.debit_account_id
+                        ),
+                        "credit_account_id": u128_decimal(
+                            transfer_spec.credit_account_id
+                        ),
+                    },
+                )
+            )
+        for index, ref in zip(indexes, self._persist_transfer_batch(session, prepared)):
+            refs[index] = ref
+        return refs
+
+    def journal_execution_tca_metrics(
+        self,
+        session: Session,
+        metrics: Sequence[ExecutionTCAMetric],
+    ) -> list[TigerBeetleTransferRef | None]:
+        if (
+            not self._settings.tigerbeetle_enabled
+            or not self._settings.tigerbeetle_journal_enabled
+        ):
+            return [None for _ in metrics]
+
+        indexes: list[int] = []
+        prepared: list[_PreparedTigerBeetleTransferWrite] = []
+        refs: list[TigerBeetleTransferRef | None] = [None for _ in metrics]
+        for index, metric in enumerate(metrics):
+            plan = build_execution_tca_metric_transfer_plan(metric)
+            if plan is None:
+                continue
+            transfer_spec = plan.transfer_spec
+            indexes.append(index)
+            prepared.append(
+                _PreparedTigerBeetleTransferWrite(
+                    account_specs=plan.account_specs,
+                    transfer_spec=transfer_spec,
+                    trade_decision_id=metric.trade_decision_id,
+                    execution_id=metric.execution_id,
+                    execution_order_event_id=None,
+                    execution_tca_metric_id=metric.id,
+                    runtime_ledger_bucket_id=None,
+                    event_fingerprint=None,
+                    source_type=SOURCE_TYPE_EXECUTION_TCA_METRIC,
+                    source_id=execution_tca_metric_source_id(metric),
+                    payload_json={
+                        "source": SOURCE_TYPE_EXECUTION_TCA_METRIC,
+                        "source_refs": [
+                            f"postgres:execution_tca_metrics:{metric.id}",
+                            f"postgres:executions:{metric.execution_id}",
+                        ],
+                        "source_row_id": str(metric.id),
+                        "source_economic_fingerprint": (
+                            execution_tca_metric_source_id(metric).split(":", 1)[1]
+                        ),
+                        "economic_event_key": (
+                            execution_tca_metric_economic_event_key(metric)
+                        ),
+                        "shortfall_notional": str(metric.shortfall_notional),
+                        "realized_shortfall_bps": str(metric.realized_shortfall_bps),
+                        "simulator_version": metric.simulator_version,
+                        "amount_source": str(plan.amount_source),
+                        "cost_micros": transfer_spec.amount,
+                        "transfer_id": u128_decimal(transfer_spec.transfer_id),
+                        "ledger": transfer_spec.ledger,
+                        "code": transfer_spec.code,
+                        "debit_account_id": u128_decimal(
+                            transfer_spec.debit_account_id
+                        ),
+                        "credit_account_id": u128_decimal(
+                            transfer_spec.credit_account_id
+                        ),
+                        "account_ids": [
+                            u128_decimal(spec.account_id) for spec in plan.account_specs
+                        ],
+                        "account_keys": [
+                            spec.account_key for spec in plan.account_specs
+                        ],
+                        "authority": "accounting_parity_only",
+                        "promotion_authority": False,
+                        "overrides_runtime_ledger_authority": False,
+                    },
+                )
+            )
+        for index, ref in zip(indexes, self._persist_transfer_batch(session, prepared)):
+            refs[index] = ref
+        return refs
+
+    def journal_runtime_ledger_buckets(
+        self,
+        session: Session,
+        buckets: Sequence[StrategyRuntimeLedgerBucket],
+    ) -> list[TigerBeetleTransferRef | None]:
+        if (
+            not self._settings.tigerbeetle_enabled
+            or not self._settings.tigerbeetle_journal_enabled
+        ):
+            return [None for _ in buckets]
+
+        indexes: list[int] = []
+        prepared: list[_PreparedTigerBeetleTransferWrite] = []
+        refs: list[TigerBeetleTransferRef | None] = [None for _ in buckets]
+        for index, bucket in enumerate(buckets):
+            plan = build_runtime_ledger_bucket_transfer_plan(bucket)
+            if plan is None:
+                continue
+            transfer_spec = plan.transfer_spec
+            indexes.append(index)
+            prepared.append(
+                _PreparedTigerBeetleTransferWrite(
+                    account_specs=plan.account_specs,
+                    transfer_spec=transfer_spec,
+                    trade_decision_id=None,
+                    execution_id=None,
+                    execution_order_event_id=None,
+                    execution_tca_metric_id=None,
+                    runtime_ledger_bucket_id=bucket.id,
+                    event_fingerprint=None,
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id=str(bucket.id),
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "source_refs": [
+                            f"postgres:strategy_runtime_ledger_buckets:{bucket.id}",
+                        ],
+                        "source_row_id": str(bucket.id),
+                        "run_id": bucket.run_id,
+                        "candidate_id": bucket.candidate_id,
+                        "hypothesis_id": bucket.hypothesis_id,
+                        "observed_stage": bucket.observed_stage,
+                        "pnl_basis": bucket.pnl_basis,
+                        "ledger_schema_version": bucket.ledger_schema_version,
+                        "filled_notional": str(bucket.filled_notional),
+                        "gross_strategy_pnl": str(bucket.gross_strategy_pnl),
+                        "cost_amount": str(bucket.cost_amount),
+                        "net_strategy_pnl_after_costs": str(
+                            bucket.net_strategy_pnl_after_costs
+                        ),
+                        "amount_source": str(plan.amount_source),
+                        "amount_micros": transfer_spec.amount,
+                        "signed_amount_micros": plan.signed_amount_micros,
+                        "pnl_direction": plan.pnl_direction,
+                        "runtime_key": plan.runtime_key,
+                        "transfer_id": u128_decimal(transfer_spec.transfer_id),
+                        "ledger": transfer_spec.ledger,
+                        "code": transfer_spec.code,
+                        "debit_account_id": u128_decimal(
+                            transfer_spec.debit_account_id
+                        ),
+                        "credit_account_id": u128_decimal(
+                            transfer_spec.credit_account_id
+                        ),
+                    },
+                )
+            )
+        for index, ref in zip(indexes, self._persist_transfer_batch(session, prepared)):
+            refs[index] = ref
+        return refs
 
     def journal_order_event(
         self, session: Session, event: ExecutionOrderEvent

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -442,6 +442,7 @@ def _journal_source_batch(
     source: str,
     rows: list[Any],
     journal_one: Any,
+    journal_many: Any | None = None,
 ) -> dict[str, Any]:
     batch: dict[str, Any] = {
         "source": source,
@@ -460,6 +461,121 @@ def _journal_source_batch(
         source=source,
         selected=len(rows),
     )
+    if journal_many is not None and rows and not args.dry_run:
+        try:
+            with session.begin_nested():
+                refs = list(journal_many(rows))
+            if len(refs) != len(rows):
+                raise RuntimeError("tigerbeetle_journal_batch_result_count_mismatch")
+            for row, ref in zip(rows, refs):
+                if ref is None:
+                    batch["skipped"] = int(batch["skipped"]) + 1
+                    continue
+                if source == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET and isinstance(
+                    ref, TigerBeetleTransferRef
+                ):
+                    _attach_runtime_bucket_journal_payload(row, ref)
+                batch["journaled"] = int(batch["journaled"]) + 1
+        except Exception as exc:
+            if not isinstance(exc, TigerBeetleClientTimeoutError):
+                _emit_progress(
+                    "source_batch_fallback_row_by_row",
+                    source=source,
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
+                for row in rows:
+                    try:
+                        with session.begin_nested():
+                            ref = journal_one(row)
+                        if ref is None:
+                            batch["skipped"] = int(batch["skipped"]) + 1
+                        else:
+                            if (
+                                source == SOURCE_TYPE_RUNTIME_LEDGER_BUCKET
+                                and isinstance(ref, TigerBeetleTransferRef)
+                            ):
+                                _attach_runtime_bucket_journal_payload(row, ref)
+                            batch["journaled"] = int(batch["journaled"]) + 1
+                            if bool(getattr(args, "commit_each_row", False)):
+                                session.commit()
+                                _reset_session_identity_map(session)
+                    except Exception as row_exc:
+                        batch["failed"] = int(batch["failed"]) + 1
+                        error_counts = batch["error_counts"]
+                        if isinstance(error_counts, dict):
+                            error_key = _error_summary(row_exc)
+                            error_counts[error_key] = (
+                                int(error_counts.get(error_key, 0)) + 1
+                            )
+                        sample_errors = batch["sample_errors"]
+                        if isinstance(sample_errors, list) and len(sample_errors) < 5:
+                            sample_errors.append(
+                                {
+                                    "row_id": str(getattr(row, "id", "unknown")),
+                                    "error_type": type(row_exc).__name__,
+                                    "error": str(row_exc),
+                                }
+                            )
+                        if isinstance(row_exc, TigerBeetleClientTimeoutError):
+                            batch["stopped_early"] = True
+                            batch["stop_reason"] = "tigerbeetle_rpc_timeout"
+                            _emit_progress(
+                                "source_batch_stopped",
+                                source=source,
+                                reason=batch["stop_reason"],
+                                failed=batch["failed"],
+                                journaled=batch["journaled"],
+                                skipped=batch["skipped"],
+                            )
+                            break
+                _emit_progress(
+                    "source_batch_complete",
+                    source=source,
+                    selected=batch["selected"],
+                    journaled=batch["journaled"],
+                    skipped=batch["skipped"],
+                    failed=batch["failed"],
+                    stopped_early=batch["stopped_early"],
+                    stop_reason=batch["stop_reason"],
+                )
+                return batch
+
+            batch["failed"] = int(batch["failed"]) + 1
+            error_counts = batch["error_counts"]
+            if isinstance(error_counts, dict):
+                error_key = _error_summary(exc)
+                error_counts[error_key] = int(error_counts.get(error_key, 0)) + 1
+            sample_errors = batch["sample_errors"]
+            if isinstance(sample_errors, list) and len(sample_errors) < 5:
+                sample_errors.append(
+                    {
+                        "row_id": "batch",
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    }
+                )
+            batch["stopped_early"] = True
+            batch["stop_reason"] = "tigerbeetle_rpc_timeout"
+            _emit_progress(
+                "source_batch_stopped",
+                source=source,
+                reason=batch["stop_reason"],
+                failed=batch["failed"],
+                journaled=batch["journaled"],
+                skipped=batch["skipped"],
+            )
+        _emit_progress(
+            "source_batch_complete",
+            source=source,
+            selected=batch["selected"],
+            journaled=batch["journaled"],
+            skipped=batch["skipped"],
+            failed=batch["failed"],
+            stopped_early=batch["stopped_early"],
+            stop_reason=batch["stop_reason"],
+        )
+        return batch
     for row in rows:
         if progress_interval == 1:
             _emit_progress(
@@ -1112,6 +1228,10 @@ def main() -> int:
                         session,
                         event,
                     ),
+                    journal_many=lambda rows: journal.journal_order_events(
+                        session,
+                        rows,
+                    ),
                 )
                 if events.scan_failed:
                     event_batch["failed"] = (
@@ -1137,6 +1257,10 @@ def main() -> int:
                         session,
                         execution,
                     ),
+                    journal_many=lambda rows: journal.journal_executions(
+                        session,
+                        rows,
+                    ),
                 )
                 batches.append(execution_batch)
                 batch_lengths.append(len(executions))
@@ -1160,6 +1284,10 @@ def main() -> int:
                         session,
                         metric,
                     ),
+                    journal_many=lambda rows: journal.journal_execution_tca_metrics(
+                        session,
+                        rows,
+                    ),
                 )
                 batches.append(tca_batch)
                 batch_lengths.append(len(tca_metrics))
@@ -1182,6 +1310,10 @@ def main() -> int:
                     journal_one=lambda bucket: journal.journal_runtime_ledger_bucket(
                         session,
                         bucket,
+                    ),
+                    journal_many=lambda rows: journal.journal_runtime_ledger_buckets(
+                        session,
+                        rows,
                     ),
                 )
                 batches.append(runtime_batch)

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from collections.abc import Sequence
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -182,12 +183,26 @@ class FakeJournal:
             )
         return SimpleNamespace(transfer_id="1")
 
+    def journal_order_events(
+        self,
+        session: Session,
+        events: Sequence[ExecutionOrderEvent],
+    ) -> list[object | None]:
+        return [self.journal_order_event(session, event) for event in events]
+
     def journal_execution(
         self, session: Session, execution: Execution
     ) -> object | None:
         del session
         self.executions.append(execution.alpaca_order_id)
         return SimpleNamespace(transfer_id="2")
+
+    def journal_executions(
+        self,
+        session: Session,
+        executions: Sequence[Execution],
+    ) -> list[object | None]:
+        return [self.journal_execution(session, execution) for execution in executions]
 
     def journal_execution_tca_metric(
         self,
@@ -198,6 +213,15 @@ class FakeJournal:
         self.tca_metrics.append(metric.symbol)
         return SimpleNamespace(transfer_id="3")
 
+    def journal_execution_tca_metrics(
+        self,
+        session: Session,
+        metrics: Sequence[ExecutionTCAMetric],
+    ) -> list[object | None]:
+        return [
+            self.journal_execution_tca_metric(session, metric) for metric in metrics
+        ]
+
     def journal_runtime_ledger_bucket(
         self,
         session: Session,
@@ -206,6 +230,15 @@ class FakeJournal:
         del session
         self.runtime_buckets.append(bucket.run_id)
         return SimpleNamespace(transfer_id="4")
+
+    def journal_runtime_ledger_buckets(
+        self,
+        session: Session,
+        buckets: Sequence[StrategyRuntimeLedgerBucket],
+    ) -> list[object | None]:
+        return [
+            self.journal_runtime_ledger_bucket(session, bucket) for bucket in buckets
+        ]
 
     def client_for_reconciliation(self) -> object:
         return self.reconciliation_client
@@ -226,6 +259,70 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         FakeJournal.instances = []
         self.engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
         Base.metadata.create_all(self.engine)
+
+    def _add_runtime_bucket_with_ref(
+        self,
+        session: Session,
+        *,
+        run_id: str,
+    ) -> tuple[StrategyRuntimeLedgerBucket, TigerBeetleTransferRef]:
+        settings_obj = Settings(
+            TORGHUT_TIGERBEETLE_ENABLED=True,
+            TORGHUT_TIGERBEETLE_JOURNAL_ENABLED=True,
+        )
+        observed_at = datetime.now(timezone.utc)
+        bucket = StrategyRuntimeLedgerBucket(
+            run_id=run_id,
+            candidate_id="candidate",
+            hypothesis_id="hypothesis",
+            observed_stage="paper",
+            bucket_started_at=observed_at,
+            bucket_ended_at=observed_at,
+            account_label="paper",
+            runtime_strategy_name="demo-runtime",
+            strategy_family="demo",
+            fill_count=1,
+            decision_count=1,
+            submitted_order_count=1,
+            cancelled_order_count=0,
+            rejected_order_count=0,
+            unfilled_order_count=0,
+            closed_trade_count=1,
+            open_position_count=0,
+            filled_notional=Decimal("190.25"),
+            gross_strategy_pnl=Decimal("3.00"),
+            cost_amount=Decimal("0.50"),
+            net_strategy_pnl_after_costs=Decimal("2.50"),
+            post_cost_expectancy_bps=Decimal("12.50"),
+            ledger_schema_version="torghut.runtime-ledger.v1",
+            pnl_basis="post_cost",
+            payload_json={
+                "source_refs": ["postgres:execution_order_events:event-1"],
+                "source_row_counts": {"execution_order_events": 1},
+                "source_window_refs": ["kafka:torghut.trade-updates.v1:0:1-2"],
+            },
+        )
+        session.add(bucket)
+        session.flush()
+        ref = TigerBeetleTransferRef(
+            cluster_id=settings_obj.tigerbeetle_cluster_id,
+            transfer_id=str(340282366920938463463374607431768000 + int(bucket.id)),
+            transfer_kind=TRANSFER_KIND_RUNTIME_NET_PNL,
+            ledger=LEDGER_USD_MICRO,
+            code=TRANSFER_CODE_FILL_POST,
+            amount=Decimal("2500000"),
+            status="created",
+            runtime_ledger_bucket_id=bucket.id,
+            source_type=script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+            source_id=str(bucket.id),
+            payload_json={
+                "debit_account_id": "100100100100100100100100100100100101",
+                "credit_account_id": "100100100100100100100100100100100102",
+            },
+        )
+        session.add(ref)
+        session.flush()
+        return bucket, ref
 
     def test_sqlalchemy_dsn_normalizes_postgres_urls(self) -> None:
         self.assertEqual(
@@ -870,6 +967,94 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         )
         self.assertFalse(
             payload["tigerbeetle_journal_parity"]["promotion_authority"],
+        )
+
+    def test_source_batch_uses_batch_refs_for_runtime_attach_and_skips(self) -> None:
+        with Session(self.engine) as session:
+            bucket, ref = self._add_runtime_bucket_with_ref(
+                session,
+                run_id="runtime-run-batch-attach",
+            )
+            skipped = SimpleNamespace(id="skipped-runtime-row")
+
+            batch = script._journal_source_batch(
+                session,
+                args=argparse.Namespace(dry_run=False, progress_interval=0),
+                source=script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                rows=[bucket, skipped],
+                journal_one=lambda row: (_ for _ in ()).throw(
+                    AssertionError(f"unexpected row fallback: {row!r}")
+                ),
+                journal_many=lambda rows: [ref, None],
+            )
+
+        self.assertEqual(batch["journaled"], 1)
+        self.assertEqual(batch["skipped"], 1)
+        self.assertEqual(batch["failed"], 0)
+        payload = bucket.payload_json
+        self.assertIsInstance(payload, dict)
+        self.assertIn(
+            f"postgres:tigerbeetle_transfer_refs:{ref.id}",
+            payload["source_refs"],
+        )
+        self.assertEqual(
+            payload["tigerbeetle_transfer_ids"],
+            [ref.transfer_id],
+        )
+
+    def test_source_batch_falls_back_from_count_mismatch_and_stops_on_timeout(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            bucket, ref = self._add_runtime_bucket_with_ref(
+                session,
+                run_id="runtime-run-fallback-attach",
+            )
+            bucket_id = bucket.id
+            ref_id = ref.id
+            timeout_row = SimpleNamespace(id="timeout-row")
+            seen: list[str] = []
+
+            def journal_one(row: object) -> object:
+                seen.append(str(getattr(row, "id", "unknown")))
+                if row is timeout_row:
+                    raise TigerBeetleClientTimeoutError(
+                        "tigerbeetle_create_transfers_timeout:10.000s"
+                    )
+                return ref
+
+            batch = script._journal_source_batch(
+                session,
+                args=argparse.Namespace(
+                    dry_run=False,
+                    progress_interval=0,
+                    commit_each_row=True,
+                ),
+                source=script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                rows=[bucket, timeout_row],
+                journal_one=journal_one,
+                journal_many=lambda rows: [],
+            )
+            persisted_bucket = session.get(StrategyRuntimeLedgerBucket, bucket_id)
+            self.assertIsNotNone(persisted_bucket)
+            assert persisted_bucket is not None
+            payload = persisted_bucket.payload_json
+
+        self.assertEqual(seen, [str(bucket_id), "timeout-row"])
+        self.assertEqual(batch["journaled"], 1)
+        self.assertEqual(batch["failed"], 1)
+        self.assertTrue(batch["stopped_early"])
+        self.assertEqual(batch["stop_reason"], "tigerbeetle_rpc_timeout")
+        self.assertEqual(
+            batch["error_counts"],
+            {
+                "TigerBeetleClientTimeoutError:tigerbeetle_create_transfers_timeout:10.000s": 1
+            },
+        )
+        self.assertIsInstance(payload, dict)
+        self.assertIn(
+            f"postgres:tigerbeetle_transfer_refs:{ref_id}",
+            payload["source_refs"],
         )
 
     def test_runtime_bucket_journal_materializes_signed_ref_and_is_idempotent(

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -33,12 +33,15 @@ from app.trading.tigerbeetle_journal import (
     TIGERBEETLE_RUNTIME_LEDGER_JOURNAL_STATUS_PASS,
     TigerBeetleLedgerJournal,
     _account_specs,
+    _dedupe_account_specs,
     _event_amount_usd,
     _lookup_payload_decimal,
     _order_event_precedes,
     _persist_account_refs,
     _positive_payload_count,
+    _result_index,
     _result_status,
+    _result_statuses_by_index,
     _transfer_attr,
     _transfer_flag,
     _transfer_ref_mismatches,
@@ -82,6 +85,26 @@ class NumericExistsFakeTigerBeetleClient(FakeTigerBeetleClient):
     def create_transfers(self, transfers: Sequence[object]) -> list[SimpleNamespace]:
         del transfers
         return [SimpleNamespace(status=46)]
+
+
+class AccountFailureFakeTigerBeetleClient(FakeTigerBeetleClient):
+    def create_accounts(self, accounts: Sequence[object]) -> Sequence[object]:
+        return [{"index": 0, "status": "linked_event_failed"} for _ in accounts[:1]]
+
+
+class BatchCountingFakeTigerBeetleClient(FakeTigerBeetleClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.account_call_sizes: list[int] = []
+        self.transfer_call_sizes: list[int] = []
+
+    def create_accounts(self, accounts: Sequence[object]) -> Sequence[object]:
+        self.account_call_sizes.append(len(accounts))
+        return super().create_accounts(accounts)
+
+    def create_transfers(self, transfers: Sequence[object]) -> Sequence[object]:
+        self.transfer_call_sizes.append(len(transfers))
+        return super().create_transfers(transfers)
 
 
 class _ScalarResult:
@@ -312,9 +335,31 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertIsNone(disabled.journal_execution(session, execution))
             self.assertIsNone(disabled.journal_execution_tca_metric(session, metric))
             self.assertIsNone(disabled.journal_runtime_ledger_bucket(session, bucket))
+            self.assertEqual(disabled.journal_order_events(session, [event]), [None])
+            self.assertEqual(disabled.journal_executions(session, [execution]), [None])
+            self.assertEqual(
+                disabled.journal_execution_tca_metrics(session, [metric]),
+                [None],
+            )
+            self.assertEqual(
+                disabled.journal_runtime_ledger_buckets(session, [bucket]),
+                [None],
+            )
 
             enabled = TigerBeetleLedgerJournal(settings_obj=_settings(), client=client)
+            event.avg_fill_price = None
+            event.filled_qty = None
             execution.avg_fill_price = None
+            self.assertEqual(enabled.journal_order_events(session, [event]), [None])
+            self.assertEqual(enabled.journal_executions(session, [execution]), [None])
+            self.assertEqual(
+                enabled.journal_execution_tca_metrics(session, [metric]),
+                [None],
+            )
+            self.assertEqual(
+                enabled.journal_runtime_ledger_buckets(session, [bucket]),
+                [None],
+            )
             self.assertIsNone(enabled.journal_execution(session, execution))
             self.assertIsNone(enabled.journal_execution_tca_metric(session, metric))
             self.assertIsNone(enabled.journal_runtime_ledger_bucket(session, bucket))
@@ -579,6 +624,113 @@ class TestTigerBeetleLedgerJournal(TestCase):
             refs = session.execute(select(TigerBeetleTransferRef)).scalars().all()
             self.assertEqual(len(refs), 1)
             self.assertEqual(len(client.transfers), 1)
+
+    def test_cost_source_batch_uses_single_native_transfer_request(self) -> None:
+        with Session(self.engine) as session:
+            metrics: list[ExecutionTCAMetric] = []
+            for index in range(3):
+                event = _create_fill_event(
+                    session,
+                    fingerprint=f"fingerprint-cost-batch-{index}",
+                )
+                metric = ExecutionTCAMetric(
+                    execution_id=event.execution_id,
+                    trade_decision_id=event.trade_decision_id,
+                    strategy_id=event.trade_decision.strategy_id
+                    if event.trade_decision
+                    else None,
+                    alpaca_account_label="paper",
+                    symbol="AAPL",
+                    side="buy",
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("1"),
+                    shortfall_notional=Decimal("0.25"),
+                    realized_shortfall_bps=Decimal("1.3"),
+                    computed_at=datetime.now(timezone.utc),
+                )
+                session.add(metric)
+                session.flush()
+                metrics.append(metric)
+            client = BatchCountingFakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            refs = journal.journal_execution_tca_metrics(session, metrics)
+            second_refs = journal.journal_execution_tca_metrics(session, metrics)
+
+            self.assertEqual(len([ref for ref in refs if ref is not None]), 3)
+            self.assertEqual(len([ref for ref in second_refs if ref is not None]), 3)
+            self.assertEqual(client.transfer_call_sizes, [3])
+            self.assertEqual(len(client.account_call_sizes), 1)
+            self.assertGreater(client.account_call_sizes[0], 0)
+            self.assertEqual(len(client.transfers), 3)
+            persisted = session.execute(select(TigerBeetleTransferRef)).scalars().all()
+            self.assertEqual(len(persisted), 3)
+
+    def test_source_batches_cover_order_execution_and_runtime_paths(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(session, fingerprint="fingerprint-source-batch")
+            execution = event.execution
+            self.assertIsNotNone(execution)
+            assert execution is not None
+            bucket = _runtime_bucket()
+            session.add(bucket)
+            session.flush()
+            client = BatchCountingFakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            order_refs = journal.journal_order_events(session, [event])
+            execution_refs = journal.journal_executions(session, [execution])
+            runtime_refs = journal.journal_runtime_ledger_buckets(session, [bucket])
+
+            self.assertEqual(len([ref for ref in order_refs if ref is not None]), 1)
+            self.assertEqual(len([ref for ref in execution_refs if ref is not None]), 1)
+            self.assertEqual(len([ref for ref in runtime_refs if ref is not None]), 1)
+            self.assertEqual(client.transfer_call_sizes, [1, 1, 1])
+            runtime_ref = runtime_refs[0]
+            self.assertIsNotNone(runtime_ref)
+            assert runtime_ref is not None
+            self.assertEqual(
+                runtime_ref.payload_json["source_refs"],
+                [f"postgres:strategy_runtime_ledger_buckets:{bucket.id}"],
+            )
+            self.assertIn("runtime-run-1", runtime_ref.payload_json["runtime_key"])
+
+    def test_batch_account_failures_are_reported_with_account_id(self) -> None:
+        with Session(self.engine) as session:
+            event = _create_fill_event(session, fingerprint="fingerprint-account-fail")
+            metric = ExecutionTCAMetric(
+                execution_id=event.execution_id,
+                trade_decision_id=event.trade_decision_id,
+                strategy_id=event.trade_decision.strategy_id
+                if event.trade_decision
+                else None,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("1"),
+                signed_qty=Decimal("1"),
+                shortfall_notional=Decimal("0.25"),
+                realized_shortfall_bps=Decimal("1.3"),
+                computed_at=datetime.now(timezone.utc),
+            )
+            session.add(metric)
+            session.flush()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=AccountFailureFakeTigerBeetleClient(),
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "tigerbeetle_create_account_failed:.*:linked_event_failed",
+            ):
+                journal.journal_execution_tca_metrics(session, [metric])
 
     def test_cost_source_changed_economics_create_distinct_revision_ref(
         self,
@@ -1240,11 +1392,61 @@ class TestTigerBeetleLedgerJournal(TestCase):
         ):
             self.assertEqual(_result_status(SimpleNamespace(status=46)), "exists")
             self.assertEqual(_result_status(SimpleNamespace(status=1)), "1")
+        self.assertEqual(_result_index({"index": "2"}, 0), 2)
+        self.assertEqual(
+            _result_statuses_by_index(
+                [{"index": "1", "status": "exists"}],
+                count=3,
+                default_status="created",
+            ),
+            {0: "created", 1: "exists", 2: "created"},
+        )
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "tigerbeetle_result_index_invalid:not-int",
+        ):
+            _result_index({"index": "not-int"}, 0)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "tigerbeetle_result_index_out_of_range:3",
+        ):
+            _result_statuses_by_index(
+                [{"index": 3, "status": "exists"}],
+                count=1,
+                default_status="created",
+            )
         self.assertEqual(_transfer_attr({"transfer_id": 123}, "id"), 123)
         self.assertEqual(_transfer_attr(SimpleNamespace(transfer_id=456), "id"), 456)
         with self.assertRaises(AttributeError):
             _transfer_attr(object(), "id")
         self.assertIsNone(_lookup_payload_decimal({"amount": "bad"}, ("amount",)))
+        base_account = TigerBeetleAccountSpec(
+            account_id=101,
+            account_key="paper:AAPL:cash",
+            ledger=LEDGER_USD_MICRO,
+            code=1001,
+        )
+        duplicate_account = TigerBeetleAccountSpec(
+            account_id=101,
+            account_key="paper:AAPL:cash",
+            ledger=LEDGER_USD_MICRO,
+            code=1001,
+        )
+        self.assertEqual(
+            _dedupe_account_specs([base_account, duplicate_account]),
+            [base_account],
+        )
+        conflicting_account = TigerBeetleAccountSpec(
+            account_id=101,
+            account_key="paper:AAPL:cash",
+            ledger=LEDGER_USD_MICRO,
+            code=1002,
+        )
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "tigerbeetle_account_spec_conflict",
+        ):
+            _dedupe_account_specs([base_account, conflicting_account])
 
     def test_event_amount_uses_notional_and_payload_fallbacks(self) -> None:
         notional_event = ExecutionOrderEvent(


### PR DESCRIPTION
## Summary

- Adds batched TigerBeetle account and transfer writes for Torghut journal source batches while preserving existing deterministic transfer specs and stable ref payloads.
- Updates the scheduled journal runner to use batch entrypoints first, with row-by-row fallback only for non-timeout batch errors; TigerBeetle RPC timeouts still fail closed.
- Adds regression coverage proving TCA source batches use one native transfer request and keeps the existing cron/live manifest contract tests green.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/tigerbeetle_journal.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen pytest tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim`
- `uv run --frozen ruff check app/trading/tigerbeetle_journal.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
