### PR TITLE
fix(torghut): preserve source collection lineage

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -59,6 +59,15 @@ from .session_context import is_regular_equities_session_date
 logger = logging.getLogger(__name__)
 
 
+def _paper_route_evidence_query_timeout_ms() -> int:
+    raw_value = os.getenv("TORGHUT_PAPER_ROUTE_EVIDENCE_QUERY_TIMEOUT_MS", "1500")
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        return 1500
+    return max(250, min(value, 5000))
+
+
 PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = "torghut.paper-route-evidence.v1"
 PAPER_ROUTE_TARGET_PLAN_PAYLOAD_SCHEMA_VERSION = "torghut.paper-route-target-plan.v1"
 NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION = (
@@ -92,7 +101,7 @@ PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT = 100
 PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT = 25
 MAX_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 168
 MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
-PAPER_ROUTE_EVIDENCE_QUERY_TIMEOUT_MS = 5000
+PAPER_ROUTE_EVIDENCE_QUERY_TIMEOUT_MS = _paper_route_evidence_query_timeout_ms()
 US_EQUITIES_TIMEZONE = "America/New_York"
 US_EQUITIES_OPEN = time(hour=9, minute=30)
 US_EQUITIES_CLOSE = time(hour=16, minute=0)
@@ -578,6 +587,34 @@ def _unique_text_items(value: object) -> list[str]:
         item = str(raw_item).strip()
         if item and item not in items:
             items.append(item)
+    return items
+
+
+def _unique_source_offset_items(value: object) -> list[dict[str, object]]:
+    items: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for raw_item in _as_sequence(value):
+        item = _as_mapping(raw_item)
+        topic = _safe_text(item.get("topic")) or _safe_text(item.get("source_topic"))
+        partition = _safe_text(item.get("partition")) or _safe_text(
+            item.get("source_partition")
+        )
+        offset = _safe_text(item.get("offset")) or _safe_text(item.get("source_offset"))
+        if topic is None or partition is None or offset is None:
+            continue
+        key = (topic, partition, offset)
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append(
+            {
+                "topic": topic,
+                "partition": int(partition)
+                if partition.lstrip("-").isdigit()
+                else partition,
+                "offset": int(offset) if offset.lstrip("-").isdigit() else offset,
+            }
+        )
     return items
 
 
@@ -9193,6 +9230,60 @@ def _sanitized_runtime_ledger_source_collection_target(
     sanitized.update(_runtime_window_import_target_metadata(target))
     if runtime_ledger_bucket_ref := _safe_text(target.get("runtime_ledger_bucket_ref")):
         sanitized["runtime_ledger_bucket_ref"] = runtime_ledger_bucket_ref
+    for source_key, sanitized_key in (
+        ("source_window_ids", "source_window_ids"),
+        ("runtime_ledger_source_window_ids", "runtime_ledger_source_window_ids"),
+        ("execution_order_event_ids", "execution_order_event_ids"),
+        (
+            "runtime_ledger_execution_order_event_ids",
+            "runtime_ledger_execution_order_event_ids",
+        ),
+        ("execution_ids", "execution_ids"),
+        ("runtime_ledger_execution_ids", "runtime_ledger_execution_ids"),
+        ("execution_tca_metric_ids", "execution_tca_metric_ids"),
+        (
+            "runtime_ledger_execution_tca_metric_ids",
+            "runtime_ledger_execution_tca_metric_ids",
+        ),
+        ("trade_decision_ids", "trade_decision_ids"),
+        (
+            "runtime_ledger_trade_decision_ids",
+            "runtime_ledger_trade_decision_ids",
+        ),
+        ("source_materializations", "source_materializations"),
+        ("authority_classes", "authority_classes"),
+        ("authority_reasons", "authority_reasons"),
+    ):
+        if values := _unique_text_items(target.get(source_key)):
+            sanitized[sanitized_key] = values
+    if source_refs := [
+        ref
+        for ref in _unique_text_items(target.get("source_refs"))
+        if "strategy_runtime_ledger_buckets" not in ref
+    ]:
+        sanitized["source_refs"] = source_refs
+    if source_offsets := _unique_source_offset_items(target.get("source_offsets")):
+        sanitized["source_offsets"] = source_offsets
+    if source_row_counts := _as_mapping(target.get("source_row_counts")):
+        sanitized["source_row_counts"] = {
+            key: count
+            for key, raw_count in source_row_counts.items()
+            if (count := _safe_int(raw_count)) > 0
+        }
+    for source_key, sanitized_key in (
+        ("source_materialization", "source_materialization"),
+        ("authority_class", "authority_class"),
+        ("authority_reason", "authority_reason"),
+    ):
+        if value := _safe_text(target.get(source_key)):
+            sanitized[sanitized_key] = value
+            plural_key = (
+                "authority_classes"
+                if sanitized_key == "authority_class"
+                else f"{sanitized_key}s"
+            )
+            if plural_key not in sanitized:
+                sanitized[plural_key] = [value]
     observed_from_contaminated_target = _as_mapping(
         target.get("observed_from_contaminated_target")
     )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import tempfile
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -69,6 +70,26 @@ class TestPaperRouteEvidenceAudit(TestCase):
             poolclass=StaticPool,
         )
         Base.metadata.create_all(self.engine)
+
+    def test_paper_route_evidence_query_timeout_is_bounded(self) -> None:
+        with patch.dict(
+            os.environ, {"TORGHUT_PAPER_ROUTE_EVIDENCE_QUERY_TIMEOUT_MS": "10000"}
+        ):
+            self.assertEqual(
+                paper_route_evidence._paper_route_evidence_query_timeout_ms(), 5000
+            )
+        with patch.dict(
+            os.environ, {"TORGHUT_PAPER_ROUTE_EVIDENCE_QUERY_TIMEOUT_MS": "50"}
+        ):
+            self.assertEqual(
+                paper_route_evidence._paper_route_evidence_query_timeout_ms(), 250
+            )
+        with patch.dict(
+            os.environ, {"TORGHUT_PAPER_ROUTE_EVIDENCE_QUERY_TIMEOUT_MS": "bad"}
+        ):
+            self.assertEqual(
+                paper_route_evidence._paper_route_evidence_query_timeout_ms(), 1500
+            )
 
     def test_order_event_source_offset_refs_skip_deduplicate_and_limit(self) -> None:
         rows = [
@@ -5531,16 +5552,34 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         "target_dsn_env": "SIM_DB_DSN",
                         "source_row_counts": {"execution_order_events": 2},
                         "source_window_ids": ["window-1"],
+                        "runtime_ledger_source_window_ids": ["runtime-window-1"],
                         "execution_order_event_ids": ["event-1", "event-2"],
+                        "runtime_ledger_execution_order_event_ids": ["runtime-event-1"],
                         "execution_ids": ["execution-1"],
+                        "runtime_ledger_execution_ids": ["runtime-execution-1"],
+                        "execution_tca_metric_ids": ["tca-1"],
+                        "runtime_ledger_execution_tca_metric_ids": ["runtime-tca-1"],
                         "trade_decision_ids": ["decision-1"],
+                        "runtime_ledger_trade_decision_ids": ["runtime-decision-1"],
                         "source_offsets": [
                             {
                                 "topic": "trade_updates",
                                 "partition": 0,
                                 "offset": 101,
-                            }
+                            },
+                            {
+                                "source_topic": "trade_updates",
+                                "source_partition": "0",
+                                "source_offset": "101",
+                            },
                         ],
+                        "source_refs": [
+                            ("strategy_runtime_ledger_buckets:run-1:start:end"),
+                            "postgres:execution_order_events:event-1",
+                        ],
+                        "source_materialization": "execution_order_events",
+                        "authority_class": "runtime_order_feed_execution_source",
+                        "authority_reason": "source_offsets_and_order_events_present",
                         "live_paper_evidence_requirements": [
                             "runtime_ledger_source_materialization",
                             "runtime_ledger_execution_refs",
@@ -5581,6 +5620,55 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(
             target["runtime_ledger_bucket_ref"],
             "strategy_runtime_ledger_buckets:run-1:start:end",
+        )
+        self.assertEqual(target["source_window_ids"], ["window-1"])
+        self.assertEqual(
+            target["runtime_ledger_source_window_ids"],
+            ["runtime-window-1"],
+        )
+        self.assertEqual(target["execution_order_event_ids"], ["event-1", "event-2"])
+        self.assertEqual(
+            target["runtime_ledger_execution_order_event_ids"],
+            ["runtime-event-1"],
+        )
+        self.assertEqual(target["execution_ids"], ["execution-1"])
+        self.assertEqual(
+            target["runtime_ledger_execution_ids"], ["runtime-execution-1"]
+        )
+        self.assertEqual(target["execution_tca_metric_ids"], ["tca-1"])
+        self.assertEqual(
+            target["runtime_ledger_execution_tca_metric_ids"],
+            ["runtime-tca-1"],
+        )
+        self.assertEqual(target["trade_decision_ids"], ["decision-1"])
+        self.assertEqual(
+            target["runtime_ledger_trade_decision_ids"],
+            ["runtime-decision-1"],
+        )
+        self.assertEqual(
+            target["source_offsets"],
+            [{"topic": "trade_updates", "partition": 0, "offset": 101}],
+        )
+        self.assertEqual(
+            target["source_refs"], ["postgres:execution_order_events:event-1"]
+        )
+        self.assertEqual(target["source_row_counts"], {"execution_order_events": 2})
+        self.assertEqual(target["source_materialization"], "execution_order_events")
+        self.assertEqual(target["source_materializations"], ["execution_order_events"])
+        self.assertEqual(
+            target["authority_class"], "runtime_order_feed_execution_source"
+        )
+        self.assertEqual(
+            target["authority_classes"],
+            ["runtime_order_feed_execution_source"],
+        )
+        self.assertEqual(
+            target["authority_reason"],
+            "source_offsets_and_order_events_present",
+        )
+        self.assertEqual(
+            target["authority_reasons"],
+            ["source_offsets_and_order_events_present"],
         )
         self.assertEqual(target["artifact_refs"], ["runtime-ledger/proof.json"])
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Preserve source-window, execution, TCA, decision, source-offset, source-ref, materialization, and authority markers when sanitizing runtime-ledger source-collection targets.
- Keep unsafe aggregate replay bucket refs filtered out of source refs while retaining real materializable lineage.
- Bound paper-route evidence SQL statement timeouts to a 1.5s default with a safe env override so slow source-activity reads fail closed without consuming the whole endpoint budget.
- Add focused paper-route evidence regression coverage that proves lineage survives sanitization and promotion/live-capital authority remains stripped.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "paper_route_evidence_query_timeout_is_bounded or source_collection_import_plan_sanitizer_filters_and_preserves_refs or source_collection_import_allows_aggregate_replay_with_materializable_lineage or source_collection_import_plan_skips_aggregate_replay_bucket_without_lineage" -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "main_audit_only_reports_source_to_ledger_path_without_persisting or query_timestamps_requires_source_lineage_for_candidate_import or source_activity_diagnostic_blockers_classify_materialization_gap" -q`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -k "packet_blocks_authority_when_runtime_import_readback_lacks_source_refs or packet_blocks_runtime_import_profit_proof_blockers or packet_blocks_runtime_import_without_materialized_runtime_ledger" -q`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
