### PR TITLE
fix(torghut): size paper targets from notional

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -953,6 +953,61 @@ def _target_probe_symbol_quantities(
     return quantities
 
 
+@dataclass(frozen=True)
+class _TargetProbeQuantityResolution:
+    qty: Decimal
+    audit: dict[str, Any]
+    price_params: dict[str, Any]
+
+
+def _target_probe_symbol_notional_budget(
+    *,
+    target: Mapping[str, Any],
+    symbol: str,
+    symbols: Sequence[str],
+    symbol_quantities: Mapping[str, Decimal],
+    max_notional: Decimal,
+) -> Decimal | None:
+    target_notional = _target_probe_cap(target) or max_notional
+    if target_notional <= 0 or max_notional <= 0:
+        return None
+    budget = min(target_notional, max_notional)
+    normalized_symbols = [
+        item.strip().upper() for item in symbols if item.strip()
+    ]
+    if symbol not in normalized_symbols:
+        return None
+    weights = {
+        item: symbol_quantities[item]
+        for item in normalized_symbols
+        if symbol_quantities.get(item, Decimal("0")) > 0
+    }
+    if weights:
+        total_weight = sum(weights.values(), Decimal("0"))
+        if total_weight > 0:
+            return budget * (weights.get(symbol, Decimal("0")) / total_weight)
+    return budget / Decimal(len(normalized_symbols))
+
+
+def _quote_snapshot_reference_price(
+    snapshot: Mapping[str, Any],
+    *,
+    action: Literal["buy", "sell"],
+) -> Decimal | None:
+    bid = _decimal_from_mapping(snapshot, ("bid", "bid_px", "bid_price", "bp"))
+    ask = _decimal_from_mapping(snapshot, ("ask", "ask_px", "ask_price", "ap"))
+    price = _decimal_from_mapping(snapshot, ("price", "mid", "mid_price", "midpoint"))
+    if action == "buy" and ask is not None and ask > 0:
+        return ask
+    if action == "sell" and bid is not None and bid > 0:
+        return bid
+    if bid is not None and ask is not None and bid > 0 and ask >= bid:
+        return (bid + ask) / Decimal("2")
+    if price is not None and price > 0:
+        return price
+    return None
+
+
 def _target_pair_balance_state(
     target: Mapping[str, Any],
     symbol_actions: Mapping[str, Literal["buy", "sell"]],
@@ -3118,13 +3173,36 @@ class SimpleTradingPipeline(TradingPipeline):
                 else raw_created_at.replace(tzinfo=timezone.utc)
             )
         event_ts = event_ts.astimezone(timezone.utc)
-        qty = (
-            _optional_decimal(payload.get("qty"))
-            or symbol_quantities.get(symbol)
-            or Decimal("1")
+        timeframe = (
+            _safe_text(payload.get("timeframe"))
+            or strategy.base_timeframe
+            or "1Min"
         )
-        if qty <= 0:
+        payload_qty = _optional_decimal(payload.get("qty"))
+        if payload_qty is not None and payload_qty <= 0:
             return None
+        requested_qty = payload_qty or symbol_quantities.get(symbol) or Decimal("1")
+        quantity_resolution = self._paper_route_target_quantity_resolution(
+            target=target,
+            symbol=symbol,
+            symbols=target_symbols,
+            action=action,
+            requested_qty=requested_qty,
+            symbol_quantities=symbol_quantities,
+            max_notional=max_notional,
+            event_ts=event_ts,
+            timeframe=timeframe,
+        )
+        if quantity_resolution is None:
+            return None
+        qty = quantity_resolution.qty
+        metadata["paper_route_target_notional_sizing"] = quantity_resolution.audit
+        simple_lane["paper_route_target_notional_sizing"] = quantity_resolution.audit
+        simple_lane["target_source_notional_sized"] = (
+            quantity_resolution.audit.get("sizing_source") == "target_notional"
+        )
+        params["paper_route_target_notional_sizing"] = quantity_resolution.audit
+        params.update(quantity_resolution.price_params)
 
         order_type_text = _safe_text(payload.get("order_type")) or "market"
         order_type: Literal["market", "limit", "stop", "stop_limit"] = (
@@ -3146,9 +3224,7 @@ class SimpleTradingPipeline(TradingPipeline):
             strategy_id=str(strategy.id),
             symbol=symbol,
             event_ts=event_ts or now,
-            timeframe=_safe_text(payload.get("timeframe"))
-            or strategy.base_timeframe
-            or "1Min",
+            timeframe=timeframe,
             action=action,
             qty=qty,
             order_type=order_type,
@@ -3728,6 +3804,161 @@ class SimpleTradingPipeline(TradingPipeline):
         if snapshot.quote_source is not None:
             payload["quote_source"] = snapshot.quote_source
         return payload
+
+    def _paper_route_target_sizing_price(
+        self,
+        *,
+        target: Mapping[str, Any],
+        symbol: str,
+        action: Literal["buy", "sell"],
+        event_ts: datetime,
+        timeframe: str,
+    ) -> tuple[Decimal | None, dict[str, Any], str | None]:
+        target_snapshot = _target_metadata_quote_snapshot(
+            target,
+            symbol=symbol,
+        ) or _quote_snapshot_from_mapping(target, symbol=symbol)
+        if target_snapshot is not None:
+            reference_price = _quote_snapshot_reference_price(
+                target_snapshot,
+                action=action,
+            )
+            if reference_price is not None and reference_price > 0:
+                price_params = self._paper_route_params_with_quote_snapshot(
+                    {},
+                    target_snapshot,
+                    signal_price=None,
+                )
+                price_params["price"] = reference_price
+                price_params["reference_price"] = reference_price
+                return reference_price, price_params, "target_plan_quote_snapshot"
+
+        price_fetcher = getattr(self, "price_fetcher", None)
+        if price_fetcher is None:
+            return None, {}, None
+        try:
+            snapshot = price_fetcher.fetch_market_snapshot(
+                SignalEnvelope(
+                    event_ts=event_ts,
+                    symbol=symbol,
+                    payload={},
+                    timeframe=timeframe,
+                )
+            )
+        except Exception:
+            logger.exception(
+                "Failed to fetch paper-route target sizing quote symbol=%s timeframe=%s",
+                symbol,
+                timeframe,
+            )
+            return None, {}, None
+        if snapshot is None:
+            return None, {}, None
+        snapshot_payload = self._paper_route_price_snapshot_payload(snapshot)
+        reference_price = _quote_snapshot_reference_price(
+            snapshot_payload,
+            action=action,
+        )
+        if reference_price is None or reference_price <= 0:
+            return None, {"price_snapshot": snapshot_payload}, "price_fetcher_snapshot"
+        return (
+            reference_price,
+            {
+                "price": reference_price,
+                "reference_price": reference_price,
+                "price_snapshot": snapshot_payload,
+            },
+            "price_fetcher_snapshot",
+        )
+
+    def _paper_route_target_quantity_resolution(
+        self,
+        *,
+        target: Mapping[str, Any],
+        symbol: str,
+        symbols: Sequence[str],
+        action: Literal["buy", "sell"],
+        requested_qty: Decimal,
+        symbol_quantities: Mapping[str, Decimal],
+        max_notional: Decimal,
+        event_ts: datetime,
+        timeframe: str,
+    ) -> _TargetProbeQuantityResolution | None:
+        if requested_qty <= 0:
+            return None
+        normalized_symbol = symbol.strip().upper()
+        symbol_budget = _target_probe_symbol_notional_budget(
+            target=target,
+            symbol=normalized_symbol,
+            symbols=symbols,
+            symbol_quantities=symbol_quantities,
+            max_notional=max_notional,
+        )
+        reference_price, price_params, price_source = (
+            self._paper_route_target_sizing_price(
+                target=target,
+                symbol=normalized_symbol,
+                action=action,
+                event_ts=event_ts,
+                timeframe=timeframe,
+            )
+        )
+        audit: dict[str, Any] = {
+            "schema_version": "torghut.paper-route-target-notional-sizing.v1",
+            "symbol": normalized_symbol,
+            "action": action,
+            "sizing_source": "quantity_fallback",
+            "requested_qty": str(requested_qty),
+            "resolved_qty": str(requested_qty),
+            "target_notional": str(_target_probe_cap(target) or max_notional),
+            "paper_route_probe_max_notional": str(max_notional),
+            "symbol_notional_budget": (
+                str(symbol_budget) if symbol_budget is not None else None
+            ),
+            "reference_price": (
+                str(reference_price) if reference_price is not None else None
+            ),
+            "reference_price_source": price_source,
+            "symbols": [item.strip().upper() for item in symbols if item.strip()],
+            "blockers": [],
+        }
+        if reference_price is not None and reference_price > 0:
+            requested_notional = requested_qty * reference_price
+            audit["requested_notional"] = str(requested_notional)
+            if symbol_budget is not None and requested_notional > 0:
+                audit["notional_scale_gap"] = str(symbol_budget / requested_notional)
+
+        if symbol_budget is None or symbol_budget <= 0:
+            audit["blockers"] = ["paper_route_target_symbol_notional_budget_missing"]
+            return _TargetProbeQuantityResolution(
+                qty=requested_qty,
+                audit=audit,
+                price_params=price_params,
+            )
+        if reference_price is None or reference_price <= 0:
+            audit["blockers"] = ["paper_route_target_notional_price_missing"]
+            return _TargetProbeQuantityResolution(
+                qty=requested_qty,
+                audit=audit,
+                price_params=price_params,
+            )
+
+        resolved_qty = (symbol_budget / reference_price).quantize(
+            _PAPER_ROUTE_PROBE_QTY_STEP,
+            rounding=ROUND_DOWN,
+        )
+        if resolved_qty <= 0:
+            audit["blockers"] = ["paper_route_target_notional_qty_below_min_step"]
+            return None
+        audit["sizing_source"] = "target_notional"
+        audit["resolved_qty"] = str(resolved_qty)
+        audit["resolved_notional"] = str(resolved_qty * reference_price)
+        audit["overrode_requested_qty"] = resolved_qty != requested_qty
+        return _TargetProbeQuantityResolution(
+            qty=resolved_qty,
+            audit=audit,
+            price_params=price_params,
+        )
 
     @staticmethod
     def _paper_route_decision_requires_executable_quote(
@@ -5646,6 +5877,35 @@ class SimpleTradingPipeline(TradingPipeline):
                     or _safe_text(strategy.base_timeframe)
                     or "1Min"
                 )
+                requested_qty = symbol_quantities.get(symbol, Decimal("1"))
+                quantity_resolution = self._paper_route_target_quantity_resolution(
+                    target=target,
+                    symbol=symbol,
+                    symbols=symbols,
+                    action=action,
+                    requested_qty=requested_qty,
+                    symbol_quantities=symbol_quantities,
+                    max_notional=target_cap,
+                    event_ts=now,
+                    timeframe=timeframe,
+                )
+                if quantity_resolution is None:
+                    continue
+                qty = quantity_resolution.qty
+                metadata["paper_route_target_notional_sizing"] = (
+                    quantity_resolution.audit
+                )
+                simple_lane["paper_route_target_notional_sizing"] = (
+                    quantity_resolution.audit
+                )
+                simple_lane["target_source_notional_sized"] = (
+                    quantity_resolution.audit.get("sizing_source")
+                    == "target_notional"
+                )
+                params["paper_route_target_notional_sizing"] = (
+                    quantity_resolution.audit
+                )
+                params.update(quantity_resolution.price_params)
                 decisions.append(
                     StrategyDecision(
                         strategy_id=str(strategy.id),
@@ -5653,7 +5913,7 @@ class SimpleTradingPipeline(TradingPipeline):
                         event_ts=now,
                         timeframe=timeframe,
                         action=action,
-                        qty=symbol_quantities.get(symbol, Decimal("1")),
+                        qty=qty,
                         order_type="market",
                         time_in_force="day",
                         rationale="external paper-route target plan source decision",

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -17,10 +17,12 @@ from app.trading.scheduler.simple_pipeline import (
     SimpleTradingPipeline,
     _bounded_sim_collection_blockers,
     _bounded_sim_collection_metadata_from_decision,
+    _quote_snapshot_reference_price,
     _quote_snapshot_matches_symbol,
     _target_metadata_quote_snapshot,
-    _target_symbols,
+    _target_probe_symbol_notional_budget,
     _target_probe_symbol_quantities,
+    _target_symbols,
 )
 from app.trading.runtime_window_import import (
     _runtime_promotion_blocking_reasons,
@@ -377,6 +379,315 @@ def test_target_probe_symbol_quantities_apply_target_quantity_fallback() -> None
     )
 
     assert quantities == {"AAPL": Decimal("3"), "AMZN": Decimal("3")}
+
+
+def test_target_notional_budget_and_quote_reference_defensive_paths() -> None:
+    assert (
+        _target_probe_symbol_notional_budget(
+            target={"target_notional": "0"},
+            symbol="AAPL",
+            symbols=["AAPL"],
+            symbol_quantities={},
+            max_notional=Decimal("0"),
+        )
+        is None
+    )
+    assert (
+        _target_probe_symbol_notional_budget(
+            target={"target_notional": "100"},
+            symbol="MSFT",
+            symbols=["AAPL"],
+            symbol_quantities={},
+            max_notional=Decimal("100"),
+        )
+        is None
+    )
+    assert (
+        _quote_snapshot_reference_price(
+            {"bid": "99", "ask": "101"},
+            action="hold",  # type: ignore[arg-type]
+        )
+        == Decimal("100")
+    )
+    assert _quote_snapshot_reference_price({}, action="buy") is None
+
+
+def test_target_quantity_resolution_records_fallback_blockers() -> None:
+    now = datetime(2026, 6, 4, 14, 30, tzinfo=timezone.utc)
+    pipeline = object.__new__(SimpleTradingPipeline)
+    pipeline.price_fetcher = SimpleNamespace(
+        fetch_market_snapshot=lambda signal: MarketSnapshot(
+            symbol=signal.symbol,
+            as_of=signal.event_ts,
+            price=Decimal("100"),
+            spread=None,
+            source="fixture",
+        )
+    )
+
+    assert (
+        pipeline._paper_route_target_quantity_resolution(
+            target={"target_notional": "100"},
+            symbol="AAPL",
+            symbols=["AAPL"],
+            action="buy",
+            requested_qty=Decimal("0"),
+            symbol_quantities={},
+            max_notional=Decimal("100"),
+            event_ts=now,
+            timeframe="1Min",
+        )
+        is None
+    )
+
+    missing_budget = pipeline._paper_route_target_quantity_resolution(
+        target={"target_notional": "100"},
+        symbol="MSFT",
+        symbols=["AAPL"],
+        action="buy",
+        requested_qty=Decimal("1"),
+        symbol_quantities={},
+        max_notional=Decimal("100"),
+        event_ts=now,
+        timeframe="1Min",
+    )
+    assert missing_budget is not None
+    assert missing_budget.qty == Decimal("1")
+    assert missing_budget.audit["blockers"] == [
+        "paper_route_target_symbol_notional_budget_missing"
+    ]
+
+    no_price_pipeline = object.__new__(SimpleTradingPipeline)
+    no_price = no_price_pipeline._paper_route_target_quantity_resolution(
+        target={"target_notional": "100"},
+        symbol="AAPL",
+        symbols=["AAPL"],
+        action="buy",
+        requested_qty=Decimal("1"),
+        symbol_quantities={},
+        max_notional=Decimal("100"),
+        event_ts=now,
+        timeframe="1Min",
+    )
+    assert no_price is not None
+    assert no_price.audit["blockers"] == ["paper_route_target_notional_price_missing"]
+
+    too_small = pipeline._paper_route_target_quantity_resolution(
+        target={"target_notional": "0.000001"},
+        symbol="AAPL",
+        symbols=["AAPL"],
+        action="buy",
+        requested_qty=Decimal("1"),
+        symbol_quantities={},
+        max_notional=Decimal("0.000001"),
+        event_ts=now,
+        timeframe="1Min",
+    )
+    assert too_small is None
+
+
+def test_target_sizing_price_uses_target_snapshot_and_handles_fetcher_failures() -> (
+    None
+):
+    now = datetime(2026, 6, 4, 14, 30, tzinfo=timezone.utc)
+    pipeline = object.__new__(SimpleTradingPipeline)
+    reference_price, price_params, price_source = pipeline._paper_route_target_sizing_price(
+        target={"price_snapshot": {"symbol": "AAPL", "bid": "99", "ask": "101"}},
+        symbol="AAPL",
+        action="buy",
+        event_ts=now,
+        timeframe="1Min",
+    )
+    assert reference_price == Decimal("101")
+    assert price_params["reference_price"] == Decimal("101")
+    assert price_source == "target_plan_quote_snapshot"
+
+    no_fetcher = object.__new__(SimpleTradingPipeline)
+    assert no_fetcher._paper_route_target_sizing_price(
+        target={},
+        symbol="AAPL",
+        action="buy",
+        event_ts=now,
+        timeframe="1Min",
+    ) == (None, {}, None)
+
+    class RaisingFetcher:
+        def fetch_market_snapshot(self, signal: object) -> MarketSnapshot | None:
+            raise RuntimeError("boom")
+
+    failing = object.__new__(SimpleTradingPipeline)
+    failing.price_fetcher = RaisingFetcher()
+    assert failing._paper_route_target_sizing_price(
+        target={},
+        symbol="AAPL",
+        action="buy",
+        event_ts=now,
+        timeframe="1Min",
+    ) == (None, {}, None)
+
+    invalid = object.__new__(SimpleTradingPipeline)
+    invalid.price_fetcher = SimpleNamespace(
+        fetch_market_snapshot=lambda signal: MarketSnapshot(
+            symbol="AAPL",
+            as_of=now,
+            price=None,
+            spread=None,
+            source="fixture",
+        )
+    )
+    reference_price, price_params, price_source = invalid._paper_route_target_sizing_price(
+        target={},
+        symbol="AAPL",
+        action="buy",
+        event_ts=now,
+        timeframe="1Min",
+    )
+    assert reference_price is None
+    assert "price_snapshot" in price_params
+    assert price_source == "price_fetcher_snapshot"
+
+
+def test_target_source_decisions_size_default_quantities_from_target_notional(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    allow_shorts_before = settings.trading_allow_shorts
+    try:
+        settings.trading_mode = "paper"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_allow_shorts = True
+        now = datetime(2026, 6, 4, 14, 30, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            target_notional="20000",
+            paper_route_probe_next_session_max_notional="20000",
+            paper_route_probe_window_start="2026-06-04T13:30:00+00:00",
+            paper_route_probe_window_end="2026-06-04T20:00:00+00:00",
+            paper_route_probe_symbol_actions={"AAPL": "buy", "AMZN": "sell"},
+            paper_route_probe_symbol_quantities={"AAPL": "1", "AMZN": "1"},
+        )
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="metadata fixture",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "TORGHUT_SIM"
+        pipeline.price_fetcher = SimpleNamespace(
+            fetch_market_snapshot=lambda signal: MarketSnapshot(
+                symbol=signal.symbol,
+                as_of=signal.event_ts,
+                price=Decimal("100"),
+                spread=Decimal("0"),
+                source="fixture",
+                bid=Decimal("100"),
+                ask=Decimal("100"),
+            )
+        )
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+            {"AAPL", "AMZN"},
+            None,
+            [target],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[strategy],
+            allowed_symbols={"AAPL", "AMZN"},
+            positions=[],
+            session=None,
+        )
+
+        assert {decision.symbol: decision.qty for decision in decisions} == {
+            "AAPL": Decimal("100.0000"),
+            "AMZN": Decimal("100.0000"),
+        }
+        for decision in decisions:
+            sizing = decision.params["paper_route_target_notional_sizing"]
+            assert sizing["sizing_source"] == "target_notional"
+            assert sizing["requested_qty"] == "1"
+            assert Decimal(str(sizing["symbol_notional_budget"])) == Decimal("10000")
+            assert sizing["reference_price"] == "100"
+            assert sizing["overrode_requested_qty"] is True
+            assert decision.params["reference_price"] == Decimal("100")
+            assert (
+                decision.params["simple_lane"]["paper_route_target_notional_sizing"]
+                == sizing
+            )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_allow_shorts = allow_shorts_before
+
+
+def test_target_source_decisions_skip_target_notional_below_min_step(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    allow_shorts_before = settings.trading_allow_shorts
+    try:
+        settings.trading_mode = "paper"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_allow_shorts = True
+        now = datetime(2026, 6, 4, 14, 30, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            target_notional="0.000001",
+            paper_route_probe_next_session_max_notional="0.000001",
+            paper_route_probe_window_start="2026-06-04T13:30:00+00:00",
+            paper_route_probe_window_end="2026-06-04T20:00:00+00:00",
+            paper_route_probe_symbol_actions={"AAPL": "buy", "AMZN": "sell"},
+            paper_route_probe_symbol_quantities={"AAPL": "1", "AMZN": "1"},
+        )
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="metadata fixture",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "TORGHUT_SIM"
+        pipeline.price_fetcher = SimpleNamespace(
+            fetch_market_snapshot=lambda signal: MarketSnapshot(
+                symbol=signal.symbol,
+                as_of=signal.event_ts,
+                price=Decimal("100"),
+                spread=None,
+                source="fixture",
+            )
+        )
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+            {"AAPL", "AMZN"},
+            None,
+            [target],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[strategy],
+            allowed_symbols={"AAPL", "AMZN"},
+            positions=[],
+            session=None,
+        )
+
+        assert decisions == []
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_allow_shorts = allow_shorts_before
 
 
 def test_target_symbols_accept_action_and_execution_source_fields() -> None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -7240,7 +7240,7 @@ class TestTradingPipeline(TestCase):
 
         self.assertEqual(len(alpaca_client.submitted), 1)
         self.assertEqual(alpaca_client.submitted[0]["side"], "buy")
-        self.assertEqual(alpaca_client.submitted[0]["qty"], "2.5")
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "2.4997")
         with self.session_local() as session:
             decisions = list(session.execute(select(TradeDecision)).scalars())
             executions = list(session.execute(select(Execution)).scalars())
@@ -7265,8 +7265,8 @@ class TestTradingPipeline(TestCase):
             )
 
             self.assertEqual(decision.status, "submitted")
-            self.assertEqual(Decimal(str(decision_json["qty"])), Decimal("2.5"))
-            self.assertEqual(execution.submitted_qty, Decimal("2.50000000"))
+            self.assertEqual(Decimal(str(decision_json["qty"])), Decimal("2.4997"))
+            self.assertEqual(execution.submitted_qty, Decimal("2.49970000"))
             created_at = decision.created_at
             if created_at.tzinfo is None:
                 created_at = created_at.replace(tzinfo=timezone.utc)
@@ -7333,15 +7333,15 @@ class TestTradingPipeline(TestCase):
                 paper_route_probe["exit_due_at"],
                 "2026-05-26T15:30:00+00:00",
             )
-            self.assertEqual(paper_route_probe["capped_qty"], "2.5000")
+            self.assertEqual(paper_route_probe["capped_qty"], "2.4997")
             self.assertEqual(
-                Decimal(str(paper_route_probe["capped_notional"])), Decimal("250")
+                Decimal(str(paper_route_probe["capped_notional"])), Decimal("249.994997")
             )
             self.assertTrue(paper_route_probe["target_source_notional_sized"])
-            self.assertEqual(Decimal(str(simple_lane["final_qty"])), Decimal("2.5"))
-            self.assertEqual(Decimal(str(simple_lane["notional"])), Decimal("250"))
-            self.assertEqual(simple_lane_precheck["requested_qty"], "2.5000")
-            self.assertEqual(simple_lane_precheck["final_qty"], "2.5000")
+            self.assertEqual(Decimal(str(simple_lane["final_qty"])), Decimal("2.4997"))
+            self.assertEqual(Decimal(str(simple_lane["notional"])), Decimal("249.994997"))
+            self.assertEqual(simple_lane_precheck["requested_qty"], "2.4997")
+            self.assertEqual(simple_lane_precheck["final_qty"], "2.4997")
             self.assertEqual(
                 bounded_execution_policy["authority"],
                 "bounded_paper_route_collection_only",
@@ -9208,7 +9208,7 @@ class TestTradingPipeline(TestCase):
         evaluate_signals.assert_called_once()
         self.assertEqual(len(alpaca_client.submitted), 1)
         self.assertEqual(alpaca_client.submitted[0]["side"], "buy")
-        self.assertEqual(alpaca_client.submitted[0]["qty"], "0.25")
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "0.2499")
         with self.session_local() as session:
             decision = session.execute(select(TradeDecision)).scalar_one()
             decision_json = cast(dict[str, Any], decision.decision_json)

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8099,6 +8099,7 @@ class TestTradingPipeline(TestCase):
             state=TradingState(),
             account_label="TORGHUT_SIM",
             session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(Decimal("100")),
         )
         window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
         window_end = datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc)
@@ -8151,6 +8152,13 @@ class TestTradingPipeline(TestCase):
             typed_decision.event_ts,
             datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc),
         )
+        self.assertEqual(typed_decision.qty, Decimal("2.0000"))
+        sizing = typed_decision.params["paper_route_target_notional_sizing"]
+        self.assertEqual(sizing["sizing_source"], "target_notional")
+        self.assertEqual(sizing["requested_qty"], "1")
+        self.assertEqual(sizing["resolved_qty"], "2.0000")
+        self.assertEqual(sizing["symbol_notional_budget"], "200")
+        self.assertEqual(typed_decision.params["reference_price"], Decimal("100"))
 
         rejected = pipeline._paper_route_materialized_decision_with_execution_metadata(
             decision_row=decision_row,


### PR DESCRIPTION
## Summary

- Sizes bounded paper-route target-plan decisions from target notional and executable reference price instead of blindly preserving default 1-share quantities.
- Applies the same notional sizing to materialized target-plan replay decisions so imported proof windows do not replay undersized rows.
- Persists `paper_route_target_notional_sizing` audit metadata with requested quantity, resolved quantity, symbol budget, reference price, and fallback blockers.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_simple_pipeline.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'target_source_decisions or materialized_target_plan_decision_builder_defaults_event_time or simple_pipeline_submits_materialized_target_plan_source_decisions'`
- `uv run --frozen pytest tests/test_simple_pipeline.py tests/test_trading_pipeline.py -k 'target_notional_budget or target_quantity_resolution or target_sizing_price or target_source_decisions or materialized_target_plan_decision_builder_defaults_event_time or simple_pipeline_submits_materialized_target_plan_source_decisions'`
- `uv run --frozen python -m py_compile app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin-https/main` after focused coverage generation: changed-line coverage `105/106 (99.06%)`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
