### PR TITLE
fix(torghut): require adaptive falsification evidence

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -205,6 +205,36 @@ BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS = (
     "out_of_sample_generalization_passed",
     "bootstrap_robust_optimization_source_markers",
 )
+ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS = (
+    "requires_adaptive_signal_falsification",
+    "required_adaptive_signal_falsification",
+    "requires_negative_control_falsification",
+    "required_negative_control_falsification",
+    "requires_label_permutation_test",
+    "required_label_permutation_test",
+    "requires_leakage_probe",
+    "required_leakage_probe",
+    "requires_effective_multiplicity_adjustment",
+    "required_effective_multiplicity_adjustment",
+    "rejects_adaptive_specification_search_as_profit_proof",
+    "rejects_in_sample_factor_generation_without_falsification",
+    "required_min_null_model_sample_count",
+    "required_max_effective_multiplicity_adjusted_p_value",
+    "adaptive_signal_falsification_passed",
+    "adaptive_signal_falsification_artifact_ref",
+    "adaptive_signal_falsification_artifact_refs",
+    "negative_control_passed",
+    "placebo_label_test_passed",
+    "label_permutation_test_passed",
+    "feature_permutation_stability_passed",
+    "leakage_probe_passed",
+    "walk_forward_falsification_passed",
+    "null_model_sample_count",
+    "effective_multiplicity_adjusted_p_value",
+    "candidate_vs_null_return_delta",
+    "candidate_vs_incumbent_return_delta",
+    "adaptive_signal_falsification_source_markers",
+)
 OFI_RESPONSE_HORIZON_SCORECARD_KEYS = (
     "requires_ofi_response_horizon_selection",
     "required_ofi_response_horizon_selection",
@@ -1142,6 +1172,13 @@ def evidence_bundle_from_frontier_candidate(
             if key in source:
                 scorecard = {**scorecard, key: source[key]}
                 break
+    for key in ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS:
+        if key in scorecard:
+            continue
+        for source in (candidate, summary, full_window):
+            if key in source:
+                scorecard = {**scorecard, key: source[key]}
+                break
     for key in OFI_RESPONSE_HORIZON_SCORECARD_KEYS:
         if key in scorecard:
             continue
@@ -1222,6 +1259,7 @@ def evidence_bundle_from_frontier_candidate(
     ):
         for key in (
             *BOOTSTRAP_ROBUST_OPTIMIZATION_SCORECARD_KEYS,
+            *ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS,
             *OFI_RESPONSE_HORIZON_SCORECARD_KEYS,
             *ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS,
             *STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS,
@@ -1885,6 +1923,143 @@ def _bootstrap_robust_optimization_blockers(
     return blockers
 
 
+def _adaptive_signal_falsification_required(scorecard: Mapping[str, Any]) -> bool:
+    if any(
+        _bool(scorecard.get(key))
+        for key in (
+            "requires_adaptive_signal_falsification",
+            "required_adaptive_signal_falsification",
+            "requires_negative_control_falsification",
+            "required_negative_control_falsification",
+            "requires_label_permutation_test",
+            "required_label_permutation_test",
+            "requires_leakage_probe",
+            "required_leakage_probe",
+            "requires_effective_multiplicity_adjustment",
+            "required_effective_multiplicity_adjustment",
+            "rejects_adaptive_specification_search_as_profit_proof",
+            "rejects_in_sample_factor_generation_without_falsification",
+        )
+    ):
+        return True
+    hard_vetoes = {veto.lower() for veto in _string_list(scorecard.get("hard_vetoes"))}
+    if hard_vetoes.intersection(
+        {
+            "required_adaptive_signal_falsification",
+            "required_negative_control_falsification",
+            "required_label_permutation_test",
+            "required_leakage_probe",
+            "required_effective_multiplicity_adjustment",
+            "required_min_null_model_sample_count",
+            "required_max_effective_multiplicity_adjusted_p_value",
+        }
+    ):
+        return True
+    source_markers = {
+        marker.lower()
+        for marker in (
+            *_string_list(
+                scorecard.get("adaptive_signal_falsification_source_markers")
+            ),
+            *_string_list(
+                scorecard.get("bootstrap_robust_optimization_source_markers")
+            ),
+        )
+    }
+    return bool(
+        source_markers.intersection(
+            {
+                "spurious_predictability_arxiv_2604_15531_2026",
+                "adaptive_signal_discovery_agent_nvidia_2026",
+            }
+        )
+    )
+
+
+def _scorecard_or_null_comparator_value(
+    *,
+    scorecard: Mapping[str, Any],
+    null_comparator: Mapping[str, Any],
+    key: str,
+) -> Any:
+    if key in scorecard:
+        return scorecard.get(key)
+    return null_comparator.get(key)
+
+
+def _adaptive_signal_falsification_blockers(
+    *,
+    scorecard: Mapping[str, Any],
+    null_comparator: Mapping[str, Any],
+) -> list[str]:
+    if not _adaptive_signal_falsification_required(scorecard):
+        return []
+
+    blockers: list[str] = []
+    if not null_comparator:
+        blockers.append("adaptive_signal_null_comparator_missing")
+    if not _bool(scorecard.get("adaptive_signal_falsification_passed")):
+        blockers.append("adaptive_signal_falsification_missing_or_failed")
+    if not _has_artifact_ref(
+        scorecard,
+        "adaptive_signal_falsification_artifact_ref",
+        "adaptive_signal_falsification_artifact_refs",
+    ):
+        blockers.append("adaptive_signal_falsification_artifact_missing")
+    if not _bool(null_comparator.get("baseline_outperformed")):
+        blockers.append("adaptive_signal_baseline_not_outperformed")
+
+    raw_null_delta = _scorecard_or_null_comparator_value(
+        scorecard=scorecard,
+        null_comparator=null_comparator,
+        key="candidate_vs_null_return_delta",
+    )
+    if raw_null_delta is None:
+        blockers.append("candidate_vs_null_return_delta_missing")
+    elif _decimal(raw_null_delta) <= 0:
+        blockers.append("candidate_vs_null_return_delta_non_positive")
+
+    raw_incumbent_delta = _scorecard_or_null_comparator_value(
+        scorecard=scorecard,
+        null_comparator=null_comparator,
+        key="candidate_vs_incumbent_return_delta",
+    )
+    if raw_incumbent_delta is None:
+        blockers.append("candidate_vs_incumbent_return_delta_missing")
+    elif _decimal(raw_incumbent_delta) < 0:
+        blockers.append("candidate_vs_incumbent_return_delta_negative")
+
+    required_sample_count = max(
+        1,
+        _int(scorecard.get("required_min_null_model_sample_count") or 100),
+    )
+    if _int(scorecard.get("null_model_sample_count")) < required_sample_count:
+        blockers.append("null_model_sample_count_below_min")
+
+    raw_adjusted_p_value = scorecard.get("effective_multiplicity_adjusted_p_value")
+    required_max_p_value = _decimal(
+        scorecard.get("required_max_effective_multiplicity_adjusted_p_value") or "0.05"
+    )
+    if raw_adjusted_p_value is None:
+        blockers.append("effective_multiplicity_adjusted_p_value_missing")
+    elif _decimal(raw_adjusted_p_value) > required_max_p_value:
+        blockers.append("effective_multiplicity_adjusted_p_value_above_max")
+
+    if not _bool(scorecard.get("negative_control_passed")):
+        blockers.append("negative_control_missing_or_failed")
+    if not _bool(scorecard.get("placebo_label_test_passed")):
+        blockers.append("placebo_label_test_missing_or_failed")
+    if not _bool(scorecard.get("label_permutation_test_passed")):
+        blockers.append("label_permutation_test_missing_or_failed")
+    if not _bool(scorecard.get("feature_permutation_stability_passed")):
+        blockers.append("feature_permutation_stability_missing_or_failed")
+    if not _bool(scorecard.get("leakage_probe_passed")):
+        blockers.append("leakage_probe_missing_or_failed")
+    if not _bool(scorecard.get("walk_forward_falsification_passed")):
+        blockers.append("walk_forward_falsification_missing_or_failed")
+    return blockers
+
+
 def _ofi_response_horizon_required(scorecard: Mapping[str, Any]) -> bool:
     if any(
         _bool(scorecard.get(key))
@@ -2322,6 +2497,12 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         blockers.extend(_implementation_uncertainty_blockers(scorecard))
         blockers.extend(_implementation_risk_backtest_stability_blockers(scorecard))
         blockers.extend(_bootstrap_robust_optimization_blockers(scorecard))
+        blockers.extend(
+            _adaptive_signal_falsification_blockers(
+                scorecard=scorecard,
+                null_comparator=bundle.null_comparator,
+            )
+        )
         blockers.extend(_ofi_response_horizon_blockers(scorecard))
         blockers.extend(_alpha_decay_predictability_blockers(scorecard))
         blockers.extend(_stochastic_liquidity_resilience_blockers(scorecard))

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -610,6 +610,196 @@ def test_promotion_ready_bundle_accepts_materialized_bootstrap_robust_evidence()
     assert "out_of_sample_generalization_missing_or_failed" not in blockers
 
 
+def test_promotion_ready_bundle_blocks_required_adaptive_signal_falsification_gaps() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-adaptive-falsification-gap",
+        candidate_id="candidate-adaptive-falsification-gap",
+        candidate_spec_id="spec-adaptive-falsification-gap",
+        dataset_snapshot_id="snapshot-adaptive-falsification-gap",
+        feature_spec_hash="feature-adaptive-falsification-gap",
+        code_commit="commit-adaptive-falsification-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_adaptive_signal_falsification": True,
+            "required_min_null_model_sample_count": "100",
+            "required_max_effective_multiplicity_adjusted_p_value": "0.05",
+            "bootstrap_robust_optimization_source_markers": [
+                "spurious_predictability_arxiv_2604_15531_2026",
+            ],
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": False},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "adaptive_signal_falsification_missing_or_failed" in blockers
+    assert "adaptive_signal_falsification_artifact_missing" in blockers
+    assert "adaptive_signal_baseline_not_outperformed" in blockers
+    assert "candidate_vs_null_return_delta_missing" in blockers
+    assert "candidate_vs_incumbent_return_delta_missing" in blockers
+    assert "null_model_sample_count_below_min" in blockers
+    assert "effective_multiplicity_adjusted_p_value_missing" in blockers
+    assert "negative_control_missing_or_failed" in blockers
+    assert "placebo_label_test_missing_or_failed" in blockers
+    assert "label_permutation_test_missing_or_failed" in blockers
+    assert "feature_permutation_stability_missing_or_failed" in blockers
+    assert "leakage_probe_missing_or_failed" in blockers
+    assert "walk_forward_falsification_missing_or_failed" in blockers
+
+
+def test_promotion_ready_bundle_accepts_materialized_adaptive_signal_falsification() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-adaptive-falsification-ready",
+        candidate_id="candidate-adaptive-falsification-ready",
+        candidate_spec_id="spec-adaptive-falsification-ready",
+        dataset_snapshot_id="snapshot-adaptive-falsification-ready",
+        feature_spec_hash="feature-adaptive-falsification-ready",
+        code_commit="commit-adaptive-falsification-ready",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_adaptive_signal_falsification": True,
+            "required_min_null_model_sample_count": "100",
+            "required_max_effective_multiplicity_adjusted_p_value": "0.05",
+            "adaptive_signal_falsification_passed": True,
+            "adaptive_signal_falsification_artifact_ref": (
+                "artifact://adaptive-falsification"
+            ),
+            "negative_control_passed": True,
+            "placebo_label_test_passed": True,
+            "label_permutation_test_passed": True,
+            "feature_permutation_stability_passed": True,
+            "leakage_probe_passed": True,
+            "walk_forward_falsification_passed": True,
+            "null_model_sample_count": 128,
+            "effective_multiplicity_adjusted_p_value": "0.02",
+            "candidate_vs_null_return_delta": "0.025",
+            "candidate_vs_incumbent_return_delta": "0.004",
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={
+            "baseline_outperformed": True,
+        },
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "adaptive_signal_falsification_missing_or_failed" not in blockers
+    assert "adaptive_signal_falsification_artifact_missing" not in blockers
+    assert "adaptive_signal_baseline_not_outperformed" not in blockers
+    assert "candidate_vs_null_return_delta_missing" not in blockers
+    assert "candidate_vs_incumbent_return_delta_missing" not in blockers
+    assert "null_model_sample_count_below_min" not in blockers
+    assert "effective_multiplicity_adjusted_p_value_missing" not in blockers
+    assert "negative_control_missing_or_failed" not in blockers
+    assert "placebo_label_test_missing_or_failed" not in blockers
+    assert "label_permutation_test_missing_or_failed" not in blockers
+    assert "feature_permutation_stability_missing_or_failed" not in blockers
+    assert "leakage_probe_missing_or_failed" not in blockers
+    assert "walk_forward_falsification_missing_or_failed" not in blockers
+
+
+def test_promotion_ready_bundle_blocks_weak_adaptive_signal_comparator_values() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-adaptive-falsification-weak-comparator",
+        candidate_id="candidate-adaptive-falsification-weak-comparator",
+        candidate_spec_id="spec-adaptive-falsification-weak-comparator",
+        dataset_snapshot_id="snapshot-adaptive-falsification-weak-comparator",
+        feature_spec_hash="feature-adaptive-falsification-weak-comparator",
+        code_commit="commit-adaptive-falsification-weak-comparator",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_adaptive_signal_falsification": True,
+            "adaptive_signal_falsification_passed": True,
+            "adaptive_signal_falsification_artifact_ref": (
+                "artifact://adaptive-falsification"
+            ),
+            "negative_control_passed": True,
+            "placebo_label_test_passed": True,
+            "label_permutation_test_passed": True,
+            "feature_permutation_stability_passed": True,
+            "leakage_probe_passed": True,
+            "walk_forward_falsification_passed": True,
+            "null_model_sample_count": 128,
+            "effective_multiplicity_adjusted_p_value": "0.10",
+            "candidate_vs_null_return_delta": "0",
+            "candidate_vs_incumbent_return_delta": "-0.001",
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "adaptive_signal_null_comparator_missing" in blockers
+    assert "candidate_vs_null_return_delta_non_positive" in blockers
+    assert "candidate_vs_incumbent_return_delta_negative" in blockers
+    assert "effective_multiplicity_adjusted_p_value_above_max" in blockers
+
+
+def test_promotion_ready_bundle_infers_adaptive_signal_falsification_from_hard_veto() -> (
+    None
+):
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-adaptive-falsification-hard-veto",
+        candidate_id="candidate-adaptive-falsification-hard-veto",
+        candidate_spec_id="spec-adaptive-falsification-hard-veto",
+        dataset_snapshot_id="snapshot-adaptive-falsification-hard-veto",
+        feature_spec_hash="feature-adaptive-falsification-hard-veto",
+        code_commit="commit-adaptive-falsification-hard-veto",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "hard_vetoes": ["required_adaptive_signal_falsification"],
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "adaptive_signal_falsification_missing_or_failed" in blockers
+
+
 def test_promotion_ready_bundle_blocks_required_ofi_response_gaps() -> None:
     bundle = CandidateEvidenceBundle(
         schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
@@ -795,6 +985,71 @@ def test_frontier_candidate_preserves_bootstrap_robust_fields() -> None:
     )
     blockers = evidence_bundle_blockers(bundle)
     assert "bootstrap_robust_optimization_artifact_missing" not in blockers
+
+
+def test_frontier_candidate_preserves_adaptive_signal_falsification_fields() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-adaptive-falsification-preserved",
+        candidate={
+            "candidate_id": "candidate-adaptive-falsification-preserved",
+            "objective_scorecard": {
+                **_promotion_quality_scorecard(),
+                "requires_adaptive_signal_falsification": True,
+            },
+            "hard_vetoes": {
+                "required_adaptive_signal_falsification": True,
+                "required_min_null_model_sample_count": "100",
+                "required_max_effective_multiplicity_adjusted_p_value": "0.05",
+            },
+            "promotion_contract": {
+                "requires_negative_control_falsification": True,
+                "requires_effective_multiplicity_adjustment": True,
+            },
+            "adaptive_signal_falsification_passed": True,
+            "adaptive_signal_falsification_artifact_ref": (
+                "artifact://adaptive-falsification"
+            ),
+            "negative_control_passed": True,
+            "placebo_label_test_passed": True,
+            "label_permutation_test_passed": True,
+            "feature_permutation_stability_passed": True,
+            "leakage_probe_passed": True,
+            "walk_forward_falsification_passed": True,
+            "null_model_sample_count": 128,
+            "effective_multiplicity_adjusted_p_value": "0.02",
+            "adaptive_signal_falsification_source_markers": [
+                "spurious_predictability_arxiv_2604_15531_2026",
+            ],
+            "null_comparator": {
+                "baseline_outperformed": True,
+                "candidate_vs_null_return_delta": "0.025",
+                "candidate_vs_incumbent_return_delta": "0.004",
+            },
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-adaptive-falsification-preserved",
+        result_path="artifact://replay",
+        code_commit="commit-adaptive-falsification-preserved",
+    )
+
+    assert bundle.objective_scorecard["required_adaptive_signal_falsification"] is True
+    assert bundle.objective_scorecard["requires_negative_control_falsification"] is True
+    assert (
+        bundle.objective_scorecard["requires_effective_multiplicity_adjustment"] is True
+    )
+    assert (
+        bundle.objective_scorecard["adaptive_signal_falsification_artifact_ref"]
+        == "artifact://adaptive-falsification"
+    )
+    assert bundle.null_comparator["baseline_outperformed"] is True
+    blockers = evidence_bundle_blockers(bundle)
+    assert "adaptive_signal_falsification_artifact_missing" not in blockers
+    assert "adaptive_signal_baseline_not_outperformed" not in blockers
 
 
 def test_frontier_candidate_preserves_ofi_response_fields() -> None:


### PR DESCRIPTION
## Summary

- Adds a fail-closed adaptive signal falsification evidence gate for promotion candidates that invoke spurious-predictability or adaptive signal-discovery mechanisms.
- Requires materialized negative-control, placebo-label, label-permutation, feature-permutation, leakage-probe, walk-forward falsification, null-model sample-count, multiplicity-adjusted p-value, and null/incumbent comparator evidence before promotion can pass.
- Preserves adaptive falsification scorecard fields from frontier candidates and nested promotion contracts into evidence bundles.
- Adds regression coverage for missing evidence rejection, materialized evidence acceptance, and frontier-candidate field preservation.

## Related Issues

None.

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv sync --frozen --extra dev` failed locally because `crosshair-tool==0.0.102` requires a missing `cc` compiler in this workspace.
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this backend research/evidence-gate change has no UI.
- [x] Breaking Changes section is filled in.
- [x] Documentation, release notes, and follow-ups are tracked in the PR summary and test coverage.
