### PR TITLE
feat(torghut): emit breakeven cost buffer frontier metrics

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -11687,6 +11687,21 @@ def _candidate_board_payload(
                 "conformal_tail_risk_buffer_per_day": _candidate_board_decimal_field(
                     scorecard, "conformal_tail_risk_buffer_per_day"
                 ),
+                "breakeven_transaction_cost_buffer_passed": _boolish(
+                    scorecard.get("breakeven_transaction_cost_buffer_passed")
+                ),
+                "breakeven_transaction_cost_buffer_bps": _candidate_board_decimal_field(
+                    scorecard, "breakeven_transaction_cost_buffer_bps"
+                ),
+                "transaction_cost_buffer_bps": _candidate_board_decimal_field(
+                    scorecard, "transaction_cost_buffer_bps"
+                ),
+                "post_cost_net_pnl_after_breakeven_transaction_cost_buffer": (
+                    _candidate_board_decimal_field(
+                        scorecard,
+                        "post_cost_net_pnl_after_breakeven_transaction_cost_buffer",
+                    )
+                ),
                 "trading_day_count": _candidate_board_int_field(
                     scorecard, "trading_day_count"
                 ),

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -2514,6 +2514,7 @@ DELAY_ADJUSTED_DEPTH_STRESS_GRID_MS = (
     Decimal("250"),
 )
 CONFORMAL_TAIL_RISK_ALPHA = Decimal("0.20")
+BREAKEVEN_TRANSACTION_COST_BUFFER_MIN_BPS = Decimal("1")
 MARKET_IMPACT_STRESS_SOURCE_MARKERS = (
     "realistic_market_impact_arxiv_2603_29086_2026",
     "double_square_root_impact_arxiv_2502_16246_2025",
@@ -2570,6 +2571,54 @@ def _conformal_tail_risk_metrics(
         "conformal_tail_risk_passed": passed,
         "conformal_tail_risk_source_markers": [
             "regime_weighted_conformal_var_arxiv_2602_03903_2026"
+        ],
+    }
+
+
+def _breakeven_transaction_cost_buffer_metrics(
+    *,
+    target_net_per_day: Decimal,
+    conformal_adjusted_net_per_day: Decimal,
+    avg_filled_notional_per_day: Decimal,
+    required_cost_buffer_bps: Decimal,
+) -> dict[str, Any]:
+    selected_cost_buffer_bps = max(
+        BREAKEVEN_TRANSACTION_COST_BUFFER_MIN_BPS,
+        required_cost_buffer_bps,
+    )
+    breakeven_surplus_per_day = max(
+        Decimal("0"),
+        conformal_adjusted_net_per_day - target_net_per_day,
+    )
+    breakeven_buffer_bps = (
+        breakeven_surplus_per_day / avg_filled_notional_per_day * Decimal("10000")
+        if avg_filled_notional_per_day > 0
+        else Decimal("0")
+    )
+    buffer_cost_per_day = (
+        avg_filled_notional_per_day * selected_cost_buffer_bps / Decimal("10000")
+    )
+    buffered_net_per_day = conformal_adjusted_net_per_day - buffer_cost_per_day
+    passed = (
+        avg_filled_notional_per_day > 0
+        and breakeven_buffer_bps >= selected_cost_buffer_bps
+        and buffered_net_per_day >= target_net_per_day
+    )
+    return {
+        "required_breakeven_transaction_cost_buffer": True,
+        "breakeven_transaction_cost_buffer_passed": passed,
+        "breakeven_transaction_cost_buffer_bps": str(breakeven_buffer_bps),
+        "transaction_cost_buffer_bps": str(selected_cost_buffer_bps),
+        "transaction_cost_buffer_cost_per_day": str(buffer_cost_per_day),
+        "post_cost_net_pnl_after_breakeven_transaction_cost_buffer": str(
+            buffered_net_per_day
+        ),
+        "breakeven_transaction_cost_buffer_target_net_pnl_per_day": str(
+            target_net_per_day
+        ),
+        "breakeven_transaction_cost_buffer_source_markers": [
+            "regime_weighted_conformal_var_arxiv_2602_03903_2026",
+            "realistic_market_impact_arxiv_2603_29086_2026",
         ],
     }
 
@@ -3018,6 +3067,20 @@ def _consistency_penalty(
         net_per_day=summary.net_per_day,
         daily_net=summary.daily_net,
     )
+    breakeven_cost_buffer_metrics = _breakeven_transaction_cost_buffer_metrics(
+        target_net_per_day=policy.target_net_per_day,
+        conformal_adjusted_net_per_day=Decimal(
+            str(
+                conformal_tail_risk_metrics[
+                    "conformal_tail_risk_adjusted_net_pnl_per_day"
+                ]
+            )
+        ),
+        avg_filled_notional_per_day=avg_filled_notional_per_day,
+        required_cost_buffer_bps=Decimal(
+            str(replay_stress_metrics.get("market_impact_stress_cost_bps") or "0")
+        ),
+    )
     best_day_share_of_total_pnl = _max_best_day_share_of_total_pnl(
         daily_net=summary.daily_net,
         total_net_pnl=summary.net_pnl,
@@ -3152,6 +3215,20 @@ def _consistency_penalty(
                 )
             ),
         )
+    if not bool(
+        breakeven_cost_buffer_metrics["breakeven_transaction_cost_buffer_passed"]
+    ):
+        penalties += max(
+            Decimal("0"),
+            policy.target_net_per_day
+            - Decimal(
+                str(
+                    breakeven_cost_buffer_metrics[
+                        "post_cost_net_pnl_after_breakeven_transaction_cost_buffer"
+                    ]
+                )
+            ),
+        )
 
     return (
         penalties,
@@ -3186,6 +3263,7 @@ def _consistency_penalty(
             "avg_liquidity_notional_per_day": str(avg_liquidity_notional_per_day),
             **replay_stress_metrics,
             **conformal_tail_risk_metrics,
+            **breakeven_cost_buffer_metrics,
             "best_day_share_of_total_pnl": str(best_day_share_of_total_pnl),
             "max_gross_exposure_pct_equity": str(max_gross_exposure_pct_equity),
             "max_gross_exposure_pct_equity_required": str(
@@ -6795,6 +6873,10 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     )
                 if not bool(full_window_summary.get("conformal_tail_risk_passed")):
                     hard_vetoes.append("conformal_tail_risk_below_target")
+                if not bool(
+                    full_window_summary.get("breakeven_transaction_cost_buffer_passed")
+                ):
+                    hard_vetoes.append("breakeven_transaction_cost_buffer_below_target")
                 if (
                     objective_scorecard.symbol_concentration_share
                     > consistency_policy.max_symbol_concentration_share
@@ -7180,6 +7262,53 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                                 Sequence[Any],
                                 full_window_summary.get(
                                     "conformal_tail_risk_source_markers"
+                                )
+                                or (),
+                            )
+                        ),
+                        "required_breakeven_transaction_cost_buffer": bool(
+                            full_window_summary.get(
+                                "required_breakeven_transaction_cost_buffer"
+                            )
+                        ),
+                        "breakeven_transaction_cost_buffer_passed": bool(
+                            full_window_summary.get(
+                                "breakeven_transaction_cost_buffer_passed"
+                            )
+                        ),
+                        "breakeven_transaction_cost_buffer_bps": str(
+                            full_window_summary.get(
+                                "breakeven_transaction_cost_buffer_bps"
+                            )
+                            or "0"
+                        ),
+                        "transaction_cost_buffer_bps": str(
+                            full_window_summary.get("transaction_cost_buffer_bps")
+                            or "0"
+                        ),
+                        "transaction_cost_buffer_cost_per_day": str(
+                            full_window_summary.get(
+                                "transaction_cost_buffer_cost_per_day"
+                            )
+                            or "0"
+                        ),
+                        "post_cost_net_pnl_after_breakeven_transaction_cost_buffer": str(
+                            full_window_summary.get(
+                                "post_cost_net_pnl_after_breakeven_transaction_cost_buffer"
+                            )
+                            or "0"
+                        ),
+                        "breakeven_transaction_cost_buffer_target_net_pnl_per_day": str(
+                            full_window_summary.get(
+                                "breakeven_transaction_cost_buffer_target_net_pnl_per_day"
+                            )
+                            or "0"
+                        ),
+                        "breakeven_transaction_cost_buffer_source_markers": list(
+                            cast(
+                                Sequence[Any],
+                                full_window_summary.get(
+                                    "breakeven_transaction_cost_buffer_source_markers"
                                 )
                                 or (),
                             )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -8858,6 +8858,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "implementation_uncertainty_lower_net_pnl_per_day": "525",
                 "conformal_tail_risk_passed": True,
                 "conformal_tail_risk_adjusted_net_pnl_per_day": "525",
+                "breakeven_transaction_cost_buffer_passed": True,
+                "breakeven_transaction_cost_buffer_bps": "5",
+                "transaction_cost_buffer_bps": "1",
+                "post_cost_net_pnl_after_breakeven_transaction_cost_buffer": "520",
                 "delay_adjusted_depth_fill_survival_evidence_present": True,
                 "delay_adjusted_depth_fill_survival_sample_count": 9,
                 "delay_adjusted_depth_fill_survival_rate": "0.85",
@@ -8970,6 +8974,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ["live_paper_parity", "route_tca", "runtime_ledger"],
         )
         self.assertEqual(row["paper_required_evidence_count"], 3)
+        self.assertTrue(row["breakeven_transaction_cost_buffer_passed"])
+        self.assertEqual(row["breakeven_transaction_cost_buffer_bps"], "5")
+        self.assertEqual(row["transaction_cost_buffer_bps"], "1")
+        self.assertEqual(
+            row["post_cost_net_pnl_after_breakeven_transaction_cost_buffer"],
+            "520",
+        )
         expected_runtime_ledger_handoff = {
             "status": "requires_runtime_ledger_materialization_before_authoritative_pnl",
             "runtime_ledger_required": True,

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -1279,6 +1279,138 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         )
         self.assertGreaterEqual(penalties, Decimal("140"))
 
+    def test_consistency_penalty_emits_breakeven_transaction_cost_buffer(self) -> None:
+        penalties, summary = frontier._consistency_penalty(
+            full_window_payload=self._payload(
+                start_date="2026-04-01",
+                end_date="2026-04-07",
+                daily_net={
+                    "2026-04-01": "700",
+                    "2026-04-02": "700",
+                    "2026-04-03": "700",
+                    "2026-04-06": "700",
+                    "2026-04-07": "700",
+                },
+                daily_filled_notional={
+                    "2026-04-01": "100000",
+                    "2026-04-02": "100000",
+                    "2026-04-03": "100000",
+                    "2026-04-06": "100000",
+                    "2026-04-07": "100000",
+                },
+                daily_liquidity_notional={
+                    "2026-04-01": "10000000000",
+                    "2026-04-02": "10000000000",
+                    "2026-04-03": "10000000000",
+                    "2026-04-06": "10000000000",
+                    "2026-04-07": "10000000000",
+                },
+                decision_count=5,
+                filled_count=5,
+                wins=5,
+                losses=0,
+            ),
+            policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=Decimal("500"),
+                min_daily_net_pnl=Decimal("-1000"),
+                min_active_days=5,
+                min_active_ratio=Decimal("1"),
+                min_positive_days=4,
+                max_worst_day_loss=Decimal("1000"),
+                max_negative_days=1,
+                max_drawdown=Decimal("1000"),
+                max_best_day_share_of_total_pnl=Decimal("1"),
+                min_avg_filled_notional_per_day=Decimal("0"),
+                min_avg_filled_notional_per_active_day=Decimal("0"),
+                require_every_day_active=True,
+            ),
+        )
+
+        self.assertTrue(summary["breakeven_transaction_cost_buffer_passed"])
+        self.assertTrue(summary["required_breakeven_transaction_cost_buffer"])
+        self.assertEqual(summary["transaction_cost_buffer_bps"], "1")
+        self.assertEqual(
+            Decimal(str(summary["breakeven_transaction_cost_buffer_bps"])),
+            Decimal("20"),
+        )
+        self.assertEqual(
+            Decimal(
+                str(
+                    summary["post_cost_net_pnl_after_breakeven_transaction_cost_buffer"]
+                )
+            ),
+            Decimal("690"),
+        )
+        self.assertIn(
+            "realistic_market_impact_arxiv_2603_29086_2026",
+            summary["breakeven_transaction_cost_buffer_source_markers"],
+        )
+        self.assertEqual(penalties, Decimal("0"))
+
+    def test_consistency_penalty_blocks_breakeven_transaction_cost_shortfall(
+        self,
+    ) -> None:
+        penalties, summary = frontier._consistency_penalty(
+            full_window_payload=self._payload(
+                start_date="2026-04-01",
+                end_date="2026-04-07",
+                daily_net={
+                    "2026-04-01": "510",
+                    "2026-04-02": "510",
+                    "2026-04-03": "510",
+                    "2026-04-06": "510",
+                    "2026-04-07": "510",
+                },
+                daily_filled_notional={
+                    "2026-04-01": "200000",
+                    "2026-04-02": "200000",
+                    "2026-04-03": "200000",
+                    "2026-04-06": "200000",
+                    "2026-04-07": "200000",
+                },
+                daily_liquidity_notional={
+                    "2026-04-01": "10000000000",
+                    "2026-04-02": "10000000000",
+                    "2026-04-03": "10000000000",
+                    "2026-04-06": "10000000000",
+                    "2026-04-07": "10000000000",
+                },
+                decision_count=5,
+                filled_count=5,
+                wins=5,
+                losses=0,
+            ),
+            policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=Decimal("500"),
+                min_daily_net_pnl=Decimal("-1000"),
+                min_active_days=5,
+                min_active_ratio=Decimal("1"),
+                min_positive_days=4,
+                max_worst_day_loss=Decimal("1000"),
+                max_negative_days=1,
+                max_drawdown=Decimal("1000"),
+                max_best_day_share_of_total_pnl=Decimal("1"),
+                min_avg_filled_notional_per_day=Decimal("0"),
+                min_avg_filled_notional_per_active_day=Decimal("0"),
+                require_every_day_active=True,
+            ),
+        )
+
+        self.assertFalse(summary["breakeven_transaction_cost_buffer_passed"])
+        self.assertEqual(
+            Decimal(str(summary["breakeven_transaction_cost_buffer_bps"])),
+            Decimal("0.5"),
+        )
+        self.assertEqual(
+            Decimal(
+                str(
+                    summary["post_cost_net_pnl_after_breakeven_transaction_cost_buffer"]
+                )
+            ),
+            Decimal("490"),
+        )
+        self.assertGreaterEqual(penalties, Decimal("10"))
+
     def test_consistency_penalty_caps_impossible_count_activity_gates(self) -> None:
         penalties, summary = frontier._consistency_penalty(
             full_window_payload=self._payload(


### PR DESCRIPTION
## Summary

- Emits breakeven transaction-cost buffer metrics from the consistent profitability frontier using conformal adjusted net PnL and market-impact cost stress.
- Adds a hard veto when candidates cannot clear the daily target after the conformal tail-risk buffer and the selected transaction-cost buffer.
- Surfaces the breakeven cost-buffer fields in the autoresearch candidate board so the evidence-bundle gate added in PR #10464 receives materialized inputs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format scripts/search_consistent_profitability_frontier.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check scripts/search_consistent_profitability_frontier.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_search_consistent_profitability_frontier.py -k 'breakeven_transaction_cost or tail_loss_adjusted'`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'surfaces_paper_probation_without_promotion'`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && rm -f coverage.xml .coverage && uv run --frozen --with coverage --with pytest --with hypothesis coverage run -m pytest tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py && uv run --frozen --with coverage coverage xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main; status=$?; rm -f coverage.xml .coverage; exit $status`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev` failed because `crosshair-tool==0.0.102` requires missing system compiler `cc` in this workspace.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
