### PR TITLE
test(torghut): align live proof manifest contract

### DIFF
--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1787,7 +1787,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertFalse(sim_runtime_command.skip_reconcile)
         self.assertTrue(sim_runtime_command.reconcile_empty_selection)
 
-    def test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db(
+    def test_empirical_promotion_renewal_imports_authoritative_live_paper_plan_and_sim_db(
         self,
     ) -> None:
         spec, container = _load_cronjob_container(
@@ -1857,6 +1857,11 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(args.count("--dsn-env SIM_DB_DSN"), 2)
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
+            "--runtime-window-target-plan-url "
+            "'http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5'",
+            args,
+        )
+        self.assertNotIn(
             "--runtime-window-target-plan-url "
             "'http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5'",
             args,
@@ -1941,11 +1946,11 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertIn(
-            "--paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local",
+            "--paper-route-service-base-url http://torghut.torghut.svc.cluster.local",
             args,
         )
         self.assertNotIn(
-            "--paper-route-service-base-url http://torghut.torghut.svc.cluster.local",
+            "--paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local",
             args,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary

- Update the empirical-promotion renewal manifest contract test to require the live Torghut paper-route evidence endpoint.
- Keep the SIM database import target assertions in place so paper evidence is still materialized into the simulation database.
- Assert the old `torghut-sim` service URL is no longer used for the runtime target plan or proof-packet paper-route base.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal_imports_authoritative_live_paper_plan_and_sim_db -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
