### PR TITLE
fix(torghut): require order type tca evidence

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -39,6 +39,16 @@ REPLAY_ACTIVITY_SCORECARD_KEYS = (
     "market_limit_order_mix_passed",
     "limit_fill_probability_sample_count",
     "limit_fill_probability_evidence_present",
+    "requires_market_limit_order_type_validation",
+    "market_limit_order_type_validation_required",
+    "order_type_ablation_required",
+    "order_type_ablation_sample_count",
+    "order_type_ablation_passed",
+    "market_limit_execution_policy_passed",
+    "order_type_ablation_selected_order_type",
+    "order_type_opportunity_cost_bps",
+    "order_type_opportunity_cost_evidence_present",
+    "order_type_execution_source_markers",
     "route_tca_artifact_ref",
     "route_tca_artifact_refs",
     "route_tca_evidence_present",
@@ -1390,6 +1400,87 @@ def _has_artifact_ref(scorecard: Mapping[str, Any], *keys: str) -> bool:
     return False
 
 
+def _order_type_execution_validation_required(scorecard: Mapping[str, Any]) -> bool:
+    if any(
+        _bool(scorecard.get(key))
+        for key in (
+            "requires_market_limit_order_type_validation",
+            "market_limit_order_type_validation_required",
+            "order_type_ablation_required",
+        )
+    ):
+        return True
+    if _int(scorecard.get("market_limit_order_mix_sample_count")) > 0:
+        return True
+    if _has_artifact_ref(
+        scorecard,
+        "order_type_ablation_artifact_ref",
+        "order_type_ablation_artifact_refs",
+        "market_limit_order_mix_artifact_ref",
+        "market_limit_order_mix_artifact_refs",
+    ):
+        return True
+    source_markers = {
+        marker.lower()
+        for marker in _string_list(scorecard.get("order_type_execution_source_markers"))
+    }
+    return bool(
+        source_markers
+        & {
+            "retail_limit_orders_rof_rfaf049_2025",
+            "retail_order_flow_segmentation_ssrn_6414558_2026",
+            "payment_for_order_flow_ssrn_6704839_2026",
+            "mpc_execution_schedule_arxiv_2603_28898_2026",
+        }
+    )
+
+
+def _order_type_execution_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    if not _order_type_execution_validation_required(scorecard):
+        return []
+
+    blockers: list[str] = []
+    if not _bool(scorecard.get("market_limit_order_mix_evidence_present")):
+        blockers.append("market_limit_order_mix_evidence_missing")
+    if _int(scorecard.get("market_limit_order_mix_sample_count")) <= 0:
+        blockers.append("market_limit_order_mix_sample_count_zero")
+    if not (
+        _bool(scorecard.get("market_limit_order_mix_passed"))
+        or _bool(scorecard.get("market_limit_execution_policy_passed"))
+    ):
+        blockers.append("market_limit_order_mix_missing_or_failed")
+    if not _has_artifact_ref(
+        scorecard,
+        "route_tca_artifact_ref",
+        "route_tca_artifact_refs",
+    ) and not _bool(scorecard.get("route_tca_evidence_present")):
+        blockers.append("route_tca_evidence_missing")
+    if not _has_artifact_ref(
+        scorecard,
+        "order_type_ablation_artifact_ref",
+        "order_type_ablation_artifact_refs",
+    ):
+        blockers.append("order_type_ablation_artifact_missing")
+    if _int(scorecard.get("order_type_ablation_sample_count")) <= 0:
+        blockers.append("order_type_ablation_sample_count_zero")
+    if not _bool(scorecard.get("order_type_ablation_passed")):
+        blockers.append("order_type_ablation_missing_or_failed")
+    if not _bool(scorecard.get("limit_fill_probability_evidence_present")):
+        blockers.append("limit_fill_probability_evidence_missing")
+    if _int(scorecard.get("limit_fill_probability_sample_count")) <= 0:
+        blockers.append("limit_fill_probability_sample_count_zero")
+    if not _bool(scorecard.get("price_improvement_evidence_present")):
+        blockers.append("price_improvement_evidence_missing")
+    if not _bool(scorecard.get("execution_shortfall_evidence_present")):
+        blockers.append("execution_shortfall_evidence_missing")
+    if not (
+        _bool(scorecard.get("opportunity_cost_evidence_present"))
+        or _bool(scorecard.get("order_type_opportunity_cost_evidence_present"))
+    ):
+        blockers.append("opportunity_cost_evidence_missing")
+    return blockers
+
+
 def _market_impact_stress_blockers(scorecard: Mapping[str, Any]) -> list[str]:
     blockers: list[str] = []
     market_impact_passed = _bool(
@@ -1585,6 +1676,7 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
             )
         )
         blockers.extend(_market_impact_stress_blockers(scorecard))
+        blockers.extend(_order_type_execution_blockers(scorecard))
         blockers.extend(_implementation_uncertainty_blockers(scorecard))
         blockers.extend(_implementation_risk_backtest_stability_blockers(scorecard))
         blockers.extend(_conformal_tail_risk_blockers(scorecard))

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -132,6 +132,165 @@ def test_promotion_ready_bundle_blocks_missing_market_impact_stress() -> None:
     assert "market_impact_liquidity_evidence_missing" in blockers
 
 
+def test_promotion_ready_bundle_blocks_missing_order_type_tca_evidence() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-order-type-gap",
+        candidate_id="candidate-order-type-gap",
+        candidate_spec_id="spec-order-type-gap",
+        dataset_snapshot_id="snapshot-order-type-gap",
+        feature_spec_hash="feature-order-type-gap",
+        code_commit="commit-order-type-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_market_limit_order_type_validation": True,
+            "market_limit_order_mix_evidence_present": True,
+            "market_limit_order_mix_sample_count": 12,
+            "market_limit_order_mix_passed": False,
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "market_limit_order_mix_missing_or_failed" in blockers
+    assert "route_tca_evidence_missing" in blockers
+    assert "order_type_ablation_artifact_missing" in blockers
+    assert "order_type_ablation_sample_count_zero" in blockers
+    assert "order_type_ablation_missing_or_failed" in blockers
+    assert "limit_fill_probability_evidence_missing" in blockers
+    assert "limit_fill_probability_sample_count_zero" in blockers
+    assert "price_improvement_evidence_missing" in blockers
+    assert "execution_shortfall_evidence_missing" in blockers
+    assert "opportunity_cost_evidence_missing" in blockers
+
+
+def test_promotion_ready_bundle_infers_order_type_validation_from_mix_sample() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-order-type-sample-gap",
+        candidate_id="candidate-order-type-sample-gap",
+        candidate_spec_id="spec-order-type-sample-gap",
+        dataset_snapshot_id="snapshot-order-type-sample-gap",
+        feature_spec_hash="feature-order-type-sample-gap",
+        code_commit="commit-order-type-sample-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "market_limit_order_mix_sample_count": 7,
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "market_limit_order_mix_evidence_missing" in blockers
+    assert "market_limit_order_mix_sample_count_zero" not in blockers
+    assert "route_tca_evidence_missing" in blockers
+
+
+def test_promotion_ready_bundle_infers_order_type_validation_from_ablation_ref() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-order-type-ablation-ref-gap",
+        candidate_id="candidate-order-type-ablation-ref-gap",
+        candidate_spec_id="spec-order-type-ablation-ref-gap",
+        dataset_snapshot_id="snapshot-order-type-ablation-ref-gap",
+        feature_spec_hash="feature-order-type-ablation-ref-gap",
+        code_commit="commit-order-type-ablation-ref-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "order_type_ablation_artifact_ref": "artifact://order-type-ablation",
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "market_limit_order_mix_evidence_missing" in blockers
+    assert "market_limit_order_mix_sample_count_zero" in blockers
+    assert "order_type_ablation_artifact_missing" not in blockers
+
+
+def test_promotion_ready_bundle_accepts_materialized_order_type_tca_evidence() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-order-type-ok",
+        candidate_id="candidate-order-type-ok",
+        candidate_spec_id="spec-order-type-ok",
+        dataset_snapshot_id="snapshot-order-type-ok",
+        feature_spec_hash="feature-order-type-ok",
+        code_commit="commit-order-type-ok",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_market_limit_order_type_validation": True,
+            "market_limit_order_mix_evidence_present": True,
+            "market_limit_order_mix_sample_count": 24,
+            "market_limit_order_mix_passed": True,
+            "route_tca_artifact_ref": "artifact://route-tca",
+            "order_type_ablation_artifact_ref": "artifact://order-type-ablation",
+            "order_type_ablation_sample_count": 24,
+            "order_type_ablation_passed": True,
+            "limit_fill_probability_evidence_present": True,
+            "limit_fill_probability_sample_count": 12,
+            "price_improvement_evidence_present": True,
+            "execution_shortfall_evidence_present": True,
+            "opportunity_cost_evidence_present": True,
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "market_limit_order_mix_missing_or_failed" not in blockers
+    assert "route_tca_evidence_missing" not in blockers
+    assert "order_type_ablation_artifact_missing" not in blockers
+    assert "order_type_ablation_sample_count_zero" not in blockers
+    assert "order_type_ablation_missing_or_failed" not in blockers
+    assert "limit_fill_probability_evidence_missing" not in blockers
+    assert "limit_fill_probability_sample_count_zero" not in blockers
+    assert "price_improvement_evidence_missing" not in blockers
+    assert "execution_shortfall_evidence_missing" not in blockers
+    assert "opportunity_cost_evidence_missing" not in blockers
+
+
 def test_promotion_ready_bundle_blocks_missing_implementation_risk_parity() -> None:
     bundle = CandidateEvidenceBundle(
         schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
@@ -260,6 +419,52 @@ def test_promotion_ready_bundle_blocks_required_uncertainty_and_tail_risk_gaps()
     assert "conformal_tail_risk_failed" in blockers
     assert "conformal_tail_risk_sample_count_zero" in blockers
     assert "conformal_tail_risk_adjusted_net_pnl_non_positive" in blockers
+
+
+def test_frontier_candidate_preserves_order_type_tca_fields() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-order-type-preserved",
+        candidate={
+            "candidate_id": "candidate-order-type-preserved",
+            "objective_scorecard": _promotion_quality_scorecard(),
+            "requires_market_limit_order_type_validation": True,
+            "market_limit_order_mix_sample_count": 24,
+            "market_limit_order_mix_evidence_present": True,
+            "market_limit_order_mix_passed": True,
+            "route_tca_artifact_ref": "artifact://route-tca",
+            "order_type_ablation_artifact_ref": "artifact://order-type-ablation",
+            "order_type_ablation_sample_count": 24,
+            "order_type_ablation_passed": True,
+            "limit_fill_probability_sample_count": 12,
+            "limit_fill_probability_evidence_present": True,
+            "price_improvement_evidence_present": True,
+            "execution_shortfall_evidence_present": True,
+            "opportunity_cost_evidence_present": True,
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-order-type-preserved",
+        result_path="artifact://replay",
+        code_commit="commit-order-type-preserved",
+    )
+
+    assert (
+        bundle.objective_scorecard["requires_market_limit_order_type_validation"]
+        is True
+    )
+    assert bundle.objective_scorecard["order_type_ablation_sample_count"] == 24
+    assert bundle.objective_scorecard["order_type_ablation_passed"] is True
+    assert (
+        bundle.objective_scorecard["route_tca_artifact_ref"] == "artifact://route-tca"
+    )
+    blockers = evidence_bundle_blockers(bundle)
+    assert "order_type_ablation_artifact_missing" not in blockers
+    assert "price_improvement_evidence_missing" not in blockers
+    assert "execution_shortfall_evidence_missing" not in blockers
 
 
 def test_frontier_candidate_preserves_implementation_risk_parity_fields() -> None:


### PR DESCRIPTION
## Summary

- Adds fail-closed promotion blockers for market/limit order-type execution evidence when a candidate requires order-type validation or carries market/limit mix evidence.
- Requires route TCA, order-type ablation, limit-fill probability, price-improvement, execution-shortfall, and opportunity-cost evidence before market/limit execution policy evidence can support promotion readiness.
- Preserves order-type TCA fields when building evidence bundles from frontier candidates and adds regression tests for missing versus materialized evidence.

## Related Issues

None

## Testing

- `cd /workspace/lab && uv run --frozen --with ruff ruff format services/torghut/app/trading/discovery/evidence_bundles.py services/torghut/tests/test_evidence_bundles.py`
- `cd /workspace/lab && uv run --frozen --with ruff ruff check services/torghut/app/trading/discovery/evidence_bundles.py services/torghut/tests/test_evidence_bundles.py`
- `cd /workspace/lab/services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py`
- `cd /workspace/lab/services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd /workspace/lab/services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd /workspace/lab/services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- Attempted `cd /workspace/lab/services/torghut && uv sync --frozen --extra dev`; blocked in this workspace because `crosshair-tool==0.0.102` needs `cc`, which is not installed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
