### PR TITLE
fix(torghut): require queue-position fill survival proof

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -1383,6 +1383,38 @@ def _delay_depth_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
         <= 0
     ):
         blockers.append("queue_ahead_depletion_sample_count_zero")
+
+    if not _bool(scorecard.get("queue_position_survival_fill_curve_evidence_present")):
+        blockers.append("queue_position_survival_fill_curve_evidence_missing")
+    if _int(scorecard.get("queue_position_survival_sample_count")) <= 0:
+        blockers.append("queue_position_survival_sample_count_zero")
+    if _decimal(scorecard.get("queue_position_survival_fill_rate")) <= 0:
+        blockers.append("queue_position_survival_fill_rate_non_positive")
+    if not _bool(
+        scorecard.get("queue_position_survival_queue_ahead_depletion_evidence_present")
+    ):
+        blockers.append(
+            "queue_position_survival_queue_ahead_depletion_evidence_missing"
+        )
+    if (
+        _int(
+            scorecard.get("queue_position_survival_queue_ahead_depletion_sample_count")
+        )
+        <= 0
+    ):
+        blockers.append(
+            "queue_position_survival_queue_ahead_depletion_sample_count_zero"
+        )
+    if _decimal(scorecard.get("queue_position_survival_adjusted_fillable_ratio")) <= 0:
+        blockers.append("queue_position_survival_adjusted_fillable_ratio_non_positive")
+    if (
+        _decimal(
+            scorecard.get("post_cost_net_pnl_after_queue_position_survival_fill_stress")
+            or scorecard.get("queue_position_survival_stress_net_pnl_per_day")
+        )
+        <= 0
+    ):
+        blockers.append("queue_position_survival_stress_net_pnl_non_positive")
     return blockers
 
 

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -169,6 +169,25 @@ _PAPER_PROBATION_TAIL_RISK_REASONS = frozenset(
         "fill_survival_rate_below_min",
     }
 )
+_PAPER_PROBATION_QUEUE_SURVIVAL_REASONS = frozenset(
+    {
+        "fill_survival_sample_count_below_min",
+        "fill_survival_rate_below_min",
+        "required_min_queue_position_survival_sample_count",
+        "queue_position_survival_fill_curve_evidence_present_failed",
+        "queue_position_survival_sample_count_failed",
+        "queue_position_survival_fill_rate_failed",
+        "queue_position_survival_nonfill_opportunity_cost_present_failed",
+        "queue_position_survival_nonfill_opportunity_cost_bps_failed",
+        "queue_position_survival_fill_curve_evidence_missing",
+        "queue_position_survival_sample_count_zero",
+        "queue_position_survival_fill_rate_non_positive",
+        "queue_position_survival_queue_ahead_depletion_evidence_missing",
+        "queue_position_survival_queue_ahead_depletion_sample_count_zero",
+        "queue_position_survival_adjusted_fillable_ratio_non_positive",
+        "queue_position_survival_stress_net_pnl_non_positive",
+    }
+)
 _CONSISTENCY_REPAIR_ENTRY_KEYS = (
     "max_entries_per_session",
     "max_entries_per_day",
@@ -4627,6 +4646,8 @@ def _paper_probation_required_actions(hard_vetoes: Sequence[str]) -> list[str]:
         actions.append("collect_consistency_and_activity_evidence")
     if reasons & _PAPER_PROBATION_TAIL_RISK_REASONS:
         actions.append("collect_tail_risk_and_fill_survival_evidence")
+    if reasons & _PAPER_PROBATION_QUEUE_SURVIVAL_REASONS:
+        actions.append("collect_queue_position_survival_fill_curve_evidence")
     if "stale_dataset_snapshot" in reasons:
         actions.append("refresh_dataset_snapshot_before_paper_orders")
     return actions
@@ -5028,6 +5049,8 @@ def _paper_probation_repair_actions(
         actions.append("close_or_exclude_open_replay_position_windows")
     if "proof_only_full_window_replay_not_probation_authority" in blocker_set:
         actions.append("rerun_exact_replay_with_authoritative_runtime_events")
+    if blocker_set & _PAPER_PROBATION_QUEUE_SURVIVAL_REASONS:
+        actions.append("collect_queue_position_survival_fill_curve_evidence")
     actions.append("keep_final_promotion_gates_fail_closed")
     return list(dict.fromkeys(actions))
 

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -28,6 +28,13 @@ def _promotion_quality_scorecard() -> dict[str, object]:
         "fill_survival_sample_count": 12,
         "queue_ahead_depletion_evidence_present": True,
         "queue_ahead_depletion_sample_count": 12,
+        "queue_position_survival_fill_curve_evidence_present": True,
+        "queue_position_survival_sample_count": 12,
+        "queue_position_survival_fill_rate": "0.85",
+        "queue_position_survival_queue_ahead_depletion_evidence_present": True,
+        "queue_position_survival_queue_ahead_depletion_sample_count": 12,
+        "queue_position_survival_adjusted_fillable_ratio": "0.80",
+        "post_cost_net_pnl_after_queue_position_survival_fill_stress": "600",
     }
 
 
@@ -289,6 +296,54 @@ def test_promotion_ready_bundle_accepts_materialized_order_type_tca_evidence() -
     assert "price_improvement_evidence_missing" not in blockers
     assert "execution_shortfall_evidence_missing" not in blockers
     assert "opportunity_cost_evidence_missing" not in blockers
+
+
+def test_promotion_ready_bundle_blocks_generic_fill_survival_without_queue_position_curve() -> (
+    None
+):
+    scorecard = _promotion_quality_scorecard()
+    for key in (
+        "queue_position_survival_fill_curve_evidence_present",
+        "queue_position_survival_sample_count",
+        "queue_position_survival_fill_rate",
+        "queue_position_survival_queue_ahead_depletion_evidence_present",
+        "queue_position_survival_queue_ahead_depletion_sample_count",
+        "queue_position_survival_adjusted_fillable_ratio",
+        "post_cost_net_pnl_after_queue_position_survival_fill_stress",
+    ):
+        scorecard.pop(key)
+
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-generic-fill-only",
+        candidate_id="candidate-generic-fill-only",
+        candidate_spec_id="spec-generic-fill-only",
+        dataset_snapshot_id="snapshot-generic-fill-only",
+        feature_spec_hash="feature-generic-fill-only",
+        code_commit="commit-generic-fill-only",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard=scorecard,
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "fill_survival_evidence_missing" not in blockers
+    assert "queue_ahead_depletion_evidence_missing" not in blockers
+    assert "queue_position_survival_fill_curve_evidence_missing" in blockers
+    assert "queue_position_survival_sample_count_zero" in blockers
+    assert "queue_position_survival_fill_rate_non_positive" in blockers
+    assert "queue_position_survival_queue_ahead_depletion_evidence_missing" in blockers
+    assert "queue_position_survival_adjusted_fillable_ratio_non_positive" in blockers
+    assert "queue_position_survival_stress_net_pnl_non_positive" in blockers
 
 
 def test_promotion_ready_bundle_blocks_missing_implementation_risk_parity() -> None:

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2749,6 +2749,27 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             item["required_actions_before_or_during_probation"],
         )
 
+    def test_paper_probation_actions_collect_queue_position_survival_for_fill_vetoes(
+        self,
+    ) -> None:
+        actions = frontier._paper_probation_required_actions(
+            ["fill_survival_rate_below_min"]
+        )
+
+        self.assertIn("collect_tail_risk_and_fill_survival_evidence", actions)
+        self.assertIn("collect_queue_position_survival_fill_curve_evidence", actions)
+
+    def test_paper_probation_repair_actions_collect_queue_position_survival_for_bundle_blockers(
+        self,
+    ) -> None:
+        actions = frontier._paper_probation_repair_actions(
+            blockers=["queue_position_survival_fill_curve_evidence_missing"],
+            hard_vetoes=[],
+        )
+
+        self.assertIn("collect_queue_position_survival_fill_curve_evidence", actions)
+        self.assertIn("keep_final_promotion_gates_fail_closed", actions)
+
     def test_paper_probation_shortlist_prioritizes_handoff_ready_candidate(
         self,
     ) -> None:

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -981,6 +981,17 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                     "fill_survival_fill_rate": "0.75",
                     "queue_ahead_depletion_evidence_present": True,
                     "queue_ahead_depletion_sample_count": 8,
+                    "queue_position_survival_fill_curve_evidence_present": True,
+                    "queue_position_survival_sample_count": 8,
+                    "queue_position_survival_fill_rate": "0.75",
+                    "queue_position_survival_queue_ahead_depletion_evidence_present": (
+                        True
+                    ),
+                    "queue_position_survival_queue_ahead_depletion_sample_count": 8,
+                    "queue_position_survival_adjusted_fillable_ratio": "0.75",
+                    "post_cost_net_pnl_after_queue_position_survival_fill_stress": (
+                        "487.50"
+                    ),
                 },
                 "promotion_readiness": {
                     "stage": "paper_probation",
@@ -996,6 +1007,17 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
         blockers = evidence_bundle_blockers(bundle)
 
         self.assertEqual(bundle.objective_scorecard["fill_survival_fill_rate"], "0.75")
+        self.assertTrue(
+            bundle.objective_scorecard[
+                "queue_position_survival_fill_curve_evidence_present"
+            ]
+        )
+        self.assertEqual(
+            bundle.objective_scorecard[
+                "post_cost_net_pnl_after_queue_position_survival_fill_stress"
+            ],
+            "487.50",
+        )
         self.assertEqual(blockers, ())
 
     def test_evidence_bundle_blocks_stage_promotion_with_missing_depth_fields(


### PR DESCRIPTION
## Summary

- Require promotion-grade evidence bundles to include queue-position fill-curve proof, queue-ahead depletion samples, positive queue-adjusted fillability, and positive post-cost queue-survival stress PnL.
- Map queue-position survival blockers and fill-survival hard vetoes to an explicit paper-probation collection action.
- Add regression coverage so generic fill-survival evidence cannot satisfy queue-position executable proof.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/discovery/evidence_bundles.py scripts/search_consistent_profitability_frontier.py tests/test_evidence_bundles.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen ruff check app/trading/discovery/evidence_bundles.py scripts/search_consistent_profitability_frontier.py tests/test_evidence_bundles.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen pytest tests/test_evidence_bundles.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py::TestWhitepaperAutoresearchArtifacts::test_evidence_bundle_copies_fill_survival_from_full_window tests/test_evidence_bundles.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
