### PR TITLE
fix(torghut): require ofi response evidence

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -205,6 +205,27 @@ BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS = (
     "out_of_sample_generalization_passed",
     "bootstrap_robust_optimization_source_markers",
 )
+OFI_RESPONSE_HORIZON_SCORECARD_KEYS = (
+    "requires_ofi_response_horizon_selection",
+    "required_ofi_response_horizon_selection",
+    "required_min_ofi_response_sample_count",
+    "required_min_ofi_response_stable_split_pass_rate",
+    "required_max_ofi_response_best_split_share",
+    "requires_executable_quote_evidence",
+    "required_executable_quote_evidence",
+    "rejects_ohlcv_only_ofi_proxies",
+    "ofi_response_horizon_passed",
+    "ofi_response_horizon_artifact_ref",
+    "ofi_response_horizon_artifact_refs",
+    "ofi_response_sample_count",
+    "ofi_response_stable_split_pass_rate",
+    "ofi_response_best_split_share",
+    "executable_quote_evidence_present",
+    "quote_evidence_present",
+    "quote_evidence_sample_count",
+    "post_cost_net_pnl_after_ofi_response_horizon",
+    "ofi_response_horizon_source_markers",
+)
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -1048,6 +1069,13 @@ def evidence_bundle_from_frontier_candidate(
             if key in source:
                 scorecard = {**scorecard, key: source[key]}
                 break
+    for key in OFI_RESPONSE_HORIZON_SCORECARD_KEYS:
+        if key in scorecard:
+            continue
+        for source in (candidate, summary, full_window):
+            if key in source:
+                scorecard = {**scorecard, key: source[key]}
+                break
     for source in (candidate, summary, full_window):
         for key, value in _order_type_execution_metrics(source).items():
             if key not in scorecard:
@@ -1105,7 +1133,10 @@ def evidence_bundle_from_frontier_candidate(
         _mapping(candidate.get("hard_vetoes")),
         _mapping(candidate.get("promotion_contract")),
     ):
-        for key in BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS:
+        for key in (
+            *BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS,
+            *OFI_RESPONSE_HORIZON_SCORECARD_KEYS,
+        ):
             if key in nested_contract and key not in scorecard:
                 scorecard = {**scorecard, key: nested_contract[key]}
     replay_params = _frontier_replay_params(candidate)
@@ -1765,6 +1796,100 @@ def _bootstrap_robust_optimization_blockers(
     return blockers
 
 
+def _ofi_response_horizon_required(scorecard: Mapping[str, Any]) -> bool:
+    if any(
+        _bool(scorecard.get(key))
+        for key in (
+            "requires_ofi_response_horizon_selection",
+            "required_ofi_response_horizon_selection",
+            "requires_executable_quote_evidence",
+            "required_executable_quote_evidence",
+            "rejects_ohlcv_only_ofi_proxies",
+        )
+    ):
+        return True
+    hard_vetoes = {veto.lower() for veto in _string_list(scorecard.get("hard_vetoes"))}
+    if hard_vetoes.intersection(
+        {
+            "required_min_ofi_response_sample_count",
+            "required_min_ofi_response_stable_split_pass_rate",
+            "required_max_ofi_response_best_split_share",
+            "required_executable_quote_evidence",
+        }
+    ):
+        return True
+    return bool(
+        {
+            marker.lower()
+            for marker in _string_list(
+                scorecard.get("ofi_response_horizon_source_markers")
+            )
+        }.intersection(
+            {
+                "ofi_response_horizon_arxiv_2505_17388_2025",
+                "intraday_ofi_macro_news_arxiv_2508_06788_2025",
+            }
+        )
+    )
+
+
+def _route_tca_present(scorecard: Mapping[str, Any]) -> bool:
+    return (
+        _bool(scorecard.get("route_tca_evidence_present"))
+        or _string(scorecard.get("route_tca_artifact_ref")) != ""
+        or bool(_string_list(scorecard.get("route_tca_artifact_refs")))
+    )
+
+
+def _ofi_response_horizon_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    if not _ofi_response_horizon_required(scorecard):
+        return []
+
+    blockers: list[str] = []
+    if not _bool(scorecard.get("ofi_response_horizon_passed")):
+        blockers.append("ofi_response_horizon_missing_or_failed")
+    if not _has_artifact_ref(
+        scorecard,
+        "ofi_response_horizon_artifact_ref",
+        "ofi_response_horizon_artifact_refs",
+    ):
+        blockers.append("ofi_response_horizon_artifact_missing")
+    required_sample_count = max(
+        1,
+        _int(scorecard.get("required_min_ofi_response_sample_count") or 120),
+    )
+    if _int(scorecard.get("ofi_response_sample_count")) < required_sample_count:
+        blockers.append("ofi_response_sample_count_below_min")
+    required_split_rate = _decimal(
+        scorecard.get("required_min_ofi_response_stable_split_pass_rate") or "0.60"
+    )
+    if (
+        _decimal(scorecard.get("ofi_response_stable_split_pass_rate"))
+        < required_split_rate
+    ):
+        blockers.append("ofi_response_stable_split_pass_rate_below_min")
+    max_best_split_share = _decimal(
+        scorecard.get("required_max_ofi_response_best_split_share") or "0.35"
+    )
+    raw_best_split_share = scorecard.get("ofi_response_best_split_share")
+    if raw_best_split_share is None:
+        blockers.append("ofi_response_best_split_share_missing")
+    elif _decimal(raw_best_split_share) > max_best_split_share:
+        blockers.append("ofi_response_best_split_share_above_max")
+    quote_sample_count = _int(scorecard.get("quote_evidence_sample_count"))
+    if not (
+        _bool(scorecard.get("executable_quote_evidence_present"))
+        or _bool(scorecard.get("quote_evidence_present"))
+        or quote_sample_count > 0
+    ):
+        blockers.append("executable_quote_evidence_missing")
+    if not _route_tca_present(scorecard):
+        blockers.append("ofi_route_tca_evidence_missing")
+    if _decimal(scorecard.get("post_cost_net_pnl_after_ofi_response_horizon")) <= 0:
+        blockers.append("ofi_response_horizon_net_pnl_non_positive")
+    return blockers
+
+
 def _conformal_tail_risk_blockers(scorecard: Mapping[str, Any]) -> list[str]:
     requires_conformal_tail_risk = _bool(
         scorecard.get("conformal_tail_risk_required")
@@ -1847,6 +1972,7 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         blockers.extend(_implementation_uncertainty_blockers(scorecard))
         blockers.extend(_implementation_risk_backtest_stability_blockers(scorecard))
         blockers.extend(_bootstrap_robust_optimization_blockers(scorecard))
+        blockers.extend(_ofi_response_horizon_blockers(scorecard))
         blockers.extend(_conformal_tail_risk_blockers(scorecard))
         blockers.extend(_delay_depth_survival_blockers(scorecard))
     return tuple(dict.fromkeys(blockers))

--- a/services/torghut/app/trading/discovery/ofi_response_horizon_stress.py
+++ b/services/torghut/app/trading/discovery/ofi_response_horizon_stress.py
@@ -50,6 +50,10 @@ OFI_RESPONSE_HORIZON_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
         ),
     },
 )
+OFI_RESPONSE_HORIZON_STRESS_SOURCE_MARKERS: tuple[str, ...] = (
+    "ofi_response_horizon_arxiv_2505_17388_2025",
+    "intraday_ofi_macro_news_arxiv_2508_06788_2025",
+)
 
 _PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
 _OFI_FIELDS = (
@@ -104,6 +108,7 @@ class OfiResponseHorizonStressSummary:
             "source_papers": [
                 dict(item) for item in OFI_RESPONSE_HORIZON_STRESS_PRIMARY_SOURCES
             ],
+            "source_markers": list(OFI_RESPONSE_HORIZON_STRESS_SOURCE_MARKERS),
             "row_count": self.row_count,
             "observed_ofi_count": self.observed_ofi_count,
             "observed_price_count": self.observed_price_count,
@@ -181,6 +186,7 @@ def ofi_response_horizon_stress_contract() -> dict[str, Any]:
         "source_papers": [
             dict(item) for item in OFI_RESPONSE_HORIZON_STRESS_PRIMARY_SOURCES
         ],
+        "source_markers": list(OFI_RESPONSE_HORIZON_STRESS_SOURCE_MARKERS),
         "stress_policy": (
             "ofi_response_ratio_memory_decay_and_macro_news_distortion_ranking"
         ),

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -610,6 +610,99 @@ def test_promotion_ready_bundle_accepts_materialized_bootstrap_robust_evidence()
     assert "out_of_sample_generalization_missing_or_failed" not in blockers
 
 
+def test_promotion_ready_bundle_blocks_required_ofi_response_gaps() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-ofi-response-gap",
+        candidate_id="candidate-ofi-response-gap",
+        candidate_spec_id="spec-ofi-response-gap",
+        dataset_snapshot_id="snapshot-ofi-response-gap",
+        feature_spec_hash="feature-ofi-response-gap",
+        code_commit="commit-ofi-response-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_ofi_response_horizon_selection": True,
+            "required_min_ofi_response_sample_count": "120",
+            "required_min_ofi_response_stable_split_pass_rate": "0.60",
+            "required_max_ofi_response_best_split_share": "0.35",
+            "ofi_response_horizon_source_markers": [
+                "ofi_response_horizon_arxiv_2505_17388_2025",
+                "intraday_ofi_macro_news_arxiv_2508_06788_2025",
+            ],
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "ofi_response_horizon_missing_or_failed" in blockers
+    assert "ofi_response_horizon_artifact_missing" in blockers
+    assert "ofi_response_sample_count_below_min" in blockers
+    assert "ofi_response_stable_split_pass_rate_below_min" in blockers
+    assert "ofi_response_best_split_share_missing" in blockers
+    assert "executable_quote_evidence_missing" in blockers
+    assert "ofi_route_tca_evidence_missing" in blockers
+    assert "ofi_response_horizon_net_pnl_non_positive" in blockers
+
+
+def test_promotion_ready_bundle_accepts_materialized_ofi_response_evidence() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-ofi-response-ready",
+        candidate_id="candidate-ofi-response-ready",
+        candidate_spec_id="spec-ofi-response-ready",
+        dataset_snapshot_id="snapshot-ofi-response-ready",
+        feature_spec_hash="feature-ofi-response-ready",
+        code_commit="commit-ofi-response-ready",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_ofi_response_horizon_selection": True,
+            "required_min_ofi_response_sample_count": "120",
+            "required_min_ofi_response_stable_split_pass_rate": "0.60",
+            "required_max_ofi_response_best_split_share": "0.35",
+            "ofi_response_horizon_passed": True,
+            "ofi_response_horizon_artifact_ref": "artifact://ofi-response",
+            "ofi_response_sample_count": 120,
+            "ofi_response_stable_split_pass_rate": "0.65",
+            "ofi_response_best_split_share": "0.30",
+            "executable_quote_evidence_present": True,
+            "quote_evidence_sample_count": 120,
+            "route_tca_artifact_ref": "artifact://route-tca",
+            "post_cost_net_pnl_after_ofi_response_horizon": "540",
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "ofi_response_horizon_missing_or_failed" not in blockers
+    assert "ofi_response_horizon_artifact_missing" not in blockers
+    assert "ofi_response_sample_count_below_min" not in blockers
+    assert "ofi_response_stable_split_pass_rate_below_min" not in blockers
+    assert "ofi_response_best_split_share_missing" not in blockers
+    assert "executable_quote_evidence_missing" not in blockers
+    assert "ofi_route_tca_evidence_missing" not in blockers
+    assert "ofi_response_horizon_net_pnl_non_positive" not in blockers
+
+
 def test_frontier_candidate_preserves_order_type_tca_fields() -> None:
     bundle = evidence_bundle_from_frontier_candidate(
         candidate_spec_id="spec-order-type-preserved",
@@ -702,6 +795,53 @@ def test_frontier_candidate_preserves_bootstrap_robust_fields() -> None:
     )
     blockers = evidence_bundle_blockers(bundle)
     assert "bootstrap_robust_optimization_artifact_missing" not in blockers
+
+
+def test_frontier_candidate_preserves_ofi_response_fields() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-ofi-response-preserved",
+        candidate={
+            "candidate_id": "candidate-ofi-response-preserved",
+            "objective_scorecard": _promotion_quality_scorecard(),
+            "hard_vetoes": {
+                "required_min_ofi_response_sample_count": "120",
+                "required_min_ofi_response_stable_split_pass_rate": "0.60",
+                "required_max_ofi_response_best_split_share": "0.35",
+                "required_executable_quote_evidence": True,
+            },
+            "promotion_contract": {
+                "requires_ofi_response_horizon_selection": True,
+            },
+            "ofi_response_horizon_passed": True,
+            "ofi_response_horizon_artifact_ref": "artifact://ofi-response",
+            "ofi_response_sample_count": 120,
+            "ofi_response_stable_split_pass_rate": "0.65",
+            "ofi_response_best_split_share": "0.30",
+            "executable_quote_evidence_present": True,
+            "quote_evidence_sample_count": 120,
+            "route_tca_artifact_ref": "artifact://route-tca",
+            "post_cost_net_pnl_after_ofi_response_horizon": "540",
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-ofi-response-preserved",
+        result_path="artifact://replay",
+        code_commit="commit-ofi-response-preserved",
+    )
+
+    assert bundle.objective_scorecard["requires_ofi_response_horizon_selection"] is True
+    assert bundle.objective_scorecard["required_executable_quote_evidence"] is True
+    assert (
+        bundle.objective_scorecard["ofi_response_horizon_artifact_ref"]
+        == "artifact://ofi-response"
+    )
+    blockers = evidence_bundle_blockers(bundle)
+    assert "ofi_response_horizon_artifact_missing" not in blockers
+    assert "ofi_route_tca_evidence_missing" not in blockers
 
 
 def test_frontier_candidate_preserves_implementation_risk_parity_fields() -> None:

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -843,6 +843,14 @@ class TestFastReplayPreview(TestCase):
                 ]
             },
         )
+        self.assertIn(
+            "ofi_response_horizon_arxiv_2505_17388_2025",
+            row_payload["ofi_response_horizon_stress"]["source_markers"],
+        )
+        self.assertIn(
+            "intraday_ofi_macro_news_arxiv_2508_06788_2025",
+            row_payload["ofi_response_horizon_stress"]["source_markers"],
+        )
         self.assertFalse(row_payload["ofi_response_horizon_stress"]["proof_authority"])
         self.assertFalse(
             row_payload["ofi_response_horizon_stress"]["promotion_authority"]

--- a/services/torghut/tests/test_ofi_response_horizon_stress.py
+++ b/services/torghut/tests/test_ofi_response_horizon_stress.py
@@ -123,6 +123,14 @@ class TestOfiResponseHorizonStress(TestCase):
         self.assertFalse(payload["proof_authority"])
         self.assertFalse(payload["promotion_authority"])
         self.assertFalse(payload["final_authority_ok"])
+        self.assertIn(
+            "ofi_response_horizon_arxiv_2505_17388_2025",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "intraday_ofi_macro_news_arxiv_2508_06788_2025",
+            payload["source_markers"],
+        )
 
     def test_missing_ofi_fails_closed_with_source_gap_and_contract_sources(
         self,
@@ -143,6 +151,22 @@ class TestOfiResponseHorizonStress(TestCase):
         )
         self.assertIn("arxiv-2505.17388", source_ids)
         self.assertIn("arxiv-2508.06788", source_ids)
+        self.assertIn(
+            "ofi_response_horizon_arxiv_2505_17388_2025",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "intraday_ofi_macro_news_arxiv_2508_06788_2025",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "ofi_response_horizon_arxiv_2505_17388_2025",
+            contract["source_markers"],
+        )
+        self.assertIn(
+            "intraday_ofi_macro_news_arxiv_2508_06788_2025",
+            contract["source_markers"],
+        )
         self.assertIn(
             "missing_order_flow_imbalance_for_response_horizon", payload["warnings"]
         )


### PR DESCRIPTION
## Summary

- Adds fail-closed promotion blockers for OFI response-horizon claims unless materialized response-horizon evidence, executable quote evidence, route TCA, stable split coverage, and positive post-cost OFI-filtered PnL are present.
- Propagates OFI response-horizon source markers from the preview stress contract so source-backed candidates carry the stricter evidence requirements into evidence bundles.
- Adds regression coverage for missing vs materialized OFI evidence and for source marker preservation in fast replay previews.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py app/trading/discovery/ofi_response_horizon_stress.py tests/test_evidence_bundles.py tests/test_ofi_response_horizon_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py app/trading/discovery/ofi_response_horizon_stress.py tests/test_evidence_bundles.py tests/test_ofi_response_horizon_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py tests/test_ofi_response_horizon_stress.py tests/test_fast_replay.py::TestFastReplayPreview::test_whitepaper_features_rank_and_label_preview_only`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv sync --frozen --extra dev` fails in this workspace because `crosshair-tool==0.0.102` needs a system `cc` compiler that is not installed (`error: command 'cc' failed: No such file or directory`).
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
