### PR TITLE
fix(autotrader): add exploratory starter orders

### DIFF
--- a/scripts/autotrader/live_scan_cycle.py
+++ b/scripts/autotrader/live_scan_cycle.py
@@ -41,6 +41,10 @@ ACTIONABLE_SETUP_GRADES = {"A+", "A", "B"}
 DEFAULT_SCORECARD_LIMIT = 100
 MIN_ACTIONABLE_EXPECTED_R = Decimal("2.0")
 MIN_ACTIONABLE_BRACKET_R = Decimal("2.0")
+MIN_EXPLORATORY_ACTIONABLE_EXPECTED_R = Decimal("1.0")
+EXPLORATORY_SYNTHETIC_BRACKET_R = Decimal("2.1")
+EXPLORATORY_STOP_DISTANCE_PCT = Decimal("0.003")
+EXPLORATORY_RISK_EQUITY_PCT = Decimal("0.001")
 MIN_SCORECARD_RISK_SCALE_SAMPLE_SIZE = 2
 MIN_SCORECARD_ACTIONABLE_AVG_REALIZED_R = Decimal("0.5")
 LOSSY_SCORECARD_EDGE_DISCOUNT = Decimal("0.5")
@@ -58,6 +62,7 @@ ACCOUNT_RATIO_QUANT = Decimal("0.000001")
 R_MULTIPLE_QUANT = Decimal("0.000001")
 PROFIT_PROTECT_BREAKEVEN_TRIGGER_R = Decimal("0.5")
 PROFIT_PROTECT_LOCK_TRIGGER_R = Decimal("1.0")
+EXPLORATORY_BLOCKING_RISK_NOTES = {"wide_spread", "weak_liquidity_score"}
 PROFIT_LOCK_R = Decimal("0.25")
 
 
@@ -1562,6 +1567,49 @@ def first_decimal_value(result: dict[str, Any], *keys: str) -> Decimal | None:
     return None
 
 
+def result_risk_notes(result: dict[str, Any]) -> list[str]:
+    value = result.get("risk_notes") or result.get("riskNotes")
+    if not isinstance(value, list):
+        return []
+    notes: list[str] = []
+    for item in value:
+        text = optional_text(item, max_length=120)
+        if text:
+            notes.append(text)
+    return notes
+
+
+def has_blocking_exploratory_risk_note(result: dict[str, Any]) -> bool:
+    return any(note in EXPLORATORY_BLOCKING_RISK_NOTES for note in result_risk_notes(result))
+
+
+def exploratory_scorecard_sample_values(result: dict[str, Any]) -> tuple[int, Decimal | None]:
+    return (
+        int_text_value(result.get("scorecard_sample_size") or result.get("scorecardSampleSize")),
+        decimal_value(result.get("scorecard_avg_realized_r") or result.get("scorecardAvgRealizedR")),
+    )
+
+
+def exploratory_starter_candidate(result: dict[str, Any]) -> bool:
+    grade = setup_grade(result.get("setup_grade") or result.get("setupGrade"))
+    type_ = setup_type(result.get("setup_type") or result.get("setupType"))
+    if grade not in ACTIONABLE_SETUP_GRADES or type_ == "no_trade":
+        return False
+    if has_blocking_exploratory_risk_note(result):
+        return False
+    sample_size, avg_realized_r = exploratory_scorecard_sample_values(result)
+    if sample_size > 0 or avg_realized_r is not None:
+        return False
+    expected_r = decimal_value(result.get("expected_r") or result.get("expectedR"))
+    return expected_r is not None and expected_r >= MIN_EXPLORATORY_ACTIONABLE_EXPECTED_R
+
+
+def actionable_expected_r_floor(result: dict[str, Any]) -> Decimal:
+    if exploratory_starter_candidate(result):
+        return MIN_EXPLORATORY_ACTIONABLE_EXPECTED_R
+    return MIN_ACTIONABLE_EXPECTED_R
+
+
 def result_side(result: dict[str, Any]) -> str:
     return schema_enum(result.get("side"), SYNTHESIS_SIDES, "buy")
 
@@ -1581,6 +1629,38 @@ def bracket_r_value(*, side: str, entry: Decimal, stop: Decimal, target: Decimal
     if risk <= 0 or reward <= 0:
         return None
     return reward / risk
+
+
+def exploratory_synthetic_bracket(
+    result: dict[str, Any],
+    *,
+    side: str,
+    direction: str,
+    entry: Decimal,
+) -> dict[str, Decimal | str] | None:
+    if not exploratory_starter_candidate(result):
+        return None
+    stop_distance = max(entry * EXPLORATORY_STOP_DISTANCE_PCT, ACCOUNT_MONEY_QUANT)
+    bracket_r = max(
+        EXPLORATORY_SYNTHETIC_BRACKET_R,
+        decimal_value(result.get("expected_r") or result.get("expectedR")) or EXPLORATORY_SYNTHETIC_BRACKET_R,
+    )
+    if direction == "buy":
+        stop = entry - stop_distance
+        target = entry + (stop_distance * bracket_r)
+    else:
+        stop = entry + stop_distance
+        target = entry - (stop_distance * bracket_r)
+    if stop <= 0 or target <= 0:
+        return None
+    actual_r = bracket_r_value(side=side, entry=entry, stop=stop, target=target)
+    if actual_r is None:
+        return None
+    return {
+        "stop": Decimal(quantized_decimal_text(stop, ACCOUNT_MONEY_QUANT)),
+        "target": Decimal(quantized_decimal_text(target, ACCOUNT_MONEY_QUANT)),
+        "actualR": actual_r,
+    }
 
 
 def derived_bracket_for_scan_result(result: dict[str, Any]) -> dict[str, Any]:
@@ -1611,6 +1691,14 @@ def derived_bracket_for_scan_result(result: dict[str, Any]) -> dict[str, Any]:
         elif direction == "sell" and support is not None and support < entry:
             target = support
             target_source = "support"
+
+    if entry is not None and (stop is None or target is None):
+        synthetic = exploratory_synthetic_bracket(result, side=side, direction=direction, entry=entry)
+        if synthetic is not None:
+            stop = synthetic["stop"] if isinstance(synthetic["stop"], Decimal) else None
+            target = synthetic["target"] if isinstance(synthetic["target"], Decimal) else None
+            stop_source = "exploratory_synthetic_pct_stop"
+            target_source = "exploratory_synthetic_r_target"
 
     missing = []
     if entry is None:
@@ -1727,7 +1815,7 @@ def result_no_trade_reason(
     account: dict[str, Any] | None = None,
 ) -> str | None:
     reason = optional_text(result.get("no_trade_reason") or result.get("noTradeReason"), max_length=1000)
-    if reason:
+    if reason and not (reason == "expected_r_below_threshold" and exploratory_starter_candidate(result)):
         return reason
     if grade in {"C", "blocked"}:
         return "scanner_blocked_grade"
@@ -1740,12 +1828,14 @@ def result_no_trade_reason(
     expected_r = decimal_value(result.get("expected_r") or result.get("expectedR"))
     if expected_r is None:
         return "missing_expected_r"
-    if expected_r < MIN_ACTIONABLE_EXPECTED_R:
+    if expected_r < actionable_expected_r_floor(result):
         return "expected_r_below_threshold"
     bracket_reason = executable_bracket_no_trade_reason(result)
     if bracket_reason:
         return bracket_reason
     if scorecard_sample_size <= 0 or scorecard_avg_r is None or scorecard_avg_r <= 0:
+        if exploratory_starter_candidate(result):
+            return None
         return "positive_scorecard_edge_required"
     if scorecard_avg_r < MIN_SCORECARD_ACTIONABLE_AVG_REALIZED_R:
         return "scorecard_avg_realized_r_below_actionable_floor"
@@ -1943,6 +2033,39 @@ def scorecard_edge_weight(sample_size: int) -> Decimal:
 
 def scorecard_risk_directive(result: dict[str, Any], account: dict[str, Any] | None = None) -> dict[str, Any] | None:
     sample_size, avg_realized_r, confidence = scorecard_edge_values(result)
+    if exploratory_starter_candidate(result):
+        directive: dict[str, Any] = {
+            "source": "exploratory_starter",
+            "mode": "starter_probe_without_scorecard_edge",
+            "riskMultiplier": "1.0",
+            "exploratoryRiskPct": normalized_quantized_decimal_text(
+                EXPLORATORY_RISK_EQUITY_PCT, ACCOUNT_RATIO_QUANT
+            ),
+            "minimumExpectedR": str(MIN_EXPLORATORY_ACTIONABLE_EXPECTED_R),
+            "syntheticBracketR": str(EXPLORATORY_SYNTHETIC_BRACKET_R),
+            "syntheticStopDistancePct": normalized_quantized_decimal_text(
+                EXPLORATORY_STOP_DISTANCE_PCT, ACCOUNT_RATIO_QUANT
+            ),
+            "reason": "exploratory_starter_no_scorecard",
+        }
+        risk_budget = risk_budget_for_account(account)
+        if risk_budget is not None:
+            directive["accountRiskBudget"] = risk_budget
+            equity = decimal_value(risk_budget.get("equity"))
+            if equity is not None:
+                recommended_risk_dollars = equity * EXPLORATORY_RISK_EQUITY_PCT
+                directive["recommendedRiskDollars"] = quantized_decimal_text(
+                    recommended_risk_dollars, ACCOUNT_MONEY_QUANT
+                )
+                max_notional = decimal_value(risk_budget.get("maxPositionNotionalDollars"))
+                position_size = position_size_for_bracket(
+                    bracket=derived_bracket_for_scan_result(result),
+                    recommended_risk_dollars=recommended_risk_dollars,
+                    max_position_notional_dollars=max_notional,
+                )
+                directive.update({key: value for key, value in position_size.items() if value is not None})
+                directive["positionSizeReason"] = str(position_size.get("reason"))
+        return directive
     if sample_size <= 0 or avg_realized_r is None or avg_realized_r <= 0:
         return None
     if avg_realized_r < MIN_SCORECARD_ACTIONABLE_AVG_REALIZED_R:
@@ -2065,7 +2188,7 @@ def actionable_candidate_for_result(
     expected_r = decimal_value(payload.get("expectedR"))
     if payload.get("status") != "candidate" or grade not in ACTIONABLE_SETUP_GRADES:
         return None
-    if expected_r is None or expected_r < MIN_ACTIONABLE_EXPECTED_R:
+    if expected_r is None or expected_r < actionable_expected_r_floor(result):
         return None
     ticket = tickets_by_idempotency_key.get(str(payload["idempotencyKey"]), {})
     return {

--- a/scripts/autotrader/test_live_scan_cycle.py
+++ b/scripts/autotrader/test_live_scan_cycle.py
@@ -858,7 +858,7 @@ class LiveScanCycleTest(unittest.TestCase):
             },
         )
         self.assertEqual(summary["bestCandidate"]["ticketId"], "ticket-amd")
-        self.assertEqual(summary["candidateSymbols"], ["AMD"])
+        self.assertEqual(summary["candidateSymbols"], ["AMD", "AVGO"])
 
     def test_decision_summary_quality_adjusts_scorecard_edge_by_loss_rate(self) -> None:
         summary = live_scan_cycle.decision_summary_for_scan(
@@ -1045,7 +1045,7 @@ class LiveScanCycleTest(unittest.TestCase):
             },
         )
 
-    def test_decision_summary_blocks_unproven_raw_edge_without_positive_scorecard(self) -> None:
+    def test_decision_summary_allows_bounded_exploratory_starter_without_scorecard(self) -> None:
         result = {
             "symbol": "AVGO",
             "setup_type": "vwap_reclaim",
@@ -1055,11 +1055,19 @@ class LiveScanCycleTest(unittest.TestCase):
             "support": "278.00",
             "resistance": "290.00",
         }
+        account = {
+            "account": {
+                "equity": "30000.00",
+                "buying_power": "120000.00",
+                "daytrading_buying_power": "120000.00",
+            }
+        }
         payload = live_scan_cycle.ticket_payload_for_scan_result(
             session_id="session-1",
             cycle=10,
             index=1,
             result=result,
+            account=account,
         )
         summary = live_scan_cycle.decision_summary_for_scan(
             cycle=10,
@@ -1070,16 +1078,22 @@ class LiveScanCycleTest(unittest.TestCase):
                     "ticketId": "ticket-avgo",
                 }
             ],
+            account=account,
         )
 
         assert payload is not None
-        self.assertEqual(payload["status"], "blocked")
-        self.assertEqual(payload["noTradeReason"], "positive_scorecard_edge_required")
-        self.assertEqual(summary["action"], "no_actionable_candidate")
-        self.assertEqual(summary["actionableCandidateCount"], 0)
-        self.assertEqual(summary["blockedResultCount"], 1)
+        self.assertEqual(payload["status"], "candidate")
+        self.assertIsNone(payload["noTradeReason"])
+        self.assertEqual(payload["riskDollars"], "30.00")
+        self.assertEqual(payload["plannedQuantity"], "15")
+        self.assertEqual(payload["brokerOrderPlan"]["riskDirective"]["source"], "exploratory_starter")
+        self.assertEqual(payload["brokerOrderPlan"]["riskDirective"]["mode"], "starter_probe_without_scorecard_edge")
+        self.assertEqual(payload["brokerOrderPlan"]["riskDirective"]["positionSizeReason"], "account_risk_budget_stop_distance")
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["actionableCandidateCount"], 1)
+        self.assertEqual(summary["blockedResultCount"], 0)
         self.assertEqual(summary["noTradeResultCount"], 0)
-        self.assertIsNone(summary["bestCandidate"])
+        self.assertEqual(summary["candidateSymbols"], ["AVGO"])
 
     def test_decision_summary_blocks_one_sample_positive_scorecard_edge(self) -> None:
         result = {
@@ -1321,12 +1335,65 @@ class LiveScanCycleTest(unittest.TestCase):
         self.assertEqual(summary["action"], "no_actionable_candidate")
         self.assertEqual(summary["blockedResultCount"], 1)
 
-    def test_decision_summary_blocks_sub_two_r_candidates(self) -> None:
+    def test_decision_summary_allows_sub_two_r_exploratory_starter_with_synthetic_bracket(self) -> None:
         result = {
             "symbol": "GOOGL",
             "setup_type": "vwap_reclaim",
             "setup_grade": "B",
             "expected_r": "1.786",
+            "last": "364.10",
+        }
+        account = {
+            "account": {
+                "equity": "30000.00",
+                "buying_power": "120000.00",
+                "daytrading_buying_power": "120000.00",
+            }
+        }
+        payload = live_scan_cycle.ticket_payload_for_scan_result(
+            session_id="session-1",
+            cycle=7,
+            index=1,
+            result=result,
+            account=account,
+        )
+        summary = live_scan_cycle.decision_summary_for_scan(
+            cycle=7,
+            scan={"results": [result]},
+            recorded_tickets=[
+                {
+                    "idempotencyKey": "scan-cycle-7-1-GOOGL-vwap_reclaim-B",
+                    "ticketId": "ticket-googl",
+                }
+            ],
+            account=account,
+        )
+
+        assert payload is not None
+        self.assertEqual(payload["status"], "candidate")
+        self.assertIsNone(payload["noTradeReason"])
+        self.assertEqual(payload["stopPrice"], "363.01")
+        self.assertEqual(payload["targetPrice"], "366.39")
+        actual_bracket_r = live_scan_cycle.decimal_value(payload["actualBracketR"])
+        self.assertIsNotNone(actual_bracket_r)
+        assert actual_bracket_r is not None
+        self.assertGreaterEqual(actual_bracket_r, live_scan_cycle.MIN_ACTIONABLE_BRACKET_R)
+        self.assertEqual(payload["riskDollars"], "30.00")
+        self.assertEqual(payload["plannedQuantity"], "27")
+        self.assertEqual(payload["brokerOrderPlan"]["executableBracket"]["stopSource"], "exploratory_synthetic_pct_stop")
+        self.assertEqual(payload["brokerOrderPlan"]["executableBracket"]["targetSource"], "exploratory_synthetic_r_target")
+        self.assertEqual(summary["action"], "run_strategy_order_guard")
+        self.assertEqual(summary["actionableCandidateCount"], 1)
+        self.assertEqual(summary["blockedResultCount"], 0)
+        self.assertEqual(summary["noTradeResultCount"], 0)
+        self.assertEqual(summary["candidateSymbols"], ["GOOGL"])
+
+    def test_decision_summary_blocks_below_exploratory_expected_r_candidates(self) -> None:
+        result = {
+            "symbol": "GOOGL",
+            "setup_type": "vwap_reclaim",
+            "setup_grade": "B",
+            "expected_r": "0.786",
             "last": "364.10",
         }
         payload = live_scan_cycle.ticket_payload_for_scan_result(


### PR DESCRIPTION
## Summary

- Adds a bounded exploratory starter lane for live autotrader scan results that have an actionable setup but no scorecard history.
- Generates deterministic synthetic bracket prices when the scanner has a valid live price but no support/resistance bracket, with starter risk capped at 0.1% of equity.
- Keeps negative scorecard, weak scorecard, one-sample positive scorecard, C-grade, wide-spread, weak-liquidity, post-loss, and June 3 replay blocks intact.

## Related Issues

None

## Testing

- `PYTHONPATH=scripts/autotrader python -m unittest discover -s scripts/autotrader`
- `PYTHONPATH=scripts/autotrader python -m unittest discover -s scripts/autotrader -p 'test_market_open_cycle.py'`
- `PYTHONPATH=scripts/autotrader python -m unittest discover -s scripts/autotrader -p 'test_market_open_bootstrap.py'`
- `PYTHONPATH=scripts/autotrader python - <<'PY' ... live_scan_cycle.run_june3_failure_path_replay() ... PY`
- Replayed June 4 live event slices 240, 245, and 246 through patched candidate selection; each produced a complete MSFT starter candidate with bracket prices, planned quantity, and capped risk.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
