### PR TITLE
fix(torghut): require bounded materialization targets

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -235,8 +235,16 @@ def _nested_mapping(payload: Mapping[str, Any], *keys: str) -> dict[str, Any]:
     return _to_str_map(current)
 
 
+def _target_bounded_materialization_authorized(target: Mapping[str, Any]) -> bool:
+    return _truthy(target.get("bounded_evidence_collection_authorized")) and _truthy(
+        target.get("evidence_collection_ok")
+    )
+
+
 def _target_materialization_score(target: Mapping[str, Any]) -> tuple[int, int, int]:
+    bounded_authorized = int(_target_bounded_materialization_authorized(target))
     return (
+        bounded_authorized,
         int(
             _safe_text(target.get("hypothesis_id"))
             == PAPER_ROUTE_MATERIALIZATION_HPAIRS_HYPOTHESIS_ID
@@ -246,23 +254,22 @@ def _target_materialization_score(target: Mapping[str, Any]) -> tuple[int, int, 
             and _target_notional(target) > 0
             and _target_quantity(target) > 0
         ),
-        int(_truthy(target.get("bounded_evidence_collection_authorized"))),
     )
 
 
 def _plan_materialization_score(plan: Mapping[str, Any]) -> tuple[int, int, int, int]:
+    bounded_authorized = 0
     hpairs = 0
     materializable_shape = 0
-    bounded_authorized = 0
     targets = paper_route_target_plan_targets(plan)
     for target in targets:
-        target_hpairs, target_shape, target_authorized = _target_materialization_score(
+        target_authorized, target_hpairs, target_shape = _target_materialization_score(
             target
         )
+        bounded_authorized += target_authorized
         hpairs += target_hpairs
         materializable_shape += target_shape
-        bounded_authorized += target_authorized
-    return (materializable_shape, bounded_authorized, hpairs, len(targets))
+    return (bounded_authorized, hpairs, materializable_shape, len(targets))
 
 
 def _candidate_materialization_plans(
@@ -484,6 +491,9 @@ def _target_summaries(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
         actions = _target_symbol_actions(target)
         quantities = _target_symbol_quantities(target)
         target_notional = _target_notional(target)
+        bounded_evidence_collection_authorized = _truthy(
+            target.get("bounded_evidence_collection_authorized")
+        )
         summaries.append(
             {
                 "target_index": index,
@@ -507,6 +517,13 @@ def _target_summaries(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
                 or _safe_text(target.get("observed_stage")),
                 "target_notional": _decimal_text(target_notional),
                 "target_quantity": _decimal_text(_target_quantity(target)),
+                "bounded_evidence_collection_authorized": (
+                    bounded_evidence_collection_authorized
+                ),
+                "bounded_materialization_authorized": (
+                    _target_bounded_materialization_authorized(target)
+                ),
+                "evidence_collection_ok": _truthy(target.get("evidence_collection_ok")),
                 "symbols": sorted(actions),
                 "symbol_actions": actions,
                 "symbol_quantities": {
@@ -829,6 +846,14 @@ def _safety_blockers(
         if _safe_decimal(summary.get("target_quantity")) <= 0:
             blockers.append(
                 f"paper_route_materialization_target_{index}_target_quantity_missing"
+            )
+        if not _truthy(summary.get("evidence_collection_ok")):
+            blockers.append(
+                f"paper_route_materialization_target_{index}_evidence_collection_ok_required"
+            )
+        if not _truthy(summary.get("bounded_evidence_collection_authorized")):
+            blockers.append(
+                f"paper_route_materialization_target_{index}_bounded_evidence_collection_authorized_required"
             )
         if not cast(Sequence[object], summary.get("symbols", [])):
             blockers.append(

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -605,6 +605,9 @@ def test_paper_route_target_plan_target_summary_accepts_explicit_quantity_and_sy
             "bounded_collection_stage": "paper",
             "target_notional": "20",
             "target_quantity": "3",
+            "bounded_evidence_collection_authorized": True,
+            "bounded_materialization_authorized": True,
+            "evidence_collection_ok": True,
             "symbols": ["AAPL", "AMZN"],
             "symbol_actions": {"AAPL": "buy", "AMZN": "sell"},
             "symbol_quantities": {"AAPL": "3", "AMZN": "3"},
@@ -721,6 +724,109 @@ def test_url_payload_prefers_nested_hpairs_materialization_plan(
     assert report["materialized_decision_count"] == 2
     assert report["route_submission_count"] == 2
     assert report["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_url_payload_prefers_bounded_plan_over_larger_source_collection_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source_collection_hpairs = _hpairs_target(
+        candidate_id="source-collection-hpairs",
+        bounded_evidence_collection_authorized=False,
+        evidence_collection_ok=True,
+    )
+    source_collection_tsmom = _tsmom_target(
+        bounded_evidence_collection_authorized=False,
+        evidence_collection_ok=True,
+    )
+    payload = {
+        "schema_version": "torghut.paper-route-target-plan.v1",
+        "next_paper_route_runtime_window_targets": _plan(
+            source_collection_hpairs,
+            source_collection_tsmom,
+        ),
+        "live_submission_gate": {
+            "runtime_ledger_paper_probation_import_plan": _plan(_hpairs_target())
+        },
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--max-notional",
+            "25",
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["plan_source"]["selected_plan"] == (
+        "live_submission_gate.runtime_ledger_paper_probation_import_plan"
+    )
+    assert report["candidate_ids"] == ["c88421d619759b2cfaa6f4d0"]
+    assert report["hypothesis_ids"] == ["H-PAIRS-01"]
+    assert report["materialized_decision_count"] == 2
+    assert report["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 0
+
+
+def test_source_collection_only_plan_blocks_materialization_before_db_write(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "schema_version": "torghut.paper-route-target-plan.v1",
+        "next_paper_route_runtime_window_targets": _plan(
+            _hpairs_target(
+                bounded_evidence_collection_authorized=False,
+                evidence_collection_ok=True,
+            ),
+        ),
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "25",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            "next_paper_route_runtime_window_targets",
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "25",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert report["materialized"] is False
+    assert report["blocked"] is True
+    assert (
+        "paper_route_materialization_target_0_bounded_evidence_collection_authorized_required"
+        in report["blockers"]
+    )
     assert _count_decisions(sqlite_dsn) == 0
 
 


### PR DESCRIPTION
## Summary

- Prioritizes bounded, evidence-authorized target plans when the materializer chooses among nested paper-route target-plan surfaces.
- Adds an explicit fail-closed preflight blocker when a selected target is source-collection-only or lacks the bounded evidence-collection authorization needed to create planned paper-route decisions.
- Covers the stale source-collection selection path with regression tests so aggregate/import-only targets cannot be materialized as authority-grade paper-route decisions.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev` — pass
- `cd services/torghut && uv run --frozen ruff format --check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py` — pass
- `cd services/torghut && uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py` — pass
- `cd services/torghut && uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py` — pass
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json` — pass
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json` — pass
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json` — pass
- `git diff --check` — pass
- Live read-only dry run against `torghut-sim-01154` target-plan endpoint with the patched script selected `live_submission_gate.runtime_ledger_paper_probation_import_plan` and returned bounded-authorization blockers for source-collection-only targets instead of materializing them.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
