### PR TITLE
fix(torghut): queue robustness evidence for probation

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -10607,6 +10607,23 @@ def _paper_probation_candidate_payload(
     ]
     if not final_promotion_blockers:
         final_promotion_blockers.append("final_promotion_requires_runtime_governance")
+    live_paper_evidence_requirements = list(
+        _PAPER_PROBATION_LIVE_PAPER_EVIDENCE_REQUIREMENTS
+    )
+    safe_evidence_collection_path = list(_PAPER_PROBATION_SAFE_EVIDENCE_COLLECTION_PATH)
+    if bool(payload.get("required_seed_model_family_robustness")):
+        live_paper_evidence_requirements.extend(
+            (
+                "seed_robustness_replay_grid",
+                "model_family_robustness_replay_grid",
+            )
+        )
+        safe_evidence_collection_path.extend(
+            (
+                "run_offline_seed_model_family_robustness_grid_before_paper_probation",
+                "attach_seed_model_family_robustness_artifact_to_evidence_bundle",
+            )
+        )
     payload.update(
         {
             "candidate_selection": "oracle_recommended_paper_probation",
@@ -10631,10 +10648,10 @@ def _paper_probation_candidate_payload(
                 "linear_notional_sizing_estimate_for_repair_only_not_capital_authority"
             ),
             "live_paper_evidence_requirements": list(
-                _PAPER_PROBATION_LIVE_PAPER_EVIDENCE_REQUIREMENTS
+                dict.fromkeys(live_paper_evidence_requirements)
             ),
             "safe_evidence_collection_path": list(
-                _PAPER_PROBATION_SAFE_EVIDENCE_COLLECTION_PATH
+                dict.fromkeys(safe_evidence_collection_path)
             ),
             "live_capital_authorized": False,
             "final_promotion_requires_live_paper_runtime_proof": True,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -9045,6 +9045,22 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             probation_candidate["paper_probation_authorization_scope"],
             "evidence_collection_only",
         )
+        self.assertIn(
+            "seed_robustness_replay_grid",
+            probation_candidate["live_paper_evidence_requirements"],
+        )
+        self.assertIn(
+            "model_family_robustness_replay_grid",
+            probation_candidate["live_paper_evidence_requirements"],
+        )
+        self.assertIn(
+            "run_offline_seed_model_family_robustness_grid_before_paper_probation",
+            probation_candidate["safe_evidence_collection_path"],
+        )
+        self.assertIn(
+            "attach_seed_model_family_robustness_artifact_to_evidence_bundle",
+            probation_candidate["safe_evidence_collection_path"],
+        )
         self.assertEqual(probation_candidate["evidence_collection_stage"], "paper")
         self.assertEqual(
             probation_candidate["selection_reason"], "target_met_but_oracle_blocked"


### PR DESCRIPTION
## Summary

- Adds seed/model-family robustness replay-grid requirements to paper-probation evidence requirements when a candidate is marked as requiring robustness proof.
- Adds safe evidence-collection actions to run the offline robustness grid and attach the resulting artifact before any paper-probation/final promotion use.
- Keeps live capital and final promotion blocked; this is an evidence-collection routing change only.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --with ruff ruff format scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with ruff ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'surfaces_paper_probation_without_promotion'`
- `cd services/torghut && uv run --frozen --with pytest --with hypothesis pytest tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen --with pyright pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev` failed because `crosshair-tool==0.0.102` requires missing system compiler `cc` in this workspace.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
