### PR TITLE
fix(torghut): require bootstrap robust evidence

### DIFF
--- a/services/torghut/app/trading/discovery/bootstrap_robust_optimization_stress.py
+++ b/services/torghut/app/trading/discovery/bootstrap_robust_optimization_stress.py
@@ -48,6 +48,10 @@ BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], .
         "mechanism": "adaptive_specification_search_falsification_effective_multiplicity_and_walk_forward_inflation_gap_stress",
     },
 )
+BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_SOURCE_MARKERS: tuple[str, ...] = (
+    "bootstrap_robust_optimization_arxiv_2510_12725_2025",
+    "spurious_predictability_arxiv_2604_15531_2026",
+)
 
 _POST_COST_UTILITY_BPS_FIELDS = (
     "post_cost_utility_bps",
@@ -119,6 +123,7 @@ class BootstrapRobustOptimizationStressSummary:
                 dict(item)
                 for item in BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_PRIMARY_SOURCES
             ],
+            "source_markers": list(BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_SOURCE_MARKERS),
             "row_count": self.row_count,
             "utility_observation_count": self.utility_observation_count,
             "fold_observation_count": self.fold_observation_count,
@@ -196,6 +201,7 @@ def bootstrap_robust_optimization_stress_contract() -> dict[str, Any]:
         "source_papers": [
             dict(item) for item in BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_PRIMARY_SOURCES
         ],
+        "source_markers": list(BOOTSTRAP_ROBUST_OPTIMIZATION_STRESS_SOURCE_MARKERS),
         "stress_policy": "stationary_block_bootstrap_percentile_utility_and_selection_bias_replay_ranking",
         "stress_components": [
             "stationary_block_bootstrap_utility_p20_bps",

--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -177,6 +177,34 @@ FILL_SURVIVAL_SCORECARD_KEYS = (
 RUNTIME_LEDGER_LINEAGE_HANDOFF_SCORECARD_KEYS = (
     "runtime_ledger_lineage_materialization_handoff",
 )
+BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS = (
+    "requires_bootstrap_robust_optimization",
+    "required_bootstrap_robust_optimization",
+    "requires_bootstrap_confidence_intervals",
+    "required_bootstrap_confidence_interval",
+    "requires_utility_percentile_optimization",
+    "required_utility_percentile_optimization",
+    "requires_selection_bias_stress",
+    "required_selection_bias_stress",
+    "requires_parameter_instability_stress",
+    "required_parameter_instability_stress",
+    "requires_model_misspecification_stress",
+    "required_model_misspecification_stress",
+    "required_min_bootstrap_replicates",
+    "bootstrap_robust_optimization_passed",
+    "bootstrap_robust_optimization_artifact_ref",
+    "bootstrap_robust_optimization_artifact_refs",
+    "bootstrap_confidence_interval_passed",
+    "bootstrap_replicate_count",
+    "bootstrap_robust_optimization_replicate_count",
+    "utility_percentile_optimization_passed",
+    "bootstrap_percentile_robust_net_pnl_per_day",
+    "selection_bias_stress_passed",
+    "parameter_instability_stress_passed",
+    "model_misspecification_stress_passed",
+    "out_of_sample_generalization_passed",
+    "bootstrap_robust_optimization_source_markers",
+)
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -1013,6 +1041,13 @@ def evidence_bundle_from_frontier_candidate(
             if key in source:
                 scorecard = {**scorecard, key: source[key]}
                 break
+    for key in BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS:
+        if key in scorecard:
+            continue
+        for source in (candidate, summary, full_window):
+            if key in source:
+                scorecard = {**scorecard, key: source[key]}
+                break
     for source in (candidate, summary, full_window):
         for key, value in _order_type_execution_metrics(source).items():
             if key not in scorecard:
@@ -1066,6 +1101,13 @@ def evidence_bundle_from_frontier_candidate(
     )
     if hard_vetoes and "hard_vetoes" not in scorecard:
         scorecard = {**scorecard, "hard_vetoes": list(hard_vetoes)}
+    for nested_contract in (
+        _mapping(candidate.get("hard_vetoes")),
+        _mapping(candidate.get("promotion_contract")),
+    ):
+        for key in BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS:
+            if key in nested_contract and key not in scorecard:
+                scorecard = {**scorecard, key: nested_contract[key]}
     replay_params = _frontier_replay_params(candidate)
     if replay_params and "runtime_params" not in scorecard:
         scorecard = {**scorecard, "runtime_params": replay_params}
@@ -1634,6 +1676,95 @@ def _implementation_risk_backtest_stability_blockers(
     return blockers
 
 
+def _bootstrap_robust_optimization_required(scorecard: Mapping[str, Any]) -> bool:
+    if any(
+        _bool(scorecard.get(key))
+        for key in (
+            "requires_bootstrap_robust_optimization",
+            "required_bootstrap_robust_optimization",
+            "requires_bootstrap_confidence_intervals",
+            "required_bootstrap_confidence_interval",
+            "requires_utility_percentile_optimization",
+            "required_utility_percentile_optimization",
+            "requires_selection_bias_stress",
+            "required_selection_bias_stress",
+            "requires_parameter_instability_stress",
+            "required_parameter_instability_stress",
+            "requires_model_misspecification_stress",
+            "required_model_misspecification_stress",
+        )
+    ):
+        return True
+    hard_vetoes = {veto.lower() for veto in _string_list(scorecard.get("hard_vetoes"))}
+    if hard_vetoes.intersection(
+        {
+            "required_bootstrap_robust_optimization",
+            "required_bootstrap_confidence_interval",
+            "required_utility_percentile_optimization",
+            "required_selection_bias_stress",
+            "required_parameter_instability_stress",
+            "required_model_misspecification_stress",
+            "required_distribution_free_confidence_intervals",
+        }
+    ):
+        return True
+    return bool(
+        {
+            marker.lower()
+            for marker in _string_list(
+                scorecard.get("bootstrap_robust_optimization_source_markers")
+            )
+        }.intersection(
+            {
+                "bootstrap_robust_optimization_arxiv_2510_12725_2025",
+                "spurious_predictability_arxiv_2604_15531_2026",
+            }
+        )
+    )
+
+
+def _bootstrap_robust_optimization_blockers(
+    scorecard: Mapping[str, Any],
+) -> list[str]:
+    if not _bootstrap_robust_optimization_required(scorecard):
+        return []
+
+    blockers: list[str] = []
+    if not _bool(scorecard.get("bootstrap_robust_optimization_passed")):
+        blockers.append("bootstrap_robust_optimization_missing_or_failed")
+    if not _has_artifact_ref(
+        scorecard,
+        "bootstrap_robust_optimization_artifact_ref",
+        "bootstrap_robust_optimization_artifact_refs",
+    ):
+        blockers.append("bootstrap_robust_optimization_artifact_missing")
+    required_replicates = max(
+        1,
+        _int(scorecard.get("required_min_bootstrap_replicates") or 500),
+    )
+    observed_replicates = max(
+        _int(scorecard.get("bootstrap_replicate_count")),
+        _int(scorecard.get("bootstrap_robust_optimization_replicate_count")),
+    )
+    if observed_replicates < required_replicates:
+        blockers.append("bootstrap_replicate_count_below_min")
+    if not _bool(scorecard.get("bootstrap_confidence_interval_passed")):
+        blockers.append("bootstrap_confidence_interval_missing_or_failed")
+    if not _bool(scorecard.get("utility_percentile_optimization_passed")):
+        blockers.append("utility_percentile_optimization_missing_or_failed")
+    if _decimal(scorecard.get("bootstrap_percentile_robust_net_pnl_per_day")) <= 0:
+        blockers.append("bootstrap_percentile_robust_net_pnl_non_positive")
+    if not _bool(scorecard.get("selection_bias_stress_passed")):
+        blockers.append("selection_bias_stress_missing_or_failed")
+    if not _bool(scorecard.get("parameter_instability_stress_passed")):
+        blockers.append("parameter_instability_stress_missing_or_failed")
+    if not _bool(scorecard.get("model_misspecification_stress_passed")):
+        blockers.append("model_misspecification_stress_missing_or_failed")
+    if not _bool(scorecard.get("out_of_sample_generalization_passed")):
+        blockers.append("out_of_sample_generalization_missing_or_failed")
+    return blockers
+
+
 def _conformal_tail_risk_blockers(scorecard: Mapping[str, Any]) -> list[str]:
     requires_conformal_tail_risk = _bool(
         scorecard.get("conformal_tail_risk_required")
@@ -1715,6 +1846,7 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         blockers.extend(_order_type_execution_blockers(scorecard))
         blockers.extend(_implementation_uncertainty_blockers(scorecard))
         blockers.extend(_implementation_risk_backtest_stability_blockers(scorecard))
+        blockers.extend(_bootstrap_robust_optimization_blockers(scorecard))
         blockers.extend(_conformal_tail_risk_blockers(scorecard))
         blockers.extend(_delay_depth_survival_blockers(scorecard))
     return tuple(dict.fromkeys(blockers))

--- a/services/torghut/tests/test_bootstrap_robust_optimization_stress.py
+++ b/services/torghut/tests/test_bootstrap_robust_optimization_stress.py
@@ -86,6 +86,10 @@ class TestBootstrapRobustOptimizationStress(TestCase):
             "preview_only_bootstrap_robust_optimization_stress_ranking",
         )
         self.assertTrue(payload["stationary_block_bootstrap_preview"])
+        self.assertIn(
+            "bootstrap_robust_optimization_arxiv_2510_12725_2025",
+            payload["source_markers"],
+        )
         self.assertFalse(payload["proof_authority"])
         self.assertFalse(payload["promotion_authority"])
         self.assertFalse(payload["final_authority_ok"])
@@ -106,6 +110,10 @@ class TestBootstrapRobustOptimizationStress(TestCase):
         )
         self.assertIn("arxiv-2510.12725", source_ids)
         self.assertIn("arxiv-2604.15531", source_ids)
+        self.assertIn(
+            "spurious_predictability_arxiv_2604_15531_2026",
+            contract["source_markers"],
+        )
         self.assertIn("missing_post_cost_utility_inputs", payload["warnings"])
         self.assertIn("missing_walk_forward_fold_inputs", payload["warnings"])
         self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -514,6 +514,102 @@ def test_promotion_ready_bundle_blocks_required_uncertainty_and_tail_risk_gaps()
     assert "conformal_tail_risk_adjusted_net_pnl_non_positive" in blockers
 
 
+def test_promotion_ready_bundle_blocks_required_bootstrap_robust_gaps() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-bootstrap-gap",
+        candidate_id="candidate-bootstrap-gap",
+        candidate_spec_id="spec-bootstrap-gap",
+        dataset_snapshot_id="snapshot-bootstrap-gap",
+        feature_spec_hash="feature-bootstrap-gap",
+        code_commit="commit-bootstrap-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_bootstrap_robust_optimization": True,
+            "required_min_bootstrap_replicates": "500",
+            "bootstrap_robust_optimization_source_markers": [
+                "bootstrap_robust_optimization_arxiv_2510_12725_2025",
+                "spurious_predictability_arxiv_2604_15531_2026",
+            ],
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "bootstrap_robust_optimization_missing_or_failed" in blockers
+    assert "bootstrap_robust_optimization_artifact_missing" in blockers
+    assert "bootstrap_replicate_count_below_min" in blockers
+    assert "bootstrap_confidence_interval_missing_or_failed" in blockers
+    assert "utility_percentile_optimization_missing_or_failed" in blockers
+    assert "bootstrap_percentile_robust_net_pnl_non_positive" in blockers
+    assert "selection_bias_stress_missing_or_failed" in blockers
+    assert "parameter_instability_stress_missing_or_failed" in blockers
+    assert "model_misspecification_stress_missing_or_failed" in blockers
+    assert "out_of_sample_generalization_missing_or_failed" in blockers
+
+
+def test_promotion_ready_bundle_accepts_materialized_bootstrap_robust_evidence() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-bootstrap-ready",
+        candidate_id="candidate-bootstrap-ready",
+        candidate_spec_id="spec-bootstrap-ready",
+        dataset_snapshot_id="snapshot-bootstrap-ready",
+        feature_spec_hash="feature-bootstrap-ready",
+        code_commit="commit-bootstrap-ready",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_bootstrap_robust_optimization": True,
+            "required_min_bootstrap_replicates": "500",
+            "bootstrap_robust_optimization_passed": True,
+            "bootstrap_robust_optimization_artifact_ref": "artifact://bootstrap",
+            "bootstrap_replicate_count": 500,
+            "bootstrap_confidence_interval_passed": True,
+            "utility_percentile_optimization_passed": True,
+            "bootstrap_percentile_robust_net_pnl_per_day": "550",
+            "selection_bias_stress_passed": True,
+            "parameter_instability_stress_passed": True,
+            "model_misspecification_stress_passed": True,
+            "out_of_sample_generalization_passed": True,
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "bootstrap_robust_optimization_missing_or_failed" not in blockers
+    assert "bootstrap_robust_optimization_artifact_missing" not in blockers
+    assert "bootstrap_replicate_count_below_min" not in blockers
+    assert "bootstrap_confidence_interval_missing_or_failed" not in blockers
+    assert "utility_percentile_optimization_missing_or_failed" not in blockers
+    assert "bootstrap_percentile_robust_net_pnl_non_positive" not in blockers
+    assert "selection_bias_stress_missing_or_failed" not in blockers
+    assert "parameter_instability_stress_missing_or_failed" not in blockers
+    assert "model_misspecification_stress_missing_or_failed" not in blockers
+    assert "out_of_sample_generalization_missing_or_failed" not in blockers
+
+
 def test_frontier_candidate_preserves_order_type_tca_fields() -> None:
     bundle = evidence_bundle_from_frontier_candidate(
         candidate_spec_id="spec-order-type-preserved",
@@ -558,6 +654,54 @@ def test_frontier_candidate_preserves_order_type_tca_fields() -> None:
     assert "order_type_ablation_artifact_missing" not in blockers
     assert "price_improvement_evidence_missing" not in blockers
     assert "execution_shortfall_evidence_missing" not in blockers
+
+
+def test_frontier_candidate_preserves_bootstrap_robust_fields() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-bootstrap-preserved",
+        candidate={
+            "candidate_id": "candidate-bootstrap-preserved",
+            "objective_scorecard": _promotion_quality_scorecard(),
+            "hard_vetoes": {
+                "required_bootstrap_robust_optimization": True,
+                "required_min_bootstrap_replicates": "500",
+            },
+            "promotion_contract": {
+                "requires_utility_percentile_optimization": True,
+            },
+            "bootstrap_robust_optimization_passed": True,
+            "bootstrap_robust_optimization_artifact_ref": "artifact://bootstrap",
+            "bootstrap_replicate_count": 500,
+            "bootstrap_confidence_interval_passed": True,
+            "utility_percentile_optimization_passed": True,
+            "bootstrap_percentile_robust_net_pnl_per_day": "550",
+            "selection_bias_stress_passed": True,
+            "parameter_instability_stress_passed": True,
+            "model_misspecification_stress_passed": True,
+            "out_of_sample_generalization_passed": True,
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-bootstrap-preserved",
+        result_path="artifact://replay",
+        code_commit="commit-bootstrap-preserved",
+    )
+
+    assert bundle.objective_scorecard["required_bootstrap_robust_optimization"] is True
+    assert bundle.objective_scorecard["required_min_bootstrap_replicates"] == "500"
+    assert (
+        bundle.objective_scorecard["requires_utility_percentile_optimization"] is True
+    )
+    assert (
+        bundle.objective_scorecard["bootstrap_robust_optimization_artifact_ref"]
+        == "artifact://bootstrap"
+    )
+    blockers = evidence_bundle_blockers(bundle)
+    assert "bootstrap_robust_optimization_artifact_missing" not in blockers
 
 
 def test_frontier_candidate_preserves_implementation_risk_parity_fields() -> None:

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -830,6 +830,10 @@ class TestFastReplayPreview(TestCase):
                 ]
             },
         )
+        self.assertIn(
+            "spurious_predictability_arxiv_2604_15531_2026",
+            row_payload["bootstrap_robust_optimization_stress"]["source_markers"],
+        )
         self.assertFalse(
             row_payload["bootstrap_robust_optimization_stress"]["proof_authority"]
         )


### PR DESCRIPTION
## Summary

- Adds fail-closed promotion blockers when a candidate or scorecard requires bootstrap robust optimization evidence.
- Preserves bootstrap robust optimization fields from frontier candidates, nested hard vetoes, and promotion contracts into evidence bundles.
- Tags bootstrap robust optimization stress payloads/contracts with 2025-2026 source markers while keeping the stress preview-only and non-authoritative.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py app/trading/discovery/bootstrap_robust_optimization_stress.py tests/test_evidence_bundles.py tests/test_bootstrap_robust_optimization_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py tests/test_bootstrap_robust_optimization_stress.py tests/test_fast_replay.py::TestFastReplayPreview::test_whitepaper_features_rank_and_label_preview_only`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv sync --frozen --extra dev` failed before dependency sync completed because `crosshair-tool==0.0.102` attempted to compile `_crosshair_tracers` and `cc` is unavailable in this container.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
