### PR TITLE
fix(torghut): normalize completed journal worker timeouts

### DIFF
--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -1092,6 +1092,128 @@ def _last_journal_payload(text: str) -> dict[str, Any] | None:
     return payload
 
 
+def _journal_progress_events(text: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        clean_line = line.strip()
+        if not clean_line.startswith("{"):
+            continue
+        try:
+            candidate = json.loads(clean_line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            isinstance(candidate, dict)
+            and candidate.get("schema_version")
+            == "torghut.tigerbeetle-journal-progress.v1"
+        ):
+            events.append(candidate)
+    return events
+
+
+def _progress_int(value: object) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError, ArithmeticError):
+        return 0
+
+
+def _completed_progress_batch_from_timeout(
+    text: str,
+    *,
+    worker_args: argparse.Namespace,
+) -> dict[str, Any] | None:
+    if not bool(getattr(worker_args, "skip_reconcile", False)):
+        return None
+    sources = _parse_sources(getattr(worker_args, "sources", "all"))
+    if len(sources) != 1:
+        return None
+    source = sources[0]
+    events = _journal_progress_events(text)
+    complete_events = [
+        event
+        for event in events
+        if event.get("event") == "source_batch_complete"
+        and str(event.get("source") or "").strip() == source
+    ]
+    if not complete_events:
+        return None
+    complete = complete_events[-1]
+    selected = _progress_int(complete.get("selected"))
+    journaled = _progress_int(complete.get("journaled"))
+    skipped = _progress_int(complete.get("skipped"))
+    failed = _progress_int(complete.get("failed"))
+    if failed != 0:
+        return None
+    if (
+        bool(complete.get("stopped_early"))
+        or str(complete.get("stop_reason") or "").strip()
+    ):
+        return None
+    if journaled + skipped + failed != selected:
+        return None
+    chunk_events = [
+        event
+        for event in events
+        if event.get("event") == "source_batch_chunk_complete"
+        and str(event.get("source") or "").strip() == source
+    ]
+    return {
+        "source": source,
+        "selected": selected,
+        "journaled": journaled,
+        "skipped": skipped,
+        "failed": failed,
+        "error_counts": {},
+        "sample_errors": [],
+        "stopped_early": False,
+        "stop_reason": None,
+        "journal_batch_chunk_size": max(
+            1,
+            min(
+                int(
+                    getattr(
+                        worker_args,
+                        "journal_batch_chunk_size",
+                        DEFAULT_JOURNAL_BATCH_CHUNK_SIZE,
+                    )
+                    or DEFAULT_JOURNAL_BATCH_CHUNK_SIZE
+                ),
+                MAX_JOURNAL_BATCH_CHUNK_SIZE,
+            ),
+        ),
+        "journal_batch_chunks": len(chunk_events),
+        "supervised_worker_timeout_normalized": True,
+    }
+
+
+def _payload_from_completed_timeout_progress(
+    text: str,
+    *,
+    worker_args: argparse.Namespace,
+    started_at: datetime,
+    timeout_seconds: float,
+) -> dict[str, Any] | None:
+    batch = _completed_progress_batch_from_timeout(text, worker_args=worker_args)
+    if batch is None:
+        return None
+    payload = _payload(
+        args=worker_args,
+        started_at=started_at,
+        batches=[batch],
+        reconciliation=None,
+    )
+    payload.update(
+        {
+            "supervised_worker": False,
+            "supervise_timeout_seconds": timeout_seconds,
+            "supervised_worker_timeout_normalized": True,
+            "supervised_worker_timeout_reason": "worker_completed_batch_before_process_exit_timeout",
+        }
+    )
+    return payload
+
+
 def _safe_payload_allows_success(payload: Mapping[str, Any] | None) -> bool:
     if not payload:
         return False
@@ -1165,6 +1287,24 @@ def _run_supervised_worker_once(
     except subprocess.TimeoutExpired as exc:
         stdout_text += _write_supervised_output(exc.stdout, stream=sys.stdout)
         stderr_text += _write_supervised_output(exc.stderr, stream=sys.stderr)
+        completed_payload = _payload_from_completed_timeout_progress(
+            stdout_text + "\n" + stderr_text,
+            worker_args=worker_args,
+            started_at=started_at,
+            timeout_seconds=timeout_seconds,
+        )
+        if completed_payload is not None:
+            _emit_progress(
+                "supervised_worker_timeout_after_complete_normalized",
+                timeout_seconds=timeout_seconds,
+                sources=list(_parse_sources(getattr(worker_args, "sources", "all"))),
+            )
+            print(
+                json.dumps(completed_payload, separators=(",", ":"))
+                if worker_args.json
+                else json.dumps(completed_payload, indent=2)
+            )
+            return 0
         _emit_progress(
             "supervised_worker_timeout",
             timeout_seconds=timeout_seconds,

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -563,6 +563,289 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
         self.assertTrue(run_mock.call_args.kwargs["capture_output"])
         self.assertTrue(run_mock.call_args.kwargs["text"])
 
+    def test_progress_events_ignore_invalid_json_and_non_progress_lines(self) -> None:
+        progress = json.dumps(
+            {
+                "schema_version": "torghut.tigerbeetle-journal-progress.v1",
+                "event": "source_batch_complete",
+                "source": script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+            },
+            separators=(",", ":"),
+        )
+
+        events = script._journal_progress_events(
+            "\n".join(
+                [
+                    "plain log line",
+                    "{not-json",
+                    json.dumps({"schema_version": "other"}),
+                    progress,
+                ]
+            )
+        )
+
+        self.assertEqual(events, [json.loads(progress)])
+        self.assertEqual(script._progress_int("not-an-int"), 0)
+
+    def test_completed_timeout_progress_rejects_untrusted_progress(self) -> None:
+        def worker_args(
+            sources: str = script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+        ) -> argparse.Namespace:
+            return argparse.Namespace(
+                skip_reconcile=True,
+                sources=sources,
+                journal_batch_chunk_size=25,
+            )
+
+        def complete_event(**overrides: object) -> str:
+            payload: dict[str, object] = {
+                "schema_version": "torghut.tigerbeetle-journal-progress.v1",
+                "event": "source_batch_complete",
+                "source": script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                "selected": 1,
+                "journaled": 1,
+                "skipped": 0,
+                "failed": 0,
+                "stopped_early": False,
+                "stop_reason": None,
+            }
+            payload.update(overrides)
+            return json.dumps(payload, separators=(",", ":"))
+
+        self.assertIsNone(
+            script._completed_progress_batch_from_timeout(
+                complete_event(),
+                worker_args=worker_args(
+                    f"{script.SOURCE_TYPE_EXECUTION_ORDER_EVENT},{script.SOURCE_TYPE_EXECUTION_TCA_METRIC}"
+                ),
+            )
+        )
+        self.assertIsNone(
+            script._completed_progress_batch_from_timeout(
+                json.dumps(
+                    {
+                        "schema_version": "torghut.tigerbeetle-journal-progress.v1",
+                        "event": "source_batch_chunk_complete",
+                        "source": script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                    },
+                    separators=(",", ":"),
+                ),
+                worker_args=worker_args(),
+            )
+        )
+        self.assertIsNone(
+            script._completed_progress_batch_from_timeout(
+                complete_event(failed=1),
+                worker_args=worker_args(),
+            )
+        )
+        self.assertIsNone(
+            script._completed_progress_batch_from_timeout(
+                complete_event(stopped_early=True),
+                worker_args=worker_args(),
+            )
+        )
+        self.assertIsNone(
+            script._completed_progress_batch_from_timeout(
+                complete_event(journaled=0, skipped=0, failed=0, selected=2),
+                worker_args=worker_args(),
+            )
+        )
+
+    def test_supervised_worker_timeout_after_complete_progress_is_success(
+        self,
+    ) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        progress = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "schema_version": "torghut.tigerbeetle-journal-progress.v1",
+                        "event": "source_batch_start",
+                        "source": script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                        "selected": 50,
+                    },
+                    separators=(",", ":"),
+                ),
+                json.dumps(
+                    {
+                        "schema_version": "torghut.tigerbeetle-journal-progress.v1",
+                        "event": "source_batch_chunk_complete",
+                        "source": script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                        "chunk_index": 0,
+                        "chunk_size": 25,
+                        "selected": 50,
+                        "journaled": 25,
+                        "skipped": 0,
+                        "failed": 0,
+                    },
+                    separators=(",", ":"),
+                ),
+                json.dumps(
+                    {
+                        "schema_version": "torghut.tigerbeetle-journal-progress.v1",
+                        "event": "source_batch_chunk_complete",
+                        "source": script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                        "chunk_index": 1,
+                        "chunk_size": 25,
+                        "selected": 50,
+                        "journaled": 50,
+                        "skipped": 0,
+                        "failed": 0,
+                    },
+                    separators=(",", ":"),
+                ),
+                json.dumps(
+                    {
+                        "schema_version": "torghut.tigerbeetle-journal-progress.v1",
+                        "event": "source_batch_complete",
+                        "source": script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                        "selected": 50,
+                        "journaled": 50,
+                        "skipped": 0,
+                        "failed": 0,
+                        "stopped_early": False,
+                        "stop_reason": None,
+                    },
+                    separators=(",", ":"),
+                ),
+            ]
+        )
+
+        with (
+            patch.dict(os.environ, {"DB_DSN": "sqlite+pysqlite:///:memory:"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "journal_tigerbeetle_order_events.py",
+                    "--dsn-env",
+                    "DB_DSN",
+                    "--sources",
+                    script.SOURCE_TYPE_EXECUTION_ORDER_EVENT,
+                    "--batch-size",
+                    "50",
+                    "--max-batches",
+                    "1",
+                    "--skip-reconcile",
+                    "--fail-on-degraded",
+                    "--allow-data-quality-degraded",
+                    "--commit-each-row",
+                    "--json",
+                    "--supervise-timeout-seconds",
+                    "0.01",
+                ],
+            ),
+            patch(
+                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(
+                    cmd=["python", "journal_tigerbeetle_order_events.py"],
+                    timeout=0.01,
+                    stderr=progress,
+                ),
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            exit_code = script.main()
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(stdout.getvalue().splitlines()[-1])
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "ok")
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["overrides_runtime_ledger_authority"])
+        self.assertFalse(payload["exit_nonzero"])
+        self.assertEqual(payload["selected"], 50)
+        self.assertEqual(payload["journaled"], 50)
+        self.assertEqual(payload["skipped"], 0)
+        self.assertEqual(payload["failed"], 0)
+        self.assertEqual(payload["stop_reasons"], [])
+        self.assertEqual(payload["hard_failure_reasons"], [])
+        self.assertTrue(payload["supervised_worker_timeout_normalized"])
+        self.assertEqual(
+            payload["supervised_worker_timeout_reason"],
+            "worker_completed_batch_before_process_exit_timeout",
+        )
+        self.assertEqual(payload["batches"][0]["journal_batch_chunks"], 2)
+        self.assertTrue(payload["batches"][0]["supervised_worker_timeout_normalized"])
+        self.assertIn(
+            "supervised_worker_timeout_after_complete_normalized",
+            stderr.getvalue(),
+        )
+
+    def test_supervised_worker_timeout_after_complete_requires_skip_reconcile(
+        self,
+    ) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        progress = json.dumps(
+            {
+                "schema_version": "torghut.tigerbeetle-journal-progress.v1",
+                "event": "source_batch_complete",
+                "source": script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                "selected": 1,
+                "journaled": 1,
+                "skipped": 0,
+                "failed": 0,
+                "stopped_early": False,
+                "stop_reason": None,
+            },
+            separators=(",", ":"),
+        )
+
+        with (
+            patch.dict(os.environ, {"DB_DSN": "sqlite+pysqlite:///:memory:"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "journal_tigerbeetle_order_events.py",
+                    "--dsn-env",
+                    "DB_DSN",
+                    "--sources",
+                    script.SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    "--batch-size",
+                    "1",
+                    "--max-batches",
+                    "1",
+                    "--reconcile-empty-selection",
+                    "--fail-on-degraded",
+                    "--allow-data-quality-degraded",
+                    "--json",
+                    "--supervise-timeout-seconds",
+                    "0.01",
+                ],
+            ),
+            patch(
+                "scripts.journal_tigerbeetle_order_events.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(
+                    cmd=["python", "journal_tigerbeetle_order_events.py"],
+                    timeout=0.01,
+                    stderr=progress,
+                ),
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            exit_code = script.main()
+
+        self.assertEqual(exit_code, 1)
+        payload = json.loads(stdout.getvalue().splitlines()[-1])
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["failed"], 1)
+        self.assertEqual(
+            payload["stop_reasons"],
+            ["tigerbeetle_journal_worker_timeout"],
+        )
+        self.assertTrue(payload["exit_nonzero"])
+        self.assertIn("supervised_worker_timeout", stderr.getvalue())
+        self.assertNotIn(
+            "supervised_worker_timeout_after_complete_normalized",
+            stderr.getvalue(),
+        )
+
     def test_supervised_worker_splits_multi_source_timeout_budget(self) -> None:
         stdout = io.StringIO()
         stderr = io.StringIO()


### PR DESCRIPTION
## Summary

- Normalizes supervised TigerBeetle journal worker timeouts only when captured progress proves a single skip-reconcile source completed with zero failures.
- Preserves fail-closed timeout behavior for reconciliation-required sources and incomplete, failed, or stopped progress.
- Adds regression coverage for the live order-event timeout-after-complete case and the runtime-ledger negative case.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_journal_tigerbeetle_order_events.py tests/test_run_tigerbeetle_journal_cron.py --cov --cov-branch --cov-report=xml --cov-fail-under=0 -q && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `cd services/torghut && uv run --frozen ruff check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/journal_tigerbeetle_order_events.py tests/test_journal_tigerbeetle_order_events.py`
- `git diff --check`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m py_compile scripts/journal_tigerbeetle_order_events.py scripts/run_tigerbeetle_journal_cron.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
