### PR TITLE
fix(torghut): apply adaptive falsification evidence patches

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -595,6 +595,7 @@ def _artifact_refs_from_scorecard(scorecard: Mapping[str, Any]) -> tuple[str, ..
         "market_impact_stress_artifact_ref",
         "delay_adjusted_depth_stress_artifact_ref",
         "exact_replay_ledger_artifact_ref",
+        "adaptive_signal_falsification_artifact_ref",
     ):
         ref = _string(scorecard.get(key))
         if ref:
@@ -605,6 +606,7 @@ def _artifact_refs_from_scorecard(scorecard: Mapping[str, Any]) -> tuple[str, ..
         "market_limit_order_mix_artifact_refs",
         "order_type_ablation_artifact_refs",
         "exact_replay_ledger_artifact_refs",
+        "adaptive_signal_falsification_artifact_refs",
     ):
         raw_refs = scorecard.get(key)
         if isinstance(raw_refs, str):
@@ -1137,6 +1139,23 @@ def evidence_bundle_from_frontier_candidate(
             "best_day_share": _string(full_window.get("best_day_share")),
             "max_drawdown": _string(full_window.get("max_drawdown")),
         }
+    adaptive_signal_falsification_stress = _mapping(
+        candidate.get("fast_replay_adaptive_signal_falsification_stress")
+        or candidate.get("adaptive_signal_falsification_stress")
+    )
+    adaptive_signal_falsification_scorecard_patch = _mapping(
+        candidate.get(
+            "fast_replay_adaptive_signal_falsification_objective_scorecard_patch"
+        )
+        or adaptive_signal_falsification_stress.get("objective_scorecard_patch")
+    )
+    if adaptive_signal_falsification_scorecard_patch:
+        for key in ADAPTIVE_SIGNAL_FALSIFICATION_SCORECARD_KEYS:
+            if key in adaptive_signal_falsification_scorecard_patch:
+                scorecard = {
+                    **scorecard,
+                    key: adaptive_signal_falsification_scorecard_patch[key],
+                }
     for key in REPLAY_ACTIVITY_SCORECARD_KEYS:
         if key in scorecard:
             continue
@@ -1458,6 +1477,7 @@ def evidence_bundle_from_frontier_candidate(
         cost_calibration=_mapping(candidate.get("cost_calibration"))
         or {"status": "provisional", "source": "frontier_replay"},
         null_comparator=_mapping(candidate.get("null_comparator"))
+        or _mapping(adaptive_signal_falsification_stress.get("null_comparator_patch"))
         or {
             "baseline_outperformed": bool(
                 float(str(scorecard.get("net_pnl_per_day") or 0)) > 0

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -1052,6 +1052,84 @@ def test_frontier_candidate_preserves_adaptive_signal_falsification_fields() -> 
     assert "adaptive_signal_baseline_not_outperformed" not in blockers
 
 
+def test_frontier_candidate_applies_fast_replay_adaptive_falsification_patch() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-fast-replay-adaptive-falsification",
+        candidate={
+            "candidate_id": "candidate-fast-replay-adaptive-falsification",
+            "objective_scorecard": _promotion_quality_scorecard(),
+            "fast_replay_adaptive_signal_falsification_stress": {
+                "status": (
+                    "research_only_adaptive_signal_falsification_evidence_collection"
+                ),
+                "artifact_ref": "artifact://adaptive-falsification/fast-replay",
+                "adaptive_signal_falsification_passed": False,
+                "objective_scorecard_patch": {
+                    "required_adaptive_signal_falsification": True,
+                    "requires_negative_control_falsification": True,
+                    "requires_label_permutation_test": True,
+                    "requires_leakage_probe": True,
+                    "requires_effective_multiplicity_adjustment": True,
+                    "adaptive_signal_falsification_passed": False,
+                    "adaptive_signal_falsification_artifact_ref": (
+                        "artifact://adaptive-falsification/fast-replay"
+                    ),
+                    "negative_control_passed": False,
+                    "placebo_label_test_passed": False,
+                    "label_permutation_test_passed": False,
+                    "feature_permutation_stability_passed": False,
+                    "leakage_probe_passed": False,
+                    "walk_forward_falsification_passed": False,
+                    "null_model_sample_count": 0,
+                    "required_min_null_model_sample_count": 30,
+                    "effective_multiplicity_adjusted_p_value": 1.0,
+                    "required_max_effective_multiplicity_adjusted_p_value": 0.05,
+                    "candidate_vs_null_return_delta": 0.0,
+                    "candidate_vs_incumbent_return_delta": 0.0,
+                    "adaptive_signal_falsification_source_markers": [
+                        "spurious_predictability_arxiv_2604_15531_2026",
+                    ],
+                },
+                "null_comparator_patch": {
+                    "baseline_outperformed": False,
+                    "candidate_vs_null_return_delta": 0.0,
+                    "candidate_vs_incumbent_return_delta": 0.0,
+                    "null_model_sample_count": 0,
+                },
+            },
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-fast-replay-adaptive-falsification",
+        result_path="artifact://replay",
+        code_commit="commit-fast-replay-adaptive-falsification",
+    )
+
+    assert bundle.objective_scorecard["required_adaptive_signal_falsification"] is True
+    assert bundle.objective_scorecard["adaptive_signal_falsification_passed"] is False
+    assert (
+        bundle.objective_scorecard["adaptive_signal_falsification_artifact_ref"]
+        == "artifact://adaptive-falsification/fast-replay"
+    )
+    assert bundle.objective_scorecard[
+        "adaptive_signal_falsification_source_markers"
+    ] == ["spurious_predictability_arxiv_2604_15531_2026"]
+    assert bundle.null_comparator["baseline_outperformed"] is False
+    assert (
+        "artifact://adaptive-falsification/fast-replay" in bundle.replay_artifact_refs
+    )
+    blockers = evidence_bundle_blockers(bundle)
+    assert "adaptive_signal_falsification_missing_or_failed" in blockers
+    assert "adaptive_signal_falsification_artifact_missing" not in blockers
+    assert "adaptive_signal_baseline_not_outperformed" in blockers
+    assert "null_model_sample_count_below_min" in blockers
+    assert "leakage_probe_missing_or_failed" in blockers
+
+
 def test_frontier_candidate_preserves_ofi_response_fields() -> None:
     bundle = evidence_bundle_from_frontier_candidate(
         candidate_spec_id="spec-ofi-response-preserved",


### PR DESCRIPTION
## Summary

- Applies fast replay adaptive falsification objective-scorecard patches when building candidate evidence bundles.
- Carries nested adaptive falsification null-comparator patches and artifact refs into bundle artifacts.
- Adds regression coverage that incomplete adaptive falsification remains fail-closed while avoiding false artifact-missing blockers.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py -k 'fast_replay_adaptive_falsification_patch or preserves_adaptive_signal_falsification_fields or promotion_ready_bundle_blocks_required_adaptive_signal_falsification_gaps'`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && rm -f coverage.xml .coverage && uv run --frozen --with coverage --with pytest --with hypothesis coverage run -m pytest tests/test_evidence_bundles.py && uv run --frozen --with coverage coverage xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main; status=$?; rm -f coverage.xml .coverage; exit $status`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev` failed because `crosshair-tool==0.0.102` requires `cc`, which is unavailable in this workspace.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked in the PR summary and testing notes.
