### PR TITLE
fix(torghut): prefer source-backed repair candidates

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -59,6 +59,7 @@ from .runtime_ledger_source_authority import (
     RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
     RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
     runtime_ledger_promotion_source_authority_blockers,
+    runtime_ledger_promotion_source_authority_present,
 )
 from .runtime_strategy_resolution import (
     derived_strategy_name_from_strategy_id,
@@ -1579,7 +1580,7 @@ def _runtime_ledger_repair_reason_codes(
 
 def _runtime_ledger_repair_score(
     candidate: Mapping[str, object],
-) -> tuple[int, int, int, int, int, Decimal, Decimal, Decimal, float]:
+) -> tuple[int, int, int, int, int, int, int, Decimal, Decimal, Decimal, float]:
     reason_codes = set(
         str(reason).strip()
         for reason in cast(Sequence[object], candidate.get("reason_codes") or [])
@@ -1594,8 +1595,25 @@ def _runtime_ledger_repair_score(
     ) or Decimal("0")
     ended_at = _coerce_aware_datetime(candidate.get("bucket_ended_at"))
     observed_stage = _safe_text(candidate.get("observed_stage"))
+    payload: dict[str, object] = {}
+    raw_bucket = candidate.get("runtime_ledger_bucket")
+    if isinstance(raw_bucket, Mapping):
+        payload.update(cast(Mapping[str, object], raw_bucket))
+    payload.update(
+        {
+            str(key): value
+            for key, value in candidate.items()
+            if key != "runtime_ledger_bucket"
+        }
+    )
+    source_authority_present = int(
+        runtime_ledger_promotion_source_authority_present(payload)
+    )
+    clear_live_candidate = observed_stage == "live" and not reason_codes
     return (
         (
+            2 if clear_live_candidate else source_authority_present,
+            source_authority_present,
             int(filled_notional > 0),
             int(_safe_int(candidate.get("fill_count")) > 0),
             int(_safe_int(candidate.get("closed_trade_count")) > 0),
@@ -1606,8 +1624,10 @@ def _runtime_ledger_repair_score(
             filled_notional,
             ended_at.timestamp() if ended_at is not None else 0.0,
         )
-        if observed_stage != "live" or reason_codes
+        if not clear_live_candidate
         else (
+            2,
+            source_authority_present,
             2,
             2,
             2,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -56,6 +56,7 @@ from app.trading.submission_council import (
     _metric_window_activity_reason_codes,
     _rollback_runtime_ledger_status_session,
     _runtime_ledger_repair_reason_codes,
+    _runtime_ledger_repair_score,
     _runtime_ledger_status_query_timeout_ms,
     _refresh_runtime_summary_totals,
     _runtime_ledger_paper_probation_blockers,
@@ -2161,6 +2162,76 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(
             target["source_collection_next_action"],
             "materialize_runtime_ledger_source_window_refs",
+        )
+
+    def test_runtime_ledger_repair_score_prefers_source_backed_positive_candidate(
+        self,
+    ) -> None:
+        aggregate_profit_candidate = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "observed_stage": "paper",
+            "bucket_ended_at": "2026-05-13T17:30:00+00:00",
+            "submitted_order_count": 8,
+            "fill_count": 35,
+            "closed_trade_count": 2,
+            "filled_notional": "127090.02495200",
+            "net_strategy_pnl_after_costs": "567.44720578",
+            "post_cost_expectancy_bps": "44.64923238",
+            "reason_codes": [
+                "runtime_ledger_source_window_missing",
+                "runtime_ledger_source_refs_missing",
+                "execution_reconstruction_not_runtime_ledger_proof",
+            ],
+        }
+        source_backed_candidate = {
+            "hypothesis_id": "H-TSMOM-LIQ-01",
+            "candidate_id": "ca4e6e3c7d639e3363dc5860",
+            "observed_stage": "paper",
+            "bucket_ended_at": "2026-06-02T18:14:43.066253+00:00",
+            "submitted_order_count": 2,
+            "fill_count": 8,
+            "closed_trade_count": 5,
+            "filled_notional": "7546.75932928",
+            "net_strategy_pnl_after_costs": "44.74192128",
+            "post_cost_expectancy_bps": "59.28641313",
+            "reason_codes": ["runtime_ledger_stage_not_live"],
+            "runtime_ledger_bucket": {
+                "source_window_start": "2026-06-02T13:51:11.262153+00:00",
+                "source_window_end": "2026-06-02T18:14:43.066253+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 2,
+                    "executions": 2,
+                    "execution_order_events": 2,
+                    "order_feed_source_windows": 2,
+                },
+                "trade_decision_ids": ["decision-1", "decision-2"],
+                "execution_ids": ["execution-1", "execution-2"],
+                "execution_order_event_ids": ["event-1", "event-2"],
+                "source_window_ids": ["window-1", "window-2"],
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42},
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 43},
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
+                "filled_notional": "7546.75932928",
+                "cost_amount": "0.25000000",
+                "cost_basis_counts": {"broker_reported_zero_cost": 1},
+                "cost_model_hash_counts": {"cost-model": 1},
+            },
+        }
+
+        self.assertGreater(
+            _runtime_ledger_repair_score(source_backed_candidate),
+            _runtime_ledger_repair_score(aggregate_profit_candidate),
         )
 
     def test_runtime_ledger_source_collection_bucket_without_account_uses_sim_source(


### PR DESCRIPTION
## Summary

- Prioritizes source-backed runtime-ledger repair candidates ahead of higher-PnL aggregate buckets that still lack row-level source authority.
- Keeps live/final promotion gates fail-closed; this only changes repair/probation candidate ordering for evidence collection.
- Adds a regression test for the current H-PAIRS aggregate-profit versus H-TSMOM source-backed-positive ranking failure mode.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py -k 'repair_score_prefers_source_backed_positive_candidate or runtime_ledger_source_collection_replay_bucket_reads_from_live_db'`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
