### PR TITLE
fix(torghut): block unmaterialized ledger handoffs

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -149,6 +149,9 @@ FILL_SURVIVAL_SCORECARD_KEYS = (
     "post_cost_survival_rate",
     "gross_positive_killed_by_cost_count",
 )
+RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS = (
+    "runtime_ledger_lineage_materialization_handoff",
+)
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -437,6 +440,66 @@ def _artifact_refs_from_scorecard(scorecard: Mapping[str, Any]) -> tuple[str, ..
             if ref:
                 refs.append(ref)
     return tuple(dict.fromkeys(refs))
+
+
+def _runtime_ledger_lineage_handoff(
+    *,
+    scorecard: Mapping[str, Any],
+    promotion_readiness: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _mapping(
+        scorecard.get("runtime_ledger_lineage_materialization_handoff")
+    ) or _mapping(
+        promotion_readiness.get("runtime_ledger_lineage_materialization_handoff")
+    )
+
+
+def _runtime_ledger_lineage_handoff_blockers(
+    *,
+    scorecard: Mapping[str, Any],
+    promotion_readiness: Mapping[str, Any],
+) -> list[str]:
+    handoff = _runtime_ledger_lineage_handoff(
+        scorecard=scorecard,
+        promotion_readiness=promotion_readiness,
+    )
+    if not handoff:
+        return []
+
+    blockers: list[str] = []
+    if _bool(handoff.get("zero_authoritative_daily_pnl_until_materialized")):
+        blockers.append("authoritative_daily_pnl_missing")
+
+    requires_runtime_ledger = (
+        _bool(handoff.get("runtime_ledger_required"))
+        or _bool(handoff.get("source_backed_runtime_ledger_required"))
+        or _string(handoff.get("status"))
+        == "requires_runtime_ledger_materialization_before_authoritative_pnl"
+    )
+    materialized = (
+        _bool(handoff.get("runtime_ledger_materialized"))
+        or _string(handoff.get("status")) == "runtime_ledger_materialized"
+    )
+    if requires_runtime_ledger and not materialized:
+        blockers.append("runtime_ledger_lineage_materialization_missing")
+
+    for key, blocker in (
+        ("proof_authority", "runtime_ledger_handoff_not_proof_authority"),
+        ("promotion_allowed", "runtime_ledger_handoff_not_promotion_authority"),
+        ("final_authority_ok", "runtime_ledger_handoff_final_authority_blocked"),
+    ):
+        if key in handoff and not _bool(handoff.get(key)):
+            blockers.append(blocker)
+
+    required_artifacts = handoff.get("required_materialized_artifacts")
+    if (
+        isinstance(required_artifacts, Sequence)
+        and not isinstance(required_artifacts, (str, bytes, bytearray))
+        and not materialized
+    ):
+        blockers.append("runtime_ledger_required_artifacts_unmaterialized")
+
+    return blockers
 
 
 def _p10(values: Sequence[Decimal]) -> Decimal:
@@ -918,6 +981,13 @@ def evidence_bundle_from_frontier_candidate(
             if key in source:
                 scorecard = {**scorecard, key: source[key]}
                 break
+    for key in RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS:
+        if key in scorecard:
+            continue
+        for source in (candidate, summary, full_window):
+            if key in source:
+                scorecard = {**scorecard, key: source[key]}
+                break
     for source in (candidate, summary, full_window):
         for key, value in _order_type_execution_metrics(source).items():
             if key not in scorecard:
@@ -1345,6 +1415,12 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
     ):
         blockers.append("synthetic_evidence_not_promotion_proof")
     if _requires_promotion_proof(bundle):
+        blockers.extend(
+            _runtime_ledger_lineage_handoff_blockers(
+                scorecard=scorecard,
+                promotion_readiness=bundle.promotion_readiness,
+            )
+        )
         blockers.extend(_delay_depth_survival_blockers(scorecard))
     return tuple(dict.fromkeys(blockers))
 

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from app.trading.discovery.evidence_bundles import (
+    EVIDENCE_BUNDLE_SCHEMA_VERSION,
+    CandidateEvidenceBundle,
+    evidence_bundle_blockers,
+    evidence_bundle_from_frontier_candidate,
+)
+
+
+def _promotion_quality_scorecard() -> dict[str, object]:
+    return {
+        "delay_adjusted_depth_stress_passed": True,
+        "delay_adjusted_depth_stress_model": "delay_adjusted_depth_fixture",
+        "delay_adjusted_depth_stress_ms": "50",
+        "delay_adjusted_depth_stress_artifact_ref": "artifact://delay-depth",
+        "delay_adjusted_depth_tail_coverage_passed": True,
+        "delay_adjusted_depth_p10_active_day_fillable_notional": "1000",
+        "delay_adjusted_depth_worst_active_day_fillable_notional": "1000",
+        "delay_adjusted_depth_stress_net_pnl_per_day": "600",
+        "fill_survival_evidence_present": True,
+        "fill_survival_sample_count": 12,
+        "queue_ahead_depletion_evidence_present": True,
+        "queue_ahead_depletion_sample_count": 12,
+    }
+
+
+def _unmaterialized_runtime_handoff() -> dict[str, object]:
+    return {
+        "schema_version": "torghut.fast-replay-runtime-ledger-lineage-handoff.v1",
+        "status": "requires_runtime_ledger_materialization_before_authoritative_pnl",
+        "candidate_spec_id": "spec-runtime-gap",
+        "required_materialized_artifacts": [
+            "closed_round_trip_ledger",
+            "route_tca_observations",
+            "trade_level_cost_log",
+            "lineage_hash",
+        ],
+        "required_daily_pnl_basis": "post_cost_closed_round_trip_daily_pnl",
+        "zero_authoritative_daily_pnl_until_materialized": True,
+        "runtime_ledger_required": True,
+        "source_backed_runtime_ledger_required": True,
+        "proof_authority": False,
+        "promotion_allowed": False,
+        "final_authority_ok": False,
+    }
+
+
+def test_promotion_ready_bundle_blocks_unmaterialized_runtime_ledger_handoff() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-runtime-gap",
+        candidate_id="candidate-runtime-gap",
+        candidate_spec_id="spec-runtime-gap",
+        dataset_snapshot_id="snapshot-runtime-gap",
+        feature_spec_hash="feature-runtime-gap",
+        code_commit="commit-runtime-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "runtime_ledger_lineage_materialization_handoff": (
+                _unmaterialized_runtime_handoff()
+            ),
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "authoritative_daily_pnl_missing" in blockers
+    assert "runtime_ledger_lineage_materialization_missing" in blockers
+    assert "runtime_ledger_handoff_not_proof_authority" in blockers
+    assert "runtime_ledger_handoff_not_promotion_authority" in blockers
+    assert "runtime_ledger_handoff_final_authority_blocked" in blockers
+    assert "runtime_ledger_required_artifacts_unmaterialized" in blockers
+
+
+def test_frontier_candidate_preserves_runtime_handoff_as_promotion_blocker() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-runtime-gap",
+        candidate={
+            "candidate_id": "candidate-runtime-gap",
+            "objective_scorecard": _promotion_quality_scorecard(),
+            "runtime_ledger_lineage_materialization_handoff": (
+                _unmaterialized_runtime_handoff()
+            ),
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-runtime-gap",
+        result_path="artifact://replay",
+        code_commit="commit-runtime-gap",
+    )
+
+    assert (
+        "runtime_ledger_lineage_materialization_handoff" in bundle.objective_scorecard
+    )
+    blockers = evidence_bundle_blockers(bundle)
+    assert "authoritative_daily_pnl_missing" in blockers
+    assert "runtime_ledger_lineage_materialization_missing" in blockers


### PR DESCRIPTION
## Summary

- Adds an evidence-bundle promotion blocker for fast-replay runtime-ledger lineage handoffs that still report zero authoritative daily PnL.
- Preserves handoff metadata from frontier candidates into candidate evidence bundles so later promotion checks can fail closed.
- Adds focused tests proving promotion-ready bundles remain blocked until runtime-ledger lineage/materialization becomes authoritative.

## Related Issues

None

## Testing

- `uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py`
- `uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
