### PR TITLE
feat(torghut): carry runtime ledger lineage handoff

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -3292,6 +3292,52 @@ def _candidate_family_goal_rows(
     return payload_rows
 
 
+def _candidate_board_runtime_ledger_lineage_handoff(
+    *,
+    scorecard: Mapping[str, Any],
+    evidence: CandidateEvidenceBundle | None,
+) -> dict[str, Any]:
+    scorecard_handoff = _mapping(
+        scorecard.get("runtime_ledger_lineage_materialization_handoff")
+    )
+    if scorecard_handoff:
+        return scorecard_handoff
+    if evidence is None:
+        return {}
+    promotion_readiness = _mapping(evidence.promotion_readiness)
+    return _mapping(
+        promotion_readiness.get("runtime_ledger_lineage_materialization_handoff")
+    )
+
+
+def _candidate_board_runtime_ledger_required_materialized_artifacts(
+    handoff: Mapping[str, Any],
+) -> list[str]:
+    raw_artifacts = handoff.get("required_materialized_artifacts") or handoff.get(
+        "required_artifacts"
+    )
+    if isinstance(raw_artifacts, str):
+        artifacts = [_string(raw_artifacts)]
+    elif isinstance(raw_artifacts, Sequence):
+        artifacts = []
+        for item in cast(Sequence[Any], raw_artifacts):
+            if isinstance(item, Mapping):
+                artifact = _string(
+                    item.get("artifact_ref")
+                    or item.get("ref")
+                    or item.get("path")
+                    or item.get("name")
+                    or item.get("artifact")
+                )
+            else:
+                artifact = _string(item)
+            if artifact:
+                artifacts.append(artifact)
+    else:
+        artifacts = []
+    return list(dict.fromkeys(artifacts))
+
+
 def _candidate_sleeve_goal_proof_handoff_fields(
     *,
     selection: Mapping[str, Any],
@@ -3340,7 +3386,16 @@ def _candidate_sleeve_goal_proof_handoff_fields(
         or paper_mechanism_overlay_ids
         or paper_required_evidence_tokens
     )
-    return {
+    runtime_ledger_lineage_handoff = _candidate_board_runtime_ledger_lineage_handoff(
+        scorecard=scorecard,
+        evidence=evidence,
+    )
+    runtime_ledger_required_materialized_artifacts = (
+        _candidate_board_runtime_ledger_required_materialized_artifacts(
+            runtime_ledger_lineage_handoff
+        )
+    )
+    proof_handoff: dict[str, Any] = {
         "replay_selection_reason": _string(selection.get("selection_reason"))
         or ("selected_for_replay" if selected_for_replay else "not_selected_budget"),
         "paper_contract_candidate": paper_contract_candidate,
@@ -3357,17 +3412,35 @@ def _candidate_sleeve_goal_proof_handoff_fields(
         "exact_replay_ledger_artifact_ref": exact_replay_ledger_artifact_ref,
         "exact_replay_ledger_artifact_row_count": _candidate_board_first_int_field(
             scorecard,
-            (
-                "exact_replay_ledger_artifact_row_count",
-            ),
+            ("exact_replay_ledger_artifact_row_count",),
         ),
         "exact_replay_ledger_artifact_fill_count": _candidate_board_first_int_field(
             scorecard,
-            (
-                "exact_replay_ledger_artifact_fill_count",
-            ),
+            ("exact_replay_ledger_artifact_fill_count",),
         ),
     }
+    if runtime_ledger_lineage_handoff:
+        proof_handoff["runtime_ledger_lineage_materialization_handoff"] = dict(
+            runtime_ledger_lineage_handoff
+        )
+        proof_handoff["runtime_ledger_required_materialized_artifacts"] = (
+            runtime_ledger_required_materialized_artifacts
+        )
+        materialization_status = _string(
+            runtime_ledger_lineage_handoff.get("materialization_status")
+            or runtime_ledger_lineage_handoff.get("status")
+        )
+        if materialization_status:
+            proof_handoff["runtime_ledger_materialization_status"] = (
+                materialization_status
+            )
+        if _boolish(
+            runtime_ledger_lineage_handoff.get(
+                "zero_authoritative_daily_pnl_until_materialized"
+            )
+        ):
+            proof_handoff["zero_authoritative_daily_pnl_until_materialized"] = True
+    return proof_handoff
 
 
 def _candidate_sleeve_goal_rows(
@@ -10742,7 +10815,9 @@ def _candidate_board_runtime_window_import_bounds(
     )
 
 
-def _candidate_board_exact_replay_ledger_refs(row: Mapping[str, Any]) -> tuple[str, ...]:
+def _candidate_board_exact_replay_ledger_refs(
+    row: Mapping[str, Any],
+) -> tuple[str, ...]:
     refs: list[str] = []
     for key in ("exact_replay_ledger_artifact_ref",):
         ref = _string(row.get(key))
@@ -10763,8 +10838,7 @@ def _candidate_board_exact_replay_ledger_refs(row: Mapping[str, Any]) -> tuple[s
         ref = _string(raw_ref)
         ref_lower = ref.lower()
         if ref and (
-            "exact-replay-ledger" in ref_lower
-            or "exact_replay_ledger" in ref_lower
+            "exact-replay-ledger" in ref_lower or "exact_replay_ledger" in ref_lower
         ):
             refs.append(ref)
     return tuple(dict.fromkeys(refs))
@@ -10908,6 +10982,14 @@ def _candidate_board_runtime_window_import_plan(
         if dedupe_key in seen_keys:
             continue
         seen_keys.add(dedupe_key)
+        runtime_ledger_lineage_handoff = _mapping(
+            row.get("runtime_ledger_lineage_materialization_handoff")
+        )
+        runtime_ledger_required_materialized_artifacts = (
+            _candidate_board_runtime_ledger_required_materialized_artifacts(
+                runtime_ledger_lineage_handoff
+            )
+        )
         target = {
             "run_id": _string(row.get("epoch_id"))
             or "candidate-board-runtime-window-import",
@@ -10950,6 +11032,27 @@ def _candidate_board_runtime_window_import_plan(
             "handoff": "runtime_window_import_only",
             "promotion_gate": "existing_runtime_governance_fail_closed",
         }
+        if runtime_ledger_lineage_handoff:
+            target["runtime_ledger_lineage_materialization_handoff"] = dict(
+                runtime_ledger_lineage_handoff
+            )
+            target["runtime_ledger_required_materialized_artifacts"] = (
+                runtime_ledger_required_materialized_artifacts
+            )
+            materialization_status = _string(
+                row.get("runtime_ledger_materialization_status")
+                or runtime_ledger_lineage_handoff.get("materialization_status")
+                or runtime_ledger_lineage_handoff.get("status")
+            )
+            if materialization_status:
+                target["runtime_ledger_materialization_status"] = materialization_status
+            if _boolish(
+                row.get("zero_authoritative_daily_pnl_until_materialized")
+                or runtime_ledger_lineage_handoff.get(
+                    "zero_authoritative_daily_pnl_until_materialized"
+                )
+            ):
+                target["zero_authoritative_daily_pnl_until_materialized"] = True
         if bool(row.get("paper_probation_authorized")):
             target.update(
                 {
@@ -11261,6 +11364,21 @@ def _candidate_board_payload(
         exact_replay_ledger_artifact_ref = _string(
             scorecard.get("exact_replay_ledger_artifact_ref")
         )
+        runtime_ledger_lineage_handoff = (
+            _candidate_board_runtime_ledger_lineage_handoff(
+                scorecard=scorecard,
+                evidence=evidence,
+            )
+        )
+        runtime_ledger_required_materialized_artifacts = (
+            _candidate_board_runtime_ledger_required_materialized_artifacts(
+                runtime_ledger_lineage_handoff
+            )
+        )
+        runtime_ledger_materialization_status = _string(
+            runtime_ledger_lineage_handoff.get("materialization_status")
+            or runtime_ledger_lineage_handoff.get("status")
+        )
         factor_acceptance_replay_metadata = (
             _candidate_factor_acceptance_replay_metadata(
                 spec=spec,
@@ -11534,6 +11652,20 @@ def _candidate_board_payload(
                     _candidate_board_first_int_field(
                         scorecard,
                         ("exact_replay_ledger_artifact_fill_count",),
+                    )
+                ),
+                "runtime_ledger_lineage_materialization_handoff": dict(
+                    runtime_ledger_lineage_handoff
+                ),
+                "runtime_ledger_required_materialized_artifacts": (
+                    runtime_ledger_required_materialized_artifacts
+                ),
+                "runtime_ledger_materialization_status": (
+                    runtime_ledger_materialization_status
+                ),
+                "zero_authoritative_daily_pnl_until_materialized": _boolish(
+                    runtime_ledger_lineage_handoff.get(
+                        "zero_authoritative_daily_pnl_until_materialized"
                     )
                 ),
                 "replay_artifact_refs": list(evidence.replay_artifact_refs)

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6156,8 +6156,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertNotIn("runtime_ledger_artifact_refs", direct_sleeve_row)
         self.assertNotIn("runtime_ledger_artifact_ref", direct_sleeve_row)
-        self.assertEqual(direct_sleeve_row["exact_replay_ledger_artifact_row_count"], 12)
-        self.assertEqual(direct_sleeve_row["exact_replay_ledger_artifact_fill_count"], 4)
+        self.assertEqual(
+            direct_sleeve_row["exact_replay_ledger_artifact_row_count"], 12
+        )
+        self.assertEqual(
+            direct_sleeve_row["exact_replay_ledger_artifact_fill_count"], 4
+        )
         source_compiler_mock.assert_not_called()
         candidate_compiler_mock.assert_not_called()
         selection_mock.assert_not_called()
@@ -8562,6 +8566,65 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
         )
 
+    def test_candidate_sleeve_goal_proof_handoff_surfaces_runtime_ledger_materialization(
+        self,
+    ) -> None:
+        spec = self._candidate_spec("spec-sleeve-runtime-ledger-handoff")
+        runtime_ledger_handoff = {
+            "materialization_status": "lineage_unmaterialized",
+            "runtime_ledger_required": True,
+            "zero_authoritative_daily_pnl_until_materialized": True,
+            "required_artifacts": "runtime-ledger/daily-pnl.json",
+        }
+        evidence = runner.CandidateEvidenceBundle(
+            schema_version="torghut.candidate-evidence-bundle.v1",
+            evidence_bundle_id="ev-sleeve-runtime-ledger-handoff",
+            candidate_id="cand-sleeve-runtime-ledger-handoff",
+            candidate_spec_id=spec.candidate_spec_id,
+            dataset_snapshot_id="snapshot-sleeve-runtime-ledger-handoff",
+            feature_spec_hash="hash-sleeve-runtime-ledger-handoff",
+            code_commit="commit-test",
+            replay_artifact_refs=("sleeve-runtime-ledger-handoff.json",),
+            objective_scorecard={},
+            fold_metrics=(),
+            stress_metrics=(),
+            cost_calibration={},
+            null_comparator={},
+            promotion_readiness={
+                "runtime_ledger_lineage_materialization_handoff": (
+                    runtime_ledger_handoff
+                )
+            },
+        )
+
+        proof_handoff = runner._candidate_sleeve_goal_proof_handoff_fields(
+            selection={"selected_for_replay": True},
+            spec=spec,
+            scorecard=evidence.objective_scorecard,
+            evidence=evidence,
+            selected_for_replay=True,
+        )
+
+        self.assertEqual(
+            proof_handoff["runtime_ledger_lineage_materialization_handoff"],
+            runtime_ledger_handoff,
+        )
+        self.assertEqual(
+            proof_handoff["runtime_ledger_required_materialized_artifacts"],
+            ["runtime-ledger/daily-pnl.json"],
+        )
+        self.assertEqual(
+            proof_handoff["runtime_ledger_materialization_status"],
+            "lineage_unmaterialized",
+        )
+        self.assertTrue(
+            proof_handoff["zero_authoritative_daily_pnl_until_materialized"]
+        )
+        self.assertEqual(
+            runner._candidate_board_runtime_ledger_required_materialized_artifacts({}),
+            [],
+        )
+
     def test_candidate_board_surfaces_paper_probation_without_promotion(
         self,
     ) -> None:
@@ -8622,6 +8685,22 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 },
                 "profit_target_oracle": {
                     "blockers": ["delay_adjusted_depth_tail_coverage_passed_failed"]
+                },
+                "runtime_ledger_lineage_materialization_handoff": {
+                    "status": "requires_runtime_ledger_materialization_before_authoritative_pnl",
+                    "runtime_ledger_required": True,
+                    "source_backed_runtime_ledger_required": True,
+                    "proof_authority": False,
+                    "promotion_allowed": False,
+                    "final_authority_ok": False,
+                    "zero_authoritative_daily_pnl_until_materialized": True,
+                    "required_materialized_artifacts": [
+                        {
+                            "artifact_ref": "paper-probation-exact-ledger.json",
+                            "kind": "exact_replay_ledger",
+                        },
+                        "runtime-ledger/daily-pnl.parquet",
+                    ],
                 },
             },
             fold_metrics=(),
@@ -8687,6 +8766,39 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ["live_paper_parity", "route_tca", "runtime_ledger"],
         )
         self.assertEqual(row["paper_required_evidence_count"], 3)
+        expected_runtime_ledger_handoff = {
+            "status": "requires_runtime_ledger_materialization_before_authoritative_pnl",
+            "runtime_ledger_required": True,
+            "source_backed_runtime_ledger_required": True,
+            "proof_authority": False,
+            "promotion_allowed": False,
+            "final_authority_ok": False,
+            "zero_authoritative_daily_pnl_until_materialized": True,
+            "required_materialized_artifacts": [
+                {
+                    "artifact_ref": "paper-probation-exact-ledger.json",
+                    "kind": "exact_replay_ledger",
+                },
+                "runtime-ledger/daily-pnl.parquet",
+            ],
+        }
+        expected_required_materialized_artifacts = [
+            "paper-probation-exact-ledger.json",
+            "runtime-ledger/daily-pnl.parquet",
+        ]
+        self.assertEqual(
+            row["runtime_ledger_lineage_materialization_handoff"],
+            expected_runtime_ledger_handoff,
+        )
+        self.assertEqual(
+            row["runtime_ledger_required_materialized_artifacts"],
+            expected_required_materialized_artifacts,
+        )
+        self.assertEqual(
+            row["runtime_ledger_materialization_status"],
+            "requires_runtime_ledger_materialization_before_authoritative_pnl",
+        )
+        self.assertTrue(row["zero_authoritative_daily_pnl_until_materialized"])
         self.assertEqual(
             board["paper_probation_candidate"]["candidate_id"], "cand-paper-probation"
         )
@@ -8704,6 +8816,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(probation_candidate["evidence_collection_stage"], "paper")
         self.assertEqual(
             probation_candidate["selection_reason"], "target_met_but_oracle_blocked"
+        )
+        self.assertEqual(
+            probation_candidate["runtime_ledger_lineage_materialization_handoff"],
+            expected_runtime_ledger_handoff,
+        )
+        self.assertEqual(
+            probation_candidate["runtime_ledger_required_materialized_artifacts"],
+            expected_required_materialized_artifacts,
+        )
+        self.assertTrue(
+            probation_candidate["zero_authoritative_daily_pnl_until_materialized"]
         )
         self.assertFalse(probation_candidate["promotion_allowed"])
         self.assertFalse(probation_candidate["final_promotion_authorized"])
@@ -8748,6 +8871,19 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(target["exact_replay_ledger_artifact_row_count"], 27)
         self.assertEqual(target["exact_replay_ledger_artifact_fill_count"], 9)
         self.assertEqual(
+            target["runtime_ledger_lineage_materialization_handoff"],
+            expected_runtime_ledger_handoff,
+        )
+        self.assertEqual(
+            target["runtime_ledger_required_materialized_artifacts"],
+            expected_required_materialized_artifacts,
+        )
+        self.assertEqual(
+            target["runtime_ledger_materialization_status"],
+            "requires_runtime_ledger_materialization_before_authoritative_pnl",
+        )
+        self.assertTrue(target["zero_authoritative_daily_pnl_until_materialized"])
+        self.assertEqual(
             target["replay_selection_reason"], "paper_contract_exploration"
         )
         self.assertTrue(target["paper_contract_candidate"])
@@ -8776,6 +8912,21 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             import_metadata["exact_replay_ledger_artifact_ref"],
             "paper-probation-exact-ledger.json",
+        )
+        self.assertEqual(
+            import_metadata["runtime_ledger_lineage_materialization_handoff"],
+            expected_runtime_ledger_handoff,
+        )
+        self.assertEqual(
+            import_metadata["runtime_ledger_required_materialized_artifacts"],
+            expected_required_materialized_artifacts,
+        )
+        self.assertEqual(
+            import_metadata["runtime_ledger_materialization_status"],
+            "requires_runtime_ledger_materialization_before_authoritative_pnl",
+        )
+        self.assertTrue(
+            import_metadata["zero_authoritative_daily_pnl_until_materialized"]
         )
         self.assertEqual(import_metadata["window_start"], target["window_start"])
         self.assertEqual(import_metadata["window_end"], target["window_end"])

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -8624,6 +8624,63 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             runner._candidate_board_runtime_ledger_required_materialized_artifacts({}),
             [],
         )
+        self.assertEqual(
+            runner._candidate_board_runtime_ledger_required_materialized_artifacts(
+                {"required_materialized_artifacts": "runtime-ledger/string.json"}
+            ),
+            ["runtime-ledger/string.json"],
+        )
+        self.assertEqual(
+            runner._candidate_board_runtime_ledger_required_materialized_artifacts(
+                {
+                    "required_materialized_artifacts": [
+                        {"path": "runtime-ledger/path.json"},
+                        {"name": "runtime-ledger/name.json"},
+                        {"artifact": "runtime-ledger/artifact.json"},
+                        "runtime-ledger/raw.json",
+                        {"kind": "missing-ref"},
+                    ]
+                }
+            ),
+            [
+                "runtime-ledger/path.json",
+                "runtime-ledger/name.json",
+                "runtime-ledger/artifact.json",
+                "runtime-ledger/raw.json",
+            ],
+        )
+
+        scorecard_handoff = {
+            "status": "requires_runtime_ledger_materialization_before_authority",
+            "zero_authoritative_daily_pnl_until_materialized": True,
+            "required_materialized_artifacts": [
+                {"ref": "runtime-ledger/scorecard-ref.json"}
+            ],
+        }
+        scorecard_proof_handoff = runner._candidate_sleeve_goal_proof_handoff_fields(
+            selection={},
+            spec=None,
+            scorecard={
+                "runtime_ledger_lineage_materialization_handoff": scorecard_handoff
+            },
+            evidence=None,
+            selected_for_replay=False,
+        )
+        self.assertEqual(
+            scorecard_proof_handoff["runtime_ledger_lineage_materialization_handoff"],
+            scorecard_handoff,
+        )
+        self.assertEqual(
+            scorecard_proof_handoff["runtime_ledger_required_materialized_artifacts"],
+            ["runtime-ledger/scorecard-ref.json"],
+        )
+        self.assertEqual(
+            scorecard_proof_handoff["runtime_ledger_materialization_status"],
+            "requires_runtime_ledger_materialization_before_authority",
+        )
+        self.assertTrue(
+            scorecard_proof_handoff["zero_authoritative_daily_pnl_until_materialized"]
+        )
 
     def test_candidate_board_surfaces_paper_probation_without_promotion(
         self,


### PR DESCRIPTION
## Summary

- Carries `runtime_ledger_lineage_materialization_handoff` from candidate scorecards/promotion readiness into candidate-board rows, paper-probation candidates, and runtime-window import targets.
- Normalizes `required_materialized_artifacts` into explicit runtime-ledger materialization requirements so runtime import handoffs can materialize ledger lineage before authoritative PnL.
- Preserves fail-closed semantics: paper probation remains evidence-collection-only and `promotion_allowed` / `final_promotion_allowed` remain false in the covered path.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'candidate_sleeve_goal_proof_handoff_surfaces_runtime_ledger_materialization or candidate_board_surfaces_paper_probation_without_promotion'`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py --cov=scripts.run_whitepaper_autoresearch_profit_target --cov-report=xml`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
