### PR TITLE
fix(torghut): reduce paper route evidence readback churn

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -19,7 +19,7 @@ from zoneinfo import ZoneInfo
 
 from sqlalchemy import create_engine, func, select, text
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, contains_eager
 
 from ..config import settings
 from ..models import (
@@ -4224,6 +4224,7 @@ def _strategy_source_activity(
     decision_stmt = (
         select(TradeDecision)
         .join(Strategy, TradeDecision.strategy_id == Strategy.id)
+        .options(contains_eager(TradeDecision.strategy))
         .where(Strategy.name.in_(strategy_filters))
         .where(TradeDecision.created_at >= window_start)
         .where(TradeDecision.created_at <= window_end)
@@ -4286,9 +4287,10 @@ def _strategy_source_activity(
         "hypothesis_ids": [],
         "blockers": [],
     }
+    unfiltered_decision_rows = list(decision_rows)
     lineage_blockers = (
         _source_lineage_blockers(
-            decision_rows,
+            unfiltered_decision_rows,
             candidate_id=candidate_id,
             hypothesis_id=hypothesis_id,
         )
@@ -4296,9 +4298,15 @@ def _strategy_source_activity(
         else []
     )
     if require_source_lineage:
+        source_lineage_observation = _source_lineage_observation(
+            unfiltered_decision_rows,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            strategy_filters=strategy_filters,
+        )
         decision_rows = [
             row
-            for row in decision_rows
+            for row in unfiltered_decision_rows
             if _source_decision_lineage_matches(
                 row,
                 candidate_id=candidate_id,
@@ -4501,11 +4509,15 @@ def _strategy_source_activity(
             )
     else:
         tca_truncated = False
-    if require_source_lineage and (
-        candidate_id is not None or hypothesis_id is not None
+    if (
+        require_source_lineage
+        and (candidate_id is not None or hypothesis_id is not None)
+        and not decision_rows
     ):
         lineage_stmt = (
             select(TradeDecision)
+            .outerjoin(Strategy, TradeDecision.strategy_id == Strategy.id)
+            .options(contains_eager(TradeDecision.strategy))
             .where(TradeDecision.created_at >= window_start)
             .where(TradeDecision.created_at <= window_end)
         )
@@ -7775,6 +7787,45 @@ def _target_audit_fail_closed(
         )
 
 
+def _target_audit_cache_key(
+    raw_target: Mapping[str, Any],
+    *,
+    probe: Mapping[str, object],
+    generated_at: datetime,
+    lookback_hours: int,
+) -> tuple[object, ...]:
+    target = _target_identity(raw_target, probe=probe)
+    window_start, window_end = _target_window(
+        target,
+        generated_at=generated_at,
+        lookback_hours=lookback_hours,
+    )
+    return (
+        _safe_text(target.get("hypothesis_id")),
+        _safe_text(target.get("candidate_id")),
+        _safe_text(target.get("observed_stage")),
+        _safe_text(target.get("strategy_name")),
+        tuple(_strategy_lookup_names_for_target(target)),
+        _safe_text(target.get("strategy_family")),
+        _safe_text(target.get("account_label")),
+        _safe_text(target.get("source_account_label")),
+        tuple(_target_probe_symbols(target, probe)),
+        _safe_text(target.get("source_kind")),
+        _safe_text(target.get("source_dsn_env")),
+        _safe_text(target.get("target_dsn_env")),
+        _isoformat(window_start),
+        _isoformat(window_end),
+    )
+
+
+def _target_audit_has_query_unavailable(audit: Mapping[str, object]) -> bool:
+    return (
+        bool(audit.get("db_load_error"))
+        or bool(_as_mapping(audit.get("source_activity")).get("query_unavailable"))
+        or bool(_as_mapping(audit.get("runtime_ledger")).get("db_load_error"))
+    )
+
+
 def _runtime_window_import_audit(
     *,
     next_targets: Mapping[str, object],
@@ -9885,13 +9936,37 @@ def build_paper_route_evidence_audit(
             live_submission_gate.get("paper_route_target_plan_error")
         ),
     )
-    target_audits = [
-        _target_audit_fail_closed(
-            session,
-            raw_target=target,
+    target_audit_cache: dict[tuple[object, ...], dict[str, object]] = {}
+
+    def cached_target_audit(
+        raw_target: Mapping[str, Any],
+        *,
+        error_source: str,
+    ) -> dict[str, object]:
+        cache_key = _target_audit_cache_key(
+            raw_target,
             probe=probe,
             generated_at=resolved_generated_at,
             lookback_hours=effective_lookback_hours,
+        )
+        cached = target_audit_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        audit = _target_audit_fail_closed(
+            session,
+            raw_target=raw_target,
+            probe=probe,
+            generated_at=resolved_generated_at,
+            lookback_hours=effective_lookback_hours,
+            error_source=error_source,
+        )
+        if not _target_audit_has_query_unavailable(audit):
+            target_audit_cache[cache_key] = audit
+        return audit
+
+    target_audits = [
+        cached_target_audit(
+            target,
             error_source="paper_route_source_target_audit",
         )
         for target in targets
@@ -9920,12 +9995,8 @@ def build_paper_route_evidence_audit(
         target_account_audit_available=target_account_audit_available,
     )
     next_target_audits = [
-        _target_audit_fail_closed(
-            session,
-            raw_target=target,
-            probe=probe,
-            generated_at=resolved_generated_at,
-            lookback_hours=effective_lookback_hours,
+        cached_target_audit(
+            target,
             error_source="paper_route_next_target_audit",
         )
         for target in _as_mapping_items(next_targets.get("targets"))
@@ -9950,12 +10021,8 @@ def build_paper_route_evidence_audit(
     )
     if latest_closed_runtime_window_import_plan is latest_closed_targets:
         latest_closed_target_audits = [
-            _target_audit_fail_closed(
-                session,
-                raw_target=target,
-                probe=probe,
-                generated_at=resolved_generated_at,
-                lookback_hours=effective_lookback_hours,
+            cached_target_audit(
+                target,
                 error_source="paper_route_runtime_window_import_target_audit",
             )
             for target in _as_mapping_items(latest_closed_targets.get("targets"))
@@ -9996,12 +10063,8 @@ def build_paper_route_evidence_audit(
             )
             runtime_window_import_plan = next_clean_after_discard_targets
             runtime_window_import_target_audits = [
-                _target_audit_fail_closed(
-                    session,
-                    raw_target=target,
-                    probe=probe,
-                    generated_at=resolved_generated_at,
-                    lookback_hours=effective_lookback_hours,
+                cached_target_audit(
+                    target,
                     error_source="paper_route_runtime_window_import_target_audit",
                 )
                 for target in _as_mapping_items(
@@ -10021,12 +10084,8 @@ def build_paper_route_evidence_audit(
         source_targets = observed_strategy_source_targets
         runtime_window_import_plan = observed_strategy_source_targets
         runtime_window_import_target_audits = [
-            _target_audit_fail_closed(
-                session,
-                raw_target=target,
-                probe=probe,
-                generated_at=resolved_generated_at,
-                lookback_hours=effective_lookback_hours,
+            cached_target_audit(
+                target,
                 error_source="paper_route_observed_strategy_source_target_audit",
             )
             for target in _as_mapping_items(runtime_window_import_plan.get("targets"))

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
@@ -1359,6 +1359,241 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertIn(
             "source_submitted_orders_missing",
             activity["source_lifecycle_blockers"],
+        )
+
+    def test_source_activity_reuses_exact_lineage_readback_without_broad_rescan(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc)
+        window_end = window_start + timedelta(hours=1)
+        event_at = window_start + timedelta(minutes=5)
+        strategy_name = "paper-route-exact-lineage-readback"
+        trade_decision_selects = 0
+
+        def _count_trade_decision_selects(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _parameters: object,
+            _context: object,
+            _executemany: object,
+        ) -> None:
+            nonlocal trade_decision_selects
+            normalized = " ".join(statement.lower().split())
+            if (
+                normalized.startswith("select")
+                and " from trade_decisions" in normalized
+            ):
+                trade_decision_selects += 1
+
+        event.listen(
+            self.engine,
+            "before_cursor_execute",
+            _count_trade_decision_selects,
+        )
+        self.addCleanup(
+            event.remove,
+            self.engine,
+            "before_cursor_execute",
+            _count_trade_decision_selects,
+        )
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="exact lineage source activity fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "params": {
+                        "paper_route_probe": {
+                            "source_candidate_ids": ["candidate-exact-lineage"],
+                            "source_hypothesis_ids": ["H-EXACT-LINEAGE"],
+                        }
+                    },
+                },
+                rationale="exact source lineage readback",
+                status="executed",
+                created_at=event_at,
+                executed_at=event_at + timedelta(minutes=1),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="exact-lineage-order",
+                client_order_id="exact-lineage-client",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=event_at + timedelta(minutes=2),
+                updated_at=event_at + timedelta(minutes=2),
+                last_update_at=event_at + timedelta(minutes=2),
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionTCAMetric(
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    side="buy",
+                    arrival_price=Decimal("99"),
+                    avg_fill_price=Decimal("100"),
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("1"),
+                    slippage_bps=Decimal("1"),
+                    shortfall_notional=Decimal("0.01"),
+                    realized_shortfall_bps=Decimal("1"),
+                    churn_qty=Decimal("0"),
+                    churn_ratio=Decimal("0"),
+                    computed_at=event_at + timedelta(minutes=3),
+                    created_at=event_at + timedelta(minutes=3),
+                    updated_at=event_at + timedelta(minutes=3),
+                )
+            )
+            session.commit()
+
+            activity = _strategy_source_activity(
+                session,
+                strategy_name=strategy_name,
+                account_label="TORGHUT_SIM",
+                symbols=["AAPL"],
+                window_start=window_start,
+                window_end=window_end,
+                candidate_id="candidate-exact-lineage",
+                hypothesis_id="H-EXACT-LINEAGE",
+                require_source_lineage=True,
+            )
+
+        self.assertEqual(trade_decision_selects, 1)
+        self.assertEqual(activity["raw_decision_count"], 1)
+        self.assertEqual(activity["lineage_matched_decision_count"], 1)
+        self.assertEqual(activity["decision_count"], 1)
+        self.assertEqual(activity["execution_count"], 1)
+        self.assertEqual(activity["tca_sample_count"], 1)
+        self.assertFalse(activity["missing"])
+        observation = activity["source_lineage_observation"]
+        self.assertEqual(observation["observed_decision_count"], 1)
+        self.assertEqual(observation["exact_match_decision_count"], 1)
+        self.assertEqual(observation["blockers"], [])
+
+    def test_evidence_audit_reuses_duplicate_target_window_audits(self) -> None:
+        window_start = datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc)
+        window_end = window_start + timedelta(hours=1)
+        generated_at = window_end + timedelta(minutes=30)
+        target = {
+            "hypothesis_id": "H-CACHED-AUDIT",
+            "candidate_id": "candidate-cached-audit",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_pairs",
+            "strategy_name": "paper-route-cached-audit",
+            "strategy_lookup_names": ["paper-route-cached-audit"],
+            "account_label": "TORGHUT_SIM",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "window_start": window_start.isoformat(),
+            "window_end": window_end.isoformat(),
+            "paper_probation_authorized": True,
+            "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+        }
+        target_plan = {
+            "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+            "source": "test_duplicate_target_scope",
+            "purpose": "latest_closed_session_paper_route_runtime_window_import",
+            "target_count": 1,
+            "targets": [target],
+            "session_readiness": {
+                "import_ready": True,
+                "import_blockers": [],
+            },
+        }
+        audit = {
+            "target": target,
+            "source_activity": {
+                "missing": False,
+                "missing_reasons": [],
+                "query_limits": {"truncated_sources": []},
+            },
+            "runtime_ledger": {
+                "bucket_count": 0,
+                "evidence_grade_bucket_count": 0,
+            },
+            "rejected_signal_activity": {"event_count": 0},
+            "promotion_decisions": {"decision_count": 0},
+            "readiness": {"blockers": []},
+            "evidence_readback": {"state": "source_activity_present"},
+            "evidence_window_contract": {"state": "clean_window"},
+            "account_contamination": {"blockers": []},
+            "account_state": {"blockers": []},
+        }
+
+        with (
+            Session(self.engine) as session,
+            patch(
+                "app.trading.paper_route_evidence._next_paper_route_runtime_window_targets",
+                return_value=target_plan,
+            ),
+            patch(
+                "app.trading.paper_route_evidence._target_audit_fail_closed",
+                return_value=audit,
+            ) as audit_mock,
+        ):
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": "1",
+                        "targets": [target],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=generated_at,
+            )
+
+        self.assertEqual(audit_mock.call_count, 1)
+        self.assertEqual(payload["summary"]["target_count"], 1)
+        self.assertEqual(
+            payload["summary"]["target_with_source_activity_count"],
+            1,
         )
 
     def test_evidence_readback_diagnostics_distinguish_source_lifecycle_and_blockers(


### PR DESCRIPTION
## Summary

- Reuses exact source-lineage readback in paper-route evidence audits instead of running a second broad `trade_decisions` scan when the scoped target already matched.
- Eager-loads `Strategy` on source-lineage decision reads so lineage diagnostics do not add hidden lazy-load queries.
- Caches successful duplicate target/window audits within one `/trading/paper-route-evidence` payload build to reduce repeated source/next/import readback churn.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Live readback before this fix: active `torghut-sim-01169` returned `/trading/status` in 11.776s with budget skips, while `/trading/paper-route-evidence?target_limit=5` timed out after 25s.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
