### PR TITLE
fix(torghut): extend journal worker timeout budget

### DIFF
--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -62,7 +62,7 @@ spec:
                     --order-event-batch-size 50 \
                     --runtime-ledger-batch-size 100 \
                     --journal-batch-chunk-size 25 \
-                    --supervise-timeout-seconds 45 \
+                    --supervise-timeout-seconds 120 \
                     --json
               env:
                 - name: DB_DSN
@@ -150,10 +150,10 @@ spec:
                   cd /app
                   exec /opt/venv/bin/python scripts/run_tigerbeetle_journal_cron.py \
                     --preset sim \
-                    --sim-batch-size 250 \
+                    --sim-batch-size 100 \
                     --runtime-ledger-batch-size 100 \
                     --journal-batch-chunk-size 25 \
-                    --supervise-timeout-seconds 45 \
+                    --supervise-timeout-seconds 120 \
                     --json
               env:
                 - name: TORGHUT_SIM_DB_HOST

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -36,7 +36,8 @@ LIVE_TCA_METRIC_MAX_BATCHES = 1
 LIVE_RUNTIME_LEDGER_BATCH_SIZE = 100
 LIVE_RECONCILE_LIMIT = 500
 LIVE_JOURNAL_BATCH_CHUNK_SIZE = 25
-SIM_SOURCE_BATCH_SIZE = 250
+LIVE_SUPERVISE_TIMEOUT_SECONDS = 120.0
+SIM_SOURCE_BATCH_SIZE = 100
 SIM_RUNTIME_LEDGER_BATCH_SIZE = 100
 SIM_ORDER_EVENT_SCAN_LIMIT = 5000
 RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS = 120.0
@@ -93,7 +94,11 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=LIVE_JOURNAL_BATCH_CHUNK_SIZE,
     )
-    parser.add_argument("--supervise-timeout-seconds", type=float, default=45.0)
+    parser.add_argument(
+        "--supervise-timeout-seconds",
+        type=float,
+        default=LIVE_SUPERVISE_TIMEOUT_SECONDS,
+    )
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -862,7 +862,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 ],
             )
             self.assertNotIn("execution,execution_tca_metric", section)
-            self.assertEqual(section.count("--supervise-timeout-seconds 45"), 1)
+            self.assertEqual(section.count("--supervise-timeout-seconds 120"), 1)
             command_argvs = [
                 cron_runner._argv_for_command(
                     command,

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1634,7 +1634,7 @@ class TestLiveConfigManifestContract(TestCase):
             self.assertNotIn("|| status=1", args)
             self.assertNotIn('exit "$status"', args)
             self.assertIn("--preset", args)
-            self.assertIn("--supervise-timeout-seconds 45", args)
+            self.assertIn("--supervise-timeout-seconds 120", args)
             self.assertIn("--json", args)
             security_context = cast(
                 Mapping[str, object],
@@ -1667,7 +1667,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--order-event-batch-size 50", live_args)
         self.assertIn("--runtime-ledger-batch-size 100", live_args)
         self.assertIn("--journal-batch-chunk-size 25", live_args)
-        self.assertIn("--supervise-timeout-seconds 45", live_args)
+        self.assertIn("--supervise-timeout-seconds 120", live_args)
         self.assertNotIn("--dsn-env DB_DSN", live_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", live_args)
         self.assertNotIn("--account-label TORGHUT_SIM", live_args)
@@ -1718,12 +1718,12 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertLessEqual(
             live_order_event_command.max_batches,
             2,
-            "live order-event slices must not run PR #9799's unsafe 3-batch shape under the 45s watchdog",
+            "live order-event slices must not run PR #9799's unsafe 3-batch shape under the bounded watchdog",
         )
         self.assertLessEqual(
             live_order_event_command.batch_size * live_order_event_command.max_batches,
             tigerbeetle_journal_runner.LIVE_ORDER_EVENT_BATCH_SIZE,
-            "live order-event slices must stay to one bounded batch under the 45s watchdog",
+            "live order-event slices must stay to one bounded batch under the bounded watchdog",
         )
         self.assertTrue(live_order_event_command.skip_reconcile)
         self.assertTrue(live_order_event_command.allow_data_quality_degraded)
@@ -1767,7 +1767,7 @@ class TestLiveConfigManifestContract(TestCase):
             )
         sim_args = "\n".join(str(item) for item in sim_container.get("args", []))
         self.assertIn("--preset sim", sim_args)
-        self.assertIn("--sim-batch-size 250", sim_args)
+        self.assertIn("--sim-batch-size 100", sim_args)
         self.assertIn("--runtime-ledger-batch-size 100", sim_args)
         self.assertIn("--journal-batch-chunk-size 25", sim_args)
         self.assertNotIn("--dsn-env SIM_DB_DSN", sim_args)

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -117,6 +117,10 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
         self.assertTrue(command.skip_reconcile)
         self.assertTrue(command.allow_data_quality_degraded)
+        self.assertEqual(
+            args.supervise_timeout_seconds,
+            runner.LIVE_SUPERVISE_TIMEOUT_SECONDS,
+        )
 
     def test_live_preset_can_tune_source_batch_sizes_independently(self) -> None:
         commands = runner._live_commands(
@@ -222,7 +226,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
         argv = runner._argv_for_command(
             command,
             json_output=True,
-            supervise_timeout_seconds=45.0,
+            supervise_timeout_seconds=runner.LIVE_SUPERVISE_TIMEOUT_SECONDS,
         )
 
         self.assertEqual(argv[argv.index("--sources") + 1], "execution_order_event")
@@ -244,7 +248,14 @@ class RunTigerBeetleJournalCronTest(TestCase):
             argv[argv.index("--event-scan-limit") + 1],
             str(runner.LIVE_ORDER_EVENT_SCAN_LIMIT),
         )
-        self.assertEqual(argv[argv.index("--supervise-timeout-seconds") + 1], "45.0")
+        self.assertEqual(
+            argv[argv.index("--supervise-timeout-seconds") + 1],
+            str(runner.LIVE_SUPERVISE_TIMEOUT_SECONDS),
+        )
+        self.assertGreaterEqual(
+            runner.LIVE_SUPERVISE_TIMEOUT_SECONDS,
+            2 * 45.0,
+        )
         self.assertIn("--fail-on-degraded", argv)
         self.assertIn("--allow-data-quality-degraded", argv)
         self.assertIn("--json", argv)
@@ -259,7 +270,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
         argv = runner._argv_for_command(
             command,
             json_output=True,
-            supervise_timeout_seconds=45.0,
+            supervise_timeout_seconds=runner.LIVE_SUPERVISE_TIMEOUT_SECONDS,
         )
 
         self.assertEqual(argv[argv.index("--sources") + 1], "execution_tca_metric")
@@ -272,7 +283,10 @@ class RunTigerBeetleJournalCronTest(TestCase):
             str(runner.LIVE_TCA_METRIC_MAX_BATCHES),
         )
         self.assertEqual(int(argv[argv.index("--max-batches") + 1]), 1)
-        self.assertEqual(argv[argv.index("--supervise-timeout-seconds") + 1], "45.0")
+        self.assertEqual(
+            argv[argv.index("--supervise-timeout-seconds") + 1],
+            str(runner.LIVE_SUPERVISE_TIMEOUT_SECONDS),
+        )
         self.assertEqual(
             argv[argv.index("--journal-batch-chunk-size") + 1],
             str(runner.LIVE_JOURNAL_BATCH_CHUNK_SIZE),


### PR DESCRIPTION
## Summary

- Increase the TigerBeetle journal cron supervised worker timeout from 45s to 120s so live 25-row chunks can finish instead of failing after partial progress.
- Reduce the sim journal source batch from 250 to 100 to keep sim slices within the same bounded worker budget.
- Lock the cron manifest and runner behavior with regression tests so the timeout and batch budget do not drift back.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pytest tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check scripts/run_tigerbeetle_journal_cron.py tests/test_run_tigerbeetle_journal_cron.py tests/test_live_config_manifest_contract.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
