### PR TITLE
fix(torghut): preserve source bucket lineage

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -5340,6 +5340,18 @@ def _runtime_ledger_bucket_metadata(
             for blocker in _runtime_ledger_bucket_profit_proof_blockers(payload)
         )
     )
+    source_bucket_ids = sorted(
+        {
+            bucket_id
+            for payload in payloads
+            if (
+                bucket_id := _text_or_none(
+                    payload.get("source_runtime_ledger_bucket_id") or payload.get("id")
+                )
+            )
+            is not None
+        }
+    )
     metadata: dict[str, Any] = {
         f"runtime_ledger_{prefix}_bucket_count": len(payloads),
         f"runtime_ledger_{prefix}_bucket_run_ids": sorted(
@@ -5364,6 +5376,12 @@ def _runtime_ledger_bucket_metadata(
         metadata[f"runtime_ledger_{prefix}_bucket_candidate_ids"] = candidate_ids
     if len(candidate_ids) == 1:
         metadata[f"runtime_ledger_{prefix}_bucket_candidate_id"] = candidate_ids[0]
+    if source_bucket_ids:
+        metadata[f"runtime_ledger_{prefix}_bucket_ids"] = source_bucket_ids
+        metadata[f"runtime_ledger_{prefix}_bucket_refs"] = [
+            f"postgres:strategy_runtime_ledger_buckets:{bucket_id}"
+            for bucket_id in source_bucket_ids
+        ]
     return metadata
 
 
@@ -5415,6 +5433,7 @@ def _runtime_ledger_tca_rows_from_durable_buckets(
 
 
 _SOURCE_RUNTIME_LEDGER_COLUMNS = (
+    "id",
     "run_id",
     "candidate_id",
     "hypothesis_id",
@@ -5456,6 +5475,25 @@ def _source_runtime_ledger_payload_from_row(
         for key, value in _as_mapping(payload.get("payload_json")).items()
         if key != "payload_json"
     }
+    if source_bucket_id := _text_or_none(payload.get("id")):
+        source_bucket_ref = (
+            f"postgres:strategy_runtime_ledger_buckets:{source_bucket_id}"
+        )
+        source_refs = _metadata_text_list(payload_json.get("source_refs"))
+        if source_bucket_ref not in source_refs:
+            source_refs.append(source_bucket_ref)
+        source_row_counts = {
+            str(key): _nonnegative_int(value)
+            for key, value in _as_mapping(payload_json.get("source_row_counts")).items()
+        }
+        source_row_counts["strategy_runtime_ledger_buckets"] = max(
+            1,
+            source_row_counts.get("strategy_runtime_ledger_buckets", 0),
+        )
+        payload_json["source_refs"] = source_refs
+        payload_json["source_row_counts"] = source_row_counts
+        payload_json["source_runtime_ledger_bucket_id"] = source_bucket_id
+        payload_json["source_runtime_ledger_bucket_ref"] = source_bucket_ref
     row_payload = {
         key: value for key, value in payload.items() if key != "payload_json"
     }

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -193,6 +193,7 @@ class _SourceLedgerCursor:
         self._results = [
             [
                 (
+                    "source-runtime-ledger-bucket-1",
                     "runtime-proof-source",
                     "H-TSMOM-LIQ-01",
                     "H-TSMOM-LIQ-01",
@@ -2595,6 +2596,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(metadata["runtime_ledger_source_bucket_count"], 1)
         self.assertEqual(
+            metadata["runtime_ledger_source_bucket_ids"],
+            ["source-runtime-ledger-bucket-1"],
+        )
+        self.assertEqual(
+            metadata["runtime_ledger_source_bucket_refs"],
+            ["postgres:strategy_runtime_ledger_buckets:source-runtime-ledger-bucket-1"],
+        )
+        self.assertEqual(
             metadata["runtime_ledger_source_bucket_run_ids"],
             ["runtime-proof-source"],
         )
@@ -2617,6 +2626,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
         self.assertEqual(bucket["run_id"], "runtime-proof-source")
+        self.assertEqual(
+            bucket["source_runtime_ledger_bucket_id"],
+            "source-runtime-ledger-bucket-1",
+        )
+        self.assertIn(
+            "postgres:strategy_runtime_ledger_buckets:source-runtime-ledger-bucket-1",
+            bucket["source_refs"],
+        )
+        self.assertEqual(
+            bucket["source_row_counts"]["strategy_runtime_ledger_buckets"],
+            1,
+        )
         self.assertEqual(
             bucket["cost_basis_counts"], {"broker_reported_commission_and_fees": 2}
         )
@@ -2652,6 +2673,24 @@ class TestImportHypothesisRuntimeWindows(TestCase):
 
         self.assertNotIn("payload_json", payload)
         self.assertEqual(payload["run_id"], "runtime-proof-source")
+        self.assertEqual(
+            payload["source_runtime_ledger_bucket_id"],
+            "source-runtime-ledger-bucket-1",
+        )
+        self.assertEqual(
+            payload["source_runtime_ledger_bucket_ref"],
+            "postgres:strategy_runtime_ledger_buckets:source-runtime-ledger-bucket-1",
+        )
+        self.assertIn(
+            "postgres:strategy_runtime_ledger_buckets:source-runtime-ledger-bucket-1",
+            payload["source_refs"],
+        )
+        self.assertEqual(
+            cast(Mapping[str, object], payload["source_row_counts"])[
+                "strategy_runtime_ledger_buckets"
+            ],
+            1,
+        )
         self.assertEqual(
             payload["source_decision_mode_counts"],
             {"strategy_signal_paper": 2},
@@ -2743,6 +2782,17 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             metadata["runtime_ledger_source_bucket_profit_proof_blockers"],
         )
         self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertIn(
+            "postgres:strategy_runtime_ledger_buckets:source-runtime-ledger-bucket-1",
+            bucket["source_refs"],
+        )
+        self.assertEqual(
+            bucket["source_row_counts"],
+            {"strategy_runtime_ledger_buckets": 1},
+        )
         self.assertIn(
             "runtime_ledger_source_refs_missing",
             rows[0]["runtime_ledger_blockers"],


### PR DESCRIPTION
## Summary

- Preserve the real source `strategy_runtime_ledger_buckets.id` when importing runtime-ledger source buckets from a source DSN.
- Add explicit aggregate source-bucket refs and row counts to imported runtime-ledger payloads/readback metadata without treating aggregate/replay-only buckets as promotion authority.
- Cover the source-DSN import path and no-authority aggregate fallback with regression assertions.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "source_runtime_ledger"`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "runtime_ledger_tca_rows_from_source_dsn"`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
