### PR TITLE
feat(torghut): add hawkes transient impact replay stress

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -40,6 +40,9 @@ from app.trading.discovery.execution_schedule_stress import (
 from app.trading.discovery.feed_lag_liquidity_stress import (
     extract_feed_lag_liquidity_stress,
 )
+from app.trading.discovery.hawkes_transient_impact_stress import (
+    extract_hawkes_transient_impact_stress,
+)
 from app.trading.discovery.intraday_jump_burst_stress import (
     extract_intraday_jump_burst_stress,
 )
@@ -93,8 +96,8 @@ from app.trading.discovery.signal_adaptive_execution_resilience_stress import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v12"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v13"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v13"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v14"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -128,6 +131,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "cost_aware_forecast_filter_stress",
     "adaptive_market_limit_allocation_stress",
     "metaorder_adverse_selection_stress",
+    "hawkes_transient_impact_execution_stress",
     "ofi_horizon_decay_regime_screen",
     "macro_news_ofi_stress_veto_if_present",
     "square_root_impact_capacity_prefilter",
@@ -301,6 +305,9 @@ class FastReplayPreviewRow:
     metaorder_adverse_selection_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
+    hawkes_transient_impact_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
     bootstrap_robust_optimization_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
@@ -439,6 +446,7 @@ class FastReplayPreviewRow:
             "metaorder_adverse_selection_stress": dict(
                 self.metaorder_adverse_selection_stress
             ),
+            "hawkes_transient_impact_stress": dict(self.hawkes_transient_impact_stress),
             "bootstrap_robust_optimization_stress": dict(
                 self.bootstrap_robust_optimization_stress
             ),
@@ -650,6 +658,7 @@ class FastReplayPreviewResult:
                 "adaptive_market_limit_allocation_stress": "deterministic observed market/limit allocation, fill-uncertainty, tactical-imbalance, and trade-level cost logging stress from arXiv:2507.06345 and arXiv:2603.29086; allocation models are not fill or PnL authority; preview ranking only",
                 "metaorder_adverse_selection_stress": "deterministic Hawkes-style event clustering, same-direction metaorder footprint, adverse-selection drift, and liquidity-replenishment gap stress from arXiv:2510.27334 and DOI:10.1007/s10203-026-00570-z; metaorder footprints and Hawkes intensity are not fill or PnL authority; preview ranking only",
                 "bootstrap_robust_optimization_stress": "deterministic stationary-block bootstrap percentile utility, parameter-instability, and adaptive-search selection-bias stress from arXiv:2510.12725 and arXiv:2604.15531; model utility is not PnL authority; preview ranking only",
+                "hawkes_transient_impact_execution_stress": "deterministic event-time Hawkes burst/self-excitation, transient-impact pressure, and square-root impact pressure stress from arXiv:2504.10282 and arXiv:2603.29086; intensity and modeled impact are not fill or PnL authority; preview ranking only",
                 "cluster_lob": "cheap event-mix/OFI proxy only; exact replay remains authoritative",
                 "ofi_horizon_decay_regime": "EWMA short-vs-long OFI alignment plus spread/liquidity regime score",
                 "macro_news_stress_veto": "penalizes rows carrying macro/news stress fields; absent fields are neutral",
@@ -1326,6 +1335,7 @@ def _score_candidate_spec(
             cost_aware_forecast_filter_stress={},
             adaptive_market_limit_allocation_stress={},
             metaorder_adverse_selection_stress={},
+            hawkes_transient_impact_stress={},
             candidate_frontier_hash=candidate_frontier_hash,
             exact_replay_frontier_key=exact_replay_frontier_key,
             candidate_lineage=_candidate_lineage(spec),
@@ -1656,6 +1666,19 @@ def _score_candidate_spec(
     bootstrap_lower_percentile_post_cost_utility_bps = (
         _bootstrap_lower_percentile_post_cost_utility_bps(post_cost_utilities_bps)
     )
+    hawkes_transient_impact_stress = extract_hawkes_transient_impact_stress(
+        matched_source_rows,
+        direction=direction,
+        max_notional=_candidate_notional(spec),
+    ).to_payload()
+    hawkes_transient_impact_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(hawkes_transient_impact_stress.get("ranking_features")).get(
+                "replay_rank_penalty_bps"
+            )
+        )
+        or 0.0
+    )
     bootstrap_robust_optimization_stress = extract_bootstrap_robust_optimization_stress(
         matched_source_rows,
         post_cost_utilities_bps=post_cost_utilities_bps,
@@ -1720,6 +1743,7 @@ def _score_candidate_spec(
         - cost_aware_forecast_filter_rank_penalty_bps * 0.05
         - adaptive_market_limit_allocation_rank_penalty_bps * 0.05
         - metaorder_adverse_selection_rank_penalty_bps * 0.05
+        - hawkes_transient_impact_rank_penalty_bps * 0.06
         - bootstrap_robust_optimization_rank_penalty_bps * 0.07
         - conformal_tail_risk_penalty_bps * 0.12
         - macro_stress_veto_score * 18.0
@@ -1771,6 +1795,7 @@ def _score_candidate_spec(
         - cost_aware_forecast_filter_rank_penalty_bps * 0.03
         - adaptive_market_limit_allocation_rank_penalty_bps * 0.03
         - metaorder_adverse_selection_rank_penalty_bps * 0.03
+        - hawkes_transient_impact_rank_penalty_bps * 0.04
         - bootstrap_robust_optimization_rank_penalty_bps * 0.04
     )
     return FastReplayPreviewRow(
@@ -1836,6 +1861,7 @@ def _score_candidate_spec(
             adaptive_market_limit_allocation_stress
         ),
         metaorder_adverse_selection_stress=dict(metaorder_adverse_selection_stress),
+        hawkes_transient_impact_stress=dict(hawkes_transient_impact_stress),
         bootstrap_robust_optimization_stress=dict(bootstrap_robust_optimization_stress),
         candidate_frontier_hash=candidate_frontier_hash,
         exact_replay_frontier_key=exact_replay_frontier_key,
@@ -1892,6 +1918,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - _cost_aware_forecast_filter_rank_penalty_bps(row) * 0.04
         - _adaptive_market_limit_allocation_rank_penalty_bps(row) * 0.04
         - _metaorder_adverse_selection_rank_penalty_bps(row) * 0.04
+        - _hawkes_transient_impact_rank_penalty_bps(row) * 0.05
         - _bootstrap_robust_optimization_rank_penalty_bps(row) * 0.05
         - float(row.conformal_tail_risk_penalty_bps) * 0.10
     )
@@ -2042,6 +2069,15 @@ def _metaorder_adverse_selection_rank_penalty_bps(
 ) -> float:
     ranking_features = _mapping(
         row.metaorder_adverse_selection_stress.get("ranking_features")
+    )
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _hawkes_transient_impact_rank_penalty_bps(
+    row: FastReplayPreviewRow,
+) -> float:
+    ranking_features = _mapping(
+        row.hawkes_transient_impact_stress.get("ranking_features")
     )
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
@@ -2274,6 +2310,7 @@ def _row_with_rank_and_selection(
             row.adaptive_market_limit_allocation_stress
         ),
         metaorder_adverse_selection_stress=dict(row.metaorder_adverse_selection_stress),
+        hawkes_transient_impact_stress=dict(row.hawkes_transient_impact_stress),
         bootstrap_robust_optimization_stress=dict(
             row.bootstrap_robust_optimization_stress
         ),
@@ -2367,6 +2404,7 @@ def _row_with_frontier_dedupe(
             row.adaptive_market_limit_allocation_stress
         ),
         metaorder_adverse_selection_stress=dict(row.metaorder_adverse_selection_stress),
+        hawkes_transient_impact_stress=dict(row.hawkes_transient_impact_stress),
         bootstrap_robust_optimization_stress=dict(
             row.bootstrap_robust_optimization_stress
         ),
@@ -3306,6 +3344,8 @@ def _risk_flags_for_row(
         flags.add("adaptive_market_limit_allocation_stress_penalty_active")
     if _metaorder_adverse_selection_rank_penalty_bps(row) > 0:
         flags.add("metaorder_adverse_selection_stress_penalty_active")
+    if _hawkes_transient_impact_rank_penalty_bps(row) > 0:
+        flags.add("hawkes_transient_impact_stress_penalty_active")
     if _bootstrap_robust_optimization_rank_penalty_bps(row) > 0:
         flags.add("bootstrap_robust_optimization_stress_penalty_active")
     if row.matched_symbol_count < row.requested_symbol_count:
@@ -3376,6 +3416,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("adaptive_market_limit_allocation_stress_downranks_only")
     if _metaorder_adverse_selection_rank_penalty_bps(row) > 0:
         reasons.add("metaorder_adverse_selection_stress_downranks_only")
+    if _hawkes_transient_impact_rank_penalty_bps(row) > 0:
+        reasons.add("hawkes_transient_impact_stress_downranks_only")
     if _bootstrap_robust_optimization_rank_penalty_bps(row) > 0:
         reasons.add("bootstrap_robust_optimization_stress_downranks_only")
     if row.selection_reason == "insufficient_replay_tape_rows":
@@ -3439,6 +3481,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("adaptive_market_limit_allocation_stress_penalty")
     if _metaorder_adverse_selection_rank_penalty_bps(row) > 0:
         vetoes.add("metaorder_adverse_selection_stress_penalty")
+    if _hawkes_transient_impact_rank_penalty_bps(row) > 0:
+        vetoes.add("hawkes_transient_impact_stress_penalty")
     if _bootstrap_robust_optimization_rank_penalty_bps(row) > 0:
         vetoes.add("bootstrap_robust_optimization_stress_penalty")
     if row.robust_lower_percentile_post_cost_utility_bps <= 0:

--- a/services/torghut/app/trading/discovery/hawkes_transient_impact_stress.py
+++ b/services/torghut/app/trading/discovery/hawkes_transient_impact_stress.py
@@ -1,0 +1,658 @@
+"""Preview-only Hawkes transient-impact stress for replay ranking.
+
+This module actualizes recent 2025-2026 execution papers into deterministic
+replay-ranking features. It uses only local replay rows/fixtures, records source
+coverage gaps explicitly, and never claims realized PnL, fills, promotion
+authority, or live-capital eligibility.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import isfinite, sqrt
+from typing import Any
+
+from app.trading.models import SignalEnvelope
+
+HAWKES_TRANSIENT_IMPACT_STRESS_SCHEMA_VERSION = (
+    "torghut.hawkes-transient-impact-stress.v1"
+)
+HAWKES_TRANSIENT_IMPACT_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.hawkes-transient-impact-stress-contract.v1"
+)
+HAWKES_TRANSIENT_IMPACT_STRESS_PROOF_SEMANTICS_LABEL = "hawkes_transient_impact_stress_preview_only_exact_event_replay_route_tca_order_lifecycle_runtime_ledger_required"
+HAWKES_TRANSIENT_IMPACT_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
+    {
+        "source_id": "arxiv-2504.10282",
+        "url": "https://arxiv.org/abs/2504.10282",
+        "title": "Optimal Execution in Intraday Energy Markets under Hawkes Processes with Transient Impact",
+        "date": "2025-11-25",
+        "mechanism": "mutually_exciting_order_flow_with_transient_impact_changes_intraday_execution_costs",
+    },
+    {
+        "source_id": "arxiv-2603.29086",
+        "url": "https://arxiv.org/abs/2603.29086",
+        "title": "Realistic Market Impact Modeling for Reinforcement Learning Trading Environments",
+        "date": "2026-04-04",
+        "mechanism": "nonlinear_square_root_impact_permanent_decay_and_trade_level_cost_logging_change_replay_rankings",
+    },
+)
+
+_PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
+_SPREAD_FIELDS = (
+    "spread_bps",
+    "quoted_spread_bps",
+    "effective_spread_bps",
+    "nbbo_spread_bps",
+)
+_SIZE_FIELDS = (
+    "signed_size",
+    "signed_qty",
+    "signed_quantity",
+    "signed_order_flow",
+    "ofi_size",
+    "order_size",
+    "quantity",
+    "qty",
+    "size",
+    "trade_size",
+    "shares",
+)
+_VOLUME_FIELDS = (
+    "microbar_volume",
+    "volume",
+    "share_volume",
+    "trade_volume",
+    "notional_volume",
+)
+_OFI_FIELDS = (
+    "ofi",
+    "order_flow_imbalance",
+    "orderflow_imbalance",
+    "imbalance_pressure",
+    "signed_order_flow",
+)
+_DEPTH_FIELDS = (
+    "top_depth",
+    "top_of_book_depth",
+    "visible_depth",
+    "queue_depth",
+    "bid_depth",
+    "ask_depth",
+    "bid_size",
+    "ask_size",
+)
+_PARTICIPATION_FIELDS = (
+    "participation_rate",
+    "target_participation_rate",
+    "arrival_participation_rate",
+)
+_LATENCY_FIELDS = (
+    "submit_latency_ms",
+    "route_latency_ms",
+    "ack_latency_ms",
+    "decision_latency_ms",
+)
+_BUY_TOKENS = frozenset(("buy", "b", "bid", "buyer", "lift", "aggressive_buy"))
+_SELL_TOKENS = frozenset(("sell", "s", "ask", "seller", "hit", "aggressive_sell"))
+_SIDE_FIELDS = (
+    "side",
+    "trade_side",
+    "aggressor_side",
+    "order_side",
+    "direction",
+    "signed_direction",
+)
+
+
+@dataclass(frozen=True)
+class HawkesTransientImpactStressSummary:
+    row_count: int
+    event_observation_count: int
+    signed_event_count: int
+    size_observation_count: int
+    volume_observation_count: int
+    spread_observation_count: int
+    depth_observation_count: int
+    participation_observation_count: int
+    latency_observation_count: int
+    median_interarrival_seconds: float
+    burst_event_share: float
+    same_side_cluster_share: float
+    cross_side_excitation_share: float
+    transient_impact_pressure_bps: float
+    square_root_impact_pressure_bps: float
+    impact_decay_gap_score: float
+    source_gap_score: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": HAWKES_TRANSIENT_IMPACT_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_hawkes_transient_impact_stress_ranking",
+            "source_papers": [
+                dict(item) for item in HAWKES_TRANSIENT_IMPACT_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "event_observation_count": self.event_observation_count,
+            "signed_event_count": self.signed_event_count,
+            "size_observation_count": self.size_observation_count,
+            "volume_observation_count": self.volume_observation_count,
+            "spread_observation_count": self.spread_observation_count,
+            "depth_observation_count": self.depth_observation_count,
+            "participation_observation_count": self.participation_observation_count,
+            "latency_observation_count": self.latency_observation_count,
+            "median_interarrival_seconds": _stable_float(
+                self.median_interarrival_seconds
+            ),
+            "burst_event_share": _stable_float(self.burst_event_share),
+            "same_side_cluster_share": _stable_float(self.same_side_cluster_share),
+            "cross_side_excitation_share": _stable_float(
+                self.cross_side_excitation_share
+            ),
+            "transient_impact_pressure_bps": _stable_float(
+                self.transient_impact_pressure_bps
+            ),
+            "square_root_impact_pressure_bps": _stable_float(
+                self.square_root_impact_pressure_bps
+            ),
+            "impact_decay_gap_score": _stable_float(self.impact_decay_gap_score),
+            "source_gap_score": _stable_float(self.source_gap_score),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "burst_event_share": _stable_float(self.burst_event_share),
+                "same_side_cluster_share": _stable_float(self.same_side_cluster_share),
+                "cross_side_excitation_share": _stable_float(
+                    self.cross_side_excitation_share
+                ),
+                "transient_impact_pressure_bps": _stable_float(
+                    self.transient_impact_pressure_bps
+                ),
+                "square_root_impact_pressure_bps": _stable_float(
+                    self.square_root_impact_pressure_bps
+                ),
+                "impact_decay_gap_score": _stable_float(self.impact_decay_gap_score),
+                "source_gap_score": _stable_float(self.source_gap_score),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "hawkes_excitation_preview": True,
+            "transient_impact_preview": True,
+            "square_root_impact_preview": True,
+            "requires_event_time_replay_downstream": True,
+            "requires_order_lifecycle_events_downstream": True,
+            "requires_route_tca_downstream": True,
+            "requires_runtime_ledger_downstream": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": HAWKES_TRANSIENT_IMPACT_STRESS_PROOF_SEMANTICS_LABEL,
+        }
+
+
+def hawkes_transient_impact_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": HAWKES_TRANSIENT_IMPACT_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": HAWKES_TRANSIENT_IMPACT_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item) for item in HAWKES_TRANSIENT_IMPACT_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": "hawkes_event_time_transient_impact_execution_replay_guard",
+        "stress_components": [
+            "burst_event_share",
+            "same_side_cluster_share",
+            "cross_side_excitation_share",
+            "transient_impact_pressure_bps",
+            "square_root_impact_pressure_bps",
+            "impact_decay_gap_score",
+            "source_gap_score",
+        ],
+        "price_fields": list(_PRICE_FIELDS),
+        "spread_fields": list(_SPREAD_FIELDS),
+        "size_fields": list(_SIZE_FIELDS),
+        "volume_fields": list(_VOLUME_FIELDS),
+        "ofi_fields": list(_OFI_FIELDS),
+        "depth_fields": list(_DEPTH_FIELDS),
+        "participation_fields": list(_PARTICIPATION_FIELDS),
+        "latency_fields": list(_LATENCY_FIELDS),
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_event_time_replay": True,
+            "requires_order_lifecycle_events": True,
+            "requires_route_tca": True,
+            "requires_runtime_ledger": True,
+            "rejects_hawkes_intensity_as_fill_authority": True,
+            "rejects_modeled_impact_as_realized_pnl_authority": True,
+            "rejects_missing_event_signs_as_neutral_order_flow": True,
+        },
+    }
+
+
+def build_hawkes_transient_impact_stress_schema_hash() -> str:
+    return _stable_hash(hawkes_transient_impact_stress_contract())
+
+
+def extract_hawkes_transient_impact_stress(
+    records: Sequence[SignalEnvelope],
+    *,
+    direction: int | float = 1,
+    max_notional: float | int | None = None,
+) -> HawkesTransientImpactStressSummary:
+    """Extract deterministic Hawkes/transient-impact stress from replay rows."""
+
+    ordered = tuple(
+        sorted(records, key=lambda item: (item.event_ts, item.symbol, item.seq))
+    )
+    signed_direction = 1.0 if float(direction) >= 0.0 else -1.0
+    event_rows = tuple(row for row in ordered if _is_event_observation(row))
+    signed_events = tuple(
+        (row, sign, size)
+        for row in event_rows
+        if (sign := _row_sign(row)) is not None
+        and (size := _row_size(row, fallback_abs_ofi=True)) is not None
+        and size > 0.0
+    )
+    interarrivals = _interarrival_seconds(event_rows)
+    median_interarrival_seconds = _median(interarrivals)
+    burst_threshold_seconds = _burst_threshold_seconds(interarrivals)
+    burst_count = sum(
+        1 for seconds in interarrivals if seconds <= burst_threshold_seconds
+    )
+    same_side_cluster_count = 0
+    cross_side_excitation_count = 0
+    transient_pressures: list[float] = []
+    for (previous_row, previous_sign, _), (row, sign, _) in zip(
+        signed_events, signed_events[1:]
+    ):
+        if previous_row.symbol != row.symbol:
+            continue
+        seconds = (row.event_ts - previous_row.event_ts).total_seconds()
+        if seconds < 0.0 or seconds > max(burst_threshold_seconds * 3.0, 30.0):
+            continue
+        if previous_sign == sign:
+            same_side_cluster_count += 1
+        else:
+            cross_side_excitation_count += 1
+        return_bps = _row_return_bps(previous_row, row)
+        if return_bps is not None:
+            transient_pressures.append(
+                max(0.0, return_bps * previous_sign)
+                + max(0.0, return_bps * signed_direction) * 0.25
+            )
+
+    spread_values: list[float] = []
+    volume_values: list[float] = []
+    depth_values: list[float] = []
+    participation_values: list[float] = []
+    latency_values: list[float] = []
+    for row in ordered:
+        spread = _row_spread_bps(row)
+        if spread is not None:
+            spread_values.append(spread)
+        volume = _row_volume(row)
+        if volume is not None:
+            volume_values.append(volume)
+        depth = _row_depth(row)
+        if depth is not None:
+            depth_values.append(depth)
+        participation = _row_participation(row)
+        if participation is not None:
+            participation_values.append(participation)
+        latency = _row_latency_ms(row)
+        if latency is not None:
+            latency_values.append(latency)
+    size_values = tuple(size for _, _, size in signed_events)
+    median_spread_bps = _median(spread_values)
+    median_volume = _median(volume_values)
+    median_size = _median(size_values)
+    explicit_notional = float(max_notional or 0.0)
+    impact_notional_proxy = max(
+        explicit_notional, median_size * max(1.0, _median_price(ordered))
+    )
+    square_root_impact_pressure_bps = _square_root_impact_pressure_bps(
+        impact_notional_proxy=impact_notional_proxy,
+        median_volume=median_volume,
+        median_price=_median_price(ordered),
+        median_spread_bps=median_spread_bps,
+    )
+    denominator = max(1, len(interarrivals))
+    signed_denominator = max(1, len(signed_events) - 1)
+    burst_event_share = burst_count / denominator
+    same_side_cluster_share = same_side_cluster_count / signed_denominator
+    cross_side_excitation_share = cross_side_excitation_count / signed_denominator
+    transient_impact_pressure_bps = _percentile(tuple(transient_pressures), 0.75)
+    impact_decay_gap_score = _impact_decay_gap_score(
+        latency_observation_count=len(latency_values),
+        depth_observation_count=len(depth_values),
+        participation_observation_count=len(participation_values),
+        transient_impact_pressure_bps=transient_impact_pressure_bps,
+        square_root_impact_pressure_bps=square_root_impact_pressure_bps,
+    )
+    source_gap_score, warnings = _source_gap_score(
+        ordered=ordered,
+        event_observation_count=len(event_rows),
+        signed_event_count=len(signed_events),
+        size_observation_count=len(size_values),
+        volume_observation_count=len(volume_values),
+        spread_observation_count=len(spread_values),
+        median_interarrival_seconds=median_interarrival_seconds,
+    )
+    warnings_set = set(warnings)
+    if burst_event_share >= 0.50:
+        warnings_set.add("hawkes_event_time_burst_cluster_detected")
+    if same_side_cluster_share >= 0.35:
+        warnings_set.add("same_side_self_excitation_cluster_detected")
+    if cross_side_excitation_share >= 0.35:
+        warnings_set.add("cross_side_mutual_excitation_cluster_detected")
+    if transient_impact_pressure_bps > 0.0 and not latency_values:
+        warnings_set.add("transient_impact_without_latency_decay_context")
+    if square_root_impact_pressure_bps > 0.0 and not volume_values:
+        warnings_set.add("square_root_impact_without_volume_context")
+    replay_rank_penalty_bps = min(
+        275.0,
+        burst_event_share * 22.0
+        + same_side_cluster_share * 32.0
+        + cross_side_excitation_share * 18.0
+        + transient_impact_pressure_bps * 0.75
+        + square_root_impact_pressure_bps * 0.55
+        + impact_decay_gap_score * 34.0
+        + source_gap_score * 28.0,
+    )
+    return HawkesTransientImpactStressSummary(
+        row_count=len(ordered),
+        event_observation_count=len(event_rows),
+        signed_event_count=len(signed_events),
+        size_observation_count=len(size_values),
+        volume_observation_count=len(volume_values),
+        spread_observation_count=len(spread_values),
+        depth_observation_count=len(depth_values),
+        participation_observation_count=len(participation_values),
+        latency_observation_count=len(latency_values),
+        median_interarrival_seconds=median_interarrival_seconds,
+        burst_event_share=burst_event_share,
+        same_side_cluster_share=same_side_cluster_share,
+        cross_side_excitation_share=cross_side_excitation_share,
+        transient_impact_pressure_bps=transient_impact_pressure_bps,
+        square_root_impact_pressure_bps=square_root_impact_pressure_bps,
+        impact_decay_gap_score=impact_decay_gap_score,
+        source_gap_score=source_gap_score,
+        replay_rank_penalty_bps=replay_rank_penalty_bps,
+        warnings=tuple(sorted(warnings_set)),
+        feature_schema_hash=build_hawkes_transient_impact_stress_schema_hash(),
+    )
+
+
+def _is_event_observation(row: SignalEnvelope) -> bool:
+    return (
+        _row_sign(row) is not None
+        or _row_size(row, fallback_abs_ofi=False) is not None
+        or _coalesce_numeric(row.payload, _OFI_FIELDS) is not None
+    )
+
+
+def _row_return_bps(previous_row: SignalEnvelope, row: SignalEnvelope) -> float | None:
+    previous_price = _row_price(previous_row)
+    price = _row_price(row)
+    if previous_price is None or price is None or previous_price <= 0.0:
+        return None
+    return (price - previous_price) / previous_price * 10_000.0
+
+
+def _source_gap_score(
+    *,
+    ordered: Sequence[SignalEnvelope],
+    event_observation_count: int,
+    signed_event_count: int,
+    size_observation_count: int,
+    volume_observation_count: int,
+    spread_observation_count: int,
+    median_interarrival_seconds: float,
+) -> tuple[float, tuple[str, ...]]:
+    warnings: set[str] = set()
+    if not ordered:
+        return 1.0, ("missing_replay_rows",)
+    score = 0.0
+    if event_observation_count == 0:
+        score += 0.25
+        warnings.add("missing_event_time_observations")
+    if signed_event_count == 0:
+        score += 0.25
+        warnings.add("missing_signed_order_flow_events")
+    elif signed_event_count < max(2, event_observation_count // 2):
+        score += 0.10
+        warnings.add("partial_signed_order_flow_coverage")
+    if size_observation_count == 0:
+        score += 0.15
+        warnings.add("missing_event_size_context")
+    if volume_observation_count == 0:
+        score += 0.15
+        warnings.add("missing_volume_context")
+    if spread_observation_count == 0:
+        score += 0.10
+        warnings.add("missing_spread_context")
+    if median_interarrival_seconds >= 300.0:
+        score += 0.25
+        warnings.add("coarse_replay_clock_for_hawkes_stress")
+    elif median_interarrival_seconds >= 60.0:
+        score += 0.12
+        warnings.add("minute_bar_clock_for_hawkes_stress")
+    return min(1.0, score), tuple(sorted(warnings))
+
+
+def _impact_decay_gap_score(
+    *,
+    latency_observation_count: int,
+    depth_observation_count: int,
+    participation_observation_count: int,
+    transient_impact_pressure_bps: float,
+    square_root_impact_pressure_bps: float,
+) -> float:
+    score = 0.0
+    if transient_impact_pressure_bps > 0.0 and latency_observation_count == 0:
+        score += 0.35
+    if square_root_impact_pressure_bps > 0.0 and participation_observation_count == 0:
+        score += 0.25
+    if (
+        transient_impact_pressure_bps > 0.0 or square_root_impact_pressure_bps > 0.0
+    ) and depth_observation_count == 0:
+        score += 0.25
+    if transient_impact_pressure_bps >= 10.0:
+        score += 0.15
+    return min(1.0, score)
+
+
+def _square_root_impact_pressure_bps(
+    *,
+    impact_notional_proxy: float,
+    median_volume: float,
+    median_price: float,
+    median_spread_bps: float,
+) -> float:
+    dollar_volume = median_volume * max(0.0, median_price)
+    if impact_notional_proxy <= 0.0 or dollar_volume <= 0.0:
+        return 0.0
+    participation = min(25.0, impact_notional_proxy / dollar_volume)
+    return max(0.0, median_spread_bps) + 12.5 * sqrt(max(0.0, participation))
+
+
+def _burst_threshold_seconds(interarrivals: Sequence[float]) -> float:
+    if not interarrivals:
+        return 0.0
+    median = _median(interarrivals)
+    p25 = _percentile(interarrivals, 0.25)
+    return max(0.001, min(30.0, max(p25, median * 0.50)))
+
+
+def _interarrival_seconds(rows: Sequence[SignalEnvelope]) -> tuple[float, ...]:
+    if len(rows) < 2:
+        return ()
+    ordered = tuple(sorted(rows, key=lambda row: (row.symbol, row.event_ts, row.seq)))
+    deltas: list[float] = []
+    for previous, current in zip(ordered, ordered[1:]):
+        if previous.symbol != current.symbol:
+            continue
+        seconds = (current.event_ts - previous.event_ts).total_seconds()
+        if seconds >= 0.0 and isfinite(seconds):
+            deltas.append(seconds)
+    return tuple(deltas)
+
+
+def _row_sign(row: SignalEnvelope) -> float | None:
+    side = _coalesce_string(row.payload, _SIDE_FIELDS)
+    if side is not None:
+        lowered = side.strip().lower()
+        if lowered in _BUY_TOKENS:
+            return 1.0
+        if lowered in _SELL_TOKENS:
+            return -1.0
+        numeric = _float_or_none(lowered)
+        if numeric is not None and numeric != 0.0:
+            return 1.0 if numeric > 0.0 else -1.0
+    signed_size = _coalesce_numeric(
+        row.payload,
+        ("signed_size", "signed_qty", "signed_quantity", "signed_order_flow"),
+    )
+    if signed_size is not None and signed_size != 0.0:
+        return 1.0 if signed_size > 0.0 else -1.0
+    ofi = _coalesce_numeric(row.payload, _OFI_FIELDS)
+    if ofi is not None and ofi != 0.0:
+        return 1.0 if ofi > 0.0 else -1.0
+    return None
+
+
+def _row_size(row: SignalEnvelope, *, fallback_abs_ofi: bool) -> float | None:
+    value = _coalesce_numeric(row.payload, _SIZE_FIELDS)
+    if value is not None:
+        value = abs(value)
+        if value > 0.0:
+            return value
+    if fallback_abs_ofi:
+        ofi = _coalesce_numeric(row.payload, _OFI_FIELDS)
+        if ofi is not None and ofi != 0.0:
+            return abs(ofi)
+    return None
+
+
+def _row_price(row: SignalEnvelope) -> float | None:
+    value = _coalesce_numeric(row.payload, _PRICE_FIELDS)
+    if value is None or value <= 0.0:
+        return None
+    return value
+
+
+def _row_spread_bps(row: SignalEnvelope) -> float | None:
+    value = _coalesce_numeric(row.payload, _SPREAD_FIELDS)
+    if value is None or value < 0.0:
+        return None
+    return value
+
+
+def _row_volume(row: SignalEnvelope) -> float | None:
+    value = _coalesce_numeric(row.payload, _VOLUME_FIELDS)
+    if value is None or value <= 0.0:
+        return None
+    return value
+
+
+def _row_depth(row: SignalEnvelope) -> float | None:
+    value = _coalesce_numeric(row.payload, _DEPTH_FIELDS)
+    if value is None or value <= 0.0:
+        return None
+    return value
+
+
+def _row_participation(row: SignalEnvelope) -> float | None:
+    value = _coalesce_numeric(row.payload, _PARTICIPATION_FIELDS)
+    if value is None or value < 0.0:
+        return None
+    return value
+
+
+def _row_latency_ms(row: SignalEnvelope) -> float | None:
+    value = _coalesce_numeric(row.payload, _LATENCY_FIELDS)
+    if value is None or value < 0.0:
+        return None
+    return value
+
+
+def _median_price(rows: Sequence[SignalEnvelope]) -> float:
+    return _median(
+        tuple(value for row in rows if (value := _row_price(row)) is not None)
+    )
+
+
+def _coalesce_numeric(
+    payload: Mapping[str, Any], fields: Sequence[str]
+) -> float | None:
+    for field in fields:
+        value = payload.get(field)
+        numeric = _float_or_none(value)
+        if numeric is not None and isfinite(numeric):
+            return numeric
+    return None
+
+
+def _coalesce_string(payload: Mapping[str, Any], fields: Sequence[str]) -> str | None:
+    for field in fields:
+        value = payload.get(field)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(numeric):
+        return None
+    return numeric
+
+
+def _median(values: Sequence[float]) -> float:
+    return _percentile(values, 0.50)
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    clean = sorted(float(value) for value in values if isfinite(float(value)))
+    if not clean:
+        return 0.0
+    if len(clean) == 1:
+        return clean[0]
+    position = max(0.0, min(1.0, percentile)) * (len(clean) - 1)
+    lower = int(position)
+    upper = min(lower + 1, len(clean) - 1)
+    fraction = position - lower
+    return clean[lower] * (1.0 - fraction) + clean[upper] * fraction
+
+
+def _stable_float(value: float) -> float:
+    if not isfinite(value):
+        return 0.0
+    return round(float(value), 8)
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()[:24]

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -307,6 +307,10 @@ class TestFastReplayPreview(TestCase):
             "bootstrap_robust_optimization_stress",
             payload["implemented_mechanisms"],
         )
+        self.assertIn(
+            "hawkes_transient_impact_execution_stress",
+            payload["implemented_mechanisms"],
+        )
         self.assertEqual(
             row_payload["target_implied_notional_context"]["target_net_pnl_per_day"],
             "500",
@@ -778,6 +782,34 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn(
             "metaorder_adverse_selection_stress_downranks_only",
+            row_payload["ranking_only_reasons"],
+        )
+        self.assertIn("hawkes_transient_impact_stress", row_payload)
+        self.assertEqual(
+            row_payload["hawkes_transient_impact_stress"]["status"],
+            "preview_only_hawkes_transient_impact_stress_ranking",
+        )
+        self.assertIn(
+            "arxiv-2504.10282",
+            {
+                source["source_id"]
+                for source in row_payload["hawkes_transient_impact_stress"][
+                    "source_papers"
+                ]
+            },
+        )
+        self.assertFalse(
+            row_payload["hawkes_transient_impact_stress"]["proof_authority"]
+        )
+        self.assertFalse(
+            row_payload["hawkes_transient_impact_stress"]["promotion_authority"]
+        )
+        self.assertIn(
+            "hawkes_transient_impact_stress_penalty_active",
+            row_payload["risk_flags"],
+        )
+        self.assertIn(
+            "hawkes_transient_impact_stress_downranks_only",
             row_payload["ranking_only_reasons"],
         )
         self.assertIn("bootstrap_robust_optimization_stress", row_payload)

--- a/services/torghut/tests/test_hawkes_transient_impact_stress.py
+++ b/services/torghut/tests/test_hawkes_transient_impact_stress.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.hawkes_transient_impact_stress import (
+    build_hawkes_transient_impact_stress_schema_hash,
+    extract_hawkes_transient_impact_stress,
+    hawkes_transient_impact_stress_contract,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestHawkesTransientImpactStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset_ms: int,
+        price: str,
+        side: str | None = "buy",
+        quantity: str | None = "100",
+        volume: str | None = "10000",
+        spread_bps: str | None = "1.0",
+        depth: str | None = "5000",
+        participation_rate: str | None = "0.01",
+        latency_ms: str | None = "4",
+    ) -> SignalEnvelope:
+        payload: dict[str, object] = {"price": Decimal(price)}
+        if side is not None:
+            payload["side"] = side
+        if quantity is not None:
+            payload["quantity"] = Decimal(quantity)
+        if volume is not None:
+            payload["microbar_volume"] = Decimal(volume)
+        if spread_bps is not None:
+            payload["spread_bps"] = Decimal(spread_bps)
+        if depth is not None:
+            payload["top_depth"] = Decimal(depth)
+        if participation_rate is not None:
+            payload["participation_rate"] = Decimal(participation_rate)
+        if latency_ms is not None:
+            payload["route_latency_ms"] = Decimal(latency_ms)
+        return SignalEnvelope(
+            event_ts=datetime(2026, 4, 4, 14, 0, tzinfo=timezone.utc)
+            + timedelta(milliseconds=offset_ms),
+            symbol="IMPACT",
+            timeframe="event",
+            seq=offset_ms,
+            source="hawkes-transient-impact-fixture",
+            payload=payload,
+            ingest_ts=datetime(2026, 4, 4, 14, 1, tzinfo=timezone.utc),
+        )
+
+    def test_bursty_same_side_flow_increases_transient_impact_penalty(self) -> None:
+        calm = extract_hawkes_transient_impact_stress(
+            (
+                self._row(offset_ms=0, price="100.00", side="buy"),
+                self._row(offset_ms=60000, price="100.01", side="sell"),
+                self._row(offset_ms=120000, price="100.00", side="buy"),
+                self._row(offset_ms=180000, price="100.01", side="sell"),
+            ),
+            max_notional=10_000,
+        )
+        stressed = extract_hawkes_transient_impact_stress(
+            (
+                self._row(offset_ms=0, price="100.00", side="buy", quantity="1500"),
+                self._row(offset_ms=50, price="100.08", side="buy", quantity="1800"),
+                self._row(offset_ms=90, price="100.17", side="buy", quantity="1600"),
+                self._row(offset_ms=120, price="100.22", side="sell", quantity="900"),
+                self._row(offset_ms=160, price="100.31", side="buy", quantity="1700"),
+            ),
+            direction=1,
+            max_notional=250_000,
+        )
+
+        self.assertGreater(stressed.burst_event_share, calm.burst_event_share)
+        self.assertGreater(
+            stressed.same_side_cluster_share, calm.same_side_cluster_share
+        )
+        self.assertGreater(
+            stressed.transient_impact_pressure_bps,
+            calm.transient_impact_pressure_bps,
+        )
+        self.assertGreater(
+            stressed.square_root_impact_pressure_bps,
+            calm.square_root_impact_pressure_bps,
+        )
+        self.assertGreater(
+            stressed.replay_rank_penalty_bps, calm.replay_rank_penalty_bps
+        )
+        payload = stressed.to_payload()
+        self.assertEqual(
+            payload["status"],
+            "preview_only_hawkes_transient_impact_stress_ranking",
+        )
+        self.assertTrue(payload["hawkes_excitation_preview"])
+        self.assertTrue(payload["transient_impact_preview"])
+        self.assertTrue(payload["square_root_impact_preview"])
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["final_authority_ok"])
+
+    def test_missing_event_signs_and_execution_context_fail_closed(self) -> None:
+        summary = extract_hawkes_transient_impact_stress(
+            (
+                self._row(
+                    offset_ms=0,
+                    price="100.00",
+                    side=None,
+                    quantity="1000",
+                    volume=None,
+                    spread_bps=None,
+                    depth=None,
+                    participation_rate=None,
+                    latency_ms=None,
+                ),
+                self._row(
+                    offset_ms=600000,
+                    price="100.25",
+                    side=None,
+                    quantity="1100",
+                    volume=None,
+                    spread_bps=None,
+                    depth=None,
+                    participation_rate=None,
+                    latency_ms=None,
+                ),
+            )
+        )
+        payload = summary.to_payload()
+
+        self.assertGreater(summary.source_gap_score, 0.0)
+        self.assertIn("missing_signed_order_flow_events", summary.warnings)
+        self.assertIn("missing_volume_context", summary.warnings)
+        self.assertIn("missing_spread_context", summary.warnings)
+        self.assertIn("coarse_replay_clock_for_hawkes_stress", summary.warnings)
+        self.assertFalse(payload["promotion_proof"])
+        self.assertFalse(payload["promotion_allowed"])
+        self.assertFalse(payload["final_promotion_allowed"])
+
+    def test_contract_embeds_primary_sources_and_proof_boundary(self) -> None:
+        contract = hawkes_transient_impact_stress_contract()
+        payload = extract_hawkes_transient_impact_stress(
+            (
+                self._row(offset_ms=0, price="100.00"),
+                self._row(offset_ms=50, price="100.08"),
+            )
+        ).to_payload()
+
+        source_ids = {source["source_id"] for source in contract["source_papers"]}
+        self.assertIn("arxiv-2504.10282", source_ids)
+        self.assertIn("arxiv-2603.29086", source_ids)
+        proof_neutrality = contract["proof_neutrality"]
+        self.assertTrue(proof_neutrality["requires_exact_replay"])
+        self.assertTrue(proof_neutrality["requires_event_time_replay"])
+        self.assertTrue(proof_neutrality["requires_order_lifecycle_events"])
+        self.assertTrue(proof_neutrality["requires_route_tca"])
+        self.assertTrue(proof_neutrality["requires_runtime_ledger"])
+        self.assertTrue(proof_neutrality["rejects_hawkes_intensity_as_fill_authority"])
+        self.assertTrue(
+            proof_neutrality["rejects_modeled_impact_as_realized_pnl_authority"]
+        )
+        self.assertTrue(
+            proof_neutrality["rejects_missing_event_signs_as_neutral_order_flow"]
+        )
+        self.assertEqual(
+            payload["feature_schema_hash"],
+            build_hawkes_transient_impact_stress_schema_hash(),
+        )
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["promotion_authority"])


### PR DESCRIPTION
## Summary

- Adds a preview-only Hawkes/transient-impact replay stress that converts arXiv:2504.10282 and arXiv:2603.29086 mechanisms into executable event-time ranking features.
- Integrates the stress into fast replay scoring, row payloads, risk flags, ranking-only reasons, and the implemented whitepaper mechanism manifest.
- Preserves proof semantics by requiring exact event replay, order lifecycle evidence, route TCA, and runtime ledger authority before any profitability or promotion claim.

## Related Issues

None

## Testing

- `cd services/torghut && uvx ruff format --check app/trading/discovery/hawkes_transient_impact_stress.py app/trading/discovery/fast_replay.py tests/test_hawkes_transient_impact_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/hawkes_transient_impact_stress.py app/trading/discovery/fast_replay.py tests/test_hawkes_transient_impact_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen pytest tests/test_hawkes_transient_impact_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
