### PR TITLE
docs(torghut): tag hawkes stress sources

### DIFF
--- a/services/torghut/app/trading/discovery/hawkes_transient_impact_stress.py
+++ b/services/torghut/app/trading/discovery/hawkes_transient_impact_stress.py
@@ -39,6 +39,26 @@ HAWKES_TRANSIENT_IMPACT_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = 
         "date": "2026-04-04",
         "mechanism": "nonlinear_square_root_impact_permanent_decay_and_trade_level_cost_logging_change_replay_rankings",
     },
+    {
+        "source_id": "ssrn-5170318",
+        "url": "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5170318",
+        "title": "Assessing the Impact of the Order Book with a Hawkes Process in a Random Environment",
+        "date": "2025-03-08",
+        "mechanism": "order_book_conditioned_hawkes_arrivals_require_session_specific_execution_context",
+    },
+    {
+        "source_id": "arxiv-2604.23961",
+        "url": "https://arxiv.org/abs/2604.23961",
+        "title": "Extended State-dependent Hawkes Process for Limit Order Books: Mathematical Foundation and the Reproduction of Volatility Signature Plots",
+        "date": "2026-04-27",
+        "mechanism": "state_dependent_lob_hawkes_models_require_physical_consistency_and_marketable_limit_order_context",
+    },
+)
+HAWKES_TRANSIENT_IMPACT_STRESS_SOURCE_MARKERS: tuple[str, ...] = (
+    "hawkes_transient_impact_arxiv_2504_10282_2025",
+    "realistic_market_impact_arxiv_2603_29086_2026",
+    "orderbook_hawkes_random_environment_ssrn_5170318_2025",
+    "state_dependent_hawkes_arxiv_2604_23961_2026",
 )
 
 _PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
@@ -139,6 +159,7 @@ class HawkesTransientImpactStressSummary:
             "source_papers": [
                 dict(item) for item in HAWKES_TRANSIENT_IMPACT_STRESS_PRIMARY_SOURCES
             ],
+            "source_markers": list(HAWKES_TRANSIENT_IMPACT_STRESS_SOURCE_MARKERS),
             "row_count": self.row_count,
             "event_observation_count": self.event_observation_count,
             "signed_event_count": self.signed_event_count,
@@ -209,6 +230,7 @@ def hawkes_transient_impact_stress_contract() -> dict[str, Any]:
         "source_papers": [
             dict(item) for item in HAWKES_TRANSIENT_IMPACT_STRESS_PRIMARY_SOURCES
         ],
+        "source_markers": list(HAWKES_TRANSIENT_IMPACT_STRESS_SOURCE_MARKERS),
         "stress_policy": "hawkes_event_time_transient_impact_execution_replay_guard",
         "stress_components": [
             "burst_event_share",

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -798,6 +798,10 @@ class TestFastReplayPreview(TestCase):
                 ]
             },
         )
+        self.assertIn(
+            "state_dependent_hawkes_arxiv_2604_23961_2026",
+            row_payload["hawkes_transient_impact_stress"]["source_markers"],
+        )
         self.assertFalse(
             row_payload["hawkes_transient_impact_stress"]["proof_authority"]
         )

--- a/services/torghut/tests/test_hawkes_transient_impact_stress.py
+++ b/services/torghut/tests/test_hawkes_transient_impact_stress.py
@@ -95,6 +95,14 @@ class TestHawkesTransientImpactStress(TestCase):
             "preview_only_hawkes_transient_impact_stress_ranking",
         )
         self.assertTrue(payload["hawkes_excitation_preview"])
+        self.assertIn(
+            "hawkes_transient_impact_arxiv_2504_10282_2025",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "state_dependent_hawkes_arxiv_2604_23961_2026",
+            payload["source_markers"],
+        )
         self.assertTrue(payload["transient_impact_preview"])
         self.assertTrue(payload["square_root_impact_preview"])
         self.assertFalse(payload["proof_authority"])
@@ -151,6 +159,16 @@ class TestHawkesTransientImpactStress(TestCase):
         source_ids = {source["source_id"] for source in contract["source_papers"]}
         self.assertIn("arxiv-2504.10282", source_ids)
         self.assertIn("arxiv-2603.29086", source_ids)
+        self.assertIn("ssrn-5170318", source_ids)
+        self.assertIn("arxiv-2604.23961", source_ids)
+        self.assertIn(
+            "orderbook_hawkes_random_environment_ssrn_5170318_2025",
+            contract["source_markers"],
+        )
+        self.assertIn(
+            "state_dependent_hawkes_arxiv_2604_23961_2026",
+            contract["source_markers"],
+        )
         proof_neutrality = contract["proof_neutrality"]
         self.assertTrue(proof_neutrality["requires_exact_replay"])
         self.assertTrue(proof_neutrality["requires_event_time_replay"])


### PR DESCRIPTION
## Summary

- Tags Hawkes transient-impact replay stress with source markers for transient Hawkes execution, realistic impact, order-book conditioned Hawkes, and state-dependent LOB Hawkes sources.
- Adds the existing curated 2025 SSRN order-book Hawkes source and 2026 state-dependent LOB Hawkes source to the Hawkes stress contract source list.
- Keeps the stress preview-only and proof-neutral; modeled Hawkes intensity and impact remain ranking signals only and do not authorize fills, PnL, promotion, or capital.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/hawkes_transient_impact_stress.py tests/test_hawkes_transient_impact_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_hawkes_transient_impact_stress.py tests/test_fast_replay.py::TestFastReplayPreview::test_whitepaper_features_rank_and_label_preview_only`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv sync --frozen --extra dev` failed before dependency sync completed because `crosshair-tool==0.0.102` attempted to compile `_crosshair_tracers` and `cc` is unavailable in this container.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
