### PR TITLE
fix(torghut): rank replay ledgers by execution quality

### DIFF
--- a/services/torghut/app/trading/discovery/replay_ledger_ranker.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_ranker.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal, InvalidOperation
@@ -14,6 +14,7 @@ from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
 from app.trading.runtime_ledger import RuntimeLedgerBucket, build_runtime_ledger_buckets
 
 EXACT_REPLAY_LEDGER_RANKING_SCHEMA_VERSION = "torghut.exact-replay-ledger-ranking.v1"
+EXECUTION_QUALITY_SCHEMA_VERSION = "torghut.exact-replay-execution-quality.v1"
 _LIVE_PROMOTION_AUTHORITIES = frozenset(
     {
         "live",
@@ -22,6 +23,78 @@ _LIVE_PROMOTION_AUTHORITIES = frozenset(
         "runtime_execution_ledger",
         "live_paper_runtime_ledger",
     }
+)
+_EXECUTION_QUALITY_SOURCE_PAPERS = (
+    {
+        "source_id": "rof-rfaf049",
+        "url": "https://doi.org/10.1093/rof/rfaf049",
+        "title": "Retail Limit Orders",
+        "mechanism": "market_limit_order_type_fill_probability_price_improvement_opportunity_cost",
+    },
+    {
+        "source_id": "arxiv-2507.06345",
+        "url": "https://arxiv.org/abs/2507.06345",
+        "title": "Reinforcement Learning for Trade Execution with Market and Limit Orders",
+        "mechanism": "dynamic_market_limit_order_allocation_with_fill_uncertainty",
+    },
+    {
+        "source_id": "arxiv-2512.05734",
+        "url": "https://arxiv.org/abs/2512.05734",
+        "title": "KANFormer for Predicting Fill Probabilities via Survival Analysis in Limit Order Books",
+        "mechanism": "queue_position_time_to_fill_survival_fill_probability",
+    },
+)
+_ORDER_TYPE_FIELDS = (
+    "order_type",
+    "order_kind",
+    "execution_order_type",
+    "execution_type",
+    "order_instruction",
+    "route_order_type",
+    "adjusted_order_type",
+    "selected_order_type",
+)
+_FILL_STATUS_FIELDS = (
+    "fill_status",
+    "order_fill_status",
+    "execution_status",
+    "route_fill_status",
+    "order_status",
+    "status",
+)
+_EXECUTION_SHORTFALL_FIELDS = (
+    "execution_shortfall_bps",
+    "realized_shortfall_bps",
+    "shortfall_bps",
+    "route_tca_bps",
+    "arrival_shortfall_bps",
+)
+_PRICE_IMPROVEMENT_FIELDS = (
+    "price_improvement_bps",
+    "realized_price_improvement_bps",
+    "price_improvement_against_arrival_bps",
+)
+_OPPORTUNITY_COST_FIELDS = (
+    "nonfill_opportunity_cost_bps",
+    "opportunity_cost_bps",
+    "missed_fill_opportunity_cost_bps",
+)
+_QUEUE_POSITION_FIELDS = (
+    "queue_position",
+    "queue_ahead",
+    "queue_ahead_qty",
+    "queue_ahead_size",
+    "queue_rank",
+    "limit_queue_position",
+    "queue_ratio",
+    "queue_ahead_ratio",
+    "queue_position_ratio",
+)
+_LIMIT_FILL_PROBABILITY_FIELDS = (
+    "limit_fill_probability",
+    "fill_probability",
+    "estimated_limit_fill_probability",
+    "survival_fill_probability",
 )
 
 
@@ -95,6 +168,11 @@ class ReplayLedgerCandidateRanking:
     fills_with_participation_rate: int
     fills_with_capacity_warning_contract: int
     capacity_warning_counts: Mapping[str, int]
+    execution_quality: Mapping[str, object]
+    execution_quality_blockers: tuple[str, ...]
+    execution_quality_penalty_bps: Decimal
+    execution_quality_penalty_amount: Decimal
+    execution_quality_adjusted_window_net_pnl_per_day: Decimal
 
     def to_payload(self) -> dict[str, object]:
         return {
@@ -158,6 +236,15 @@ class ReplayLedgerCandidateRanking:
             ),
             "capacity_warning_counts": dict(
                 sorted(self.capacity_warning_counts.items())
+            ),
+            "execution_quality": _payload_object(self.execution_quality),
+            "execution_quality_blockers": list(self.execution_quality_blockers),
+            "execution_quality_penalty_bps": str(self.execution_quality_penalty_bps),
+            "execution_quality_penalty_amount": str(
+                self.execution_quality_penalty_amount
+            ),
+            "execution_quality_adjusted_window_net_pnl_per_day": str(
+                self.execution_quality_adjusted_window_net_pnl_per_day
             ),
         }
 
@@ -240,6 +327,22 @@ def rank_replay_ledger_payload(
     candidate_identity = _mapping(payload.get("candidate_identity"))
     cost_lineage = _mapping(payload.get("cost_lineage"))
     capacity_summary = _capacity_lineage_summary(rows)
+    execution_quality = _execution_quality_summary(
+        rows=rows,
+        total_filled_notional=total_filled_notional,
+        window_weekday_count=window_weekday_count,
+    )
+    execution_quality_penalty_bps = cast(
+        Decimal, execution_quality["execution_quality_penalty_bps"]
+    )
+    execution_quality_penalty_amount = _safe_divide(
+        total_filled_notional * execution_quality_penalty_bps,
+        Decimal("10000"),
+    )
+    execution_quality_adjusted_window_net_pnl_per_day = _safe_divide(
+        total_net - execution_quality_penalty_amount,
+        Decimal(window_weekday_count),
+    )
     blockers = _promotion_blockers(
         payload=payload,
         rows=rows,
@@ -316,13 +419,20 @@ def rank_replay_ledger_payload(
         candidate_identity=candidate_identity,
         cost_lineage=cost_lineage,
         fills_with_adv_notional=capacity_summary["fills_with_adv_notional"],
-        fills_with_participation_rate=capacity_summary[
-            "fills_with_participation_rate"
-        ],
+        fills_with_participation_rate=capacity_summary["fills_with_participation_rate"],
         fills_with_capacity_warning_contract=capacity_summary[
             "fills_with_capacity_warning_contract"
         ],
         capacity_warning_counts=capacity_summary["capacity_warning_counts"],
+        execution_quality=execution_quality,
+        execution_quality_blockers=tuple(
+            cast(tuple[str, ...], execution_quality["execution_quality_blockers"])
+        ),
+        execution_quality_penalty_bps=execution_quality_penalty_bps,
+        execution_quality_penalty_amount=execution_quality_penalty_amount,
+        execution_quality_adjusted_window_net_pnl_per_day=(
+            execution_quality_adjusted_window_net_pnl_per_day
+        ),
     )
 
 
@@ -502,7 +612,8 @@ def _candidate_identity_blockers(payload: Mapping[str, Any]) -> list[str]:
     identity = _mapping(payload.get("candidate_identity"))
     identity_candidate_id = _text(identity.get("candidate_id"))
     identity_hash = _text(
-        payload.get("candidate_identity_hash") or identity.get("candidate_identity_hash")
+        payload.get("candidate_identity_hash")
+        or identity.get("candidate_identity_hash")
     )
     if not candidate_id:
         blockers.append("candidate_id_missing")
@@ -577,6 +688,162 @@ def _capacity_lineage_summary(
     }
 
 
+def _execution_quality_summary(
+    *,
+    rows: Sequence[Mapping[str, object]],
+    total_filled_notional: Decimal,
+    window_weekday_count: int,
+) -> Mapping[str, object]:
+    submitted_rows = [row for row in rows if _event_type(row) == "order_submitted"]
+    fill_rows = [row for row in rows if _event_type(row) == "fill"]
+    order_type_by_order_id: dict[str, str] = {}
+    for row in rows:
+        order_id = _text(row.get("order_id"))
+        order_type = _normalized_order_type(_first_text(row, _ORDER_TYPE_FIELDS))
+        if order_id and order_type:
+            order_type_by_order_id[order_id] = order_type
+
+    submitted_order_types = [
+        _order_type_for_row(row, order_type_by_order_id) for row in submitted_rows
+    ]
+    fill_order_types = [
+        _order_type_for_row(row, order_type_by_order_id) for row in fill_rows
+    ]
+    order_type_counts = _count_texts(
+        order_type for order_type in submitted_order_types if order_type
+    )
+    order_type_fill_counts = _count_texts(
+        order_type for order_type in fill_order_types if order_type
+    )
+    limit_order_count = sum(
+        count
+        for order_type, count in order_type_counts.items()
+        if "limit" in order_type
+    )
+    limit_fill_count = sum(
+        count
+        for order_type, count in order_type_fill_counts.items()
+        if "limit" in order_type
+    )
+    market_order_count = order_type_counts.get("market", 0)
+    order_type_sample_count = sum(
+        1 for order_type in submitted_order_types if order_type
+    )
+    fill_order_type_sample_count = sum(
+        1 for order_type in fill_order_types if order_type
+    )
+    route_tca_samples = [
+        value
+        for row in fill_rows
+        if (value := _first_decimal(row, _EXECUTION_SHORTFALL_FIELDS)) is not None
+    ]
+    price_improvement_samples = [
+        value
+        for row in fill_rows
+        if (value := _first_decimal(row, _PRICE_IMPROVEMENT_FIELDS)) is not None
+    ]
+    opportunity_cost_samples = [
+        value
+        for row in rows
+        if (value := _first_decimal(row, _OPPORTUNITY_COST_FIELDS)) is not None
+    ]
+    queue_position_sample_count = sum(
+        1 for row in rows if _first_decimal(row, _QUEUE_POSITION_FIELDS) is not None
+    )
+    limit_fill_probability_samples = [
+        value
+        for row in rows
+        if (value := _first_decimal(row, _LIMIT_FILL_PROBABILITY_FIELDS)) is not None
+    ]
+    filled_status_count = sum(1 for row in rows if _row_has_fill_status(row))
+    blockers: list[str] = []
+    penalty_bps = Decimal("0")
+    if submitted_rows and order_type_sample_count < len(submitted_rows):
+        blockers.append("order_type_mix_evidence_incomplete")
+        penalty_bps += Decimal("4")
+    if fill_rows and fill_order_type_sample_count < len(fill_rows):
+        blockers.append("fill_order_type_evidence_incomplete")
+        penalty_bps += Decimal("3")
+    if fill_rows and len(route_tca_samples) < len(fill_rows):
+        blockers.append("execution_shortfall_evidence_incomplete")
+        penalty_bps += Decimal("6")
+    if (
+        limit_order_count > 0
+        and len(limit_fill_probability_samples) < limit_order_count
+    ):
+        blockers.append("limit_fill_probability_evidence_incomplete")
+        penalty_bps += Decimal("6")
+    if limit_order_count > 0 and queue_position_sample_count < limit_order_count:
+        blockers.append("queue_position_survival_evidence_incomplete")
+        penalty_bps += Decimal("6")
+    if limit_order_count > 0 and not price_improvement_samples:
+        blockers.append("price_improvement_evidence_incomplete")
+        penalty_bps += Decimal("2")
+    if limit_order_count > 0 and not opportunity_cost_samples:
+        blockers.append("nonfill_opportunity_cost_evidence_incomplete")
+        penalty_bps += Decimal("2")
+    limit_fill_rate = (
+        _safe_divide(Decimal(limit_fill_count), Decimal(limit_order_count))
+        if limit_order_count > 0
+        else None
+    )
+    if limit_fill_rate is not None and limit_fill_rate < Decimal("0.50"):
+        blockers.append("limit_fill_rate_below_execution_quality_floor")
+        penalty_bps += (Decimal("0.50") - limit_fill_rate) * Decimal("20")
+    avg_shortfall_bps = _average_decimal(route_tca_samples)
+    if avg_shortfall_bps is not None and avg_shortfall_bps > Decimal("8"):
+        blockers.append("execution_shortfall_bps_above_quality_floor")
+        penalty_bps += avg_shortfall_bps - Decimal("8")
+    avg_opportunity_cost_bps = _average_decimal(opportunity_cost_samples)
+    if avg_opportunity_cost_bps is not None and avg_opportunity_cost_bps > Decimal("8"):
+        blockers.append("nonfill_opportunity_cost_bps_above_quality_floor")
+        penalty_bps += avg_opportunity_cost_bps - Decimal("8")
+    penalty_amount = _safe_divide(total_filled_notional * penalty_bps, Decimal("10000"))
+    return {
+        "schema_version": EXECUTION_QUALITY_SCHEMA_VERSION,
+        "source_papers": [dict(item) for item in _EXECUTION_QUALITY_SOURCE_PAPERS],
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_order_lifecycle_fill_evidence": True,
+            "requires_runtime_ledger": True,
+            "rejects_model_fill_probability_as_fill_authority": True,
+            "rejects_adjusted_pnl_as_promotion_authority": True,
+        },
+        "submitted_order_count": len(submitted_rows),
+        "fill_count": len(fill_rows),
+        "order_type_sample_count": order_type_sample_count,
+        "fill_order_type_sample_count": fill_order_type_sample_count,
+        "order_type_counts": order_type_counts,
+        "order_type_fill_counts": order_type_fill_counts,
+        "market_order_count": market_order_count,
+        "limit_order_count": limit_order_count,
+        "limit_fill_count": limit_fill_count,
+        "limit_fill_rate": limit_fill_rate,
+        "filled_status_count": filled_status_count,
+        "execution_shortfall_sample_count": len(route_tca_samples),
+        "avg_execution_shortfall_bps": avg_shortfall_bps,
+        "price_improvement_sample_count": len(price_improvement_samples),
+        "avg_price_improvement_bps": _average_decimal(price_improvement_samples),
+        "nonfill_opportunity_cost_sample_count": len(opportunity_cost_samples),
+        "avg_nonfill_opportunity_cost_bps": avg_opportunity_cost_bps,
+        "queue_position_sample_count": queue_position_sample_count,
+        "limit_fill_probability_sample_count": len(limit_fill_probability_samples),
+        "avg_limit_fill_probability": _average_decimal(limit_fill_probability_samples),
+        "execution_quality_blockers": tuple(_dedupe(blockers)),
+        "execution_quality_penalty_bps": penalty_bps,
+        "execution_quality_penalty_amount": penalty_amount,
+        "execution_quality_penalty_per_window_weekday": _safe_divide(
+            penalty_amount,
+            Decimal(window_weekday_count),
+        ),
+    }
+
+
 def _daily_bucket_ranges(
     start: datetime,
     end: datetime,
@@ -627,6 +894,88 @@ def _string_list(value: object) -> list[str]:
         if text:
             result.append(text)
     return result
+
+
+def _payload_object(value: object) -> object:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _payload_object(item)
+            for key, item in sorted(cast(Mapping[object, object], value).items())
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_payload_object(item) for item in cast(Sequence[object], value)]
+    return value
+
+
+def _first_text(row: Mapping[str, object], fields: Sequence[str]) -> str:
+    for field in fields:
+        text = _text(row.get(field))
+        if text:
+            return text
+    return ""
+
+
+def _first_decimal(
+    row: Mapping[str, object],
+    fields: Sequence[str],
+) -> Decimal | None:
+    for field in fields:
+        value = _decimal(row.get(field))
+        if value is not None:
+            return value
+    return None
+
+
+def _decimal(value: object) -> Decimal | None:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def _average_decimal(values: Sequence[Decimal]) -> Decimal | None:
+    if not values:
+        return None
+    return sum(values, Decimal("0")) / Decimal(len(values))
+
+
+def _normalized_order_type(value: str) -> str:
+    normalized = value.lower().replace("-", "_").replace(" ", "_").strip()
+    if not normalized:
+        return ""
+    if "market" in normalized and "limit" in normalized:
+        return "marketable_limit"
+    if "limit" in normalized or "passive" in normalized:
+        return "limit"
+    if "market" in normalized:
+        return "market"
+    return normalized
+
+
+def _order_type_for_row(
+    row: Mapping[str, object],
+    order_type_by_order_id: Mapping[str, str],
+) -> str:
+    direct = _normalized_order_type(_first_text(row, _ORDER_TYPE_FIELDS))
+    if direct:
+        return direct
+    return order_type_by_order_id.get(_text(row.get("order_id")), "")
+
+
+def _count_texts(values: Iterable[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values:
+        counts[value] = counts.get(value, 0) + 1
+    return counts
+
+
+def _row_has_fill_status(row: Mapping[str, object]) -> bool:
+    status = _first_text(row, _FILL_STATUS_FIELDS).lower().replace("-", "_")
+    if not status:
+        return False
+    return any(token in status for token in ("fill", "filled", "partial"))
 
 
 def _text(value: object) -> str:
@@ -756,8 +1105,10 @@ def _dedupe(values: Sequence[str]) -> list[str]:
 
 def _ranking_sort_key(candidate: ReplayLedgerCandidateRanking) -> tuple[object, ...]:
     return (
+        -candidate.execution_quality_adjusted_window_net_pnl_per_day,
         -candidate.window_net_pnl_per_day,
         -candidate.total_net_pnl_after_costs,
+        candidate.execution_quality_penalty_bps,
         candidate.best_day_share,
         candidate.max_drawdown,
         candidate.candidate_id,

--- a/services/torghut/app/trading/discovery/replay_ledger_remediation.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_remediation.py
@@ -34,6 +34,58 @@ _RUNTIME_CLOSURE_BLOCKERS = frozenset(
         "unclosed_position",
     }
 )
+_EXECUTION_QUALITY_ACTIONS = {
+    "order_type_mix_evidence_incomplete": (
+        "collect_order_type_mix_evidence",
+        "exact replay rows do not fully label market/limit order selection",
+        ["record_selected_order_type", "preserve_order_type_on_fill_rows"],
+    ),
+    "fill_order_type_evidence_incomplete": (
+        "preserve_fill_order_type_evidence",
+        "fills cannot be attributed to market/limit order type choices",
+        ["join_fills_to_submitted_order_type", "preserve_order_id_on_fills"],
+    ),
+    "execution_shortfall_evidence_incomplete": (
+        "collect_route_tca_shortfall_evidence",
+        "route TCA/shortfall is required before execution quality can influence collection",
+        ["route_tca_bps", "execution_shortfall_bps", "arrival_shortfall_bps"],
+    ),
+    "limit_fill_probability_evidence_incomplete": (
+        "collect_limit_fill_probability_evidence",
+        "limit-order candidates need real fill-probability evidence",
+        ["limit_fill_probability", "survival_fill_probability", "fill_probability"],
+    ),
+    "queue_position_survival_evidence_incomplete": (
+        "collect_queue_position_survival_fill_curve_evidence",
+        "queue-position/time-to-fill evidence is missing for limit-order candidates",
+        ["queue_position", "queue_ahead_qty", "time_to_fill_seconds"],
+    ),
+    "price_improvement_evidence_incomplete": (
+        "collect_limit_order_price_improvement_evidence",
+        "passive order price improvement is unverified",
+        ["price_improvement_bps", "realized_price_improvement_bps"],
+    ),
+    "nonfill_opportunity_cost_evidence_incomplete": (
+        "collect_nonfill_opportunity_cost_evidence",
+        "patient limit orders need missed-fill opportunity-cost evidence",
+        ["nonfill_opportunity_cost_bps", "missed_fill_opportunity_cost_bps"],
+    ),
+    "limit_fill_rate_below_execution_quality_floor": (
+        "tighten_or_downrank_low_fill_limit_policy",
+        "observed limit-fill rate is below the execution-quality floor",
+        ["raise_limit_fill_probability_floor", "compare_market_vs_limit_ablation"],
+    ),
+    "execution_shortfall_bps_above_quality_floor": (
+        "downrank_high_shortfall_execution_policy",
+        "realized shortfall is above the execution-quality floor",
+        ["lower_market_order_share", "route_tca_ablation", "spread_state_filter"],
+    ),
+    "nonfill_opportunity_cost_bps_above_quality_floor": (
+        "downrank_high_opportunity_cost_limit_policy",
+        "missed-fill opportunity cost is above the execution-quality floor",
+        ["cancel_replace_age_grid", "marketable_limit_fallback", "urgency_response"],
+    ),
+}
 
 
 def build_replay_ledger_remediation_report(
@@ -76,10 +128,17 @@ def build_replay_ledger_remediation_report(
 
     promotion_blockers = _string_list(best_candidate.get("promotion_blockers"))
     runtime_blockers = _string_list(best_candidate.get("runtime_ledger_blockers"))
+    execution_quality_blockers = _string_list(
+        best_candidate.get("execution_quality_blockers")
+    )
     blockers = _dedupe([*promotion_blockers, *runtime_blockers])
     blocker_remediations = [
         _blocker_remediation(blocker, best_candidate=best_candidate, policy=policy)
         for blocker in blockers
+    ]
+    execution_quality_actions = [
+        _execution_quality_remediation(blocker, best_candidate=best_candidate)
+        for blocker in execution_quality_blockers
     ]
     status = (
         "blocked_pending_runtime_promotion_proof"
@@ -97,6 +156,8 @@ def build_replay_ledger_remediation_report(
         "promotion_status": _string(best_candidate.get("promotion_status")),
         "promotion_blockers": promotion_blockers,
         "runtime_ledger_blockers": runtime_blockers,
+        "execution_quality_blockers": execution_quality_blockers,
+        "execution_quality": _mapping(best_candidate.get("execution_quality")),
         "required_evidence": list(_RUNTIME_PROMOTION_EVIDENCE),
         "metric_snapshot": _metric_snapshot(best_candidate, policy),
         "recommended_objective_adjustments": _recommended_objective_adjustments(
@@ -107,8 +168,9 @@ def build_replay_ledger_remediation_report(
             blockers=blockers,
             best_candidate=best_candidate,
             policy=policy,
-        ),
-        "blocker_remediations": blocker_remediations,
+        )
+        + execution_quality_actions,
+        "blocker_remediations": blocker_remediations + execution_quality_actions,
     }
 
 
@@ -319,6 +381,34 @@ def _blocker_remediation(
         "action": "fix_runtime_ledger_or_policy_blocker_before_research_continues",
         "reason": "unmapped_replay_ledger_blocker",
         "parameter_hints": ["inspect_exact_replay_ledger_rows", "inspect_policy"],
+    }
+
+
+def _execution_quality_remediation(
+    blocker: str,
+    *,
+    best_candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    action, reason, hints = _EXECUTION_QUALITY_ACTIONS.get(
+        blocker,
+        (
+            "inspect_execution_quality_blocker",
+            "execution-quality blocker has no specific remediation mapping yet",
+            ["inspect_execution_quality"],
+        ),
+    )
+    return {
+        "blocker": blocker,
+        "action": action,
+        "reason": reason,
+        "observed_penalty_bps": _string(
+            best_candidate.get("execution_quality_penalty_bps")
+        ),
+        "adjusted_window_net_pnl_per_day": _string(
+            best_candidate.get("execution_quality_adjusted_window_net_pnl_per_day")
+        ),
+        "authority": "research_ranking_only_final_promotion_still_requires_runtime_ledger",
+        "parameter_hints": list(hints),
     }
 
 

--- a/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
+++ b/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
@@ -318,6 +318,15 @@ def _target_replay_window_metadata(
             "fills_with_capacity_warning_contract",
             "replay_fills_with_capacity_warning_contract",
         ),
+        ("execution_quality_penalty_bps", "replay_execution_quality_penalty_bps"),
+        (
+            "execution_quality_penalty_amount",
+            "replay_execution_quality_penalty_amount",
+        ),
+        (
+            "execution_quality_adjusted_window_net_pnl_per_day",
+            "replay_execution_quality_adjusted_window_net_pnl_per_day",
+        ),
     ):
         if (value := best_candidate.get(source_key)) is not None:
             metadata[target_key] = value
@@ -325,9 +334,16 @@ def _target_replay_window_metadata(
         ("candidate_identity", "replay_candidate_identity"),
         ("cost_lineage", "replay_cost_lineage"),
         ("capacity_warning_counts", "replay_capacity_warning_counts"),
+        ("execution_quality", "replay_execution_quality"),
     ):
         if isinstance(value := best_candidate.get(source_key), Mapping):
             metadata[target_key] = dict(cast(Mapping[str, Any], value))
+    for source_key, target_key in (
+        ("execution_quality_blockers", "replay_execution_quality_blockers"),
+    ):
+        values = _string_list(best_candidate.get(source_key))
+        if values:
+            metadata[target_key] = values
     for source_key, target_key in (
         ("min_window_weekday_count", "replay_min_window_weekday_count"),
         ("target_net_pnl_per_day", "replay_target_net_pnl_per_day"),

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -2340,14 +2340,24 @@ def _offline_replay_triage_candidate_from_ranking(
         "avg_filled_notional_per_window_weekday",
         "best_day_share",
         "max_single_fill_notional_pct_equity",
+        "execution_quality_penalty_bps",
+        "execution_quality_penalty_amount",
+        "execution_quality_adjusted_window_net_pnl_per_day",
     ):
         value = candidate.get(key)
         if value not in (None, ""):
             payload[key] = value
-    for key in ("promotion_blockers", "runtime_ledger_blockers"):
+    for key in (
+        "promotion_blockers",
+        "runtime_ledger_blockers",
+        "execution_quality_blockers",
+    ):
         values = _as_text_list(candidate.get(key))
         if values:
             payload[key] = values
+    execution_quality = _as_dict(candidate.get("execution_quality"))
+    if execution_quality:
+        payload["execution_quality"] = execution_quality
     return payload
 
 

--- a/services/torghut/tests/test_replay_ledger_ranker.py
+++ b/services/torghut/tests/test_replay_ledger_ranker.py
@@ -84,6 +84,32 @@ def _round_trip(
     ]
 
 
+def _with_execution_quality(
+    rows: list[dict[str, object]],
+    *,
+    order_type: str,
+    shortfall_bps: str,
+    limit_fill_probability: str | None = None,
+    queue_position: str | None = None,
+    opportunity_cost_bps: str | None = None,
+    price_improvement_bps: str | None = None,
+) -> list[dict[str, object]]:
+    for row in rows:
+        if row.get("event_type") in {"order_submitted", "fill"}:
+            row["order_type"] = order_type
+            row["execution_shortfall_bps"] = shortfall_bps
+            row["fill_status"] = "filled"
+            if limit_fill_probability is not None:
+                row["limit_fill_probability"] = limit_fill_probability
+            if queue_position is not None:
+                row["queue_position"] = queue_position
+            if opportunity_cost_bps is not None:
+                row["nonfill_opportunity_cost_bps"] = opportunity_cost_bps
+            if price_improvement_bps is not None:
+                row["price_improvement_bps"] = price_improvement_bps
+    return rows
+
+
 def _payload(
     candidate_id: str,
     rows: list[dict[str, object]],
@@ -206,6 +232,81 @@ def test_ranker_uses_runtime_ledger_net_pnl_and_window_day_ranking(
     assert top["total_net_pnl_after_costs"] == "120.0"
     assert top["window_net_pnl_per_day"] == "24.0"
     assert top["active_net_pnl_per_day"] == "40.0"
+
+
+def test_ranker_uses_market_limit_queue_execution_quality_for_adjusted_ranking(
+    tmp_path: Path,
+) -> None:
+    cleaner = _payload(
+        "cleaner-limit-fill-evidence",
+        _with_execution_quality(
+            _round_trip(
+                day=18,
+                symbol="NVDA",
+                qty="1000",
+                buy_price="100",
+                sell_price="100.90",
+                prefix="cleaner",
+            ),
+            order_type="limit",
+            shortfall_bps="1",
+            limit_fill_probability="0.82",
+            queue_position="0.15",
+            opportunity_cost_bps="2",
+            price_improvement_bps="3",
+        ),
+    )
+    raw_winner_execution_risk = _payload(
+        "raw-winner-execution-risk",
+        _with_execution_quality(
+            _round_trip(
+                day=18,
+                symbol="NVDA",
+                qty="1000",
+                buy_price="100",
+                sell_price="101.00",
+                prefix="riskier",
+            ),
+            order_type="limit",
+            shortfall_bps="18",
+        ),
+    )
+    cleaner_path = tmp_path / "cleaner.json"
+    riskier_path = tmp_path / "riskier.json"
+    cleaner_path.write_text(json.dumps(cleaner))
+    riskier_path.write_text(json.dumps(raw_winner_execution_risk))
+
+    report = build_replay_ledger_ranking_report(
+        [cleaner_path, riskier_path],
+        policy=ReplayLedgerRankingPolicy(
+            target_net_pnl_per_day=Decimal("1"),
+            min_window_weekday_count=1,
+            min_avg_filled_notional_per_day=Decimal("1"),
+            max_best_day_share=Decimal("1.0"),
+            max_gross_exposure_pct_equity=Decimal("1000.0"),
+            start_equity=Decimal("100000000"),
+        ),
+    )
+    top = report["candidates"][0]
+    raw_winner = report["candidates"][1]
+
+    assert top["candidate_id"] == "cleaner-limit-fill-evidence"
+    assert top["execution_quality_penalty_bps"] == "0"
+    assert top["execution_quality"]["limit_fill_rate"] == "1"
+    assert top["execution_quality"]["limit_fill_probability_sample_count"] == 4
+    assert top["execution_quality"]["queue_position_sample_count"] == 4
+    assert raw_winner["candidate_id"] == "raw-winner-execution-risk"
+    assert (
+        "limit_fill_probability_evidence_incomplete"
+        in raw_winner["execution_quality_blockers"]
+    )
+    assert (
+        "queue_position_survival_evidence_incomplete"
+        in raw_winner["execution_quality_blockers"]
+    )
+    assert Decimal(
+        str(top["execution_quality_adjusted_window_net_pnl_per_day"])
+    ) > Decimal(str(raw_winner["execution_quality_adjusted_window_net_pnl_per_day"]))
 
 
 def test_ranker_blocks_replay_only_and_over_equity_artifacts() -> None:

--- a/services/torghut/tests/test_replay_ledger_remediation.py
+++ b/services/torghut/tests/test_replay_ledger_remediation.py
@@ -124,6 +124,51 @@ class TestReplayLedgerRemediation(TestCase):
             "start_runtime_paper_validation",
         )
 
+    def test_report_surfaces_execution_quality_actions_without_promotion(self) -> None:
+        report = build_replay_ledger_remediation_report(
+            {
+                "schema_version": "torghut.exact-replay-ledger-ranking.v1",
+                "policy": {"target_net_pnl_per_day": "500"},
+                "candidates": [
+                    {
+                        "candidate_id": "candidate-needs-fill-curve",
+                        "promotion_status": "candidate_replay_evidence_only",
+                        "promotion_blockers": ["replay_artifact_only_not_live"],
+                        "runtime_ledger_blockers": [],
+                        "execution_quality_blockers": [
+                            "limit_fill_probability_evidence_incomplete",
+                            "queue_position_survival_evidence_incomplete",
+                        ],
+                        "execution_quality_penalty_bps": "12",
+                        "execution_quality_adjusted_window_net_pnl_per_day": "480",
+                        "execution_quality": {
+                            "schema_version": "torghut.exact-replay-execution-quality.v1",
+                            "limit_order_count": 4,
+                            "limit_fill_probability_sample_count": 0,
+                        },
+                    }
+                ],
+            }
+        )
+
+        self.assertFalse(report["promotion_allowed"])
+        self.assertEqual(
+            report["execution_quality"]["schema_version"],
+            "torghut.exact-replay-execution-quality.v1",
+        )
+        actions = {
+            item["action"]: item for item in report["recommended_search_actions"]
+        }
+        self.assertIn("collect_limit_fill_probability_evidence", actions)
+        self.assertIn(
+            "collect_queue_position_survival_fill_curve_evidence",
+            actions,
+        )
+        self.assertEqual(
+            actions["collect_queue_position_survival_fill_curve_evidence"]["authority"],
+            "research_ranking_only_final_promotion_still_requires_runtime_ledger",
+        )
+
     def test_report_handles_malformed_shapes_without_promotion(self) -> None:
         report = build_replay_ledger_remediation_report(
             {

--- a/services/torghut/tests/test_replay_runtime_window_plan.py
+++ b/services/torghut/tests/test_replay_runtime_window_plan.py
@@ -178,21 +178,27 @@ def test_handoff_builds_non_promotional_runtime_window_target(
     target = plan["targets"][0]
     assert target["candidate_id"] == "candidate-strong-one-day"
     assert (
-        target["replay_candidate_identity_hash"]
-        == "identity-candidate-strong-one-day"
+        target["replay_candidate_identity_hash"] == "identity-candidate-strong-one-day"
     )
     assert target["replay_cost_lineage_hash"] == "cost-lineage-candidate-strong-one-day"
     assert target["replay_fills_with_adv_notional"] == 2
     assert target["replay_fills_with_participation_rate"] == 2
     assert target["replay_fills_with_capacity_warning_contract"] == 2
     assert target["replay_capacity_warning_counts"] == {}
+    assert target["replay_execution_quality"]["schema_version"] == (
+        "torghut.exact-replay-execution-quality.v1"
+    )
+    assert (
+        "order_type_mix_evidence_incomplete"
+        in target["replay_execution_quality_blockers"]
+    )
+    assert target["replay_execution_quality_penalty_bps"] != "0"
+    assert "replay_execution_quality_adjusted_window_net_pnl_per_day" in target
     assert target["hypothesis_id"] == "H-PAIRS-01"
     assert target["strategy_family"] == "microbar_cross_sectional_pairs"
     assert target["strategy_name"] == "microbar-cross-sectional-pairs-v1"
     assert target["dataset_snapshot_ref"] == "snapshot-1"
-    assert target["exact_replay_ledger_artifact_refs"] == [
-        str(artifact_path.resolve())
-    ]
+    assert target["exact_replay_ledger_artifact_refs"] == [str(artifact_path.resolve())]
     assert target["exact_replay_ledger_artifact_row_count"] == 6
     assert target["exact_replay_ledger_artifact_fill_count"] == 2
     assert "runtime_ledger_artifact_ref" not in target


### PR DESCRIPTION
## Summary

- Adds proof-neutral execution-quality scoring to exact replay ledger ranking using market/limit order mix, limit-fill probability, queue-position, route TCA/shortfall, price-improvement, and opportunity-cost evidence.
- Ranks candidates by execution-quality-adjusted daily post-cost PnL while keeping final promotion blocked behind live-paper/runtime-ledger authority.
- Propagates execution-quality diagnostics through remediation reports, runtime-window handoff metadata, and offline replay triage so bounded paper collection can target the right missing evidence.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_replay_ledger_ranker.py tests/test_replay_ledger_remediation.py tests/test_replay_runtime_window_plan.py -q`
- `cd services/torghut && uv run --frozen ruff format app/trading/discovery/replay_ledger_ranker.py app/trading/discovery/replay_runtime_window_plan.py app/trading/discovery/replay_ledger_remediation.py tests/test_replay_ledger_ranker.py tests/test_replay_ledger_remediation.py tests/test_replay_runtime_window_plan.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/replay_ledger_ranker.py app/trading/discovery/replay_runtime_window_plan.py app/trading/discovery/replay_ledger_remediation.py tests/test_replay_ledger_ranker.py tests/test_replay_ledger_remediation.py tests/test_replay_runtime_window_plan.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
