### PR TITLE
fix(torghut): preserve deferred dependency quorum

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -499,6 +499,22 @@ def _deferred_hypothesis_payload_for_live_submission_gate() -> dict[str, object]
             reason="hypothesis_runtime_deferred_until_after_live_submission_gate"
         )
     )
+    dependency_quorum = payload.get("dependency_quorum")
+    if not isinstance(dependency_quorum, Mapping):
+        return payload
+
+    nested_summary = payload.get("summary")
+    summary_payload: dict[str, object] = (
+        dict(cast(Mapping[str, object], nested_summary))
+        if isinstance(nested_summary, Mapping)
+        else {}
+    )
+    if "dependency_quorum" not in summary_payload:
+        payload = dict(payload)
+        summary_payload["dependency_quorum"] = dict(
+            cast(Mapping[str, object], dependency_quorum)
+        )
+        payload["summary"] = summary_payload
     return payload
 
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -10600,6 +10600,36 @@ class TestTradingApi(TestCase):
         self.assertIsInstance(summary, dict)
         self.assertNotIn("dependency_quorum", summary)
 
+    def test_deferred_live_gate_payload_ignores_malformed_dependency_quorum(
+        self,
+    ) -> None:
+        with patch(
+            "app.main._budget_unavailable_hypothesis_runtime_payload",
+            return_value=(
+                {
+                    "registry_loaded": True,
+                    "dependency_quorum": "cached_quorum_allow",
+                    "summary": {
+                        "read_model_unavailable": True,
+                        "reason_codes": [
+                            "hypothesis_runtime_deferred_until_after_live_submission_gate"
+                        ],
+                    },
+                    "items": [],
+                },
+                {},
+                SimpleNamespace(as_payload=lambda: {}),
+            ),
+        ):
+            payload = (
+                main_module._deferred_hypothesis_payload_for_live_submission_gate()
+            )
+
+        summary = payload["summary"]
+        self.assertIsInstance(summary, dict)
+        self.assertEqual(payload["dependency_quorum"], "cached_quorum_allow")
+        self.assertNotIn("dependency_quorum", summary)
+
     def test_trading_paper_route_evidence_uses_external_plan_when_url_configured(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -10513,6 +10513,93 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
+    def test_deferred_live_gate_payload_preserves_dependency_quorum_for_target_plan(
+        self,
+    ) -> None:
+        dependency_quorum = {
+            "schema_version": "torghut.jangar-dependency-quorum.v1",
+            "decision": "allow",
+            "reason": "cached_quorum_allow",
+        }
+
+        with patch(
+            "app.main._budget_unavailable_hypothesis_runtime_payload",
+            return_value=(
+                {
+                    "registry_loaded": True,
+                    "dependency_quorum": dependency_quorum,
+                    "summary": {
+                        "read_model_unavailable": True,
+                        "reason_codes": [
+                            "hypothesis_runtime_deferred_until_after_live_submission_gate"
+                        ],
+                    },
+                    "items": [],
+                },
+                {},
+                SimpleNamespace(as_payload=lambda: dependency_quorum),
+            ),
+        ):
+            payload = (
+                main_module._deferred_hypothesis_payload_for_live_submission_gate()
+            )
+
+        summary = payload["summary"]
+        self.assertIsInstance(summary, dict)
+        self.assertEqual(summary["dependency_quorum"], dependency_quorum)
+
+        gate = _build_live_submission_gate_payload(
+            SimpleNamespace(
+                drift_live_promotion_eligible=True,
+                last_signal_continuity_state="signals_present",
+                last_signal_continuity_actionable=False,
+            ),
+            hypothesis_summary=payload,
+            empirical_jobs_status={"ready": True},
+            quant_health_status={
+                "required": False,
+                "ok": True,
+                "status": "not_required",
+                "blocking_reasons": [],
+            },
+            clickhouse_ta_status={
+                "state": "current",
+                "latest_signal_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+        self.assertEqual(gate["dependency_quorum_decision"], "allow")
+        self.assertEqual(gate["runtime_window_import_health_gate"]["blockers"], [])
+        self.assertTrue(gate["runtime_window_import_health_gate"]["ready"])
+
+    def test_deferred_live_gate_payload_leaves_missing_dependency_quorum_fail_closed(
+        self,
+    ) -> None:
+        with patch(
+            "app.main._budget_unavailable_hypothesis_runtime_payload",
+            return_value=(
+                {
+                    "registry_loaded": True,
+                    "summary": {
+                        "read_model_unavailable": True,
+                        "reason_codes": [
+                            "hypothesis_runtime_deferred_until_after_live_submission_gate"
+                        ],
+                    },
+                    "items": [],
+                },
+                {},
+                SimpleNamespace(as_payload=lambda: {}),
+            ),
+        ):
+            payload = (
+                main_module._deferred_hypothesis_payload_for_live_submission_gate()
+            )
+
+        summary = payload["summary"]
+        self.assertIsInstance(summary, dict)
+        self.assertNotIn("dependency_quorum", summary)
+
     def test_trading_paper_route_evidence_uses_external_plan_when_url_configured(
         self,
     ) -> None:


### PR DESCRIPTION
"## Summary\n\n- Preserves the dependency quorum already resolved for the deferred live-submission gate by copying it into the nested summary shape consumed by the shared gate evaluator.\n- Prevents lightweight paper-route target-plan/evidence endpoints from reporting `dependency_quorum_not_allow` solely because the deferred hypothesis read skipped the full status read.\n- Adds a regression covering the deferred payload and runtime-window import health gate readiness when quorum, continuity, and drift are already passing.\n- Keeps source lineage, execution/TCA, settlement, PnL, simple-submit, and live-capital gates unchanged and fail-closed.\n\n## Related Issues\n\nNone\n\n## Testing\n\n- `cd services/torghut && uv sync --frozen --extra dev`\n- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'deferred_live_gate_payload'`\n- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan or deferred_live_gate_payload_preserves_dependency_quorum_for_target_plan' tests/test_paper_route_evidence.py -k 'runtime_window_import_health_gate or target_plan'`\n- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py tests/test_paper_route_evidence.py`\n- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`\n- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py`\n- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`\n- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`\n- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`\n- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` (after a narrow coverage run; changed-line coverage passed at 100%)\n- `git diff --check`\n\n## Screenshots (if applicable)\n\nN/A\n\n## Breaking Changes\n\nNone\n\n## Checklist\n\n- [x] Testing section documents the exact validation performed.\n- [x] Screenshots and Breaking Changes sections are handled appropriately.\n- [x] Documentation, release notes, and follow-ups are updated or tracked; no documentation update is required for this narrow runtime evidence propagation fix.\n"
