### PR TITLE
fix(torghut): gate evidence bundles on impact proof

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -1361,6 +1361,99 @@ def _delay_depth_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
     return blockers
 
 
+def _has_artifact_ref(scorecard: Mapping[str, Any], *keys: str) -> bool:
+    for key in keys:
+        raw_value = scorecard.get(key)
+        if isinstance(raw_value, Sequence) and not isinstance(
+            raw_value, (str, bytes, bytearray)
+        ):
+            if any(_string(item) for item in cast(Sequence[Any], raw_value)):
+                return True
+            continue
+        if _string(raw_value):
+            return True
+    return False
+
+
+def _market_impact_stress_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    market_impact_passed = _bool(
+        scorecard.get("nonlinear_market_impact_stress_passed")
+    ) or _bool(scorecard.get("market_impact_stress_passed"))
+    if not market_impact_passed:
+        blockers.append("market_impact_stress_failed")
+    if not _has_artifact_ref(
+        scorecard,
+        "market_impact_stress_artifact_ref",
+        "market_impact_stress_artifact_refs",
+        "nonlinear_market_impact_stress_artifact_ref",
+        "nonlinear_market_impact_stress_artifact_refs",
+    ):
+        blockers.append("market_impact_stress_artifact_missing")
+    if not _string(
+        scorecard.get("nonlinear_market_impact_stress_model")
+        or scorecard.get("market_impact_stress_model")
+        or scorecard.get("market_impact_cost_model")
+    ):
+        blockers.append("market_impact_stress_model_missing")
+    if (
+        _decimal(
+            scorecard.get("nonlinear_market_impact_stress_cost_bps")
+            or scorecard.get("market_impact_stress_cost_bps")
+            or scorecard.get("market_impact_cost_bps")
+        )
+        < MARKET_IMPACT_STRESS_COST_BPS
+    ):
+        blockers.append("market_impact_stress_cost_bps_below_min")
+    if (
+        _decimal(
+            scorecard.get("nonlinear_market_impact_stress_net_pnl_per_day")
+            or scorecard.get("market_impact_stress_net_pnl_per_day")
+        )
+        <= 0
+    ):
+        blockers.append("market_impact_stress_net_pnl_non_positive")
+    if not _bool(scorecard.get("market_impact_liquidity_evidence_present")):
+        blockers.append("market_impact_liquidity_evidence_missing")
+    return blockers
+
+
+def _implementation_uncertainty_blockers(
+    scorecard: Mapping[str, Any],
+) -> list[str]:
+    requires_implementation_uncertainty = _bool(
+        scorecard.get("implementation_uncertainty_required")
+    ) or _bool(scorecard.get("requires_implementation_uncertainty_stability"))
+    if not requires_implementation_uncertainty:
+        return []
+
+    blockers: list[str] = []
+    if not _bool(scorecard.get("implementation_uncertainty_stability_passed")):
+        blockers.append("implementation_uncertainty_stability_failed")
+    if _int(scorecard.get("implementation_uncertainty_model_count")) < 2:
+        blockers.append("implementation_uncertainty_model_count_below_min")
+    if _decimal(scorecard.get("implementation_uncertainty_lower_net_pnl_per_day")) <= 0:
+        blockers.append("implementation_uncertainty_lower_net_pnl_non_positive")
+    return blockers
+
+
+def _conformal_tail_risk_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    requires_conformal_tail_risk = _bool(
+        scorecard.get("conformal_tail_risk_required")
+    ) or _bool(scorecard.get("requires_conformal_tail_risk"))
+    if not requires_conformal_tail_risk:
+        return []
+
+    blockers: list[str] = []
+    if not _bool(scorecard.get("conformal_tail_risk_passed")):
+        blockers.append("conformal_tail_risk_failed")
+    if _int(scorecard.get("conformal_tail_risk_sample_count")) <= 0:
+        blockers.append("conformal_tail_risk_sample_count_zero")
+    if _decimal(scorecard.get("conformal_tail_risk_adjusted_net_pnl_per_day")) <= 0:
+        blockers.append("conformal_tail_risk_adjusted_net_pnl_non_positive")
+    return blockers
+
+
 def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]:
     blockers: list[str] = []
     if not _string(bundle.dataset_snapshot_id):
@@ -1421,6 +1514,9 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
                 promotion_readiness=bundle.promotion_readiness,
             )
         )
+        blockers.extend(_market_impact_stress_blockers(scorecard))
+        blockers.extend(_implementation_uncertainty_blockers(scorecard))
+        blockers.extend(_conformal_tail_risk_blockers(scorecard))
         blockers.extend(_delay_depth_survival_blockers(scorecard))
     return tuple(dict.fromkeys(blockers))
 

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -10,6 +10,12 @@ from app.trading.discovery.evidence_bundles import (
 
 def _promotion_quality_scorecard() -> dict[str, object]:
     return {
+        "market_impact_stress_passed": True,
+        "market_impact_stress_artifact_ref": "artifact://market-impact",
+        "market_impact_stress_model": "nonlinear_square_root_impact",
+        "market_impact_stress_cost_bps": "1",
+        "market_impact_stress_net_pnl_per_day": "600",
+        "market_impact_liquidity_evidence_present": True,
         "delay_adjusted_depth_stress_passed": True,
         "delay_adjusted_depth_stress_model": "delay_adjusted_depth_fixture",
         "delay_adjusted_depth_stress_ms": "50",
@@ -81,6 +87,93 @@ def test_promotion_ready_bundle_blocks_unmaterialized_runtime_ledger_handoff() -
     assert "runtime_ledger_handoff_not_promotion_authority" in blockers
     assert "runtime_ledger_handoff_final_authority_blocked" in blockers
     assert "runtime_ledger_required_artifacts_unmaterialized" in blockers
+
+
+def test_promotion_ready_bundle_blocks_missing_market_impact_stress() -> None:
+    scorecard = _promotion_quality_scorecard()
+    for key in (
+        "market_impact_stress_passed",
+        "market_impact_stress_artifact_ref",
+        "market_impact_stress_model",
+        "market_impact_stress_cost_bps",
+        "market_impact_stress_net_pnl_per_day",
+        "market_impact_liquidity_evidence_present",
+    ):
+        scorecard.pop(key)
+
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-market-impact-gap",
+        candidate_id="candidate-market-impact-gap",
+        candidate_spec_id="spec-market-impact-gap",
+        dataset_snapshot_id="snapshot-market-impact-gap",
+        feature_spec_hash="feature-market-impact-gap",
+        code_commit="commit-market-impact-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard=scorecard,
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "market_impact_stress_failed" in blockers
+    assert "market_impact_stress_artifact_missing" in blockers
+    assert "market_impact_stress_model_missing" in blockers
+    assert "market_impact_stress_cost_bps_below_min" in blockers
+    assert "market_impact_stress_net_pnl_non_positive" in blockers
+    assert "market_impact_liquidity_evidence_missing" in blockers
+
+
+def test_promotion_ready_bundle_blocks_required_uncertainty_and_tail_risk_gaps() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-uncertainty-tail-gap",
+        candidate_id="candidate-uncertainty-tail-gap",
+        candidate_spec_id="spec-uncertainty-tail-gap",
+        dataset_snapshot_id="snapshot-uncertainty-tail-gap",
+        feature_spec_hash="feature-uncertainty-tail-gap",
+        code_commit="commit-uncertainty-tail-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "implementation_uncertainty_required": True,
+            "implementation_uncertainty_stability_passed": False,
+            "implementation_uncertainty_model_count": 1,
+            "implementation_uncertainty_lower_net_pnl_per_day": "0",
+            "conformal_tail_risk_required": True,
+            "conformal_tail_risk_passed": False,
+            "conformal_tail_risk_sample_count": 0,
+            "conformal_tail_risk_adjusted_net_pnl_per_day": "0",
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "implementation_uncertainty_stability_failed" in blockers
+    assert "implementation_uncertainty_model_count_below_min" in blockers
+    assert "implementation_uncertainty_lower_net_pnl_non_positive" in blockers
+    assert "conformal_tail_risk_failed" in blockers
+    assert "conformal_tail_risk_sample_count_zero" in blockers
+    assert "conformal_tail_risk_adjusted_net_pnl_non_positive" in blockers
 
 
 def test_frontier_candidate_preserves_runtime_handoff_as_promotion_blocker() -> None:

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -959,6 +959,14 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                 "candidate_id": "cand-stage-proof",
                 "objective_scorecard": {
                     "net_pnl_per_day": "650",
+                    "market_impact_stress_passed": True,
+                    "market_impact_stress_artifact_ref": "/tmp/stage-proof.json",
+                    "market_impact_stress_model": "nonlinear_square_root_impact",
+                    "market_impact_stress_cost_bps": "1",
+                    "market_impact_stress_net_pnl_per_day": "650",
+                    "market_impact_stress_components": {
+                        "source_marker": "realistic_market_impact_arxiv_2603_29086_2026"
+                    },
                     "delay_adjusted_depth_stress_passed": True,
                     "delay_adjusted_depth_tail_coverage_passed": True,
                     "fill_survival_evidence_present": True,


### PR DESCRIPTION
## Summary

- Adds promotion-only evidence-bundle blockers for missing or failed market-impact stress proof.
- Adds required implementation-uncertainty blockers when the scorecard marks implementation uncertainty as required.
- Adds required conformal-tail-risk blockers when the scorecard marks tail-risk proof as required.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
