### PR TITLE
feat(torghut): add latency-aware execution stress

### DIFF
--- a/services/torghut/app/trading/discovery/execution_schedule_stress.py
+++ b/services/torghut/app/trading/discovery/execution_schedule_stress.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from math import isfinite, sqrt
+from math import isfinite, log2, sqrt
 from typing import Any, cast
 
 from app.trading.models import SignalEnvelope
@@ -32,7 +32,19 @@ EXECUTION_SCHEDULE_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
     {
         "source_id": "arxiv-2507.06345",
         "url": "https://arxiv.org/abs/2507.06345",
+        "date": "2025-07-08",
+        "title": "Reinforcement Learning for Trade Execution with Market and Limit Orders",
         "mechanism": "market_limit_order_mix_allocation_fill_shortfall_tradeoff",
+    },
+    {
+        "source_id": "arxiv-2504.00846",
+        "url": "https://arxiv.org/abs/2504.00846",
+        "date": "2025-04-01",
+        "title": "The effect of latency on optimal order execution policy",
+        "mechanism": (
+            "submission_latency_fill_probability_limit_price_tradeoff_forced_market_"
+            "order_risk"
+        ),
     },
 )
 
@@ -47,6 +59,11 @@ class ExecutionScheduleStressSummary:
     impact_cost_bps: float
     market_order_share: float
     limit_order_share: float
+    observed_latency_count: int
+    median_latency_ms: float
+    latency_adjusted_limit_fill_probability: float
+    latency_forced_market_order_risk: float
+    market_limit_mix_entropy_score: float
     shortfall_stress_bps: float
     replay_rank_penalty_bps: float
     warnings: tuple[str, ...]
@@ -68,6 +85,17 @@ class ExecutionScheduleStressSummary:
             "impact_cost_bps": _stable_float(self.impact_cost_bps),
             "market_order_share": _stable_float(self.market_order_share),
             "limit_order_share": _stable_float(self.limit_order_share),
+            "observed_latency_count": self.observed_latency_count,
+            "median_latency_ms": _stable_float(self.median_latency_ms),
+            "latency_adjusted_limit_fill_probability": _stable_float(
+                self.latency_adjusted_limit_fill_probability
+            ),
+            "latency_forced_market_order_risk": _stable_float(
+                self.latency_forced_market_order_risk
+            ),
+            "market_limit_mix_entropy_score": _stable_float(
+                self.market_limit_mix_entropy_score
+            ),
             "shortfall_stress_bps": _stable_float(self.shortfall_stress_bps),
             "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
             "warnings": list(self.warnings),
@@ -77,12 +105,22 @@ class ExecutionScheduleStressSummary:
                 "impact_cost_bps": _stable_float(self.impact_cost_bps),
                 "market_order_share": _stable_float(self.market_order_share),
                 "limit_order_share": _stable_float(self.limit_order_share),
+                "latency_adjusted_limit_fill_probability": _stable_float(
+                    self.latency_adjusted_limit_fill_probability
+                ),
+                "latency_forced_market_order_risk": _stable_float(
+                    self.latency_forced_market_order_risk
+                ),
+                "market_limit_mix_entropy_score": _stable_float(
+                    self.market_limit_mix_entropy_score
+                ),
                 "shortfall_stress_bps": _stable_float(self.shortfall_stress_bps),
                 "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
             },
             "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
             "mpc_schedule_trace_preview": True,
             "market_limit_mix_preview": True,
+            "latency_adjusted_fill_probability_preview": True,
             "research_ranking_only": True,
             "prefilter_only": True,
             "promotion_proof": False,
@@ -108,6 +146,8 @@ def execution_schedule_stress_contract() -> dict[str, Any]:
             "opportunity_cost_bps",
             "impact_cost_bps",
             "market_limit_order_mix_proxy",
+            "latency_adjusted_limit_fill_probability",
+            "latency_forced_market_order_risk",
         ],
         "output_scope": "preview_replay_ranking_only",
         "proof_neutrality": {
@@ -119,6 +159,8 @@ def execution_schedule_stress_contract() -> dict[str, Any]:
             "requires_exact_replay": True,
             "requires_route_tca": True,
             "requires_runtime_ledger": True,
+            "rejects_latency_fill_probability_as_promotion_proof": True,
+            "rejects_market_limit_mix_proxy_as_runtime_ledger_authority": True,
         },
     }
 
@@ -152,6 +194,10 @@ def extract_execution_schedule_stress(
     spreads = tuple(
         _nonnegative_float(row.payload.get("spread_bps")) for row in ordered
     )
+    depths = tuple(
+        _nonnegative_float(_first_payload_value(row, _DEPTH_FIELDS)) for row in ordered
+    )
+    latencies_ms = tuple(_latency_ms(row) for row in ordered)
     notional = _nonnegative_float(max_notional)
     warnings: list[str] = []
     if len(ordered) < 2:
@@ -164,6 +210,9 @@ def extract_execution_schedule_stress(
     positive_volumes = tuple(volume for volume in volumes if volume > 0.0)
     if not positive_volumes:
         warnings.append("missing_execution_volume_curve")
+    observed_latency_count = sum(item is not None for item in latencies_ms)
+    if observed_latency_count == 0:
+        warnings.append("missing_submission_latency_for_limit_fill_probability")
     if notional <= 0.0:
         warnings.append("missing_candidate_notional_for_execution_stress")
 
@@ -192,7 +241,26 @@ def extract_execution_schedule_stress(
         0.95, max(0.05, 0.30 + urgency_score * 0.45 - liquidity_score * 0.20)
     )
     limit_order_share = 1.0 - market_order_share
+    median_latency_ms = _median(
+        tuple(item for item in latencies_ms if item is not None)
+    )
+    latency_adjusted_limit_fill_probability = _latency_adjusted_limit_fill_probability(
+        median_latency_ms=median_latency_ms,
+        median_spread_bps=median_spread_bps,
+        median_depth=_median(depths),
+        median_volume=median_volume,
+        notional=notional,
+    )
+    latency_forced_market_order_risk = limit_order_share * (
+        1.0 - latency_adjusted_limit_fill_probability
+    )
+    market_limit_mix_entropy_score = _binary_entropy_score(market_order_share)
+    latency_shortfall_bps = latency_forced_market_order_risk * (
+        median_spread_bps + impact_cost_bps * 0.25
+    )
+    mix_degeneracy_bps = (1.0 - market_limit_mix_entropy_score) * 2.5
     missing_penalty_bps = 6.0 * len(warnings)
+    shortfall_stress_bps += latency_shortfall_bps + mix_degeneracy_bps
     replay_rank_penalty_bps = shortfall_stress_bps + missing_penalty_bps
     return ExecutionScheduleStressSummary(
         row_count=len(ordered),
@@ -203,6 +271,11 @@ def extract_execution_schedule_stress(
         impact_cost_bps=impact_cost_bps,
         market_order_share=market_order_share,
         limit_order_share=limit_order_share,
+        observed_latency_count=observed_latency_count,
+        median_latency_ms=median_latency_ms,
+        latency_adjusted_limit_fill_probability=latency_adjusted_limit_fill_probability,
+        latency_forced_market_order_risk=latency_forced_market_order_risk,
+        market_limit_mix_entropy_score=market_limit_mix_entropy_score,
         shortfall_stress_bps=shortfall_stress_bps,
         replay_rank_penalty_bps=replay_rank_penalty_bps,
         warnings=tuple(dict.fromkeys(warnings)),
@@ -218,6 +291,39 @@ _VOLUME_FIELDS = (
     "size",
     "trade_size",
     "last_size",
+)
+_DEPTH_FIELDS = (
+    "executable_depth",
+    "visible_depth",
+    "book_depth",
+    "depth",
+    "bid_size",
+    "ask_size",
+    "best_bid_size",
+    "best_ask_size",
+)
+_LATENCY_FIELDS_MS = (
+    "route_latency_ms",
+    "broker_latency_ms",
+    "submit_latency_ms",
+    "submission_latency_ms",
+    "order_submission_latency_ms",
+    "execution_latency_ms",
+    "latency_ms",
+)
+_LATENCY_FIELDS_US = (
+    "route_latency_us",
+    "broker_latency_us",
+    "submit_latency_us",
+    "submission_latency_us",
+    "order_submission_latency_us",
+)
+_LATENCY_FIELDS_NS = (
+    "route_latency_ns",
+    "broker_latency_ns",
+    "submit_latency_ns",
+    "submission_latency_ns",
+    "order_submission_latency_ns",
 )
 
 
@@ -264,6 +370,41 @@ def _impact_cost_bps(
     return min(500.0, sqrt(max(0.0, participation)) * 75.0 + median_spread_bps * 0.35)
 
 
+def _latency_adjusted_limit_fill_probability(
+    *,
+    median_latency_ms: float,
+    median_spread_bps: float,
+    median_depth: float,
+    median_volume: float,
+    notional: float,
+) -> float:
+    if median_latency_ms <= 0.0 and median_depth <= 0.0:
+        return 0.35
+    latency_survival = 1.0 / (1.0 + max(0.0, median_latency_ms) / 150.0)
+    spread_acceptance = 1.0 / (1.0 + max(0.0, median_spread_bps - 1.0) / 8.0)
+    if notional <= 0.0:
+        size_pressure = 0.65
+    else:
+        dollar_depth = max(median_depth, median_volume, 0.0)
+        size_pressure = min(1.0, dollar_depth / max(1.0, notional))
+    return min(
+        0.98,
+        max(
+            0.02,
+            0.10
+            + latency_survival * 0.42
+            + spread_acceptance * 0.23
+            + size_pressure * 0.25,
+        ),
+    )
+
+
+def _binary_entropy_score(probability: float) -> float:
+    clamped = min(1.0 - 1e-12, max(1e-12, probability))
+    entropy = -(clamped * log2(clamped) + (1.0 - clamped) * log2(1.0 - clamped))
+    return min(1.0, max(0.0, entropy))
+
+
 def _observed_window_seconds(event_times: Sequence[float | None]) -> float:
     values = tuple(item for item in event_times if item is not None)
     if len(values) < 2:
@@ -282,6 +423,21 @@ def _first_payload_value(record: SignalEnvelope, keys: Sequence[str]) -> Any:
         if key in record.payload:
             return record.payload.get(key)
     return None
+
+
+def _latency_ms(record: SignalEnvelope) -> float | None:
+    explicit_ms = _float_or_none(_first_payload_value(record, _LATENCY_FIELDS_MS))
+    if explicit_ms is not None:
+        return max(0.0, explicit_ms)
+    explicit_us = _float_or_none(_first_payload_value(record, _LATENCY_FIELDS_US))
+    if explicit_us is not None:
+        return max(0.0, explicit_us / 1_000.0)
+    explicit_ns = _float_or_none(_first_payload_value(record, _LATENCY_FIELDS_NS))
+    if explicit_ns is not None:
+        return max(0.0, explicit_ns / 1_000_000.0)
+    if record.ingest_ts is None:
+        return None
+    return max(0.0, (record.ingest_ts - record.event_ts).total_seconds() * 1_000.0)
 
 
 def _positive_float(value: Any) -> float | None:

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -618,7 +618,7 @@ class FastReplayPreviewResult:
                 "hpairs_clusterlob_ofi_prefilter": "deterministic bounded H-PAIRS candidate prefilter metadata only; never promotion authority",
                 "clusterlob_order_flow_feature_lane": "offline replay-tape/fixture ClusterLOB and horizon OFI features for preview ranking only",
                 "hawkes_event_time_excitation_replay_stress": "deterministic Hawkes-style event-time burst/self-excitation proxy from arXiv:2510.08085 and arXiv:2604.23961; preview ranking only",
-                "mpc_market_limit_execution_schedule_stress": "deterministic MPC-style schedule deviation/opportunity-cost/market-limit-mix stress from arXiv:2603.28898 and arXiv:2507.06345; preview ranking only",
+                "mpc_market_limit_execution_schedule_stress": "deterministic MPC-style schedule deviation/opportunity-cost/market-limit-mix and submission-latency fill-probability stress from arXiv:2603.28898, arXiv:2507.06345, and arXiv:2504.00846; preview ranking only",
                 "order_book_observability_feedback_stress": "deterministic order-book feedback/censored-trade and state-dependent spread-cost stress from arXiv:2605.19584 and arXiv:2507.09196; preview ranking only",
                 "markov_order_transition_latent_regime_stress": "deterministic Markov transition entropy/inertia plus latent rising-edge stress from arXiv:2502.07625 and arXiv:2604.20949; preview ranking only",
                 "order_flow_entropy_hmm_regime_stress": "deterministic OFI Markov entropy, asymmetric HMM-regime, and multi-scale volatility/intensity stress from SSRN:5315733, arXiv:2512.15720, and arXiv:2603.20456; entropy is not directional alpha proof; preview ranking only",

--- a/services/torghut/tests/test_execution_schedule_stress.py
+++ b/services/torghut/tests/test_execution_schedule_stress.py
@@ -20,6 +20,9 @@ class TestExecutionScheduleStress(TestCase):
         price: str,
         volume: str,
         spread_bps: str = "2",
+        latency_ms: str = "25",
+        bid_size: str = "250000",
+        ask_size: str = "250000",
     ) -> SignalEnvelope:
         return SignalEnvelope(
             event_ts=datetime(2026, 3, 30, 13, 30, tzinfo=timezone.utc)
@@ -32,8 +35,12 @@ class TestExecutionScheduleStress(TestCase):
                 "price": Decimal(price),
                 "microbar_volume": Decimal(volume),
                 "spread_bps": Decimal(spread_bps),
+                "route_latency_ms": Decimal(latency_ms),
+                "bid_size": Decimal(bid_size),
+                "ask_size": Decimal(ask_size),
             },
-            ingest_ts=datetime(2026, 3, 30, 13, 30, 1, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 3, 30, 13, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset, milliseconds=int(Decimal(latency_ms))),
         )
 
     def test_clustered_volume_and_adverse_price_path_raise_schedule_stress(
@@ -64,6 +71,11 @@ class TestExecutionScheduleStress(TestCase):
             float(benign["schedule_deviation_bps"]),
         )
         self.assertGreater(float(adverse["opportunity_cost_bps"]), 0)
+        self.assertGreater(adverse["observed_latency_count"], 0)
+        self.assertIn(
+            "latency_adjusted_limit_fill_probability",
+            adverse["ranking_features"],
+        )
         self.assertGreater(
             float(adverse["replay_rank_penalty_bps"]),
             float(benign["replay_rank_penalty_bps"]),
@@ -73,6 +85,90 @@ class TestExecutionScheduleStress(TestCase):
         self.assertFalse(adverse["proof_authority"])
         self.assertFalse(adverse["promotion_authority"])
 
+    def test_submission_latency_and_sparse_depth_raise_limit_fill_risk(self) -> None:
+        low_latency_liquid = [
+            self._row(
+                offset=0,
+                price="100",
+                volume="2500",
+                spread_bps="1",
+                latency_ms="15",
+                bid_size="400000",
+                ask_size="420000",
+            ),
+            self._row(
+                offset=1,
+                price="100.01",
+                volume="2600",
+                spread_bps="1",
+                latency_ms="20",
+                bid_size="390000",
+                ask_size="410000",
+            ),
+            self._row(
+                offset=2,
+                price="100.00",
+                volume="2400",
+                spread_bps="1",
+                latency_ms="18",
+                bid_size="410000",
+                ask_size="400000",
+            ),
+        ]
+        high_latency_sparse = [
+            self._row(
+                offset=0,
+                price="100",
+                volume="250",
+                spread_bps="9",
+                latency_ms="450",
+                bid_size="12000",
+                ask_size="11000",
+            ),
+            self._row(
+                offset=1,
+                price="100.20",
+                volume="200",
+                spread_bps="11",
+                latency_ms="500",
+                bid_size="9000",
+                ask_size="8500",
+            ),
+            self._row(
+                offset=2,
+                price="100.35",
+                volume="180",
+                spread_bps="12",
+                latency_ms="550",
+                bid_size="7000",
+                ask_size="7500",
+            ),
+        ]
+
+        liquid = extract_execution_schedule_stress(
+            low_latency_liquid, direction=1, max_notional=Decimal("25000")
+        ).to_payload()
+        sparse = extract_execution_schedule_stress(
+            high_latency_sparse, direction=1, max_notional=Decimal("25000")
+        ).to_payload()
+
+        self.assertEqual(liquid["observed_latency_count"], 3)
+        self.assertEqual(sparse["observed_latency_count"], 3)
+        self.assertGreater(
+            float(liquid["latency_adjusted_limit_fill_probability"]),
+            float(sparse["latency_adjusted_limit_fill_probability"]),
+        )
+        self.assertGreater(
+            float(sparse["latency_forced_market_order_risk"]),
+            float(liquid["latency_forced_market_order_risk"]),
+        )
+        self.assertGreater(
+            float(sparse["replay_rank_penalty_bps"]),
+            float(liquid["replay_rank_penalty_bps"]),
+        )
+        self.assertFalse(sparse["promotion_allowed"])
+        self.assertFalse(sparse["final_promotion_allowed"])
+
     def test_contract_records_primary_sources_without_promotion_authority(self) -> None:
         contract = execution_schedule_stress_contract()
 
@@ -80,7 +176,20 @@ class TestExecutionScheduleStress(TestCase):
             [item["source_id"] for item in contract["source_papers"]],
             [item["source_id"] for item in EXECUTION_SCHEDULE_STRESS_PRIMARY_SOURCES],
         )
+        self.assertIn(
+            "arxiv-2504.00846",
+            [item["source_id"] for item in contract["source_papers"]],
+        )
+        self.assertIn(
+            "latency_adjusted_limit_fill_probability",
+            contract["stress_components"],
+        )
         self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
         self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
         self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertTrue(
+            contract["proof_neutrality"][
+                "rejects_latency_fill_probability_as_promotion_proof"
+            ]
+        )
         self.assertFalse(contract["proof_neutrality"]["promotion_proof"])


### PR DESCRIPTION
## Summary

- Added a latency-aware limit-fill probability and forced-market-order risk component to Torghut's execution schedule stress harness.
- Recorded primary-source metadata for arXiv:2504.00846 and expanded arXiv:2507.06345 metadata while preserving existing MPC execution stress lineage.
- Surfaced latency/depth stress features in replay ranking payloads and fast replay mechanism metadata without granting promotion or runtime-ledger authority.
- Added regression coverage showing high submission latency plus sparse displayed depth increases replay penalty versus liquid low-latency fixtures.

## Related Issues

None

## Testing

- `cd services/torghut && uvx ruff format --check app/trading/discovery/execution_schedule_stress.py app/trading/discovery/fast_replay.py tests/test_execution_schedule_stress.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/execution_schedule_stress.py app/trading/discovery/fast_replay.py tests/test_execution_schedule_stress.py`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_schedule_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A; backend replay harness feature and tests only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
