### PR TITLE
fix(torghut): require implementation parity evidence

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -72,6 +72,21 @@ MARKET_IMPACT_SCORECARD_KEYS = (
     "implementation_uncertainty_target_net_pnl_per_day",
     "implementation_uncertainty_scenarios",
     "implementation_uncertainty_source_markers",
+    "requires_implementation_risk_backtest_stability",
+    "implementation_risk_backtest_stability_required",
+    "requires_multi_engine_replay",
+    "required_multi_engine_replay",
+    "multi_engine_replay_passed",
+    "multi_engine_replay_engine_count",
+    "implementation_engine_count",
+    "requires_engine_sensitivity_report",
+    "engine_sensitivity_report_present",
+    "engine_sensitivity_report_ref",
+    "engine_sensitivity_artifact_ref",
+    "requires_conclusion_stability",
+    "conclusion_stability_passed",
+    "conclusion_stability_index",
+    "required_conclusion_stability_index",
     "conformal_tail_risk_required",
     "conformal_tail_risk_model",
     "conformal_tail_risk_alpha",
@@ -1437,6 +1452,61 @@ def _implementation_uncertainty_blockers(
     return blockers
 
 
+def _implementation_risk_backtest_stability_required(
+    scorecard: Mapping[str, Any],
+) -> bool:
+    if any(
+        _bool(scorecard.get(key))
+        for key in (
+            "requires_implementation_risk_backtest_stability",
+            "implementation_risk_backtest_stability_required",
+            "requires_multi_engine_replay",
+            "required_multi_engine_replay",
+            "requires_engine_sensitivity_report",
+            "requires_conclusion_stability",
+        )
+    ):
+        return True
+    return "implementation_risk_backtesting_arxiv_2603_20319_2026" in {
+        marker.lower()
+        for marker in _string_list(
+            scorecard.get("implementation_uncertainty_source_markers")
+        )
+    }
+
+
+def _implementation_risk_backtest_stability_blockers(
+    scorecard: Mapping[str, Any],
+) -> list[str]:
+    if not _implementation_risk_backtest_stability_required(scorecard):
+        return []
+
+    blockers: list[str] = []
+    engine_count = max(
+        _int(scorecard.get("multi_engine_replay_engine_count")),
+        _int(scorecard.get("implementation_engine_count")),
+    )
+    if not _bool(scorecard.get("multi_engine_replay_passed")):
+        blockers.append("multi_engine_replay_missing_or_failed")
+    if engine_count < 2:
+        blockers.append("multi_engine_replay_engine_count_below_min")
+    if not (
+        _bool(scorecard.get("engine_sensitivity_report_present"))
+        or _string(scorecard.get("engine_sensitivity_report_ref"))
+        or _string(scorecard.get("engine_sensitivity_artifact_ref"))
+    ):
+        blockers.append("engine_sensitivity_report_missing")
+    required_index = _decimal(
+        scorecard.get("required_conclusion_stability_index") or "1"
+    )
+    observed_index = _decimal(scorecard.get("conclusion_stability_index"))
+    if not _bool(scorecard.get("conclusion_stability_passed")):
+        blockers.append("conclusion_stability_missing_or_failed")
+    if observed_index < required_index:
+        blockers.append("conclusion_stability_index_below_min")
+    return blockers
+
+
 def _conformal_tail_risk_blockers(scorecard: Mapping[str, Any]) -> list[str]:
     requires_conformal_tail_risk = _bool(
         scorecard.get("conformal_tail_risk_required")
@@ -1516,6 +1586,7 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         )
         blockers.extend(_market_impact_stress_blockers(scorecard))
         blockers.extend(_implementation_uncertainty_blockers(scorecard))
+        blockers.extend(_implementation_risk_backtest_stability_blockers(scorecard))
         blockers.extend(_conformal_tail_risk_blockers(scorecard))
         blockers.extend(_delay_depth_survival_blockers(scorecard))
     return tuple(dict.fromkeys(blockers))

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -132,6 +132,92 @@ def test_promotion_ready_bundle_blocks_missing_market_impact_stress() -> None:
     assert "market_impact_liquidity_evidence_missing" in blockers
 
 
+def test_promotion_ready_bundle_blocks_missing_implementation_risk_parity() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-implementation-risk-gap",
+        candidate_id="candidate-implementation-risk-gap",
+        candidate_spec_id="spec-implementation-risk-gap",
+        dataset_snapshot_id="snapshot-implementation-risk-gap",
+        feature_spec_hash="feature-implementation-risk-gap",
+        code_commit="commit-implementation-risk-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "implementation_uncertainty_required": True,
+            "implementation_uncertainty_stability_passed": True,
+            "implementation_uncertainty_model_count": 5,
+            "implementation_uncertainty_lower_net_pnl_per_day": "600",
+            "implementation_uncertainty_source_markers": [
+                "implementation_risk_backtesting_arxiv_2603_20319_2026"
+            ],
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "multi_engine_replay_missing_or_failed" in blockers
+    assert "multi_engine_replay_engine_count_below_min" in blockers
+    assert "engine_sensitivity_report_missing" in blockers
+    assert "conclusion_stability_missing_or_failed" in blockers
+    assert "conclusion_stability_index_below_min" in blockers
+
+
+def test_promotion_ready_bundle_accepts_materialized_implementation_risk_parity() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-implementation-risk-ok",
+        candidate_id="candidate-implementation-risk-ok",
+        candidate_spec_id="spec-implementation-risk-ok",
+        dataset_snapshot_id="snapshot-implementation-risk-ok",
+        feature_spec_hash="feature-implementation-risk-ok",
+        code_commit="commit-implementation-risk-ok",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "implementation_uncertainty_required": True,
+            "implementation_uncertainty_stability_passed": True,
+            "implementation_uncertainty_model_count": 5,
+            "implementation_uncertainty_lower_net_pnl_per_day": "600",
+            "requires_multi_engine_replay": True,
+            "multi_engine_replay_passed": True,
+            "multi_engine_replay_engine_count": 2,
+            "engine_sensitivity_report_ref": "artifact://engine-sensitivity",
+            "conclusion_stability_passed": True,
+            "conclusion_stability_index": "1.00",
+            "required_conclusion_stability_index": "1.00",
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "multi_engine_replay_missing_or_failed" not in blockers
+    assert "multi_engine_replay_engine_count_below_min" not in blockers
+    assert "engine_sensitivity_report_missing" not in blockers
+    assert "conclusion_stability_missing_or_failed" not in blockers
+    assert "conclusion_stability_index_below_min" not in blockers
+
+
 def test_promotion_ready_bundle_blocks_required_uncertainty_and_tail_risk_gaps() -> (
     None
 ):
@@ -174,6 +260,45 @@ def test_promotion_ready_bundle_blocks_required_uncertainty_and_tail_risk_gaps()
     assert "conformal_tail_risk_failed" in blockers
     assert "conformal_tail_risk_sample_count_zero" in blockers
     assert "conformal_tail_risk_adjusted_net_pnl_non_positive" in blockers
+
+
+def test_frontier_candidate_preserves_implementation_risk_parity_fields() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-implementation-risk-preserved",
+        candidate={
+            "candidate_id": "candidate-implementation-risk-preserved",
+            "objective_scorecard": _promotion_quality_scorecard(),
+            "requires_multi_engine_replay": True,
+            "multi_engine_replay_passed": True,
+            "multi_engine_replay_engine_count": 2,
+            "engine_sensitivity_report_ref": "artifact://engine-sensitivity",
+            "conclusion_stability_passed": True,
+            "conclusion_stability_index": "1.00",
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-implementation-risk-preserved",
+        result_path="artifact://replay",
+        code_commit="commit-implementation-risk-preserved",
+    )
+
+    assert bundle.objective_scorecard["requires_multi_engine_replay"] is True
+    assert bundle.objective_scorecard["multi_engine_replay_passed"] is True
+    assert bundle.objective_scorecard["multi_engine_replay_engine_count"] == 2
+    assert (
+        bundle.objective_scorecard["engine_sensitivity_report_ref"]
+        == "artifact://engine-sensitivity"
+    )
+    assert bundle.objective_scorecard["conclusion_stability_passed"] is True
+    assert bundle.objective_scorecard["conclusion_stability_index"] == "1.00"
+    blockers = evidence_bundle_blockers(bundle)
+    assert "multi_engine_replay_missing_or_failed" not in blockers
+    assert "engine_sensitivity_report_missing" not in blockers
+    assert "conclusion_stability_missing_or_failed" not in blockers
 
 
 def test_frontier_candidate_preserves_runtime_handoff_as_promotion_blocker() -> None:


### PR DESCRIPTION
## Summary

- Adds fail-closed promotion blockers for implementation-risk parity evidence when candidates require implementation-risk backtest stability or cite the 2026 implementation-risk source marker.
- Requires multi-engine replay pass, at least two replay/implementation engines, engine-sensitivity evidence, and conclusion-stability evidence before promotion proof can pass.
- Preserves implementation-risk parity fields when building evidence bundles from frontier candidates and adds regression tests for missing versus materialized parity evidence.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- Attempted `cd services/torghut && uv sync --frozen --extra dev`; blocked in this workspace because `crosshair-tool==0.0.102` needs `cc`, which is not installed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
