### PR TITLE
fix(torghut): select clean paper route import plan

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -926,8 +926,29 @@ def _runtime_window_target_plan_from_payload(
         str(payload.get("schema_version") or "").strip()
         == "torghut.paper-route-evidence.v1"
     )
-    if paper_route_evidence_payload and paper_route_plan:
-        plan = paper_route_plan
+    direct_plan = _as_dict(payload.get("runtime_window_import_plan"))
+    if paper_route_evidence_payload:
+        plan = next(
+            (
+                candidate_plan
+                for candidate_plan in (
+                    direct_plan,
+                    _as_dict(
+                        payload.get(
+                            "next_clean_paper_route_runtime_window_targets_after_discard"
+                        )
+                    ),
+                    _as_dict(
+                        payload.get(
+                            "observed_strategy_source_runtime_window_import_plan"
+                        )
+                    ),
+                    paper_route_plan,
+                )
+                if _runtime_window_plan_target_items(candidate_plan)
+            ),
+            {},
+        )
     else:
         plan = {}
     source_runtime_window_plan = _as_dict(
@@ -936,7 +957,6 @@ def _runtime_window_target_plan_from_payload(
     if not plan and _runtime_window_plan_target_items(source_runtime_window_plan):
         plan = source_runtime_window_plan
     if not plan:
-        direct_plan = _as_dict(payload.get("runtime_window_import_plan"))
         if direct_plan:
             plan = direct_plan
         else:

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1128,6 +1128,114 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             plan["targets"][0]["window_start"], "2026-05-26T13:30:00+00:00"
         )
 
+    def test_runtime_window_target_plan_payload_prefers_selected_runtime_import_plan(
+        self,
+    ) -> None:
+        plan = renewal._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "runtime_window_import_plan": {
+                    "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                    "source": "paper_route_observed_strategy_source_collection",
+                    "purpose": "observed_strategy_runtime_ledger_source_collection_import",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-selected-source",
+                            "hypothesis_id": "H-TSMOM-LIQ-01",
+                            "strategy_family": "intraday_tsmom",
+                            "strategy_name": "intraday-tsmom-v2",
+                            "account_label": "TORGHUT_SIM",
+                            "source_account_label": "TORGHUT_SIM",
+                            "source_kind": "runtime_ledger_source_collection_candidate",
+                            "window_start": "2026-06-04T13:30:00+00:00",
+                            "window_end": "2026-06-04T20:00:00+00:00",
+                            "candidate_blockers": [
+                                "runtime_ledger_source_collection_only"
+                            ],
+                        }
+                    ],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-contaminated-next",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "window_start": "2026-06-04T13:30:00+00:00",
+                            "window_end": "2026-06-04T20:00:00+00:00",
+                            "candidate_blockers": [
+                                "paper_route_account_contamination_detected",
+                                "foreign_order_events_present",
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(
+            plan["source"], "paper_route_observed_strategy_source_collection"
+        )
+        self.assertEqual(plan["targets"][0]["candidate_id"], "cand-selected-source")
+        self.assertNotIn(
+            "paper_route_account_contamination_detected",
+            plan["targets"][0]["candidate_blockers"],
+        )
+
+    def test_runtime_window_target_plan_payload_prefers_clean_after_discard(
+        self,
+    ) -> None:
+        plan = renewal._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "next_clean_paper_route_runtime_window_targets_after_discard": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "purpose": "next_clean_session_paper_route_runtime_window_collection_after_discard",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-clean-followup",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "window_start": "2026-06-05T13:30:00+00:00",
+                            "window_end": "2026-06-05T20:00:00+00:00",
+                        }
+                    ],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-contaminated-next",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "window_start": "2026-06-04T13:30:00+00:00",
+                            "window_end": "2026-06-04T20:00:00+00:00",
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(
+            plan["purpose"],
+            "next_clean_session_paper_route_runtime_window_collection_after_discard",
+        )
+        self.assertEqual(plan["targets"][0]["candidate_id"], "cand-clean-followup")
+
     def test_runtime_window_target_plan_payload_accepts_paper_route_evidence_plan(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Make `renew_latest_empirical_promotion_jobs.py` consume the selected `runtime_window_import_plan` from `/trading/paper-route-evidence` before falling back to raw next-session targets.
- Preserve ordinary paper-route fallback behavior while letting clean-after-discard and selected observed-strategy source plans bypass contaminated raw next-window targets.
- Add regression tests for selected runtime import plans and clean-after-discard plans winning over contaminated raw next-window payloads.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k "runtime_window_target_plan_payload_prefers_selected_runtime_import_plan or runtime_window_target_plan_payload_prefers_clean_after_discard or runtime_window_target_plan_payload_prefers_next_paper_route_plan or runtime_window_target_plan_payload_prefers_source_runtime_plan or runtime_window_target_plan_payload_accepts_paper_route_evidence_plan" -q`
- `cd services/torghut && uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py && uv run --frozen ruff format --check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `cd services/torghut && rm -f .coverage coverage.xml && uv run --frozen coverage run -m pytest tests/test_run_empirical_promotion_jobs.py -k "runtime_window_target_plan_payload_prefers_selected_runtime_import_plan or runtime_window_target_plan_payload_prefers_clean_after_discard or runtime_window_target_plan_payload_prefers_next_paper_route_plan or runtime_window_target_plan_payload_prefers_source_runtime_plan or runtime_window_target_plan_payload_accepts_paper_route_evidence_plan" -q && uv run --frozen coverage xml --fail-under=0 -o coverage.xml && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin-https/main`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m py_compile scripts/renew_latest_empirical_promotion_jobs.py`
- Live payload parser readback: current `/trading/paper-route-evidence?target_limit=8` parsed to zero selected targets carrying `paper_route_account_contamination_detected` or `foreign_order_events_present`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
