### PR TITLE
fix(torghut): propagate impact source markers

### DIFF
--- a/services/torghut/app/trading/discovery/nonlinear_impact_execution_stress.py
+++ b/services/torghut/app/trading/discovery/nonlinear_impact_execution_stress.py
@@ -43,6 +43,10 @@ NONLINEAR_IMPACT_EXECUTION_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...]
         "mechanism": "child_order_square_root_impact_with_inverse_square_root_time_decay",
     },
 )
+NONLINEAR_IMPACT_EXECUTION_STRESS_SOURCE_MARKERS: tuple[str, ...] = (
+    "realistic_market_impact_arxiv_2603_29086_2026",
+    "double_square_root_impact_arxiv_2502_16246_2025",
+)
 
 _PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
 _SPREAD_BPS_FIELDS = ("spread_bps", "quoted_spread_bps", "effective_spread_bps")
@@ -112,6 +116,7 @@ class NonlinearImpactExecutionStressSummary:
             "source_papers": [
                 dict(item) for item in NONLINEAR_IMPACT_EXECUTION_STRESS_PRIMARY_SOURCES
             ],
+            "source_markers": list(NONLINEAR_IMPACT_EXECUTION_STRESS_SOURCE_MARKERS),
             "row_count": self.row_count,
             "observed_price_count": self.observed_price_count,
             "observed_volume_count": self.observed_volume_count,
@@ -197,6 +202,7 @@ def nonlinear_impact_execution_stress_contract() -> dict[str, Any]:
         "source_papers": [
             dict(item) for item in NONLINEAR_IMPACT_EXECUTION_STRESS_PRIMARY_SOURCES
         ],
+        "source_markers": list(NONLINEAR_IMPACT_EXECUTION_STRESS_SOURCE_MARKERS),
         "stress_policy": "nonlinear_market_impact_participation_and_permanent_decay_stress",
         "stress_components": [
             "square_root_impact_cost_bps",

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -8914,6 +8914,13 @@ def _runtime_report_source_markers(report: Mapping[str, Any]) -> list[str]:
     return sorted(set(_string_list_from_value(report.get("source_markers"))))
 
 
+def _market_impact_default_source_markers() -> list[str]:
+    return [
+        "double_square_root_impact_arxiv_2502_16246_2025",
+        "realistic_market_impact_arxiv_2603_29086_2026",
+    ]
+
+
 def _runtime_closure_start_equity(runtime_closure: Mapping[str, Any]) -> Decimal:
     replay_plan = _load_json_mapping_artifact(runtime_closure.get("replay_plan_path"))
     execution_context = _mapping(replay_plan.get("execution_context"))
@@ -8974,21 +8981,29 @@ def _runtime_closure_market_impact_stress_update(
         )
     )
     components = _mapping(market_impact_report.get("market_impact_stress_components"))
+    source_markers = _runtime_report_source_markers(market_impact_report)
+    if not source_markers:
+        source_markers = sorted(
+            set(_string_list_from_value(components.get("source_markers")))
+        )
+    if not source_markers and (components or model):
+        source_markers = _market_impact_default_source_markers()
     if not components and model and _decimal(cost_bps) > 0:
         components = {
             "selected_model": model,
             "selected_cost_bps": cost_bps,
             "source_marker": "realistic_market_impact_arxiv_2603_29086_2026",
+            "source_markers": source_markers,
         }
+    elif components and source_markers and "source_markers" not in components:
+        components = {**components, "source_markers": source_markers}
     return {
         "market_impact_stress_passed": _boolish(
             market_impact_report.get("objective_met")
             or market_impact_report.get("passed")
         ),
         "market_impact_stress_artifact_ref": market_impact_report_path,
-        "market_impact_stress_source_markers": _runtime_report_source_markers(
-            market_impact_report
-        ),
+        "market_impact_stress_source_markers": source_markers,
         "market_impact_stress_model": model,
         "market_impact_stress_cost_bps": cost_bps,
         "market_impact_stress_components": components,
@@ -10184,6 +10199,12 @@ def _candidate_board_market_impact_proof_summary(
 ) -> dict[str, Any]:
     components = _mapping(scorecard.get("market_impact_stress_components"))
     source_marker = _string(components.get("source_marker"))
+    source_marker_candidates = [
+        *_string_list_from_value(scorecard.get("market_impact_stress_source_markers")),
+        *_string_list_from_value(components.get("source_markers")),
+        *([source_marker] if source_marker else []),
+    ]
+    source_markers = sorted({marker for marker in source_marker_candidates if marker})
     model = _string(
         scorecard.get("nonlinear_market_impact_stress_model")
         or scorecard.get("market_impact_stress_model")
@@ -10232,6 +10253,7 @@ def _candidate_board_market_impact_proof_summary(
         "net_pnl_per_day": net_pnl_per_day,
         "artifact_ref": artifact_ref,
         "component_source_marker": source_marker,
+        "source_markers": source_markers,
         "selected_component_model": _string(components.get("selected_model")),
         "selected_component_cost_bps": _string(components.get("selected_cost_bps")),
         "blockers": blockers,

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -2496,6 +2496,10 @@ DELAY_ADJUSTED_DEPTH_STRESS_GRID_MS = (
     Decimal("250"),
 )
 CONFORMAL_TAIL_RISK_ALPHA = Decimal("0.20")
+MARKET_IMPACT_STRESS_SOURCE_MARKERS = (
+    "realistic_market_impact_arxiv_2603_29086_2026",
+    "double_square_root_impact_arxiv_2502_16246_2025",
+)
 
 
 def _p10(values: Sequence[Decimal]) -> Decimal:
@@ -2634,6 +2638,7 @@ def _implementation_uncertainty_metrics(
         "implementation_uncertainty_source_markers": [
             "lob_simulation_reality_gap_arxiv_2603_24137_2026",
             "order_flow_market_impact_volatility_arxiv_2601_23172_2026",
+            "double_square_root_impact_arxiv_2502_16246_2025",
             "implementation_risk_backtesting_arxiv_2603_20319_2026",
         ],
     }
@@ -2764,6 +2769,9 @@ def _replay_stress_metrics(
         "market_impact_stress_model": market_impact_model,
         "market_impact_stress_cost_bps": str(nonlinear_impact_cost_bps),
         "market_impact_stress_net_pnl_per_day": str(market_impact_net_per_day),
+        "market_impact_stress_source_markers": list(
+            MARKET_IMPACT_STRESS_SOURCE_MARKERS
+        ),
         "market_impact_stress_components": {
             "square_root_cost_bps": str(square_root_impact_cost_bps),
             "almgren_chriss_temporary_impact_bps": str(
@@ -2776,6 +2784,7 @@ def _replay_stress_metrics(
             "selected_cost_bps": str(nonlinear_impact_cost_bps),
             "selected_model": market_impact_model,
             "source_marker": "realistic_market_impact_arxiv_2603_29086_2026",
+            "source_markers": list(MARKET_IMPACT_STRESS_SOURCE_MARKERS),
         },
         "nonlinear_market_impact_stress_passed": bool(
             total_liquidity_notional > 0

--- a/services/torghut/tests/test_nonlinear_impact_execution_stress.py
+++ b/services/torghut/tests/test_nonlinear_impact_execution_stress.py
@@ -123,6 +123,10 @@ class TestNonlinearImpactExecutionStress(TestCase):
         self.assertTrue(payload["square_root_market_impact_preview"])
         self.assertTrue(payload["permanent_impact_decay_preview"])
         self.assertTrue(payload["trade_level_logging_required_downstream"])
+        self.assertIn(
+            "double_square_root_impact_arxiv_2502_16246_2025",
+            payload["source_markers"],
+        )
         self.assertFalse(payload["proof_authority"])
         self.assertFalse(payload["promotion_authority"])
         self.assertFalse(payload["final_authority_ok"])
@@ -140,6 +144,10 @@ class TestNonlinearImpactExecutionStress(TestCase):
         source_ids = {source["source_id"] for source in contract["source_papers"]}
         self.assertIn("arxiv-2603.29086", source_ids)
         self.assertIn("arxiv-2502.16246", source_ids)
+        self.assertIn(
+            "double_square_root_impact_arxiv_2502_16246_2025",
+            contract["source_markers"],
+        )
         proof_neutrality = contract["proof_neutrality"]
         self.assertTrue(proof_neutrality["requires_exact_replay"])
         self.assertTrue(proof_neutrality["requires_route_tca"])

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6792,7 +6792,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                         "net_pnl_per_day": "999",
                         "post_impact_net_pnl_per_day": "610",
                         "source_markers": [
-                            "realistic_market_impact_arxiv_2603_29086_2026"
+                            "double_square_root_impact_arxiv_2502_16246_2025",
+                            "realistic_market_impact_arxiv_2603_29086_2026",
                         ],
                     }
                 )
@@ -6969,7 +6970,16 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertEqual(
             updated.objective_scorecard["market_impact_stress_source_markers"],
-            ["realistic_market_impact_arxiv_2603_29086_2026"],
+            [
+                "double_square_root_impact_arxiv_2502_16246_2025",
+                "realistic_market_impact_arxiv_2603_29086_2026",
+            ],
+        )
+        self.assertIn(
+            "double_square_root_impact_arxiv_2502_16246_2025",
+            updated.objective_scorecard["market_impact_stress_components"][
+                "source_markers"
+            ],
         )
         self.assertEqual(
             updated.objective_scorecard["delay_adjusted_depth_stress_checks_total"],
@@ -7048,6 +7058,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             updated.objective_scorecard["runtime_closure_source_markers"],
             [
                 "double_oos_walkforward_arxiv_2602_10785_2026",
+                "double_square_root_impact_arxiv_2502_16246_2025",
                 "lob_simulation_reality_gap_arxiv_2603_24137_2026",
                 "realistic_market_impact_arxiv_2603_29086_2026",
             ],
@@ -7143,6 +7154,76 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             program,
         )
 
+    def test_runtime_closure_market_impact_source_marker_fallbacks(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            default_marker_path = tmp_path / "impact-default-marker.json"
+            default_marker_path.write_text(
+                json.dumps(
+                    {
+                        "objective_met": True,
+                        "model": "square_root",
+                        "impact_cost_bps": "7",
+                        "post_impact_net_pnl_per_day": "512",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            default_marker_update = runner._runtime_closure_market_impact_stress_update(
+                {"market_impact_stress_report_path": str(default_marker_path)}
+            )
+            self.assertEqual(
+                default_marker_update["market_impact_stress_source_markers"],
+                [
+                    "double_square_root_impact_arxiv_2502_16246_2025",
+                    "realistic_market_impact_arxiv_2603_29086_2026",
+                ],
+            )
+            self.assertEqual(
+                default_marker_update["market_impact_stress_components"][
+                    "source_markers"
+                ],
+                [
+                    "double_square_root_impact_arxiv_2502_16246_2025",
+                    "realistic_market_impact_arxiv_2603_29086_2026",
+                ],
+            )
+
+            component_marker_path = tmp_path / "impact-component-marker.json"
+            component_marker_path.write_text(
+                json.dumps(
+                    {
+                        "objective_met": True,
+                        "model": "square_root",
+                        "impact_cost_bps": "8",
+                        "post_impact_net_pnl_per_day": "513",
+                        "source_markers": [
+                            "double_square_root_impact_arxiv_2502_16246_2025",
+                            "realistic_market_impact_arxiv_2603_29086_2026",
+                        ],
+                        "market_impact_stress_components": {
+                            "source_marker": "realistic_market_impact_arxiv_2603_29086_2026",
+                            "selected_model": "square_root",
+                            "selected_cost_bps": "8",
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            component_marker_update = (
+                runner._runtime_closure_market_impact_stress_update(
+                    {"market_impact_stress_report_path": str(component_marker_path)}
+                )
+            )
+            self.assertIn(
+                "double_square_root_impact_arxiv_2502_16246_2025",
+                component_marker_update["market_impact_stress_components"][
+                    "source_markers"
+                ],
+            )
+
     def test_candidate_board_helpers_keep_blockers_explicit(self) -> None:
         spec = replace(
             self._candidate_spec("spec-regime-diagnostics"),
@@ -7187,6 +7268,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     "market_impact_stress_artifact_ref": "/tmp/impact.json",
                     "market_impact_stress_components": {
                         "source_marker": "realistic_market_impact_arxiv_2603_29086_2026",
+                        "source_markers": [
+                            "double_square_root_impact_arxiv_2502_16246_2025",
+                            "realistic_market_impact_arxiv_2603_29086_2026",
+                        ],
                         "selected_model": "almgren_chriss_proxy",
                         "selected_cost_bps": "150",
                     },
@@ -7194,6 +7279,27 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 }
             )["state"],
             "passed",
+        )
+        self.assertIn(
+            "double_square_root_impact_arxiv_2502_16246_2025",
+            runner._candidate_board_market_impact_proof_summary(
+                {
+                    "market_impact_stress_model": "almgren_chriss_proxy",
+                    "market_impact_stress_cost_bps": "150",
+                    "market_impact_stress_net_pnl_per_day": "510",
+                    "market_impact_stress_artifact_ref": "/tmp/impact.json",
+                    "market_impact_stress_components": {
+                        "source_marker": "realistic_market_impact_arxiv_2603_29086_2026",
+                        "source_markers": [
+                            "double_square_root_impact_arxiv_2502_16246_2025",
+                            "realistic_market_impact_arxiv_2603_29086_2026",
+                        ],
+                        "selected_model": "almgren_chriss_proxy",
+                        "selected_cost_bps": "150",
+                    },
+                    "nonlinear_market_impact_stress_passed": True,
+                }
+            )["source_markers"],
         )
         missing_impact = runner._candidate_board_market_impact_proof_summary(
             {"target_met": True}

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -4079,6 +4079,14 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             summary["market_impact_stress_components"]["source_marker"],
             "realistic_market_impact_arxiv_2603_29086_2026",
         )
+        self.assertIn(
+            "double_square_root_impact_arxiv_2502_16246_2025",
+            summary["market_impact_stress_source_markers"],
+        )
+        self.assertIn(
+            "double_square_root_impact_arxiv_2502_16246_2025",
+            summary["market_impact_stress_components"]["source_markers"],
+        )
         self.assertEqual(
             summary["market_impact_stress_components"]["almgren_chriss_cost_bps"],
             "10.00",
@@ -4945,6 +4953,12 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     "market_impact_stress_components"
                 ]["source_marker"],
                 "realistic_market_impact_arxiv_2603_29086_2026",
+            )
+            self.assertIn(
+                "double_square_root_impact_arxiv_2502_16246_2025",
+                top_by_stop["18"]["objective_scorecard"][
+                    "market_impact_stress_components"
+                ]["source_markers"],
             )
             self.assertTrue(
                 top_by_stop["18"]["objective_scorecard"][


### PR DESCRIPTION
## Summary

- Propagates the curated double-square-root impact-decay source marker through nonlinear impact stress payloads and contracts.
- Carries both nonlinear impact source markers into profitability-frontier scorecards, runtime-closure market-impact updates, and candidate-board summaries.
- Keeps authority proof fail-closed: the market-impact proof summary still requires artifact, model, positive cost, net PnL, component source marker, and a passed stress flag before marking impact evidence passed.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/nonlinear_impact_execution_stress.py scripts/search_consistent_profitability_frontier.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_nonlinear_impact_execution_stress.py tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_nonlinear_impact_execution_stress.py tests/test_search_consistent_profitability_frontier.py::TestSearchConsistentProfitabilityFrontier::test_consistency_penalty_rejects_lucky_strike_and_low_notional_profile tests/test_search_consistent_profitability_frontier.py::TestSearchConsistentProfitabilityFrontier::test_run_frontier_vetoes_candidate_that_fails_second_oos tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_market_impact_source_marker_fallbacks tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_proof_blocks_oracle_without_source_runtime_ledger tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_candidate_board_helpers_keep_blockers_explicit`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv sync --frozen --extra dev` failed before dependency sync completed because `crosshair-tool==0.0.102` attempted to compile `_crosshair_tracers` and `cc` is unavailable in this container.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.