### PR TITLE
feat(torghut): hand off adaptive falsification in autoresearch

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6839,6 +6839,44 @@ def _apply_fast_replay_preview_narrowing(
             updated["fast_replay_frontier_dedupe_metadata"] = preview_row.get(
                 "frontier_dedupe_metadata"
             )
+            adaptive_signal_falsification_stress = _mapping(
+                preview_row.get("adaptive_signal_falsification_stress")
+            )
+            if adaptive_signal_falsification_stress:
+                updated["fast_replay_adaptive_signal_falsification_stress"] = (
+                    adaptive_signal_falsification_stress
+                )
+                updated[
+                    "fast_replay_adaptive_signal_falsification_objective_scorecard_patch"
+                ] = _mapping(
+                    adaptive_signal_falsification_stress.get(
+                        "objective_scorecard_patch"
+                    )
+                )
+                updated["fast_replay_adaptive_signal_falsification_required"] = True
+                updated["fast_replay_adaptive_signal_falsification_passed"] = bool(
+                    adaptive_signal_falsification_stress.get(
+                        "adaptive_signal_falsification_passed"
+                    )
+                )
+                updated["fast_replay_adaptive_signal_falsification_artifact_ref"] = (
+                    adaptive_signal_falsification_stress.get("artifact_ref")
+                )
+                updated["fast_replay_adaptive_signal_falsification_source_markers"] = (
+                    list(
+                        cast(
+                            Sequence[Any],
+                            adaptive_signal_falsification_stress.get("source_markers")
+                            or (),
+                        )
+                    )
+                )
+                updated["fast_replay_adaptive_signal_falsification_warnings"] = list(
+                    cast(
+                        Sequence[Any],
+                        adaptive_signal_falsification_stress.get("warnings") or (),
+                    )
+                )
             updated["fast_replay_proof_semantics_label"] = preview_row[
                 "proof_semantics_label"
             ]
@@ -6994,6 +7032,7 @@ def _fast_replay_preview_proof_semantics() -> dict[str, Any]:
             "exact_replay_evidence",
             "source_backed_runtime_ledger",
             "live_paper_runtime_evidence",
+            "adaptive_signal_falsification_if_adaptive_factor_or_signal_source",
             "unchanged_promotion_gates",
         ],
         "whitepaper_gpu_fast_replay_policy": (
@@ -10555,11 +10594,9 @@ def _paper_probation_candidate_payload(
         lower_bound=lower_bound,
         target=target,
     )
-    required_notional_repair_scale = (
-        _candidate_board_required_notional_repair_scale(
-            lower_bound=lower_bound,
-            target=target,
-        )
+    required_notional_repair_scale = _candidate_board_required_notional_repair_scale(
+        lower_bound=lower_bound,
+        target=target,
     )
     deployable_missing_count = deployable_lower_bound_missing_count(payload)
     deployable_failed_gate_count = deployable_proof_failed_gate_count(payload)

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4670,6 +4670,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn(
             "exact_replay_required", selection["replay_tape_preview"]["blockers"]
         )
+        self.assertIn(
+            "adaptive_signal_falsification_if_adaptive_factor_or_signal_source",
+            selection["replay_tape_preview"]["proof_semantics"][
+                "final_promotion_requires"
+            ],
+        )
         self.assertTrue(preview_scores_exists)
         nvda_row = next(
             row
@@ -4685,6 +4691,41 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn("fast_replay_adv_capacity_context", nvda_row)
         self.assertIn("fast_replay_lineage_blockers", nvda_row)
         self.assertIn("fast_replay_risk_flags", nvda_row)
+        self.assertIn("fast_replay_adaptive_signal_falsification_stress", nvda_row)
+        adaptive_falsification_stress = nvda_row[
+            "fast_replay_adaptive_signal_falsification_stress"
+        ]
+        self.assertEqual(
+            adaptive_falsification_stress["status"],
+            "research_only_adaptive_signal_falsification_evidence_collection",
+        )
+        self.assertTrue(nvda_row["fast_replay_adaptive_signal_falsification_required"])
+        self.assertFalse(nvda_row["fast_replay_adaptive_signal_falsification_passed"])
+        self.assertIn(
+            "spurious_predictability_arxiv_2604_15531_2026",
+            nvda_row["fast_replay_adaptive_signal_falsification_source_markers"],
+        )
+        self.assertIn(
+            "null_model_sample_count_below_min",
+            nvda_row["fast_replay_adaptive_signal_falsification_warnings"],
+        )
+        self.assertIn(
+            "leakage_probe_missing_or_failed",
+            nvda_row["fast_replay_adaptive_signal_falsification_warnings"],
+        )
+        scorecard_patch = nvda_row[
+            "fast_replay_adaptive_signal_falsification_objective_scorecard_patch"
+        ]
+        self.assertTrue(scorecard_patch["required_adaptive_signal_falsification"])
+        self.assertFalse(scorecard_patch["adaptive_signal_falsification_passed"])
+        self.assertEqual(
+            scorecard_patch["adaptive_signal_falsification_artifact_ref"],
+            nvda_row["fast_replay_adaptive_signal_falsification_artifact_ref"],
+        )
+        self.assertFalse(adaptive_falsification_stress["proof_authority"])
+        self.assertFalse(adaptive_falsification_stress["promotion_authority"])
+        self.assertFalse(adaptive_falsification_stress["promotion_allowed"])
+        self.assertFalse(adaptive_falsification_stress["final_authority_ok"])
         self.assertTrue(nvda_row["fast_replay_prefilter_only"])
         self.assertFalse(nvda_row["fast_replay_proof_authority"])
         self.assertFalse(nvda_row["fast_replay_promotion_allowed"])


### PR DESCRIPTION
## Summary

- Propagates fast replay adaptive signal falsification stress payloads into autoresearch candidate-selection rows.
- Carries the fail-closed objective scorecard patch, artifact ref, source markers, and warnings without granting proof or promotion authority.
- Adds the adaptive falsification requirement to fast replay proof semantics for adaptive factor or signal sources.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'replay_tape_preview_narrows_direct_specs_without_promotion_proof or fast_replay_preview_builds_bounded_sim_target_queue_and_caps_exact_replay'`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && rm -f coverage.xml .coverage && uv run --frozen --with coverage --with pytest --with hypothesis coverage run -m pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'replay_tape_preview_narrows_direct_specs_without_promotion_proof or fast_replay_preview_builds_bounded_sim_target_queue_and_caps_exact_replay' && uv run --frozen --with coverage coverage xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90; status=$?; rm -f coverage.xml .coverage; exit $status`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev` failed because `crosshair-tool==0.0.102` requires `cc`, which is unavailable in this workspace.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked in the PR summary and testing notes.
