### PR TITLE
fix(torghut): require liquidity resilience evidence

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -260,6 +260,45 @@ ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS = (
     "predictability_decay_stress_net_pnl_per_day",
     "alpha_decay_predictability_source_markers",
 )
+STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS = (
+    "requires_stochastic_liquidity_resilience_execution_grid",
+    "required_stochastic_liquidity_resilience_execution_grid",
+    "requires_liquidity_regime_transition_trace",
+    "required_liquidity_regime_transition_trace",
+    "requires_stochastic_market_depth_state",
+    "required_stochastic_market_depth_state",
+    "requires_lob_shape_parameter_history",
+    "required_lob_shape_parameter_history",
+    "requires_depth_recovery_after_child_order",
+    "required_depth_recovery_after_child_order",
+    "requires_execution_shortfall_by_liquidity_regime",
+    "required_execution_shortfall_by_liquidity_regime",
+    "required_resilience_decay_half_life",
+    "required_max_liquidity_regime_shortfall_bps",
+    "rejects_modeled_liquidity_resilience_as_profit_proof",
+    "rejects_synthetic_depth_recovery_as_fill_authority",
+    "stochastic_liquidity_resilience_stress_passed",
+    "stochastic_liquidity_resilience_stress_artifact_ref",
+    "stochastic_liquidity_resilience_stress_artifact_refs",
+    "liquidity_regime_transition_trace_present",
+    "liquidity_regime_transition_count",
+    "stochastic_market_depth_state_present",
+    "stochastic_market_depth_state_count",
+    "observed_depth_count",
+    "lob_shape_parameter_history_present",
+    "lob_shape_parameter_sample_count",
+    "resilience_decay_half_life_present",
+    "median_resilience_half_life_seconds",
+    "depth_recovery_after_child_order_present",
+    "depth_recovery_sample_count",
+    "execution_shortfall_by_liquidity_regime_present",
+    "execution_shortfall_by_liquidity_regime_sample_count",
+    "observed_shortfall_count",
+    "shortfall_by_liquidity_regime_bps",
+    "post_cost_net_pnl_after_liquidity_regime_resilience_shortfall_stress",
+    "liquidity_regime_resilience_shortfall_stress_net_pnl_per_day",
+    "stochastic_liquidity_resilience_source_markers",
+)
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -1117,6 +1156,13 @@ def evidence_bundle_from_frontier_candidate(
             if key in source:
                 scorecard = {**scorecard, key: source[key]}
                 break
+    for key in STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS:
+        if key in scorecard:
+            continue
+        for source in (candidate, summary, full_window):
+            if key in source:
+                scorecard = {**scorecard, key: source[key]}
+                break
     for source in (candidate, summary, full_window):
         for key, value in _order_type_execution_metrics(source).items():
             if key not in scorecard:
@@ -1178,6 +1224,7 @@ def evidence_bundle_from_frontier_candidate(
             *BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS,
             *OFI_RESPONSE_HORIZON_SCORECARD_KEYS,
             *ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS,
+            *STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS,
         ):
             if key in nested_contract and key not in scorecard:
                 scorecard = {**scorecard, key: nested_contract[key]}
@@ -2060,6 +2107,139 @@ def _alpha_decay_predictability_blockers(scorecard: Mapping[str, Any]) -> list[s
     return blockers
 
 
+def _stochastic_liquidity_resilience_required(scorecard: Mapping[str, Any]) -> bool:
+    if any(
+        _bool(scorecard.get(key))
+        for key in (
+            "requires_stochastic_liquidity_resilience_execution_grid",
+            "required_stochastic_liquidity_resilience_execution_grid",
+            "requires_liquidity_regime_transition_trace",
+            "required_liquidity_regime_transition_trace",
+            "requires_stochastic_market_depth_state",
+            "required_stochastic_market_depth_state",
+            "requires_lob_shape_parameter_history",
+            "required_lob_shape_parameter_history",
+            "requires_depth_recovery_after_child_order",
+            "required_depth_recovery_after_child_order",
+            "requires_execution_shortfall_by_liquidity_regime",
+            "required_execution_shortfall_by_liquidity_regime",
+            "required_resilience_decay_half_life",
+            "rejects_modeled_liquidity_resilience_as_profit_proof",
+            "rejects_synthetic_depth_recovery_as_fill_authority",
+        )
+    ):
+        return True
+    hard_vetoes = {veto.lower() for veto in _string_list(scorecard.get("hard_vetoes"))}
+    if hard_vetoes.intersection(
+        {
+            "required_stochastic_liquidity_resilience_execution_grid",
+            "required_liquidity_regime_transition_trace",
+            "required_stochastic_market_depth_state",
+            "required_lob_shape_parameter_history",
+            "required_resilience_decay_half_life",
+            "required_depth_recovery_after_child_order",
+            "required_execution_shortfall_by_liquidity_regime",
+            "required_max_liquidity_regime_shortfall_bps",
+        }
+    ):
+        return True
+    return bool(
+        {
+            marker.lower()
+            for marker in _string_list(
+                scorecard.get("stochastic_liquidity_resilience_source_markers")
+            )
+        }.intersection(
+            {
+                "optimal_execution_liquidity_uncertainty_arxiv_2506_11813_2025",
+                "stochastic_market_depth_ssrn_3798235_2025",
+            }
+        )
+    )
+
+
+def _stochastic_liquidity_resilience_blockers(
+    scorecard: Mapping[str, Any],
+) -> list[str]:
+    if not _stochastic_liquidity_resilience_required(scorecard):
+        return []
+
+    blockers: list[str] = []
+    if not _bool(scorecard.get("stochastic_liquidity_resilience_stress_passed")):
+        blockers.append("stochastic_liquidity_resilience_missing_or_failed")
+    if not _has_artifact_ref(
+        scorecard,
+        "stochastic_liquidity_resilience_stress_artifact_ref",
+        "stochastic_liquidity_resilience_stress_artifact_refs",
+    ):
+        blockers.append("stochastic_liquidity_resilience_artifact_missing")
+    transition_count = _int(scorecard.get("liquidity_regime_transition_count"))
+    if not (
+        _bool(scorecard.get("liquidity_regime_transition_trace_present"))
+        or transition_count > 0
+    ):
+        blockers.append("liquidity_regime_transition_trace_missing")
+    market_depth_count = max(
+        _int(scorecard.get("stochastic_market_depth_state_count")),
+        _int(scorecard.get("observed_depth_count")),
+    )
+    if not (
+        _bool(scorecard.get("stochastic_market_depth_state_present"))
+        or market_depth_count > 0
+    ):
+        blockers.append("stochastic_market_depth_state_missing")
+    lob_shape_count = _int(scorecard.get("lob_shape_parameter_sample_count"))
+    if not (
+        _bool(scorecard.get("lob_shape_parameter_history_present"))
+        or lob_shape_count > 0
+    ):
+        blockers.append("lob_shape_parameter_history_missing")
+    raw_resilience_half_life = scorecard.get("median_resilience_half_life_seconds")
+    if not (
+        _bool(scorecard.get("resilience_decay_half_life_present"))
+        or _decimal(raw_resilience_half_life) > 0
+    ):
+        blockers.append("resilience_decay_half_life_missing")
+    depth_recovery_sample_count = _int(scorecard.get("depth_recovery_sample_count"))
+    if not (
+        _bool(scorecard.get("depth_recovery_after_child_order_present"))
+        or depth_recovery_sample_count > 0
+    ):
+        blockers.append("depth_recovery_after_child_order_missing")
+    shortfall_sample_count = max(
+        _int(scorecard.get("execution_shortfall_by_liquidity_regime_sample_count")),
+        _int(scorecard.get("observed_shortfall_count")),
+    )
+    if not (
+        _bool(scorecard.get("execution_shortfall_by_liquidity_regime_present"))
+        or shortfall_sample_count > 0
+    ):
+        blockers.append("execution_shortfall_by_liquidity_regime_missing")
+    required_max_shortfall_bps = _decimal(
+        scorecard.get("required_max_liquidity_regime_shortfall_bps") or "10"
+    )
+    if (
+        _decimal(scorecard.get("shortfall_by_liquidity_regime_bps"))
+        > required_max_shortfall_bps
+    ):
+        blockers.append("liquidity_regime_shortfall_above_max")
+    if not _route_tca_present(scorecard):
+        blockers.append("liquidity_resilience_route_tca_evidence_missing")
+    if (
+        _decimal(
+            scorecard.get(
+                "post_cost_net_pnl_after_liquidity_regime_resilience_shortfall_stress"
+            )
+            or scorecard.get(
+                "liquidity_regime_resilience_shortfall_stress_net_pnl_per_day"
+            )
+        )
+        <= 0
+    ):
+        blockers.append("liquidity_resilience_net_pnl_non_positive")
+    return blockers
+
+
 def _conformal_tail_risk_blockers(scorecard: Mapping[str, Any]) -> list[str]:
     requires_conformal_tail_risk = _bool(
         scorecard.get("conformal_tail_risk_required")
@@ -2144,6 +2324,7 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         blockers.extend(_bootstrap_robust_optimization_blockers(scorecard))
         blockers.extend(_ofi_response_horizon_blockers(scorecard))
         blockers.extend(_alpha_decay_predictability_blockers(scorecard))
+        blockers.extend(_stochastic_liquidity_resilience_blockers(scorecard))
         blockers.extend(_conformal_tail_risk_blockers(scorecard))
         blockers.extend(_delay_depth_survival_blockers(scorecard))
     return tuple(dict.fromkeys(blockers))

--- a/services/torghut/app/trading/discovery/stochastic_liquidity_resilience_stress.py
+++ b/services/torghut/app/trading/discovery/stochastic_liquidity_resilience_stress.py
@@ -51,6 +51,10 @@ STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PRIMARY_SOURCES: tuple[
         ),
     },
 )
+STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_SOURCE_MARKERS: tuple[str, ...] = (
+    "optimal_execution_liquidity_uncertainty_arxiv_2506_11813_2025",
+    "stochastic_market_depth_ssrn_3798235_2025",
+)
 
 _PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
 _SPREAD_BPS_FIELDS = ("spread_bps", "quoted_spread_bps", "effective_spread_bps")
@@ -127,6 +131,9 @@ class StochasticLiquidityResilienceStressSummary:
                 dict(item)
                 for item in STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PRIMARY_SOURCES
             ],
+            "source_markers": list(
+                STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_SOURCE_MARKERS
+            ),
             "row_count": self.row_count,
             "observed_price_count": self.observed_price_count,
             "observed_depth_count": self.observed_depth_count,
@@ -214,6 +221,7 @@ def stochastic_liquidity_resilience_stress_contract() -> dict[str, Any]:
             dict(item)
             for item in STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_PRIMARY_SOURCES
         ],
+        "source_markers": list(STOCHASTIC_LIQUIDITY_RESILIENCE_STRESS_SOURCE_MARKERS),
         "stress_policy": (
             "stochastic_market_depth_regime_lob_shape_and_resilience_ranking"
         ),

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -1014,6 +1014,186 @@ def test_frontier_candidate_preserves_alpha_decay_predictability_fields() -> Non
     assert "predictability_decay_route_tca_evidence_missing" not in blockers
 
 
+def test_promotion_ready_bundle_blocks_required_stochastic_liquidity_resilience_gaps() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-liquidity-resilience-gap",
+        candidate_id="candidate-liquidity-resilience-gap",
+        candidate_spec_id="spec-liquidity-resilience-gap",
+        dataset_snapshot_id="snapshot-liquidity-resilience-gap",
+        feature_spec_hash="feature-liquidity-resilience-gap",
+        code_commit="commit-liquidity-resilience-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_stochastic_liquidity_resilience_execution_grid": True,
+            "required_max_liquidity_regime_shortfall_bps": "10",
+            "stochastic_liquidity_resilience_source_markers": [
+                "optimal_execution_liquidity_uncertainty_arxiv_2506_11813_2025",
+                "stochastic_market_depth_ssrn_3798235_2025",
+            ],
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "stochastic_liquidity_resilience_missing_or_failed" in blockers
+    assert "stochastic_liquidity_resilience_artifact_missing" in blockers
+    assert "liquidity_regime_transition_trace_missing" in blockers
+    assert "stochastic_market_depth_state_missing" in blockers
+    assert "lob_shape_parameter_history_missing" in blockers
+    assert "resilience_decay_half_life_missing" in blockers
+    assert "depth_recovery_after_child_order_missing" in blockers
+    assert "execution_shortfall_by_liquidity_regime_missing" in blockers
+    assert "liquidity_resilience_route_tca_evidence_missing" in blockers
+    assert "liquidity_resilience_net_pnl_non_positive" in blockers
+
+
+def test_promotion_ready_bundle_accepts_materialized_stochastic_liquidity_resilience_evidence() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-liquidity-resilience-ready",
+        candidate_id="candidate-liquidity-resilience-ready",
+        candidate_spec_id="spec-liquidity-resilience-ready",
+        dataset_snapshot_id="snapshot-liquidity-resilience-ready",
+        feature_spec_hash="feature-liquidity-resilience-ready",
+        code_commit="commit-liquidity-resilience-ready",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_stochastic_liquidity_resilience_execution_grid": True,
+            "required_max_liquidity_regime_shortfall_bps": "10",
+            "stochastic_liquidity_resilience_stress_passed": True,
+            "stochastic_liquidity_resilience_stress_artifact_ref": (
+                "artifact://liquidity-resilience"
+            ),
+            "liquidity_regime_transition_trace_present": True,
+            "liquidity_regime_transition_count": 4,
+            "stochastic_market_depth_state_present": True,
+            "stochastic_market_depth_state_count": 48,
+            "lob_shape_parameter_history_present": True,
+            "lob_shape_parameter_sample_count": 48,
+            "resilience_decay_half_life_present": True,
+            "median_resilience_half_life_seconds": "120",
+            "depth_recovery_after_child_order_present": True,
+            "depth_recovery_sample_count": 24,
+            "execution_shortfall_by_liquidity_regime_present": True,
+            "execution_shortfall_by_liquidity_regime_sample_count": 24,
+            "shortfall_by_liquidity_regime_bps": "6.5",
+            "route_tca_artifact_ref": "artifact://route-tca",
+            "post_cost_net_pnl_after_liquidity_regime_resilience_shortfall_stress": (
+                "530"
+            ),
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "stochastic_liquidity_resilience_missing_or_failed" not in blockers
+    assert "stochastic_liquidity_resilience_artifact_missing" not in blockers
+    assert "liquidity_regime_transition_trace_missing" not in blockers
+    assert "stochastic_market_depth_state_missing" not in blockers
+    assert "lob_shape_parameter_history_missing" not in blockers
+    assert "resilience_decay_half_life_missing" not in blockers
+    assert "depth_recovery_after_child_order_missing" not in blockers
+    assert "execution_shortfall_by_liquidity_regime_missing" not in blockers
+    assert "liquidity_regime_shortfall_above_max" not in blockers
+    assert "liquidity_resilience_route_tca_evidence_missing" not in blockers
+    assert "liquidity_resilience_net_pnl_non_positive" not in blockers
+
+
+def test_frontier_candidate_preserves_stochastic_liquidity_resilience_fields() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-liquidity-resilience-preserved",
+        candidate={
+            "candidate_id": "candidate-liquidity-resilience-preserved",
+            "objective_scorecard": _promotion_quality_scorecard(),
+            "hard_vetoes": {
+                "required_stochastic_liquidity_resilience_execution_grid": True,
+                "required_liquidity_regime_transition_trace": True,
+                "required_stochastic_market_depth_state": True,
+                "required_lob_shape_parameter_history": True,
+                "required_resilience_decay_half_life": True,
+                "required_depth_recovery_after_child_order": True,
+                "required_execution_shortfall_by_liquidity_regime": True,
+                "required_max_liquidity_regime_shortfall_bps": "10",
+            },
+            "promotion_contract": {
+                "requires_stochastic_liquidity_resilience_execution_grid": True,
+                "requires_route_tca": True,
+            },
+            "stochastic_liquidity_resilience_stress_passed": True,
+            "stochastic_liquidity_resilience_stress_artifact_ref": (
+                "artifact://liquidity-resilience"
+            ),
+            "liquidity_regime_transition_trace_present": True,
+            "liquidity_regime_transition_count": 4,
+            "stochastic_market_depth_state_present": True,
+            "stochastic_market_depth_state_count": 48,
+            "lob_shape_parameter_history_present": True,
+            "lob_shape_parameter_sample_count": 48,
+            "resilience_decay_half_life_present": True,
+            "median_resilience_half_life_seconds": "120",
+            "depth_recovery_after_child_order_present": True,
+            "depth_recovery_sample_count": 24,
+            "execution_shortfall_by_liquidity_regime_present": True,
+            "execution_shortfall_by_liquidity_regime_sample_count": 24,
+            "shortfall_by_liquidity_regime_bps": "6.5",
+            "route_tca_artifact_ref": "artifact://route-tca",
+            "post_cost_net_pnl_after_liquidity_regime_resilience_shortfall_stress": (
+                "530"
+            ),
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-liquidity-resilience-preserved",
+        result_path="artifact://replay",
+        code_commit="commit-liquidity-resilience-preserved",
+    )
+
+    assert (
+        bundle.objective_scorecard[
+            "requires_stochastic_liquidity_resilience_execution_grid"
+        ]
+        is True
+    )
+    assert (
+        bundle.objective_scorecard[
+            "stochastic_liquidity_resilience_stress_artifact_ref"
+        ]
+        == "artifact://liquidity-resilience"
+    )
+    blockers = evidence_bundle_blockers(bundle)
+    assert "stochastic_liquidity_resilience_artifact_missing" not in blockers
+    assert "liquidity_resilience_route_tca_evidence_missing" not in blockers
+
+
 def test_frontier_candidate_preserves_implementation_risk_parity_fields() -> None:
     bundle = evidence_bundle_from_frontier_candidate(
         candidate_spec_id="spec-implementation-risk-preserved",

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -671,6 +671,14 @@ class TestFastReplayPreview(TestCase):
                 ]
             },
         )
+        self.assertIn(
+            "optimal_execution_liquidity_uncertainty_arxiv_2506_11813_2025",
+            row_payload["stochastic_liquidity_resilience_stress"]["source_markers"],
+        )
+        self.assertIn(
+            "stochastic_market_depth_ssrn_3798235_2025",
+            row_payload["stochastic_liquidity_resilience_stress"]["source_markers"],
+        )
         self.assertFalse(
             row_payload["stochastic_liquidity_resilience_stress"]["proof_authority"]
         )

--- a/services/torghut/tests/test_stochastic_liquidity_resilience_stress.py
+++ b/services/torghut/tests/test_stochastic_liquidity_resilience_stress.py
@@ -130,6 +130,14 @@ class TestStochasticLiquidityResilienceStress(TestCase):
         self.assertFalse(payload["proof_authority"])
         self.assertFalse(payload["promotion_authority"])
         self.assertFalse(payload["final_authority_ok"])
+        self.assertIn(
+            "optimal_execution_liquidity_uncertainty_arxiv_2506_11813_2025",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "stochastic_market_depth_ssrn_3798235_2025",
+            payload["source_markers"],
+        )
 
     def test_missing_depth_fails_closed_with_source_gap_and_contract_sources(
         self,
@@ -151,6 +159,22 @@ class TestStochasticLiquidityResilienceStress(TestCase):
         )
         self.assertIn("arxiv-2506.11813", source_ids)
         self.assertIn("ssrn-3798235", source_ids)
+        self.assertIn(
+            "optimal_execution_liquidity_uncertainty_arxiv_2506_11813_2025",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "stochastic_market_depth_ssrn_3798235_2025",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "optimal_execution_liquidity_uncertainty_arxiv_2506_11813_2025",
+            contract["source_markers"],
+        )
+        self.assertIn(
+            "stochastic_market_depth_ssrn_3798235_2025",
+            contract["source_markers"],
+        )
         self.assertIn(
             "missing_lob_depth_for_stochastic_liquidity_resilience",
             payload["warnings"],


### PR DESCRIPTION
## Summary

- Adds fail-closed promotion blockers for stochastic liquidity/regime-resilience evidence when candidates invoke liquidity uncertainty or stochastic market-depth sources.
- Preserves liquidity-resilience scorecard fields from frontier candidates into evidence bundles so promotion decisions can audit depth states, LOB-shape history, resilience decay, route TCA, and stressed net PnL.
- Tags stochastic liquidity resilience stress payloads/contracts with source markers for arXiv:2506.11813 and SSRN 3798235.
- Adds regression coverage for missing evidence rejection, materialized evidence acceptance, candidate-field preservation, and fast-replay/source-marker surfacing.

## Related Issues

None.

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py app/trading/discovery/stochastic_liquidity_resilience_stress.py tests/test_evidence_bundles.py tests/test_stochastic_liquidity_resilience_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py app/trading/discovery/stochastic_liquidity_resilience_stress.py tests/test_evidence_bundles.py tests/test_stochastic_liquidity_resilience_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py tests/test_stochastic_liquidity_resilience_stress.py tests/test_fast_replay.py::TestFastReplayPreview::test_whitepaper_features_rank_and_label_preview_only`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv sync --frozen --extra dev` failed locally because `crosshair-tool==0.0.102` requires a missing `cc` compiler in this workspace.
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this backend research/evidence-gate change has no UI.
- [x] Breaking Changes section is filled in.
- [x] Documentation, release notes, and follow-ups are tracked in the PR summary and test coverage.
