### PR TITLE
feat(torghut): stress state-dependent queue fills

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -105,8 +105,8 @@ from app.trading.discovery.stochastic_liquidity_resilience_stress import (
 from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
-FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v18"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v19"
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v19"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v20"
 FAST_REPLAY_PROOF_SEMANTICS_LABEL = (
     "preview_ranking_only_exact_replay_and_runtime_ledger_required"
 )
@@ -669,7 +669,7 @@ class FastReplayPreviewResult:
                 "markov_order_transition_latent_regime_stress": "deterministic Markov transition entropy/inertia plus latent rising-edge stress from arXiv:2502.07625 and arXiv:2604.20949; preview ranking only",
                 "order_flow_entropy_hmm_regime_stress": "deterministic OFI Markov entropy, asymmetric HMM-regime, and multi-scale volatility/intensity stress from SSRN:5315733, arXiv:2512.15720, and arXiv:2603.20456; entropy is not directional alpha proof; preview ranking only",
                 "dynamic_lead_lag_cross_asset_stress": "deterministic event-grid dynamic pair-specific lead-lag, cross-market LOB/order-flow predictability, and one-second OFI endogeneity stress from arXiv:2511.00390, SSRN:5523878, and arXiv:2508.06788; lead-lag is not alpha proof; preview ranking only",
-                "queue_position_survival_fill_stress": "deterministic queue-position survival fill probability, depth-delay, MDQR queue-reactive event-mix/order-size replay parity, queue-allocation-rule sensitivity, maker fill/return tradeoff, and group-normalized downside reward stress from arXiv:2512.05734, arXiv:2501.08822, arXiv:2511.15262, arXiv:2502.18625, arXiv:2605.25527, SSRN:6440898, SSRN:6730443, SSRN:6574208, and SSRN:6578978; preview ranking only",
+                "queue_position_survival_fill_stress": "deterministic queue-position survival fill probability, state-dependent fill-before-price-move, market/limit allocation, depth-delay, MDQR queue-reactive event-mix/order-size replay parity, queue-allocation-rule sensitivity, maker fill/return tradeoff, and group-normalized downside reward stress from arXiv:2512.05734, arXiv:2403.02572v2, arXiv:2507.06345v2, arXiv:2501.08822, arXiv:2511.15262, arXiv:2502.18625, arXiv:2605.25527, SSRN:6440898, SSRN:6730443, SSRN:6574208, and SSRN:6578978; preview ranking only",
                 "public_feed_lag_quoted_liquidity_stress": "deterministic public-feed delay, quoted-liquidity reliability, stale-quote, and authoritative trade-direction join stress from SSRN:6675338, arXiv:2604.24366, and arXiv:2511.20606; preview ranking only",
                 "lob_simulation_reality_gap_execution_stress": "deterministic spread-volume imbalance, latency-race mode, power-law signed-flow impact, odd-lot liquidity reliability, and responsive exchange event-mix stress from arXiv:2603.24137, OFR WP 25-01, arXiv:2507.06345, and arXiv:2502.07071; preview ranking only",
                 "alpha_decay_predictability_stress": "deterministic multi-horizon spread-adjusted alpha decay, cost-crossover, latency-horizon mismatch, and efficiency-regime compression stress from arXiv:2601.02310 and SSRN:6608199; preview ranking only",

--- a/services/torghut/app/trading/discovery/queue_survival_fill_stress.py
+++ b/services/torghut/app/trading/discovery/queue_survival_fill_stress.py
@@ -16,9 +16,9 @@ from typing import Any, cast
 
 from app.trading.models import SignalEnvelope
 
-QUEUE_SURVIVAL_FILL_STRESS_SCHEMA_VERSION = "torghut.queue-survival-fill-stress.v4"
+QUEUE_SURVIVAL_FILL_STRESS_SCHEMA_VERSION = "torghut.queue-survival-fill-stress.v5"
 QUEUE_SURVIVAL_FILL_STRESS_CONTRACT_SCHEMA_VERSION = (
-    "torghut.queue-survival-fill-stress-contract.v4"
+    "torghut.queue-survival-fill-stress-contract.v5"
 )
 QUEUE_SURVIVAL_FILL_STRESS_PROOF_SEMANTICS_LABEL = "queue_survival_fill_stress_preview_only_exact_replay_route_tca_order_lifecycle_runtime_ledger_required"
 QUEUE_SURVIVAL_FILL_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
@@ -28,6 +28,20 @@ QUEUE_SURVIVAL_FILL_STRESS_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
         "title": "KANFormer for Predicting Fill Probabilities via Survival Analysis in Limit Order Books",
         "date": "2025-12-05",
         "mechanism": "queue_position_survival_time_to_fill_probability_features",
+    },
+    {
+        "source_id": "arxiv-2403.02572v2",
+        "url": "https://arxiv.org/abs/2403.02572",
+        "title": "Fill Probabilities in a Limit Order Book with State-Dependent Stochastic Order Flows",
+        "date": "2026-02-06",
+        "mechanism": "state_dependent_fill_probability_before_opposite_quote_or_midprice_move",
+    },
+    {
+        "source_id": "arxiv-2507.06345v2",
+        "url": "https://arxiv.org/abs/2507.06345",
+        "title": "Reinforcement Learning for Trade Execution with Market and Limit Orders",
+        "date": "2026-01-26",
+        "mechanism": "market_limit_allocation_under_order_book_imbalance_tactical_response",
     },
     {
         "source_id": "ssrn-6440898",
@@ -149,6 +163,12 @@ class QueueSurvivalFillStressSummary:
     time_priority_edge_concentration_score: float
     randomized_priority_fill_gap_proxy_bps: float
     queue_allocation_rule_sensitivity_penalty_bps: float
+    fill_before_move_trial_count: int
+    observed_opportunity_midprice_move_count: int
+    opportunity_midprice_move_before_fill_share: float
+    state_dependent_fill_before_move_probability: float
+    state_dependent_order_flow_gap_score: float
+    state_dependent_fill_risk_penalty_bps: float
     observed_order_book_imbalance_count: int
     median_directional_order_book_imbalance: float
     contrarian_reversal_support_score: float
@@ -203,6 +223,22 @@ class QueueSurvivalFillStressSummary:
             ),
             "queue_allocation_rule_sensitivity_penalty_bps": _stable_float(
                 self.queue_allocation_rule_sensitivity_penalty_bps
+            ),
+            "fill_before_move_trial_count": self.fill_before_move_trial_count,
+            "observed_opportunity_midprice_move_count": (
+                self.observed_opportunity_midprice_move_count
+            ),
+            "opportunity_midprice_move_before_fill_share": _stable_float(
+                self.opportunity_midprice_move_before_fill_share
+            ),
+            "state_dependent_fill_before_move_probability": _stable_float(
+                self.state_dependent_fill_before_move_probability
+            ),
+            "state_dependent_order_flow_gap_score": _stable_float(
+                self.state_dependent_order_flow_gap_score
+            ),
+            "state_dependent_fill_risk_penalty_bps": _stable_float(
+                self.state_dependent_fill_risk_penalty_bps
             ),
             "observed_order_book_imbalance_count": (
                 self.observed_order_book_imbalance_count
@@ -262,6 +298,18 @@ class QueueSurvivalFillStressSummary:
                 "queue_allocation_rule_sensitivity_penalty_bps": _stable_float(
                     self.queue_allocation_rule_sensitivity_penalty_bps
                 ),
+                "opportunity_midprice_move_before_fill_share": _stable_float(
+                    self.opportunity_midprice_move_before_fill_share
+                ),
+                "state_dependent_fill_before_move_probability": _stable_float(
+                    self.state_dependent_fill_before_move_probability
+                ),
+                "state_dependent_order_flow_gap_score": _stable_float(
+                    self.state_dependent_order_flow_gap_score
+                ),
+                "state_dependent_fill_risk_penalty_bps": _stable_float(
+                    self.state_dependent_fill_risk_penalty_bps
+                ),
                 "median_directional_order_book_imbalance": _stable_float(
                     self.median_directional_order_book_imbalance
                 ),
@@ -290,6 +338,7 @@ class QueueSurvivalFillStressSummary:
             "queue_reactive_replay_parity_preview": True,
             "order_size_distribution_preview": True,
             "queue_allocation_rule_sensitivity_preview": True,
+            "state_dependent_fill_before_move_preview": True,
             "maker_fill_return_tradeoff_preview": True,
             "group_normalized_downside_reward_preview": True,
             "research_ranking_only": True,
@@ -302,6 +351,14 @@ class QueueSurvivalFillStressSummary:
             "final_authority_ok": False,
             "proof_semantics_label": QUEUE_SURVIVAL_FILL_STRESS_PROOF_SEMANTICS_LABEL,
         }
+
+
+@dataclass(frozen=True)
+class _FillBeforeMoveStats:
+    trial_count: int
+    observed_move_count: int
+    fill_before_move_share: float
+    opportunity_move_before_fill_share: float
 
 
 def queue_survival_fill_stress_contract() -> dict[str, Any]:
@@ -325,6 +382,10 @@ def queue_survival_fill_stress_contract() -> dict[str, Any]:
             "time_priority_edge_concentration_score",
             "randomized_priority_fill_gap_proxy_bps",
             "queue_allocation_rule_sensitivity_penalty_bps",
+            "opportunity_midprice_move_before_fill_share",
+            "state_dependent_fill_before_move_probability",
+            "state_dependent_order_flow_gap_score",
+            "state_dependent_fill_risk_penalty_bps",
             "median_directional_order_book_imbalance",
             "contrarian_reversal_support_score",
             "maker_fill_return_tradeoff_penalty_bps",
@@ -346,6 +407,7 @@ def queue_survival_fill_stress_contract() -> dict[str, Any]:
             "requires_order_lifecycle_fill_evidence": True,
             "requires_queue_reactive_replay_parity": True,
             "requires_queue_allocation_rule_audit": True,
+            "requires_state_dependent_fill_before_move_audit": True,
             "requires_maker_fill_return_tradeoff_audit": True,
             "requires_group_downside_reward_out_of_sample_audit": True,
             "requires_runtime_ledger": True,
@@ -353,6 +415,8 @@ def queue_survival_fill_stress_contract() -> dict[str, Any]:
             "rejects_queue_reactive_replay_parity_as_pnl_proof": True,
             "rejects_order_size_distribution_proxy_as_fill_authority": True,
             "rejects_time_priority_edge_as_mechanism_neutral_pnl_proof": True,
+            "rejects_state_dependent_fill_probability_as_fill_authority": True,
+            "rejects_opportunity_move_proxy_as_pnl_or_promotion_authority": True,
             "rejects_contrarian_reversal_proxy_as_promotion_authority": True,
             "rejects_order_flow_policy_reward_as_pnl_proof": True,
         },
@@ -523,6 +587,47 @@ def extract_queue_survival_fill_stress(
         fill_probability=estimated_limit_fill_probability,
     )
     median_spread_bps = _median(tuple(spread for spread in spreads if spread > 0.0))
+    fill_before_move_stats = _fill_before_opportunity_move_stats(
+        rows=ordered,
+        prices=prices,
+        event_labels=event_labels,
+        direction=signed_direction,
+        median_spread_bps=median_spread_bps,
+    )
+    if fill_before_move_stats.trial_count <= 0:
+        warnings.append("missing_state_dependent_fill_before_move_trials")
+    if fill_before_move_stats.observed_move_count <= 0 and len(valid_prices) >= 2:
+        warnings.append("missing_opportunity_midprice_move_before_fill_observations")
+    state_dependent_fill_before_move_probability = _state_dependent_fill_before_move_probability(
+        estimated_limit_fill_probability=estimated_limit_fill_probability,
+        fill_before_move_trial_count=fill_before_move_stats.trial_count,
+        fill_before_move_success_share=fill_before_move_stats.fill_before_move_share,
+        queue_reactive_event_mix_l1=queue_reactive_event_mix_l1,
+        observed_order_book_imbalance_count=observed_order_book_imbalance_count,
+    )
+    opportunity_midprice_move_before_fill_share = (
+        fill_before_move_stats.opportunity_move_before_fill_share
+    )
+    state_dependent_order_flow_gap_score = _state_dependent_order_flow_gap_score(
+        fill_before_move_trial_count=fill_before_move_stats.trial_count,
+        opportunity_midprice_move_before_fill_share=(
+            opportunity_midprice_move_before_fill_share
+        ),
+        queue_reactive_event_mix_l1=queue_reactive_event_mix_l1,
+        observed_order_book_imbalance_count=observed_order_book_imbalance_count,
+        cancellation_or_reject_share=cancellation_or_reject_share,
+    )
+    state_dependent_fill_risk_penalty_bps = _state_dependent_fill_risk_penalty_bps(
+        state_dependent_fill_before_move_probability=(
+            state_dependent_fill_before_move_probability
+        ),
+        opportunity_midprice_move_before_fill_share=(
+            opportunity_midprice_move_before_fill_share
+        ),
+        state_dependent_order_flow_gap_score=state_dependent_order_flow_gap_score,
+        nonfill_opportunity_cost_bps=nonfill_opportunity_cost_bps,
+        median_spread_bps=median_spread_bps,
+    )
     directional_imbalances = tuple(
         signed_direction * item for item in order_book_imbalances if item is not None
     )
@@ -564,6 +669,7 @@ def extract_queue_survival_fill_stress(
         + group_normalized_downside_reward_penalty_bps
         + nonfill_opportunity_cost_bps
         + adverse_selection_after_touch_bps
+        + state_dependent_fill_risk_penalty_bps
         + missing_penalty_bps
     )
     return QueueSurvivalFillStressSummary(
@@ -583,6 +689,12 @@ def extract_queue_survival_fill_stress(
         time_priority_edge_concentration_score=time_priority_edge_concentration_score,
         randomized_priority_fill_gap_proxy_bps=randomized_priority_fill_gap_proxy_bps,
         queue_allocation_rule_sensitivity_penalty_bps=queue_allocation_rule_sensitivity_penalty_bps,
+        fill_before_move_trial_count=fill_before_move_stats.trial_count,
+        observed_opportunity_midprice_move_count=fill_before_move_stats.observed_move_count,
+        opportunity_midprice_move_before_fill_share=opportunity_midprice_move_before_fill_share,
+        state_dependent_fill_before_move_probability=state_dependent_fill_before_move_probability,
+        state_dependent_order_flow_gap_score=state_dependent_order_flow_gap_score,
+        state_dependent_fill_risk_penalty_bps=state_dependent_fill_risk_penalty_bps,
         observed_order_book_imbalance_count=observed_order_book_imbalance_count,
         median_directional_order_book_imbalance=median_directional_order_book_imbalance,
         contrarian_reversal_support_score=contrarian_reversal_support_score,
@@ -690,6 +802,144 @@ def _randomized_priority_fill_gap_proxy_bps(
         25.0,
         fifo_edge_bps * clob_speed_gap_decline_fraction + depth_uncertainty_bps,
     )
+
+
+def _fill_before_opportunity_move_stats(
+    *,
+    rows: Sequence[SignalEnvelope],
+    prices: Sequence[float | None],
+    event_labels: Sequence[str],
+    direction: float,
+    median_spread_bps: float,
+) -> _FillBeforeMoveStats:
+    """Measure whether fills arrive before the intended-side mid-price move.
+
+    arXiv:2403.02572v2 models LOB fill probabilities jointly with the
+    probability that prices move first. Torghut keeps this as a deterministic
+    replay-ranking proxy: it does not infer actual fills without lifecycle/TCA
+    evidence and does not authorize capital.
+    """
+
+    if not rows or len(rows) != len(prices) or len(rows) != len(event_labels):
+        return _FillBeforeMoveStats(
+            trial_count=0,
+            observed_move_count=0,
+            fill_before_move_share=0.0,
+            opportunity_move_before_fill_share=0.0,
+        )
+    start_indexes = [
+        index
+        for index, label in enumerate(event_labels)
+        if _label_has_token(label, _ADD_TOKENS)
+        and not _label_has_token(label, _CANCEL_TOKENS | _REJECT_TOKENS)
+    ]
+    if not start_indexes and prices[0] is not None:
+        start_indexes = [0]
+    threshold_bps = max(0.5, median_spread_bps * 0.5)
+    trial_count = 0
+    fill_before_move_count = 0
+    opportunity_move_before_fill_count = 0
+    observed_move_count = 0
+    for start_index in start_indexes:
+        start_price = prices[start_index]
+        if start_price is None or start_price <= 0.0:
+            continue
+        horizon_end = min(len(rows), start_index + 7)
+        for index in range(start_index + 1, horizon_end):
+            price = prices[index]
+            if price is None or price <= 0.0:
+                continue
+            move_bps = direction * (price - start_price) / start_price * 10_000.0
+            label = event_labels[index]
+            if _label_has_token(label, _FILL_TOKENS):
+                trial_count += 1
+                fill_before_move_count += 1
+                break
+            if move_bps >= threshold_bps:
+                trial_count += 1
+                observed_move_count += 1
+                opportunity_move_before_fill_count += 1
+                break
+    if trial_count <= 0:
+        return _FillBeforeMoveStats(
+            trial_count=0,
+            observed_move_count=observed_move_count,
+            fill_before_move_share=0.0,
+            opportunity_move_before_fill_share=0.0,
+        )
+    return _FillBeforeMoveStats(
+        trial_count=trial_count,
+        observed_move_count=observed_move_count,
+        fill_before_move_share=fill_before_move_count / trial_count,
+        opportunity_move_before_fill_share=(
+            opportunity_move_before_fill_count / trial_count
+        ),
+    )
+
+
+def _state_dependent_fill_before_move_probability(
+    *,
+    estimated_limit_fill_probability: float,
+    fill_before_move_trial_count: int,
+    fill_before_move_success_share: float,
+    queue_reactive_event_mix_l1: float,
+    observed_order_book_imbalance_count: int,
+) -> float:
+    if fill_before_move_trial_count <= 0:
+        source_coverage_penalty = (
+            0.15 if observed_order_book_imbalance_count > 0 else 0.30
+        )
+        return max(0.0, estimated_limit_fill_probability - source_coverage_penalty)
+    parity_penalty = min(0.20, queue_reactive_event_mix_l1 * 0.08)
+    probability = (
+        estimated_limit_fill_probability * 0.45
+        + min(1.0, max(0.0, fill_before_move_success_share)) * 0.55
+        - parity_penalty
+    )
+    return min(0.99, max(0.0, probability))
+
+
+def _state_dependent_order_flow_gap_score(
+    *,
+    fill_before_move_trial_count: int,
+    opportunity_midprice_move_before_fill_share: float,
+    queue_reactive_event_mix_l1: float,
+    observed_order_book_imbalance_count: int,
+    cancellation_or_reject_share: float,
+) -> float:
+    missing_trial_penalty = 0.35 if fill_before_move_trial_count <= 0 else 0.0
+    missing_state_penalty = 0.20 if observed_order_book_imbalance_count <= 0 else 0.0
+    raw = (
+        missing_trial_penalty
+        + missing_state_penalty
+        + min(1.0, max(0.0, opportunity_midprice_move_before_fill_share)) * 0.45
+        + min(2.0, max(0.0, queue_reactive_event_mix_l1)) * 0.12
+        + min(1.0, max(0.0, cancellation_or_reject_share)) * 0.18
+    )
+    return min(1.0, raw)
+
+
+def _state_dependent_fill_risk_penalty_bps(
+    *,
+    state_dependent_fill_before_move_probability: float,
+    opportunity_midprice_move_before_fill_share: float,
+    state_dependent_order_flow_gap_score: float,
+    nonfill_opportunity_cost_bps: float,
+    median_spread_bps: float,
+) -> float:
+    spread_floor_bps = max(1.0, median_spread_bps)
+    raw = (
+        (1.0 - min(1.0, max(0.0, state_dependent_fill_before_move_probability)))
+        * spread_floor_bps
+        * 4.0
+        + min(1.0, max(0.0, opportunity_midprice_move_before_fill_share))
+        * max(spread_floor_bps, nonfill_opportunity_cost_bps)
+        * 0.55
+        + min(1.0, max(0.0, state_dependent_order_flow_gap_score))
+        * spread_floor_bps
+        * 2.5
+    )
+    return min(35.0, max(0.0, raw))
 
 
 def _queue_reactive_event_mix_l1(

--- a/services/torghut/tests/test_fast_replay.py
+++ b/services/torghut/tests/test_fast_replay.py
@@ -438,6 +438,20 @@ class TestFastReplayPreview(TestCase):
             },
         )
         self.assertIn(
+            "arxiv-2403.02572v2",
+            {
+                source["source_id"]
+                for source in row_payload["queue_survival_fill_stress"]["source_papers"]
+            },
+        )
+        self.assertIn(
+            "arxiv-2507.06345v2",
+            {
+                source["source_id"]
+                for source in row_payload["queue_survival_fill_stress"]["source_papers"]
+            },
+        )
+        self.assertIn(
             "ssrn-6574208",
             {
                 source["source_id"]
@@ -470,9 +484,18 @@ class TestFastReplayPreview(TestCase):
             "group_normalized_downside_reward_penalty_bps",
             row_payload["queue_survival_fill_stress"]["ranking_features"],
         )
+        self.assertIn(
+            "state_dependent_fill_risk_penalty_bps",
+            row_payload["queue_survival_fill_stress"]["ranking_features"],
+        )
         self.assertTrue(
             row_payload["queue_survival_fill_stress"][
                 "queue_allocation_rule_sensitivity_preview"
+            ]
+        )
+        self.assertTrue(
+            row_payload["queue_survival_fill_stress"][
+                "state_dependent_fill_before_move_preview"
             ]
         )
         self.assertTrue(

--- a/services/torghut/tests/test_queue_survival_fill_stress.py
+++ b/services/torghut/tests/test_queue_survival_fill_stress.py
@@ -145,6 +145,14 @@ class TestQueueSurvivalFillStress(TestCase):
         )
         self.assertGreater(stressed.nonfill_opportunity_cost_bps, 0.0)
         self.assertGreaterEqual(stressed.visible_depth_notional_shortfall_share, 0.75)
+        self.assertGreater(
+            fillable.state_dependent_fill_before_move_probability,
+            stressed.state_dependent_fill_before_move_probability,
+        )
+        self.assertGreater(
+            stressed.state_dependent_fill_risk_penalty_bps,
+            fillable.state_dependent_fill_risk_penalty_bps,
+        )
 
         stressed_payload = stressed.to_payload()
         self.assertEqual(
@@ -161,6 +169,110 @@ class TestQueueSurvivalFillStress(TestCase):
         self.assertIn(
             "queue_reactive_event_mix_l1", stressed_payload["ranking_features"]
         )
+        self.assertIn(
+            "state_dependent_fill_before_move_probability",
+            stressed_payload["ranking_features"],
+        )
+        self.assertTrue(stressed_payload["state_dependent_fill_before_move_preview"])
+
+    def test_state_dependent_fill_before_move_downranks_missed_momentum(
+        self,
+    ) -> None:
+        fill_before_move = extract_queue_survival_fill_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    queue_ratio="0.10",
+                    bid_size="1000",
+                    volume="500",
+                    event_type="add",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.01",
+                    queue_ratio="0.10",
+                    bid_size="1000",
+                    volume="500",
+                    event_type="trade",
+                    fill_qty="500",
+                    status="filled",
+                ),
+                self._row(
+                    offset=3,
+                    price="100.04",
+                    queue_ratio="0.12",
+                    bid_size="980",
+                    volume="450",
+                    event_type="trade",
+                    fill_qty="500",
+                    status="filled",
+                ),
+            ),
+            direction=1,
+            max_notional=5_000,
+        ).to_payload()
+        moved_before_fill = extract_queue_survival_fill_stress(
+            (
+                self._row(
+                    offset=1,
+                    price="100.00",
+                    queue_ratio="0.10",
+                    bid_size="1000",
+                    volume="10",
+                    event_type="add",
+                ),
+                self._row(
+                    offset=2,
+                    price="100.12",
+                    queue_ratio="0.18",
+                    bid_size="700",
+                    volume="10",
+                    event_type="add",
+                ),
+                self._row(
+                    offset=3,
+                    price="100.24",
+                    queue_ratio="0.25",
+                    bid_size="600",
+                    volume="10",
+                    event_type="cancel",
+                    status="cancelled",
+                ),
+            ),
+            direction=1,
+            max_notional=5_000,
+        ).to_payload()
+
+        self.assertGreater(
+            float(fill_before_move["state_dependent_fill_before_move_probability"]),
+            float(moved_before_fill["state_dependent_fill_before_move_probability"]),
+        )
+        self.assertGreater(
+            float(moved_before_fill["opportunity_midprice_move_before_fill_share"]),
+            float(fill_before_move["opportunity_midprice_move_before_fill_share"]),
+        )
+        self.assertGreater(
+            float(
+                moved_before_fill["ranking_features"][
+                    "state_dependent_fill_risk_penalty_bps"
+                ]
+            ),
+            float(
+                fill_before_move["ranking_features"][
+                    "state_dependent_fill_risk_penalty_bps"
+                ]
+            ),
+        )
+        self.assertIn(
+            "arxiv-2403.02572v2",
+            {source["source_id"] for source in moved_before_fill["source_papers"]},
+        )
+        self.assertIn(
+            "arxiv-2507.06345v2",
+            {source["source_id"] for source in moved_before_fill["source_papers"]},
+        )
+        self.assertFalse(moved_before_fill["promotion_authority"])
 
     def test_queue_reactive_event_mix_and_order_size_parity_penalize_bad_replay(
         self,
@@ -536,6 +648,8 @@ class TestQueueSurvivalFillStress(TestCase):
             build_queue_survival_fill_stress_schema_hash(),
         )
         self.assertIn("arxiv-2512.05734", source_ids)
+        self.assertIn("arxiv-2403.02572v2", source_ids)
+        self.assertIn("arxiv-2507.06345v2", source_ids)
         self.assertIn("arxiv-2501.08822", source_ids)
         self.assertIn("arxiv-2511.15262", source_ids)
         self.assertIn("ssrn-6440898", source_ids)
@@ -556,6 +670,11 @@ class TestQueueSurvivalFillStress(TestCase):
             contract["proof_neutrality"]["requires_queue_allocation_rule_audit"]
         )
         self.assertTrue(
+            contract["proof_neutrality"][
+                "requires_state_dependent_fill_before_move_audit"
+            ]
+        )
+        self.assertTrue(
             contract["proof_neutrality"]["requires_maker_fill_return_tradeoff_audit"]
         )
         self.assertTrue(
@@ -572,6 +691,16 @@ class TestQueueSurvivalFillStress(TestCase):
         self.assertTrue(
             contract["proof_neutrality"][
                 "rejects_time_priority_edge_as_mechanism_neutral_pnl_proof"
+            ]
+        )
+        self.assertTrue(
+            contract["proof_neutrality"][
+                "rejects_state_dependent_fill_probability_as_fill_authority"
+            ]
+        )
+        self.assertTrue(
+            contract["proof_neutrality"][
+                "rejects_opportunity_move_proxy_as_pnl_or_promotion_authority"
             ]
         )
         self.assertTrue(


### PR DESCRIPTION
## Summary

- Adds state-dependent fill-before-price-move stress to Torghut queue-survival replay ranking using arXiv:2403.02572v2 and arXiv:2507.06345v2 mechanisms.
- Emits proof-neutral ranking features for fill-before-move probability, opportunity move-before-fill share, order-flow gap score, and fill-risk penalty.
- Bumps queue-survival and fast-replay preview schemas and records new source metadata in executable payloads.
- Extends focused tests so missed momentum paths downrank relative to fill-before-move paths without granting promotion or fill authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_queue_survival_fill_stress.py tests/test_fast_replay.py -q`
- `cd services/torghut && uvx ruff format app/trading/discovery/queue_survival_fill_stress.py app/trading/discovery/fast_replay.py tests/test_queue_survival_fill_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff check app/trading/discovery/queue_survival_fill_stress.py app/trading/discovery/fast_replay.py tests/test_queue_survival_fill_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uvx ruff format --check app/trading/discovery/queue_survival_fill_stress.py app/trading/discovery/fast_replay.py tests/test_queue_survival_fill_stress.py tests/test_fast_replay.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m coverage erase && uv run --frozen python -m coverage run -m pytest tests/test_queue_survival_fill_stress.py tests/test_fast_replay.py -q && uv run --frozen python -m coverage xml --fail-under=0 -o coverage.xml && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend replay ranking and test-only change.

## Breaking Changes

None. Preview schema versions are bumped for queue-survival and fast-replay payloads; no runtime ledger, promotion gate, or live-capital semantics changed.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
