### PR TITLE
feat(torghut): stress queue allocation rule sensitivity

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -102,8 +102,8 @@ from app.trading.discovery.stochastic_liquidity_resilience_stress import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v15"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v16"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v16"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v17"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -659,7 +659,7 @@ class FastReplayPreviewResult:
                 "markov_order_transition_latent_regime_stress": "deterministic Markov transition entropy/inertia plus latent rising-edge stress from arXiv:2502.07625 and arXiv:2604.20949; preview ranking only",
                 "order_flow_entropy_hmm_regime_stress": "deterministic OFI Markov entropy, asymmetric HMM-regime, and multi-scale volatility/intensity stress from SSRN:5315733, arXiv:2512.15720, and arXiv:2603.20456; entropy is not directional alpha proof; preview ranking only",
                 "dynamic_lead_lag_cross_asset_stress": "deterministic event-grid dynamic pair-specific lead-lag, cross-market LOB/order-flow predictability, and one-second OFI endogeneity stress from arXiv:2511.00390, SSRN:5523878, and arXiv:2508.06788; lead-lag is not alpha proof; preview ranking only",
-                "queue_position_survival_fill_stress": "deterministic queue-position survival fill probability, depth-delay, MDQR queue-reactive event-mix/order-size replay parity, and nonfill opportunity-cost stress from arXiv:2512.05734, arXiv:2501.08822, arXiv:2511.15262, SSRN:6440898, and SSRN:6730443; preview ranking only",
+                "queue_position_survival_fill_stress": "deterministic queue-position survival fill probability, depth-delay, MDQR queue-reactive event-mix/order-size replay parity, queue-allocation-rule sensitivity, and nonfill opportunity-cost stress from arXiv:2512.05734, arXiv:2501.08822, arXiv:2511.15262, SSRN:6440898, SSRN:6730443, SSRN:6574208, and SSRN:6578978; preview ranking only",
                 "public_feed_lag_quoted_liquidity_stress": "deterministic public-feed delay, quoted-liquidity reliability, stale-quote, and authoritative trade-direction join stress from SSRN:6675338, arXiv:2604.24366, and arXiv:2511.20606; preview ranking only",
                 "lob_simulation_reality_gap_execution_stress": "deterministic spread-volume imbalance, latency-race mode, power-law signed-flow impact, odd-lot liquidity reliability, and responsive exchange event-mix stress from arXiv:2603.24137, OFR WP 25-01, arXiv:2507.06345, and arXiv:2502.07071; preview ranking only",
                 "alpha_decay_predictability_stress": "deterministic multi-horizon spread-adjusted alpha decay, cost-crossover, latency-horizon mismatch, and efficiency-regime compression stress from arXiv:2601.02310 and SSRN:6608199; preview ranking only",

--- a/services/torghut/app/trading/discovery/queue_survival_fill_stress.py
+++ b/services/torghut/app/trading/discovery/queue_survival_fill_stress.py
@@ -16,9 +16,9 @@ from typing import Any, cast
 
 from app.trading.models import SignalEnvelope
 
-QUEUE_SURVIVAL_FILL_STRESS_SCHEMA_VERSION = "torghut.queue-survival-fill-stress.v2"
+QUEUE_SURVIVAL_FILL_STRESS_SCHEMA_VERSION = "torghut.queue-survival-fill-stress.v3"
 QUEUE_SURVIVAL_FILL_STRESS_CONTRACT_SCHEMA_VERSION = (
-    "torghut.queue-survival-fill-stress-contract.v2"
+    "torghut.queue-survival-fill-stress-contract.v3"
 )
 QUEUE_SURVIVAL_FILL_STRESS_PROOF_SEMANTICS_LABEL = "queue_survival_fill_stress_preview_only_exact_replay_route_tca_order_lifecycle_runtime_ledger_required"
 QUEUE_SURVIVAL_FILL_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
@@ -56,6 +56,20 @@ QUEUE_SURVIVAL_FILL_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
         "title": "Reinforcement Learning in Queue-Reactive Models: Application to Optimal Execution",
         "date": "2025-11-19",
         "mechanism": "queue_reactive_counterfactual_execution_policy_depth_state_stress",
+    },
+    {
+        "source_id": "ssrn-6574208",
+        "url": "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6574208",
+        "title": "Random Queue Priority in Continuous Limit Order Books: Evidence from a Large-Scale Controlled Simulation",
+        "date": "2026-04-14",
+        "mechanism": "allocation_rule_execution_quality_bias_time_priority_sensitivity",
+    },
+    {
+        "source_id": "ssrn-6578978",
+        "url": "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6578978",
+        "title": "Beyond Time Priority: A Taxonomy of Queue Allocation Mechanisms in Continuous Limit Order Books",
+        "date": "2026-04-15",
+        "mechanism": "queue_allocation_mechanism_taxonomy_priority_rule_fragility",
     },
 )
 
@@ -109,6 +123,9 @@ class QueueSurvivalFillStressSummary:
     queue_reactive_event_mix_l1: float
     order_size_distribution_wasserstein_proxy: float
     queue_reactive_replay_parity_penalty_bps: float
+    time_priority_edge_concentration_score: float
+    randomized_priority_fill_gap_proxy_bps: float
+    queue_allocation_rule_sensitivity_penalty_bps: float
     estimated_limit_fill_probability: float
     nonfill_opportunity_cost_bps: float
     adverse_selection_after_touch_bps: float
@@ -150,6 +167,15 @@ class QueueSurvivalFillStressSummary:
             "queue_reactive_replay_parity_penalty_bps": _stable_float(
                 self.queue_reactive_replay_parity_penalty_bps
             ),
+            "time_priority_edge_concentration_score": _stable_float(
+                self.time_priority_edge_concentration_score
+            ),
+            "randomized_priority_fill_gap_proxy_bps": _stable_float(
+                self.randomized_priority_fill_gap_proxy_bps
+            ),
+            "queue_allocation_rule_sensitivity_penalty_bps": _stable_float(
+                self.queue_allocation_rule_sensitivity_penalty_bps
+            ),
             "estimated_limit_fill_probability": _stable_float(
                 self.estimated_limit_fill_probability
             ),
@@ -184,6 +210,15 @@ class QueueSurvivalFillStressSummary:
                 "queue_reactive_replay_parity_penalty_bps": _stable_float(
                     self.queue_reactive_replay_parity_penalty_bps
                 ),
+                "time_priority_edge_concentration_score": _stable_float(
+                    self.time_priority_edge_concentration_score
+                ),
+                "randomized_priority_fill_gap_proxy_bps": _stable_float(
+                    self.randomized_priority_fill_gap_proxy_bps
+                ),
+                "queue_allocation_rule_sensitivity_penalty_bps": _stable_float(
+                    self.queue_allocation_rule_sensitivity_penalty_bps
+                ),
                 "nonfill_opportunity_cost_bps": _stable_float(
                     self.nonfill_opportunity_cost_bps
                 ),
@@ -199,6 +234,7 @@ class QueueSurvivalFillStressSummary:
             "limit_fill_probability_preview": True,
             "queue_reactive_replay_parity_preview": True,
             "order_size_distribution_preview": True,
+            "queue_allocation_rule_sensitivity_preview": True,
             "research_ranking_only": True,
             "prefilter_only": True,
             "promotion_proof": False,
@@ -229,6 +265,9 @@ def queue_survival_fill_stress_contract() -> dict[str, Any]:
             "queue_reactive_event_mix_l1",
             "order_size_distribution_wasserstein_proxy",
             "queue_reactive_replay_parity_penalty_bps",
+            "time_priority_edge_concentration_score",
+            "randomized_priority_fill_gap_proxy_bps",
+            "queue_allocation_rule_sensitivity_penalty_bps",
             "nonfill_opportunity_cost_bps",
             "adverse_selection_after_touch_bps",
         ],
@@ -245,10 +284,12 @@ def queue_survival_fill_stress_contract() -> dict[str, Any]:
             "requires_route_tca": True,
             "requires_order_lifecycle_fill_evidence": True,
             "requires_queue_reactive_replay_parity": True,
+            "requires_queue_allocation_rule_audit": True,
             "requires_runtime_ledger": True,
             "rejects_queue_position_free_fill_assumptions": True,
             "rejects_queue_reactive_replay_parity_as_pnl_proof": True,
             "rejects_order_size_distribution_proxy_as_fill_authority": True,
+            "rejects_time_priority_edge_as_mechanism_neutral_pnl_proof": True,
         },
     }
 
@@ -383,6 +424,23 @@ def extract_queue_survival_fill_stress(
         cancellation_or_reject_share=cancellation_or_reject_share,
         observed_queue_position_count=observed_queue_position_count,
     )
+    time_priority_edge_concentration_score = _time_priority_edge_concentration_score(
+        median_queue_ahead_ratio=median_queue_ahead_ratio,
+        execution_turnover_ratio=execution_turnover_ratio,
+        cancellation_or_reject_share=cancellation_or_reject_share,
+        fill_probability=estimated_limit_fill_probability,
+        observed_queue_position_count=observed_queue_position_count,
+    )
+    randomized_priority_fill_gap_proxy_bps = _randomized_priority_fill_gap_proxy_bps(
+        time_priority_edge_concentration_score=time_priority_edge_concentration_score,
+        median_spread_bps=_median(tuple(spread for spread in spreads if spread > 0.0)),
+        visible_depth_notional_shortfall_share=visible_depth_notional_shortfall_share,
+    )
+    queue_allocation_rule_sensitivity_penalty_bps = (
+        randomized_priority_fill_gap_proxy_bps
+        + time_priority_edge_concentration_score * 5.0
+        + queue_reactive_event_mix_l1 * 1.5
+    )
     nonfill_opportunity_cost_bps = _nonfill_opportunity_cost_bps(
         valid_prices,
         direction=signed_direction,
@@ -405,6 +463,7 @@ def extract_queue_survival_fill_stress(
     replay_rank_penalty_bps = (
         queue_delay_penalty_bps
         + queue_reactive_replay_parity_penalty_bps
+        + queue_allocation_rule_sensitivity_penalty_bps
         + nonfill_opportunity_cost_bps
         + adverse_selection_after_touch_bps
         + missing_penalty_bps
@@ -423,6 +482,9 @@ def extract_queue_survival_fill_stress(
         queue_reactive_event_mix_l1=queue_reactive_event_mix_l1,
         order_size_distribution_wasserstein_proxy=order_size_distribution_wasserstein_proxy,
         queue_reactive_replay_parity_penalty_bps=queue_reactive_replay_parity_penalty_bps,
+        time_priority_edge_concentration_score=time_priority_edge_concentration_score,
+        randomized_priority_fill_gap_proxy_bps=randomized_priority_fill_gap_proxy_bps,
+        queue_allocation_rule_sensitivity_penalty_bps=queue_allocation_rule_sensitivity_penalty_bps,
         estimated_limit_fill_probability=estimated_limit_fill_probability,
         nonfill_opportunity_cost_bps=nonfill_opportunity_cost_bps,
         adverse_selection_after_touch_bps=adverse_selection_after_touch_bps,
@@ -471,6 +533,60 @@ def _estimated_fill_probability(
     )
     probability = 1.0 / (1.0 + exp(-logit))
     return min(0.98, max(0.02, probability))
+
+
+def _time_priority_edge_concentration_score(
+    *,
+    median_queue_ahead_ratio: float,
+    execution_turnover_ratio: float,
+    cancellation_or_reject_share: float,
+    fill_probability: float,
+    observed_queue_position_count: int,
+) -> float:
+    """Bounded proxy for FIFO-specific early-queue ownership reliance.
+
+    Recent queue-allocation mechanism papers show that measured execution
+    quality can depend on the priority rule itself. This proxy does not
+    estimate fills; it downranks replay rows whose apparent edge is highly
+    concentrated in being early in a price-time queue.
+    """
+
+    if observed_queue_position_count <= 0:
+        return 0.0
+    front_of_queue_advantage = max(0.0, 0.50 - median_queue_ahead_ratio) * 2.0
+    turnover_support = min(1.0, max(0.0, execution_turnover_ratio) / 2.0)
+    cancellation_survival = max(0.0, 1.0 - cancellation_or_reject_share)
+    return min(
+        1.0,
+        front_of_queue_advantage
+        * turnover_support
+        * cancellation_survival
+        * max(0.0, min(1.0, fill_probability)),
+    )
+
+
+def _randomized_priority_fill_gap_proxy_bps(
+    *,
+    time_priority_edge_concentration_score: float,
+    median_spread_bps: float,
+    visible_depth_notional_shortfall_share: float,
+) -> float:
+    """Estimate ranking penalty for mechanism-specific time-priority edge.
+
+    SSRN:6574208 reports that randomized priority reduced the fast/slow
+    execution-quality gap by 35.6% in a controlled dual-engine simulation.
+    Torghut uses the effect size only as a stress multiplier and never as fill,
+    PnL, or promotion authority.
+    """
+
+    clob_speed_gap_decline_fraction = 0.356
+    spread_floor_bps = max(1.0, median_spread_bps)
+    fifo_edge_bps = time_priority_edge_concentration_score * spread_floor_bps * 2.0
+    depth_uncertainty_bps = visible_depth_notional_shortfall_share * 1.5
+    return min(
+        25.0,
+        fifo_edge_bps * clob_speed_gap_decline_fraction + depth_uncertainty_bps,
+    )
 
 
 def _queue_reactive_event_mix_l1(

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -421,6 +421,22 @@ class TestFastReplayPreview(TestCase):
                 for source in row_payload["queue_survival_fill_stress"]["source_papers"]
             },
         )
+        self.assertIn(
+            "ssrn-6574208",
+            {
+                source["source_id"]
+                for source in row_payload["queue_survival_fill_stress"]["source_papers"]
+            },
+        )
+        self.assertIn(
+            "queue_allocation_rule_sensitivity_penalty_bps",
+            row_payload["queue_survival_fill_stress"]["ranking_features"],
+        )
+        self.assertTrue(
+            row_payload["queue_survival_fill_stress"][
+                "queue_allocation_rule_sensitivity_preview"
+            ]
+        )
         self.assertIn("feed_lag_liquidity_stress", row_payload)
         self.assertFalse(row_payload["feed_lag_liquidity_stress"]["proof_authority"])
         self.assertFalse(

--- a/services/torghut/tests/test_queue_survival_fill_stress.py
+++ b/services/torghut/tests/test_queue_survival_fill_stress.py
@@ -268,6 +268,117 @@ class TestQueueSurvivalFillStress(TestCase):
         self.assertFalse(bad_replay["promotion_allowed"])
         self.assertFalse(bad_replay["final_authority_ok"])
 
+    def test_queue_allocation_rule_sensitivity_downranks_time_priority_edge(
+        self,
+    ) -> None:
+        time_priority_edge = extract_queue_survival_fill_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    queue_ratio="0.01",
+                    bid_size="1800",
+                    volume="900",
+                    event_type="add",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.01",
+                    queue_ratio="0.02",
+                    bid_size="1750",
+                    volume="1100",
+                    event_type="trade",
+                    fill_qty="700",
+                    status="filled",
+                ),
+                self._row(
+                    offset=3,
+                    price="100.02",
+                    queue_ratio="0.02",
+                    bid_size="1700",
+                    volume="950",
+                    event_type="trade",
+                    fill_qty="650",
+                    status="filled",
+                ),
+                self._row(
+                    offset=4,
+                    price="100.03",
+                    queue_ratio="0.03",
+                    bid_size="1650",
+                    volume="850",
+                    event_type="trade",
+                    fill_qty="600",
+                    status="filled",
+                ),
+            ),
+            direction=1,
+            max_notional=10_000,
+        )
+        neutral_queue = extract_queue_survival_fill_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    queue_ratio="0.48",
+                    bid_size="1800",
+                    volume="350",
+                    event_type="add",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.01",
+                    queue_ratio="0.50",
+                    bid_size="1750",
+                    volume="400",
+                    event_type="trade",
+                    fill_qty="120",
+                    status="filled",
+                ),
+                self._row(
+                    offset=3,
+                    price="100.02",
+                    queue_ratio="0.52",
+                    bid_size="1700",
+                    volume="300",
+                    event_type="cancel",
+                    status="cancelled",
+                ),
+                self._row(
+                    offset=4,
+                    price="100.03",
+                    queue_ratio="0.49",
+                    bid_size="1650",
+                    volume="360",
+                    event_type="add",
+                ),
+            ),
+            direction=1,
+            max_notional=10_000,
+        )
+
+        self.assertGreater(
+            time_priority_edge.time_priority_edge_concentration_score,
+            neutral_queue.time_priority_edge_concentration_score,
+        )
+        self.assertGreater(
+            time_priority_edge.randomized_priority_fill_gap_proxy_bps,
+            neutral_queue.randomized_priority_fill_gap_proxy_bps,
+        )
+        self.assertGreater(
+            time_priority_edge.queue_allocation_rule_sensitivity_penalty_bps,
+            neutral_queue.queue_allocation_rule_sensitivity_penalty_bps,
+        )
+        payload = time_priority_edge.to_payload()
+        self.assertTrue(payload["queue_allocation_rule_sensitivity_preview"])
+        self.assertFalse(payload["proof_authority"])
+        self.assertFalse(payload["promotion_authority"])
+        self.assertFalse(payload["final_authority_ok"])
+        self.assertIn(
+            "queue_allocation_rule_sensitivity_penalty_bps",
+            payload["ranking_features"],
+        )
+
     def test_contract_embeds_recent_sources_and_requires_authoritative_proof(
         self,
     ) -> None:
@@ -292,6 +403,8 @@ class TestQueueSurvivalFillStress(TestCase):
         self.assertIn("arxiv-2511.15262", source_ids)
         self.assertIn("ssrn-6440898", source_ids)
         self.assertIn("ssrn-6730443", source_ids)
+        self.assertIn("ssrn-6574208", source_ids)
+        self.assertIn("ssrn-6578978", source_ids)
         self.assertTrue(contract["proof_neutrality"]["requires_exact_replay"])
         self.assertTrue(contract["proof_neutrality"]["requires_route_tca"])
         self.assertTrue(
@@ -300,10 +413,18 @@ class TestQueueSurvivalFillStress(TestCase):
         self.assertTrue(
             contract["proof_neutrality"]["requires_queue_reactive_replay_parity"]
         )
+        self.assertTrue(
+            contract["proof_neutrality"]["requires_queue_allocation_rule_audit"]
+        )
         self.assertTrue(contract["proof_neutrality"]["requires_runtime_ledger"])
         self.assertTrue(
             contract["proof_neutrality"][
                 "rejects_queue_reactive_replay_parity_as_pnl_proof"
+            ]
+        )
+        self.assertTrue(
+            contract["proof_neutrality"][
+                "rejects_time_priority_edge_as_mechanism_neutral_pnl_proof"
             ]
         )
         self.assertFalse(contract["proof_neutrality"]["promotion_proof"])


### PR DESCRIPTION
## Summary

- Adds queue-allocation-rule sensitivity to Torghut's preview-only queue survival fill stress.
- Records current 2026 queue allocation sources SSRN:6574208 and SSRN:6578978 alongside the existing queue-reactive execution sources.
- Emits deterministic ranking features for time-priority edge concentration, randomized-priority fill-gap proxy, and allocation-rule sensitivity penalty.
- Preserves proof boundaries: the new fields are replay-ranking inputs only and provide no fill, PnL, runtime-ledger, promotion, or live-capital authority.

## Related Issues

None

## Testing

- PASS: `cd services/torghut && uv run --frozen pytest tests/test_queue_survival_fill_stress.py tests/test_fast_replay.py -q`
- PASS: `cd services/torghut && uvx ruff check app/trading/discovery/queue_survival_fill_stress.py app/trading/discovery/fast_replay.py tests/test_queue_survival_fill_stress.py tests/test_fast_replay.py`
- PASS: `cd services/torghut && uvx ruff format --check app/trading/discovery/queue_survival_fill_stress.py app/trading/discovery/fast_replay.py tests/test_queue_survival_fill_stress.py tests/test_fast_replay.py`
- PASS: `cd services/torghut && uv run --frozen python -m coverage erase && uv run --frozen python -m coverage run -m pytest tests/test_queue_survival_fill_stress.py tests/test_fast_replay.py -q && uv run --frozen python -m coverage xml -o coverage.xml && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 && rm -f coverage.xml`
- PASS: `cd services/torghut && uv sync --frozen --extra dev`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- PASS: `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- PASS: `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
