### PR TITLE
fix(torghut): use sim evidence for runtime import

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -23,7 +23,8 @@ workflow submissions in `torghut` do not rely on manual secret copies from `argo
 
 The `torghut-empirical-promotion-renewal` CronJob is also the scheduled runtime-ledger proof packet conductor for the
 paper-route proof lane. It first runs `renew_latest_empirical_promotion_jobs.py` with the sim
-`/trading/paper-route-target-plan` target plan, then runs `assemble_runtime_ledger_proof_packet.py` in explicit
+`/trading/paper-route-evidence?target_limit=5` target plan/evidence payload, then runs
+`assemble_runtime_ledger_proof_packet.py` in explicit
 `authority` mode and uploads the packet under `runtime-ledger-proof-packets/{run_id}`. The scheduled packet uses the
 final authority thresholds: 20 runtime-ledger trading days, $10,000 total post-cost net PnL, $500/day post-cost net PnL,
 3% max drawdown/equity, 25% best-day share, and 35% symbol concentration. When the paper-route window is import-ready,

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -61,7 +61,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url 'http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5' \
+                    --runtime-window-target-plan-url 'http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5' \
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \
@@ -82,7 +82,7 @@ spec:
                     | tee "${RENEWAL_OUTPUT}"
                   /opt/venv/bin/python scripts/assemble_runtime_ledger_proof_packet.py \
                     --status-service-base-url http://torghut.torghut.svc.cluster.local \
-                    --paper-route-service-base-url http://torghut.torghut.svc.cluster.local \
+                    --paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local \
                     --completion-service-base-url http://torghut.torghut.svc.cluster.local \
                     --timeout-seconds 30 \
                     --proof-mode authority \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1858,12 +1858,12 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
-            "'http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5'",
+            "'http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5'",
             args,
         )
         self.assertNotIn(
             "--runtime-window-target-plan-url "
-            "'http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5'",
+            "'http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5'",
             args,
         )
         self.assertNotIn(
@@ -1946,11 +1946,11 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertIn(
-            "--paper-route-service-base-url http://torghut.torghut.svc.cluster.local",
+            "--paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local",
             args,
         )
         self.assertNotIn(
-            "--paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local",
+            "--paper-route-service-base-url http://torghut.torghut.svc.cluster.local",
             args,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary

- Point the empirical promotion renewal runtime-window import plan URL at the torghut-sim paper-route evidence endpoint so SIM imports inspect SIM source activity.
- Point the proof packet paper-route evidence read at torghut-sim while keeping live status/completion gates on torghut.
- Update the Torghut GitOps README and manifest contract test to preserve the SIM evidence contract.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal`
- `bun run lint:argocd`
- Manual live validation: compared `http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5` with `http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5`; live reported source activity missing while sim exposed June 4 SIM decisions/executions/TCA and the real contamination blocker.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
