### PR TITLE
fix(torghut): reconcile materialized open-order projections

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline_helpers.py
+++ b/services/torghut/app/trading/scheduler/pipeline_helpers.py
@@ -38,6 +38,7 @@ _PROJECTED_ORDER_ACTIONS = {"buy", "sell"}
 _PROJECTED_ORDER_TYPES = {"market", "limit", "stop", "stop_limit"}
 _PROJECTED_ORDER_TIME_IN_FORCE = {"day", "gtc", "ioc", "fok"}
 
+
 def _runtime_uncertainty_gate_rank(action: RuntimeUncertaintyGateAction) -> int:
     ranking: dict[RuntimeUncertaintyGateAction, int] = {
         "pass": 0,
@@ -82,6 +83,7 @@ def _autonomy_gate_report_is_saturated_fail_sentinel(
 
 def _clone_positions(positions: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [dict(position) for position in positions]
+
 
 def _resolve_llm_unavailable_reject_reason(reason: str | None) -> str:
     normalized = _normalize_reason_metric(reason)
@@ -191,6 +193,7 @@ def _format_order_submit_rejection(error: Exception) -> str:
             parts.append(f"existing_order_id={existing_order_id}")
         return " ".join(parts)
     return f"alpaca_order_submit_failed {type(error).__name__}: {error}"
+
 
 def _coerce_json(value: Any) -> dict[str, Any]:
     if isinstance(value, Mapping):
@@ -384,6 +387,7 @@ def _coerce_strategy_symbols(raw: object) -> set[str]:
         return {symbol.strip() for symbol in raw.split(",") if symbol.strip()}
     return set()
 
+
 def _optional_decimal(value: Any) -> Optional[Decimal]:
     if value is None:
         return None
@@ -575,12 +579,44 @@ def _project_open_orders_onto_positions(
         action = str(side).strip().lower()
         if action not in _PROJECTED_ORDER_ACTIONS:
             continue
-        order_type = str(order.get("type") or order.get("order_type") or "market").strip().lower()
+        order_type = (
+            str(order.get("type") or order.get("order_type") or "market")
+            .strip()
+            .lower()
+        )
         if order_type not in _PROJECTED_ORDER_TYPES:
             order_type = "market"
         time_in_force = str(order.get("time_in_force") or "day").strip().lower()
         if time_in_force not in _PROJECTED_ORDER_TIME_IN_FORCE:
             time_in_force = "day"
+        existing_positions = [
+            position
+            for position in positions
+            if str(position.get("symbol") or "").strip().upper() == symbol
+        ]
+        existing_projection_ids: list[str] = []
+        existing_projection_only = True
+        existing_projection_count = 0
+        for position in existing_positions:
+            if not bool(position.get("open_order_projection")):
+                existing_projection_only = False
+                continue
+            existing_projection_count += int(
+                position.get("open_order_projection_count") or 1
+            )
+            raw_ids = position.get("open_order_client_order_ids")
+            if isinstance(raw_ids, list):
+                existing_projection_ids.extend(
+                    str(item).strip()
+                    for item in cast(list[Any], raw_ids)
+                    if str(item).strip()
+                )
+            raw_id = str(position.get("open_order_client_order_id") or "").strip()
+            if raw_id:
+                existing_projection_ids.append(raw_id)
+        client_order_id = str(
+            order.get("client_order_id") or order.get("client_orderid") or ""
+        ).strip()
         projected_total += 1
         _apply_projected_position_decision(
             positions,
@@ -591,11 +627,30 @@ def _project_open_orders_onto_positions(
                 timeframe="open_order",
                 action=cast(Literal["buy", "sell"], action),
                 qty=remaining_qty,
-                order_type=cast(Literal["market", "limit", "stop", "stop_limit"], order_type),
+                order_type=cast(
+                    Literal["market", "limit", "stop", "stop_limit"], order_type
+                ),
                 time_in_force=cast(Literal["day", "gtc", "ioc", "fok"], time_in_force),
                 params=params,
             ),
         )
+        for position in positions:
+            if str(position.get("symbol") or "").strip().upper() != symbol:
+                continue
+            projection_ids = [*existing_projection_ids]
+            if client_order_id:
+                projection_ids.append(client_order_id)
+                position["open_order_client_order_id"] = client_order_id
+            if projection_ids:
+                position["open_order_client_order_ids"] = list(
+                    dict.fromkeys(projection_ids)
+                )
+            position["open_order_projection"] = True
+            position["open_order_projection_only"] = existing_projection_only and bool(
+                projection_ids or not existing_positions
+            )
+            position["open_order_projection_count"] = existing_projection_count + 1
+            break
     return projected_total
 
 

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -3166,6 +3166,75 @@ class SimpleTradingPipeline(TradingPipeline):
         decision_row.decision_json = decision_json
         return True
 
+    def _active_materialized_paper_route_client_order_ids(
+        self,
+        *,
+        session: Session,
+        rows: Sequence[TradeDecision],
+        strategies: Sequence[Strategy],
+        positions: Sequence[Mapping[str, Any]],
+        now: datetime,
+    ) -> set[str]:
+        client_order_ids: set[str] = set()
+        for decision_row in rows:
+            decision_hash = _safe_text(decision_row.decision_hash)
+            if decision_hash is None:
+                continue
+            payload = self._paper_route_materialized_source_payload(decision_row)
+            if payload is None:
+                continue
+            if self.executor.execution_exists(session, decision_row):
+                continue
+            raw_target = self._paper_route_materialized_target_from_payload(payload)
+            if raw_target is None:
+                continue
+            target = _bounded_sim_collection_target_with_runtime_account_audit(
+                raw_target,
+                positions=positions,
+                account_label=self.account_label,
+            )
+            if not _target_requires_bounded_sim_collection_gate(target):
+                continue
+            collection_blockers = _bounded_sim_collection_blockers(
+                target,
+                account_label=self.account_label,
+            )
+            if collection_blockers:
+                continue
+            window = _target_probe_window(target)
+            if window is None:
+                continue
+            window_start, window_end = window
+            if now < window_start or now >= window_end:
+                continue
+            target_cap = _target_probe_cap(target)
+            if target_cap is None or target_cap <= 0:
+                continue
+            strategy = session.get(Strategy, decision_row.strategy_id)
+            if strategy is None:
+                strategy = self._paper_route_target_strategy(target, strategies)
+            if strategy is None:
+                continue
+            symbol = _safe_text(decision_row.symbol) or _safe_text(
+                payload.get("symbol")
+            )
+            if symbol is None:
+                continue
+            symbol = symbol.upper()
+            strategy_symbols = self._paper_route_target_strategy_symbols(strategy)
+            if strategy_symbols and symbol not in strategy_symbols:
+                continue
+            symbol_actions = _target_probe_symbol_actions(target, [symbol])
+            action_text = _safe_text(payload.get("action")) or symbol_actions.get(
+                symbol
+            )
+            if action_text not in {"buy", "sell"}:
+                action_text = _target_probe_action(target)
+            if action_text == "sell" and not settings.trading_allow_shorts:
+                continue
+            client_order_ids.add(decision_hash)
+        return client_order_ids
+
     def _paper_route_materialized_planned_decisions(
         self,
         *,
@@ -3196,6 +3265,21 @@ class SimpleTradingPipeline(TradingPipeline):
         decisions: list[StrategyDecision] = []
         seen: set[str] = set()
         expired_count = 0
+        materialized_client_order_ids = (
+            self._active_materialized_paper_route_client_order_ids(
+                session=session,
+                rows=rows,
+                strategies=strategies,
+                positions=positions,
+                now=now,
+            )
+        )
+        flat_check_positions = (
+            self._paper_route_positions_without_materialized_open_order_projections(
+                positions,
+                materialized_client_order_ids,
+            )
+        )
         for decision_row in rows:
             if str(decision_row.id) in seen:
                 continue
@@ -3273,14 +3357,16 @@ class SimpleTradingPipeline(TradingPipeline):
             action = cast(Literal["buy", "sell"], action_text)
             if action == "sell" and not settings.trading_allow_shorts:
                 continue
-            if self._paper_route_target_account_has_open_exposure(positions):
+            if self._paper_route_target_account_has_open_exposure(flat_check_positions):
                 logger.warning(
                     "Skipping materialized paper-route target source decision because "
                     "account is not flat for bounded SIM evidence decision_id=%s",
                     decision_row.id,
                 )
                 continue
-            if self._paper_route_target_symbol_has_open_position(positions, symbol):
+            if self._paper_route_target_symbol_has_open_position(
+                flat_check_positions, symbol
+            ):
                 continue
             if self._paper_route_target_symbol_has_open_strategy_exposure(
                 session=session,
@@ -5824,6 +5910,50 @@ class SimpleTradingPipeline(TradingPipeline):
             if market_value is not None and market_value != 0:
                 return True
         return False
+
+    @staticmethod
+    def _paper_route_positions_without_materialized_open_order_projections(
+        positions: Sequence[Mapping[str, Any]] | None,
+        materialized_client_order_ids: set[str],
+    ) -> list[Mapping[str, Any]]:
+        if not positions:
+            return []
+        if not materialized_client_order_ids:
+            return [position for position in positions]
+
+        filtered_positions: list[Mapping[str, Any]] = []
+        for position in positions:
+            if SimpleTradingPipeline._paper_route_position_is_materialized_projection(
+                position,
+                materialized_client_order_ids,
+            ):
+                continue
+            filtered_positions.append(position)
+        return filtered_positions
+
+    @staticmethod
+    def _paper_route_position_is_materialized_projection(
+        position: Mapping[str, Any],
+        materialized_client_order_ids: set[str],
+    ) -> bool:
+        if not bool(position.get("open_order_projection")):
+            return False
+        if not bool(position.get("open_order_projection_only")):
+            return False
+        raw_ids = position.get("open_order_client_order_ids")
+        client_order_ids: set[str] = set()
+        if isinstance(raw_ids, list):
+            client_order_ids.update(
+                str(item).strip()
+                for item in cast(list[Any], raw_ids)
+                if str(item).strip()
+            )
+        raw_id = str(position.get("open_order_client_order_id") or "").strip()
+        if raw_id:
+            client_order_ids.add(raw_id)
+        if not client_order_ids:
+            return False
+        return client_order_ids.issubset(materialized_client_order_ids)
 
     @staticmethod
     def _paper_route_target_account_has_open_exposure(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8406,6 +8406,252 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(decisions[0].action, "buy")
         self.assertEqual(blocked_by_exposure, [])
 
+    def test_materialized_target_plan_reconciles_matching_open_order_projections(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = True
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                description="bounded H-PAIRS materialized target",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+
+            materialize_bounded_paper_route_target_plan(
+                session,
+                {
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "c88421d619759b2cfaa6f4d0",
+                            "runtime_strategy_name": (
+                                "microbar-cross-sectional-pairs-v1"
+                            ),
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "account_label": "TORGHUT_SIM",
+                            "source_account_label": "TORGHUT_REPLAY",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "source_plan_ref": (
+                                "s3://torghut-proof/hpairs/current-window.json"
+                            ),
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-pairs.json"
+                            ),
+                            "observed_stage": "paper",
+                            "bounded_collection_stage": "bounded_paper_collection",
+                            "target_notional": "200",
+                            "target_quantity": "2",
+                            "paper_route_probe_next_session_max_notional": "200",
+                            "paper_route_probe_window_start": (
+                                window_start.isoformat()
+                            ),
+                            "paper_route_probe_window_end": window_end.isoformat(),
+                            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                            "paper_route_probe_symbol_actions": {
+                                "AAPL": "buy",
+                                "AMZN": "sell",
+                            },
+                            "paper_route_probe_symbol_quantities": {
+                                "AAPL": "1",
+                                "AMZN": "1",
+                            },
+                            "paper_route_probe_pair_balance_state": "balanced",
+                            "paper_route_clean_window_baseline_state": {
+                                "state": "clean",
+                                "blockers": [],
+                            },
+                            "paper_route_clean_window_state": "clean",
+                            "source_decision_readiness": {
+                                "ready": True,
+                                "blockers": [],
+                            },
+                            "bounded_evidence_collection_authorized": True,
+                            "bounded_live_paper_collection_authorized": True,
+                            "canary_collection_authorized": True,
+                            "evidence_collection_ok": True,
+                            "runtime_window_import_health_gate_blockers": [],
+                            "paper_route_target_account_audit_state": {
+                                "state": "available",
+                                "audit_available": True,
+                                "blockers": [],
+                            },
+                            "paper_route_target_account_audit_blockers": [],
+                            "paper_route_account_pre_session_blockers": [],
+                            "paper_route_hpairs_symbol_blockers": [],
+                            "promotion_allowed": False,
+                            "final_promotion_authorized": False,
+                            "final_promotion_allowed": False,
+                        },
+                    ]
+                },
+                generated_at=now,
+                bounded_notional_limit=Decimal("500"),
+            )
+            session.commit()
+            rows = list(
+                session.execute(select(TradeDecision).order_by(TradeDecision.symbol))
+                .scalars()
+                .all()
+            )
+            hashes_by_symbol = {str(row.symbol): str(row.decision_hash) for row in rows}
+
+            pipeline = SimpleTradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="TORGHUT_SIM",
+                session_factory=self.session_local,
+            )
+            pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+            matching_projection_positions = [
+                {
+                    "symbol": "AAPL",
+                    "qty": "1",
+                    "side": "long",
+                    "market_value": "100",
+                    "open_order_projection": True,
+                    "open_order_projection_only": True,
+                    "open_order_client_order_ids": [hashes_by_symbol["AAPL"]],
+                },
+                {
+                    "symbol": "AMZN",
+                    "qty": "1",
+                    "side": "short",
+                    "market_value": "-100",
+                    "open_order_projection": True,
+                    "open_order_projection_only": True,
+                    "open_order_client_order_ids": [hashes_by_symbol["AMZN"]],
+                },
+            ]
+            unrelated_projection_positions = [
+                {
+                    "symbol": "AAPL",
+                    "qty": "1",
+                    "side": "long",
+                    "market_value": "100",
+                    "open_order_projection": True,
+                    "open_order_projection_only": True,
+                    "open_order_client_order_ids": ["unrelated-client-order-id"],
+                }
+            ]
+
+            with patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=now,
+            ):
+                decisions = pipeline._paper_route_materialized_planned_decisions(
+                    session=session,
+                    strategies=[strategy],
+                    allowed_symbols={"AAPL", "AMZN"},
+                    positions=matching_projection_positions,
+                )
+                blocked_by_unrelated_projection = (
+                    pipeline._paper_route_materialized_planned_decisions(
+                        session=session,
+                        strategies=[strategy],
+                        allowed_symbols={"AAPL", "AMZN"},
+                        positions=unrelated_projection_positions,
+                    )
+                )
+
+        self.assertEqual(
+            {decision.symbol: decision.action for decision in decisions},
+            {"AAPL": "buy", "AMZN": "sell"},
+        )
+        self.assertEqual(blocked_by_unrelated_projection, [])
+
+    def test_materialized_target_plan_projection_helpers_fail_closed(self) -> None:
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_position_is_materialized_projection(
+                {
+                    "symbol": "AAPL",
+                    "open_order_projection": True,
+                    "open_order_projection_only": False,
+                    "open_order_client_order_ids": ["matching-client-order-id"],
+                },
+                {"matching-client-order-id"},
+            )
+        )
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_position_is_materialized_projection(
+                {
+                    "symbol": "AAPL",
+                    "open_order_projection": True,
+                    "open_order_projection_only": True,
+                    "open_order_client_order_id": "matching-client-order-id",
+                },
+                {"matching-client-order-id"},
+            )
+        )
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_position_is_materialized_projection(
+                {
+                    "symbol": "AAPL",
+                    "open_order_projection": True,
+                    "open_order_projection_only": True,
+                },
+                {"matching-client-order-id"},
+            )
+        )
+
+        with self.session_local() as session:
+            decision_without_hash = TradeDecision(
+                strategy_id=uuid4(),
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={},
+                decision_hash=None,
+                status="planned",
+            )
+            self.assertEqual(
+                pipeline._active_materialized_paper_route_client_order_ids(
+                    session=session,
+                    rows=[decision_without_hash],
+                    strategies=[],
+                    positions=[],
+                    now=datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc),
+                ),
+                set(),
+            )
+
     def test_materialized_target_plan_ignores_transient_batch_symbol_filter(
         self,
     ) -> None:
@@ -18148,6 +18394,7 @@ class TestTradingPipeline(TestCase):
                     "limit_price": "100",
                     "type": "limit",
                     "time_in_force": "day",
+                    "client_order_id": "client-aapl-buy",
                 }
             ],
         )
@@ -18155,7 +18402,19 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(projected, 1)
         self.assertEqual(
             positions,
-            [{"symbol": "AAPL", "qty": "2", "side": "long", "market_value": "200"}],
+            [
+                {
+                    "symbol": "AAPL",
+                    "qty": "2",
+                    "side": "long",
+                    "market_value": "200",
+                    "open_order_projection": True,
+                    "open_order_projection_only": True,
+                    "open_order_client_order_id": "client-aapl-buy",
+                    "open_order_client_order_ids": ["client-aapl-buy"],
+                    "open_order_projection_count": 1,
+                }
+            ],
         )
 
     def test_project_open_orders_onto_positions_projects_sell_against_existing_long(
@@ -18183,7 +18442,74 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(projected, 1)
         self.assertEqual(
             positions,
-            [{"symbol": "AAPL", "qty": "2", "side": "long", "market_value": "200"}],
+            [
+                {
+                    "symbol": "AAPL",
+                    "qty": "2",
+                    "side": "long",
+                    "market_value": "200",
+                    "open_order_projection": True,
+                    "open_order_projection_only": False,
+                    "open_order_projection_count": 1,
+                }
+            ],
+        )
+
+    def test_project_open_orders_onto_positions_preserves_projection_client_ids(
+        self,
+    ) -> None:
+        positions: list[dict[str, Any]] = [
+            {"symbol": "MSFT", "qty": "1", "side": "long"},
+            {
+                "symbol": "AAPL",
+                "qty": "1",
+                "side": "long",
+                "market_value": "100",
+                "open_order_projection": True,
+                "open_order_projection_only": True,
+                "open_order_client_order_id": "legacy-client",
+                "open_order_client_order_ids": ["existing-client"],
+                "open_order_projection_count": 1,
+            },
+        ]
+
+        projected = _project_open_orders_onto_positions(
+            positions,
+            [
+                {
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "qty": "1",
+                    "filled_qty": "0",
+                    "limit_price": "100",
+                    "type": "limit",
+                    "time_in_force": "day",
+                    "client_order_id": "new-client",
+                }
+            ],
+        )
+
+        self.assertEqual(projected, 1)
+        self.assertEqual(
+            positions,
+            [
+                {"symbol": "MSFT", "qty": "1", "side": "long"},
+                {
+                    "symbol": "AAPL",
+                    "qty": "2",
+                    "side": "long",
+                    "market_value": "200",
+                    "open_order_client_order_id": "new-client",
+                    "open_order_client_order_ids": [
+                        "existing-client",
+                        "legacy-client",
+                        "new-client",
+                    ],
+                    "open_order_projection": True,
+                    "open_order_projection_only": True,
+                    "open_order_projection_count": 2,
+                },
+            ],
         )
 
     def test_resolve_execution_context_positions_projects_open_orders(self) -> None:
@@ -18214,7 +18540,17 @@ class TestTradingPipeline(TestCase):
 
         self.assertEqual(
             positions,
-            [{"symbol": "AAPL", "qty": "2", "side": "long", "market_value": "200"}],
+            [
+                {
+                    "symbol": "AAPL",
+                    "qty": "2",
+                    "side": "long",
+                    "market_value": "200",
+                    "open_order_projection": True,
+                    "open_order_projection_only": True,
+                    "open_order_projection_count": 1,
+                }
+            ],
         )
 
     def test_resolve_execution_context_positions_tags_matching_strategy_fill(


### PR DESCRIPTION
## Summary

- Tags projected open-order exposure with broker client order IDs so the scheduler can distinguish pure order projections from real positions.
- Lets bounded paper-route materialized decisions proceed to existing-order reconciliation when the only open exposure is their own active materialized client orders.
- Keeps the flat-account gate fail-closed for real positions, unrelated open-order projections, expired/inactive materialized rows, and all existing TCA/lifecycle/cost authority blockers.
- Adds regression coverage for matching materialized projections and unrelated projection blocking.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k "materialized_target_plan or project_open_orders_onto_positions or resolve_execution_context_positions_projects_open_orders"`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/pipeline_helpers.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/pipeline_helpers.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A; backend scheduler/runtime-ledger lineage fix with pytest and static validation.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no documentation changes were required for this scheduler bug fix.
