### PR TITLE
chore(torghut): promote image 93cccb0e

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.595.0-86-g5b8d79715
+              value: 93cccb0ea
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5b8d79715430d2cfc32ea3003aa45c14c86ce4ee
+              value: 93cccb0ea7163d77a0ca8cc0a7ac51e57e1a2e69
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.595.0-86-g5b8d79715
+              value: 93cccb0ea
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5b8d79715430d2cfc32ea3003aa45c14c86ce4ee
+              value: 93cccb0ea7163d77a0ca8cc0a7ac51e57e1a2e69
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: materialize-targets
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -126,7 +126,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+                  value: sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-04T07:11:18Z"
+        client.knative.dev/updateTimestamp: "2026-06-04T07:37:32Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           ports:
             - name: http1
               containerPort: 8181
@@ -531,11 +531,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.595.0-86-g5b8d79715
+              value: 93cccb0ea
             - name: TORGHUT_COMMIT
-              value: 5b8d79715430d2cfc32ea3003aa45c14c86ce4ee
+              value: 93cccb0ea7163d77a0ca8cc0a7ac51e57e1a2e69
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+              value: sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-04T07:11:18Z"
+        client.knative.dev/updateTimestamp: "2026-06-04T07:37:32Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           ports:
             - name: http1
               containerPort: 8181
@@ -373,11 +373,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.595.0-86-g5b8d79715
+              value: 93cccb0ea
             - name: TORGHUT_COMMIT
-              value: 5b8d79715430d2cfc32ea3003aa45c14c86ce4ee
+              value: 93cccb0ea7163d77a0ca8cc0a7ac51e57e1a2e69
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+              value: sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -86,7 +86,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+                  value: sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -122,7 +122,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -193,6 +193,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+                  value: sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: 5b8d79715430d2cfc32ea3003aa45c14c86ce4ee
+            value: 93cccb0ea7163d77a0ca8cc0a7ac51e57e1a2e69
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+            value: sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:eaf909a008e6c888b8e7b3a02be046cdf2fbc3c28c5c89e3ba156460a51763ee
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- Promotes Torghut image tag `93cccb0e` into GitOps manifests.
- Pins the promoted image digest to `sha256:d6b47e573a468b6cf9a6e8a974b2a6cf37a9a7f19bada56d6fae893d8f4684e1`.
- Updates Torghut service, simulation, job, workflow, journal, and options manifests to source commit `93cccb0ea7163d77a0ca8cc0a7ac51e57e1a2e69`.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
