### PR TITLE
fix(torghut): require alpha decay evidence

### DIFF
--- a/services/torghut/app/trading/discovery/alpha_decay_predictability_stress.py
+++ b/services/torghut/app/trading/discovery/alpha_decay_predictability_stress.py
@@ -43,6 +43,10 @@ ALPHA_DECAY_PREDICTABILITY_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...]
         "mechanism": "tight_spread_heavy_trading_algorithmic_activity_predictability_compression",
     },
 )
+ALPHA_DECAY_PREDICTABILITY_STRESS_SOURCE_MARKERS: tuple[str, ...] = (
+    "alpha_decay_predictability_arxiv_2601_02310_2026",
+    "short_run_market_efficiency_ssrn_6608199_2026",
+)
 
 _PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
 _BID_FIELDS = ("bid", "best_bid", "bid_price", "best_bid_price")
@@ -107,6 +111,7 @@ class AlphaDecayPredictabilityStressSummary:
             "source_papers": [
                 dict(item) for item in ALPHA_DECAY_PREDICTABILITY_STRESS_PRIMARY_SOURCES
             ],
+            "source_markers": list(ALPHA_DECAY_PREDICTABILITY_STRESS_SOURCE_MARKERS),
             "row_count": self.row_count,
             "observed_price_count": self.observed_price_count,
             "observed_spread_count": self.observed_spread_count,
@@ -195,6 +200,7 @@ def alpha_decay_predictability_stress_contract() -> dict[str, Any]:
         "source_papers": [
             dict(item) for item in ALPHA_DECAY_PREDICTABILITY_STRESS_PRIMARY_SOURCES
         ],
+        "source_markers": list(ALPHA_DECAY_PREDICTABILITY_STRESS_SOURCE_MARKERS),
         "stress_policy": "multi_horizon_alpha_decay_spread_adjusted_efficiency_regime_stress",
         "stress_components": [
             "horizon_curve",

--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -226,6 +226,40 @@ OFI_RESPONSE_HORIZON_SCORECARD_KEYS = (
     "post_cost_net_pnl_after_ofi_response_horizon",
     "ofi_response_horizon_source_markers",
 )
+ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS = (
+    "requires_predictability_decay_stress",
+    "required_predictability_decay_stress",
+    "requires_horizon_decay_curve",
+    "required_horizon_decay_curve",
+    "requires_spread_adjusted_label_replay",
+    "required_spread_adjusted_label_replay",
+    "requires_tight_spread_and_high_volume_slices",
+    "requires_model_latency_budget",
+    "rejects_single_horizon_lob_alpha_promotion",
+    "rejects_classification_accuracy_without_costs",
+    "required_min_decay_stress_horizon_count",
+    "required_min_tight_spread_regime_count",
+    "required_min_high_volume_regime_count",
+    "required_min_decay_stress_split_pass_rate",
+    "required_max_decay_stress_best_split_share",
+    "required_max_model_inference_latency_ms",
+    "predictability_decay_stress_passed",
+    "predictability_decay_stress_artifact_ref",
+    "predictability_decay_stress_artifact_refs",
+    "horizon_decay_curve_present",
+    "predictability_horizon_decay_curve_present",
+    "spread_adjusted_label_replay_passed",
+    "spread_adjusted_label_evidence_present",
+    "predictability_decay_stress_horizon_count",
+    "tight_spread_regime_count",
+    "high_volume_regime_count",
+    "predictability_decay_stress_split_pass_rate",
+    "predictability_decay_stress_best_split_share",
+    "model_inference_latency_ms",
+    "post_cost_net_pnl_after_predictability_decay_stress",
+    "predictability_decay_stress_net_pnl_per_day",
+    "alpha_decay_predictability_source_markers",
+)
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -1076,6 +1110,13 @@ def evidence_bundle_from_frontier_candidate(
             if key in source:
                 scorecard = {**scorecard, key: source[key]}
                 break
+    for key in ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS:
+        if key in scorecard:
+            continue
+        for source in (candidate, summary, full_window):
+            if key in source:
+                scorecard = {**scorecard, key: source[key]}
+                break
     for source in (candidate, summary, full_window):
         for key, value in _order_type_execution_metrics(source).items():
             if key not in scorecard:
@@ -1136,6 +1177,7 @@ def evidence_bundle_from_frontier_candidate(
         for key in (
             *BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS,
             *OFI_RESPONSE_HORIZON_SCORECARD_KEYS,
+            *ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS,
         ):
             if key in nested_contract and key not in scorecard:
                 scorecard = {**scorecard, key: nested_contract[key]}
@@ -1890,6 +1932,134 @@ def _ofi_response_horizon_blockers(scorecard: Mapping[str, Any]) -> list[str]:
     return blockers
 
 
+def _alpha_decay_predictability_required(scorecard: Mapping[str, Any]) -> bool:
+    if any(
+        _bool(scorecard.get(key))
+        for key in (
+            "requires_predictability_decay_stress",
+            "required_predictability_decay_stress",
+            "requires_horizon_decay_curve",
+            "required_horizon_decay_curve",
+            "requires_spread_adjusted_label_replay",
+            "required_spread_adjusted_label_replay",
+            "requires_tight_spread_and_high_volume_slices",
+            "requires_model_latency_budget",
+            "rejects_single_horizon_lob_alpha_promotion",
+            "rejects_classification_accuracy_without_costs",
+        )
+    ):
+        return True
+    hard_vetoes = {veto.lower() for veto in _string_list(scorecard.get("hard_vetoes"))}
+    if hard_vetoes.intersection(
+        {
+            "required_predictability_decay_stress",
+            "required_horizon_decay_curve",
+            "required_spread_adjusted_label_replay",
+            "required_min_decay_stress_horizon_count",
+            "required_min_tight_spread_regime_count",
+            "required_min_high_volume_regime_count",
+            "required_min_decay_stress_split_pass_rate",
+            "required_max_decay_stress_best_split_share",
+            "required_max_model_inference_latency_ms",
+        }
+    ):
+        return True
+    return bool(
+        {
+            marker.lower()
+            for marker in _string_list(
+                scorecard.get("alpha_decay_predictability_source_markers")
+            )
+        }.intersection(
+            {
+                "alpha_decay_predictability_arxiv_2601_02310_2026",
+                "short_run_market_efficiency_ssrn_6608199_2026",
+            }
+        )
+    )
+
+
+def _alpha_decay_predictability_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    if not _alpha_decay_predictability_required(scorecard):
+        return []
+
+    blockers: list[str] = []
+    if not _bool(scorecard.get("predictability_decay_stress_passed")):
+        blockers.append("predictability_decay_stress_missing_or_failed")
+    if not _has_artifact_ref(
+        scorecard,
+        "predictability_decay_stress_artifact_ref",
+        "predictability_decay_stress_artifact_refs",
+    ):
+        blockers.append("predictability_decay_stress_artifact_missing")
+    if not (
+        _bool(scorecard.get("horizon_decay_curve_present"))
+        or _bool(scorecard.get("predictability_horizon_decay_curve_present"))
+    ):
+        blockers.append("horizon_decay_curve_missing")
+    if not (
+        _bool(scorecard.get("spread_adjusted_label_replay_passed"))
+        or _bool(scorecard.get("spread_adjusted_label_evidence_present"))
+    ):
+        blockers.append("spread_adjusted_label_replay_missing_or_failed")
+    required_horizon_count = max(
+        1,
+        _int(scorecard.get("required_min_decay_stress_horizon_count") or 3),
+    )
+    if (
+        _int(scorecard.get("predictability_decay_stress_horizon_count"))
+        < required_horizon_count
+    ):
+        blockers.append("predictability_decay_horizon_count_below_min")
+    required_tight_spread_count = max(
+        1,
+        _int(scorecard.get("required_min_tight_spread_regime_count") or 20),
+    )
+    if _int(scorecard.get("tight_spread_regime_count")) < required_tight_spread_count:
+        blockers.append("tight_spread_regime_count_below_min")
+    required_high_volume_count = max(
+        1,
+        _int(scorecard.get("required_min_high_volume_regime_count") or 20),
+    )
+    if _int(scorecard.get("high_volume_regime_count")) < required_high_volume_count:
+        blockers.append("high_volume_regime_count_below_min")
+    required_split_rate = _decimal(
+        scorecard.get("required_min_decay_stress_split_pass_rate") or "0.60"
+    )
+    if (
+        _decimal(scorecard.get("predictability_decay_stress_split_pass_rate"))
+        < required_split_rate
+    ):
+        blockers.append("predictability_decay_split_pass_rate_below_min")
+    max_best_split_share = _decimal(
+        scorecard.get("required_max_decay_stress_best_split_share") or "0.35"
+    )
+    raw_best_split_share = scorecard.get("predictability_decay_stress_best_split_share")
+    if raw_best_split_share is None:
+        blockers.append("predictability_decay_best_split_share_missing")
+    elif _decimal(raw_best_split_share) > max_best_split_share:
+        blockers.append("predictability_decay_best_split_share_above_max")
+    raw_latency_ms = scorecard.get("model_inference_latency_ms")
+    max_latency_ms = _decimal(
+        scorecard.get("required_max_model_inference_latency_ms") or "200"
+    )
+    if raw_latency_ms is None:
+        blockers.append("model_inference_latency_missing")
+    elif _decimal(raw_latency_ms) > max_latency_ms:
+        blockers.append("model_inference_latency_above_max")
+    if not _route_tca_present(scorecard):
+        blockers.append("predictability_decay_route_tca_evidence_missing")
+    if (
+        _decimal(
+            scorecard.get("post_cost_net_pnl_after_predictability_decay_stress")
+            or scorecard.get("predictability_decay_stress_net_pnl_per_day")
+        )
+        <= 0
+    ):
+        blockers.append("predictability_decay_net_pnl_non_positive")
+    return blockers
+
+
 def _conformal_tail_risk_blockers(scorecard: Mapping[str, Any]) -> list[str]:
     requires_conformal_tail_risk = _bool(
         scorecard.get("conformal_tail_risk_required")
@@ -1973,6 +2143,7 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         blockers.extend(_implementation_risk_backtest_stability_blockers(scorecard))
         blockers.extend(_bootstrap_robust_optimization_blockers(scorecard))
         blockers.extend(_ofi_response_horizon_blockers(scorecard))
+        blockers.extend(_alpha_decay_predictability_blockers(scorecard))
         blockers.extend(_conformal_tail_risk_blockers(scorecard))
         blockers.extend(_delay_depth_survival_blockers(scorecard))
     return tuple(dict.fromkeys(blockers))

--- a/services/torghut/tests/test_alpha_decay_predictability_stress.py
+++ b/services/torghut/tests/test_alpha_decay_predictability_stress.py
@@ -133,6 +133,14 @@ class TestAlphaDecayPredictabilityStress(TestCase):
         self.assertFalse(payload["proof_authority"])
         self.assertFalse(payload["promotion_authority"])
         self.assertFalse(payload["final_authority_ok"])
+        self.assertIn(
+            "alpha_decay_predictability_arxiv_2601_02310_2026",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "short_run_market_efficiency_ssrn_6608199_2026",
+            payload["source_markers"],
+        )
 
     def test_contract_embeds_sources_and_keeps_proof_fail_closed(self) -> None:
         contract = alpha_decay_predictability_stress_contract()
@@ -151,6 +159,22 @@ class TestAlphaDecayPredictabilityStress(TestCase):
         )
         self.assertIn("arxiv-2601.02310", source_ids)
         self.assertIn("ssrn-6608199", source_ids)
+        self.assertIn(
+            "alpha_decay_predictability_arxiv_2601_02310_2026",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "short_run_market_efficiency_ssrn_6608199_2026",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "alpha_decay_predictability_arxiv_2601_02310_2026",
+            contract["source_markers"],
+        )
+        self.assertIn(
+            "short_run_market_efficiency_ssrn_6608199_2026",
+            contract["source_markers"],
+        )
         self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
         self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
         self.assertTrue(

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -844,6 +844,176 @@ def test_frontier_candidate_preserves_ofi_response_fields() -> None:
     assert "ofi_route_tca_evidence_missing" not in blockers
 
 
+def test_promotion_ready_bundle_blocks_required_alpha_decay_predictability_gaps() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-alpha-decay-gap",
+        candidate_id="candidate-alpha-decay-gap",
+        candidate_spec_id="spec-alpha-decay-gap",
+        dataset_snapshot_id="snapshot-alpha-decay-gap",
+        feature_spec_hash="feature-alpha-decay-gap",
+        code_commit="commit-alpha-decay-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_predictability_decay_stress": True,
+            "required_min_decay_stress_horizon_count": "3",
+            "required_min_tight_spread_regime_count": "20",
+            "required_min_high_volume_regime_count": "20",
+            "required_min_decay_stress_split_pass_rate": "0.60",
+            "required_max_decay_stress_best_split_share": "0.35",
+            "required_max_model_inference_latency_ms": "200",
+            "alpha_decay_predictability_source_markers": [
+                "alpha_decay_predictability_arxiv_2601_02310_2026",
+                "short_run_market_efficiency_ssrn_6608199_2026",
+            ],
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "predictability_decay_stress_missing_or_failed" in blockers
+    assert "predictability_decay_stress_artifact_missing" in blockers
+    assert "horizon_decay_curve_missing" in blockers
+    assert "spread_adjusted_label_replay_missing_or_failed" in blockers
+    assert "predictability_decay_horizon_count_below_min" in blockers
+    assert "tight_spread_regime_count_below_min" in blockers
+    assert "high_volume_regime_count_below_min" in blockers
+    assert "predictability_decay_split_pass_rate_below_min" in blockers
+    assert "predictability_decay_best_split_share_missing" in blockers
+    assert "model_inference_latency_missing" in blockers
+    assert "predictability_decay_route_tca_evidence_missing" in blockers
+    assert "predictability_decay_net_pnl_non_positive" in blockers
+
+
+def test_promotion_ready_bundle_accepts_materialized_alpha_decay_predictability_evidence() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-alpha-decay-ready",
+        candidate_id="candidate-alpha-decay-ready",
+        candidate_spec_id="spec-alpha-decay-ready",
+        dataset_snapshot_id="snapshot-alpha-decay-ready",
+        feature_spec_hash="feature-alpha-decay-ready",
+        code_commit="commit-alpha-decay-ready",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_predictability_decay_stress": True,
+            "required_min_decay_stress_horizon_count": "3",
+            "required_min_tight_spread_regime_count": "20",
+            "required_min_high_volume_regime_count": "20",
+            "required_min_decay_stress_split_pass_rate": "0.60",
+            "required_max_decay_stress_best_split_share": "0.35",
+            "required_max_model_inference_latency_ms": "200",
+            "predictability_decay_stress_passed": True,
+            "predictability_decay_stress_artifact_ref": "artifact://alpha-decay",
+            "horizon_decay_curve_present": True,
+            "spread_adjusted_label_replay_passed": True,
+            "predictability_decay_stress_horizon_count": 4,
+            "tight_spread_regime_count": 24,
+            "high_volume_regime_count": 25,
+            "predictability_decay_stress_split_pass_rate": "0.65",
+            "predictability_decay_stress_best_split_share": "0.30",
+            "model_inference_latency_ms": "80",
+            "route_tca_artifact_ref": "artifact://route-tca",
+            "post_cost_net_pnl_after_predictability_decay_stress": "535",
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "predictability_decay_stress_missing_or_failed" not in blockers
+    assert "predictability_decay_stress_artifact_missing" not in blockers
+    assert "horizon_decay_curve_missing" not in blockers
+    assert "spread_adjusted_label_replay_missing_or_failed" not in blockers
+    assert "predictability_decay_horizon_count_below_min" not in blockers
+    assert "tight_spread_regime_count_below_min" not in blockers
+    assert "high_volume_regime_count_below_min" not in blockers
+    assert "predictability_decay_split_pass_rate_below_min" not in blockers
+    assert "predictability_decay_best_split_share_missing" not in blockers
+    assert "model_inference_latency_missing" not in blockers
+    assert "predictability_decay_route_tca_evidence_missing" not in blockers
+    assert "predictability_decay_net_pnl_non_positive" not in blockers
+
+
+def test_frontier_candidate_preserves_alpha_decay_predictability_fields() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-alpha-decay-preserved",
+        candidate={
+            "candidate_id": "candidate-alpha-decay-preserved",
+            "objective_scorecard": _promotion_quality_scorecard(),
+            "hard_vetoes": {
+                "required_predictability_decay_stress": True,
+                "required_horizon_decay_curve": True,
+                "required_spread_adjusted_label_replay": True,
+                "required_min_decay_stress_horizon_count": "3",
+                "required_min_tight_spread_regime_count": "20",
+                "required_min_high_volume_regime_count": "20",
+                "required_min_decay_stress_split_pass_rate": "0.60",
+                "required_max_decay_stress_best_split_share": "0.35",
+                "required_max_model_inference_latency_ms": "200",
+            },
+            "promotion_contract": {
+                "requires_predictability_decay_stress": True,
+                "requires_route_tca": True,
+            },
+            "predictability_decay_stress_passed": True,
+            "predictability_decay_stress_artifact_ref": "artifact://alpha-decay",
+            "horizon_decay_curve_present": True,
+            "spread_adjusted_label_replay_passed": True,
+            "predictability_decay_stress_horizon_count": 4,
+            "tight_spread_regime_count": 24,
+            "high_volume_regime_count": 25,
+            "predictability_decay_stress_split_pass_rate": "0.65",
+            "predictability_decay_stress_best_split_share": "0.30",
+            "model_inference_latency_ms": "80",
+            "route_tca_artifact_ref": "artifact://route-tca",
+            "post_cost_net_pnl_after_predictability_decay_stress": "535",
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-alpha-decay-preserved",
+        result_path="artifact://replay",
+        code_commit="commit-alpha-decay-preserved",
+    )
+
+    assert bundle.objective_scorecard["requires_predictability_decay_stress"] is True
+    assert bundle.objective_scorecard["required_horizon_decay_curve"] is True
+    assert (
+        bundle.objective_scorecard["predictability_decay_stress_artifact_ref"]
+        == "artifact://alpha-decay"
+    )
+    blockers = evidence_bundle_blockers(bundle)
+    assert "predictability_decay_stress_artifact_missing" not in blockers
+    assert "predictability_decay_route_tca_evidence_missing" not in blockers
+
+
 def test_frontier_candidate_preserves_implementation_risk_parity_fields() -> None:
     bundle = evidence_bundle_from_frontier_candidate(
         candidate_spec_id="spec-implementation-risk-preserved",

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -479,6 +479,14 @@ class TestFastReplayPreview(TestCase):
                 ]
             },
         )
+        self.assertIn(
+            "alpha_decay_predictability_arxiv_2601_02310_2026",
+            row_payload["alpha_decay_predictability_stress"]["source_markers"],
+        )
+        self.assertIn(
+            "short_run_market_efficiency_ssrn_6608199_2026",
+            row_payload["alpha_decay_predictability_stress"]["source_markers"],
+        )
         self.assertIn("counterfactual_regime_replay_stress", row_payload)
         self.assertFalse(
             row_payload["counterfactual_regime_replay_stress"]["proof_authority"]


### PR DESCRIPTION
## Summary

- Adds fail-closed evidence-bundle blockers for alpha-decay / short-horizon LOB predictability candidates unless materialized multi-horizon decay, spread-adjusted label, regime-slice, latency, route TCA, and positive post-cost evidence is present.
- Propagates alpha-decay predictability source markers from the preview stress contract so source-backed candidates inherit the stricter promotion requirements.
- Adds regression coverage for missing vs materialized alpha-decay evidence, frontier candidate field preservation, and fast replay source marker propagation.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py app/trading/discovery/alpha_decay_predictability_stress.py tests/test_evidence_bundles.py tests/test_alpha_decay_predictability_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py app/trading/discovery/alpha_decay_predictability_stress.py tests/test_evidence_bundles.py tests/test_alpha_decay_predictability_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py tests/test_alpha_decay_predictability_stress.py tests/test_fast_replay.py::TestFastReplayPreview::test_whitepaper_features_rank_and_label_preview_only`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv sync --frozen --extra dev` fails in this workspace because `crosshair-tool==0.0.102` needs a system `cc` compiler that is not installed (`error: command 'cc' failed: No such file or directory`).
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
