### PR TITLE
fix(torghut): require source lineage cache keys

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6340,6 +6340,39 @@ def _paper_route_target_plan_truthy(value: object) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _paper_route_source_collection_target_cache_safe(
+    target: Mapping[str, Any],
+) -> bool:
+    source_kind = str(target.get("source_kind") or "").strip()
+    handoff = str(target.get("handoff") or "").strip()
+    selected_by = str(target.get("selected_by") or "").strip()
+    if (
+        source_kind != "runtime_ledger_source_collection_candidate"
+        and handoff != "runtime_ledger_source_collection_import"
+        and selected_by != "runtime_ledger_source_collection"
+    ):
+        return True
+
+    if not str(target.get("window_start") or "").strip():
+        return False
+    if not str(target.get("window_end") or "").strip():
+        return False
+    if str(target.get("runtime_ledger_bucket_ref") or "").strip():
+        return True
+    return any(
+        target.get(key)
+        for key in (
+            "source_window_ids",
+            "runtime_ledger_source_window_ids",
+            "trade_decision_ids",
+            "execution_ids",
+            "execution_order_event_ids",
+            "source_offsets",
+            "source_refs",
+        )
+    )
+
+
 def _paper_route_target_plan_cache_safe_for_live(
     plan: Mapping[str, Any],
 ) -> bool:
@@ -6358,6 +6391,8 @@ def _paper_route_target_plan_cache_safe_for_live(
             target.get("account_label") or target.get("source_account_label") or ""
         ).strip()
         if target_account != _PAPER_ROUTE_BOUNDED_COLLECTION_ACCOUNT_LABEL:
+            return False
+        if not _paper_route_source_collection_target_cache_safe(target):
             return False
         for key in (
             "promotion_allowed",

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -10132,6 +10132,66 @@ class TestTradingApi(TestCase):
                 require_bounded_sim_targets=True,
             )
         )
+        unsafe_source_collection_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "source_account_label": "TORGHUT_SIM",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_collection_authorized": True,
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ],
+            }
+        }
+        self.assertIsNone(
+            main_module._paper_route_cached_live_submission_gate(
+                SimpleNamespace(
+                    _last_live_submission_gate=unsafe_source_collection_gate
+                ),
+                require_bounded_sim_targets=True,
+            )
+        )
+        source_collection_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "source_account_label": "TORGHUT_SIM",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_collection_authorized": True,
+                        "window_start": "2026-05-13T17:00:00+00:00",
+                        "window_end": "2026-05-13T17:30:00+00:00",
+                        "runtime_ledger_bucket_ref": (
+                            "strategy_runtime_ledger_buckets:run:2026-05-13T17:00:00+00:00:"
+                            "2026-05-13T17:30:00+00:00"
+                        ),
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ],
+            }
+        }
+        self.assertIsNotNone(
+            main_module._paper_route_cached_live_submission_gate(
+                SimpleNamespace(_last_live_submission_gate=source_collection_gate),
+                require_bounded_sim_targets=True,
+            )
+        )
 
     def test_paper_route_target_strategy_lookup_names_skip_missing_values(
         self,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -10132,6 +10132,24 @@ class TestTradingApi(TestCase):
                 require_bounded_sim_targets=True,
             )
         )
+        self.assertFalse(
+            main_module._paper_route_source_collection_target_cache_safe(
+                {
+                    "source_kind": "runtime_ledger_source_collection_candidate",
+                    "window_start": "2026-05-13T17:00:00+00:00",
+                }
+            )
+        )
+        self.assertTrue(
+            main_module._paper_route_source_collection_target_cache_safe(
+                {
+                    "source_kind": "runtime_ledger_source_collection_candidate",
+                    "window_start": "2026-05-13T17:00:00+00:00",
+                    "window_end": "2026-05-13T17:30:00+00:00",
+                    "source_window_ids": ["runtime-ledger-window-20260513T1700Z"],
+                }
+            )
+        )
         unsafe_source_collection_gate = {
             "runtime_ledger_paper_probation_import_plan": {
                 "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",


### PR DESCRIPTION
## Summary

- Reject cached live paper-route target plans when runtime-ledger source-collection targets lack source window/materialization keys.
- Force live target-plan/evidence endpoints to rebuild the full live gate instead of reusing sanitized cache entries that drop runtime-ledger bucket/window lineage.
- Add regression coverage for unsafe source-collection cache entries and for complete source-collection cache entries that preserve bucket/window evidence.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k "cached_gate_requires_target_plan"`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
