### PR TITLE
fix(torghut): preserve source audit lineage scope

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -49,6 +49,28 @@ spec:
                 secretKeyRef:
                   name: torghut-db-app
                   key: uri
+            - name: TORGHUT_SIM_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: host
+            - name: TORGHUT_SIM_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: port
+            - name: TORGHUT_SIM_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: username
+            - name: TORGHUT_SIM_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-db-app
+                  key: password
+            - name: SIM_DB_DSN
+              value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
             - name: TORGHUT_TIGERBEETLE_ENABLED
               value: "true"
             - name: TORGHUT_TIGERBEETLE_REQUIRED

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1682,6 +1682,14 @@ def _target_identity(
         "paper_probation_authorization_scope": _safe_text(
             target.get("paper_probation_authorization_scope")
         ),
+        "source_collection_authorized": _truthy_plan_value(
+            target.get("source_collection_authorized")
+        ),
+        "source_collection_authorization_scope": _safe_text(
+            target.get("source_collection_authorization_scope")
+        ),
+        "handoff": _safe_text(target.get("handoff")),
+        "selected_by": _safe_text(target.get("selected_by")),
         "proof_mode": _safe_text(target.get("proof_mode")) or "probation",
         "evidence_collection_ok": bool(
             target.get("evidence_collection_ok")

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -11592,6 +11592,71 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertTrue(readback["evidence_grade_runtime_buckets_present"])
         self.assertFalse(target_audit["readiness"]["promotion_authority"]["allowed"])
 
+    def test_paper_route_observed_source_collection_target_uses_source_dsn(
+        self,
+    ) -> None:
+        target = paper_route_evidence._target_identity(
+            {
+                "hypothesis_id": "H-SOURCE-DSN",
+                "candidate_id": "candidate-source-dsn",
+                "observed_stage": "paper",
+                "strategy_family": "intraday_tsmom_consistent",
+                "strategy_name": "intraday-tsmom-profit-v3",
+                "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                "account_label": "TORGHUT_SIM",
+                "source_account_label": "TORGHUT_SOURCE",
+                "source_dsn_env": "TORGHUT_SOURCE_TEST_DSN",
+                "target_dsn_env": "SIM_DB_DSN",
+                "source_kind": "paper_route_probe_runtime_observed",
+                "source_collection_authorized": True,
+                "source_collection_authorization_scope": (
+                    "source_window_evidence_collection_only"
+                ),
+                "handoff": "next_paper_route_runtime_window_import",
+                "selected_by": "paper_route_evidence_audit",
+            },
+            probe={},
+        )
+
+        self.assertTrue(target["source_collection_authorized"])
+        self.assertEqual(
+            target["source_collection_authorization_scope"],
+            "source_window_evidence_collection_only",
+        )
+        self.assertEqual(target["handoff"], "next_paper_route_runtime_window_import")
+        self.assertEqual(target["selected_by"], "paper_route_evidence_audit")
+        self.assertTrue(
+            paper_route_evidence._target_is_runtime_ledger_source_collection(target)
+        )
+        disabled_target = paper_route_evidence._target_identity(
+            {
+                "source_dsn_env": "TORGHUT_SOURCE_TEST_DSN",
+                "source_kind": "paper_route_probe_runtime_observed",
+                "source_collection_authorized": "false",
+            },
+            probe={},
+        )
+        self.assertFalse(disabled_target["source_collection_authorized"])
+        self.assertFalse(
+            paper_route_evidence._target_is_runtime_ledger_source_collection(
+                disabled_target
+            )
+        )
+        with (
+            patch.dict(
+                "os.environ",
+                {"TORGHUT_SOURCE_TEST_DSN": "sqlite+pysqlite:///:memory:"},
+                clear=False,
+            ),
+            Session(self.engine) as session,
+        ):
+            with paper_route_evidence._target_source_audit_session(
+                session, target=target
+            ) as (_, source_scope):
+                self.assertTrue(source_scope["source_session_expected"])
+                self.assertTrue(source_scope["source_session_used"])
+                self.assertEqual(source_scope["source_account_label"], "TORGHUT_SOURCE")
+
     def test_source_audit_sqlalchemy_dsn_uses_installed_psycopg_driver(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Preserve paper-route source collection authorization, handoff, and selection metadata when normalizing target identity for evidence audits.
- Allows source-authorized `paper_route_probe_runtime_observed` latest-closed targets to use their real source DSN audit session instead of silently falling back to the live service database.
- Add the Torghut SIM database DSN env wiring to the live Torghut Knative service so live proof endpoints can read source-backed paper-runtime evidence without enabling capital.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k "source_dsn or latest_closed_runtime_window_import_selection"`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `PATH="/tmp/kubeconform-bin:$PATH" bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
