### PR TITLE
fix(torghut): prioritize broker alias order-feed repairs

### DIFF
--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -46,6 +46,7 @@ spec:
                   /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
                     --dsn-env DB_DSN \
                     --account-label PA3SX7FYNUTF \
+                    --canonical-account-label TORGHUT_SIM \
                     --batch-size 1000 \
                     --max-batches 5 \
                     --backfill-execution-events \

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -1946,6 +1946,26 @@ def repair_order_feed_execution_links(
         if canonical_account_label is not None and canonical_account_label.strip()
         else None
     )
+    if canonical_label is not None:
+        event_ordering = (
+            ExecutionOrderEvent.raw_event["_torghut_linkage"]
+            .as_string()
+            .is_(None)
+            .desc(),
+            ExecutionOrderEvent.event_ts.desc().nullslast(),
+            ExecutionOrderEvent.feed_seq.desc().nullslast(),
+            ExecutionOrderEvent.created_at.desc(),
+        )
+    else:
+        event_ordering = (
+            ExecutionOrderEvent.raw_event["_torghut_linkage"]
+            .as_string()
+            .is_(None)
+            .desc(),
+            ExecutionOrderEvent.event_ts.asc().nullsfirst(),
+            ExecutionOrderEvent.feed_seq.asc().nullsfirst(),
+            ExecutionOrderEvent.created_at.asc(),
+        )
     stmt = (
         select(ExecutionOrderEvent)
         .where(
@@ -1958,15 +1978,7 @@ def repair_order_feed_execution_links(
                 | (ExecutionOrderEvent.client_order_id.is_not(None))
             ),
         )
-        .order_by(
-            ExecutionOrderEvent.raw_event["_torghut_linkage"]
-            .as_string()
-            .is_(None)
-            .desc(),
-            ExecutionOrderEvent.event_ts.asc().nullsfirst(),
-            ExecutionOrderEvent.feed_seq.asc().nullsfirst(),
-            ExecutionOrderEvent.created_at.asc(),
-        )
+        .order_by(*event_ordering)
         .limit(bounded_limit)
     )
     if account_label:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1360,6 +1360,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/repair_order_feed_source_windows.py", args)
         self.assertIn("--dsn-env DB_DSN", args)
         self.assertIn("--account-label PA3SX7FYNUTF", args)
+        self.assertIn("--canonical-account-label TORGHUT_SIM", args)
         self.assertIn("--batch-size 1000", args)
         self.assertIn("--max-batches 5", args)
         self.assertIn("--backfill-execution-events", args)

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -1951,6 +1951,84 @@ class TestOrderFeed(TestCase):
         self.assertTrue(source_window.payload_json["source_coverage_complete"])
         self.assertFalse(source_window.payload_json["promotion_authority_eligible"])
 
+    def test_repair_order_feed_execution_links_prioritizes_recent_account_alias_event(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            old_unmatchable_event = ExecutionOrderEvent(
+                event_fingerprint="repair-old-broker-account-unmatchable-fill",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=331,
+                alpaca_account_label="PA3SX7FYNUTF",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id="old-broker-missing-order",
+                client_order_id="old-broker-missing-client",
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+            )
+            execution = self._seed_execution(
+                session,
+                account_label="TORGHUT_SIM",
+                order_id="new-sim-alias-order",
+                client_order_id="new-sim-alias-client",
+            )
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+            linkable_event = ExecutionOrderEvent(
+                event_fingerprint="repair-new-broker-account-linkable-fill",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=332,
+                alpaca_account_label="PA3SX7FYNUTF",
+                event_ts=datetime(2026, 2, 1, 10, 1, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id="new-sim-alias-order",
+                client_order_id="new-sim-alias-client",
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+            )
+            session.add_all([old_unmatchable_event, linkable_event])
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="PA3SX7FYNUTF",
+                canonical_account_label="TORGHUT_SIM",
+                limit=1,
+            )
+            session.commit()
+            session.refresh(old_unmatchable_event)
+            session.refresh(linkable_event)
+
+        self.assertEqual(result["selected"], 1)
+        self.assertEqual(result["events_linked"], 1)
+        self.assertEqual(result["account_alias_events_linked"], 1)
+        self.assertIsNone(old_unmatchable_event.execution_id)
+        self.assertIsNone(old_unmatchable_event.trade_decision_id)
+        self.assertEqual(
+            order_feed_module._order_event_linkage_blockers(old_unmatchable_event),
+            [],
+        )
+        self.assertEqual(linkable_event.alpaca_account_label, "PA3SX7FYNUTF")
+        self.assertEqual(linkable_event.execution_id, execution_id)
+        self.assertEqual(linkable_event.trade_decision_id, trade_decision_id)
+        self.assertEqual(
+            linkable_event.raw_event["_torghut_account_label_alias"],
+            {
+                "source_account_label": "PA3SX7FYNUTF",
+                "canonical_account_label": "TORGHUT_SIM",
+                "basis": "matched_order_identity",
+            },
+        )
+
     def test_linkage_helpers_preserve_actionable_blocker_classifications(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Add the canonical `TORGHUT_SIM` account label to the live order-feed source-window repair CronJob for broker account `PA3SX7FYNUTF`.
- Prioritize newest order-feed rows for canonical account-alias repairs so bounded batches reach current fills instead of starving on old unmatchable broker events.
- Add regression coverage for one-row alias repair batches and the GitOps manifest contract.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_order_feed.py -k 'prioritizes_recent_account_alias_event or resolves_configured_account_alias or marks_missing_links_to_advance_scan' -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k order_feed_source_window_repair_cronjob -q`
- `uv run --frozen ruff check app/trading/order_feed.py tests/test_order_feed.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check app/trading/order_feed.py tests/test_order_feed.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
