### PR TITLE
chore(symphony): promote image 05ba6f5b

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-02T18:20:14Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-04T08:49:10Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "824b75c8"
-    digest: sha256:a315f78d9dee8a1f5852fc4b721bae964b02e55f0c4c776d4d82d56f5e70c43d
+    newTag: "05ba6f5b"
+    digest: sha256:21874a01097eae0dc8a12b2bedcecab4532dbbe7d32506d7b8c76b1c83cec778

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-02T18:20:14Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-04T08:49:10Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "824b75c8"
-    digest: sha256:a315f78d9dee8a1f5852fc4b721bae964b02e55f0c4c776d4d82d56f5e70c43d
+    newTag: "05ba6f5b"
+    digest: sha256:21874a01097eae0dc8a12b2bedcecab4532dbbe7d32506d7b8c76b1c83cec778

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-06-02T18:20:14Z"
+        kubectl.kubernetes.io/restartedAt: "2026-06-04T08:49:10Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "824b75c8"
-    digest: sha256:a315f78d9dee8a1f5852fc4b721bae964b02e55f0c4c776d4d82d56f5e70c43d
+    newTag: "05ba6f5b"
+    digest: sha256:21874a01097eae0dc8a12b2bedcecab4532dbbe7d32506d7b8c76b1c83cec778


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `05ba6f5b4696318762d885ea18961b9b3f093a20`
- Image tag: `05ba6f5b`
- Image digest: `sha256:21874a01097eae0dc8a12b2bedcecab4532dbbe7d32506d7b8c76b1c83cec778`