### PR TITLE
fix(torghut): require market limit source evidence

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -1463,6 +1463,10 @@ def _order_type_execution_validation_required(scorecard: Mapping[str, Any]) -> b
             "retail_order_flow_segmentation_ssrn_6414558_2026",
             "payment_for_order_flow_ssrn_6704839_2026",
             "mpc_execution_schedule_arxiv_2603_28898_2026",
+            "reinforcement_learning_trade_execution_market_limit_orders_2026",
+            "arxiv_2507_06345_2026",
+            "arxiv-2507.06345",
+            "paper-arxiv-2507.06345",
         }
     )
 

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -213,6 +213,44 @@ def test_promotion_ready_bundle_infers_order_type_validation_from_mix_sample() -
     assert "route_tca_evidence_missing" in blockers
 
 
+def test_promotion_ready_bundle_infers_order_type_validation_from_2026_source_marker() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-order-type-source-marker",
+        candidate_id="candidate-order-type-source-marker",
+        candidate_spec_id="spec-order-type-source-marker",
+        dataset_snapshot_id="snapshot-order-type-source-marker",
+        feature_spec_hash="feature-order-type-source-marker",
+        code_commit="commit-order-type-source-marker",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "order_type_execution_source_markers": [
+                "paper-arxiv-2507.06345",
+            ],
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "market_limit_order_mix_evidence_missing" in blockers
+    assert "route_tca_evidence_missing" in blockers
+    assert "order_type_ablation_artifact_missing" in blockers
+    assert "price_improvement_evidence_missing" in blockers
+    assert blockers.count("price_improvement_evidence_missing") == 1
+
+
 def test_promotion_ready_bundle_infers_order_type_validation_from_ablation_ref() -> (
     None
 ):


### PR DESCRIPTION
## Summary

- Treats the newly curated arXiv:2507.06345 market/limit execution source marker as requiring order-type/TCA validation.
- Keeps promotion fail-closed: source-backed market/limit candidates now hit existing route TCA, order-type ablation, fill probability, shortfall, price-improvement, and opportunity-cost blockers unless materialized evidence is present.
- Adds a regression test for the source-marker path and duplicate blocker stability.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py` — 2 files left unchanged after final formatting.
- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py` — all checks passed.
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py` — 14 passed, 1 warning.
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json` — 0 errors.
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json` — 0 errors.
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json` — 0 errors.
- `cd services/torghut && uv sync --frozen --extra dev` — blocked by local missing `cc` while building `crosshair-tool==0.0.102`; no source or test failure was observed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
