### PR TITLE
feat(torghut): add stochastic liquidity replay stress

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -96,11 +96,14 @@ from app.trading.discovery.rough_flow_volatility_stress import (
 from app.trading.discovery.signal_adaptive_execution_resilience_stress import (
     extract_signal_adaptive_execution_resilience_stress,
 )
+from app.trading.discovery.stochastic_liquidity_resilience_stress import (
+    extract_stochastic_liquidity_resilience_stress,
+)
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v14"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v15"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v15"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v16"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -130,6 +133,7 @@ FAST_REPLAY_WHITEPAPER_MECHANISMS = (
     "rough_flow_volatility_impact_stress",
     "institutional_mechanism_fidelity_stress",
     "signal_adaptive_execution_resilience_stress",
+    "stochastic_liquidity_resilience_execution_stress",
     "microstructure_regime_tokenization_stress",
     "cost_aware_forecast_filter_stress",
     "adaptive_market_limit_allocation_stress",
@@ -297,6 +301,9 @@ class FastReplayPreviewRow:
     signal_adaptive_execution_resilience_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
+    stochastic_liquidity_resilience_stress: Mapping[str, Any] = field(
+        default_factory=lambda: cast(dict[str, Any], {})
+    )
     microstructure_regime_tokenization_stress: Mapping[str, Any] = field(
         default_factory=lambda: cast(dict[str, Any], {})
     )
@@ -441,6 +448,9 @@ class FastReplayPreviewRow:
             ),
             "signal_adaptive_execution_resilience_stress": dict(
                 self.signal_adaptive_execution_resilience_stress
+            ),
+            "stochastic_liquidity_resilience_stress": dict(
+                self.stochastic_liquidity_resilience_stress
             ),
             "microstructure_regime_tokenization_stress": dict(
                 self.microstructure_regime_tokenization_stress
@@ -661,6 +671,7 @@ class FastReplayPreviewResult:
                 "rough_flow_volatility_impact_stress": "deterministic persistent signed-flow, rough traded-volume/volatility, Poisson-arrival, and power-law impact consistency stress from arXiv:2601.23172 and arXiv:2603.13170; roughness proxies are not PnL authority; preview ranking only",
                 "institutional_mechanism_fidelity_stress": "deterministic market-calendar, auction/session-boundary, price-limit, tick-size, latency, and asynchronous cross-asset mechanism-fidelity stress from arXiv:2604.18046 and arXiv:2511.02016; simulator realism proxies are not PnL authority; preview ranking only",
                 "signal_adaptive_execution_resilience_stress": "deterministic signal-adaptive quote, fill-intensity, inventory-risk, stochastic liquidity-resilience, and regime-switch stress from arXiv:2605.24242 and arXiv:2506.11813; signal drift and modeled fill intensity are not PnL authority; preview ranking only",
+                "stochastic_liquidity_resilience_execution_stress": "deterministic stochastic market-depth regime switching, LOB shape imbalance, depth-recovery resilience, execution-boundary pressure, and shortfall-by-liquidity-regime stress from arXiv:2506.11813 and SSRN:3798235; modeled resilience is not fill, PnL, or promotion authority; preview ranking only",
                 "microstructure_regime_tokenization_stress": "deterministic latent-regime early-warning, scale-invariant trade-flow token coverage, raw event precision, and stylized-fact replay stress from arXiv:2604.20949, arXiv:2602.23784, and arXiv:2508.02247; latent triggers and tokenized trade-flow are not PnL authority; preview ranking only",
                 "cost_aware_forecast_filter_stress": "deterministic walk-forward forecast-magnitude, transaction-cost threshold, turnover churn, multi-scale trend coverage, and dynamic-variable-selection stress from arXiv:2606.00060 and arXiv:2512.12727; cost-filtered forecasts are not PnL authority; preview ranking only",
                 "adaptive_market_limit_allocation_stress": "deterministic observed market/limit allocation, fill-uncertainty, tactical-imbalance, and trade-level cost logging stress from arXiv:2507.06345 and arXiv:2603.29086; allocation models are not fill or PnL authority; preview ranking only",
@@ -1340,6 +1351,7 @@ def _score_candidate_spec(
             rough_flow_volatility_stress={},
             institutional_mechanism_fidelity_stress={},
             signal_adaptive_execution_resilience_stress={},
+            stochastic_liquidity_resilience_stress={},
             microstructure_regime_tokenization_stress={},
             cost_aware_forecast_filter_stress={},
             adaptive_market_limit_allocation_stress={},
@@ -1600,6 +1612,20 @@ def _score_candidate_spec(
         )
         or 0.0
     )
+    stochastic_liquidity_resilience_stress = (
+        extract_stochastic_liquidity_resilience_stress(
+            matched_source_rows,
+            max_notional=_candidate_notional(spec),
+        ).to_payload()
+    )
+    stochastic_liquidity_resilience_rank_penalty_bps = (
+        _float_or_none(
+            _mapping(
+                stochastic_liquidity_resilience_stress.get("ranking_features")
+            ).get("replay_rank_penalty_bps")
+        )
+        or 0.0
+    )
     microstructure_regime_tokenization_stress = (
         extract_microstructure_regime_tokenization_stress(
             matched_source_rows,
@@ -1760,6 +1786,7 @@ def _score_candidate_spec(
         - rough_flow_volatility_rank_penalty_bps * 0.06
         - institutional_mechanism_fidelity_rank_penalty_bps * 0.05
         - signal_adaptive_execution_resilience_rank_penalty_bps * 0.05
+        - stochastic_liquidity_resilience_rank_penalty_bps * 0.05
         - microstructure_regime_tokenization_rank_penalty_bps * 0.05
         - cost_aware_forecast_filter_rank_penalty_bps * 0.05
         - adaptive_market_limit_allocation_rank_penalty_bps * 0.05
@@ -1813,6 +1840,7 @@ def _score_candidate_spec(
         - rough_flow_volatility_rank_penalty_bps * 0.03
         - institutional_mechanism_fidelity_rank_penalty_bps * 0.03
         - signal_adaptive_execution_resilience_rank_penalty_bps * 0.03
+        - stochastic_liquidity_resilience_rank_penalty_bps * 0.03
         - microstructure_regime_tokenization_rank_penalty_bps * 0.03
         - cost_aware_forecast_filter_rank_penalty_bps * 0.03
         - adaptive_market_limit_allocation_rank_penalty_bps * 0.03
@@ -1876,6 +1904,9 @@ def _score_candidate_spec(
         signal_adaptive_execution_resilience_stress=dict(
             signal_adaptive_execution_resilience_stress
         ),
+        stochastic_liquidity_resilience_stress=dict(
+            stochastic_liquidity_resilience_stress
+        ),
         microstructure_regime_tokenization_stress=dict(
             microstructure_regime_tokenization_stress
         ),
@@ -1938,6 +1969,7 @@ def _risk_adjusted_robust_rank_score(row: FastReplayPreviewRow) -> float:
         - _rough_flow_volatility_rank_penalty_bps(row) * 0.04
         - _institutional_mechanism_fidelity_rank_penalty_bps(row) * 0.04
         - _signal_adaptive_execution_resilience_rank_penalty_bps(row) * 0.04
+        - _stochastic_liquidity_resilience_rank_penalty_bps(row) * 0.04
         - _microstructure_regime_tokenization_rank_penalty_bps(row) * 0.04
         - _cost_aware_forecast_filter_rank_penalty_bps(row) * 0.04
         - _adaptive_market_limit_allocation_rank_penalty_bps(row) * 0.04
@@ -2058,6 +2090,15 @@ def _signal_adaptive_execution_resilience_rank_penalty_bps(
 ) -> float:
     ranking_features = _mapping(
         row.signal_adaptive_execution_resilience_stress.get("ranking_features")
+    )
+    return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
+
+
+def _stochastic_liquidity_resilience_rank_penalty_bps(
+    row: FastReplayPreviewRow,
+) -> float:
+    ranking_features = _mapping(
+        row.stochastic_liquidity_resilience_stress.get("ranking_features")
     )
     return _float_or_none(ranking_features.get("replay_rank_penalty_bps")) or 0.0
 
@@ -2334,6 +2375,9 @@ def _row_with_rank_and_selection(
         signal_adaptive_execution_resilience_stress=dict(
             row.signal_adaptive_execution_resilience_stress
         ),
+        stochastic_liquidity_resilience_stress=dict(
+            row.stochastic_liquidity_resilience_stress
+        ),
         microstructure_regime_tokenization_stress=dict(
             row.microstructure_regime_tokenization_stress
         ),
@@ -2428,6 +2472,9 @@ def _row_with_frontier_dedupe(
         ),
         signal_adaptive_execution_resilience_stress=dict(
             row.signal_adaptive_execution_resilience_stress
+        ),
+        stochastic_liquidity_resilience_stress=dict(
+            row.stochastic_liquidity_resilience_stress
         ),
         microstructure_regime_tokenization_stress=dict(
             row.microstructure_regime_tokenization_stress
@@ -3370,6 +3417,8 @@ def _risk_flags_for_row(
         flags.add("institutional_mechanism_fidelity_stress_penalty_active")
     if _signal_adaptive_execution_resilience_rank_penalty_bps(row) > 0:
         flags.add("signal_adaptive_execution_resilience_stress_penalty_active")
+    if _stochastic_liquidity_resilience_rank_penalty_bps(row) > 0:
+        flags.add("stochastic_liquidity_resilience_stress_penalty_active")
     if _microstructure_regime_tokenization_rank_penalty_bps(row) > 0:
         flags.add("microstructure_regime_tokenization_stress_penalty_active")
     if _cost_aware_forecast_filter_rank_penalty_bps(row) > 0:
@@ -3444,6 +3493,8 @@ def _ranking_only_reasons_for_row(
         reasons.add("institutional_mechanism_fidelity_stress_downranks_only")
     if _signal_adaptive_execution_resilience_rank_penalty_bps(row) > 0:
         reasons.add("signal_adaptive_execution_resilience_stress_downranks_only")
+    if _stochastic_liquidity_resilience_rank_penalty_bps(row) > 0:
+        reasons.add("stochastic_liquidity_resilience_stress_downranks_only")
     if _microstructure_regime_tokenization_rank_penalty_bps(row) > 0:
         reasons.add("microstructure_regime_tokenization_stress_downranks_only")
     if _cost_aware_forecast_filter_rank_penalty_bps(row) > 0:
@@ -3511,6 +3562,8 @@ def _risk_veto_reasons_for_row(
         vetoes.add("institutional_mechanism_fidelity_stress_penalty")
     if _signal_adaptive_execution_resilience_rank_penalty_bps(row) > 0:
         vetoes.add("signal_adaptive_execution_resilience_stress_penalty")
+    if _stochastic_liquidity_resilience_rank_penalty_bps(row) > 0:
+        vetoes.add("stochastic_liquidity_resilience_stress_penalty")
     if _microstructure_regime_tokenization_rank_penalty_bps(row) > 0:
         vetoes.add("microstructure_regime_tokenization_stress_penalty")
     if _cost_aware_forecast_filter_rank_penalty_bps(row) > 0:

--- a/services/torghut/app/trading/discovery/stochastic_liquidity_resilience_stress.py
+++ b/services/torghut/app/trading/discovery/stochastic_liquidity_resilience_stress.py
@@ -1,0 +1,609 @@
+"""Preview-only stochastic liquidity-resilience stress for replay ranking.
+
+This module converts 2025-2026 stochastic market-depth and liquidity-resilience
+execution papers into deterministic replay-ranking inputs. It never writes
+runtime ledgers, creates fills, authorizes promotion, or enables live capital.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from math import isfinite
+from typing import Any, cast
+
+from app.trading.models import SignalEnvelope
+
+STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_SCHEMA_VERSION = (
+    "torghut.stochastic-liquidity-resilience-stress.v1"
+)
+STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_CONTRACT_SCHEMA_VERSION = (
+    "torghut.stochastic-liquidity-resilience-stress-contract.v1"
+)
+STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PROOF_SEMANTICS_LABEL = (
+    "stochastic_liquidity_resilience_stress_preview_only_exact_replay_route_tca_"
+    "order_lifecycle_runtime_ledger_required"
+)
+STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PRIMARY_SOURCES: tuple[
+    Mapping[str, str], ...
+] = (
+    {
+        "source_id": "arxiv-2506.11813",
+        "url": "https://arxiv.org/abs/2506.11813",
+        "title": "Optimal Execution under Liquidity Uncertainty",
+        "date": "2025-06-13; revised 2026-04-11",
+        "mechanism": (
+            "regime_switching_liquidity_resilience_lob_shape_execution_boundaries"
+        ),
+    },
+    {
+        "source_id": "ssrn-3798235",
+        "url": "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3798235",
+        "title": (
+            "Constrained Optimal Execution Problem in Limit Order Book Market "
+            "with Stochastic Market Depth"
+        ),
+        "date": "2025-01-22; revised 2025-02-17",
+        "mechanism": (
+            "markov_chain_stochastic_market_depth_shape_constrained_execution"
+        ),
+    },
+)
+
+_PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
+_SPREAD_BPS_FIELDS = ("spread_bps", "quoted_spread_bps", "effective_spread_bps")
+_VOLUME_FIELDS = (
+    "microbar_volume",
+    "volume",
+    "qty",
+    "quantity",
+    "size",
+    "trade_size",
+    "last_size",
+)
+_BID_DEPTH_FIELDS = (
+    "bid_depth",
+    "bid_size",
+    "bid_qty",
+    "best_bid_size",
+    "best_bid_qty",
+    "bid_depth_qty",
+)
+_ASK_DEPTH_FIELDS = (
+    "ask_depth",
+    "ask_size",
+    "ask_qty",
+    "best_ask_size",
+    "best_ask_qty",
+    "ask_depth_qty",
+)
+_EXECUTION_SHORTFALL_BPS_FIELDS = (
+    "execution_shortfall_bps",
+    "shortfall_bps",
+    "route_tca_bps",
+    "slippage_bps",
+)
+_CHILD_PARTICIPATION_FIELDS = (
+    "child_order_participation_rate",
+    "participation_rate",
+    "pov_rate",
+)
+_RECOVERY_FRACTION = 0.50
+_SHOCK_DROP_FRACTION = 0.35
+
+
+@dataclass(frozen=True)
+class StochasticLiquidityResilienceStressSummary:
+    row_count: int
+    observed_price_count: int
+    observed_depth_count: int
+    observed_spread_count: int
+    observed_volume_count: int
+    observed_shortfall_count: int
+    observed_participation_count: int
+    median_lob_depth_notional: float
+    median_spread_bps: float
+    median_resilience_half_life_seconds: float
+    liquidity_regime_transition_count: int
+    liquidity_regime_instability_score: float
+    lob_shape_imbalance_score: float
+    stochastic_depth_shortfall_share: float
+    depth_shock_recovery_gap_score: float
+    execution_boundary_pressure_bps: float
+    shortfall_by_liquidity_regime_bps: float
+    source_gap_score: float
+    replay_rank_penalty_bps: float
+    warnings: tuple[str, ...]
+    feature_schema_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_SCHEMA_VERSION,
+            "feature_schema_hash": self.feature_schema_hash,
+            "status": "preview_only_stochastic_liquidity_resilience_stress_ranking",
+            "source_papers": [
+                dict(item)
+                for item in STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PRIMARY_SOURCES
+            ],
+            "row_count": self.row_count,
+            "observed_price_count": self.observed_price_count,
+            "observed_depth_count": self.observed_depth_count,
+            "observed_spread_count": self.observed_spread_count,
+            "observed_volume_count": self.observed_volume_count,
+            "observed_shortfall_count": self.observed_shortfall_count,
+            "observed_participation_count": self.observed_participation_count,
+            "median_lob_depth_notional": _stable_float(self.median_lob_depth_notional),
+            "median_spread_bps": _stable_float(self.median_spread_bps),
+            "median_resilience_half_life_seconds": _stable_float(
+                self.median_resilience_half_life_seconds
+            ),
+            "liquidity_regime_transition_count": self.liquidity_regime_transition_count,
+            "liquidity_regime_instability_score": _stable_float(
+                self.liquidity_regime_instability_score
+            ),
+            "lob_shape_imbalance_score": _stable_float(self.lob_shape_imbalance_score),
+            "stochastic_depth_shortfall_share": _stable_float(
+                self.stochastic_depth_shortfall_share
+            ),
+            "depth_shock_recovery_gap_score": _stable_float(
+                self.depth_shock_recovery_gap_score
+            ),
+            "execution_boundary_pressure_bps": _stable_float(
+                self.execution_boundary_pressure_bps
+            ),
+            "shortfall_by_liquidity_regime_bps": _stable_float(
+                self.shortfall_by_liquidity_regime_bps
+            ),
+            "source_gap_score": _stable_float(self.source_gap_score),
+            "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            "warnings": list(self.warnings),
+            "ranking_features": {
+                "median_lob_depth_notional": _stable_float(
+                    self.median_lob_depth_notional
+                ),
+                "median_resilience_half_life_seconds": _stable_float(
+                    self.median_resilience_half_life_seconds
+                ),
+                "liquidity_regime_instability_score": _stable_float(
+                    self.liquidity_regime_instability_score
+                ),
+                "lob_shape_imbalance_score": _stable_float(
+                    self.lob_shape_imbalance_score
+                ),
+                "stochastic_depth_shortfall_share": _stable_float(
+                    self.stochastic_depth_shortfall_share
+                ),
+                "depth_shock_recovery_gap_score": _stable_float(
+                    self.depth_shock_recovery_gap_score
+                ),
+                "execution_boundary_pressure_bps": _stable_float(
+                    self.execution_boundary_pressure_bps
+                ),
+                "shortfall_by_liquidity_regime_bps": _stable_float(
+                    self.shortfall_by_liquidity_regime_bps
+                ),
+                "source_gap_score": _stable_float(self.source_gap_score),
+                "replay_rank_penalty_bps": _stable_float(self.replay_rank_penalty_bps),
+            },
+            "resource_scope": "local_offline_replay_tape_or_fixture_rows_only",
+            "stochastic_liquidity_regime_preview": True,
+            "lob_shape_depth_preview": True,
+            "depth_recovery_resilience_preview": True,
+            "execution_boundary_pressure_preview": True,
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+            "proof_semantics_label": (
+                STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PROOF_SEMANTICS_LABEL
+            ),
+        }
+
+
+def stochastic_liquidity_resilience_stress_contract() -> dict[str, Any]:
+    return {
+        "schema_version": STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_CONTRACT_SCHEMA_VERSION,
+        "feature_schema_version": STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_SCHEMA_VERSION,
+        "source_papers": [
+            dict(item)
+            for item in STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PRIMARY_SOURCES
+        ],
+        "stress_policy": (
+            "stochastic_market_depth_regime_lob_shape_and_resilience_ranking"
+        ),
+        "stress_components": [
+            "liquidity_regime_instability_score",
+            "lob_shape_imbalance_score",
+            "stochastic_depth_shortfall_share",
+            "depth_shock_recovery_gap_score",
+            "execution_boundary_pressure_bps",
+            "shortfall_by_liquidity_regime_bps",
+            "source_gap_score",
+        ],
+        "output_scope": "preview_replay_ranking_only",
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_event_replay": True,
+            "requires_real_lob_depth_history": True,
+            "requires_order_lifecycle": True,
+            "requires_route_tca": True,
+            "requires_runtime_ledger": True,
+            "rejects_modeled_liquidity_resilience_as_pnl_authority": True,
+            "rejects_synthetic_depth_recovery_as_fill_authority": True,
+        },
+        "proof_semantics_label": (
+            STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PROOF_SEMANTICS_LABEL
+        ),
+    }
+
+
+def extract_stochastic_liquidity_resilience_stress(
+    rows: Sequence[SignalEnvelope], *, max_notional: float | None = None
+) -> StochasticLiquidityResilienceStressSummary:
+    ordered = sorted(rows, key=lambda row: (row.event_ts, row.seq))
+    prices: list[float | None] = []
+    depths: list[float | None] = []
+    spreads: list[float] = []
+    volumes: list[float] = []
+    shape_imbalances: list[float] = []
+    shortfalls: list[float] = []
+    participation_rates: list[float] = []
+    event_gap_seconds: list[float] = []
+    warnings: list[str] = []
+
+    previous_ts = None
+    for row in ordered:
+        payload = row.payload
+        price = _first_finite(payload, _PRICE_FIELDS)
+        bid_depth = _first_finite(payload, _BID_DEPTH_FIELDS)
+        ask_depth = _first_finite(payload, _ASK_DEPTH_FIELDS)
+        depth = _depth_notional(price=price, bid_depth=bid_depth, ask_depth=ask_depth)
+        prices.append(price)
+        depths.append(depth)
+        if bid_depth is not None and ask_depth is not None:
+            denominator = abs(bid_depth) + abs(ask_depth)
+            if denominator > 0.0:
+                shape_imbalances.append(abs(bid_depth - ask_depth) / denominator)
+        spread = _first_finite(payload, _SPREAD_BPS_FIELDS)
+        if spread is not None:
+            spreads.append(max(0.0, spread))
+        volume = _first_finite(payload, _VOLUME_FIELDS)
+        if volume is not None:
+            volumes.append(max(0.0, volume))
+        shortfall = _first_finite(payload, _EXECUTION_SHORTFALL_BPS_FIELDS)
+        if shortfall is not None:
+            shortfalls.append(max(0.0, shortfall))
+        participation = _first_finite(payload, _CHILD_PARTICIPATION_FIELDS)
+        if participation is not None:
+            participation_rates.append(max(0.0, min(1.0, participation)))
+        if previous_ts is not None:
+            event_gap_seconds.append(
+                max(0.0, (row.event_ts - previous_ts).total_seconds())
+            )
+        previous_ts = row.event_ts
+
+    observed_price_count = sum(1 for value in prices if value is not None)
+    depth_values = [value for value in depths if value is not None]
+    if observed_price_count < 2:
+        warnings.append("missing_price_path_for_liquidity_resilience")
+    if not depth_values:
+        warnings.append("missing_lob_depth_for_stochastic_liquidity_resilience")
+    if not shape_imbalances:
+        warnings.append("missing_two_sided_lob_shape_for_resilience_stress")
+    if not spreads:
+        warnings.append("missing_spread_context_for_execution_boundary")
+    if not volumes:
+        warnings.append("missing_volume_context_for_liquidity_regime")
+    if not shortfalls:
+        warnings.append("missing_execution_shortfall_by_liquidity_regime")
+    if not participation_rates:
+        warnings.append("missing_child_order_participation_rate_context")
+
+    regime_labels = _liquidity_regime_labels(depths)
+    transition_count = _transition_count(regime_labels)
+    instability = _regime_instability_score(regime_labels)
+    recovery_gap, half_life_seconds = _depth_recovery_metrics(
+        depths=depths,
+        event_gap_seconds=event_gap_seconds,
+    )
+    median_depth = _median(depth_values)
+    depth_floor = max_notional if max_notional is not None else median_depth
+    depth_shortfall = _depth_shortfall_share(depth_values, depth_floor=depth_floor)
+    boundary_pressure = _execution_boundary_pressure_bps(
+        max_notional=max_notional,
+        median_depth=median_depth,
+        median_spread_bps=_median(spreads),
+        median_participation_rate=_median(participation_rates),
+    )
+    shortfall_by_regime = _shortfall_by_liquidity_regime_bps(
+        shortfalls=shortfalls,
+        regime_labels=tuple(label for label in regime_labels if label is not None),
+    )
+    source_gap = _source_gap_score(
+        row_count=len(ordered),
+        observed_price_count=observed_price_count,
+        observed_depth_count=len(depth_values),
+        observed_spread_count=len(spreads),
+        observed_volume_count=len(volumes),
+        observed_shortfall_count=len(shortfalls),
+    )
+    penalty = (
+        instability * 12.0
+        + _mean(shape_imbalances) * 10.0
+        + depth_shortfall * 18.0
+        + recovery_gap * 16.0
+        + min(24.0, boundary_pressure) * 0.85
+        + shortfall_by_regime * 0.55
+        + source_gap * 20.0
+    )
+
+    return StochasticLiquidityResilienceStressSummary(
+        row_count=len(ordered),
+        observed_price_count=observed_price_count,
+        observed_depth_count=len(depth_values),
+        observed_spread_count=len(spreads),
+        observed_volume_count=len(volumes),
+        observed_shortfall_count=len(shortfalls),
+        observed_participation_count=len(participation_rates),
+        median_lob_depth_notional=median_depth,
+        median_spread_bps=_median(spreads),
+        median_resilience_half_life_seconds=half_life_seconds,
+        liquidity_regime_transition_count=transition_count,
+        liquidity_regime_instability_score=instability,
+        lob_shape_imbalance_score=_mean(shape_imbalances),
+        stochastic_depth_shortfall_share=depth_shortfall,
+        depth_shock_recovery_gap_score=recovery_gap,
+        execution_boundary_pressure_bps=boundary_pressure,
+        shortfall_by_liquidity_regime_bps=shortfall_by_regime,
+        source_gap_score=source_gap,
+        replay_rank_penalty_bps=float(min(250.0, max(0.0, penalty))),
+        warnings=tuple(sorted(set(warnings))),
+        feature_schema_hash=build_stochastic_liquidity_resilience_stress_schema_hash(),
+    )
+
+
+def build_stochastic_liquidity_resilience_stress_schema_hash() -> str:
+    payload = {
+        "schema_version": STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_SCHEMA_VERSION,
+        "price_fields": _PRICE_FIELDS,
+        "spread_fields": _SPREAD_BPS_FIELDS,
+        "volume_fields": _VOLUME_FIELDS,
+        "bid_depth_fields": _BID_DEPTH_FIELDS,
+        "ask_depth_fields": _ASK_DEPTH_FIELDS,
+        "execution_shortfall_fields": _EXECUTION_SHORTFALL_BPS_FIELDS,
+        "participation_fields": _CHILD_PARTICIPATION_FIELDS,
+        "source_ids": tuple(
+            source["source_id"]
+            for source in STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PRIMARY_SOURCES
+        ),
+        "proof_semantics_label": (
+            STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PROOF_SEMANTICS_LABEL
+        ),
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+
+
+def _depth_notional(
+    *, price: float | None, bid_depth: float | None, ask_depth: float | None
+) -> float | None:
+    if bid_depth is None or ask_depth is None:
+        return None
+    units = max(0.0, bid_depth) + max(0.0, ask_depth)
+    if units <= 0.0:
+        return None
+    return units * price if price is not None and price > 0.0 else units
+
+
+def _liquidity_regime_labels(depths: Sequence[float | None]) -> tuple[str | None, ...]:
+    values = [value for value in depths if value is not None]
+    if not values:
+        return tuple(None for _ in depths)
+    low = _percentile(values, 0.33)
+    high = _percentile(values, 0.67)
+    labels: list[str | None] = []
+    for depth in depths:
+        if depth is None:
+            labels.append(None)
+        elif depth <= low:
+            labels.append("thin")
+        elif depth >= high:
+            labels.append("deep")
+        else:
+            labels.append("normal")
+    return tuple(labels)
+
+
+def _transition_count(labels: Sequence[str | None]) -> int:
+    transitions = 0
+    previous: str | None = None
+    for label in labels:
+        if label is None:
+            continue
+        if previous is not None and label != previous:
+            transitions += 1
+        previous = label
+    return transitions
+
+
+def _regime_instability_score(labels: Sequence[str | None]) -> float:
+    observed = [label for label in labels if label is not None]
+    if len(observed) <= 1:
+        return 0.0
+    return min(1.0, _transition_count(observed) / max(1, len(observed) - 1))
+
+
+def _depth_recovery_metrics(
+    *, depths: Sequence[float | None], event_gap_seconds: Sequence[float]
+) -> tuple[float, float]:
+    values = [value for value in depths if value is not None]
+    if len(values) < 3:
+        return 0.0, 0.0
+    baseline = _median(values)
+    if baseline <= 0.0:
+        return 0.0, 0.0
+    gaps: list[float] = []
+    half_lives: list[float] = []
+    for idx in range(1, len(depths)):
+        previous = depths[idx - 1]
+        current = depths[idx]
+        if previous is None or current is None or previous <= 0.0:
+            continue
+        drop_fraction = (previous - current) / previous
+        if drop_fraction < _SHOCK_DROP_FRACTION or current >= baseline:
+            continue
+        target = current + (baseline - current) * _RECOVERY_FRACTION
+        recovered_at: int | None = None
+        best_recovery = current
+        for next_idx in range(idx + 1, len(depths)):
+            next_depth = depths[next_idx]
+            if next_depth is None:
+                continue
+            best_recovery = max(best_recovery, next_depth)
+            if next_depth >= target:
+                recovered_at = next_idx
+                break
+        recovery_fraction = (best_recovery - current) / max(1.0, baseline - current)
+        gaps.append(max(0.0, 1.0 - min(1.0, recovery_fraction)))
+        if recovered_at is not None:
+            half_lives.append(_elapsed_seconds(idx, recovered_at, event_gap_seconds))
+    if not gaps:
+        return 0.0, 0.0
+    return _mean(gaps), _median(half_lives)
+
+
+def _elapsed_seconds(
+    start_idx: int, end_idx: int, event_gap_seconds: Sequence[float]
+) -> float:
+    if end_idx <= start_idx:
+        return 0.0
+    gaps = event_gap_seconds[start_idx:end_idx]
+    if not gaps:
+        return float(end_idx - start_idx)
+    return sum(gaps)
+
+
+def _depth_shortfall_share(values: Sequence[float], *, depth_floor: float) -> float:
+    if not values or depth_floor <= 0.0:
+        return 0.0 if values else 1.0
+    return sum(1 for value in values if value < depth_floor) / len(values)
+
+
+def _execution_boundary_pressure_bps(
+    *,
+    max_notional: float | None,
+    median_depth: float,
+    median_spread_bps: float,
+    median_participation_rate: float,
+) -> float:
+    if max_notional is None or max_notional <= 0.0 or median_depth <= 0.0:
+        return 0.0
+    pressure = max_notional / median_depth
+    participation_pressure = max(0.0, median_participation_rate - 0.05) * 40.0
+    return max(0.0, pressure * max(1.0, median_spread_bps) + participation_pressure)
+
+
+def _shortfall_by_liquidity_regime_bps(
+    *, shortfalls: Sequence[float], regime_labels: Sequence[str]
+) -> float:
+    if not shortfalls:
+        return 0.0
+    count = min(len(shortfalls), len(regime_labels))
+    if count <= 0:
+        return _mean(shortfalls)
+    thin = [shortfalls[idx] for idx in range(count) if regime_labels[idx] == "thin"]
+    non_thin = [shortfalls[idx] for idx in range(count) if regime_labels[idx] != "thin"]
+    if thin and non_thin:
+        return max(0.0, _mean(thin) - _mean(non_thin))
+    return _mean(shortfalls)
+
+
+def _source_gap_score(
+    *,
+    row_count: int,
+    observed_price_count: int,
+    observed_depth_count: int,
+    observed_spread_count: int,
+    observed_volume_count: int,
+    observed_shortfall_count: int,
+) -> float:
+    if row_count <= 0:
+        return 1.0
+    coverages = (
+        observed_price_count / row_count,
+        observed_depth_count / row_count,
+        observed_spread_count / row_count,
+        observed_volume_count / row_count,
+        observed_shortfall_count / row_count,
+    )
+    return max(0.0, 1.0 - sum(coverages) / len(coverages))
+
+
+def _first_finite(payload: Mapping[str, Any], keys: Sequence[str]) -> float | None:
+    for key in keys:
+        if key not in payload:
+            continue
+        parsed = _float_or_none(payload.get(key))
+        if parsed is not None:
+            return parsed
+    nested = payload.get("features")
+    if isinstance(nested, Mapping):
+        nested_payload = cast(Mapping[str, Any], nested)
+        for key in keys:
+            if key not in nested_payload:
+                continue
+            parsed = _float_or_none(nested_payload.get(key))
+            if parsed is not None:
+                return parsed
+    return None
+
+
+def _float_or_none(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(cast(Any, value))
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(parsed):
+        return None
+    return parsed
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    midpoint = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[midpoint]
+    return (ordered[midpoint - 1] + ordered[midpoint]) / 2.0
+
+
+def _percentile(values: Sequence[float], quantile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, max(0, int(round((len(ordered) - 1) * quantile))))
+    return ordered[idx]
+
+
+def _stable_float(value: float) -> float:
+    if not isfinite(value):
+        return 0.0
+    return float(round(value, 8))

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -288,6 +288,10 @@ class TestFastReplayPreview(TestCase):
             payload["implemented_mechanisms"],
         )
         self.assertIn(
+            "stochastic_liquidity_resilience_execution_stress",
+            payload["implemented_mechanisms"],
+        )
+        self.assertIn(
             "microstructure_regime_tokenization_stress",
             payload["implemented_mechanisms"],
         )
@@ -634,6 +638,43 @@ class TestFastReplayPreview(TestCase):
         )
         self.assertIn(
             "signal_adaptive_execution_resilience_stress_downranks_only",
+            row_payload["ranking_only_reasons"],
+        )
+        self.assertIn("stochastic_liquidity_resilience_stress", row_payload)
+        self.assertEqual(
+            row_payload["stochastic_liquidity_resilience_stress"]["status"],
+            "preview_only_stochastic_liquidity_resilience_stress_ranking",
+        )
+        self.assertIn(
+            "arxiv-2506.11813",
+            {
+                source["source_id"]
+                for source in row_payload["stochastic_liquidity_resilience_stress"][
+                    "source_papers"
+                ]
+            },
+        )
+        self.assertIn(
+            "ssrn-3798235",
+            {
+                source["source_id"]
+                for source in row_payload["stochastic_liquidity_resilience_stress"][
+                    "source_papers"
+                ]
+            },
+        )
+        self.assertFalse(
+            row_payload["stochastic_liquidity_resilience_stress"]["proof_authority"]
+        )
+        self.assertFalse(
+            row_payload["stochastic_liquidity_resilience_stress"]["promotion_authority"]
+        )
+        self.assertIn(
+            "stochastic_liquidity_resilience_stress_penalty_active",
+            row_payload["risk_flags"],
+        )
+        self.assertIn(
+            "stochastic_liquidity_resilience_stress_downranks_only",
             row_payload["ranking_only_reasons"],
         )
         self.assertIn("microstructure_regime_tokenization_stress", row_payload)

--- a/services/torghut/tests/test_stochastic_liquidity_resilience_stress.py
+++ b/services/torghut/tests/test_stochastic_liquidity_resilience_stress.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.discovery.stochastic_liquidity_resilience_stress import (
+    build_stochastic_liquidity_resilience_stress_schema_hash,
+    extract_stochastic_liquidity_resilience_stress,
+    stochastic_liquidity_resilience_stress_contract,
+)
+from app.trading.models import SignalEnvelope
+
+
+class TestStochasticLiquidityResilienceStress(TestCase):
+    def _row(
+        self,
+        *,
+        offset: int,
+        price: str = "100.00",
+        bid_depth: str | None = "1000",
+        ask_depth: str | None = "1000",
+        spread_bps: str = "2.0",
+        shortfall_bps: str = "1.5",
+        participation_rate: str = "0.02",
+        volume: str = "100000",
+    ) -> SignalEnvelope:
+        payload: dict[str, object] = {
+            "price": Decimal(price),
+            "spread_bps": Decimal(spread_bps),
+            "microbar_volume": Decimal(volume),
+            "execution_shortfall_bps": Decimal(shortfall_bps),
+            "child_order_participation_rate": Decimal(participation_rate),
+        }
+        if bid_depth is not None:
+            payload["bid_depth"] = Decimal(bid_depth)
+        if ask_depth is not None:
+            payload["ask_depth"] = Decimal(ask_depth)
+        return SignalEnvelope(
+            event_ts=datetime(2026, 4, 11, 14, 30, tzinfo=timezone.utc)
+            + timedelta(seconds=offset),
+            symbol="LIQ",
+            timeframe="1s",
+            seq=offset,
+            source="stochastic-liquidity-fixture",
+            payload=payload,
+            ingest_ts=datetime(2026, 4, 11, 14, 31, tzinfo=timezone.utc),
+        )
+
+    def test_stable_depth_recovery_beats_fragile_regime_switching_depth(self) -> None:
+        stable = extract_stochastic_liquidity_resilience_stress(
+            (
+                self._row(offset=0, bid_depth="1000", ask_depth="1000"),
+                self._row(offset=1, bid_depth="1000", ask_depth="1000"),
+                self._row(offset=2, bid_depth="1000", ask_depth="1000"),
+                self._row(offset=3, bid_depth="1000", ask_depth="1000"),
+                self._row(offset=4, bid_depth="1000", ask_depth="1000"),
+            ),
+            max_notional=50000.0,
+        )
+        fragile = extract_stochastic_liquidity_resilience_stress(
+            (
+                self._row(
+                    offset=0,
+                    bid_depth="1400",
+                    ask_depth="1200",
+                    spread_bps="3.0",
+                    shortfall_bps="2.0",
+                    participation_rate="0.03",
+                ),
+                self._row(
+                    offset=1,
+                    bid_depth="250",
+                    ask_depth="80",
+                    spread_bps="18.0",
+                    shortfall_bps="14.0",
+                    participation_rate="0.18",
+                ),
+                self._row(
+                    offset=2,
+                    bid_depth="1600",
+                    ask_depth="1100",
+                    spread_bps="4.0",
+                    shortfall_bps="3.0",
+                    participation_rate="0.04",
+                ),
+                self._row(
+                    offset=3,
+                    bid_depth="180",
+                    ask_depth="40",
+                    spread_bps="24.0",
+                    shortfall_bps="18.0",
+                    participation_rate="0.22",
+                ),
+                self._row(
+                    offset=4,
+                    bid_depth="220",
+                    ask_depth="70",
+                    spread_bps="26.0",
+                    shortfall_bps="20.0",
+                    participation_rate="0.20",
+                ),
+            ),
+            max_notional=50000.0,
+        )
+
+        self.assertLess(
+            stable.liquidity_regime_instability_score,
+            fragile.liquidity_regime_instability_score,
+        )
+        self.assertLess(
+            stable.lob_shape_imbalance_score,
+            fragile.lob_shape_imbalance_score,
+        )
+        self.assertLess(
+            stable.depth_shock_recovery_gap_score,
+            fragile.depth_shock_recovery_gap_score,
+        )
+        self.assertLess(
+            stable.replay_rank_penalty_bps,
+            fragile.replay_rank_penalty_bps,
+        )
+        payload = fragile.to_payload()
+        self.assertEqual(
+            payload["status"],
+            "preview_only_stochastic_liquidity_resilience_stress_ranking",
+        )
+        self.assertTrue(payload["stochastic_liquidity_regime_preview"])
+        self.assertTrue(payload["depth_recovery_resilience_preview"])
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["final_authority_ok"])
+
+    def test_missing_depth_fails_closed_with_source_gap_and_contract_sources(
+        self,
+    ) -> None:
+        summary = extract_stochastic_liquidity_resilience_stress(
+            (
+                self._row(offset=0, bid_depth=None, ask_depth=None),
+                self._row(offset=1, bid_depth=None, ask_depth=None),
+            ),
+            max_notional=50000.0,
+        )
+        payload = summary.to_payload()
+        contract = stochastic_liquidity_resilience_stress_contract()
+        source_ids = {source["source_id"] for source in payload["source_papers"]}
+
+        self.assertEqual(
+            payload["feature_schema_hash"],
+            build_stochastic_liquidity_resilience_stress_schema_hash(),
+        )
+        self.assertIn("arxiv-2506.11813", source_ids)
+        self.assertIn("ssrn-3798235", source_ids)
+        self.assertIn(
+            "missing_lob_depth_for_stochastic_liquidity_resilience",
+            payload["warnings"],
+        )
+        self.assertGreater(payload["source_gap_score"], 0)
+        self.assertFalse(contract["proof_neutrality"]["proof_authority"])
+        self.assertTrue(
+            contract["proof_neutrality"][
+                "rejects_modeled_liquidity_resilience_as_pnl_authority"
+            ]
+        )
+
+    def test_nested_payload_and_empty_rows_stay_bounded(self) -> None:
+        empty = extract_stochastic_liquidity_resilience_stress(())
+        nested = extract_stochastic_liquidity_resilience_stress(
+            (
+                SignalEnvelope(
+                    event_ts=datetime(2026, 4, 11, 14, 30, tzinfo=timezone.utc),
+                    symbol="LIQ",
+                    timeframe="1s",
+                    seq=0,
+                    source="stochastic-liquidity-fixture",
+                    payload={
+                        "features": {
+                            "mid_price": "101.5",
+                            "bid_size": "800",
+                            "ask_size": "700",
+                            "quoted_spread_bps": "3.5",
+                            "microbar_volume": "120000",
+                            "slippage_bps": "2.5",
+                            "pov_rate": "0.04",
+                        }
+                    },
+                    ingest_ts=datetime(2026, 4, 11, 14, 31, tzinfo=timezone.utc),
+                ),
+            ),
+            max_notional=10000.0,
+        )
+
+        self.assertEqual(empty.source_gap_score, 1.0)
+        self.assertEqual(nested.observed_depth_count, 1)
+        self.assertEqual(nested.observed_spread_count, 1)
+        self.assertEqual(nested.observed_shortfall_count, 1)
+        self.assertGreaterEqual(nested.execution_boundary_pressure_bps, 0.0)
+        self.assertFalse(nested.to_payload()["proof_authority"])


### PR DESCRIPTION
## Summary

- Adds a preview-only stochastic liquidity resilience replay stress extractor for Torghut candidate ranking.
- Implements replay features from arXiv:2506.11813 and SSRN:3798235: stochastic depth regime instability, LOB shape imbalance, depth shock recovery, execution-boundary pressure, and shortfall-by-regime penalties.
- Wires the stress into fast replay scoring, risk flags, ranking-only reasons, and implemented mechanism metadata without granting proof, promotion, fill, PnL, or live-capital authority.
- Adds focused unit coverage for the extractor and fast replay payload/proof-neutrality behavior.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv run --frozen pytest tests/test_stochastic_liquidity_resilience_stress.py tests/test_fast_replay.py -q`
- PASS: `cd services/torghut && uvx ruff check app/trading/discovery/stochastic_liquidity_resilience_stress.py app/trading/discovery/fast_replay.py tests/test_stochastic_liquidity_resilience_stress.py tests/test_fast_replay.py`
- PASS: `cd services/torghut && uvx ruff format --check app/trading/discovery/stochastic_liquidity_resilience_stress.py app/trading/discovery/fast_replay.py tests/test_stochastic_liquidity_resilience_stress.py tests/test_fast_replay.py`
- PASS: `cd services/torghut && uv run --frozen python -m coverage erase && uv run --frozen python -m coverage run -m pytest tests/test_stochastic_liquidity_resilience_stress.py tests/test_fast_replay.py -q && uv run --frozen python -m coverage xml -o coverage.xml && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 && rm -f coverage.xml`
- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
