### PR TITLE
fix(torghut): enforce conformal cost buffer evidence

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -19,6 +19,7 @@ DELAY_ADJUSTED_DEPTH_STRESS_GRID_MS = (
     Decimal("250"),
 )
 DELAY_ADJUSTED_DEPTH_STRESS_COST_BPS = Decimal("1")
+MIN_CONFORMAL_TAIL_RISK_SAMPLE_COUNT = 20
 REPLAY_ACTIVITY_SCORECARD_KEYS = (
     "decision_count",
     "trade_decision_count",
@@ -106,6 +107,23 @@ MARKET_IMPACT_SCORECARD_KEYS = (
     "conformal_tail_risk_target_net_pnl_per_day",
     "conformal_tail_risk_passed",
     "conformal_tail_risk_source_markers",
+)
+CONFORMAL_COST_BUFFER_SCORECARD_KEYS = (
+    "requires_conformal_tail_risk",
+    "required_conformal_tail_risk",
+    "requires_conformal_var_cost_buffer",
+    "required_regime_weighted_conformal_cost_buffer",
+    "required_breakeven_transaction_cost_buffer",
+    "required_seed_model_family_robustness",
+    "required_min_conformal_tail_risk_sample_count",
+    "breakeven_transaction_cost_buffer_passed",
+    "breakeven_transaction_cost_buffer_bps",
+    "transaction_cost_buffer_bps",
+    "post_cost_net_pnl_after_breakeven_transaction_cost_buffer",
+    "seed_robustness_passed",
+    "seed_robustness_sample_count",
+    "model_family_robustness_passed",
+    "model_family_robustness_family_count",
 )
 DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS = (
     "delay_adjusted_depth_stress_passed",
@@ -1170,6 +1188,13 @@ def evidence_bundle_from_frontier_candidate(
             if key in source:
                 scorecard = {**scorecard, key: source[key]}
                 break
+    for key in CONFORMAL_COST_BUFFER_SCORECARD_KEYS:
+        if key in scorecard:
+            continue
+        for source in (candidate, summary, full_window):
+            if key in source:
+                scorecard = {**scorecard, key: source[key]}
+                break
     for key in (*DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS, *FILL_SURVIVAL_SCORECARD_KEYS):
         if key in scorecard:
             continue
@@ -1282,6 +1307,7 @@ def evidence_bundle_from_frontier_candidate(
             *OFI_RESPONSE_HORIZON_SCORECARD_KEYS,
             *ALPHA_DECAY_PREDICTABILITY_SCORECARD_KEYS,
             *STOCHASTIC_LIQUIDITY_RESILIENCE_SCORECARD_KEYS,
+            *CONFORMAL_COST_BUFFER_SCORECARD_KEYS,
         ):
             if key in nested_contract and key not in scorecard:
                 scorecard = {**scorecard, key: nested_contract[key]}
@@ -2436,19 +2462,84 @@ def _stochastic_liquidity_resilience_blockers(
 
 
 def _conformal_tail_risk_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    requires_cost_buffer = any(
+        _bool(scorecard.get(key))
+        for key in (
+            "requires_conformal_var_cost_buffer",
+            "required_regime_weighted_conformal_cost_buffer",
+            "required_breakeven_transaction_cost_buffer",
+        )
+    )
     requires_conformal_tail_risk = _bool(
         scorecard.get("conformal_tail_risk_required")
-    ) or _bool(scorecard.get("requires_conformal_tail_risk"))
+    ) or any(
+        _bool(scorecard.get(key))
+        for key in (
+            "requires_conformal_tail_risk",
+            "required_conformal_tail_risk",
+        )
+    )
+    requires_conformal_tail_risk = requires_conformal_tail_risk or requires_cost_buffer
     if not requires_conformal_tail_risk:
         return []
 
     blockers: list[str] = []
+    sample_count = _int(scorecard.get("conformal_tail_risk_sample_count"))
+    min_sample_count = max(
+        1,
+        _int(scorecard.get("required_min_conformal_tail_risk_sample_count"))
+        or (MIN_CONFORMAL_TAIL_RISK_SAMPLE_COUNT if requires_cost_buffer else 1),
+    )
     if not _bool(scorecard.get("conformal_tail_risk_passed")):
         blockers.append("conformal_tail_risk_failed")
-    if _int(scorecard.get("conformal_tail_risk_sample_count")) <= 0:
+    if sample_count <= 0:
         blockers.append("conformal_tail_risk_sample_count_zero")
-    if _decimal(scorecard.get("conformal_tail_risk_adjusted_net_pnl_per_day")) <= 0:
+    if sample_count < min_sample_count:
+        blockers.append("conformal_tail_risk_sample_count_below_min")
+    adjusted_net_pnl = _decimal(
+        scorecard.get("conformal_tail_risk_adjusted_net_pnl_per_day")
+    )
+    if adjusted_net_pnl <= 0:
         blockers.append("conformal_tail_risk_adjusted_net_pnl_non_positive")
+    target_net_pnl = _decimal(
+        scorecard.get("conformal_tail_risk_target_net_pnl_per_day")
+        or scorecard.get("target_net_pnl_per_day")
+    )
+    if (
+        requires_cost_buffer
+        and target_net_pnl > 0
+        and adjusted_net_pnl < target_net_pnl
+    ):
+        blockers.append("conformal_tail_risk_adjusted_net_pnl_below_target")
+    if requires_cost_buffer:
+        if not _bool(scorecard.get("breakeven_transaction_cost_buffer_passed")):
+            blockers.append("breakeven_transaction_cost_buffer_missing_or_failed")
+        if (
+            max(
+                _decimal(scorecard.get("breakeven_transaction_cost_buffer_bps")),
+                _decimal(scorecard.get("transaction_cost_buffer_bps")),
+            )
+            <= 0
+        ):
+            blockers.append("breakeven_transaction_cost_buffer_bps_missing")
+        if (
+            _decimal(
+                scorecard.get(
+                    "post_cost_net_pnl_after_breakeven_transaction_cost_buffer"
+                )
+            )
+            <= 0
+        ):
+            blockers.append("breakeven_transaction_cost_buffer_net_pnl_non_positive")
+    if _bool(scorecard.get("required_seed_model_family_robustness")):
+        if not _bool(scorecard.get("seed_robustness_passed")):
+            blockers.append("seed_robustness_missing_or_failed")
+        if _int(scorecard.get("seed_robustness_sample_count")) <= 0:
+            blockers.append("seed_robustness_sample_count_zero")
+        if not _bool(scorecard.get("model_family_robustness_passed")):
+            blockers.append("model_family_robustness_missing_or_failed")
+        if _int(scorecard.get("model_family_robustness_family_count")) < 2:
+            blockers.append("model_family_robustness_family_count_below_min")
     return blockers
 
 

--- a/services/torghut/tests/test_evidence_bundles.py
+++ b/services/torghut/tests/test_evidence_bundles.py
@@ -514,6 +514,100 @@ def test_promotion_ready_bundle_blocks_required_uncertainty_and_tail_risk_gaps()
     assert "conformal_tail_risk_adjusted_net_pnl_non_positive" in blockers
 
 
+def test_promotion_ready_bundle_blocks_required_conformal_cost_buffer_gaps() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-conformal-cost-buffer-gap",
+        candidate_id="candidate-conformal-cost-buffer-gap",
+        candidate_spec_id="spec-conformal-cost-buffer-gap",
+        dataset_snapshot_id="snapshot-conformal-cost-buffer-gap",
+        feature_spec_hash="feature-conformal-cost-buffer-gap",
+        code_commit="commit-conformal-cost-buffer-gap",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_conformal_var_cost_buffer": True,
+            "required_seed_model_family_robustness": True,
+            "required_min_conformal_tail_risk_sample_count": "20",
+            "conformal_tail_risk_passed": True,
+            "conformal_tail_risk_sample_count": 12,
+            "conformal_tail_risk_adjusted_net_pnl_per_day": "525",
+            "conformal_tail_risk_target_net_pnl_per_day": "500",
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "conformal_tail_risk_sample_count_below_min" in blockers
+    assert "breakeven_transaction_cost_buffer_missing_or_failed" in blockers
+    assert "breakeven_transaction_cost_buffer_bps_missing" in blockers
+    assert "breakeven_transaction_cost_buffer_net_pnl_non_positive" in blockers
+    assert "seed_robustness_missing_or_failed" in blockers
+    assert "seed_robustness_sample_count_zero" in blockers
+    assert "model_family_robustness_missing_or_failed" in blockers
+    assert "model_family_robustness_family_count_below_min" in blockers
+    assert "conformal_tail_risk_adjusted_net_pnl_below_target" not in blockers
+
+
+def test_promotion_ready_bundle_accepts_materialized_conformal_cost_buffer() -> None:
+    bundle = CandidateEvidenceBundle(
+        schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        evidence_bundle_id="ev-conformal-cost-buffer-ok",
+        candidate_id="candidate-conformal-cost-buffer-ok",
+        candidate_spec_id="spec-conformal-cost-buffer-ok",
+        dataset_snapshot_id="snapshot-conformal-cost-buffer-ok",
+        feature_spec_hash="feature-conformal-cost-buffer-ok",
+        code_commit="commit-conformal-cost-buffer-ok",
+        replay_artifact_refs=("artifact://replay",),
+        objective_scorecard={
+            **_promotion_quality_scorecard(),
+            "requires_conformal_var_cost_buffer": True,
+            "required_seed_model_family_robustness": True,
+            "required_min_conformal_tail_risk_sample_count": "20",
+            "conformal_tail_risk_passed": True,
+            "conformal_tail_risk_sample_count": 24,
+            "conformal_tail_risk_adjusted_net_pnl_per_day": "525",
+            "conformal_tail_risk_target_net_pnl_per_day": "500",
+            "breakeven_transaction_cost_buffer_passed": True,
+            "breakeven_transaction_cost_buffer_bps": "3.5",
+            "post_cost_net_pnl_after_breakeven_transaction_cost_buffer": "525",
+            "seed_robustness_passed": True,
+            "seed_robustness_sample_count": 8,
+            "model_family_robustness_passed": True,
+            "model_family_robustness_family_count": 2,
+        },
+        fold_metrics=(),
+        stress_metrics=(),
+        cost_calibration={"status": "calibrated", "source": "route_tca"},
+        null_comparator={"baseline_outperformed": True},
+        promotion_readiness={
+            "stage": "paper_probation",
+            "status": "promotion_ready",
+            "promotable": True,
+        },
+    )
+
+    blockers = evidence_bundle_blockers(bundle)
+
+    assert "conformal_tail_risk_sample_count_below_min" not in blockers
+    assert "breakeven_transaction_cost_buffer_missing_or_failed" not in blockers
+    assert "breakeven_transaction_cost_buffer_bps_missing" not in blockers
+    assert "breakeven_transaction_cost_buffer_net_pnl_non_positive" not in blockers
+    assert "seed_robustness_missing_or_failed" not in blockers
+    assert "seed_robustness_sample_count_zero" not in blockers
+    assert "model_family_robustness_missing_or_failed" not in blockers
+    assert "model_family_robustness_family_count_below_min" not in blockers
+
+
 def test_promotion_ready_bundle_blocks_required_bootstrap_robust_gaps() -> None:
     bundle = CandidateEvidenceBundle(
         schema_version=EVIDENCE_BUNDLE_SCHEMA_VERSION,
@@ -1564,6 +1658,55 @@ def test_frontier_candidate_preserves_implementation_risk_parity_fields() -> Non
     assert "multi_engine_replay_missing_or_failed" not in blockers
     assert "engine_sensitivity_report_missing" not in blockers
     assert "conclusion_stability_missing_or_failed" not in blockers
+
+
+def test_frontier_candidate_preserves_conformal_cost_buffer_contract_fields() -> None:
+    bundle = evidence_bundle_from_frontier_candidate(
+        candidate_spec_id="spec-conformal-cost-buffer-preserved",
+        candidate={
+            "candidate_id": "candidate-conformal-cost-buffer-preserved",
+            "objective_scorecard": _promotion_quality_scorecard(),
+            "promotion_contract": {
+                "requires_conformal_var_cost_buffer": True,
+                "required_seed_model_family_robustness": True,
+            },
+            "required_min_conformal_tail_risk_sample_count": "20",
+            "conformal_tail_risk_passed": True,
+            "conformal_tail_risk_sample_count": 24,
+            "conformal_tail_risk_adjusted_net_pnl_per_day": "525",
+            "conformal_tail_risk_target_net_pnl_per_day": "500",
+            "breakeven_transaction_cost_buffer_passed": True,
+            "breakeven_transaction_cost_buffer_bps": "3.5",
+            "post_cost_net_pnl_after_breakeven_transaction_cost_buffer": "525",
+            "seed_robustness_passed": True,
+            "seed_robustness_sample_count": 8,
+            "model_family_robustness_passed": True,
+            "model_family_robustness_family_count": 2,
+            "promotion_readiness": {
+                "stage": "paper_probation",
+                "status": "promotion_ready",
+                "promotable": True,
+            },
+            "cost_calibration": {"status": "calibrated", "source": "route_tca"},
+        },
+        dataset_snapshot_id="snapshot-conformal-cost-buffer-preserved",
+        result_path="artifact://replay",
+        code_commit="commit-conformal-cost-buffer-preserved",
+    )
+
+    assert bundle.objective_scorecard["requires_conformal_var_cost_buffer"] is True
+    assert bundle.objective_scorecard["required_seed_model_family_robustness"] is True
+    assert bundle.objective_scorecard["conformal_tail_risk_sample_count"] == 24
+    assert (
+        bundle.objective_scorecard[
+            "post_cost_net_pnl_after_breakeven_transaction_cost_buffer"
+        ]
+        == "525"
+    )
+    blockers = evidence_bundle_blockers(bundle)
+    assert "breakeven_transaction_cost_buffer_missing_or_failed" not in blockers
+    assert "seed_robustness_missing_or_failed" not in blockers
+    assert "model_family_robustness_missing_or_failed" not in blockers
 
 
 def test_frontier_candidate_preserves_runtime_handoff_as_promotion_blocker() -> None:


### PR DESCRIPTION
## Summary

- Enforces conformal VaR cost-buffer evidence in Torghut candidate evidence bundles when the promotion contract requires it.
- Preserves conformal cost-buffer and seed/model-family robustness fields from frontier candidates and nested promotion contracts.
- Keeps gates fail-closed by blocking promotion-ready bundles with insufficient conformal samples, missing breakeven transaction-cost buffers, or missing seed/model-family robustness.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check app/trading/discovery/evidence_bundles.py tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py -k 'conformal_cost_buffer or uncertainty_and_tail_risk_gaps'`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_evidence_bundles.py`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && rm -f coverage.xml .coverage && uv run --frozen --with coverage --with pytest --with hypothesis coverage run -m pytest tests/test_evidence_bundles.py && uv run --frozen --with coverage coverage xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main; status=$?; rm -f coverage.xml .coverage; exit $status`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev` failed because `crosshair-tool==0.0.102` requires missing system compiler `cc` in this workspace.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
