### PR TITLE
fix(torghut): surface probation evidence path

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -170,6 +170,23 @@ _REJECTED_SIGNAL_OUTCOME_REQUIRED_FIELDS = (
     "post_cost_net_pnl",
     "executable_quote",
 )
+_PAPER_PROBATION_LIVE_PAPER_EVIDENCE_REQUIREMENTS = (
+    "real_runtime_trade_decisions",
+    "broker_order_submissions_and_status_events",
+    "broker_fill_events",
+    "post_cost_costs_tca_and_execution_shortfall",
+    "source_backed_runtime_ledger_lineage",
+    "closed_flat_position_proof",
+    "broker_runtime_ledger_reconciliation",
+)
+_PAPER_PROBATION_SAFE_EVIDENCE_COLLECTION_PATH = (
+    "preserve_final_promotion_gates_fail_closed",
+    "import_exact_replay_runtime_window_metadata_without_live_submit",
+    "run_bounded_live_paper_probe_with_configured_paper_account_only",
+    "materialize_source_backed_runtime_ledger_lineage_for_decisions_orders_fills_costs",
+    "verify_closed_flat_positions_and_broker_runtime_ledger_reconciliation",
+    "reevaluate_post_cost_runtime_profitability_before_any_final_promotion",
+)
 _CODE_COMMIT_ENV_VARS = (
     "TORGHUT_CODE_COMMIT",
     "TORGHUT_COMMIT",
@@ -1696,6 +1713,13 @@ def _decimal(value: Any, *, default: str = "0") -> Decimal:
         return Decimal(str(value if value is not None else default))
     except Exception:
         return Decimal(default)
+
+
+def _decimal_payload(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
 
 
 def _resolved_clickhouse_password(args: argparse.Namespace) -> str:
@@ -10438,6 +10462,26 @@ def _candidate_board_lower_bound_net_pnl(row: Mapping[str, Any]) -> Decimal:
     return lower_bound
 
 
+def _candidate_board_target_progress_ratio(
+    *,
+    lower_bound: Decimal,
+    target: Decimal,
+) -> Decimal:
+    if target <= 0:
+        return Decimal("0")
+    return (lower_bound / target).quantize(Decimal("0.0001"))
+
+
+def _candidate_board_required_notional_repair_scale(
+    *,
+    lower_bound: Decimal,
+    target: Decimal,
+) -> Decimal:
+    if target <= 0 or lower_bound <= 0:
+        return Decimal("0")
+    return max(Decimal("1"), target / lower_bound).quantize(Decimal("0.0001"))
+
+
 def _candidate_board_best_executed_candidate(
     rows: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any] | None:
@@ -10506,6 +10550,17 @@ def _paper_probation_candidate_payload(
 ) -> dict[str, Any]:
     payload = dict(candidate)
     lower_bound = _candidate_board_lower_bound_net_pnl(payload)
+    target_shortfall = max(target - lower_bound, Decimal("0"))
+    target_progress_ratio = _candidate_board_target_progress_ratio(
+        lower_bound=lower_bound,
+        target=target,
+    )
+    required_notional_repair_scale = (
+        _candidate_board_required_notional_repair_scale(
+            lower_bound=lower_bound,
+            target=target,
+        )
+    )
     deployable_missing_count = deployable_lower_bound_missing_count(payload)
     deployable_failed_gate_count = deployable_proof_failed_gate_count(payload)
     final_promotion_blockers = [
@@ -10529,8 +10584,23 @@ def _paper_probation_candidate_payload(
             if bool(payload.get("target_met"))
             else "closest_lower_bound_economics_below_target",
             "selected_by": "candidate_board_paper_probation_candidate",
-            "probation_lower_bound_net_pnl_per_day": str(lower_bound),
-            "probation_target_shortfall": str(max(target - lower_bound, Decimal("0"))),
+            "probation_lower_bound_net_pnl_per_day": _decimal_payload(lower_bound),
+            "probation_target_shortfall": _decimal_payload(target_shortfall),
+            "probation_target_progress_ratio": _decimal_payload(target_progress_ratio),
+            "required_notional_repair_scale_to_target": _decimal_payload(
+                required_notional_repair_scale
+            ),
+            "required_notional_repair_scale_authority": (
+                "linear_notional_sizing_estimate_for_repair_only_not_capital_authority"
+            ),
+            "live_paper_evidence_requirements": list(
+                _PAPER_PROBATION_LIVE_PAPER_EVIDENCE_REQUIREMENTS
+            ),
+            "safe_evidence_collection_path": list(
+                _PAPER_PROBATION_SAFE_EVIDENCE_COLLECTION_PATH
+            ),
+            "live_capital_authorized": False,
+            "final_promotion_requires_live_paper_runtime_proof": True,
             "deployable_lower_bound_missing_count": deployable_missing_count,
             "deployable_lower_bound_failed_gate_count": deployable_failed_gate_count,
             "promotion_allowed": False,
@@ -11095,6 +11165,25 @@ def _candidate_board_runtime_window_import_plan(
                     ),
                     "probation_target_shortfall": _string(
                         row.get("probation_target_shortfall")
+                    ),
+                    "probation_target_progress_ratio": _string(
+                        row.get("probation_target_progress_ratio")
+                    ),
+                    "required_notional_repair_scale_to_target": _string(
+                        row.get("required_notional_repair_scale_to_target")
+                    ),
+                    "required_notional_repair_scale_authority": _string(
+                        row.get("required_notional_repair_scale_authority")
+                    ),
+                    "live_paper_evidence_requirements": _string_list_from_value(
+                        row.get("live_paper_evidence_requirements")
+                    ),
+                    "safe_evidence_collection_path": _string_list_from_value(
+                        row.get("safe_evidence_collection_path")
+                    ),
+                    "live_capital_authorized": False,
+                    "final_promotion_requires_live_paper_runtime_proof": _boolish(
+                        row.get("final_promotion_requires_live_paper_runtime_proof")
                     ),
                     "promotion_allowed": False,
                     "final_promotion_authorized": False,

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -189,6 +189,23 @@ _PAPER_PROBATION_QUEUE_SURVIVAL_REASONS = frozenset(
     }
 )
 _PAPER_PROBATION_TARGET_SCALE_QUANTUM = Decimal("0.000001")
+_PAPER_PROBATION_LIVE_PAPER_EVIDENCE_REQUIREMENTS = (
+    "real_runtime_trade_decisions",
+    "broker_order_submissions_and_status_events",
+    "broker_fill_events",
+    "post_cost_costs_tca_and_execution_shortfall",
+    "source_backed_runtime_ledger_lineage",
+    "closed_flat_position_proof",
+    "broker_runtime_ledger_reconciliation",
+)
+_PAPER_PROBATION_SAFE_EVIDENCE_COLLECTION_PATH = (
+    "preserve_final_promotion_gates_fail_closed",
+    "import_exact_replay_runtime_window_metadata_without_live_submit",
+    "run_bounded_live_paper_probe_with_configured_paper_account_only",
+    "materialize_source_backed_runtime_ledger_lineage_for_decisions_orders_fills_costs",
+    "verify_closed_flat_positions_and_broker_runtime_ledger_reconciliation",
+    "reevaluate_post_cost_runtime_profitability_before_any_final_promotion",
+)
 _CONSISTENCY_REPAIR_ENTRY_KEYS = (
     "max_entries_per_session",
     "max_entries_per_day",
@@ -5155,6 +5172,12 @@ def _paper_probation_repair_plan(
         ),
         "target_scale_required": target_scale_required,
         "target_scale_authority": "planning_only_requires_bounded_paper_validation",
+        "live_paper_evidence_requirements": list(
+            _PAPER_PROBATION_LIVE_PAPER_EVIDENCE_REQUIREMENTS
+        ),
+        "safe_evidence_collection_path": list(
+            _PAPER_PROBATION_SAFE_EVIDENCE_COLLECTION_PATH
+        ),
         "target_progress_ratio": _decimal_payload(
             _paper_probation_target_progress(
                 net_pnl_per_day=net_pnl_per_day,
@@ -5166,6 +5189,7 @@ def _paper_probation_repair_plan(
         "repair_actions": repair_actions,
         "repair_blockers": list(dict.fromkeys(str(blocker) for blocker in blockers)),
         "diagnostics": [dict(diagnostic) for diagnostic in handoff_diagnostics],
+        "live_capital_authorized": False,
         "promotion_allowed": False,
         "final_promotion_authorized": False,
         "final_promotion_allowed": False,
@@ -5332,6 +5356,13 @@ def _build_paper_probation_shortlist(
             "required_actions_before_or_during_probation": list(
                 dict.fromkeys(required_actions)
             ),
+            "live_paper_evidence_requirements": repair_plan[
+                "live_paper_evidence_requirements"
+            ],
+            "safe_evidence_collection_path": repair_plan[
+                "safe_evidence_collection_path"
+            ],
+            "live_capital_authorized": False,
             "recommended_notional_scale": _decimal_payload(
                 capital_repair_notional_scale
             ),

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -8980,6 +8980,27 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             probation_candidate["selection_reason"], "target_met_but_oracle_blocked"
         )
+        self.assertEqual(probation_candidate["probation_target_shortfall"], "0")
+        self.assertEqual(probation_candidate["probation_target_progress_ratio"], "1.05")
+        self.assertEqual(
+            probation_candidate["required_notional_repair_scale_to_target"], "1"
+        )
+        self.assertIn(
+            "real_runtime_trade_decisions",
+            probation_candidate["live_paper_evidence_requirements"],
+        )
+        self.assertIn(
+            "broker_runtime_ledger_reconciliation",
+            probation_candidate["live_paper_evidence_requirements"],
+        )
+        self.assertIn(
+            "import_exact_replay_runtime_window_metadata_without_live_submit",
+            probation_candidate["safe_evidence_collection_path"],
+        )
+        self.assertFalse(probation_candidate["live_capital_authorized"])
+        self.assertTrue(
+            probation_candidate["final_promotion_requires_live_paper_runtime_proof"]
+        )
         self.assertEqual(
             probation_candidate["runtime_ledger_lineage_materialization_handoff"],
             expected_runtime_ledger_handoff,
@@ -9110,6 +9131,18 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertTrue(import_metadata["paper_probation_authorized"])
         self.assertFalse(import_metadata["promotion_allowed"])
         self.assertFalse(import_metadata["final_promotion_authorized"])
+        self.assertEqual(
+            import_metadata["required_notional_repair_scale_to_target"], "1"
+        )
+        self.assertIn(
+            "broker_fill_events",
+            import_metadata["live_paper_evidence_requirements"],
+        )
+        self.assertIn(
+            "materialize_source_backed_runtime_ledger_lineage_for_decisions_orders_fills_costs",
+            import_metadata["safe_evidence_collection_path"],
+        )
+        self.assertFalse(import_metadata["live_capital_authorized"])
         self.assertEqual(target["handoff"], "runtime_window_import_only")
         self.assertEqual(
             target["promotion_gate"], "existing_runtime_governance_fail_closed"
@@ -9407,6 +9440,19 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             probation_candidate["probation_lower_bound_net_pnl_per_day"], "430"
         )
         self.assertEqual(probation_candidate["probation_target_shortfall"], "70")
+        self.assertEqual(probation_candidate["probation_target_progress_ratio"], "0.86")
+        self.assertEqual(
+            probation_candidate["required_notional_repair_scale_to_target"], "1.1628"
+        )
+        self.assertIn(
+            "post_cost_costs_tca_and_execution_shortfall",
+            probation_candidate["live_paper_evidence_requirements"],
+        )
+        self.assertIn(
+            "verify_closed_flat_positions_and_broker_runtime_ledger_reconciliation",
+            probation_candidate["safe_evidence_collection_path"],
+        )
+        self.assertFalse(probation_candidate["live_capital_authorized"])
         self.assertEqual(
             probation_candidate["deployable_lower_bound_missing_count"],
             0,

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2746,6 +2746,20 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             "64.37503114",
         )
         self.assertIn(
+            "post_cost_costs_tca_and_execution_shortfall",
+            item["live_paper_evidence_requirements"],
+        )
+        self.assertIn(
+            "source_backed_runtime_ledger_lineage",
+            item["paper_probation_repair_plan"]["live_paper_evidence_requirements"],
+        )
+        self.assertIn(
+            "verify_closed_flat_positions_and_broker_runtime_ledger_reconciliation",
+            item["safe_evidence_collection_path"],
+        )
+        self.assertFalse(item["live_capital_authorized"])
+        self.assertFalse(item["paper_probation_repair_plan"]["live_capital_authorized"])
+        self.assertIn(
             "validate_target_notional_scale_capacity_before_paper_orders",
             item["paper_probation_repair_plan"]["repair_actions"],
         )


### PR DESCRIPTION
## Summary

- Adds explicit live-paper evidence requirements to paper-probation frontier repair plans and candidate-board handoffs.
- Surfaces the safe evidence-collection path while keeping live capital and final promotion gates fail-closed.
- Adds target-progress and required notional repair-scale fields for candidate-board paper probation entries and runtime-window import metadata.
- Covers the new handoff fields with focused paper-probation regression assertions.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -k paper_probation -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "paper_probation" -q`
- `uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
