### PR TITLE
fix(torghut): emit nonpair paper-route actions

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1297,6 +1297,40 @@ def _balanced_pair_probe_symbol_actions(
     return actions
 
 
+def _paper_route_probe_default_action(target: Mapping[str, object]) -> str:
+    for key in (
+        "paper_route_probe_action",
+        "paper_route_probe_side",
+        "probe_action",
+        "probe_side",
+        "action",
+        "side",
+    ):
+        normalized = (_safe_text(target.get(key)) or "").lower()
+        if normalized in {"buy", "long"}:
+            return "buy"
+        if normalized in {"sell", "short"}:
+            return "sell"
+    return "buy"
+
+
+def _paper_route_probe_symbol_actions(
+    target: Mapping[str, object],
+    symbols: Sequence[str],
+) -> dict[str, str]:
+    normalized_symbols = [
+        str(symbol).strip().upper() for symbol in symbols if str(symbol).strip()
+    ]
+    actions = _balanced_pair_probe_symbol_actions(target, normalized_symbols)
+    if _target_requires_balanced_pair_probe(target):
+        return actions
+
+    default_action = _paper_route_probe_default_action(target)
+    for symbol in normalized_symbols:
+        actions.setdefault(symbol, default_action)
+    return actions
+
+
 def _paper_route_probe_symbol_quantities(
     target: Mapping[str, object],
     symbols: Sequence[str],
@@ -2156,7 +2190,7 @@ def _next_paper_route_runtime_window_targets(
         pair_balance_required = _target_requires_balanced_pair_probe(
             pair_balance_target
         )
-        pair_symbol_actions = _balanced_pair_probe_symbol_actions(
+        pair_symbol_actions = _paper_route_probe_symbol_actions(
             pair_balance_target,
             target_probe_symbols,
         )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -42,6 +42,7 @@ from app.trading.paper_route_evidence import (
     _normalized_open_positions,
     _order_event_source_offset_refs,
     _paper_route_probe_summary,
+    _paper_route_probe_symbol_actions,
     _paper_route_probe_symbol_quantities,
     _pair_probe_balance_state,
     _runtime_ledger_bucket_evidence_grade,
@@ -696,6 +697,27 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
 
         self.assertEqual(quantities, {"AAPL": "0.5", "AMZN": "0.7"})
+
+    def test_non_pair_probe_symbol_actions_default_to_buy(self) -> None:
+        actions = _paper_route_probe_symbol_actions(
+            {"strategy_family": "intraday_tsmom_consistent"},
+            ["NVDA", "AAPL"],
+        )
+
+        self.assertEqual(actions, {"NVDA": "buy", "AAPL": "buy"})
+        self.assertEqual(_pair_probe_balance_state(actions), "imbalanced")
+
+    def test_non_pair_probe_symbol_actions_preserve_explicit_sell_alias(self) -> None:
+        actions = _paper_route_probe_symbol_actions(
+            {
+                "strategy_family": "intraday_tsmom_consistent",
+                "paper_route_probe_action": "long",
+                "paper_route_probe_symbol_actions": {"NVDA": "short"},
+            },
+            ["NVDA", "AAPL"],
+        )
+
+        self.assertEqual(actions, {"NVDA": "sell", "AAPL": "buy"})
 
     def test_account_contamination_reason_reports_mixed_foreign_and_unlinked(
         self,
@@ -4829,6 +4851,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "intraday-tsmom-profit-v3",
         )
         self.assertEqual(readiness["scoped_probe_symbols"], ["NVDA", "AAPL"])
+        self.assertEqual(
+            target["paper_route_probe_symbol_actions"],
+            {"NVDA": "buy", "AAPL": "buy"},
+        )
+        self.assertFalse(target["paper_route_probe_pair_balance_required"])
+        self.assertEqual(target["paper_route_probe_pair_balance_state"], "not_required")
         self.assertEqual(
             target["paper_route_probe_out_of_strategy_scope_symbols"],
             ["MSFT"],


### PR DESCRIPTION
## Summary

- Adds explicit default probe action metadata for non-pair paper-route evidence targets.
- Keeps balanced pair targets on the existing buy/sell balancing path.
- Covers the TSMOM target-plan builder shape so scoped symbols no longer emit empty `paper_route_probe_symbol_actions`.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "non_pair_probe_symbol_actions or next_paper_route_targets_use_family_runtime_harness_from_strategy_id or builder_exports_next_paper_route_runtime_window_targets or external_target_plan or next_paper_route_runtime_window" -q`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py tests/test_paper_route_target_plan.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
