### PR TITLE
fix(torghut): reserve paper route account from retries

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -1378,7 +1378,7 @@ class SimpleTradingPipeline(TradingPipeline):
                         positions=positions,
                         allowed_symbols=allowed_symbols,
                     )
-                    self._process_paper_route_probe_retry_decisions(
+                    self._process_paper_route_probe_retry_decisions_unless_target_reserved(
                         session=session,
                         strategies=strategies,
                         account=account,
@@ -1414,14 +1414,14 @@ class SimpleTradingPipeline(TradingPipeline):
                     positions=positions,
                     allowed_symbols=allowed_symbols,
                 )
-                self._process_paper_route_probe_retry_decisions(
+                self._process_paper_route_target_source_decisions(
                     session=session,
                     strategies=strategies,
                     account=account,
                     positions=positions,
                     allowed_symbols=allowed_symbols,
                 )
-                self._process_paper_route_target_source_decisions(
+                self._process_paper_route_probe_retry_decisions_unless_target_reserved(
                     session=session,
                     strategies=strategies,
                     account=account,
@@ -1485,7 +1485,7 @@ class SimpleTradingPipeline(TradingPipeline):
                 positions=positions,
                 allowed_symbols=allowed_symbols,
             )
-            self._process_paper_route_probe_retry_decisions(
+            self._process_paper_route_probe_retry_decisions_unless_target_reserved(
                 session=session,
                 strategies=strategies,
                 account=account,
@@ -2836,6 +2836,32 @@ class SimpleTradingPipeline(TradingPipeline):
                 self.state.metrics.record_decision_rejection_reasons(
                     ["broker_submit_failed"]
                 )
+
+    def _process_paper_route_probe_retry_decisions_unless_target_reserved(
+        self,
+        *,
+        session: Session,
+        strategies: list[Strategy],
+        account: dict[str, str],
+        positions: list[dict[str, Any]],
+        allowed_symbols: set[str],
+    ) -> None:
+        if self._paper_route_target_plan_reserves_account(
+            allowed_symbols=allowed_symbols
+        ):
+            logger.info(
+                "Skipping generic paper-route probe retries while bounded target-plan "
+                "evidence collection owns account=%s",
+                self.account_label,
+            )
+            return
+        self._process_paper_route_probe_retry_decisions(
+            session=session,
+            strategies=strategies,
+            account=account,
+            positions=positions,
+            allowed_symbols=allowed_symbols,
+        )
 
     @staticmethod
     def _paper_route_materialized_source_payload(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -12348,8 +12348,18 @@ class TestTradingPipeline(TestCase):
         )
         setattr(
             pipeline,
+            "_process_paper_route_materialized_decisions",
+            lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
             "_process_paper_route_target_source_decisions",
             lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_probe_retry_decisions",
+            Mock(side_effect=AssertionError("generic retry path should be skipped")),
         )
         setattr(
             pipeline,
@@ -12364,6 +12374,176 @@ class TestTradingPipeline(TestCase):
 
         pipeline.run_once()
 
+        self.assertEqual(ingestor.committed_batches, 1)
+
+    def test_run_once_skips_generic_retries_on_empty_batch_when_target_reserves_account(
+        self,
+    ) -> None:
+        ingestor = FakeIngestor([])
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "session_factory", self.session_local)
+        setattr(pipeline, "state", TradingState())
+        setattr(pipeline, "ingestor", ingestor)
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        target_source = Mock()
+        retry = Mock(side_effect=AssertionError("generic retry path should be skipped"))
+        setattr(pipeline, "_label_mature_rejected_signal_outcome_events", lambda: None)
+        setattr(pipeline, "_prepare_run_once", lambda _session: [strategy])
+        setattr(
+            pipeline,
+            "_capture_runtime_window_account_snapshot_if_due",
+            lambda _session: None,
+        )
+        setattr(
+            pipeline,
+            "_warm_session_context_from_open",
+            lambda _session, *, strategies: None,
+        )
+        setattr(
+            pipeline,
+            "_bounded_paper_route_signal_scope",
+            lambda *_args, **_kwargs: None,
+        )
+        setattr(pipeline, "_record_ingest_window", lambda _batch: None)
+        setattr(pipeline, "_signal_ingest_unavailable", lambda _batch: False)
+        setattr(
+            pipeline,
+            "_prepare_batch_for_decisions",
+            lambda *_args, **_kwargs: True,
+        )
+        setattr(
+            pipeline,
+            "_build_run_context",
+            lambda _session: ({}, {}, [], {"AAPL", "AMZN"}),
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_probe_exit_decisions",
+            lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_materialized_decisions",
+            lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_target_source_decisions",
+            target_source,
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_probe_retry_decisions",
+            retry,
+        )
+        setattr(
+            pipeline,
+            "_paper_route_target_plan_reserves_account",
+            lambda *, allowed_symbols: True,
+        )
+
+        pipeline.run_once()
+
+        target_source.assert_called_once()
+        retry.assert_not_called()
+
+    def test_run_once_processes_generic_retries_after_regular_batch_when_unreserved(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 6, 1, 14, 30, tzinfo=timezone.utc),
+            symbol="NVDA",
+            payload={"price": Decimal("100")},
+            timeframe="1Min",
+        )
+        ingestor = FakeIngestor([signal])
+        pipeline = object.__new__(SimpleTradingPipeline)
+        setattr(pipeline, "account_label", "TORGHUT_SIM")
+        setattr(pipeline, "session_factory", self.session_local)
+        setattr(pipeline, "state", TradingState())
+        setattr(pipeline, "ingestor", ingestor)
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        retry = Mock()
+        setattr(pipeline, "_label_mature_rejected_signal_outcome_events", lambda: None)
+        setattr(pipeline, "_prepare_run_once", lambda _session: [strategy])
+        setattr(
+            pipeline,
+            "_capture_runtime_window_account_snapshot_if_due",
+            lambda _session: None,
+        )
+        setattr(
+            pipeline,
+            "_warm_session_context_from_open",
+            lambda _session, *, strategies: None,
+        )
+        setattr(
+            pipeline,
+            "_bounded_paper_route_signal_scope",
+            lambda *_args, **_kwargs: None,
+        )
+        setattr(pipeline, "_record_ingest_window", lambda _batch: None)
+        setattr(
+            pipeline,
+            "_build_run_context",
+            lambda _session: ({}, {}, [], {"NVDA"}),
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_probe_exit_decisions",
+            lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_materialized_decisions",
+            lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_target_source_decisions",
+            lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
+            "_paper_route_target_plan_reserves_account",
+            lambda *, allowed_symbols: False,
+        )
+        setattr(
+            pipeline,
+            "_quality_gate_signals",
+            lambda *, signals, strategies, allowed_symbols: list(signals),
+        )
+        setattr(
+            pipeline,
+            "_prepare_batch_for_decisions",
+            lambda *_args, **_kwargs: True,
+        )
+        setattr(
+            pipeline,
+            "_process_batch_signals",
+            lambda **_kwargs: None,
+        )
+        setattr(
+            pipeline,
+            "_process_paper_route_probe_retry_decisions",
+            retry,
+        )
+
+        pipeline.run_once()
+
+        retry.assert_called_once()
         self.assertEqual(ingestor.committed_batches, 1)
 
     def test_run_once_blocks_bounded_target_decisions_when_signal_ingest_times_out(
@@ -12454,6 +12634,11 @@ class TestTradingPipeline(TestCase):
                 SimpleTradingPipeline,
                 "_external_paper_route_target_probe_symbols_cached",
                 return_value=({"AAPL", "AMZN"}, None, [target]),
+            ),
+            patch.object(
+                pipeline,
+                "_process_paper_route_probe_retry_decisions",
+                side_effect=AssertionError("generic retry path should be skipped"),
             ),
             patch(
                 "app.trading.scheduler.simple_pipeline.trading_now", return_value=now


### PR DESCRIPTION
## Summary

- Prevent generic paper-route probe retries from running while an active bounded target-plan window reserves the paper proof account.
- Keep explicit target-plan source and materialized decisions flowing before retry suppression so source-linked bounded collection still works.
- Add run-once regression coverage for reserved live-batch, reserved empty-batch, reserved signal-timeout, and unreserved regular-retry paths.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k "target_plan_reserves_account or skips_generic_retries or processes_generic_retries_after_regular_batch_when_unreserved or run_once_commits_and_skips_regular_signals_when_target_reserves_account or blocks_bounded_target_decisions_when_signal_ingest_times_out or scopes_hpairs_signal_ingest_and_emits_candidate_decisions or materialized_target_plan" -q`
- `cd services/torghut && uv run --frozen pytest tests/test_simple_pipeline.py -k "target_plan" -q`
- `cd services/torghut && rm -f .coverage coverage.xml && uv run --frozen coverage run -m pytest tests/test_trading_pipeline.py -k "target_plan_reserves_account or skips_generic_retries or processes_generic_retries_after_regular_batch_when_unreserved or run_once_commits_and_skips_regular_signals_when_target_reserves_account or blocks_bounded_target_decisions_when_signal_ingest_times_out or scopes_hpairs_signal_ingest_and_emits_candidate_decisions or materialized_target_plan" -q && uv run --frozen coverage xml --fail-under=0 -o coverage.xml && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref HEAD`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
