### PR TITLE
fix(torghut): stabilize tigerbeetle journal retries

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_journal.py
+++ b/services/torghut/app/trading/tigerbeetle_journal.py
@@ -1638,6 +1638,18 @@ class TigerBeetleLedgerJournal:
             default_status="created",
             status_type_names=("CreateTransferStatus",),
         )
+        existing_transfer_ids = list(
+            dict.fromkeys(
+                transfer_specs[index].transfer_id
+                for index, status in transfer_statuses.items()
+                if status == "exists"
+            )
+        )
+        existing_transfers_by_id: dict[int, object] = {}
+        if existing_transfer_ids:
+            for transfer in client.lookup_transfers(existing_transfer_ids):
+                existing_transfers_by_id[int(_transfer_attr(transfer, "id"))] = transfer
+
         for batch_index, (original_index, prepared, payload_json) in enumerate(
             new_writes
         ):
@@ -1646,12 +1658,13 @@ class TigerBeetleLedgerJournal:
             if status not in {"created", "exists"}:
                 raise RuntimeError(f"tigerbeetle_create_transfer_failed:{status}")
             if status == "exists":
-                matches = [
-                    item
-                    for item in client.lookup_transfers([transfer_spec.transfer_id])
-                    if _transfer_matches(item, transfer_spec)
-                ]
-                if not matches:
+                existing_transfer = existing_transfers_by_id.get(
+                    transfer_spec.transfer_id
+                )
+                if existing_transfer is None or not _transfer_matches(
+                    existing_transfer,
+                    transfer_spec,
+                ):
                     raise RuntimeError("tigerbeetle_duplicate_transfer_conflict")
             refs[original_index] = self._persist_written_transfer_ref(
                 session,

--- a/services/torghut/scripts/run_tigerbeetle_journal_cron.py
+++ b/services/torghut/scripts/run_tigerbeetle_journal_cron.py
@@ -37,6 +37,10 @@ LIVE_RUNTIME_LEDGER_BATCH_SIZE = 100
 LIVE_RECONCILE_LIMIT = 500
 LIVE_JOURNAL_BATCH_CHUNK_SIZE = 25
 LIVE_SUPERVISE_TIMEOUT_SECONDS = 120.0
+LIVE_JOURNAL_SOURCE_TIMEOUT_HEADROOM_SECONDS = 30.0
+LIVE_JOURNAL_SOURCE_TIMEOUT_PER_CHUNK_SECONDS = 30.0
+LIVE_JOURNAL_SOURCE_TIMEOUT_MIN_SECONDS = LIVE_SUPERVISE_TIMEOUT_SECONDS
+LIVE_JOURNAL_SOURCE_TIMEOUT_MAX_SECONDS = 300.0
 SIM_SOURCE_BATCH_SIZE = 100
 SIM_RUNTIME_LEDGER_BATCH_SIZE = 100
 SIM_ORDER_EVENT_SCAN_LIMIT = 5000
@@ -107,6 +111,27 @@ def _bounded_batch_size(value: object) -> int:
     return max(1, min(int(value), MAX_TIGERBEETLE_BATCH_SIZE))
 
 
+def _journal_source_timeout_seconds(
+    *,
+    batch_size: int,
+    journal_batch_chunk_size: int,
+) -> float:
+    bounded_batch_size = _bounded_batch_size(batch_size)
+    bounded_chunk_size = _bounded_batch_size(journal_batch_chunk_size)
+    chunk_count = max(
+        1,
+        (bounded_batch_size + bounded_chunk_size - 1) // bounded_chunk_size,
+    )
+    return min(
+        LIVE_JOURNAL_SOURCE_TIMEOUT_MAX_SECONDS,
+        max(
+            LIVE_JOURNAL_SOURCE_TIMEOUT_MIN_SECONDS,
+            LIVE_JOURNAL_SOURCE_TIMEOUT_HEADROOM_SECONDS
+            + (chunk_count * LIVE_JOURNAL_SOURCE_TIMEOUT_PER_CHUNK_SECONDS),
+        ),
+    )
+
+
 def _live_commands(
     *,
     execution_batch_size: int,
@@ -128,6 +153,10 @@ def _live_commands(
             progress_interval=LIVE_EXECUTION_PROGRESS_INTERVAL,
             journal_batch_chunk_size=journal_batch_chunk_size,
             repeat_count=LIVE_EXECUTION_SLICE_COUNT,
+            supervise_timeout_seconds=_journal_source_timeout_seconds(
+                batch_size=execution_batch_size,
+                journal_batch_chunk_size=journal_batch_chunk_size,
+            ),
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_TCA_METRIC,
@@ -139,6 +168,10 @@ def _live_commands(
             commit_each_row=True,
             progress_interval=LIVE_EXECUTION_PROGRESS_INTERVAL,
             journal_batch_chunk_size=journal_batch_chunk_size,
+            supervise_timeout_seconds=_journal_source_timeout_seconds(
+                batch_size=tca_metric_batch_size,
+                journal_batch_chunk_size=journal_batch_chunk_size,
+            ),
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
@@ -149,7 +182,12 @@ def _live_commands(
             event_scan_limit=LIVE_ORDER_EVENT_SCAN_LIMIT,
             skip_reconcile=True,
             allow_data_quality_degraded=True,
+            commit_each_row=True,
             journal_batch_chunk_size=journal_batch_chunk_size,
+            supervise_timeout_seconds=_journal_source_timeout_seconds(
+                batch_size=order_event_batch_size,
+                journal_batch_chunk_size=journal_batch_chunk_size,
+            ),
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
@@ -160,7 +198,13 @@ def _live_commands(
             reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
             journal_batch_chunk_size=journal_batch_chunk_size,
-            supervise_timeout_seconds=RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+            supervise_timeout_seconds=max(
+                RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+                _journal_source_timeout_seconds(
+                    batch_size=runtime_ledger_batch_size,
+                    journal_batch_chunk_size=journal_batch_chunk_size,
+                ),
+            ),
         ),
     ]
 
@@ -186,6 +230,10 @@ def _sim_commands(
             skip_reconcile=True,
             allow_data_quality_degraded=True,
             journal_batch_chunk_size=journal_batch_chunk_size,
+            supervise_timeout_seconds=_journal_source_timeout_seconds(
+                batch_size=batch_size,
+                journal_batch_chunk_size=journal_batch_chunk_size,
+            ),
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_TCA_METRIC,
@@ -198,6 +246,10 @@ def _sim_commands(
             commit_each_row=True,
             progress_interval=LIVE_EXECUTION_PROGRESS_INTERVAL,
             journal_batch_chunk_size=journal_batch_chunk_size,
+            supervise_timeout_seconds=_journal_source_timeout_seconds(
+                batch_size=batch_size,
+                journal_batch_chunk_size=journal_batch_chunk_size,
+            ),
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_EXECUTION_ORDER_EVENT,
@@ -209,7 +261,12 @@ def _sim_commands(
             event_scan_limit=SIM_ORDER_EVENT_SCAN_LIMIT,
             skip_reconcile=True,
             allow_data_quality_degraded=True,
+            commit_each_row=True,
             journal_batch_chunk_size=journal_batch_chunk_size,
+            supervise_timeout_seconds=_journal_source_timeout_seconds(
+                batch_size=batch_size,
+                journal_batch_chunk_size=journal_batch_chunk_size,
+            ),
         ),
         JournalCronCommand(
             source=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
@@ -221,7 +278,13 @@ def _sim_commands(
             reconcile_empty_selection=True,
             allow_data_quality_degraded=True,
             journal_batch_chunk_size=journal_batch_chunk_size,
-            supervise_timeout_seconds=RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+            supervise_timeout_seconds=max(
+                RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+                _journal_source_timeout_seconds(
+                    batch_size=runtime_ledger_batch_size,
+                    journal_batch_chunk_size=journal_batch_chunk_size,
+                ),
+            ),
         ),
     ]
 

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -867,7 +867,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                 cron_runner._argv_for_command(
                     command,
                     json_output=True,
-                    supervise_timeout_seconds=45.0,
+                    supervise_timeout_seconds=180.0,
                 )
                 for command in commands
             ]

--- a/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
+++ b/services/torghut/tests/test_run_tigerbeetle_journal_cron.py
@@ -121,6 +121,13 @@ class RunTigerBeetleJournalCronTest(TestCase):
             args.supervise_timeout_seconds,
             runner.LIVE_SUPERVISE_TIMEOUT_SECONDS,
         )
+        self.assertEqual(
+            command.supervise_timeout_seconds,
+            runner._journal_source_timeout_seconds(
+                batch_size=runner.LIVE_EXECUTION_BATCH_SIZE,
+                journal_batch_chunk_size=runner.LIVE_JOURNAL_BATCH_CHUNK_SIZE,
+            ),
+        )
 
     def test_live_preset_can_tune_source_batch_sizes_independently(self) -> None:
         commands = runner._live_commands(
@@ -148,6 +155,13 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertTrue(commands[1].skip_reconcile)
         self.assertTrue(commands[1].commit_each_row)
         self.assertEqual(commands[1].journal_batch_chunk_size, 6)
+        self.assertEqual(
+            commands[1].supervise_timeout_seconds,
+            runner._journal_source_timeout_seconds(
+                batch_size=20,
+                journal_batch_chunk_size=6,
+            ),
+        )
         self.assertEqual(commands[2].source, SOURCE_TYPE_EXECUTION_ORDER_EVENT)
         self.assertEqual(commands[2].batch_size, 30)
         self.assertEqual(commands[2].max_batches, runner.LIVE_ORDER_EVENT_MAX_BATCHES)
@@ -156,6 +170,14 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(
             commands[2].event_scan_limit,
             runner.LIVE_ORDER_EVENT_SCAN_LIMIT,
+        )
+        self.assertTrue(commands[2].commit_each_row)
+        self.assertEqual(
+            commands[2].supervise_timeout_seconds,
+            runner._journal_source_timeout_seconds(
+                batch_size=30,
+                journal_batch_chunk_size=6,
+            ),
         )
         self.assertEqual(commands[3].source, SOURCE_TYPE_RUNTIME_LEDGER_BUCKET)
         self.assertEqual(commands[3].batch_size, 40)
@@ -178,7 +200,15 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertNotIn("--skip-reconcile", argv)
         self.assertEqual(
             argv[argv.index("--supervise-timeout-seconds") + 1],
-            str(runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS),
+            str(
+                max(
+                    runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+                    runner._journal_source_timeout_seconds(
+                        batch_size=command.batch_size,
+                        journal_batch_chunk_size=command.journal_batch_chunk_size,
+                    ),
+                )
+            ),
         )
         self.assertEqual(
             argv[argv.index("--reconcile-limit") + 1],
@@ -200,20 +230,52 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertNotIn("--skip-reconcile", argv)
         self.assertEqual(
             argv[argv.index("--supervise-timeout-seconds") + 1],
-            str(runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS),
+            str(
+                max(
+                    runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+                    runner._journal_source_timeout_seconds(
+                        batch_size=command.batch_size,
+                        journal_batch_chunk_size=command.journal_batch_chunk_size,
+                    ),
+                )
+            ),
         )
 
-    def test_runtime_ledger_reconcile_timeout_does_not_leak_to_other_slices(
+    def test_live_source_timeouts_are_scaled_by_chunk_count(
         self,
     ) -> None:
         commands = runner._live_commands(execution_batch_size=5)
 
-        self.assertIsNone(commands[0].supervise_timeout_seconds)
-        self.assertIsNone(commands[1].supervise_timeout_seconds)
-        self.assertIsNone(commands[2].supervise_timeout_seconds)
+        self.assertEqual(
+            commands[0].supervise_timeout_seconds,
+            runner._journal_source_timeout_seconds(
+                batch_size=5,
+                journal_batch_chunk_size=runner.LIVE_JOURNAL_BATCH_CHUNK_SIZE,
+            ),
+        )
+        self.assertEqual(
+            commands[1].supervise_timeout_seconds,
+            runner._journal_source_timeout_seconds(
+                batch_size=runner.LIVE_TCA_METRIC_BATCH_SIZE,
+                journal_batch_chunk_size=runner.LIVE_JOURNAL_BATCH_CHUNK_SIZE,
+            ),
+        )
+        self.assertEqual(
+            commands[2].supervise_timeout_seconds,
+            runner._journal_source_timeout_seconds(
+                batch_size=runner.LIVE_ORDER_EVENT_BATCH_SIZE,
+                journal_batch_chunk_size=runner.LIVE_JOURNAL_BATCH_CHUNK_SIZE,
+            ),
+        )
         self.assertEqual(
             commands[3].supervise_timeout_seconds,
-            runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+            max(
+                runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+                runner._journal_source_timeout_seconds(
+                    batch_size=runner.LIVE_RUNTIME_LEDGER_BATCH_SIZE,
+                    journal_batch_chunk_size=runner.LIVE_JOURNAL_BATCH_CHUNK_SIZE,
+                ),
+            ),
         )
 
     def test_live_order_event_argv_keeps_slice_bounded_under_watchdog(self) -> None:
@@ -250,8 +312,9 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
         self.assertEqual(
             argv[argv.index("--supervise-timeout-seconds") + 1],
-            str(runner.LIVE_SUPERVISE_TIMEOUT_SECONDS),
+            str(command.supervise_timeout_seconds),
         )
+        self.assertIn("--commit-each-row", argv)
         self.assertGreaterEqual(
             runner.LIVE_SUPERVISE_TIMEOUT_SECONDS,
             2 * 45.0,
@@ -285,7 +348,7 @@ class RunTigerBeetleJournalCronTest(TestCase):
         self.assertEqual(int(argv[argv.index("--max-batches") + 1]), 1)
         self.assertEqual(
             argv[argv.index("--supervise-timeout-seconds") + 1],
-            str(runner.LIVE_SUPERVISE_TIMEOUT_SECONDS),
+            str(command.supervise_timeout_seconds),
         )
         self.assertEqual(
             argv[argv.index("--journal-batch-chunk-size") + 1],
@@ -479,7 +542,12 @@ class RunTigerBeetleJournalCronTest(TestCase):
         )
         self.assertEqual(
             first_argv[first_argv.index("--supervise-timeout-seconds") + 1],
-            "0.001",
+            str(
+                runner._journal_source_timeout_seconds(
+                    batch_size=runner.MAX_TIGERBEETLE_BATCH_SIZE,
+                    journal_batch_chunk_size=runner.LIVE_JOURNAL_BATCH_CHUNK_SIZE,
+                )
+            ),
         )
         self.assertEqual(
             [source for _, source, _ in observed[: runner.LIVE_EXECUTION_SLICE_COUNT]],
@@ -488,7 +556,15 @@ class RunTigerBeetleJournalCronTest(TestCase):
         runtime_argv = observed[-1][0]
         self.assertEqual(
             runtime_argv[runtime_argv.index("--supervise-timeout-seconds") + 1],
-            str(runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS),
+            str(
+                max(
+                    runner.RUNTIME_LEDGER_RECONCILE_TIMEOUT_SECONDS,
+                    runner._journal_source_timeout_seconds(
+                        batch_size=runner.LIVE_RUNTIME_LEDGER_BATCH_SIZE,
+                        journal_batch_chunk_size=runner.LIVE_JOURNAL_BATCH_CHUNK_SIZE,
+                    ),
+                )
+            ),
         )
         self.assertTrue(all(json_output for _, _, json_output in observed))
 

--- a/services/torghut/tests/test_tigerbeetle_journal.py
+++ b/services/torghut/tests/test_tigerbeetle_journal.py
@@ -107,6 +107,26 @@ class BatchCountingFakeTigerBeetleClient(FakeTigerBeetleClient):
         return super().create_transfers(transfers)
 
 
+class ExistingTransferLookupCountingFakeTigerBeetleClient(FakeTigerBeetleClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lookup_call_sizes: list[int] = []
+
+    def create_transfers(self, transfers: Sequence[object]) -> Sequence[object]:
+        results: list[dict[str, object]] = []
+        for index, transfer in enumerate(transfers):
+            transfer_id = int(
+                getattr(transfer, "id", getattr(transfer, "transfer_id", 0))
+            )
+            self.transfers[transfer_id] = transfer
+            results.append({"index": index, "status": "exists"})
+        return results
+
+    def lookup_transfers(self, ids: Sequence[int]) -> Sequence[object]:
+        self.lookup_call_sizes.append(len(ids))
+        return super().lookup_transfers(ids)
+
+
 class _ScalarResult:
     def __init__(self, value: object | None) -> None:
         self._value = value
@@ -666,6 +686,49 @@ class TestTigerBeetleLedgerJournal(TestCase):
             self.assertEqual(len(client.account_call_sizes), 1)
             self.assertGreater(client.account_call_sizes[0], 0)
             self.assertEqual(len(client.transfers), 3)
+            persisted = session.execute(select(TigerBeetleTransferRef)).scalars().all()
+            self.assertEqual(len(persisted), 3)
+
+    def test_existing_transfer_batch_uses_single_lookup_request(self) -> None:
+        with Session(self.engine) as session:
+            metrics: list[ExecutionTCAMetric] = []
+            for index in range(3):
+                event = _create_fill_event(
+                    session,
+                    fingerprint=f"fingerprint-existing-cost-batch-{index}",
+                )
+                metric = ExecutionTCAMetric(
+                    execution_id=event.execution_id,
+                    trade_decision_id=event.trade_decision_id,
+                    strategy_id=event.trade_decision.strategy_id
+                    if event.trade_decision
+                    else None,
+                    alpaca_account_label="paper",
+                    symbol="AAPL",
+                    side="buy",
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("1"),
+                    shortfall_notional=Decimal("0.25"),
+                    realized_shortfall_bps=Decimal("1.3"),
+                    computed_at=datetime.now(timezone.utc),
+                )
+                session.add(metric)
+                session.flush()
+                metrics.append(metric)
+            client = ExistingTransferLookupCountingFakeTigerBeetleClient()
+            journal = TigerBeetleLedgerJournal(
+                settings_obj=_settings(),
+                client=client,
+            )
+
+            refs = journal.journal_execution_tca_metrics(session, metrics)
+
+            self.assertEqual(len([ref for ref in refs if ref is not None]), 3)
+            self.assertEqual(client.lookup_call_sizes, [3])
+            self.assertEqual(
+                {ref.status for ref in refs if ref is not None},
+                {"exists"},
+            )
             persisted = session.execute(select(TigerBeetleTransferRef)).scalars().all()
             self.assertEqual(len(persisted), 3)
 


### PR DESCRIPTION
## Summary

- Stabilize scheduled TigerBeetle journal retries by committing order-event chunks after each successful native write.
- Batch duplicate transfer `exists` validation into one TigerBeetle lookup request instead of one lookup per transfer.
- Scale live journal source watchdogs from batch/chunk shape while preserving main's deployed 120-second CronJob floor timeout.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format services/torghut/app/trading/tigerbeetle_journal.py services/torghut/scripts/run_tigerbeetle_journal_cron.py services/torghut/tests/test_tigerbeetle_journal.py services/torghut/tests/test_run_tigerbeetle_journal_cron.py services/torghut/tests/test_journal_tigerbeetle_order_events.py services/torghut/tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/trading/tigerbeetle_journal.py scripts/run_tigerbeetle_journal_cron.py tests/test_tigerbeetle_journal.py tests/test_run_tigerbeetle_journal_cron.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_run_tigerbeetle_journal_cron.py tests/test_tigerbeetle_journal.py tests/test_journal_tigerbeetle_order_events.py tests/test_live_config_manifest_contract.py --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
