### PR TITLE
fix(torghut): preserve bounded source collection seeds

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -8908,8 +8908,18 @@ def _source_collection_target_has_materializable_lineage(
     return bool(source_refs)
 
 
+def _source_collection_target_has_bounded_bucket_materialization_seed(
+    target: Mapping[str, Any],
+) -> bool:
+    return (
+        _safe_text(target.get("runtime_ledger_bucket_ref")) is not None
+        and _safe_text(target.get("window_start")) is not None
+        and _safe_text(target.get("window_end")) is not None
+    )
+
+
 def _source_collection_import_target_allowed(target: Mapping[str, Any]) -> bool:
-    """Reject legacy replay buckets that cannot be materialized into source proof."""
+    """Reject replay buckets that have neither real lineage nor bounded materialization coordinates."""
 
     account_label = _safe_text(target.get("account_label"))
     source_account_label = (
@@ -8920,6 +8930,9 @@ def _source_collection_import_target_allowed(target: Mapping[str, Any]) -> bool:
         and source_account_label == "TORGHUT_REPLAY"
         and _safe_text(target.get("source_dsn_env")) == "DB_DSN"
         and not _source_collection_target_has_materializable_lineage(target)
+        and not _source_collection_target_has_bounded_bucket_materialization_seed(
+            target
+        )
     ):
         return False
     return True

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5442,6 +5442,89 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
         self.assertEqual(plan, {})
 
+    def test_source_collection_import_keeps_bounded_bucket_seed_without_authority(
+        self,
+    ) -> None:
+        live_gate = {
+            "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+        }
+
+        plan = paper_route_evidence._runtime_ledger_source_collection_import_plan_for_payload(
+            plan={
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "bounded-replay-seed",
+                        "strategy_family": "microbar_cross_sectional_pairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "account_label": "TORGHUT_REPLAY",
+                        "source_account_label": "TORGHUT_REPLAY",
+                        "source_dsn_env": "DB_DSN",
+                        "target_dsn_env": "SIM_DB_DSN",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_collection_authorized": True,
+                        "source_collection_priority": (
+                            "profit_target_source_materialization"
+                        ),
+                        "source_collection_profit_target_candidate": True,
+                        "source_collection_reason_codes": [
+                            "runtime_ledger_source_window_missing",
+                            "runtime_ledger_source_refs_missing",
+                            "runtime_ledger_execution_order_event_refs_missing",
+                            "runtime_ledger_source_offsets_missing",
+                            "runtime_ledger_source_materialization_missing",
+                            "runtime_ledger_authority_class_missing",
+                        ],
+                        "window_start": "2026-05-13T17:00:00+00:00",
+                        "window_end": "2026-05-13T17:30:00+00:00",
+                        "runtime_ledger_bucket_ref": (
+                            "strategy_runtime_ledger_buckets:"
+                            "rt-ledger-vwap-cap-safe-20260512-20260521-c88421d6:"
+                            "2026-05-13T17:00:00+00:00:"
+                            "2026-05-13T17:30:00+00:00"
+                        ),
+                    }
+                ],
+            },
+            live_submission_gate=live_gate,
+            target_limit=5,
+        )
+
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["candidate_id"], "bounded-replay-seed")
+        self.assertEqual(target["account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(target["source_dsn_env"], "DB_DSN")
+        self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["window_start"], "2026-05-13T17:00:00+00:00")
+        self.assertEqual(target["window_end"], "2026-05-13T17:30:00+00:00")
+        self.assertEqual(
+            target["runtime_ledger_bucket_ref"],
+            (
+                "strategy_runtime_ledger_buckets:"
+                "rt-ledger-vwap-cap-safe-20260512-20260521-c88421d6:"
+                "2026-05-13T17:00:00+00:00:"
+                "2026-05-13T17:30:00+00:00"
+            ),
+        )
+        self.assertEqual(target["max_notional"], "0")
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+        self.assertFalse(target["live_capital_authorized"])
+        self.assertFalse(
+            paper_route_evidence._source_collection_target_has_materializable_lineage(
+                target
+            )
+        )
+        self.assertTrue(
+            paper_route_evidence._source_collection_target_has_bounded_bucket_materialization_seed(
+                target
+            )
+        )
+
     def test_source_collection_import_allows_aggregate_replay_with_materializable_lineage(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Preserve bounded runtime-ledger source-collection seeds in the paper-route evidence readback when the live gate provides explicit source windows and a runtime ledger bucket ref.
- Keep aggregate replay-only evidence from becoming authority: unbounded bucket-only targets are still rejected, capital/promotion fields remain false, and max notional remains zero.
- Add regression coverage for bounded replay source materialization seeds alongside the existing skip/lineage cases.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k "source_collection_import"`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Manual: replayed the post-deploy live gate payload from `/tmp/torghut-postdeploy-26971080968/torghut-status.json` through `_runtime_ledger_source_collection_import_plan_for_payload` and confirmed the first three source-collection targets retain `TORGHUT_REPLAY`, `DB_DSN`, explicit windows, and `runtime_ledger_bucket_ref` while promotion remains disabled.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
