### PR TITLE
feat(torghut): add bootstrap robust replay stress

### DIFF
--- a/services/torghut/app/trading/discovery/bootstrap_robust_optimization_stress.py
+++ b/services/torghut/app/trading/discovery/bootstrap_robust_optimization_stress.py
@@ -1,0 +1,516 @@
+"""Preview-only bootstrap robust optimization stress for replay ranking.
+
+This module actualizes recent 2025-2026 robustness and falsification papers
+into deterministic, executable replay-ranking inputs.  It never rewrites PnL,
+creates synthetic profit evidence, authorizes promotion, or enables live
+capital; exact replay, route TCA, order lifecycle evidence, and runtime-ledger
+proof remain mandatory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import isfinite, log1p, sqrt
+from statistics import median
+from typing import Any, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from app.trading.models import SignalEnvelope
+
+BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_SCHEMA_VERSION = (
+    "torghut.bootstrap-robust-optimization-stress.v1"
+)
+BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.bootstrap-robust-optimization-stress-contract.v1"
+)
+BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_PROOF_SEMANTICS_LABEL = (
+    "bootstrap_robust_optimization_stress_preview_only_exact_replay_route_tca_"
+    "order_lifecycle_runtime_ledger_required"
+)
+BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2510.12725",
+        "url": "https://arxiv.org/abs/2510.12725",
+        "title": "(Non-Parametric) Bootstrap Robust Optimization for Portfolios and Trading Strategies",
+        "date": "2025-10-14",
+        "mechanism": "nonparametric_resampling_confidence_intervals_percentile_utility_selection_bias_stress",
+    },
+    {
+        "source_id": "arxiv-2604.15531",
+        "url": "https://arxiv.org/abs/2604.15531",
+        "title": "Spurious Predictability in Financial Machine Learning",
+        "date": "2026-04-16",
+        "mechanism": "adaptive_specification_search_falsification_effective_multiplicity_and_walk_forward_inflation_gap_stress",
+    },
+)
+
+_POST_COST_UTILITY_BPS_FIELDS = (
+    "post_cost_utility_bps",
+    "post_cost_return_bps",
+    "post_cost_net_pnl_bps",
+    "net_pnl_bps",
+    "realized_net_bps",
+    "cost_stressed_net_expectancy_bps",
+)
+_FOLD_FIELDS = (
+    "walk_forward_fold_id",
+    "walk_forward_fold",
+    "oos_fold_id",
+    "validation_fold",
+    "fold_id",
+    "test_fold_id",
+    "sliding_window_id",
+)
+_PARAMETER_SET_FIELDS = (
+    "parameter_set_id",
+    "strategy_params_hash",
+    "candidate_variant_id",
+    "hyperparameter_id",
+    "parameter_hash",
+    "optimization_trial_id",
+)
+_TRIAL_COUNT_FIELDS = (
+    "effective_trial_count",
+    "candidate_search_count",
+    "tested_candidate_count",
+    "optimization_trial_count",
+    "parameter_sweep_count",
+)
+_SELECTION_RANK_FIELDS = (
+    "selection_rank",
+    "optimized_rank",
+    "candidate_rank",
+    "search_rank",
+)
+
+
+@dataclass(frozen=True)
+class BootstrapRobustOptimizationStressSummary:
+    row_count: int
+    utility_observation_count: int
+    fold_observation_count: int
+    distinct_walk_forward_fold_count: int
+    parameter_set_observation_count: int
+    distinct_parameter_set_count: int
+    effective_trial_count: int
+    median_post_cost_utility_bps: float
+    lower_percentile_post_cost_utility_bps: float
+    stationary_block_bootstrap_utility_p20_bps: float
+    robust_utility_for_ranking_bps: float
+    downside_tail_bps: float
+    parameter_instability_score: float
+    walk_forward_coverage_score: float
+    selection_bias_stress_score: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_bootstrap_robust_optimization_stress_ranking",
+            "source_papers": [
+                dict(item)
+                for item in BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "utility_observation_count": self.utility_observation_count,
+            "fold_observation_count": self.fold_observation_count,
+            "distinct_walk_forward_fold_count": self.distinct_walk_forward_fold_count,
+            "parameter_set_observation_count": self.parameter_set_observation_count,
+            "distinct_parameter_set_count": self.distinct_parameter_set_count,
+            "effective_trial_count": self.effective_trial_count,
+            "median_post_cost_utility_bps": _stable_float(
+                self.median_post_cost_utility_bps
+            ),
+            "lower_percentile_post_cost_utility_bps": _stable_float(
+                self.lower_percentile_post_cost_utility_bps
+            ),
+            "stationary_block_bootstrap_utility_p20_bps": _stable_float(
+                self.stationary_block_bootstrap_utility_p20_bps
+            ),
+            "robust_utility_for_ranking_bps": _stable_float(
+                self.robust_utility_for_ranking_bps
+            ),
+            "downside_tail_bps": _stable_float(self.downside_tail_bps),
+            "parameter_instability_score": _stable_float(
+                self.parameter_instability_score
+            ),
+            "walk_forward_coverage_score": _stable_float(
+                self.walk_forward_coverage_score
+            ),
+            "selection_bias_stress_score": _stable_float(
+                self.selection_bias_stress_score
+            ),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "stationary_block_bootstrap_utility_p20_bps": _stable_float(
+                    self.stationary_block_bootstrap_utility_p20_bps
+                ),
+                "robust_utility_for_ranking_bps": _stable_float(
+                    self.robust_utility_for_ranking_bps
+                ),
+                "downside_tail_bps": _stable_float(self.downside_tail_bps),
+                "parameter_instability_score": _stable_float(
+                    self.parameter_instability_score
+                ),
+                "walk_forward_coverage_score": _stable_float(
+                    self.walk_forward_coverage_score
+                ),
+                "selection_bias_stress_score": _stable_float(
+                    self.selection_bias_stress_score
+                ),
+                "effective_trial_count": self.effective_trial_count,
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "stationary_block_bootstrap_preview": True,
+            "utility_percentile_optimization_preview": True,
+            "selection_bias_falsification_preview": True,
+            "parameter_instability_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": (
+                BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_PROOF_SEMANTICS_LABEL
+            ),
+        }
+
+
+def bootstrap_robust_optimization_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": "stationary_block_bootstrap_percentile_utility_and_selection_bias_replay_ranking",
+        "stress_components": [
+            "stationary_block_bootstrap_utility_p20_bps",
+            "robust_utility_for_ranking_bps",
+            "downside_tail_bps",
+            "parameter_instability_score",
+            "walk_forward_coverage_score",
+            "selection_bias_stress_score",
+        ],
+        "post_cost_utility_fields": list(_POST_COST_UTILITY_BPS_FIELDS),
+        "fold_fields": list(_FOLD_FIELDS),
+        "parameter_set_fields": list(_PARAMETER_SET_FIELDS),
+        "trial_count_fields": list(_TRIAL_COUNT_FIELDS),
+        "selection_rank_fields": list(_SELECTION_RANK_FIELDS),
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_order_lifecycle_fill_evidence": True,
+            "requires_runtime_ledger": True,
+            "rejects_bootstrap_percentile_utility_as_pnl_proof": True,
+            "rejects_selection_bias_falsification_preview_as_promotion_authority": True,
+            "rejects_synthetic_reference_class_as_runtime_ledger_authority": True,
+        },
+        "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+    }
+
+
+def build_bootstrap_robust_optimization_stress_schema_hash() -> str:
+    return _stable_hash(bootstrap_robust_optimization_stress_contract())
+
+
+def extract_bootstrap_robust_optimization_stress(
+    records: Sequence[SignalEnvelope | Mapping[str, Any]],
+    *,
+    post_cost_utilities_bps: Sequence[float] | NDArray[np.float64] | None = None,
+    candidate_count: int | None = None,
+) -> BootstrapRobustOptimizationStressSummary:
+    rows = tuple(records)
+    payloads = tuple(_payload(record) for record in rows)
+    utilities = _utility_array(payloads, override=post_cost_utilities_bps)
+    folds = _observed_labels(payloads, _FOLD_FIELDS)
+    parameter_sets = _observed_labels(payloads, _PARAMETER_SET_FIELDS)
+    effective_trial_count = _effective_trial_count(
+        payloads,
+        parameter_set_count=len(set(parameter_sets)),
+        candidate_count=candidate_count,
+    )
+    warnings: list[str] = []
+    if utilities.size == 0:
+        warnings.append("missing_post_cost_utility_inputs")
+    if not folds:
+        warnings.append("missing_walk_forward_fold_inputs")
+    if len(set(folds)) < 2:
+        warnings.append("insufficient_distinct_walk_forward_folds")
+    if not parameter_sets:
+        warnings.append("missing_parameter_set_inputs")
+    if effective_trial_count <= 1:
+        warnings.append("missing_effective_trial_count_inputs")
+
+    median_utility = _percentile(utilities, 50.0)
+    lower_percentile = _percentile(utilities, 20.0 if utilities.size >= 5 else 10.0)
+    stationary_bootstrap = _stationary_block_bootstrap_p20(utilities)
+    downside_tail = max(0.0, median_utility - _percentile(utilities, 10.0))
+    parameter_instability = _parameter_instability_score(payloads, utilities)
+    walk_forward_coverage = min(1.0, len(set(folds)) / 3.0) if folds else 0.0
+    selection_bias = _selection_bias_stress_score(
+        payloads,
+        effective_trial_count=effective_trial_count,
+        robust_utility=min(lower_percentile, stationary_bootstrap),
+    )
+    missing_input_penalty = 0.0
+    if utilities.size == 0:
+        missing_input_penalty += 12.0
+    if not folds:
+        missing_input_penalty += 6.0
+    if not parameter_sets:
+        missing_input_penalty += 3.0
+    if effective_trial_count <= 1:
+        missing_input_penalty += 3.0
+    robust_utility_for_ranking = min(lower_percentile, stationary_bootstrap) - (
+        downside_tail * 0.15 + parameter_instability * 4.0 + selection_bias * 5.0
+    )
+    replay_rank_penalty = min(
+        250.0,
+        missing_input_penalty
+        + downside_tail * 0.20
+        + parameter_instability * 8.0
+        + selection_bias * 10.0
+        + (1.0 - walk_forward_coverage) * 4.0,
+    )
+
+    return BootstrapRobustOptimizationStressSummary(
+        row_count=len(rows),
+        utility_observation_count=int(utilities.size),
+        fold_observation_count=len(folds),
+        distinct_walk_forward_fold_count=len(set(folds)),
+        parameter_set_observation_count=len(parameter_sets),
+        distinct_parameter_set_count=len(set(parameter_sets)),
+        effective_trial_count=effective_trial_count,
+        median_post_cost_utility_bps=median_utility,
+        lower_percentile_post_cost_utility_bps=lower_percentile,
+        stationary_block_bootstrap_utility_p20_bps=stationary_bootstrap,
+        robust_utility_for_ranking_bps=robust_utility_for_ranking,
+        downside_tail_bps=downside_tail,
+        parameter_instability_score=parameter_instability,
+        walk_forward_coverage_score=walk_forward_coverage,
+        selection_bias_stress_score=selection_bias,
+        replay_rank_penalty_bps=replay_rank_penalty,
+        warnings=tuple(sorted(set(warnings))),
+        feature_schema_hash=build_bootstrap_robust_optimization_stress_schema_hash(),
+    )
+
+
+def _payload(record: SignalEnvelope | Mapping[str, Any]) -> Mapping[str, Any]:
+    if isinstance(record, SignalEnvelope):
+        return record.payload
+    return record
+
+
+def _utility_array(
+    payloads: Sequence[Mapping[str, Any]],
+    *,
+    override: Sequence[float] | NDArray[np.float64] | None,
+) -> NDArray[np.float64]:
+    if override is not None:
+        return np.asarray(
+            [
+                _stable_float(value)
+                for value in override
+                if isfinite(_stable_float(value))
+            ],
+            dtype=np.float64,
+        )
+    values: list[float] = []
+    for payload in payloads:
+        value = _first_float(payload, _POST_COST_UTILITY_BPS_FIELDS)
+        if value is not None:
+            values.append(value)
+    return np.asarray(values, dtype=np.float64)
+
+
+def _observed_labels(
+    payloads: Sequence[Mapping[str, Any]], fields: Sequence[str]
+) -> tuple[str, ...]:
+    labels: list[str] = []
+    for payload in payloads:
+        for field in fields:
+            value = payload.get(field)
+            if value is None:
+                continue
+            label = str(value).strip()
+            if label:
+                labels.append(label)
+                break
+    return tuple(labels)
+
+
+def _effective_trial_count(
+    payloads: Sequence[Mapping[str, Any]],
+    *,
+    parameter_set_count: int,
+    candidate_count: int | None,
+) -> int:
+    counts = [max(1, parameter_set_count)]
+    if candidate_count is not None:
+        counts.append(max(1, int(candidate_count)))
+    for payload in payloads:
+        value = _first_float(payload, _TRIAL_COUNT_FIELDS)
+        if value is not None:
+            counts.append(max(1, int(value)))
+    return max(counts) if counts else 1
+
+
+def _selection_bias_stress_score(
+    payloads: Sequence[Mapping[str, Any]],
+    *,
+    effective_trial_count: int,
+    robust_utility: float,
+) -> float:
+    multiplicity = min(1.0, log1p(max(0, effective_trial_count - 1)) / log1p(100.0))
+    ranks = [
+        value
+        for payload in payloads
+        if (value := _first_float(payload, _SELECTION_RANK_FIELDS)) is not None
+    ]
+    selected_top_rank = min(ranks) <= 3 if ranks else False
+    weak_utility = robust_utility <= 0.0
+    top_rank_bonus = 0.20 if selected_top_rank else 0.0
+    weak_bonus = 0.25 if weak_utility else 0.0
+    return min(1.0, multiplicity * 0.65 + top_rank_bonus + weak_bonus)
+
+
+def _parameter_instability_score(
+    payloads: Sequence[Mapping[str, Any]], utilities: NDArray[np.float64]
+) -> float:
+    if utilities.size == 0:
+        return 1.0
+    labels = _observed_labels(payloads, _PARAMETER_SET_FIELDS)
+    if not labels:
+        return 0.75
+    grouped: dict[str, list[float]] = {}
+    for index, value in enumerate(utilities):
+        if index >= len(payloads):
+            break
+        label = _first_label(payloads[index], _PARAMETER_SET_FIELDS)
+        if not label:
+            continue
+        grouped.setdefault(label, []).append(float(value))
+    if len(grouped) < 2:
+        return 0.25
+    means = [sum(values) / len(values) for values in grouped.values() if values]
+    if len(means) < 2:
+        return 0.25
+    spread = max(means) - min(means)
+    scale = max(1.0, abs(median(means)))
+    return min(1.0, max(0.0, spread / (scale * 4.0)))
+
+
+def _stationary_block_bootstrap_p20(values: NDArray[np.float64]) -> float:
+    if values.size == 0:
+        return 0.0
+    if values.size == 1:
+        return float(values[0])
+    sample_count = int(values.size)
+    block_length = max(1, int(round(sqrt(sample_count))))
+    replicate_means: list[float] = []
+    for start in range(sample_count):
+        sample = [
+            float(values[(start + offset) % sample_count])
+            for offset in range(block_length)
+        ]
+        replicate_means.append(sum(sample) / len(sample))
+    return _percentile(np.asarray(replicate_means, dtype=np.float64), 20.0)
+
+
+def _percentile(values: NDArray[np.float64], percentile: float) -> float:
+    if values.size == 0:
+        return 0.0
+    return float(np.percentile(values, percentile))
+
+
+def _first_float(payload: Mapping[str, Any], fields: Sequence[str]) -> float | None:
+    for field in fields:
+        value = _float_or_none(payload.get(field))
+        if value is not None:
+            return value
+    return None
+
+
+def _first_label(payload: Mapping[str, Any], fields: Sequence[str]) -> str | None:
+    for field in fields:
+        value = payload.get(field)
+        if value is None:
+            continue
+        label = str(value).strip()
+        if label:
+            return label
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        resolved = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(resolved):
+        return None
+    return resolved
+
+
+def _stable_float(value: Any) -> float:
+    try:
+        resolved = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not isfinite(resolved):
+        return 0.0
+    return round(resolved, 8)
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        _json_ready(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[Any, Any], value)
+        return {
+            str(key): _json_ready(item)
+            for key, item in sorted(mapping.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        sequence = cast(Sequence[Any], value)
+        return [_json_ready(item) for item in sequence]
+    if isinstance(value, float):
+        return _stable_float(value)
+    return value
+
+
+__all__ = [
+    "BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_PRIMARY_SOURCES",
+    "BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_SCHEMA_VERSION",
+    "BootstrapRobustOptimizationStressSummary",
+    "bootstrap_robust_optimization_stress_contract",
+    "build_bootstrap_robust_optimization_stress_schema_hash",
+    "extract_bootstrap_robust_optimization_stress",
+]

--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -14,6 +14,9 @@ import numpy as np
 from numpy.typing import NDArray
 
 from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.discovery.bootstrap_robust_optimization_stress import (
+    extract_bootstrap_robust_optimization_stress,
+)
 from app.trading.discovery.adaptive_market_limit_allocation_stress import (
     extract_adaptive_market_limit_allocation_stress,
 )
@@ -90,8 +93,8 @@ from app.trading.discovery.signal_adaptive_execution_resilience_stress import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v11"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v12"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v12"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v13"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -130,6 +133,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "square_root_impact_capacity_prefilter",
     "conformal_tail_risk_prefilter",
     "bootstrap_lower_percentile_utility_prefilter",
+    "bootstrap_robust_optimization_stress",
     "implementation_risk_preview_exact_runtime_parity_reporting",
 )
 FAST_REPLAY_FRONTIER_IDENTITY_SCHEMA_VERSION = (
@@ -297,6 +301,9 @@ class FastReplayPreviewRow:
     metaorder_adverse_selection_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
+    bootstrap_robust_optimization_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
     proof_semantics_label: str = FAST_REPLAY_PROOF_SEMANTICS_LABEL
     candidate_frontier_hash: str = ""
     exact_replay_frontier_key: str = ""
@@ -431,6 +438,9 @@ class FastReplayPreviewRow:
             ),
             "metaorder_adverse_selection_stress": dict(
                 self.metaorder_adverse_selection_stress
+            ),
+            "bootstrap_robust_optimization_stress": dict(
+                self.bootstrap_robust_optimization_stress
             ),
             "ranking_only_reasons": list(ranking_only_reasons),
             "risk_veto_reasons": list(risk_veto_reasons),
@@ -639,6 +649,7 @@ class FastReplayPreviewResult:
                 "cost_aware_forecast_filter_stress": "deterministic walk-forward forecast-magnitude, transaction-cost threshold, turnover churn, multi-scale trend coverage, and dynamic-variable-selection stress from arXiv:2606.00060 and arXiv:2512.12727; cost-filtered forecasts are not PnL authority; preview ranking only",
                 "adaptive_market_limit_allocation_stress": "deterministic observed market/limit allocation, fill-uncertainty, tactical-imbalance, and trade-level cost logging stress from arXiv:2507.06345 and arXiv:2603.29086; allocation models are not fill or PnL authority; preview ranking only",
                 "metaorder_adverse_selection_stress": "deterministic Hawkes-style event clustering, same-direction metaorder footprint, adverse-selection drift, and liquidity-replenishment gap stress from arXiv:2510.27334 and DOI:10.1007/s10203-026-00570-z; metaorder footprints and Hawkes intensity are not fill or PnL authority; preview ranking only",
+                "bootstrap_robust_optimization_stress": "deterministic stationary-block bootstrap percentile utility, parameter-instability, and adaptive-search selection-bias stress from arXiv:2510.12725 and arXiv:2604.15531; model utility is not PnL authority; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1645,9 +1656,32 @@ def _score_candidate_spec(
     bootstrap_lower_percentile_post_cost_utility_bps = (
         _bootstrap_lower_percentile_post_cost_utility_bps(post_cost_utilities_bps)
     )
+    bootstrap_robust_optimization_stress = extract_bootstrap_robust_optimization_stress(
+        matched_source_rows,
+        post_cost_utilities_bps=post_cost_utilities_bps,
+        candidate_count=len(spec.strategy_overrides.get("universe_symbols", ()))
+        or None,
+    ).to_payload()
+    bootstrap_robust_optimization_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(bootstrap_robust_optimization_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
+    bootstrap_robust_utility_bps = (
+        _float_or_none(
+            _mapping(bootstrap_robust_optimization_stress.get("ranking_features")).get(
+                "robust_utility_for_ranking_bps"
+            )
+        )
+        or 0.0
+    )
     robust_lower_percentile_post_cost_utility_bps = min(
         lower_percentile_post_cost_utility_bps,
         bootstrap_lower_percentile_post_cost_utility_bps,
+        bootstrap_robust_utility_bps,
     )
     preview_score = (
         robust_lower_percentile_post_cost_utility_bps * 0.65
@@ -1686,6 +1720,7 @@ def _score_candidate_spec(
         - cost_aware_forecast_filter_rank_penalty_bps * 0.05
         - adaptive_market_limit_allocation_rank_penalty_bps * 0.05
         - metaorder_adverse_selection_rank_penalty_bps * 0.05
+        - bootstrap_robust_optimization_rank_penalty_bps * 0.07
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
     )
@@ -1736,6 +1771,7 @@ def _score_candidate_spec(
         - cost_aware_forecast_filter_rank_penalty_bps * 0.03
         - adaptive_market_limit_allocation_rank_penalty_bps * 0.03
         - metaorder_adverse_selection_rank_penalty_bps * 0.03
+        - bootstrap_robust_optimization_rank_penalty_bps * 0.04
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -1800,6 +1836,7 @@ def _score_candidate_spec(
             adaptive_market_limit_allocation_stress
         ),
         metaorder_adverse_selection_stress=dict(metaorder_adverse_selection_stress),
+        bootstrap_robust_optimization_stress=dict(bootstrap_robust_optimization_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
         candidate_lineage=_candidate_lineage(spec),
@@ -1855,6 +1892,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - _cost_aware_forecast_filter_rank_penalty_bps(row) * 0.04
         - _adaptive_market_limit_allocation_rank_penalty_bps(row) * 0.04
         - _metaorder_adverse_selection_rank_penalty_bps(row) * 0.04
+        - _bootstrap_robust_optimization_rank_penalty_bps(row) * 0.05
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
 
@@ -2004,6 +2042,15 @@ def _metaorder_adverse_selection_rank_penalty_bps(
 ) -> float:
     ranking_features = _mapping(
         row.metaorder_adverse_selection_stress.get("ranking_features")
+    )
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _bootstrap_robust_optimization_rank_penalty_bps(
+    row: FastReplayPreviewRow,
+) -> float:
+    ranking_features = _mapping(
+        row.bootstrap_robust_optimization_stress.get("ranking_features")
     )
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
@@ -2227,6 +2274,9 @@ def _row_with_rank_and_selection(
             row.adaptive_market_limit_allocation_stress
         ),
         metaorder_adverse_selection_stress=dict(row.metaorder_adverse_selection_stress),
+        bootstrap_robust_optimization_stress=dict(
+            row.bootstrap_robust_optimization_stress
+        ),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -2317,6 +2367,9 @@ def _row_with_frontier_dedupe(
             row.adaptive_market_limit_allocation_stress
         ),
         metaorder_adverse_selection_stress=dict(row.metaorder_adverse_selection_stress),
+        bootstrap_robust_optimization_stress=dict(
+            row.bootstrap_robust_optimization_stress
+        ),
         proof_semantics_label=row.proof_semantics_label,
         candidate_frontier_hash=row.candidate_frontier_hash,
         exact_replay_frontier_key=row.exact_replay_frontier_key,
@@ -3253,6 +3306,8 @@ def _risk_flags_for_row(
         flags.add("adaptive_market_limit_allocation_stress_penalty_active")
     if _metaorder_adverse_selection_rank_penalty_bps(row) > 0:
         flags.add("metaorder_adverse_selection_stress_penalty_active")
+    if _bootstrap_robust_optimization_rank_penalty_bps(row) > 0:
+        flags.add("bootstrap_robust_optimization_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
         flags.add("partial_symbol_coverage")
     if row.trading_day_count <= 0:
@@ -3321,6 +3376,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("adaptive_market_limit_allocation_stress_downranks_only")
     if _metaorder_adverse_selection_rank_penalty_bps(row) > 0:
         reasons.add("metaorder_adverse_selection_stress_downranks_only")
+    if _bootstrap_robust_optimization_rank_penalty_bps(row) > 0:
+        reasons.add("bootstrap_robust_optimization_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
         reasons.add("missing_replay_tape_source_data_explicit_blocker")
     if lineage_blockers:
@@ -3382,6 +3439,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("adaptive_market_limit_allocation_stress_penalty")
     if _metaorder_adverse_selection_rank_penalty_bps(row) > 0:
         vetoes.add("metaorder_adverse_selection_stress_penalty")
+    if _bootstrap_robust_optimization_rank_penalty_bps(row) > 0:
+        vetoes.add("bootstrap_robust_optimization_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:
         vetoes.add("robust_lower_percentile_post_cost_utility_not_positive")
     return tuple(sorted(vetoes))

--- a/services/torghut/tests/test_bootstrap_robust_optimization_stress.py
+++ b/services/torghut/tests/test_bootstrap_robust_optimization_stress.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.bootstrap_robust_optimization_stress import (
+    bootstrap_robust_optimization_stress_contract,
+    build_bootstrap_robust_optimization_stress_schema_hash,
+    extract_bootstrap_robust_optimization_stress,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestBootstrapRobustOptimizationStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        utility_bps: str | None,
+        fold: str | None = "wf-1",
+        parameter_set: str | None = "params-a",
+        trial_count: int | None = 24,
+        selection_rank: int | None = 1,
+    ) -> SignalEnvelope:
+        payload: dict[str, object] = {}
+        if utility_bps is not None:
+            payload["post_cost_utility_bps"] = Decimal(utility_bps)
+        if fold is not None:
+            payload["walk_forward_fold_id"] = fold
+        if parameter_set is not None:
+            payload["parameter_set_id"] = parameter_set
+        if trial_count is not None:
+            payload["effective_trial_count"] = Decimal(trial_count)
+        if selection_rank is not None:
+            payload["selection_rank"] = Decimal(selection_rank)
+        return SignalEnvelope(
+            event_ts=datetime(2026, 4, 16, 14, 30, tzinfo=timezone.utc)
+            + timedelta(minutes=offset),
+            symbol="BOOT",
+            timeframe="1Min",
+            seq=offset,
+            source="bootstrap-robust-optimization-fixture",
+            payload=payload,
+            ingest_ts=datetime(2026, 4, 16, 14, 31, tzinfo=timezone.utc),
+        )
+
+    def test_bootstrap_stress_downranks_unstable_selected_searches(self) -> None:
+        robust = extract_bootstrap_robust_optimization_stress(
+            (
+                self._row(offset=1, utility_bps="8", fold="wf-1", parameter_set="a"),
+                self._row(offset=2, utility_bps="7", fold="wf-2", parameter_set="a"),
+                self._row(offset=3, utility_bps="9", fold="wf-3", parameter_set="b"),
+                self._row(offset=4, utility_bps="8", fold="wf-4", parameter_set="b"),
+            ),
+            candidate_count=4,
+        )
+        fragile = extract_bootstrap_robust_optimization_stress(
+            (
+                self._row(offset=1, utility_bps="18", fold="wf-1", parameter_set="a"),
+                self._row(offset=2, utility_bps="-9", fold="wf-1", parameter_set="b"),
+                self._row(offset=3, utility_bps="16", fold="wf-1", parameter_set="a"),
+                self._row(offset=4, utility_bps="-12", fold="wf-1", parameter_set="b"),
+            ),
+            candidate_count=80,
+        )
+
+        self.assertGreater(
+            robust.robust_utility_for_ranking_bps,
+            fragile.robust_utility_for_ranking_bps,
+        )
+        self.assertGreater(
+            fragile.parameter_instability_score,
+            robust.parameter_instability_score,
+        )
+        self.assertGreater(
+            fragile.selection_bias_stress_score,
+            robust.selection_bias_stress_score,
+        )
+        self.assertGreater(
+            fragile.replay_rank_penalty_bps, robust.replay_rank_penalty_bps
+        )
+        payload = fragile.to_payload()
+        self.assertEqual(
+            payload["status"],
+            "preview_only_bootstrap_robust_optimization_stress_ranking",
+        )
+        self.assertTrue(payload["stationary_block_bootstrap_preview"])
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["final_authority_ok"])
+
+    def test_missing_inputs_fail_closed_and_contract_rejects_pnl_authority(
+        self,
+    ) -> None:
+        summary = extract_bootstrap_robust_optimization_stress(
+            (self._row(offset=1, utility_bps=None, fold=None, parameter_set=None),)
+        )
+        payload = summary.to_payload()
+        contract = bootstrap_robust_optimization_stress_contract()
+        source_ids = {source["source_id"] for source in payload["source_papers"]}
+
+        self.assertEqual(
+            payload["feature_schema_hash"],
+            build_bootstrap_robust_optimization_stress_schema_hash(),
+        )
+        self.assertIn("arxiv-2510.12725", source_ids)
+        self.assertIn("arxiv-2604.15531", source_ids)
+        self.assertIn("missing_post_cost_utility_inputs", payload["warnings"])
+        self.assertIn("missing_walk_forward_fold_inputs", payload["warnings"])
+        self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
+        self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
+        self.assertTrue(
+            contract["proof_neutrality"]["requires_order_lifecycle_fill_evidence"]
+        )
+        self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
+        self.assertTrue(
+            contract["proof_neutrality"][
+                "rejects_bootstrap_percentile_utility_as_pnl_proof"
+            ]
+        )
+        self.assertTrue(
+            contract["proof_neutrality"][
+                "rejects_selection_bias_falsification_preview_as_promotion_authority"
+            ]
+        )
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(contract["proof_neutrality"]["promotion_proof"])

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -303,6 +303,10 @@ class TestFastReplayPreview(TestCase):
             "metaorder_adverse_selection_stress",
             payload["implemented_mechanisms"],
         )
+        self.assertIn(
+            "bootstrap_robust_optimization_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",
@@ -774,6 +778,34 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn(
             "metaorder_adverse_selection_stress_downranks_only",
+            row_payload["ranking_only_reasons"],
+        )
+        self.assertIn("bootstrap_robust_optimization_stress", row_payload)
+        self.assertEqual(
+            row_payload["bootstrap_robust_optimization_stress"]["status"],
+            "preview_only_bootstrap_robust_optimization_stress_ranking",
+        )
+        self.assertIn(
+            "arxiv-2510.12725",
+            {
+                source["source_id"]
+                for source in row_payload["bootstrap_robust_optimization_stress"][
+                    "source_papers"
+                ]
+            },
+        )
+        self.assertFalse(
+            row_payload["bootstrap_robust_optimization_stress"]["proof_authority"]
+        )
+        self.assertFalse(
+            row_payload["bootstrap_robust_optimization_stress"]["promotion_authority"]
+        )
+        self.assertIn(
+            "bootstrap_robust_optimization_stress_penalty_active",
+            row_payload["risk_flags"],
+        )
+        self.assertIn(
+            "bootstrap_robust_optimization_stress_downranks_only",
             row_payload["ranking_only_reasons"],
         )
         self.assertIn(


### PR DESCRIPTION
## Summary

- Adds a preview-only bootstrap robust optimization stress module for Torghut replay ranking, sourced from 2025-2026 robustness/falsification papers.
- Integrates stationary-block bootstrap percentile utility, parameter-instability, walk-forward coverage, and adaptive-search selection-bias penalties into fast replay ranking.
- Preserves proof boundaries: the new stress is ranking-only and explicitly rejects bootstrap utility or falsification previews as PnL/promotion authority.
- Adds focused regression coverage for the standalone stress extractor and fast replay manifest/row payloads.

## Related Issues

None

## Testing

- `cd services/torghut && uvx ruff format --check app/trading/discovery/bootstrap_robust_optimization_stress.py app/trading/discovery/fast_replay.py tests/test_bootstrap_robust_optimization_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/bootstrap_robust_optimization_stress.py app/trading/discovery/fast_replay.py tests/test_bootstrap_robust_optimization_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen pytest tests/test_bootstrap_robust_optimization_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
