### PR TITLE
feat(torghut): add transient impact candidate grid

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -4641,6 +4641,173 @@ def _mechanism_overlays_for_card(card: HypothesisCard) -> dict[str, Any]:
 
     if has_any(
         (
+            "transient impact",
+            "transient price impact",
+            "transient market impact",
+            "propagator model",
+            "propagator impact",
+            "nonlinear propagator",
+            "power-law decay",
+            "power law decay",
+            "exponential decay kernel",
+            "impact decay kernel",
+            "impact_kernel",
+            "self-exciting order flow",
+            "self exciting order flow",
+            "bivariate hawkes",
+            "mutually exciting hawkes",
+            "samuelson effect",
+            "gate closure",
+            "n-player execution",
+            "n trader execution",
+            "predatory execution",
+            "execution predator",
+            "cost of anarchy",
+            "block-trade regularization",
+            "block trade regularization",
+            "fredholm",
+        )
+    ):
+        overlay_ids.append("transient_impact_hawkes_propagator_grid")
+        overlay_contracts.append(
+            {
+                "overlay_id": "transient_impact_hawkes_propagator_grid",
+                "source_papers": [
+                    {
+                        "source_id": "arxiv-2504.10282",
+                        "url": "https://arxiv.org/abs/2504.10282",
+                        "title": "Optimal Execution in Intraday Energy Markets under Hawkes Processes with Transient Impact",
+                        "mechanism": "bivariate_hawkes_order_flow_with_transient_impact_schedule_stress",
+                    },
+                    {
+                        "source_id": "arxiv-2503.04323",
+                        "url": "https://arxiv.org/abs/2503.04323",
+                        "title": "Fredholm Approach to Nonlinear Propagator Models",
+                        "mechanism": "nonlinear_propagator_alpha_signal_execution_under_exponential_and_power_law_decay",
+                    },
+                    {
+                        "source_id": "arxiv-2501.09638",
+                        "url": "https://arxiv.org/abs/2501.09638",
+                        "title": "Optimal Execution among N Traders with Transient Price Impact",
+                        "mechanism": "n_trader_transient_impact_predator_and_block_regularization_stress",
+                    },
+                ],
+                "required_evidence": [
+                    "transient_impact_kernel_fit",
+                    "impact_decay_residuals",
+                    "hawkes_self_cross_excitation_matrix",
+                    "execution_trajectory_trace",
+                    "twap_vwap_benchmark_shortfall",
+                    "alpha_signal_trace",
+                    "predator_cost_of_anarchy_stress",
+                    "route_tca",
+                    "runtime_ledger",
+                ],
+                "rank_metric": (
+                    "post_cost_net_pnl_after_transient_impact_hawkes_predator_stress"
+                ),
+                "evidence_policy": (
+                    "transient_impact_propagator_grid_is_candidate_input_only_"
+                    "and_requires_real_route_tca_kernel_fit_runtime_ledger_proof"
+                ),
+            }
+        )
+        parameter_space["transient_impact_hawkes_propagator_grid"] = {
+            "schema_version": "torghut.transient-impact-hawkes-propagator-grid.v1",
+            "source_ids": [
+                "arxiv-2504.10282",
+                "arxiv-2503.04323",
+                "arxiv-2501.09638",
+            ],
+            "candidate_search_inputs": {
+                "impact_decay_kernel_family_grid": [
+                    "exponential",
+                    "power_law",
+                    "multi_exponential",
+                ],
+                "impact_decay_half_life_seconds_grid": ["5", "30", "120", "600"],
+                "impact_concavity_exponent_grid": ["0.35", "0.50", "0.65", "1.00"],
+                "hawkes_self_excitation_grid": ["0.10", "0.30", "0.55"],
+                "hawkes_cross_excitation_grid": ["0.05", "0.20", "0.40"],
+                "trajectory_benchmark_grid": [
+                    "twap",
+                    "vwap",
+                    "front_loaded",
+                    "back_loaded",
+                ],
+                "predator_count_grid": ["0", "1", "3", "5"],
+                "block_trade_regularization_bps_grid": ["0", "1", "3", "6"],
+                "alpha_signal_half_life_seconds_grid": ["30", "120", "600"],
+            },
+            "stress_inputs_required": [
+                "signed_order_flow",
+                "hawkes_event_arrivals",
+                "child_order_schedule",
+                "realized_impact_bps",
+                "impact_decay_after_child_order",
+                "alpha_signal_return",
+                "route_tca_bps",
+                "runtime_ledger_post_cost_pnl",
+            ],
+            "diagnostics_required": [
+                "impact_kernel_fit_error_bps",
+                "hawkes_branching_ratio",
+                "self_cross_excitation_l1",
+                "twap_shortfall_bps",
+                "vwap_shortfall_bps",
+                "predator_cost_of_anarchy_bps",
+                "price_manipulation_screen_passed",
+            ],
+            "proof_neutrality": {
+                "research_ranking_only": True,
+                "promotion_proof": False,
+                "proof_authority": False,
+                "promotion_authority": False,
+                "requires_exact_replay": True,
+                "requires_real_order_flow": True,
+                "requires_real_impact_decay_fit": True,
+                "requires_route_tca": True,
+                "requires_runtime_ledger": True,
+                "rejects_modeled_transient_impact_as_profit_proof": True,
+                "rejects_hawkes_generated_order_flow_as_fill_authority": True,
+                "rejects_predator_stress_as_runtime_ledger_authority": True,
+            },
+        }
+        hard_vetoes.update(
+            {
+                "required_transient_impact_hawkes_propagator_grid": True,
+                "required_transient_impact_kernel_fit": True,
+                "required_impact_decay_residuals": True,
+                "required_hawkes_self_cross_excitation_matrix": True,
+                "required_execution_trajectory_trace": True,
+                "required_twap_vwap_benchmark_shortfall": True,
+                "required_predator_cost_of_anarchy_stress": True,
+                "required_price_manipulation_screen_passed": True,
+                "required_max_transient_impact_fit_error_bps": "8",
+                "required_max_predator_cost_of_anarchy_bps": "10",
+            }
+        )
+        promotion_contract.update(
+            {
+                "requires_transient_impact_hawkes_propagator_grid": True,
+                "requires_transient_impact_kernel_fit": True,
+                "requires_impact_decay_residuals": True,
+                "requires_hawkes_self_cross_excitation_matrix": True,
+                "requires_execution_trajectory_trace": True,
+                "requires_twap_vwap_benchmark_shortfall": True,
+                "requires_predator_cost_of_anarchy_stress": True,
+                "requires_route_tca": True,
+                "requires_runtime_ledger": True,
+                "rejects_modeled_transient_impact_as_profit_proof": True,
+                "rejects_hawkes_generated_order_flow_as_fill_authority": True,
+                "execution_impact_policy": (
+                    "transient_impact_hawkes_propagator_validation_only"
+                ),
+            }
+        )
+
+    if has_any(
+        (
             "reality gap",
             "simulation reality",
             "sim-to-live",

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -468,6 +468,93 @@ class TestCandidateSpecs(TestCase):
             "post_cost_nonlinear_impact",
         )
 
+    def test_transient_impact_claim_adds_hawkes_propagator_grid(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-transient-impact-hawkes-propagator",
+            claims=[
+                {
+                    "claim_id": "transient-impact-hawkes-propagator-execution",
+                    "claim_type": "execution_assumption",
+                    "claim_text": (
+                        "Transient price impact with a nonlinear propagator model, "
+                        "power-law decay, bivariate Hawkes self-exciting order flow, "
+                        "and N-player execution predator cost-of-anarchy stress "
+                        "should change intraday execution trajectory ranking."
+                    ),
+                    "data_requirements": [
+                        "transient_impact_kernel_fit",
+                        "impact_decay_residuals",
+                        "hawkes_self_cross_excitation_matrix",
+                        "execution_trajectory_trace",
+                        "twap_vwap_benchmark_shortfall",
+                        "predator_cost_of_anarchy_stress",
+                        "route_tca",
+                    ],
+                    "confidence": "0.76",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        self.assertIn(
+            "transient_impact_hawkes_propagator_grid",
+            specs[0].parameter_space["mechanism_overlay_ids"],
+        )
+        grid = specs[0].parameter_space["transient_impact_hawkes_propagator_grid"]
+        self.assertEqual(
+            grid["schema_version"],
+            "torghut.transient-impact-hawkes-propagator-grid.v1",
+        )
+        self.assertEqual(
+            set(grid["source_ids"]),
+            {"arxiv-2504.10282", "arxiv-2503.04323", "arxiv-2501.09638"},
+        )
+        self.assertIn(
+            "impact_decay_kernel_family_grid",
+            grid["candidate_search_inputs"],
+        )
+        self.assertIn("predator_count_grid", grid["candidate_search_inputs"])
+        self.assertIn("impact_decay_after_child_order", grid["stress_inputs_required"])
+        self.assertIn("price_manipulation_screen_passed", grid["diagnostics_required"])
+        self.assertFalse(grid["proof_neutrality"]["proof_authority"])
+        self.assertTrue(
+            grid["proof_neutrality"][
+                "rejects_hawkes_generated_order_flow_as_fill_authority"
+            ]
+        )
+        self.assertTrue(
+            specs[0].hard_vetoes["required_transient_impact_hawkes_propagator_grid"]
+        )
+        self.assertEqual(
+            specs[0].hard_vetoes["required_max_predator_cost_of_anarchy_bps"],
+            "10",
+        )
+        self.assertTrue(
+            specs[0].promotion_contract[
+                "requires_transient_impact_hawkes_propagator_grid"
+            ]
+        )
+        self.assertTrue(
+            specs[0].promotion_contract[
+                "rejects_modeled_transient_impact_as_profit_proof"
+            ]
+        )
+        mechanism_overlays = candidate_specs_module._mechanism_overlays_for_card(
+            cards[0]
+        )
+        contract = next(
+            item
+            for item in mechanism_overlays["feature_contract"]["mechanism_overlays"]
+            if item["overlay_id"] == "transient_impact_hawkes_propagator_grid"
+        )
+        self.assertEqual(
+            contract["rank_metric"],
+            "post_cost_net_pnl_after_transient_impact_hawkes_predator_stress",
+        )
+
     def test_lob_simulation_reality_gap_claim_adds_implementation_risk_overlay(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds a transient-impact Hawkes propagator candidate grid to Torghut candidate compilation for transient impact, nonlinear propagator, Hawkes order-flow, and execution-predator claims.
- Embeds executable source metadata for arXiv:2504.10282, arXiv:2503.04323, and arXiv:2501.09638 so matching whitepaper cards emit candidate/search inputs and diagnostics rather than documentation-only notes.
- Requires real impact-decay fits, self/cross-excitation evidence, TWAP/VWAP benchmark shortfall, predator cost-of-anarchy stress, route TCA, and runtime-ledger proof before promotion.
- Preserves proof semantics by rejecting modeled transient impact, Hawkes-generated order flow, or predator stress as PnL/fill/runtime-ledger authority.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_candidate_specs.py -q` — passed, 53 passed and 1 existing deprecation warning.
- `uvx ruff format --check app/trading/discovery/candidate_specs.py tests/test_candidate_specs.py` — passed.
- `uvx ruff check app/trading/discovery/candidate_specs.py tests/test_candidate_specs.py` — passed.
- `uv sync --frozen --extra dev` — passed.
- `uv run --frozen pyright --project pyrightconfig.json` — passed.
- `uv run --frozen pyright --project pyrightconfig.alpha.json` — passed.
- `uv run --frozen pyright --project pyrightconfig.scripts.json` — passed.
- `git diff --check` — passed.

## Screenshots (if applicable)

N/A — backend candidate compiler/test change with no UI.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
