### PR TITLE
fix(torghut): rank probation by target scale gap

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -188,6 +188,7 @@ _PAPER_PROBATION_QUEUE_SURVIVAL_REASONS = frozenset(
         "queue_position_survival_stress_net_pnl_non_positive",
     }
 )
+_PAPER_PROBATION_TARGET_SCALE_QUANTUM = Decimal("0.000001")
 _CONSISTENCY_REPAIR_ENTRY_KEYS = (
     "max_entries_per_session",
     "max_entries_per_day",
@@ -4653,18 +4654,18 @@ def _paper_probation_required_actions(hard_vetoes: Sequence[str]) -> list[str]:
     return actions
 
 
-def _paper_probation_notional_scale(
+def _paper_probation_notional_scale_decimal(
     *,
     item: Mapping[str, Any],
     objective_veto_policy: ObjectiveVetoPolicy,
     hard_vetoes: Sequence[str],
-) -> str:
+) -> Decimal:
     if not (
         {str(reason) for reason in hard_vetoes}
         & _PAPER_PROBATION_CAPITAL_REPAIR_REASONS
     ):
-        return "1"
-    scale = _capital_repair_exposure_scale(
+        return Decimal("1")
+    return _capital_repair_exposure_scale(
         {
             "max_gross_exposure_pct_equity": _candidate_metric_value(
                 item,
@@ -4686,7 +4687,37 @@ def _paper_probation_notional_scale(
         ),
         policy_required_min_cash=objective_veto_policy.required_min_cash,
     )
+
+
+def _paper_probation_notional_scale(
+    *,
+    item: Mapping[str, Any],
+    objective_veto_policy: ObjectiveVetoPolicy,
+    hard_vetoes: Sequence[str],
+) -> str:
+    scale = _paper_probation_notional_scale_decimal(
+        item=item,
+        objective_veto_policy=objective_veto_policy,
+        hard_vetoes=hard_vetoes,
+    )
     return _decimal_payload(scale)
+
+
+def _paper_probation_target_notional_scale(
+    *,
+    capital_repaired_net_pnl_per_day: Decimal,
+    target_net_pnl_per_day: Decimal,
+) -> Decimal:
+    if target_net_pnl_per_day <= 0:
+        return Decimal("1")
+    if capital_repaired_net_pnl_per_day <= 0:
+        return Decimal("0")
+    if capital_repaired_net_pnl_per_day >= target_net_pnl_per_day:
+        return Decimal("1")
+    return (target_net_pnl_per_day / capital_repaired_net_pnl_per_day).quantize(
+        _PAPER_PROBATION_TARGET_SCALE_QUANTUM,
+        rounding=ROUND_CEILING,
+    )
 
 
 def _candidate_metric_decimal(
@@ -5073,12 +5104,24 @@ def _paper_probation_repair_plan(
     handoff_diagnostics: Sequence[Mapping[str, Any]],
     net_pnl_per_day: Decimal,
     target_net_pnl_per_day: Decimal,
+    capital_repair_notional_scale: Decimal,
+    capital_repaired_net_pnl_per_day: Decimal,
+    target_notional_scale_after_capital_repair: Decimal,
 ) -> dict[str, Any]:
     repair_actions = _paper_probation_repair_actions(
         blockers=blockers,
         hard_vetoes=hard_vetoes,
     )
     target_shortfall = max(target_net_pnl_per_day - net_pnl_per_day, Decimal("0"))
+    capital_repaired_target_shortfall = max(
+        target_net_pnl_per_day - capital_repaired_net_pnl_per_day,
+        Decimal("0"),
+    )
+    target_scale_required = target_notional_scale_after_capital_repair > Decimal("1")
+    if target_scale_required:
+        repair_actions.append(
+            "validate_target_notional_scale_capacity_before_paper_orders"
+        )
     repair_required = bool(blockers)
     return {
         "schema_version": "torghut.paper-probation-repair-plan.v1",
@@ -5089,6 +5132,20 @@ def _paper_probation_repair_plan(
         "target_net_pnl_per_day": _decimal_payload(target_net_pnl_per_day),
         "observed_net_pnl_per_day": _decimal_payload(net_pnl_per_day),
         "target_shortfall": _decimal_payload(target_shortfall),
+        "capital_repair_notional_scale": _decimal_payload(
+            capital_repair_notional_scale
+        ),
+        "capital_repaired_net_pnl_per_day": _decimal_payload(
+            capital_repaired_net_pnl_per_day
+        ),
+        "capital_repaired_target_shortfall": _decimal_payload(
+            capital_repaired_target_shortfall
+        ),
+        "target_notional_scale_after_capital_repair": _decimal_payload(
+            target_notional_scale_after_capital_repair
+        ),
+        "target_scale_required": target_scale_required,
+        "target_scale_authority": "planning_only_requires_bounded_paper_validation",
         "target_progress_ratio": _decimal_payload(
             _paper_probation_target_progress(
                 net_pnl_per_day=net_pnl_per_day,
@@ -5128,7 +5185,7 @@ def _build_paper_probation_shortlist(
     ]
 
     shortlist_candidates: list[
-        tuple[bool, bool, Decimal, Decimal, Decimal, str, dict[str, Any]]
+        tuple[bool, bool, Decimal, Decimal, Decimal, Decimal, str, dict[str, Any]]
     ] = []
     for item in visible_items:
         hard_vetoes = [
@@ -5212,6 +5269,24 @@ def _build_paper_probation_shortlist(
             scorecard_key="net_pnl",
             full_window_key="net_pnl",
         )
+        capital_repair_notional_scale = _paper_probation_notional_scale_decimal(
+            item=item,
+            objective_veto_policy=objective_veto_policy,
+            hard_vetoes=hard_vetoes,
+        )
+        capital_repaired_net_pnl_per_day = (
+            net_pnl_per_day * capital_repair_notional_scale
+        )
+        capital_repaired_target_shortfall = max(
+            target_net_pnl_per_day - capital_repaired_net_pnl_per_day,
+            Decimal("0"),
+        )
+        target_notional_scale_after_capital_repair = (
+            _paper_probation_target_notional_scale(
+                capital_repaired_net_pnl_per_day=capital_repaired_net_pnl_per_day,
+                target_net_pnl_per_day=target_net_pnl_per_day,
+            )
+        )
         target_shortfall = max(target_net_pnl_per_day - net_pnl_per_day, Decimal("0"))
         repair_plan = _paper_probation_repair_plan(
             item=item,
@@ -5220,7 +5295,17 @@ def _build_paper_probation_shortlist(
             handoff_diagnostics=handoff_diagnostics,
             net_pnl_per_day=net_pnl_per_day,
             target_net_pnl_per_day=target_net_pnl_per_day,
+            capital_repair_notional_scale=capital_repair_notional_scale,
+            capital_repaired_net_pnl_per_day=capital_repaired_net_pnl_per_day,
+            target_notional_scale_after_capital_repair=(
+                target_notional_scale_after_capital_repair
+            ),
         )
+        required_actions = _paper_probation_required_actions(hard_vetoes)
+        if target_notional_scale_after_capital_repair > Decimal("1"):
+            required_actions.append(
+                "validate_target_notional_scale_capacity_before_paper_orders"
+            )
         entry = {
             "candidate_id": str(item.get("candidate_id") or ""),
             "strategy_name": str(item.get("strategy_name") or ""),
@@ -5235,14 +5320,25 @@ def _build_paper_probation_shortlist(
             "handoff_diagnostics": handoff_diagnostics,
             "bounded_sim_handoff": bounded_sim_handoff,
             "paper_probation_repair_plan": repair_plan,
-            "required_actions_before_or_during_probation": (
-                _paper_probation_required_actions(hard_vetoes)
+            "required_actions_before_or_during_probation": list(
+                dict.fromkeys(required_actions)
             ),
-            "recommended_notional_scale": _paper_probation_notional_scale(
-                item=item,
-                objective_veto_policy=objective_veto_policy,
-                hard_vetoes=hard_vetoes,
+            "recommended_notional_scale": _decimal_payload(
+                capital_repair_notional_scale
             ),
+            "capital_repaired_net_pnl_per_day": _decimal_payload(
+                capital_repaired_net_pnl_per_day
+            ),
+            "capital_repaired_target_shortfall": _decimal_payload(
+                capital_repaired_target_shortfall
+            ),
+            "target_notional_scale_after_capital_repair": _decimal_payload(
+                target_notional_scale_after_capital_repair
+            ),
+            "target_scale_required": (
+                target_notional_scale_after_capital_repair > Decimal("1")
+            ),
+            "target_scale_authority": "planning_only_requires_bounded_paper_validation",
             "exact_replay_ledger_artifact_refs": artifact_refs,
             "exact_replay_ledger_artifact_row_count": (exact_replay_ledger_row_count),
             "exact_replay_ledger_artifact_fill_count": (exact_replay_ledger_fill_count),
@@ -5308,7 +5404,8 @@ def _build_paper_probation_shortlist(
             (
                 paper_probation_allowed,
                 bool(bounded_sim_handoff["evidence_collection_ok"]),
-                target_shortfall,
+                capital_repaired_target_shortfall,
+                target_notional_scale_after_capital_repair,
                 net_pnl_per_day,
                 net_pnl,
                 entry["candidate_id"],
@@ -5321,12 +5418,13 @@ def _build_paper_probation_shortlist(
             0 if candidate[0] else 1,
             0 if candidate[1] else 1,
             candidate[2],
-            -candidate[3],
+            candidate[3],
             -candidate[4],
-            candidate[5],
+            -candidate[5],
+            candidate[6],
         )
     )
-    return [candidate[6] for candidate in shortlist_candidates[: max(1, int(top_n))]]
+    return [candidate[7] for candidate in shortlist_candidates[: max(1, int(top_n))]]
 
 
 def _frontier_state_item(item: Mapping[str, Any]) -> dict[str, Any]:

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2728,10 +2728,26 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(item["stage"], "paper_evidence_collection_only")
         self.assertEqual(item["target_net_pnl_per_day"], "500")
         self.assertEqual(item["target_shortfall"], "93.42")
+        self.assertEqual(item["capital_repaired_net_pnl_per_day"], "64.37503114")
+        self.assertEqual(item["capital_repaired_target_shortfall"], "435.62496886")
+        self.assertEqual(item["target_notional_scale_after_capital_repair"], "7.766987")
+        self.assertTrue(item["target_scale_required"])
+        self.assertEqual(
+            item["target_scale_authority"],
+            "planning_only_requires_bounded_paper_validation",
+        )
         self.assertEqual(item["target_progress_ratio"], "0.8132")
         self.assertEqual(
             item["paper_probation_repair_plan"]["status"],
             "ready_for_bounded_paper_evidence_collection",
+        )
+        self.assertEqual(
+            item["paper_probation_repair_plan"]["capital_repaired_net_pnl_per_day"],
+            "64.37503114",
+        )
+        self.assertIn(
+            "validate_target_notional_scale_capacity_before_paper_orders",
+            item["paper_probation_repair_plan"]["repair_actions"],
         )
         self.assertFalse(item["paper_probation_repair_plan"]["promotion_allowed"])
         self.assertFalse(item["paper_probation_repair_plan"]["final_promotion_allowed"])
@@ -2746,6 +2762,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         )
         self.assertIn(
             "collect_tail_risk_and_fill_survival_evidence",
+            item["required_actions_before_or_during_probation"],
+        )
+        self.assertIn(
+            "validate_target_notional_scale_capacity_before_paper_orders",
             item["required_actions_before_or_during_probation"],
         )
 
@@ -2855,6 +2875,87 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertFalse(item["bounded_sim_handoff"]["promotion_allowed"])
         self.assertFalse(item["bounded_sim_handoff"]["final_promotion_allowed"])
         self.assertEqual(item["probation_blockers"], [])
+
+    def test_paper_probation_shortlist_ranks_by_capital_repaired_target_gap(
+        self,
+    ) -> None:
+        evidence_fields = {
+            "exact_replay_ledger_artifact_row_count": 10,
+            "exact_replay_ledger_artifact_fill_count": 4,
+            "runtime_ledger_cost_basis_count": 4,
+            "runtime_ledger_post_cost_expectancy_bps": "18",
+            "runtime_ledger_pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+            "runtime_ledger_open_position_count": 0,
+            "dataset_snapshot_id": "snapshot",
+            "replay_lineage": {"lineage_hash": "lineage"},
+        }
+        items = [
+            {
+                **evidence_fields,
+                "candidate_id": "raw-high-capital-repaired-low",
+                "strategy_name": "capital-repaired",
+                "family": "microbar",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "900",
+                    "net_pnl": "1800",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "1",
+                    "max_drawdown": "50",
+                    "worst_day_loss": "25",
+                    "max_gross_exposure_pct_equity": "9.5",
+                    "min_cash": "100",
+                },
+                "full_window": {"net_per_day": "900", "net_pnl": "1800"},
+                "exact_replay_ledger_artifact_ref": (
+                    "/tmp/raw-high-capital-repaired-low-exact-replay-ledger.json"
+                ),
+                "replay_artifact_refs": [
+                    "/tmp/raw-high-capital-repaired-low-exact-replay-ledger.json"
+                ],
+                "candidate_evaluation_key": "eval-raw-high",
+                "hard_vetoes": ["gross_exposure_pct_equity_above_max"],
+            },
+            {
+                **evidence_fields,
+                "candidate_id": "raw-lower-target-close",
+                "strategy_name": "target-close",
+                "family": "hpairs",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "450",
+                    "net_pnl": "900",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "1",
+                    "max_drawdown": "50",
+                    "worst_day_loss": "25",
+                    "max_gross_exposure_pct_equity": "0.5",
+                    "min_cash": "100",
+                },
+                "full_window": {"net_per_day": "450", "net_pnl": "900"},
+                "exact_replay_ledger_artifact_ref": (
+                    "/tmp/raw-lower-target-close-exact-replay-ledger.json"
+                ),
+                "replay_artifact_refs": [
+                    "/tmp/raw-lower-target-close-exact-replay-ledger.json"
+                ],
+                "candidate_evaluation_key": "eval-raw-lower",
+                "hard_vetoes": [],
+            },
+        ]
+
+        shortlist = frontier._build_paper_probation_shortlist(
+            items,
+            top_n=1,
+            objective_veto_policy=frontier.ObjectiveVetoPolicy(
+                required_max_gross_exposure_pct_equity=Decimal("1"),
+                required_min_cash=Decimal("0"),
+            ),
+        )
+
+        item = shortlist[0]
+        self.assertEqual(item["candidate_id"], "raw-lower-target-close")
+        self.assertEqual(item["capital_repaired_net_pnl_per_day"], "450")
+        self.assertEqual(item["capital_repaired_target_shortfall"], "50")
+        self.assertEqual(item["target_notional_scale_after_capital_repair"], "1.111112")
 
     def test_paper_probation_shortlist_blocks_missing_ledger_artifact(self) -> None:
         shortlist = frontier._build_paper_probation_shortlist(
@@ -3868,6 +3969,41 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 policy_required_min_cash=Decimal("0"),
             ),
             Decimal("0.116117"),
+        )
+
+    def test_paper_probation_notional_scale_helpers_cover_edge_cases(self) -> None:
+        policy = frontier.ObjectiveVetoPolicy(
+            required_max_gross_exposure_pct_equity=Decimal("1"),
+            required_min_cash=Decimal("0"),
+        )
+        item = {
+            "objective_scorecard": {
+                "max_gross_exposure_pct_equity": "8",
+                "min_cash": "100",
+            }
+        }
+
+        self.assertEqual(
+            frontier._paper_probation_notional_scale(
+                item=item,
+                objective_veto_policy=policy,
+                hard_vetoes=["gross_exposure_pct_equity_above_max"],
+            ),
+            "0.11875",
+        )
+        self.assertEqual(
+            frontier._paper_probation_target_notional_scale(
+                capital_repaired_net_pnl_per_day=Decimal("100"),
+                target_net_pnl_per_day=Decimal("0"),
+            ),
+            Decimal("1"),
+        )
+        self.assertEqual(
+            frontier._paper_probation_target_notional_scale(
+                capital_repaired_net_pnl_per_day=Decimal("0"),
+                target_net_pnl_per_day=Decimal("500"),
+            ),
+            Decimal("0"),
         )
 
     def test_positive_capital_safe_summary_rejects_non_finite_values(self) -> None:


### PR DESCRIPTION
## Summary

- Adds capital-repaired paper-probation PnL and target shortfall fields so near-miss candidates are evaluated after required sizing repair.
- Adds the target notional scale needed to reach the `$500/day` paper-evidence target, with planning-only authority and explicit bounded-paper validation actions.
- Ranks paper-probation candidates by post-repair target gap before raw PnL so oversized replay candidates do not outrank safer near-target candidates.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen ruff format --check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
