### PR TITLE
fix(torghut): import source collection targets from sim plan

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -775,6 +775,30 @@ def _runtime_window_target_plan_source_collection_targets(
     return targets
 
 
+def _runtime_window_gate_allows_source_collection_merge(
+    *,
+    gate: Mapping[str, Any],
+    gate_plan: Mapping[str, Any],
+) -> bool:
+    blocked_reasons = {
+        str(reason or "").strip()
+        for reason in _as_sequence(gate.get("blocked_reasons"))
+        if str(reason or "").strip()
+    }
+    if "runtime_ledger_source_collection_pending" in blocked_reasons:
+        return True
+    try:
+        source_collection_target_count = int(
+            gate_plan.get("source_collection_target_count") or 0
+        )
+    except (TypeError, ValueError):
+        source_collection_target_count = 0
+    if source_collection_target_count <= 0:
+        return False
+    reason = str(gate.get("reason") or "").strip()
+    return reason == "non_live_mode"
+
+
 def _runtime_window_target_plan_with_live_gate_source_collection(
     *,
     payload: Mapping[str, Any],
@@ -789,12 +813,10 @@ def _runtime_window_target_plan_with_live_gate_source_collection(
     if not source_collection_targets:
         return merged_plan
 
-    blocked_reasons = {
-        str(reason or "").strip()
-        for reason in _as_sequence(gate.get("blocked_reasons"))
-        if str(reason or "").strip()
-    }
-    if "runtime_ledger_source_collection_pending" not in blocked_reasons:
+    if not _runtime_window_gate_allows_source_collection_merge(
+        gate=gate,
+        gate_plan=gate_plan,
+    ):
         return merged_plan
 
     existing_targets = _runtime_window_plan_target_items(merged_plan)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1361,6 +1361,91 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             ["H-SOURCE-COLLECTION", "H-PAPER-ROUTE"],
         )
 
+    def test_runtime_window_target_plan_payload_keeps_sim_gate_source_collection(
+        self,
+    ) -> None:
+        plan = renewal._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-paper-route",
+                            "hypothesis_id": "H-PAPER-ROUTE",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "window_start": "2026-06-04T13:30:00+00:00",
+                            "window_end": "2026-06-04T20:00:00+00:00",
+                        }
+                    ],
+                },
+                "live_submission_gate": {
+                    "allowed": True,
+                    "reason": "non_live_mode",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "candidate_id": "cand-source-collection",
+                                "hypothesis_id": "H-SOURCE-COLLECTION",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "source-collection-candidate-v1",
+                                "account_label": "TORGHUT_REPLAY",
+                                "source_kind": "runtime_ledger_source_collection_candidate",
+                                "source_collection_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_allowed": False,
+                                "window_start": "2026-05-13T17:00:00+00:00",
+                                "window_end": "2026-05-13T17:30:00+00:00",
+                            }
+                        ],
+                    },
+                },
+            }
+        )
+
+        self.assertTrue(plan["merged_live_submission_gate_source_collection"])
+        self.assertEqual(plan["source_collection_target_count"], 1)
+        self.assertEqual(plan["paper_route_target_count"], 1)
+        self.assertEqual(plan["target_count"], 2)
+        self.assertEqual(
+            [target["hypothesis_id"] for target in plan["targets"]],
+            ["H-SOURCE-COLLECTION", "H-PAPER-ROUTE"],
+        )
+        self.assertFalse(plan["targets"][0]["promotion_allowed"])
+        self.assertFalse(plan["targets"][0]["final_promotion_allowed"])
+
+    def test_runtime_window_gate_source_collection_merge_requires_pending_or_sim_count(
+        self,
+    ) -> None:
+        self.assertFalse(
+            renewal._runtime_window_gate_allows_source_collection_merge(
+                gate={"reason": "non_live_mode", "blocked_reasons": []},
+                gate_plan={"source_collection_target_count": "not-an-int"},
+            )
+        )
+        self.assertFalse(
+            renewal._runtime_window_gate_allows_source_collection_merge(
+                gate={"reason": "promotion_certificate_valid", "blocked_reasons": []},
+                gate_plan={"source_collection_target_count": 1},
+            )
+        )
+        self.assertTrue(
+            renewal._runtime_window_gate_allows_source_collection_merge(
+                gate={
+                    "reason": "simple_submit_disabled",
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                },
+                gate_plan={"source_collection_target_count": "not-an-int"},
+            )
+        )
+
     def test_runtime_window_target_plan_url_failures_are_fail_closed(self) -> None:
         with self.assertRaisesRegex(
             RuntimeError, "runtime_window_target_plan_url_empty"


### PR DESCRIPTION
## Summary

- Allows the empirical renewal runner to merge explicit runtime-ledger source-collection targets when the target-plan payload is served by the sim service in `non_live_mode`.
- Preserves fail-closed behavior for normal promotion-valid gates and malformed source-collection counts.
- Adds regression coverage for the deployed payload shape so the next renewal run includes source materialization targets instead of only next-session paper-route targets.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py --cov=scripts --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Patched parser dry-run against the current `torghut-sim` paper-route evidence payload produced `target_count=7`, `paper_route_target_count=2`, `source_collection_target_count=5`, and `source_collection_profit_target_count=1`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
