### PR TITLE
fix(torghut): skip aggregate replay source imports

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -8810,6 +8810,61 @@ def _target_is_runtime_ledger_source_collection(
     )
 
 
+def _positive_mapping_count(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    typed_value = cast(Mapping[str, object], value)
+    for raw_count in typed_value.values():
+        if _safe_int(raw_count) > 0:
+            return True
+    return False
+
+
+def _source_collection_target_has_materializable_lineage(
+    target: Mapping[str, Any],
+) -> bool:
+    for key in (
+        "source_window_ids",
+        "runtime_ledger_source_window_ids",
+        "execution_order_event_ids",
+        "runtime_ledger_execution_order_event_ids",
+        "execution_ids",
+        "trade_decision_ids",
+        "source_offsets",
+    ):
+        if _unique_text_items(target.get(key)):
+            return True
+    if _safe_text(target.get("source_materialization")) is not None:
+        return True
+    if _safe_text(target.get("authority_class")) is not None:
+        return True
+    if _positive_mapping_count(target.get("source_row_counts")):
+        return True
+    source_refs = [
+        ref
+        for ref in _unique_text_items(target.get("source_refs"))
+        if "strategy_runtime_ledger_buckets" not in ref
+    ]
+    return bool(source_refs)
+
+
+def _source_collection_import_target_allowed(target: Mapping[str, Any]) -> bool:
+    """Reject legacy replay buckets that cannot be materialized into source proof."""
+
+    account_label = _safe_text(target.get("account_label"))
+    source_account_label = (
+        _safe_text(target.get("source_account_label")) or account_label
+    )
+    if (
+        account_label == "TORGHUT_REPLAY"
+        and source_account_label == "TORGHUT_REPLAY"
+        and _safe_text(target.get("source_dsn_env")) == "DB_DSN"
+        and not _source_collection_target_has_materializable_lineage(target)
+    ):
+        return False
+    return True
+
+
 def _runtime_window_import_target_metadata(
     target: Mapping[str, Any],
 ) -> dict[str, object]:
@@ -8995,6 +9050,8 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
         if len(source_targets) >= limit:
             return
         if not _target_is_runtime_ledger_source_collection(target):
+            return
+        if not _source_collection_import_target_allowed(target):
             return
         sanitized = _sanitized_runtime_ledger_source_collection_target(target)
         key = (

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -755,6 +755,67 @@ def _runtime_window_target_plan_target_truthy(value: object) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes"}
 
 
+def _runtime_window_target_plan_positive_mapping_count(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    for raw_count in value.values():
+        try:
+            if int(str(raw_count or "0")) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _runtime_window_source_collection_target_has_materializable_lineage(
+    target: Mapping[str, Any],
+) -> bool:
+    for key in (
+        "source_window_ids",
+        "runtime_ledger_source_window_ids",
+        "execution_order_event_ids",
+        "runtime_ledger_execution_order_event_ids",
+        "execution_ids",
+        "trade_decision_ids",
+        "source_offsets",
+    ):
+        if _as_sequence(target.get(key)):
+            return True
+        if _as_text(target.get(key)) is not None:
+            return True
+    if _as_text(target.get("source_materialization")) is not None:
+        return True
+    if _as_text(target.get("authority_class")) is not None:
+        return True
+    if _runtime_window_target_plan_positive_mapping_count(
+        target.get("source_row_counts")
+    ):
+        return True
+    source_refs = [
+        ref
+        for ref in _as_text_list(target.get("source_refs"))
+        if "strategy_runtime_ledger_buckets" not in ref
+    ]
+    return bool(source_refs)
+
+
+def _runtime_window_source_collection_target_allowed(
+    target: Mapping[str, Any],
+) -> bool:
+    account_label = _as_text(target.get("account_label"))
+    source_account_label = _as_text(target.get("source_account_label")) or account_label
+    if (
+        account_label == "TORGHUT_REPLAY"
+        and source_account_label == "TORGHUT_REPLAY"
+        and _as_text(target.get("source_dsn_env")) == "DB_DSN"
+        and not _runtime_window_source_collection_target_has_materializable_lineage(
+            target
+        )
+    ):
+        return False
+    return True
+
+
 def _runtime_window_target_plan_source_collection_targets(
     gate_plan: Mapping[str, Any],
 ) -> list[dict[str, Any]]:
@@ -771,7 +832,8 @@ def _runtime_window_target_plan_source_collection_targets(
             or handoff == "runtime_ledger_source_collection_import"
             or selected_by == "runtime_ledger_source_collection"
         ):
-            targets.append(target)
+            if _runtime_window_source_collection_target_allowed(target):
+                targets.append(target)
     return targets
 
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5158,6 +5158,18 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         "source_account_label": "TORGHUT_REPLAY",
                         "source_dsn_env": "DB_DSN",
                         "target_dsn_env": "SIM_DB_DSN",
+                        "source_row_counts": {"execution_order_events": 2},
+                        "source_window_ids": ["window-1"],
+                        "execution_order_event_ids": ["event-1", "event-2"],
+                        "execution_ids": ["execution-1"],
+                        "trade_decision_ids": ["decision-1"],
+                        "source_offsets": [
+                            {
+                                "topic": "trade_updates",
+                                "partition": 0,
+                                "offset": 101,
+                            }
+                        ],
                         "runtime_ledger_bucket_ref": (
                             "strategy_runtime_ledger_buckets:run-1:start:end"
                         ),
@@ -5228,6 +5240,102 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target_limit=10,
         )
         self.assertEqual(empty_plan, {})
+
+    def test_source_collection_import_plan_skips_aggregate_replay_bucket_without_lineage(
+        self,
+    ) -> None:
+        live_gate = {
+            "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+        }
+
+        plan = paper_route_evidence._runtime_ledger_source_collection_import_plan_for_payload(
+            plan={
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "aggregate-replay",
+                        "strategy_family": "microbar_cross_sectional_pairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "account_label": "TORGHUT_REPLAY",
+                        "source_account_label": "TORGHUT_REPLAY",
+                        "source_dsn_env": "DB_DSN",
+                        "target_dsn_env": "SIM_DB_DSN",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_collection_authorized": True,
+                        "source_collection_priority": (
+                            "profit_target_source_materialization"
+                        ),
+                        "source_collection_profit_target_candidate": True,
+                        "source_collection_reason_codes": [
+                            "runtime_ledger_source_window_missing",
+                            "runtime_ledger_source_refs_missing",
+                            "runtime_ledger_execution_order_event_refs_missing",
+                            "runtime_ledger_source_offsets_missing",
+                            "runtime_ledger_source_materialization_missing",
+                            "runtime_ledger_authority_class_missing",
+                        ],
+                        "filled_notional": "127090.02495200",
+                        "fill_count": 2,
+                        "submitted_order_count": 2,
+                        "runtime_ledger_bucket_ref": (
+                            "strategy_runtime_ledger_buckets:"
+                            "rt-ledger-vwap-cap-safe-20260512-20260521-c88421d6:"
+                            "2026-05-13T17:00:00+00:00:"
+                            "2026-05-13T17:30:00+00:00"
+                        ),
+                    }
+                ],
+            },
+            live_submission_gate=live_gate,
+            target_limit=5,
+        )
+
+        self.assertEqual(plan, {})
+
+    def test_source_collection_import_allows_aggregate_replay_with_materializable_lineage(
+        self,
+    ) -> None:
+        base_target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "source-backed-replay",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "account_label": "TORGHUT_REPLAY",
+            "source_account_label": "TORGHUT_REPLAY",
+            "source_dsn_env": "DB_DSN",
+            "source_kind": "runtime_ledger_source_collection_candidate",
+            "source_collection_authorized": True,
+        }
+
+        self.assertFalse(
+            paper_route_evidence._positive_mapping_count(
+                {"execution_order_events": "not-an-int", "trade_decisions": 0}
+            )
+        )
+        self.assertTrue(
+            paper_route_evidence._positive_mapping_count(
+                {"execution_order_events": "2"}
+            )
+        )
+
+        for lineage in (
+            {"source_window_ids": ["window-1"]},
+            {"source_materialization": "execution_order_events"},
+            {"authority_class": "event_sourced_runtime_ledger_profit_proof"},
+            {"source_row_counts": {"execution_order_events": 2}},
+            {"source_refs": ["postgres:execution_order_events:event-1"]},
+        ):
+            target = {**base_target, **lineage}
+
+            self.assertTrue(
+                paper_route_evidence._source_collection_target_has_materializable_lineage(
+                    target
+                )
+            )
+            self.assertTrue(
+                paper_route_evidence._source_collection_import_target_allowed(target)
+            )
 
     def test_source_collection_import_plan_uses_direct_gate_candidates(
         self,

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1421,6 +1421,119 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertFalse(plan["targets"][0]["promotion_allowed"])
         self.assertFalse(plan["targets"][0]["final_promotion_allowed"])
 
+    def test_runtime_window_target_plan_skips_aggregate_replay_source_collection(
+        self,
+    ) -> None:
+        plan = renewal._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "runtime_window_import_plan": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-paper-route",
+                            "hypothesis_id": "H-PAPER-ROUTE",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "window_start": "2026-06-04T13:30:00+00:00",
+                            "window_end": "2026-06-04T20:00:00+00:00",
+                        }
+                    ],
+                },
+                "live_submission_gate": {
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "candidate_id": "aggregate-replay",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "source-collection-candidate-v1",
+                                "account_label": "TORGHUT_REPLAY",
+                                "source_account_label": "TORGHUT_REPLAY",
+                                "source_dsn_env": "DB_DSN",
+                                "target_dsn_env": "SIM_DB_DSN",
+                                "source_kind": "runtime_ledger_source_collection_candidate",
+                                "source_collection_authorized": True,
+                                "source_collection_reason_codes": [
+                                    "runtime_ledger_source_window_missing",
+                                    "runtime_ledger_source_refs_missing",
+                                    "runtime_ledger_execution_order_event_refs_missing",
+                                    "runtime_ledger_source_offsets_missing",
+                                    "runtime_ledger_source_materialization_missing",
+                                    "runtime_ledger_authority_class_missing",
+                                ],
+                                "runtime_ledger_bucket_ref": (
+                                    "strategy_runtime_ledger_buckets:"
+                                    "rt-ledger-vwap-cap-safe-20260512-20260521-c88421d6:"
+                                    "2026-05-13T17:00:00+00:00:"
+                                    "2026-05-13T17:30:00+00:00"
+                                ),
+                                "window_start": "2026-05-13T17:00:00+00:00",
+                                "window_end": "2026-05-13T17:30:00+00:00",
+                            }
+                        ],
+                    },
+                },
+            }
+        )
+
+        self.assertNotIn("merged_live_submission_gate_source_collection", plan)
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(
+            [target["hypothesis_id"] for target in plan["targets"]],
+            ["H-PAPER-ROUTE"],
+        )
+
+    def test_runtime_window_target_plan_allows_source_collection_with_materializable_lineage(
+        self,
+    ) -> None:
+        base_target = {
+            "candidate_id": "source-backed-replay",
+            "hypothesis_id": "H-PAIRS-01",
+            "strategy_name": "source-collection-candidate-v1",
+            "account_label": "TORGHUT_REPLAY",
+            "source_account_label": "TORGHUT_REPLAY",
+            "source_dsn_env": "DB_DSN",
+            "source_kind": "runtime_ledger_source_collection_candidate",
+            "source_collection_authorized": True,
+        }
+
+        self.assertFalse(
+            renewal._runtime_window_target_plan_positive_mapping_count(
+                {"execution_order_events": "not-an-int", "trade_decisions": 0}
+            )
+        )
+        self.assertTrue(
+            renewal._runtime_window_target_plan_positive_mapping_count(
+                {"execution_order_events": "2"}
+            )
+        )
+
+        for lineage in (
+            {"source_window_ids": ["window-1"]},
+            {"source_window_ids": "window-1"},
+            {"source_materialization": "execution_order_events"},
+            {"authority_class": "event_sourced_runtime_ledger_profit_proof"},
+            {"source_row_counts": {"execution_order_events": 2}},
+            {"source_refs": ["postgres:execution_order_events:event-1"]},
+        ):
+            target = {**base_target, **lineage}
+
+            self.assertTrue(
+                renewal._runtime_window_source_collection_target_has_materializable_lineage(
+                    target
+                )
+            )
+            self.assertTrue(
+                renewal._runtime_window_source_collection_target_allowed(target)
+            )
+
     def test_runtime_window_gate_source_collection_merge_requires_pending_or_sim_count(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Skips aggregate-only `TORGHUT_REPLAY` replay buckets from source-runtime import plans when they lack materializable source lineage.
- Applies the same fail-closed filter in the paper-route evidence payload builder and the empirical renewal target-plan parser.
- Keeps current/future SIM source-collection targets importable and adds regression coverage for both endpoint and renewal parsing paths.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
