### PR TITLE
feat(torghut): add paper probation repair queue

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -4999,11 +4999,97 @@ def _bounded_sim_handoff_metadata(
     }
 
 
+def _paper_probation_repair_actions(
+    *,
+    blockers: Sequence[str],
+    hard_vetoes: Sequence[str],
+) -> list[str]:
+    actions = list(_paper_probation_required_actions(hard_vetoes))
+    blocker_set = {str(blocker) for blocker in blockers}
+    if blocker_set & {
+        "missing_exact_replay_ledger_artifact",
+        "missing_exact_replay_ledger_row_count",
+        "missing_exact_replay_ledger_fill_count",
+        "failed_exact_replay_parity",
+    }:
+        actions.append("produce_authoritative_exact_replay_ledger")
+    if "missing_source_lineage" in blocker_set:
+        actions.append("materialize_source_lineage_receipt")
+    if any(blocker.startswith("missing_replay_tape_") for blocker in blocker_set):
+        actions.append("refresh_replay_tape_metadata")
+    if blocker_set & {
+        "missing_post_cost_pnl_basis",
+        "missing_cost_basis",
+        "missing_post_cost_expectancy_bps",
+        "non_positive_post_cost_expectancy_bps",
+    }:
+        actions.append("rematerialize_post_cost_runtime_ledger")
+    if "open_replay_positions" in blocker_set:
+        actions.append("close_or_exclude_open_replay_position_windows")
+    if "proof_only_full_window_replay_not_probation_authority" in blocker_set:
+        actions.append("rerun_exact_replay_with_authoritative_runtime_events")
+    actions.append("keep_final_promotion_gates_fail_closed")
+    return list(dict.fromkeys(actions))
+
+
+def _paper_probation_target_progress(
+    *,
+    net_pnl_per_day: Decimal,
+    target_net_pnl_per_day: Decimal,
+) -> Decimal:
+    if target_net_pnl_per_day <= 0:
+        return Decimal("0")
+    return (net_pnl_per_day / target_net_pnl_per_day).quantize(Decimal("0.0001"))
+
+
+def _paper_probation_repair_plan(
+    *,
+    item: Mapping[str, Any],
+    blockers: Sequence[str],
+    hard_vetoes: Sequence[str],
+    handoff_diagnostics: Sequence[Mapping[str, Any]],
+    net_pnl_per_day: Decimal,
+    target_net_pnl_per_day: Decimal,
+) -> dict[str, Any]:
+    repair_actions = _paper_probation_repair_actions(
+        blockers=blockers,
+        hard_vetoes=hard_vetoes,
+    )
+    target_shortfall = max(target_net_pnl_per_day - net_pnl_per_day, Decimal("0"))
+    repair_required = bool(blockers)
+    return {
+        "schema_version": "torghut.paper-probation-repair-plan.v1",
+        "status": "repair_required_before_paper_evidence_collection"
+        if repair_required
+        else "ready_for_bounded_paper_evidence_collection",
+        "candidate_id": str(item.get("candidate_id") or ""),
+        "target_net_pnl_per_day": _decimal_payload(target_net_pnl_per_day),
+        "observed_net_pnl_per_day": _decimal_payload(net_pnl_per_day),
+        "target_shortfall": _decimal_payload(target_shortfall),
+        "target_progress_ratio": _decimal_payload(
+            _paper_probation_target_progress(
+                net_pnl_per_day=net_pnl_per_day,
+                target_net_pnl_per_day=target_net_pnl_per_day,
+            )
+        ),
+        "repair_required": repair_required,
+        "repairable_for_evidence_collection": net_pnl_per_day > 0,
+        "repair_actions": repair_actions,
+        "repair_blockers": list(dict.fromkeys(str(blocker) for blocker in blockers)),
+        "diagnostics": [dict(diagnostic) for diagnostic in handoff_diagnostics],
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "authorization_scope": "evidence_collection_repair_only",
+    }
+
+
 def _build_paper_probation_shortlist(
     ranked_items: Sequence[Mapping[str, Any]],
     *,
     top_n: int,
     objective_veto_policy: ObjectiveVetoPolicy,
+    target_net_pnl_per_day: Decimal = Decimal("500"),
 ) -> list[dict[str, Any]]:
     visible_items = [
         item
@@ -5019,7 +5105,7 @@ def _build_paper_probation_shortlist(
     ]
 
     shortlist_candidates: list[
-        tuple[bool, bool, Decimal, Decimal, str, dict[str, Any]]
+        tuple[bool, bool, Decimal, Decimal, Decimal, str, dict[str, Any]]
     ] = []
     for item in visible_items:
         hard_vetoes = [
@@ -5093,6 +5179,25 @@ def _build_paper_probation_shortlist(
             exact_replay_parity_ok=exact_replay_parity_ok,
             diagnostics=handoff_diagnostics,
         )
+        net_pnl_per_day = _candidate_metric_decimal(
+            item,
+            scorecard_key="net_pnl_per_day",
+            full_window_key="net_per_day",
+        )
+        net_pnl = _candidate_metric_decimal(
+            item,
+            scorecard_key="net_pnl",
+            full_window_key="net_pnl",
+        )
+        target_shortfall = max(target_net_pnl_per_day - net_pnl_per_day, Decimal("0"))
+        repair_plan = _paper_probation_repair_plan(
+            item=item,
+            blockers=blockers,
+            hard_vetoes=hard_vetoes,
+            handoff_diagnostics=handoff_diagnostics,
+            net_pnl_per_day=net_pnl_per_day,
+            target_net_pnl_per_day=target_net_pnl_per_day,
+        )
         entry = {
             "candidate_id": str(item.get("candidate_id") or ""),
             "strategy_name": str(item.get("strategy_name") or ""),
@@ -5106,6 +5211,7 @@ def _build_paper_probation_shortlist(
             "probation_blockers": blockers,
             "handoff_diagnostics": handoff_diagnostics,
             "bounded_sim_handoff": bounded_sim_handoff,
+            "paper_probation_repair_plan": repair_plan,
             "required_actions_before_or_during_probation": (
                 _paper_probation_required_actions(hard_vetoes)
             ),
@@ -5117,20 +5223,16 @@ def _build_paper_probation_shortlist(
             "exact_replay_ledger_artifact_refs": artifact_refs,
             "exact_replay_ledger_artifact_row_count": (exact_replay_ledger_row_count),
             "exact_replay_ledger_artifact_fill_count": (exact_replay_ledger_fill_count),
-            "net_pnl_per_day": str(
-                _candidate_metric_value(
-                    item,
-                    scorecard_key="net_pnl_per_day",
-                    full_window_key="net_per_day",
+            "target_net_pnl_per_day": _decimal_payload(target_net_pnl_per_day),
+            "target_shortfall": _decimal_payload(target_shortfall),
+            "target_progress_ratio": _decimal_payload(
+                _paper_probation_target_progress(
+                    net_pnl_per_day=net_pnl_per_day,
+                    target_net_pnl_per_day=target_net_pnl_per_day,
                 )
             ),
-            "net_pnl": str(
-                _candidate_metric_value(
-                    item,
-                    scorecard_key="net_pnl",
-                    full_window_key="net_pnl",
-                )
-            ),
+            "net_pnl_per_day": str(net_pnl_per_day),
+            "net_pnl": str(net_pnl),
             "active_day_ratio": str(
                 _candidate_metric_value(
                     item,
@@ -5179,12 +5281,11 @@ def _build_paper_probation_shortlist(
             "replay_artifact_refs": artifact_refs,
             "hard_vetoes": hard_vetoes,
         }
-        net_pnl_per_day = _safe_decimal(entry["net_pnl_per_day"])
-        net_pnl = _safe_decimal(entry["net_pnl"])
         shortlist_candidates.append(
             (
                 paper_probation_allowed,
                 bool(bounded_sim_handoff["evidence_collection_ok"]),
+                target_shortfall,
                 net_pnl_per_day,
                 net_pnl,
                 entry["candidate_id"],
@@ -5196,12 +5297,13 @@ def _build_paper_probation_shortlist(
         key=lambda candidate: (
             0 if candidate[0] else 1,
             0 if candidate[1] else 1,
-            -candidate[2],
+            candidate[2],
             -candidate[3],
-            candidate[4],
+            -candidate[4],
+            candidate[5],
         )
     )
-    return [candidate[5] for candidate in shortlist_candidates[: max(1, int(top_n))]]
+    return [candidate[6] for candidate in shortlist_candidates[: max(1, int(top_n))]]
 
 
 def _frontier_state_item(item: Mapping[str, Any]) -> dict[str, Any]:
@@ -5281,6 +5383,21 @@ def _build_frontier_workflow_states(
         "paper_probation_shortlisted": [
             dict(item) for item in paper_probation_shortlist
         ],
+        "paper_probation_repair_queue": [
+            {
+                "candidate_id": str(item.get("candidate_id") or ""),
+                "target_shortfall": str(item.get("target_shortfall") or "0"),
+                "target_progress_ratio": str(item.get("target_progress_ratio") or "0"),
+                "repair_plan": dict(_mapping(item.get("paper_probation_repair_plan"))),
+            }
+            for item in paper_probation_shortlist
+            if not bool(item.get("paper_probation_allowed"))
+            and bool(
+                _mapping(item.get("paper_probation_repair_plan")).get(
+                    "repairable_for_evidence_collection"
+                )
+            )
+        ],
         "authority_proof": {
             "status": "absent",
             "promotion_allowed": False,
@@ -5324,6 +5441,7 @@ def _build_frontier_payload(
         ranked_items,
         top_n=max(3, int(top_n)),
         objective_veto_policy=objective_veto_policy,
+        target_net_pnl_per_day=consistency_policy.target_net_per_day,
     )
     return {
         "schema_version": _SWEEP_SCHEMA_VERSION,
@@ -5383,7 +5501,7 @@ def _build_frontier_payload(
                 "surface close positive candidates for controlled paper evidence "
                 "collection without authorizing final promotion"
             ),
-            "ranking_basis": "positive_full_window_net_pnl_per_day_desc",
+            "ranking_basis": "paper_readiness_then_target_shortfall_then_net_pnl",
             "items": paper_probation_shortlist_items,
         },
         "workflow_states": _build_frontier_workflow_states(

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2726,6 +2726,15 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertFalse(item["bounded_sim_handoff"]["promotion_allowed"])
         self.assertFalse(item["bounded_sim_handoff"]["final_promotion_allowed"])
         self.assertEqual(item["stage"], "paper_evidence_collection_only")
+        self.assertEqual(item["target_net_pnl_per_day"], "500")
+        self.assertEqual(item["target_shortfall"], "93.42")
+        self.assertEqual(item["target_progress_ratio"], "0.8132")
+        self.assertEqual(
+            item["paper_probation_repair_plan"]["status"],
+            "ready_for_bounded_paper_evidence_collection",
+        )
+        self.assertFalse(item["paper_probation_repair_plan"]["promotion_allowed"])
+        self.assertFalse(item["paper_probation_repair_plan"]["final_promotion_allowed"])
         self.assertEqual(item["recommended_notional_scale"], "0.158333")
         self.assertIn(
             "apply_capital_repair_sizing_before_paper_orders",
@@ -2861,6 +2870,27 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         )
         self.assertFalse(shortlist[0]["promotion_allowed"])
         self.assertFalse(shortlist[0]["evidence_collection_ok"])
+        repair_plan = shortlist[0]["paper_probation_repair_plan"]
+        self.assertEqual(
+            repair_plan["status"],
+            "repair_required_before_paper_evidence_collection",
+        )
+        self.assertEqual(repair_plan["target_shortfall"], "425")
+        self.assertEqual(repair_plan["target_progress_ratio"], "0.15")
+        self.assertIn(
+            "produce_authoritative_exact_replay_ledger",
+            repair_plan["repair_actions"],
+        )
+        self.assertIn(
+            "materialize_source_lineage_receipt",
+            repair_plan["repair_actions"],
+        )
+        self.assertIn(
+            "keep_final_promotion_gates_fail_closed",
+            repair_plan["repair_actions"],
+        )
+        self.assertFalse(repair_plan["promotion_allowed"])
+        self.assertFalse(repair_plan["final_promotion_allowed"])
         self.assertIn(
             "insufficient_days",
             {
@@ -3164,6 +3194,22 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             "promotion_allowed": False,
             "final_promotion_allowed": False,
         }
+        blocked_handoff = {
+            "candidate_id": "candidate-needs-repair",
+            "paper_probation_allowed": False,
+            "target_shortfall": "175",
+            "target_progress_ratio": "0.65",
+            "paper_probation_repair_plan": {
+                "status": "repair_required_before_paper_evidence_collection",
+                "repairable_for_evidence_collection": True,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "repair_actions": [
+                    "produce_authoritative_exact_replay_ledger",
+                    "keep_final_promotion_gates_fail_closed",
+                ],
+            },
+        }
         states = frontier._build_frontier_workflow_states(
             [
                 {
@@ -3197,7 +3243,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     "hard_vetoes": ["full_replay_candidate_budget_exhausted"],
                 },
             ],
-            paper_probation_shortlist=[paper_handoff],
+            paper_probation_shortlist=[paper_handoff, blocked_handoff],
         )
 
         self.assertEqual(
@@ -3212,7 +3258,18 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             [item["candidate_id"] for item in states["exact_replay_qualified"]],
             ["candidate-exact"],
         )
-        self.assertEqual(states["paper_probation_shortlisted"], [paper_handoff])
+        self.assertEqual(
+            states["paper_probation_shortlisted"], [paper_handoff, blocked_handoff]
+        )
+        self.assertEqual(
+            [item["candidate_id"] for item in states["paper_probation_repair_queue"]],
+            ["candidate-needs-repair"],
+        )
+        self.assertFalse(
+            states["paper_probation_repair_queue"][0]["repair_plan"][
+                "promotion_allowed"
+            ]
+        )
         self.assertEqual(states["authority_proof"]["status"], "absent")
         self.assertFalse(states["authority_proof"]["promotion_allowed"])
         self.assertFalse(states["authority_proof"]["final_promotion_allowed"])


### PR DESCRIPTION
## Summary

- Adds a target-aware paper-probation repair plan for positive Torghut frontier candidates that are close enough to justify more evidence work but still fail admission.
- Surfaces blocked candidates in a `paper_probation_repair_queue` with exact replay, lineage, post-cost ledger, and replay-tape repair actions.
- Keeps all paper probation and final promotion authority fail-closed: repair queue entries explicitly set `promotion_allowed`, `final_promotion_authorized`, and `final_promotion_allowed` to false.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -k paper_probation_shortlist`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -k frontier_workflow_states`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -k 'paper_probation_shortlist or frontier_workflow_states'`
- `uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen ruff format --check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
