### PR TITLE
chore(arc): raise lab runner capacity

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -28,7 +28,7 @@ spec:
           scaleSetLabels:
             - arc-arm64
           minRunners: 1
-          maxRunners: 2
+          maxRunners: 3
           containerMode:
             type: "kubernetes"
             kubernetesModeWorkVolumeClaim:


### PR DESCRIPTION
## Summary

- Raise the lab ARC `arc-arm64` scale-set cap from 2 to 3 runners.
- Keep `minRunners` and runner resource requests unchanged.
- Use the smallest capacity increase that fits current arm64 node request headroom for Torghut release throughput.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
