### PR TITLE
fix(torghut): scope tigerbeetle reconcile by account

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_reconcile.py
+++ b/services/torghut/app/trading/tigerbeetle_reconcile.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.config import Settings, settings
 from app.models import (
@@ -588,6 +589,7 @@ def _runtime_ledger_ref_coverage(
     session: Session,
     *,
     cluster_id: int,
+    account_label: str | None = None,
     sample_limit: int = 50,
     full_ref_scan: bool = True,
 ) -> dict[str, object]:
@@ -602,11 +604,18 @@ def _runtime_ledger_ref_coverage(
         )
         or 0
     )
+    required_bucket_filters: list[ColumnElement[bool]] = [
+        (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
+        | (StrategyRuntimeLedgerBucket.cost_amount != 0)
+    ]
+    if account_label:
+        required_bucket_filters.append(
+            StrategyRuntimeLedgerBucket.account_label == account_label
+        )
     required_runtime_bucket_count = int(
         session.scalar(
             select(func.count(StrategyRuntimeLedgerBucket.id)).where(
-                (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
-                | (StrategyRuntimeLedgerBucket.cost_amount != 0)
+                *required_bucket_filters
             )
         )
         or 0
@@ -632,8 +641,7 @@ def _runtime_ledger_ref_coverage(
                 str(bucket_id)
                 for bucket_id in session.execute(
                     select(StrategyRuntimeLedgerBucket.id).where(
-                        (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
-                        | (StrategyRuntimeLedgerBucket.cost_amount != 0)
+                        *required_bucket_filters
                     )
                 ).scalars()
             }
@@ -728,10 +736,7 @@ def _runtime_ledger_ref_coverage(
     current_bucket_ids = {
         str(bucket_id)
         for bucket_id in session.execute(
-            select(StrategyRuntimeLedgerBucket.id).where(
-                (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
-                | (StrategyRuntimeLedgerBucket.cost_amount != 0)
-            )
+            select(StrategyRuntimeLedgerBucket.id).where(*required_bucket_filters)
         ).scalars()
     }
     current_runtime_refs = [
@@ -881,6 +886,7 @@ def tigerbeetle_ref_counts(
     session: Session,
     *,
     cluster_id: int,
+    account_label: str | None = None,
     full_ref_scan: bool = True,
 ) -> dict[str, object]:
     account_total = session.scalar(
@@ -924,11 +930,13 @@ def tigerbeetle_ref_counts(
     runtime_coverage = _runtime_ledger_ref_coverage(
         session,
         cluster_id=cluster_id,
+        account_label=account_label,
         full_ref_scan=full_ref_scan,
     )
     return {
         "schema_version": "torghut.tigerbeetle-ref-counts.v1",
         "cluster_id": cluster_id,
+        "account_label": account_label,
         "account_ref_count": int(account_total or 0),
         "transfer_ref_count": int(total or 0),
         "by_source_type": by_source,
@@ -951,6 +959,7 @@ def tigerbeetle_ref_counts(
             "runtime_ledger_source_table": "strategy_runtime_ledger_buckets",
             "runtime_ledger_source_type": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
             "runtime_ledger_transfer_kind": TRANSFER_KIND_RUNTIME_NET_PNL,
+            "runtime_ledger_account_label_scope": account_label,
         },
         **runtime_coverage,
     }
@@ -1318,6 +1327,7 @@ def reconcile_tigerbeetle_transfers(
     client: TigerBeetleClientProtocol | None = None,
     limit: int = 500,
     persist: bool = True,
+    account_label: str | None = None,
 ) -> dict[str, object]:
     started_at = datetime.now(timezone.utc)
     refs = _reconciliation_transfer_refs(
@@ -1684,13 +1694,18 @@ def reconcile_tigerbeetle_transfers(
     if unlinked_cost_count:
         blockers.append(BLOCKER_UNLINKED_COST)
 
+    runtime_bucket_filters: list[ColumnElement[bool]] = [
+        (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
+        | (StrategyRuntimeLedgerBucket.cost_amount != 0)
+    ]
+    if account_label:
+        runtime_bucket_filters.append(
+            StrategyRuntimeLedgerBucket.account_label == account_label
+        )
     recent_runtime_buckets = (
         session.execute(
             select(StrategyRuntimeLedgerBucket)
-            .where(
-                (StrategyRuntimeLedgerBucket.net_strategy_pnl_after_costs != 0)
-                | (StrategyRuntimeLedgerBucket.cost_amount != 0)
-            )
+            .where(*runtime_bucket_filters)
             .order_by(StrategyRuntimeLedgerBucket.bucket_ended_at.desc())
             .limit(limit)
         )
@@ -1734,6 +1749,7 @@ def reconcile_tigerbeetle_transfers(
     ref_counts = tigerbeetle_ref_counts(
         session,
         cluster_id=settings_obj.tigerbeetle_cluster_id,
+        account_label=account_label,
     )
     compact_ref_counts = _compact_reconciliation_ref_counts(
         ref_counts,
@@ -1764,6 +1780,7 @@ def reconcile_tigerbeetle_transfers(
         "schema_version": SCHEMA_VERSION,
         "ok": ok,
         "cluster_id": settings_obj.tigerbeetle_cluster_id,
+        "account_label": account_label,
         "started_at": started_at.isoformat(),
         "finished_at": finished_at.isoformat(),
         "age_seconds": 0,

--- a/services/torghut/scripts/journal_tigerbeetle_order_events.py
+++ b/services/torghut/scripts/journal_tigerbeetle_order_events.py
@@ -778,6 +778,7 @@ def _fresh_reconciliation_for_empty_selection(
     session: Any,
     *,
     settings_obj: Settings,
+    account_label: str | None,
 ) -> dict[str, object] | None:
     latest = latest_tigerbeetle_reconciliation_payload(
         session,
@@ -805,11 +806,15 @@ def _fresh_reconciliation_for_empty_selection(
         return None
     if not bool(latest.get("client_lookup_ok", True)):
         return None
+    latest_account_label = latest.get("account_label")
+    if account_label and latest_account_label != account_label:
+        return None
     return {
         "ok": True,
         "status": "skipped",
         "reason": "fresh_reconciliation_available",
         "fresh_reconciliation_available": True,
+        "account_label": latest_account_label,
         "latest_status": str(latest.get("status") or ""),
         "latest_started_at": latest.get("started_at"),
         "latest_finished_at": latest.get("finished_at"),
@@ -1555,6 +1560,7 @@ def main() -> int:
                 reconciliation = _fresh_reconciliation_for_empty_selection(
                     session,
                     settings_obj=settings_obj,
+                    account_label=args.account_label,
                 )
             if reconciliation is None:
                 reconciliation = reconcile_tigerbeetle_transfers(
@@ -1563,6 +1569,7 @@ def main() -> int:
                     client=journal.client_for_reconciliation(),
                     limit=max(1, int(args.reconcile_limit)),
                     persist=True,
+                    account_label=args.account_label,
                 )
             session.commit()
         elif not args.dry_run and not args.skip_reconcile and not stop_journaling:

--- a/services/torghut/tests/test_journal_tigerbeetle_order_events.py
+++ b/services/torghut/tests/test_journal_tigerbeetle_order_events.py
@@ -2445,6 +2445,62 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
             reconcile.call_args.kwargs["client"],
             FakeJournal.instances[0].reconciliation_client,
         )
+        self.assertIsNone(reconcile.call_args.kwargs["account_label"])
+
+    def test_main_passes_account_label_to_empty_selection_reconciliation(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "torghut.db")
+            dsn = f"sqlite+pysqlite:///{db_path}"
+            engine = create_engine(dsn, future=True)
+            Base.metadata.create_all(engine)
+
+            stdout = io.StringIO()
+            with (
+                patch.dict(os.environ, {"TEST_DB_DSN": dsn}),
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "journal_tigerbeetle_order_events.py",
+                        "--dsn-env",
+                        "TEST_DB_DSN",
+                        "--sources",
+                        "strategy_runtime_ledger_bucket",
+                        "--account-label",
+                        "TORGHUT_SIM",
+                        "--batch-size",
+                        "5",
+                        "--reconcile-limit",
+                        "12",
+                        "--reconcile-empty-selection",
+                        "--fail-on-degraded",
+                        "--allow-data-quality-degraded",
+                        "--json",
+                    ],
+                ),
+                patch.object(script, "TigerBeetleLedgerJournal", FakeJournal),
+                patch.object(
+                    script,
+                    "reconcile_tigerbeetle_transfers",
+                    return_value={
+                        "ok": True,
+                        "status": "ok",
+                        "account_label": "TORGHUT_SIM",
+                    },
+                ) as reconcile,
+                redirect_stdout(stdout),
+            ):
+                exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["selected"], 0)
+        self.assertEqual(payload["reconciliation"]["account_label"], "TORGHUT_SIM")
+        reconcile.assert_called_once()
+        self.assertEqual(reconcile.call_args.kwargs["account_label"], "TORGHUT_SIM")
 
     def test_main_reuses_fresh_reconciliation_when_empty_source_selects_no_rows(
         self,
@@ -2563,6 +2619,7 @@ class TestJournalTigerBeetleOrderEventsScript(TestCase):
                             Settings,
                             SimpleNamespace(tigerbeetle_cluster_id=2001),
                         ),
+                        account_label=None,
                     )
 
                 self.assertIsNone(result)

--- a/services/torghut/tests/test_tigerbeetle_reconcile.py
+++ b/services/torghut/tests/test_tigerbeetle_reconcile.py
@@ -139,7 +139,7 @@ def _transfer(
 
 
 def _runtime_bucket(
-    *, net_pnl: Decimal = Decimal("2.50")
+    *, net_pnl: Decimal = Decimal("2.50"), account_label: str = "paper"
 ) -> StrategyRuntimeLedgerBucket:
     observed_at = datetime.now(timezone.utc)
     return StrategyRuntimeLedgerBucket(
@@ -149,7 +149,7 @@ def _runtime_bucket(
         observed_stage="paper",
         bucket_started_at=observed_at,
         bucket_ended_at=observed_at,
-        account_label="paper",
+        account_label=account_label,
         runtime_strategy_name="demo",
         strategy_family="demo",
         fill_count=1,
@@ -718,6 +718,88 @@ class TestTigerBeetleReconcile(TestCase):
             self.assertEqual(payload["runtime_ledger_checked_transfer_count"], 1)
             self.assertEqual(payload["runtime_ledger_signed_transfer_count"], 1)
             self.assertEqual(payload["runtime_ledger_missing_signed_ref_count"], 0)
+
+    def test_reconciliation_scopes_required_runtime_refs_by_account_label(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            sim_bucket = _runtime_bucket(
+                net_pnl=Decimal("2.50"),
+                account_label="TORGHUT_SIM",
+            )
+            replay_bucket = _runtime_bucket(
+                net_pnl=Decimal("7.50"),
+                account_label="TORGHUT_REPLAY",
+            )
+            session.add_all([sim_bucket, replay_bucket])
+            session.flush()
+            sim_plan = build_runtime_ledger_bucket_transfer_plan(sim_bucket)
+            self.assertIsNotNone(sim_plan)
+            assert sim_plan is not None
+            _add_account_refs_for_plan(session, sim_plan)
+            sim_transfer = sim_plan.transfer_spec
+            session.add(
+                TigerBeetleTransferRef(
+                    cluster_id=2001,
+                    transfer_id=str(sim_transfer.transfer_id),
+                    transfer_kind=sim_transfer.transfer_kind,
+                    ledger=sim_transfer.ledger,
+                    code=sim_transfer.code,
+                    amount=Decimal(sim_transfer.amount),
+                    status="created",
+                    runtime_ledger_bucket_id=sim_bucket.id,
+                    source_type=SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                    source_id=str(sim_bucket.id),
+                    payload_json={
+                        "source": SOURCE_TYPE_RUNTIME_LEDGER_BUCKET,
+                        "run_id": sim_bucket.run_id,
+                        "candidate_id": sim_bucket.candidate_id,
+                        "hypothesis_id": sim_bucket.hypothesis_id,
+                        "observed_stage": sim_bucket.observed_stage,
+                        "pnl_basis": sim_bucket.pnl_basis,
+                        "ledger_schema_version": sim_bucket.ledger_schema_version,
+                        "amount_source": str(sim_plan.amount_source),
+                        "signed_amount_micros": sim_plan.signed_amount_micros,
+                        "pnl_direction": sim_plan.pnl_direction,
+                        "runtime_key": sim_plan.runtime_key,
+                        "debit_account_id": str(sim_transfer.debit_account_id),
+                        "credit_account_id": str(sim_transfer.credit_account_id),
+                    },
+                )
+            )
+            client = FakeTigerBeetleClient()
+            client.transfers[sim_transfer.transfer_id] = sim_transfer
+            session.flush()
+
+            unscoped = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+                account_label=None,
+            )
+            scoped = reconcile_tigerbeetle_transfers(
+                session,
+                settings_obj=_settings(),
+                client=client,
+                account_label="TORGHUT_SIM",
+            )
+
+            self.assertFalse(unscoped["ok"], unscoped)
+            self.assertEqual(unscoped["runtime_ledger_missing_signed_ref_count"], 1)
+            self.assertEqual(scoped["account_label"], "TORGHUT_SIM")
+            self.assertTrue(scoped["ok"], scoped)
+            self.assertEqual(scoped["runtime_ledger_ref_count"], 1)
+            self.assertEqual(scoped["runtime_ledger_signed_ref_count"], 1)
+            self.assertEqual(scoped["runtime_ledger_missing_signed_ref_count"], 0)
+            ref_counts = scoped["ref_counts"]
+            assert isinstance(ref_counts, dict)
+            self.assertEqual(ref_counts["account_label"], "TORGHUT_SIM")
+            source_materialization = ref_counts["source_materialization"]
+            assert isinstance(source_materialization, dict)
+            self.assertEqual(
+                source_materialization["runtime_ledger_account_label_scope"],
+                "TORGHUT_SIM",
+            )
 
     def test_reconciliation_reports_archived_runtime_ref_without_blocking_current_ref(
         self,


### PR DESCRIPTION
## Summary

- Scopes TigerBeetle runtime-ledger required-bucket coverage to the journal/reconcile account label when one is supplied.
- Carries `account_label` through reconciliation payload/ref-count metadata so status/readbacks can identify scoped parity.
- Prevents empty-selection journal runs from reusing a fresh reconciliation from a different account scope.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen ruff check app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `python -m py_compile app/trading/tigerbeetle_reconcile.py scripts/journal_tigerbeetle_order_events.py tests/test_tigerbeetle_reconcile.py tests/test_journal_tigerbeetle_order_events.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
