### PR TITLE
fix(torghut): repair linked order-feed execution state

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -1790,8 +1790,9 @@ def latest_order_event_for_execution(
         select(ExecutionOrderEvent)
         .where(or_(*filters))
         .order_by(
-            ExecutionOrderEvent.event_ts.desc().nullslast(),
             ExecutionOrderEvent.feed_seq.desc().nullslast(),
+            ExecutionOrderEvent.source_offset.desc().nullslast(),
+            ExecutionOrderEvent.event_ts.desc().nullslast(),
             ExecutionOrderEvent.created_at.desc(),
         )
         .limit(1)
@@ -2140,6 +2141,63 @@ def repair_order_feed_execution_links(
         counters["events_linked"] += linked
         if source_account_label is not None:
             counters["account_alias_events_linked"] += linked
+    return counters
+
+
+def repair_order_feed_execution_states(
+    session: Session,
+    *,
+    account_label: str | None = None,
+    limit: int = 1000,
+) -> dict[str, int]:
+    """Reapply linked order-feed lifecycle rows to durable executions.
+
+    Link repair can attach historical events after an execution already has
+    lifecycle state. This bounded pass lets the stream-authoritative latest
+    linked event correct stale partial-fill state without synthesizing fills.
+    """
+
+    bounded_limit = max(1, min(int(limit), 5000))
+    stmt = (
+        select(Execution)
+        .where(
+            Execution.trade_decision_id.is_not(None),
+            exists().where(ExecutionOrderEvent.execution_id == Execution.id),
+        )
+        .order_by(
+            Execution.order_feed_last_seq.desc().nullslast(),
+            Execution.order_feed_last_event_ts.desc().nullslast(),
+            Execution.updated_at.desc(),
+            Execution.created_at.desc(),
+            Execution.id.asc(),
+        )
+        .limit(bounded_limit)
+    )
+    if account_label:
+        stmt = stmt.where(Execution.alpaca_account_label == account_label)
+
+    executions = session.execute(stmt).scalars().all()
+    counters = {
+        "selected": len(executions),
+        "latest_event_found": 0,
+        "executions_updated": 0,
+        "out_of_order_events_skipped": 0,
+    }
+    for execution in executions:
+        latest_event = latest_order_event_for_execution(session, execution)
+        if latest_event is None:
+            continue
+        counters["latest_event_found"] += 1
+        updated, out_of_order = apply_order_event_to_execution(execution, latest_event)
+        if out_of_order:
+            counters["out_of_order_events_skipped"] += 1
+            continue
+        if not updated:
+            continue
+        _update_trade_decision_from_execution(session, execution)
+        upsert_execution_tca_metric(session, execution)
+        session.add(execution)
+        counters["executions_updated"] += 1
     return counters
 
 
@@ -3338,6 +3396,8 @@ def _is_stale_by_seq(execution: Execution, event: ExecutionOrderEvent) -> bool:
 
 
 def _is_stale_by_ts(execution: Execution, event: ExecutionOrderEvent) -> bool:
+    if execution.order_feed_last_seq is not None and event.feed_seq is not None:
+        return False
     candidate_ts = event.event_ts
     if candidate_ts is None:
         return False
@@ -3391,6 +3451,7 @@ __all__ = [
     "backfill_order_feed_source_windows",
     "link_order_events_to_execution",
     "repair_order_feed_execution_links",
+    "repair_order_feed_execution_states",
     "repair_order_feed_fill_deltas",
     "latest_order_event_for_execution",
 ]

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -16,6 +16,7 @@ from app.trading.order_feed import (
     backfill_order_feed_events_from_executions,
     backfill_order_feed_source_windows,
     repair_order_feed_execution_links,
+    repair_order_feed_execution_states,
     repair_order_feed_fill_deltas,
 )
 
@@ -89,6 +90,18 @@ def _payload(
         ),
         "execution_link_account_alias_events_linked": sum(
             batch["execution_link_account_alias_events_linked"] for batch in batches
+        ),
+        "execution_state_candidates": sum(
+            batch["execution_state_candidates"] for batch in batches
+        ),
+        "execution_state_latest_event_found": sum(
+            batch["execution_state_latest_event_found"] for batch in batches
+        ),
+        "execution_state_executions_updated": sum(
+            batch["execution_state_executions_updated"] for batch in batches
+        ),
+        "execution_state_out_of_order_events_skipped": sum(
+            batch["execution_state_out_of_order_events_skipped"] for batch in batches
         ),
         "execution_event_backfill_candidates": sum(
             batch["execution_event_backfill_candidates"] for batch in batches
@@ -229,6 +242,14 @@ def main() -> int:
                 canonical_account_label=args.canonical_account_label,
                 limit=batch_size,
             )
+            execution_state_account_label = (
+                args.canonical_account_label or args.account_label
+            )
+            execution_state_batch = repair_order_feed_execution_states(
+                session,
+                account_label=execution_state_account_label,
+                limit=batch_size,
+            )
             execution_event_backfill_batch = (
                 backfill_order_feed_events_from_executions(
                     session,
@@ -268,6 +289,16 @@ def main() -> int:
                 "execution_link_account_alias_events_linked": execution_link_batch.get(
                     "account_alias_events_linked", 0
                 ),
+                "execution_state_candidates": execution_state_batch["selected"],
+                "execution_state_latest_event_found": execution_state_batch[
+                    "latest_event_found"
+                ],
+                "execution_state_executions_updated": execution_state_batch[
+                    "executions_updated"
+                ],
+                "execution_state_out_of_order_events_skipped": execution_state_batch[
+                    "out_of_order_events_skipped"
+                ],
                 "execution_event_backfill_candidates": execution_event_backfill_batch[
                     "selected"
                 ],
@@ -309,6 +340,7 @@ def main() -> int:
             if (
                 int(source_window_batch.get("selected") or 0) < batch_size
                 and int(execution_link_batch.get("selected") or 0) < batch_size
+                and int(execution_state_batch.get("selected") or 0) < batch_size
                 and int(execution_event_backfill_batch.get("selected") or 0)
                 < batch_size
                 and int(fill_delta_batch.get("selected") or 0) < batch_size

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -52,6 +52,7 @@ from app.trading.order_feed import (
     normalize_order_feed_record,
     persist_order_event,
     repair_order_feed_execution_links,
+    repair_order_feed_execution_states,
     repair_order_feed_fill_deltas,
 )
 
@@ -1823,6 +1824,152 @@ class TestOrderFeed(TestCase):
             unmatched_source_window.payload_json["linkage_blockers"],
             ["missing_execution_link", "missing_trade_decision_link"],
         )
+
+    def test_repair_order_feed_execution_states_reapplies_latest_stream_sequence(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session, account_label="TORGHUT_SIM")
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+            partial_event_ts = datetime(
+                2026, 2, 1, 10, 0, 0, 360000, tzinfo=timezone.utc
+            )
+            execution.status = "partially_filled"
+            execution.filled_qty = Decimal("0.16140000")
+            execution.avg_fill_price = Decimal("311.01")
+            execution.order_feed_last_seq = 183689
+            execution.order_feed_last_event_ts = partial_event_ts
+            session.add(execution)
+            partial_event = ExecutionOrderEvent(
+                event_fingerprint="repair-state-partial-later-event-ts",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=66072,
+                feed_seq=183689,
+                alpaca_account_label="PA3SX7FYNUTF",
+                event_ts=partial_event_ts,
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                execution_id=execution_id,
+                trade_decision_id=trade_decision_id,
+                event_type="partial_fill",
+                status="partially_filled",
+                filled_qty=Decimal("0.1614"),
+                avg_fill_price=Decimal("311.01"),
+                raw_event={"event": "partial_fill"},
+            )
+            fill_event = ExecutionOrderEvent(
+                event_fingerprint="repair-state-fill-higher-feed-seq",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=66073,
+                feed_seq=183690,
+                alpaca_account_label="PA3SX7FYNUTF",
+                event_ts=datetime(2026, 2, 1, 10, 0, 0, 358000, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                execution_id=execution_id,
+                trade_decision_id=trade_decision_id,
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("311.01"),
+                raw_event={"event": "fill"},
+            )
+            session.add_all([partial_event, fill_event])
+            session.commit()
+
+            result = repair_order_feed_execution_states(
+                session,
+                account_label="TORGHUT_SIM",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(execution)
+
+        self.assertEqual(
+            result,
+            {
+                "selected": 1,
+                "latest_event_found": 1,
+                "executions_updated": 1,
+                "out_of_order_events_skipped": 0,
+            },
+        )
+        self.assertEqual(execution.status, "filled")
+        self.assertEqual(execution.filled_qty, Decimal("1.00000000"))
+        self.assertEqual(execution.order_feed_last_seq, 183690)
+
+    def test_repair_order_feed_execution_states_counts_non_updating_outcomes(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            executions = [
+                self._seed_execution(
+                    session,
+                    account_label="TORGHUT_SIM",
+                    order_id=f"state-branch-order-{index}",
+                    client_order_id=f"state-branch-client-{index}",
+                )
+                for index in range(3)
+            ]
+            linked_events = []
+            for index, execution in enumerate(executions):
+                event = ExecutionOrderEvent(
+                    event_fingerprint=f"repair-state-branch-event-{index}",
+                    source_topic="torghut.trade-updates.v1",
+                    source_partition=0,
+                    source_offset=67000 + index,
+                    feed_seq=184000 + index,
+                    alpaca_account_label="TORGHUT_SIM",
+                    event_ts=datetime(2026, 2, 1, 10, index, tzinfo=timezone.utc),
+                    symbol="AAPL",
+                    alpaca_order_id=execution.alpaca_order_id,
+                    client_order_id=execution.client_order_id,
+                    execution_id=execution.id,
+                    trade_decision_id=execution.trade_decision_id,
+                    event_type="fill",
+                    status="filled",
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("311.01"),
+                    raw_event={"event": "fill"},
+                )
+                linked_events.append(event)
+            session.add_all(linked_events)
+            session.commit()
+
+            with (
+                patch.object(
+                    order_feed_module,
+                    "latest_order_event_for_execution",
+                    side_effect=[None, linked_events[1], linked_events[2]],
+                ) as latest_event,
+                patch.object(
+                    order_feed_module,
+                    "apply_order_event_to_execution",
+                    side_effect=[(False, True), (False, False)],
+                ) as apply_event,
+            ):
+                result = repair_order_feed_execution_states(
+                    session,
+                    account_label="TORGHUT_SIM",
+                    limit=10,
+                )
+
+        self.assertEqual(
+            result,
+            {
+                "selected": 3,
+                "latest_event_found": 2,
+                "executions_updated": 0,
+                "out_of_order_events_skipped": 1,
+            },
+        )
+        self.assertEqual(latest_event.call_count, 3)
+        self.assertEqual(apply_event.call_count, 2)
 
     def test_repair_order_feed_execution_links_links_by_alpaca_order_id_only(
         self,

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -95,6 +95,16 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             ) as backfill_execution_events,
             patch.object(
                 script,
+                "repair_order_feed_execution_states",
+                return_value={
+                    "selected": 7,
+                    "latest_event_found": 6,
+                    "executions_updated": 5,
+                    "out_of_order_events_skipped": 1,
+                },
+            ) as repair_states,
+            patch.object(
+                script,
                 "repair_order_feed_fill_deltas",
                 return_value={
                     "selected": 6,
@@ -128,6 +138,10 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_link_decision_events_linked"], 1)
         self.assertEqual(payload["execution_link_events_without_execution"], 1)
         self.assertEqual(payload["execution_link_events_without_decision"], 0)
+        self.assertEqual(payload["execution_state_candidates"], 7)
+        self.assertEqual(payload["execution_state_latest_event_found"], 6)
+        self.assertEqual(payload["execution_state_executions_updated"], 5)
+        self.assertEqual(payload["execution_state_out_of_order_events_skipped"], 1)
         self.assertEqual(payload["execution_event_backfill_candidates"], 0)
         self.assertEqual(payload["execution_event_backfill_events_created"], 0)
         self.assertEqual(payload["execution_event_backfill_source_windows_created"], 0)
@@ -154,6 +168,11 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             limit=5000,
         )
         backfill_execution_events.assert_not_called()
+        repair_states.assert_called_once_with(
+            fake_session,
+            account_label=None,
+            limit=5000,
+        )
         repair_deltas.assert_called_once_with(
             fake_session,
             account_label=None,
@@ -238,6 +257,24 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             ) as backfill_execution_events,
             patch.object(
                 script,
+                "repair_order_feed_execution_states",
+                side_effect=[
+                    {
+                        "selected": 2,
+                        "latest_event_found": 2,
+                        "executions_updated": 2,
+                        "out_of_order_events_skipped": 0,
+                    },
+                    {
+                        "selected": 1,
+                        "latest_event_found": 1,
+                        "executions_updated": 0,
+                        "out_of_order_events_skipped": 1,
+                    },
+                ],
+            ) as repair_states,
+            patch.object(
+                script,
                 "repair_order_feed_fill_deltas",
                 side_effect=[
                     {
@@ -277,6 +314,10 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_link_decision_events_linked"], 0)
         self.assertEqual(payload["execution_link_events_without_execution"], 0)
         self.assertEqual(payload["execution_link_events_without_decision"], 0)
+        self.assertEqual(payload["execution_state_candidates"], 3)
+        self.assertEqual(payload["execution_state_latest_event_found"], 3)
+        self.assertEqual(payload["execution_state_executions_updated"], 2)
+        self.assertEqual(payload["execution_state_out_of_order_events_skipped"], 1)
         self.assertEqual(payload["fill_delta_candidates"], 3)
         self.assertEqual(payload["fill_delta_events_repaired"], 2)
         self.assertEqual(payload["fill_delta_non_increasing_events_marked"], 1)
@@ -291,6 +332,9 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertIsNone(repair_links.call_args.kwargs["canonical_account_label"])
         self.assertEqual(repair_links.call_args.kwargs["limit"], 2)
         backfill_execution_events.assert_not_called()
+        self.assertEqual(repair_states.call_count, 2)
+        self.assertEqual(repair_states.call_args.kwargs["account_label"], "TORGHUT_SIM")
+        self.assertEqual(repair_states.call_args.kwargs["limit"], 2)
         self.assertEqual(repair_deltas.call_count, 2)
         self.assertEqual(repair_deltas.call_args.kwargs["account_label"], "TORGHUT_SIM")
         self.assertEqual(repair_deltas.call_args.kwargs["limit"], 2)
@@ -361,6 +405,16 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             ) as backfill_execution_events,
             patch.object(
                 script,
+                "repair_order_feed_execution_states",
+                return_value={
+                    "selected": 0,
+                    "latest_event_found": 0,
+                    "executions_updated": 0,
+                    "out_of_order_events_skipped": 0,
+                },
+            ) as repair_states,
+            patch.object(
+                script,
                 "repair_order_feed_fill_deltas",
                 return_value={
                     "selected": 0,
@@ -380,6 +434,8 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_event_backfill_enabled"], True)
         self.assertIsNone(payload["execution_event_backfill_skip_reason"])
         self.assertEqual(payload["account_label"], "PA3SX7FYNUTF")
+        self.assertEqual(payload["execution_state_candidates"], 0)
+        self.assertEqual(payload["execution_state_executions_updated"], 0)
         self.assertEqual(payload["execution_event_backfill_candidates"], 7)
         self.assertEqual(payload["execution_event_backfill_events_created"], 6)
         self.assertEqual(payload["execution_event_backfill_source_windows_created"], 6)
@@ -388,6 +444,11 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["fill_delta_events_repaired"], 0)
         self.assertEqual(fake_session.commits, 1)
         backfill_execution_events.assert_called_once_with(
+            fake_session,
+            account_label="PA3SX7FYNUTF",
+            limit=100,
+        )
+        repair_states.assert_called_once_with(
             fake_session,
             account_label="PA3SX7FYNUTF",
             limit=100,
@@ -461,6 +522,16 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             ) as backfill_execution_events,
             patch.object(
                 script,
+                "repair_order_feed_execution_states",
+                return_value={
+                    "selected": 1,
+                    "latest_event_found": 1,
+                    "executions_updated": 1,
+                    "out_of_order_events_skipped": 0,
+                },
+            ) as repair_states,
+            patch.object(
+                script,
                 "repair_order_feed_fill_deltas",
                 return_value={
                     "selected": 0,
@@ -485,7 +556,14 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_event_backfill_candidates"], 0)
         self.assertEqual(payload["execution_event_backfill_events_created"], 0)
         self.assertEqual(payload["execution_link_account_alias_events_linked"], 1)
+        self.assertEqual(payload["execution_state_candidates"], 1)
+        self.assertEqual(payload["execution_state_executions_updated"], 1)
         backfill_execution_events.assert_not_called()
+        repair_states.assert_called_once_with(
+            fake_session,
+            account_label="TORGHUT_SIM",
+            limit=100,
+        )
 
     def test_main_requires_configured_dsn_env(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- Make order-feed lifecycle repair choose the latest broker lifecycle event by stream sequence before event timestamp.
- Add a bounded execution-state repair pass that reapplies already-linked lifecycle events to durable executions.
- Wire the source-window repair script to run execution-state repair against the canonical account during account-alias repair.
- Add regressions for timestamp-jitter partial fills and the repair script payload/canonical-account routing.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_order_feed.py -k 'latest_stream_sequence or execution_states or prioritizes_recent_account_alias_event or resolves_configured_account_alias or marks_missing_links_to_advance_scan' tests/test_repair_order_feed_source_windows_script.py tests/test_live_config_manifest_contract.py -k 'repair_order_feed_source_window or skips_execution_event_backfill_for_account_alias_repair or latest_stream_sequence or execution_states or prioritizes_recent_account_alias_event or resolves_configured_account_alias or marks_missing_links_to_advance_scan' -q`
- `uv run --frozen ruff format --check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py`
- `uv run --frozen ruff check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py`
- `bun run lint:argocd`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
