### PR TITLE
fix(torghut): sanitize runtime ledger proof lineage

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -202,10 +202,27 @@ def _sequence(value: object) -> Sequence[object]:
 
 def _text_list(value: object) -> list[str]:
     items: list[str] = []
-    for item in _sequence(value):
-        text = _text(item)
-        if text and text not in items:
-            items.append(text)
+    if isinstance(value, Mapping):
+        return items
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in cast(Sequence[object], value):
+            if isinstance(item, Mapping):
+                continue
+            if isinstance(item, Sequence) and not isinstance(
+                item,
+                (str, bytes, bytearray),
+            ):
+                for text in _text_list(item):
+                    if text not in items:
+                        items.append(text)
+                continue
+            text = _text(item)
+            if text and text not in items:
+                items.append(text)
+        return items
+    text = _text(value)
+    if text:
+        items.append(text)
     return items
 
 

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -878,6 +878,55 @@ class TestRuntimeLedgerProofPacket(TestCase):
         ):
             self.assertIn(source_ref, lineage["source_refs"])
 
+    def test_packet_lineage_ignores_nested_empty_readback_collections(self) -> None:
+        runtime_import = _runtime_import()
+        first_import = runtime_import["imports"][0]
+        assert isinstance(first_import, dict)
+        summary = first_import["summary"]
+        assert isinstance(summary, dict)
+        target = summary["runtime_materialization_target"]
+        assert isinstance(target, dict)
+        readback = target["readback"]
+        assert isinstance(readback, dict)
+        target["runtime_ledger_bucket_ids"] = [
+            "runtime-ledger-bucket-1",
+            [],
+        ]
+        target["evidence_grade_runtime_ledger_bucket_ids"] = [
+            "runtime-ledger-bucket-1",
+            [],
+        ]
+        readback["source_row_ids"] = [[]]
+        readback["runtime_ledger_source_row_ids"] = [["source-window-nested"]]
+        readback["trade_decision_ids"] = "decision-scalar"
+        readback["source_refs"] = [
+            "postgres:trade_decisions",
+            [],
+            {},
+        ]
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(ledger_refs=[]),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        lineage = result["lineage"]
+        self.assertNotIn("[]", lineage["source_row_ids"])
+        self.assertNotIn("[]", lineage["runtime_ledger_bucket_ids"])
+        self.assertIn("source-window-nested", lineage["source_row_ids"])
+        self.assertIn("decision-scalar", lineage["source_row_ids"])
+        self.assertEqual(
+            lineage["runtime_ledger_bucket_ids"],
+            ["runtime-ledger-bucket-1"],
+        )
+
     def test_hpairs_source_proof_census_blockers_are_non_authority_packet_blockers(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Sanitizes runtime-ledger proof-packet lineage extraction so nested empty readback collections are ignored instead of being counted as literal `[]` source row or bucket IDs.
- Preserves real scalar and nested scalar lineage values from runtime-window import readback, including decision/source-window identifiers.
- Adds regression coverage for mixed empty/nested/scalar runtime-ledger readback lineage without changing authority gates.

## Related Issues

None

## Testing

- PASS: `uv sync --frozen --extra dev`
- PASS: `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py`
- PASS: `uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- PASS: `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- PASS: `uv run --frozen pyright --project pyrightconfig.json`
- PASS: `uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation or release-note updates were required for this proof-packet lineage sanitizer.
