### PR TITLE
fix(torghut): speed paper route source activity reads

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -132,6 +132,13 @@ class TradeDecision(Base, CreatedAtMixin):
             "symbol",
         ),
         Index(
+            "ix_trade_decisions_account_strategy_symbol_created",
+            "alpaca_account_label",
+            "strategy_id",
+            "symbol",
+            "created_at",
+        ),
+        Index(
             "uq_trade_decisions_account_decision_hash",
             "alpaca_account_label",
             "decision_hash",

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -19,7 +19,7 @@ from zoneinfo import ZoneInfo
 
 from sqlalchemy import create_engine, func, select, text
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session, contains_eager
+from sqlalchemy.orm import Session, selectinload
 
 from ..config import settings
 from ..models import (
@@ -4221,38 +4221,19 @@ def _strategy_source_activity(
             ],
         }
 
-    decision_stmt = (
-        select(TradeDecision)
-        .join(Strategy, TradeDecision.strategy_id == Strategy.id)
-        .options(contains_eager(TradeDecision.strategy))
-        .where(Strategy.name.in_(strategy_filters))
-        .where(TradeDecision.created_at >= window_start)
-        .where(TradeDecision.created_at <= window_end)
-    )
-    if account_label:
-        decision_stmt = decision_stmt.where(
-            TradeDecision.alpaca_account_label == account_label
-        )
-    if symbol_filters:
-        decision_stmt = decision_stmt.where(TradeDecision.symbol.in_(symbol_filters))
     decision_truncated = False
     try:
         _maybe_set_paper_route_audit_statement_timeout(session)
-        queried_decision_rows = list(
-            session.execute(
-                decision_stmt.order_by(TradeDecision.created_at.desc()).limit(
-                    PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT + 1
-                )
+        strategy_ids = [
+            strategy_id
+            for strategy_id in session.execute(
+                select(Strategy.id).where(Strategy.name.in_(strategy_filters))
             ).scalars()
-        )
-        decision_truncated = (
-            len(queried_decision_rows) > PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
-        )
-        decision_rows = queried_decision_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT]
+        ]
     except SQLAlchemyError as exc:
         _rollback_after_source_activity_error(
             session,
-            source="trade_decisions",
+            source="trade_decision_strategy_lookup",
             exc=exc,
         )
         return _unavailable_source_activity(
@@ -4266,6 +4247,54 @@ def _strategy_source_activity(
             source="trade_decisions",
             missing_reason="source_decisions_unavailable",
         )
+
+    queried_decision_rows: list[TradeDecision] = []
+    if strategy_ids:
+        decision_stmt = (
+            select(TradeDecision)
+            .options(selectinload(TradeDecision.strategy))
+            .where(TradeDecision.strategy_id.in_(strategy_ids))
+            .where(TradeDecision.created_at >= window_start)
+            .where(TradeDecision.created_at <= window_end)
+        )
+        if account_label:
+            decision_stmt = decision_stmt.where(
+                TradeDecision.alpaca_account_label == account_label
+            )
+        if symbol_filters:
+            decision_stmt = decision_stmt.where(
+                TradeDecision.symbol.in_(symbol_filters)
+            )
+        try:
+            _maybe_set_paper_route_audit_statement_timeout(session)
+            queried_decision_rows = list(
+                session.execute(
+                    decision_stmt.order_by(TradeDecision.created_at.desc()).limit(
+                        PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT + 1
+                    )
+                ).scalars()
+            )
+        except SQLAlchemyError as exc:
+            _rollback_after_source_activity_error(
+                session,
+                source="trade_decisions",
+                exc=exc,
+            )
+            return _unavailable_source_activity(
+                strategy_name=strategy_name,
+                strategy_lookup_names=strategy_filters,
+                account_label=account_label,
+                symbols=symbol_filters,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                require_source_lineage=require_source_lineage,
+                source="trade_decisions",
+                missing_reason="source_decisions_unavailable",
+            )
+    decision_truncated = (
+        len(queried_decision_rows) > PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT
+    )
+    decision_rows = queried_decision_rows[:PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT]
     raw_decision_count = len(decision_rows)
     source_lineage_observation: dict[str, object] = {
         "schema_version": SOURCE_LINEAGE_OBSERVATION_SCHEMA_VERSION,
@@ -4516,8 +4545,7 @@ def _strategy_source_activity(
     ):
         lineage_stmt = (
             select(TradeDecision)
-            .outerjoin(Strategy, TradeDecision.strategy_id == Strategy.id)
-            .options(contains_eager(TradeDecision.strategy))
+            .options(selectinload(TradeDecision.strategy))
             .where(TradeDecision.created_at >= window_start)
             .where(TradeDecision.created_at <= window_end)
         )

--- a/services/torghut/migrations/versions/0051_paper_route_source_activity_latest_index.py
+++ b/services/torghut/migrations/versions/0051_paper_route_source_activity_latest_index.py
@@ -1,0 +1,49 @@
+"""Add latest paper-route source activity index.
+
+Revision ID: 0051_paper_route_source_activity_latest_index
+Revises: 0050_tigerbeetle_reconciliation_compact_status
+Create Date: 2026-06-04 13:55:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0051_paper_route_source_activity_latest_index"
+down_revision = "0050_tigerbeetle_reconciliation_compact_status"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "ix_trade_decisions_account_strategy_symbol_created"
+TABLE_NAME = "trade_decisions"
+INDEX_COLUMNS = (
+    "alpaca_account_label",
+    "strategy_id",
+    "symbol",
+    "created_at",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(TABLE_NAME):
+        return
+    existing_indexes = {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
+    if INDEX_NAME in existing_indexes:
+        return
+    op.create_index(INDEX_NAME, TABLE_NAME, list(INDEX_COLUMNS))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if not inspector.has_table(TABLE_NAME):
+        return
+    existing_indexes = {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
+    if INDEX_NAME not in existing_indexes:
+        return
+    op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1086,7 +1086,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
     def test_source_activity_execution_query_timeout_fails_closed(self) -> None:
         activity, rollback_count = self._source_activity_with_failing_query(
-            failure_call=2
+            failure_call=4
         )
 
         self.assertEqual(rollback_count, 1)
@@ -1258,7 +1258,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
     def test_source_activity_order_event_query_timeout_fails_closed(self) -> None:
         activity, rollback_count = self._source_activity_with_failing_query(
-            failure_call=3
+            failure_call=5
         )
 
         self.assertEqual(rollback_count, 1)
@@ -1272,7 +1272,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
     def test_source_activity_tca_query_timeout_fails_closed(self) -> None:
         activity, rollback_count = self._source_activity_with_failing_query(
-            failure_call=4
+            failure_call=6
         )
 
         self.assertEqual(rollback_count, 1)
@@ -1369,6 +1369,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         event_at = window_start + timedelta(minutes=5)
         strategy_name = "paper-route-exact-lineage-readback"
         trade_decision_selects = 0
+        trade_decision_statements: list[str] = []
 
         def _count_trade_decision_selects(
             _conn: object,
@@ -1385,6 +1386,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 and " from trade_decisions" in normalized
             ):
                 trade_decision_selects += 1
+                trade_decision_statements.append(normalized)
 
         event.listen(
             self.engine,
@@ -1489,6 +1491,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             )
 
         self.assertEqual(trade_decision_selects, 1)
+        self.assertNotIn(" join strategies ", trade_decision_statements[0])
         self.assertEqual(activity["raw_decision_count"], 1)
         self.assertEqual(activity["lineage_matched_decision_count"], 1)
         self.assertEqual(activity["decision_count"], 1)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1096,6 +1096,18 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(activity["raw_decision_count"], 1)
         self.assertEqual(activity["lineage_matched_decision_count"], 1)
 
+    def test_source_activity_decision_query_timeout_fails_closed(self) -> None:
+        activity, rollback_count = self._source_activity_with_failing_query(
+            failure_call=2
+        )
+
+        self.assertEqual(rollback_count, 1)
+        self.assertTrue(activity["query_unavailable"])
+        self.assertEqual(activity["unavailable_source"], "trade_decisions")
+        self.assertEqual(activity["missing_reasons"], ["source_decisions_unavailable"])
+        self.assertEqual(activity["raw_decision_count"], 0)
+        self.assertEqual(activity["lineage_matched_decision_count"], 0)
+
     def test_source_activity_surfaces_expired_materialized_target_row(self) -> None:
         window_start = datetime(2026, 6, 3, 13, 30, tzinfo=timezone.utc)
         window_end = datetime(2026, 6, 3, 20, 0, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_paper_route_source_activity_latest_index_migration.py
+++ b/services/torghut/tests/test_paper_route_source_activity_latest_index_migration.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0051_paper_route_source_activity_latest_index.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0051", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0051")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestPaperRouteSourceActivityLatestIndexMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(
+            module.revision,
+            "0051_paper_route_source_activity_latest_index",
+        )
+        self.assertEqual(
+            module.down_revision,
+            "0050_tigerbeetle_reconciliation_compact_status",
+        )
+
+    def test_index_name_fits_postgres_identifier_limit(self) -> None:
+        module = _load_migration_module()
+
+        self.assertLessEqual(len(module.INDEX_NAME), 63)
+
+    def test_upgrade_adds_latest_source_activity_index(self) -> None:
+        module = _load_migration_module()
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_indexes.return_value = []
+
+        with (
+            patch.object(module.op, "get_bind", return_value=object()),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "create_index") as create_index,
+        ):
+            module.upgrade()
+
+        create_index.assert_called_once_with(
+            "ix_trade_decisions_account_strategy_symbol_created",
+            "trade_decisions",
+            [
+                "alpaca_account_label",
+                "strategy_id",
+                "symbol",
+                "created_at",
+            ],
+        )
+
+    def test_downgrade_drops_latest_source_activity_index(self) -> None:
+        module = _load_migration_module()
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+        inspector.get_indexes.return_value = [{"name": module.INDEX_NAME}]
+
+        with (
+            patch.object(module.op, "get_bind", return_value=object()),
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "drop_index") as drop_index,
+        ):
+            module.downgrade()
+
+        drop_index.assert_called_once_with(
+            "ix_trade_decisions_account_strategy_symbol_created",
+            table_name="trade_decisions",
+        )


### PR DESCRIPTION
## Summary

- Resolves strategy names before the paper-route source-activity `trade_decisions` read, avoiding the hot-path join against the large decision table.
- Adds a composite `trade_decisions` index for account, strategy, symbol, and created-at bounded latest-window reads.
- Keeps evidence reads fail-closed on timeouts and adds tests for the no-join source read plus the new migration.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k 'source_activity_query_timeout_fails_closed or source_activity_timeout_suppresses_rollback_failure or source_activity_execution_query_timeout_fails_closed or source_activity_order_event_query_timeout_fails_closed or source_activity_tca_query_timeout_fails_closed or source_activity_reuses_exact_lineage_readback_without_broad_rescan or source_activity_noisy_dataset_is_bounded_and_reports_truncation' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_check_migration_graph.py tests/test_paper_route_source_activity_latest_index_migration.py -q`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py app/models/entities.py migrations/versions/0051_paper_route_source_activity_latest_index.py tests/test_paper_route_evidence.py tests/test_paper_route_source_activity_latest_index_migration.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py app/models/entities.py migrations/versions/0051_paper_route_source_activity_latest_index.py tests/test_paper_route_evidence.py tests/test_paper_route_source_activity_latest_index_migration.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check origin/main..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Includes a forward migration that adds a read-path index on `trade_decisions`.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
