### PR TITLE
fix(torghut): require seed model robustness evidence

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -11702,6 +11702,24 @@ def _candidate_board_payload(
                         "post_cost_net_pnl_after_breakeven_transaction_cost_buffer",
                     )
                 ),
+                "required_seed_model_family_robustness": _boolish(
+                    scorecard.get("required_seed_model_family_robustness")
+                ),
+                "seed_model_family_robustness_status": str(
+                    scorecard.get("seed_model_family_robustness_status") or ""
+                ),
+                "seed_robustness_passed": _boolish(
+                    scorecard.get("seed_robustness_passed")
+                ),
+                "seed_robustness_sample_count": _candidate_board_int_field(
+                    scorecard, "seed_robustness_sample_count"
+                ),
+                "model_family_robustness_passed": _boolish(
+                    scorecard.get("model_family_robustness_passed")
+                ),
+                "model_family_robustness_family_count": _candidate_board_int_field(
+                    scorecard, "model_family_robustness_family_count"
+                ),
                 "trading_day_count": _candidate_board_int_field(
                     scorecard, "trading_day_count"
                 ),

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -2606,6 +2606,7 @@ def _breakeven_transaction_cost_buffer_metrics(
     )
     return {
         "required_breakeven_transaction_cost_buffer": True,
+        "required_seed_model_family_robustness": True,
         "breakeven_transaction_cost_buffer_passed": passed,
         "breakeven_transaction_cost_buffer_bps": str(breakeven_buffer_bps),
         "transaction_cost_buffer_bps": str(selected_cost_buffer_bps),
@@ -2616,9 +2617,19 @@ def _breakeven_transaction_cost_buffer_metrics(
         "breakeven_transaction_cost_buffer_target_net_pnl_per_day": str(
             target_net_per_day
         ),
+        "seed_model_family_robustness_status": (
+            "required_not_materialized_by_single_frontier_replay"
+        ),
+        "seed_robustness_passed": False,
+        "seed_robustness_sample_count": 0,
+        "model_family_robustness_passed": False,
+        "model_family_robustness_family_count": 0,
         "breakeven_transaction_cost_buffer_source_markers": [
             "regime_weighted_conformal_var_arxiv_2602_03903_2026",
             "realistic_market_impact_arxiv_2603_29086_2026",
+        ],
+        "seed_model_family_robustness_source_markers": [
+            "regime_weighted_conformal_var_arxiv_2602_03903_2026"
         ],
     }
 
@@ -7271,6 +7282,11 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                                 "required_breakeven_transaction_cost_buffer"
                             )
                         ),
+                        "required_seed_model_family_robustness": bool(
+                            full_window_summary.get(
+                                "required_seed_model_family_robustness"
+                            )
+                        ),
                         "breakeven_transaction_cost_buffer_passed": bool(
                             full_window_summary.get(
                                 "breakeven_transaction_cost_buffer_passed"
@@ -7309,6 +7325,36 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                                 Sequence[Any],
                                 full_window_summary.get(
                                     "breakeven_transaction_cost_buffer_source_markers"
+                                )
+                                or (),
+                            )
+                        ),
+                        "seed_model_family_robustness_status": str(
+                            full_window_summary.get(
+                                "seed_model_family_robustness_status"
+                            )
+                            or ""
+                        ),
+                        "seed_robustness_passed": bool(
+                            full_window_summary.get("seed_robustness_passed")
+                        ),
+                        "seed_robustness_sample_count": int(
+                            full_window_summary.get("seed_robustness_sample_count") or 0
+                        ),
+                        "model_family_robustness_passed": bool(
+                            full_window_summary.get("model_family_robustness_passed")
+                        ),
+                        "model_family_robustness_family_count": int(
+                            full_window_summary.get(
+                                "model_family_robustness_family_count"
+                            )
+                            or 0
+                        ),
+                        "seed_model_family_robustness_source_markers": list(
+                            cast(
+                                Sequence[Any],
+                                full_window_summary.get(
+                                    "seed_model_family_robustness_source_markers"
                                 )
                                 or (),
                             )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -8862,6 +8862,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "breakeven_transaction_cost_buffer_bps": "5",
                 "transaction_cost_buffer_bps": "1",
                 "post_cost_net_pnl_after_breakeven_transaction_cost_buffer": "520",
+                "required_seed_model_family_robustness": True,
+                "seed_model_family_robustness_status": (
+                    "required_not_materialized_by_single_frontier_replay"
+                ),
+                "seed_robustness_passed": False,
+                "seed_robustness_sample_count": 0,
+                "model_family_robustness_passed": False,
+                "model_family_robustness_family_count": 0,
                 "delay_adjusted_depth_fill_survival_evidence_present": True,
                 "delay_adjusted_depth_fill_survival_sample_count": 9,
                 "delay_adjusted_depth_fill_survival_rate": "0.85",
@@ -8981,6 +8989,15 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             row["post_cost_net_pnl_after_breakeven_transaction_cost_buffer"],
             "520",
         )
+        self.assertTrue(row["required_seed_model_family_robustness"])
+        self.assertEqual(
+            row["seed_model_family_robustness_status"],
+            "required_not_materialized_by_single_frontier_replay",
+        )
+        self.assertFalse(row["seed_robustness_passed"])
+        self.assertEqual(row["seed_robustness_sample_count"], 0)
+        self.assertFalse(row["model_family_robustness_passed"])
+        self.assertEqual(row["model_family_robustness_family_count"], 0)
         expected_runtime_ledger_handoff = {
             "status": "requires_runtime_ledger_materialization_before_authoritative_pnl",
             "runtime_ledger_required": True,

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -1328,6 +1328,15 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
         self.assertTrue(summary["breakeven_transaction_cost_buffer_passed"])
         self.assertTrue(summary["required_breakeven_transaction_cost_buffer"])
+        self.assertTrue(summary["required_seed_model_family_robustness"])
+        self.assertFalse(summary["seed_robustness_passed"])
+        self.assertEqual(summary["seed_robustness_sample_count"], 0)
+        self.assertFalse(summary["model_family_robustness_passed"])
+        self.assertEqual(summary["model_family_robustness_family_count"], 0)
+        self.assertEqual(
+            summary["seed_model_family_robustness_status"],
+            "required_not_materialized_by_single_frontier_replay",
+        )
         self.assertEqual(summary["transaction_cost_buffer_bps"], "1")
         self.assertEqual(
             Decimal(str(summary["breakeven_transaction_cost_buffer_bps"])),
@@ -1344,6 +1353,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertIn(
             "realistic_market_impact_arxiv_2603_29086_2026",
             summary["breakeven_transaction_cost_buffer_source_markers"],
+        )
+        self.assertIn(
+            "regime_weighted_conformal_var_arxiv_2602_03903_2026",
+            summary["seed_model_family_robustness_source_markers"],
         )
         self.assertEqual(penalties, Decimal("0"))
 


### PR DESCRIPTION
## Summary

- Marks seed/model-family robustness as required evidence when the frontier emits conformal breakeven transaction-cost buffer metrics.
- Keeps single-frontier replays fail-closed by explicitly setting seed and model-family robustness to not materialized until separate robustness evidence is collected.
- Surfaces the robustness status and counts in the autoresearch candidate board so close candidates can be queued for evidence collection without being treated as final proof.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format scripts/search_consistent_profitability_frontier.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check scripts/search_consistent_profitability_frontier.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_search_consistent_profitability_frontier.py -k 'breakeven_transaction_cost or tail_loss_adjusted'`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'surfaces_paper_probation_without_promotion'`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && rm -f coverage.xml .coverage && uv run --frozen --with coverage --with pytest --with hypothesis coverage run -m pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'surfaces_paper_probation_without_promotion' && uv run --frozen --with coverage coverage xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main; status=$?; rm -f coverage.xml .coverage; exit $status`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev` failed because `crosshair-tool==0.0.102` requires missing system compiler `cc` in this workspace.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
