### PR TITLE
fix(torghut): build source activity index concurrently

### DIFF
--- a/services/torghut/migrations/versions/0051_paper_route_source_activity_latest_index.py
+++ b/services/torghut/migrations/versions/0051_paper_route_source_activity_latest_index.py
@@ -35,7 +35,10 @@ def upgrade() -> None:
     existing_indexes = {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
     if INDEX_NAME in existing_indexes:
         return
-    op.create_index(INDEX_NAME, TABLE_NAME, list(INDEX_COLUMNS))
+    with op.get_context().autocommit_block():
+        op.create_index(
+            INDEX_NAME, TABLE_NAME, list(INDEX_COLUMNS), postgresql_concurrently=True
+        )
 
 
 def downgrade() -> None:
@@ -46,4 +49,5 @@ def downgrade() -> None:
     existing_indexes = {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
     if INDEX_NAME not in existing_indexes:
         return
-    op.drop_index(INDEX_NAME, table_name=TABLE_NAME)
+    with op.get_context().autocommit_block():
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME, postgresql_concurrently=True)

--- a/services/torghut/tests/test_paper_route_source_activity_latest_index_migration.py
+++ b/services/torghut/tests/test_paper_route_source_activity_latest_index_migration.py
@@ -48,11 +48,13 @@ class TestPaperRouteSourceActivityLatestIndexMigration(TestCase):
 
         with (
             patch.object(module.op, "get_bind", return_value=object()),
+            patch.object(module.op, "get_context") as get_context,
             patch.object(module, "inspect", return_value=inspector),
             patch.object(module.op, "create_index") as create_index,
         ):
             module.upgrade()
 
+        get_context.return_value.autocommit_block.assert_called_once_with()
         create_index.assert_called_once_with(
             "ix_trade_decisions_account_strategy_symbol_created",
             "trade_decisions",
@@ -62,6 +64,7 @@ class TestPaperRouteSourceActivityLatestIndexMigration(TestCase):
                 "symbol",
                 "created_at",
             ],
+            postgresql_concurrently=True,
         )
 
     def test_downgrade_drops_latest_source_activity_index(self) -> None:
@@ -72,12 +75,15 @@ class TestPaperRouteSourceActivityLatestIndexMigration(TestCase):
 
         with (
             patch.object(module.op, "get_bind", return_value=object()),
+            patch.object(module.op, "get_context") as get_context,
             patch.object(module, "inspect", return_value=inspector),
             patch.object(module.op, "drop_index") as drop_index,
         ):
             module.downgrade()
 
+        get_context.return_value.autocommit_block.assert_called_once_with()
         drop_index.assert_called_once_with(
             "ix_trade_decisions_account_strategy_symbol_created",
             table_name="trade_decisions",
+            postgresql_concurrently=True,
         )


### PR DESCRIPTION
## Summary

- Makes the new paper-route source activity `trade_decisions` index build concurrently.
- Wraps concurrent create/drop index operations in Alembic autocommit blocks.
- Extends the migration regression test to enforce concurrent index creation and drop behavior.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_source_activity_latest_index_migration.py tests/test_check_migration_graph.py -q`
- `uv run --frozen ruff format --check migrations/versions/0051_paper_route_source_activity_latest_index.py tests/test_paper_route_source_activity_latest_index_migration.py`
- `uv run --frozen ruff check migrations/versions/0051_paper_route_source_activity_latest_index.py tests/test_paper_route_source_activity_latest_index_migration.py`
- `git diff --check`

## Breaking Changes

None. The migration still adds the same index, but now uses PostgreSQL concurrent index operations to avoid blocking writes on the live `trade_decisions` table.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
