### PR TITLE
fix(torghut): use live proof source for runtime import

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -61,7 +61,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url 'http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5' \
+                    --runtime-window-target-plan-url 'http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5' \
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \
@@ -82,7 +82,7 @@ spec:
                     | tee "${RENEWAL_OUTPUT}"
                   /opt/venv/bin/python scripts/assemble_runtime_ledger_proof_packet.py \
                     --status-service-base-url http://torghut.torghut.svc.cluster.local \
-                    --paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local \
+                    --paper-route-service-base-url http://torghut.torghut.svc.cluster.local \
                     --completion-service-base-url http://torghut.torghut.svc.cluster.local \
                     --timeout-seconds 30 \
                     --proof-mode authority \


### PR DESCRIPTION
## Summary

- Point Torghut empirical promotion renewal runtime-window plan reads at the live service so source-collection imports use the authoritative `DB_DSN` / `TORGHUT_REPLAY` target metadata.
- Align runtime-ledger proof-packet paper-route evidence reads with the same live evidence source used for the import.
- Preserve `SIM_DB_DSN` target materialization and all existing promotion/capital gates; this does not enable live submission or relax authority checks.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`
- Read-only live pod plan extraction confirmed the changed source selects `candidate_id=c88421d619759b2cfaa6f4d0`, `source_dsn_env=DB_DSN`, `source_account_label=TORGHUT_REPLAY`, `target_dsn_env=SIM_DB_DSN`, `source_collection_net_strategy_pnl_after_costs=567.44720578`, and the historical runtime-ledger bucket ref/window.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
