### PR TITLE
fix(torghut): import latest closed runtime window plans

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -867,6 +867,11 @@ def _runtime_window_target_plan_with_live_gate_source_collection(
     plan: Mapping[str, Any],
 ) -> dict[str, Any]:
     merged_plan = dict(plan)
+    if (
+        str(merged_plan.get("purpose") or "").strip()
+        == "latest_closed_session_paper_route_runtime_window_import"
+    ):
+        return merged_plan
     gate = _as_dict(payload.get("live_submission_gate"))
     gate_plan = _as_dict(gate.get("runtime_ledger_paper_probation_import_plan"))
     source_collection_targets = _runtime_window_target_plan_source_collection_targets(
@@ -918,10 +923,45 @@ def _runtime_window_target_plan_with_live_gate_source_collection(
     return merged_plan
 
 
+def _latest_closed_runtime_window_target_plan_from_payload(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    plan = _as_dict(payload.get("latest_closed_paper_route_runtime_window_targets"))
+    if not _runtime_window_plan_target_items(plan):
+        return {}
+
+    selection = _as_dict(payload.get("latest_closed_runtime_window_import_selection"))
+    selection_state = str(selection.get("state") or "").strip()
+    selection_selected = (
+        _runtime_window_target_plan_target_truthy(selection.get("selected"))
+        or selection_state == "selected"
+    )
+    if not selection_selected:
+        return {}
+    if not _runtime_window_target_plan_target_truthy(
+        selection.get("clean_window_importable")
+    ):
+        return {}
+    if not _runtime_window_target_plan_target_truthy(
+        selection.get("source_backed_evidence_present")
+    ):
+        return {}
+
+    session_readiness = _as_dict(plan.get("session_readiness"))
+    runtime_handoff = _as_dict(plan.get("runtime_window_import_handoff"))
+    import_ready = _runtime_window_target_plan_target_truthy(
+        session_readiness.get("import_ready")
+    ) or _runtime_window_target_plan_target_truthy(runtime_handoff.get("import_ready"))
+    if not import_ready:
+        return {}
+    return plan
+
+
 def _runtime_window_target_plan_from_payload(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
     paper_route_plan = _as_dict(payload.get("next_paper_route_runtime_window_targets"))
+    latest_closed_plan = _latest_closed_runtime_window_target_plan_from_payload(payload)
     paper_route_evidence_payload = (
         str(payload.get("schema_version") or "").strip()
         == "torghut.paper-route-evidence.v1"
@@ -932,6 +972,7 @@ def _runtime_window_target_plan_from_payload(
             (
                 candidate_plan
                 for candidate_plan in (
+                    latest_closed_plan,
                     direct_plan,
                     _as_dict(
                         payload.get(
@@ -950,7 +991,7 @@ def _runtime_window_target_plan_from_payload(
             {},
         )
     else:
-        plan = {}
+        plan = latest_closed_plan
     source_runtime_window_plan = _as_dict(
         payload.get("source_runtime_window_import_plan")
     )

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -302,6 +302,244 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
         self.assertTrue(target.target_metadata["source_collection_authorized"])
         self.assertNotIn("paper_route_probe_symbols", target.target_metadata)
 
+    def test_target_plan_payload_prefers_selected_latest_closed_import_plan(
+        self,
+    ) -> None:
+        plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "schema_version": (
+                        "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                    ),
+                    "purpose": "observed_strategy_runtime_ledger_source_collection_import",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-CURRENT",
+                            "candidate_id": "current-candidate",
+                            "strategy_name": "current-strategy",
+                            "runtime_strategy_name": "current-strategy",
+                            "account_label": "TORGHUT_SIM",
+                            "source_manifest_ref": "current.json",
+                            "window_start": "2026-06-04T13:30:00+00:00",
+                            "window_end": "2026-06-04T20:00:00+00:00",
+                            "paper_route_session_import_ready": False,
+                            "paper_route_session_import_blockers": [
+                                "paper_route_session_window_not_closed"
+                            ],
+                        }
+                    ],
+                },
+                "latest_closed_runtime_window_import_selection": {
+                    "schema_version": (
+                        "torghut.paper-route-runtime-window-import-selection.v1"
+                    ),
+                    "selected": True,
+                    "state": "selected",
+                    "reason": "latest_closed_window_source_backed_and_clean",
+                    "source_backed_evidence_present": True,
+                    "clean_window_importable": True,
+                },
+                "latest_closed_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "purpose": "latest_closed_session_paper_route_runtime_window_import",
+                    "session_readiness": {"import_ready": True},
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "closed-candidate",
+                            "strategy_family": "microbar_cross_sectional_pairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "runtime_strategy_name": (
+                                "microbar-cross-sectional-pairs-v1"
+                            ),
+                            "account_label": "TORGHUT_SIM",
+                            "source_account_label": "TORGHUT_SIM",
+                            "source_dsn_env": "SIM_DB_DSN",
+                            "target_dsn_env": "SIM_DB_DSN",
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-pairs-01.json"
+                            ),
+                            "window_start": "2026-06-03T13:30:00+00:00",
+                            "window_end": "2026-06-03T20:00:00+00:00",
+                            "source_collection_authorized": True,
+                            "source_collection_authorization_scope": (
+                                "source_window_evidence_collection_only"
+                            ),
+                        }
+                    ],
+                },
+                "live_submission_gate": {
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-CURRENT",
+                                "candidate_id": "current-candidate",
+                                "strategy_family": "intraday_tsmom_consistent",
+                                "strategy_name": "current-strategy",
+                                "runtime_strategy_name": "current-strategy",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": (
+                                    "runtime_ledger_source_collection_candidate"
+                                ),
+                                "source_manifest_ref": "current.json",
+                                "source_collection_authorized": True,
+                                "window_start": "2026-06-04T13:30:00+00:00",
+                                "window_end": "2026-06-04T20:00:00+00:00",
+                            }
+                        ],
+                    },
+                },
+            }
+        )
+
+        targets = renew._runtime_window_targets_from_plan(
+            plan=plan,
+            ref="target-plan-url-fixture",
+            args=argparse.Namespace(),
+        )
+
+        self.assertEqual(
+            plan["purpose"], "latest_closed_session_paper_route_runtime_window_import"
+        )
+        self.assertEqual(len(plan["targets"]), 1)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].candidate_id, "closed-candidate")
+        self.assertEqual(str(targets[0].window_start), "2026-06-03T13:30:00+00:00")
+
+    def test_target_plan_payload_ignores_unselected_latest_closed_plan(self) -> None:
+        plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "schema_version": (
+                        "torghut.runtime-ledger-paper-probation-import-plan.v1"
+                    ),
+                    "purpose": "observed_strategy_runtime_ledger_source_collection_import",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-CURRENT",
+                            "candidate_id": "current-candidate",
+                            "strategy_name": "current-strategy",
+                            "runtime_strategy_name": "current-strategy",
+                            "account_label": "TORGHUT_SIM",
+                            "source_manifest_ref": "current.json",
+                            "window_start": "2026-06-04T13:30:00+00:00",
+                            "window_end": "2026-06-04T20:00:00+00:00",
+                        }
+                    ],
+                },
+                "latest_closed_runtime_window_import_selection": {
+                    "selected": False,
+                    "state": "discarded",
+                    "source_backed_evidence_present": True,
+                    "clean_window_importable": True,
+                },
+                "latest_closed_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "purpose": "latest_closed_session_paper_route_runtime_window_import",
+                    "session_readiness": {"import_ready": True},
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "closed-candidate",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "account_label": "TORGHUT_SIM",
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-pairs-01.json"
+                            ),
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(
+            plan["purpose"], "observed_strategy_runtime_ledger_source_collection_import"
+        )
+        self.assertEqual(plan["targets"][0]["candidate_id"], "current-candidate")
+
+    def test_target_plan_payload_requires_clean_latest_closed_selection(
+        self,
+    ) -> None:
+        plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "purpose": "observed_strategy_runtime_ledger_source_collection_import",
+                    "targets": [{"candidate_id": "current-candidate"}],
+                },
+                "latest_closed_runtime_window_import_selection": {
+                    "selected": True,
+                    "state": "selected",
+                    "source_backed_evidence_present": True,
+                    "clean_window_importable": False,
+                },
+                "latest_closed_paper_route_runtime_window_targets": {
+                    "purpose": "latest_closed_session_paper_route_runtime_window_import",
+                    "session_readiness": {"import_ready": True},
+                    "targets": [{"candidate_id": "closed-candidate"}],
+                },
+            }
+        )
+
+        self.assertEqual(plan["targets"][0]["candidate_id"], "current-candidate")
+
+    def test_target_plan_payload_requires_source_backed_latest_closed_selection(
+        self,
+    ) -> None:
+        plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "purpose": "observed_strategy_runtime_ledger_source_collection_import",
+                    "targets": [{"candidate_id": "current-candidate"}],
+                },
+                "latest_closed_runtime_window_import_selection": {
+                    "selected": True,
+                    "state": "selected",
+                    "source_backed_evidence_present": False,
+                    "clean_window_importable": True,
+                },
+                "latest_closed_paper_route_runtime_window_targets": {
+                    "purpose": "latest_closed_session_paper_route_runtime_window_import",
+                    "session_readiness": {"import_ready": True},
+                    "targets": [{"candidate_id": "closed-candidate"}],
+                },
+            }
+        )
+
+        self.assertEqual(plan["targets"][0]["candidate_id"], "current-candidate")
+
+    def test_target_plan_payload_requires_import_ready_latest_closed_plan(
+        self,
+    ) -> None:
+        plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "purpose": "observed_strategy_runtime_ledger_source_collection_import",
+                    "targets": [{"candidate_id": "current-candidate"}],
+                },
+                "latest_closed_runtime_window_import_selection": {
+                    "selected": True,
+                    "state": "selected",
+                    "source_backed_evidence_present": True,
+                    "clean_window_importable": True,
+                },
+                "latest_closed_paper_route_runtime_window_targets": {
+                    "purpose": "latest_closed_session_paper_route_runtime_window_import",
+                    "session_readiness": {"import_ready": False},
+                    "runtime_window_import_handoff": {"import_ready": False},
+                    "targets": [{"candidate_id": "closed-candidate"}],
+                },
+            }
+        )
+
+        self.assertEqual(plan["targets"][0]["candidate_id"], "current-candidate")
+
     def test_exact_replay_runtime_window_plan_preserves_exact_counts(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Prefer a selected, source-backed, clean, import-ready `latest_closed_paper_route_runtime_window_targets` plan when the runtime-window renewal job reads the live paper-route target-plan endpoint.
- Keep current live-gate source-collection targets from being prepended into a latest-closed import plan, so renewal imports only the closed settled window selected by the evidence audit.
- Add regression coverage for selecting the latest closed import plan and for ignoring it when the selection audit is not authoritative.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py -k "latest_closed_import_plan or observed_strategy_source_collection_plan_target_parses_for_import"`
- `cd services/torghut && uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/renew_latest_empirical_promotion_jobs.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Local readback with the live Torghut-sim target-plan payload now selects purpose `latest_closed_session_paper_route_runtime_window_import`, target count `2`, and window `2026-06-03T13:30:00+00:00` to `2026-06-03T20:00:00+00:00` instead of the current open window.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
