### PR TITLE
fix(torghut): count profit source collection targets

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -9145,6 +9145,10 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
         append_source_target(target)
     if not source_targets:
         return {}
+    profit_target_count = sum(
+        int(bool(target.get("source_collection_profit_target_candidate")))
+        for target in source_targets
+    )
     return {
         "schema_version": _safe_text(plan.get("schema_version"))
         or "torghut.runtime-ledger-paper-probation-import-plan.v1",
@@ -9163,6 +9167,7 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
         "target_count": len(source_targets),
         "paper_probation_target_count": 0,
         "source_collection_target_count": len(source_targets),
+        "source_collection_profit_target_count": profit_target_count,
         "skipped_target_count": 0,
         "targets": source_targets,
         "skipped_targets": [],
@@ -9707,6 +9712,24 @@ def build_paper_route_target_plan_payload(
             "promotion_eligible_total": _safe_int(
                 live_submission_gate.get("promotion_eligible_total")
             ),
+            "runtime_ledger_source_collection_candidate_total": _safe_int(
+                live_submission_gate.get(
+                    "runtime_ledger_source_collection_candidate_total"
+                )
+            )
+            or _safe_int(source_collection_import_plan.get("target_count")),
+            "runtime_ledger_source_collection_profit_target_candidate_total": (
+                _safe_int(
+                    live_submission_gate.get(
+                        "runtime_ledger_source_collection_profit_target_candidate_total"
+                    )
+                )
+                or _safe_int(
+                    source_collection_import_plan.get(
+                        "source_collection_profit_target_count"
+                    )
+                )
+            ),
             "runtime_ledger_paper_probation_import_plan": {
                 "schema_version": _safe_text(plan.get("schema_version")),
                 "target_count": _safe_int(plan.get("target_count") or len(targets)),
@@ -9714,6 +9737,12 @@ def build_paper_route_target_plan_payload(
                 "source_collection_target_count": _safe_int(
                     source_collection_import_plan.get("target_count")
                     or plan.get("source_collection_target_count")
+                ),
+                "source_collection_profit_target_count": _safe_int(
+                    source_collection_import_plan.get(
+                        "source_collection_profit_target_count"
+                    )
+                    or plan.get("source_collection_profit_target_count")
                 ),
                 "targets": _as_mapping_items(
                     source_collection_import_plan.get("targets")
@@ -10070,6 +10099,24 @@ def build_paper_route_evidence_audit(
             "promotion_eligible_total": _safe_int(
                 live_submission_gate.get("promotion_eligible_total")
             ),
+            "runtime_ledger_source_collection_candidate_total": _safe_int(
+                live_submission_gate.get(
+                    "runtime_ledger_source_collection_candidate_total"
+                )
+            )
+            or _safe_int(source_collection_import_plan.get("target_count")),
+            "runtime_ledger_source_collection_profit_target_candidate_total": (
+                _safe_int(
+                    live_submission_gate.get(
+                        "runtime_ledger_source_collection_profit_target_candidate_total"
+                    )
+                )
+                or _safe_int(
+                    source_collection_import_plan.get(
+                        "source_collection_profit_target_count"
+                    )
+                )
+            ),
             "runtime_ledger_paper_probation_import_plan": {
                 "schema_version": _safe_text(plan.get("schema_version")),
                 "target_count": _safe_int(plan.get("target_count") or len(targets)),
@@ -10077,6 +10124,12 @@ def build_paper_route_evidence_audit(
                 "source_collection_target_count": _safe_int(
                     source_collection_import_plan.get("target_count")
                     or plan.get("source_collection_target_count")
+                ),
+                "source_collection_profit_target_count": _safe_int(
+                    source_collection_import_plan.get(
+                        "source_collection_profit_target_count"
+                    )
+                    or plan.get("source_collection_profit_target_count")
                 ),
                 "targets": _as_mapping_items(
                     source_collection_import_plan.get("targets")

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5084,6 +5084,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "source_collection_reason_codes": [
                                     "runtime_ledger_source_decisions_missing"
                                 ],
+                                "source_collection_profit_target_candidate": True,
                                 "promotion_allowed": True,
                                 "final_promotion_authorized": True,
                                 "max_notional": "25000",
@@ -5131,6 +5132,19 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "runtime_ledger_paper_probation_import_plan"
         ]
         self.assertEqual(gate_plan["source_collection_target_count"], 1)
+        self.assertEqual(
+            payload["live_submission_gate"][
+                "runtime_ledger_source_collection_candidate_total"
+            ],
+            1,
+        )
+        self.assertEqual(
+            payload["live_submission_gate"][
+                "runtime_ledger_source_collection_profit_target_candidate_total"
+            ],
+            1,
+        )
+        self.assertEqual(gate_plan["source_collection_profit_target_count"], 1)
         self.assertEqual(len(gate_plan["targets"]), 1)
         self.assertEqual(
             gate_plan["targets"][0]["handoff"],
@@ -5145,6 +5159,85 @@ class TestPaperRouteEvidenceAudit(TestCase):
             payload["summary"]["promotion_authority"]["blockers"],
             ["live_runtime_ledger_required"],
         )
+
+    def test_evidence_audit_surfaces_source_collection_profit_target_totals(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 6, 2, 15, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "source_collection_pending",
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "runtime_strategy_name": (
+                                    "microbar-cross-sectional-pairs-v1"
+                                ),
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": (
+                                    "runtime_ledger_source_collection_candidate"
+                                ),
+                                "source_collection_authorized": True,
+                                "source_collection_profit_target_candidate": True,
+                                "source_collection_priority": (
+                                    "profit_target_source_materialization"
+                                ),
+                                "source_collection_net_strategy_pnl_after_costs": (
+                                    "567.44720578"
+                                ),
+                                "source_collection_filled_notional": "127090.02495200",
+                                "source_collection_post_cost_expectancy_bps": (
+                                    "44.64923238"
+                                ),
+                                "source_collection_next_action": (
+                                    "materialize_runtime_ledger_source_window_refs"
+                                ),
+                                "promotion_allowed": True,
+                                "final_promotion_authorized": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "paper_route_probe": {
+                        "configured_enabled": False,
+                        "active": False,
+                        "eligible_symbols": [],
+                        "active_symbols": [],
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=generated_at,
+                target_account_audit_available=False,
+            )
+
+        gate = payload["live_submission_gate"]
+        self.assertEqual(gate["runtime_ledger_source_collection_candidate_total"], 1)
+        self.assertEqual(
+            gate["runtime_ledger_source_collection_profit_target_candidate_total"],
+            1,
+        )
+        gate_plan = gate["runtime_ledger_paper_probation_import_plan"]
+        self.assertEqual(gate_plan["source_collection_target_count"], 1)
+        self.assertEqual(gate_plan["source_collection_profit_target_count"], 1)
+        self.assertEqual(len(gate_plan["targets"]), 1)
+        self.assertFalse(gate_plan["targets"][0]["promotion_allowed"])
+        self.assertFalse(gate_plan["targets"][0]["final_promotion_allowed"])
 
     def test_source_collection_import_plan_sanitizer_filters_and_preserves_refs(
         self,
@@ -5229,6 +5322,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
 
         self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["source_collection_profit_target_count"], 1)
         target = plan["targets"][0]
         self.assertEqual(target["candidate_id"], "keep-source-collection")
         self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")


### PR DESCRIPTION
## Summary

- Add a plan-level `source_collection_profit_target_count` for sanitized runtime-ledger source-collection import plans.
- Surface live-gate source-collection candidate totals and profit-target candidate totals in both target-plan and evidence-audit readbacks.
- Keep promotion and live-capital authority stripped for source-collection targets while exposing the safe evidence-collection path visibility needed for the current profit frontier.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k "source_collection" -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
