### PR TITLE
fix(torghut): expose source collection proof path

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -199,6 +199,24 @@ RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS = (
     "runtime_ledger_source_collection_only",
     "live_runtime_ledger_required",
 )
+RUNTIME_LEDGER_SOURCE_COLLECTION_LIVE_PAPER_EVIDENCE_REQUIREMENTS = (
+    "runtime_ledger_source_window_refs",
+    "runtime_ledger_source_window_ids",
+    "runtime_ledger_trade_decision_refs",
+    "runtime_ledger_execution_refs",
+    "runtime_ledger_execution_order_event_refs",
+    "runtime_ledger_source_offsets",
+    "runtime_ledger_source_materialization",
+    "post_cost_tca_cost_refs",
+    "closed_flat_reconciliation",
+)
+RUNTIME_LEDGER_SOURCE_COLLECTION_SAFE_EVIDENCE_COLLECTION_PATH = (
+    "materialize_runtime_ledger_source_window_refs",
+    "attach_trade_decision_execution_and_order_event_refs",
+    "persist_runtime_ledger_source_offsets_and_materialization",
+    "reconcile_post_cost_tca_and_closed_flat_state",
+    "rerun_live_paper_runtime_ledger_proof_before_final_promotion",
+)
 
 
 def _maybe_set_paper_route_audit_statement_timeout(session: Session) -> None:
@@ -9015,7 +9033,15 @@ def _sanitized_runtime_ledger_source_collection_target(
         "bounded_live_paper_collection_authorized": False,
         "bounded_evidence_collection_authorized": False,
         "capital_promotion_allowed": False,
+        "live_capital_authorized": False,
         "final_authority_ok": False,
+        "final_promotion_requires_live_paper_runtime_proof": True,
+        "live_paper_evidence_requirements": list(
+            RUNTIME_LEDGER_SOURCE_COLLECTION_LIVE_PAPER_EVIDENCE_REQUIREMENTS
+        ),
+        "safe_evidence_collection_path": list(
+            RUNTIME_LEDGER_SOURCE_COLLECTION_SAFE_EVIDENCE_COLLECTION_PATH
+        ),
         "evidence_collection_stage": "paper",
         "probation_allowed": False,
         "probation_reason": "source_window_evidence_collection_pending",
@@ -9050,9 +9076,20 @@ def _sanitized_runtime_ledger_source_collection_target(
         "source_collection_net_strategy_pnl_after_costs",
         "source_collection_post_cost_expectancy_bps",
         "source_collection_next_action",
+        "probation_target_shortfall",
+        "probation_target_progress_ratio",
+        "required_notional_repair_scale_to_target",
+        "required_notional_to_reach_target",
+        "required_notional_repair_scale_authority",
     ):
         if value := _safe_text(target.get(key)):
             sanitized[key] = value
+    for key in (
+        "live_paper_evidence_requirements",
+        "safe_evidence_collection_path",
+    ):
+        if values := _unique_text_items(target.get(key)):
+            sanitized[key] = values
     sanitized.update(_runtime_window_import_target_metadata(target))
     if runtime_ledger_bucket_ref := _safe_text(target.get("runtime_ledger_bucket_ref")):
         sanitized["runtime_ledger_bucket_ref"] = runtime_ledger_bucket_ref

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1690,6 +1690,24 @@ _RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS = (
     "runtime_ledger_source_window_evidence_pending",
     "live_runtime_ledger_required",
 )
+_RUNTIME_LEDGER_SOURCE_COLLECTION_LIVE_PAPER_EVIDENCE_REQUIREMENTS = (
+    "runtime_ledger_source_window_refs",
+    "runtime_ledger_source_window_ids",
+    "runtime_ledger_trade_decision_refs",
+    "runtime_ledger_execution_refs",
+    "runtime_ledger_execution_order_event_refs",
+    "runtime_ledger_source_offsets",
+    "runtime_ledger_source_materialization",
+    "post_cost_tca_cost_refs",
+    "closed_flat_reconciliation",
+)
+_RUNTIME_LEDGER_SOURCE_COLLECTION_SAFE_EVIDENCE_COLLECTION_PATH = (
+    "materialize_runtime_ledger_source_window_refs",
+    "attach_trade_decision_execution_and_order_event_refs",
+    "persist_runtime_ledger_source_offsets_and_materialization",
+    "reconcile_post_cost_tca_and_closed_flat_state",
+    "rerun_live_paper_runtime_ledger_proof_before_final_promotion",
+)
 _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_NET_PNL_AFTER_COSTS = Decimal("500")
 _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_BLOCKER = (
     "runtime_ledger_profit_target_source_collection_pending"
@@ -1879,6 +1897,32 @@ def _runtime_ledger_source_collection_profit_target_candidate(
     )
 
 
+def _runtime_ledger_source_collection_target_progress_payload(
+    *,
+    net_pnl_after_costs: Decimal,
+    filled_notional: Decimal,
+) -> dict[str, object]:
+    target = _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_NET_PNL_AFTER_COSTS
+    shortfall = max(target - net_pnl_after_costs, Decimal("0"))
+    progress_ratio = (
+        net_pnl_after_costs / target if target > 0 else Decimal("0")
+    )
+    if net_pnl_after_costs > 0:
+        required_notional_scale = max(target / net_pnl_after_costs, Decimal("1"))
+    else:
+        required_notional_scale = Decimal("0")
+    required_notional = filled_notional * required_notional_scale
+    return {
+        "probation_target_shortfall": str(shortfall),
+        "probation_target_progress_ratio": str(progress_ratio),
+        "required_notional_repair_scale_to_target": str(required_notional_scale),
+        "required_notional_to_reach_target": str(required_notional),
+        "required_notional_repair_scale_authority": (
+            "linear_notional_sizing_estimate_for_repair_only_not_capital_authority"
+        ),
+    }
+
+
 def _runtime_ledger_source_collection_profit_target_metadata(
     candidate: Mapping[str, object],
 ) -> dict[str, object]:
@@ -1894,23 +1938,34 @@ def _runtime_ledger_source_collection_profit_target_metadata(
         "source_collection_priority": "source_window_evidence_collection",
     }
     if profit_target_candidate:
+        net_pnl_after_costs = (
+            _safe_decimal(payload.get("net_strategy_pnl_after_costs")) or Decimal("0")
+        )
+        filled_notional = _safe_decimal(payload.get("filled_notional")) or Decimal("0")
         metadata.update(
             {
                 "source_collection_priority": "profit_target_source_materialization",
-                "source_collection_net_strategy_pnl_after_costs": str(
-                    _safe_decimal(payload.get("net_strategy_pnl_after_costs"))
-                    or Decimal("0")
-                ),
+                "source_collection_net_strategy_pnl_after_costs": str(net_pnl_after_costs),
                 "source_collection_post_cost_expectancy_bps": str(
                     _safe_decimal(payload.get("post_cost_expectancy_bps"))
                     or Decimal("0")
                 ),
-                "source_collection_filled_notional": str(
-                    _safe_decimal(payload.get("filled_notional")) or Decimal("0")
-                ),
+                "source_collection_filled_notional": str(filled_notional),
                 "source_collection_next_action": (
                     "materialize_runtime_ledger_source_window_refs"
                 ),
+                **_runtime_ledger_source_collection_target_progress_payload(
+                    net_pnl_after_costs=net_pnl_after_costs,
+                    filled_notional=filled_notional,
+                ),
+                "live_paper_evidence_requirements": list(
+                    _RUNTIME_LEDGER_SOURCE_COLLECTION_LIVE_PAPER_EVIDENCE_REQUIREMENTS
+                ),
+                "safe_evidence_collection_path": list(
+                    _RUNTIME_LEDGER_SOURCE_COLLECTION_SAFE_EVIDENCE_COLLECTION_PATH
+                ),
+                "live_capital_authorized": False,
+                "final_promotion_requires_live_paper_runtime_proof": True,
             }
         )
     return metadata
@@ -2280,6 +2335,37 @@ def _runtime_ledger_paper_probation_import_plan(
                         _safe_text(candidate.get("source_collection_next_action"))
                         or "materialize_runtime_ledger_source_window_refs"
                     ),
+                    "probation_target_shortfall": (
+                        _safe_text(candidate.get("probation_target_shortfall")) or ""
+                    ),
+                    "probation_target_progress_ratio": (
+                        _safe_text(candidate.get("probation_target_progress_ratio"))
+                        or ""
+                    ),
+                    "required_notional_repair_scale_to_target": (
+                        _safe_text(
+                            candidate.get("required_notional_repair_scale_to_target")
+                        )
+                        or ""
+                    ),
+                    "required_notional_to_reach_target": (
+                        _safe_text(candidate.get("required_notional_to_reach_target"))
+                        or ""
+                    ),
+                    "required_notional_repair_scale_authority": (
+                        _safe_text(
+                            candidate.get("required_notional_repair_scale_authority")
+                        )
+                        or "linear_notional_sizing_estimate_for_repair_only_not_capital_authority"
+                    ),
+                    "live_paper_evidence_requirements": list(
+                        _RUNTIME_LEDGER_SOURCE_COLLECTION_LIVE_PAPER_EVIDENCE_REQUIREMENTS
+                    ),
+                    "safe_evidence_collection_path": list(
+                        _RUNTIME_LEDGER_SOURCE_COLLECTION_SAFE_EVIDENCE_COLLECTION_PATH
+                    ),
+                    "live_capital_authorized": False,
+                    "final_promotion_requires_live_paper_runtime_proof": True,
                 }
             )
         if bucket_ref:

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5198,6 +5198,16 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "offset": 101,
                             }
                         ],
+                        "live_paper_evidence_requirements": [
+                            "runtime_ledger_source_materialization",
+                            "runtime_ledger_execution_refs",
+                            "runtime_ledger_source_materialization",
+                        ],
+                        "safe_evidence_collection_path": [
+                            "materialize_runtime_ledger_source_window_refs",
+                            "attach_trade_decision_execution_and_order_event_refs",
+                            "materialize_runtime_ledger_source_window_refs",
+                        ],
                         "runtime_ledger_bucket_ref": (
                             "strategy_runtime_ledger_buckets:run-1:start:end"
                         ),
@@ -5253,6 +5263,22 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(target["max_notional"], "0")
         self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["live_capital_authorized"])
+        self.assertTrue(target["final_promotion_requires_live_paper_runtime_proof"])
+        self.assertEqual(
+            target["live_paper_evidence_requirements"],
+            [
+                "runtime_ledger_source_materialization",
+                "runtime_ledger_execution_refs",
+            ],
+        )
+        self.assertEqual(
+            target["safe_evidence_collection_path"],
+            [
+                "materialize_runtime_ledger_source_window_refs",
+                "attach_trade_decision_execution_and_order_event_refs",
+            ],
+        )
 
         empty_plan = paper_route_evidence._runtime_ledger_source_collection_import_plan_for_payload(
             plan={

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -62,6 +62,7 @@ from app.trading.submission_council import (
     _runtime_ledger_paper_probation_blockers,
     _runtime_ledger_paper_probation_import_plan,
     _runtime_ledger_source_collection_candidates,
+    _runtime_ledger_source_collection_target_progress_payload,
     build_hypothesis_runtime_summary,
     build_live_submission_gate_payload,
     load_quant_evidence_status,
@@ -2162,6 +2163,41 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(
             target["source_collection_next_action"],
             "materialize_runtime_ledger_source_window_refs",
+        )
+        self.assertEqual(target["probation_target_shortfall"], "0")
+        self.assertEqual(
+            target["probation_target_progress_ratio"],
+            "1.13489441156",
+        )
+        self.assertEqual(target["required_notional_repair_scale_to_target"], "1")
+        self.assertEqual(
+            target["required_notional_repair_scale_authority"],
+            "linear_notional_sizing_estimate_for_repair_only_not_capital_authority",
+        )
+        self.assertFalse(target["live_capital_authorized"])
+        self.assertTrue(target["final_promotion_requires_live_paper_runtime_proof"])
+        self.assertIn(
+            "runtime_ledger_execution_order_event_refs",
+            target["live_paper_evidence_requirements"],
+        )
+        self.assertEqual(
+            target["safe_evidence_collection_path"][0],
+            "materialize_runtime_ledger_source_window_refs",
+        )
+
+    def test_source_collection_target_progress_payload_handles_zero_pnl(self) -> None:
+        payload = _runtime_ledger_source_collection_target_progress_payload(
+            net_pnl_after_costs=Decimal("0"),
+            filled_notional=Decimal("125000"),
+        )
+
+        self.assertEqual(payload["probation_target_shortfall"], "500")
+        self.assertEqual(payload["probation_target_progress_ratio"], "0")
+        self.assertEqual(payload["required_notional_repair_scale_to_target"], "0")
+        self.assertEqual(payload["required_notional_to_reach_target"], "0")
+        self.assertEqual(
+            payload["required_notional_repair_scale_authority"],
+            "linear_notional_sizing_estimate_for_repair_only_not_capital_authority",
         )
 
     def test_runtime_ledger_repair_score_prefers_source_backed_positive_candidate(


### PR DESCRIPTION
## Summary

- Expose the runtime-ledger source-collection safe evidence path and live-paper proof requirements directly on paper-route source-collection targets.
- Surface target shortfall/progress, required notional repair scale, required notional estimate, and explicit fail-closed live-capital/final-promotion proof flags for close-to-$500/day source-collection candidates.
- Preserve existing promotion gates: live capital remains unauthorized and final promotion still requires live/live-paper runtime-ledger proof.

## Related Issues

None

## Testing

- PASS `uv run --frozen pytest tests/test_submission_council.py -k "source_collection" -q`
- PASS `uv run --frozen pytest tests/test_paper_route_evidence.py -k "source_collection_import_plan_sanitizer" -q`
- PASS `uv run --frozen ruff check app/trading/submission_council.py app/trading/paper_route_evidence.py tests/test_submission_council.py tests/test_paper_route_evidence.py`
- PASS `uv run --frozen pyright --project pyrightconfig.json`
- PASS `uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS `uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.

## Notes

- Live read-only evidence still shows candidate `H-PAIRS-01` / `c88421d619759b2cfaa6f4d0` over the $500 post-cost target, but blocked on runtime-ledger source-window refs/materialization and live/live-paper proof.
