### PR TITLE
feat(torghut): stress robust impact uncertainty

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -102,8 +102,8 @@ from app.trading.discovery.stochastic_liquidity_resilience_stress import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v16"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v17"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v17"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v18"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -664,7 +664,7 @@ class FastReplayPreviewResult:
                 "lob_simulation_reality_gap_execution_stress": "deterministic spread-volume imbalance, latency-race mode, power-law signed-flow impact, odd-lot liquidity reliability, and responsive exchange event-mix stress from arXiv:2603.24137, OFR WP 25-01, arXiv:2507.06345, and arXiv:2502.07071; preview ranking only",
                 "alpha_decay_predictability_stress": "deterministic multi-horizon spread-adjusted alpha decay, cost-crossover, latency-horizon mismatch, and efficiency-regime compression stress from arXiv:2601.02310 and SSRN:6608199; preview ranking only",
                 "counterfactual_regime_replay_stress": "deterministic real-tape regime support, edge concentration, and temporal Wasserstein shift stress from arXiv:2602.03776 and SSRN:6232459; no synthetic PnL; preview ranking only",
-                "nonlinear_impact_execution_stress": "deterministic real-tape participation-rate, square-root impact, and permanent-impact decay stress from arXiv:2603.29086 and arXiv:2502.16246; model costs are not PnL authority; preview ranking only",
+                "nonlinear_impact_execution_stress": "deterministic real-tape participation-rate, square-root impact, directional elliptic uncertainty, and permanent-impact decay stress from arXiv:2603.29086, arXiv:2510.19950, and arXiv:2502.16246; model costs are not PnL authority; preview ranking only",
                 "option_gamma_flow_stress": "deterministic replay-row option gamma, short-horizon option availability, and dealer-hedging feedback stress from SSRN:4692190 and SSRN:6703098; gamma proxies are not PnL authority; preview ranking only",
                 "intraday_jump_burst_stress": "deterministic replay-row intraday jump, volatility burst, and spurious-jump source-gap stress from SSRN:5223127, SSRN:5199540, and arXiv:2602.10925; jump proxies are not PnL authority; preview ranking only",
                 "intraday_price_path_asymmetry_stress": "deterministic range-based open-high-low intraday path asymmetry and late-session pressure stress from SSRN:6074846 and SSRN:5039009; next-session reversal proxies are not PnL authority; preview ranking only",

--- a/services/torghut/app/trading/discovery/nonlinear_impact_execution_stress.py
+++ b/services/torghut/app/trading/discovery/nonlinear_impact_execution_stress.py
@@ -18,10 +18,10 @@ from typing import Any, Callable, cast
 from app.trading.models import SignalEnvelope
 
 NONLINEAR_IMPACT_EXECUTION_STRESS_SCHEMA_VERSION = (
-    "torghut.nonlinear-impact-execution-stress.v1"
+    "torghut.nonlinear-impact-execution-stress.v2"
 )
 NONLINEAR_IMPACT_EXECUTION_STRESS_CONTRACT_SCHEMA_VERSION = (
-    "torghut.nonlinear-impact-execution-stress-contract.v1"
+    "torghut.nonlinear-impact-execution-stress-contract.v2"
 )
 NONLINEAR_IMPACT_EXECUTION_STRESS_PROOF_SEMANTICS_LABEL = (
     "nonlinear_impact_execution_stress_preview_only_exact_replay_route_tca_"
@@ -42,10 +42,18 @@ NONLINEAR_IMPACT_EXECUTION_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...]
         "date": "2025-08-04",
         "mechanism": "child_order_square_root_impact_with_inverse_square_root_time_decay",
     },
+    {
+        "source_id": "arxiv-2510.19950",
+        "url": "https://arxiv.org/abs/2510.19950",
+        "title": "Robust Reinforcement Learning in Finance: Modeling Market Impact with Elliptic Uncertainty Sets",
+        "date": "2026-01-23",
+        "mechanism": "directional_market_impact_uncertainty_set_worst_case_participation_stress",
+    },
 )
 NONLINEAR_IMPACT_EXECUTION_STRESS_SOURCE_MARKERS: tuple[str, ...] = (
     "realistic_market_impact_arxiv_2603_29086_2026",
     "double_square_root_impact_arxiv_2502_16246_2025",
+    "elliptic_market_impact_uncertainty_arxiv_2510_19950_2026",
 )
 
 _PRICE_FIELDS = ("price", "mid_price", "mid", "mark", "last_price", "close")
@@ -101,6 +109,9 @@ class NonlinearImpactExecutionStressSummary:
     square_root_impact_cost_bps: float
     linear_cost_bps: float
     nonlinear_cost_uplift_bps: float
+    directional_impact_uncertainty_score: float
+    elliptic_uncertainty_worst_case_cost_bps: float
+    robust_impact_cost_bps: float
     permanent_impact_residual_bps: float
     impact_decay_shortfall_bps: float
     adverse_decay_reversal_share: float
@@ -136,6 +147,13 @@ class NonlinearImpactExecutionStressSummary:
             ),
             "linear_cost_bps": _stable_float(self.linear_cost_bps),
             "nonlinear_cost_uplift_bps": _stable_float(self.nonlinear_cost_uplift_bps),
+            "directional_impact_uncertainty_score": _stable_float(
+                self.directional_impact_uncertainty_score
+            ),
+            "elliptic_uncertainty_worst_case_cost_bps": _stable_float(
+                self.elliptic_uncertainty_worst_case_cost_bps
+            ),
+            "robust_impact_cost_bps": _stable_float(self.robust_impact_cost_bps),
             "permanent_impact_residual_bps": _stable_float(
                 self.permanent_impact_residual_bps
             ),
@@ -165,6 +183,13 @@ class NonlinearImpactExecutionStressSummary:
                 "nonlinear_cost_uplift_bps": _stable_float(
                     self.nonlinear_cost_uplift_bps
                 ),
+                "directional_impact_uncertainty_score": _stable_float(
+                    self.directional_impact_uncertainty_score
+                ),
+                "elliptic_uncertainty_worst_case_cost_bps": _stable_float(
+                    self.elliptic_uncertainty_worst_case_cost_bps
+                ),
+                "robust_impact_cost_bps": _stable_float(self.robust_impact_cost_bps),
                 "permanent_impact_residual_bps": _stable_float(
                     self.permanent_impact_residual_bps
                 ),
@@ -180,6 +205,7 @@ class NonlinearImpactExecutionStressSummary:
             "square_root_market_impact_preview": True,
             "permanent_impact_decay_preview": True,
             "participation_rate_capacity_preview": True,
+            "directional_elliptic_uncertainty_preview": True,
             "trade_level_logging_required_downstream": True,
             "research_ranking_only": True,
             "prefilter_only": True,
@@ -208,6 +234,9 @@ def nonlinear_impact_execution_stress_contract() -> dict[str, Any]:
             "square_root_impact_cost_bps",
             "participation_rate_tail",
             "nonlinear_cost_uplift_bps",
+            "directional_impact_uncertainty_score",
+            "elliptic_uncertainty_worst_case_cost_bps",
+            "robust_impact_cost_bps",
             "permanent_impact_residual_bps",
             "impact_decay_shortfall_bps",
             "adverse_decay_reversal_share",
@@ -224,7 +253,9 @@ def nonlinear_impact_execution_stress_contract() -> dict[str, Any]:
             "requires_order_lifecycle_fill_evidence": True,
             "requires_runtime_ledger": True,
             "requires_trade_level_logging": True,
+            "requires_directional_impact_uncertainty_audit": True,
             "rejects_model_cost_as_realized_pnl_authority": True,
+            "rejects_robust_impact_model_as_realized_pnl_authority": True,
             "rejects_synthetic_fill_authority": True,
         },
     }
@@ -312,6 +343,23 @@ def extract_nonlinear_impact_execution_stress(
     )
     linear_cost_bps = _weighted_average(linear_costs) if linear_costs else 0.0
     nonlinear_cost_uplift_bps = max(0.0, square_root_impact_cost_bps - linear_cost_bps)
+    directional_impact_uncertainty_score = _directional_impact_uncertainty_score(
+        median_participation_rate=median_participation_rate,
+        p90_participation_rate=p90_participation_rate,
+        high_participation_share=high_participation_share,
+        extreme_participation_share=extreme_participation_share,
+    )
+    # arXiv:2510.19950 motivates directional worst-case impact under elliptic
+    # uncertainty sets.  This bounded proxy is ranking-only: it perturbs modeled
+    # impact cost for stress ordering and cannot stand in for realized fill/PnL.
+    elliptic_uncertainty_worst_case_cost_bps = _elliptic_uncertainty_cost_bps(
+        square_root_impact_cost_bps=square_root_impact_cost_bps,
+        nonlinear_cost_uplift_bps=nonlinear_cost_uplift_bps,
+        directional_impact_uncertainty_score=directional_impact_uncertainty_score,
+    )
+    robust_impact_cost_bps = (
+        square_root_impact_cost_bps + elliptic_uncertainty_worst_case_cost_bps
+    )
 
     half_life_events = (
         median(decay_half_life_values)
@@ -346,6 +394,8 @@ def extract_nonlinear_impact_execution_stress(
         0.0,
         square_root_impact_cost_bps * 0.65
         + nonlinear_cost_uplift_bps * 0.80
+        + elliptic_uncertainty_worst_case_cost_bps * 0.55
+        + directional_impact_uncertainty_score * 6.0
         + permanent_impact_residual_bps * 0.25
         + impact_decay_shortfall_bps * 0.35
         + high_participation_share * 10.0
@@ -380,6 +430,9 @@ def extract_nonlinear_impact_execution_stress(
         square_root_impact_cost_bps=square_root_impact_cost_bps,
         linear_cost_bps=linear_cost_bps,
         nonlinear_cost_uplift_bps=nonlinear_cost_uplift_bps,
+        directional_impact_uncertainty_score=directional_impact_uncertainty_score,
+        elliptic_uncertainty_worst_case_cost_bps=elliptic_uncertainty_worst_case_cost_bps,
+        robust_impact_cost_bps=robust_impact_cost_bps,
         permanent_impact_residual_bps=permanent_impact_residual_bps,
         impact_decay_shortfall_bps=impact_decay_shortfall_bps,
         adverse_decay_reversal_share=adverse_decay_reversal_share,
@@ -387,6 +440,37 @@ def extract_nonlinear_impact_execution_stress(
         warnings=tuple(sorted(warnings)),
         feature_schema_hash=build_nonlinear_impact_execution_stress_schema_hash(),
     )
+
+
+def _directional_impact_uncertainty_score(
+    *,
+    median_participation_rate: float,
+    p90_participation_rate: float,
+    high_participation_share: float,
+    extreme_participation_share: float,
+) -> float:
+    participation_tail = min(1.0, max(0.0, p90_participation_rate) / 0.25)
+    median_pressure = min(1.0, max(0.0, median_participation_rate) / 0.10)
+    return min(
+        1.0,
+        median_pressure * 0.25
+        + participation_tail * 0.35
+        + high_participation_share * 0.25
+        + extreme_participation_share * 0.35,
+    )
+
+
+def _elliptic_uncertainty_cost_bps(
+    *,
+    square_root_impact_cost_bps: float,
+    nonlinear_cost_uplift_bps: float,
+    directional_impact_uncertainty_score: float,
+) -> float:
+    impact_base = (
+        max(0.0, square_root_impact_cost_bps)
+        + max(0.0, nonlinear_cost_uplift_bps) * 0.50
+    )
+    return impact_base * min(1.0, max(0.0, directional_impact_uncertainty_score))
 
 
 def _extract_price(row: SignalEnvelope) -> float | None:

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -538,14 +538,22 @@ class TestFastReplayPreview(TestCase):
             row_payload["nonlinear_impact_execution_stress"]["status"],
             "preview_only_nonlinear_impact_execution_stress_ranking",
         )
+        nonlinear_impact_source_ids = {
+            source["source_id"]
+            for source in row_payload["nonlinear_impact_execution_stress"][
+                "source_papers"
+            ]
+        }
+        self.assertIn("arxiv-2603.29086", nonlinear_impact_source_ids)
+        self.assertIn("arxiv-2510.19950", nonlinear_impact_source_ids)
         self.assertIn(
-            "arxiv-2603.29086",
-            {
-                source["source_id"]
-                for source in row_payload["nonlinear_impact_execution_stress"][
-                    "source_papers"
-                ]
-            },
+            "elliptic_uncertainty_worst_case_cost_bps",
+            row_payload["nonlinear_impact_execution_stress"]["ranking_features"],
+        )
+        self.assertTrue(
+            row_payload["nonlinear_impact_execution_stress"][
+                "directional_elliptic_uncertainty_preview"
+            ]
         )
         self.assertIn("option_gamma_flow_stress", row_payload)
         self.assertFalse(row_payload["option_gamma_flow_stress"]["proof_authority"])

--- a/services/torghut/tests/test_nonlinear_impact_execution_stress.py
+++ b/services/torghut/tests/test_nonlinear_impact_execution_stress.py
@@ -107,6 +107,17 @@ class TestNonlinearImpactExecutionStress(TestCase):
             crowded.square_root_impact_cost_bps, liquid.square_root_impact_cost_bps
         )
         self.assertGreater(
+            crowded.directional_impact_uncertainty_score,
+            liquid.directional_impact_uncertainty_score,
+        )
+        self.assertGreater(
+            crowded.elliptic_uncertainty_worst_case_cost_bps,
+            liquid.elliptic_uncertainty_worst_case_cost_bps,
+        )
+        self.assertGreater(
+            crowded.robust_impact_cost_bps, liquid.robust_impact_cost_bps
+        )
+        self.assertGreater(
             crowded.permanent_impact_residual_bps, liquid.permanent_impact_residual_bps
         )
         self.assertGreater(
@@ -122,9 +133,21 @@ class TestNonlinearImpactExecutionStress(TestCase):
         )
         self.assertTrue(payload["square_root_market_impact_preview"])
         self.assertTrue(payload["permanent_impact_decay_preview"])
+        self.assertTrue(payload["directional_elliptic_uncertainty_preview"])
         self.assertTrue(payload["trade_level_logging_required_downstream"])
         self.assertIn(
+            "elliptic_uncertainty_worst_case_cost_bps",
+            payload["ranking_features"],
+        )
+        self.assertGreater(
+            payload["robust_impact_cost_bps"], payload["square_root_impact_cost_bps"]
+        )
+        self.assertIn(
             "double_square_root_impact_arxiv_2502_16246_2025",
+            payload["source_markers"],
+        )
+        self.assertIn(
+            "elliptic_market_impact_uncertainty_arxiv_2510_19950_2026",
             payload["source_markers"],
         )
         self.assertFalse(payload["proof_authority"])
@@ -144,6 +167,7 @@ class TestNonlinearImpactExecutionStress(TestCase):
         source_ids = {source["source_id"] for source in contract["source_papers"]}
         self.assertIn("arxiv-2603.29086", source_ids)
         self.assertIn("arxiv-2502.16246", source_ids)
+        self.assertIn("arxiv-2510.19950", source_ids)
         self.assertIn(
             "double_square_root_impact_arxiv_2502_16246_2025",
             contract["source_markers"],
@@ -155,7 +179,13 @@ class TestNonlinearImpactExecutionStress(TestCase):
         self.assertTrue(proof_neutrality["requires_runtime_ledger"])
         self.assertTrue(proof_neutrality["requires_trade_level_logging"])
         self.assertTrue(
+            proof_neutrality["requires_directional_impact_uncertainty_audit"]
+        )
+        self.assertTrue(
             proof_neutrality["rejects_model_cost_as_realized_pnl_authority"]
+        )
+        self.assertTrue(
+            proof_neutrality["rejects_robust_impact_model_as_realized_pnl_authority"]
         )
         self.assertTrue(proof_neutrality["rejects_synthetic_fill_authority"])
         self.assertFalse(payload["promotion_proof"])


### PR DESCRIPTION
## Summary

- Adds a preview-only directional elliptic market-impact uncertainty stress to Torghut's nonlinear impact replay harness.
- Records arXiv:2510.19950 alongside existing 2026/2025 market-impact sources and exposes robust-impact ranking features without promotion authority.
- Bumps fast-replay preview schemas and verifies the new stress fields flow into fast replay manifests.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_nonlinear_impact_execution_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uvx ruff check app/trading/discovery/nonlinear_impact_execution_stress.py app/trading/discovery/fast_replay.py tests/test_nonlinear_impact_execution_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff format --check app/trading/discovery/nonlinear_impact_execution_stress.py app/trading/discovery/fast_replay.py tests/test_nonlinear_impact_execution_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv run --frozen python -m coverage erase && uv run --frozen python -m coverage run -m pytest tests/test_nonlinear_impact_execution_stress.py tests/test_fast_replay.py -q && uv run --frozen python -m coverage xml --fail-under=0 -o coverage.xml && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A — backend replay-harness change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; this PR records source metadata in executable stress payloads and requires no separate docs/release note.
