### PR TITLE
fix(torghut): retry zero-notional TCA deadlocks

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -20,7 +20,7 @@ from fastapi.responses import JSONResponse, Response
 import inngest
 from inngest.fast_api import serve as inngest_fastapi_serve
 from sqlalchemy import bindparam, func, select, text
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm import Session
 from urllib.parse import urlencode, urlsplit
 
@@ -228,6 +228,23 @@ _TRADING_HEALTH_SURFACE_EVALUATION_EXECUTOR = ThreadPoolExecutor(
     thread_name_prefix="torghut-health-surface",
 )
 _TRADING_HEALTH_SURFACE_EVALUATION_LOCK = Lock()
+_ZERO_NOTIONAL_TCA_RECOMPUTE_MAX_ATTEMPTS = 3
+_RETRYABLE_TCA_RECOMPUTE_SQLSTATES = frozenset({"40P01", "40001"})
+
+
+def _retryable_tca_recompute_error(exc: BaseException) -> bool:
+    if not isinstance(exc, OperationalError):
+        return False
+    original = getattr(exc, "orig", None)
+    sqlstate = str(getattr(original, "sqlstate", "") or "") or str(
+        getattr(original, "pgcode", "") or ""
+    )
+    if sqlstate in _RETRYABLE_TCA_RECOMPUTE_SQLSTATES:
+        return True
+    message = str(exc).lower()
+    return "deadlock detected" in message or "serialization failure" in message
+
+
 _TRADING_HEALTH_SURFACE_EVALUATIONS: dict[
     str,
     Future[tuple[dict[str, object], int]],
@@ -3119,28 +3136,82 @@ def trading_profit_freshness_zero_notional_repair(
     )
 
     def run_tca_recompute(_repair: Mapping[str, Any]) -> Mapping[str, object]:
-        try:
-            with SessionLocal() as session:
-                result = refresh_execution_tca_metrics(
-                    session,
-                    account_label=settings.trading_account_label,
-                    limit=tca_limit,
-                    dry_run=False,
-                )
-                session.commit()
-        except Exception as exc:  # pragma: no cover - fail-closed receipt path
-            logger.exception("Zero-notional route/TCA repair failed")
+        retry_reasons: list[str] = []
+        result: Mapping[str, object] = {}
+        for attempt in range(1, _ZERO_NOTIONAL_TCA_RECOMPUTE_MAX_ATTEMPTS + 1):
+            try:
+                with SessionLocal() as session:
+                    result = refresh_execution_tca_metrics(
+                        session,
+                        account_label=settings.trading_account_label,
+                        limit=tca_limit,
+                        dry_run=False,
+                    )
+                    session.commit()
+            except OperationalError as exc:
+                if (
+                    attempt < _ZERO_NOTIONAL_TCA_RECOMPUTE_MAX_ATTEMPTS
+                    and _retryable_tca_recompute_error(exc)
+                ):
+                    retry_reason = f"route_tca_recompute_retryable:{type(exc).__name__}"
+                    retry_reasons.append(retry_reason)
+                    logger.warning(
+                        "Zero-notional route/TCA repair retrying after retryable database error attempt=%s max_attempts=%s",
+                        attempt,
+                        _ZERO_NOTIONAL_TCA_RECOMPUTE_MAX_ATTEMPTS,
+                        exc_info=True,
+                        extra={
+                            "zero_notional_tca_recompute_attempt": attempt,
+                            "zero_notional_tca_recompute_max_attempts": (
+                                _ZERO_NOTIONAL_TCA_RECOMPUTE_MAX_ATTEMPTS
+                            ),
+                            "zero_notional_tca_recompute_retry_reason": retry_reason,
+                        },
+                    )
+                    time.sleep(min(0.25 * attempt, 1.0))
+                    continue
+                logger.exception("Zero-notional route/TCA repair failed")
+                return {
+                    "execution_state": "runner_failed",
+                    "command_exit_code": 1,
+                    "blocked_reasons": [
+                        f"route_tca_recompute_failed:{type(exc).__name__}",
+                        *retry_reasons,
+                    ],
+                    "after_refs": [],
+                    "retry_attempts": len(retry_reasons),
+                }
+            except Exception as exc:  # pragma: no cover - fail-closed receipt path
+                logger.exception("Zero-notional route/TCA repair failed")
+                return {
+                    "execution_state": "runner_failed",
+                    "command_exit_code": 1,
+                    "blocked_reasons": [
+                        f"route_tca_recompute_failed:{type(exc).__name__}",
+                        *retry_reasons,
+                    ],
+                    "after_refs": [],
+                    "retry_attempts": len(retry_reasons),
+                }
+            break
+        else:  # pragma: no cover - defensive; loop always returns or breaks.
             return {
                 "execution_state": "runner_failed",
                 "command_exit_code": 1,
-                "blocked_reasons": [f"route_tca_recompute_failed:{type(exc).__name__}"],
+                "blocked_reasons": [
+                    "route_tca_recompute_failed:retry_attempts_exhausted",
+                    *retry_reasons,
+                ],
                 "after_refs": [],
+                "retry_attempts": len(retry_reasons),
             }
         return {
             "execution_state": "executed",
             "command_exit_code": 0,
             "after_refs": ["execution_tca_metrics"],
             "result": result,
+            "retry_attempts": len(retry_reasons),
+            "retry_reasons": retry_reasons,
         }
 
     def run_drift_check_replay(repair: Mapping[str, Any]) -> Mapping[str, object]:

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -2007,6 +2007,7 @@ def _latest_source_activity_window(
     )
     if not strategy_names:
         return None
+    source_account_label = target.source_account_label or target.account_label
     with psycopg.connect(dsn) as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -2020,7 +2021,7 @@ def _latest_source_activity_window(
                 """,
                 (
                     strategy_names,
-                    target.account_label,
+                    source_account_label,
                     list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
                 ),
             )

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -172,6 +172,68 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
             {("live", "PA3SX7FYNUTF"), ("paper", "TORGHUT_SIM")},
         )
 
+    def test_latest_source_activity_window_queries_source_account_alias(self) -> None:
+        target = renew.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="c88421d619759b2cfaa6f4d0",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            target_dsn_env="SIM_DB_DSN",
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            account_label="TORGHUT_SIM",
+            source_account_label="PA3SX7FYNUTF",
+            dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+            source_kind="paper_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+        )
+        executed_params: list[object] = []
+        earliest = datetime(2026, 6, 4, 13, 31, tzinfo=timezone.utc)
+        latest = datetime(2026, 6, 4, 19, 59, tzinfo=timezone.utc)
+
+        class Cursor:
+            def __enter__(self) -> "Cursor":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+            def execute(self, _query: str, params: tuple[object, ...]) -> None:
+                executed_params.extend(params)
+
+            def fetchone(self) -> tuple[datetime, datetime]:
+                return earliest, latest
+
+        class Connection:
+            def __enter__(self) -> "Connection":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+            def cursor(self) -> Cursor:
+                return Cursor()
+
+        with (
+            patch.dict("os.environ", {"SIM_DB_DSN": "postgresql://torghut/source"}),
+            patch.object(renew.psycopg, "connect", return_value=Connection()),
+        ):
+            window = renew._latest_source_activity_window(
+                target=target,
+                runtime_manifest={"strategy_name": "microbar-cross-sectional-pairs-v1"},
+            )
+
+        self.assertEqual(
+            window,
+            (
+                datetime(2026, 6, 4, 13, 30, tzinfo=timezone.utc),
+                datetime(2026, 6, 4, 20, 0, tzinfo=timezone.utc),
+            ),
+        )
+        self.assertEqual(executed_params[1], "PA3SX7FYNUTF")
+        self.assertEqual(target.account_label, "TORGHUT_SIM")
+
     def test_explicit_runtime_window_target_preserves_metadata_and_gates(self) -> None:
         args = argparse.Namespace(
             runtime_window_target=[

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, select
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -7277,6 +7277,76 @@ class TestTradingApi(TestCase):
         self.assertEqual(payload["freshness_citation_state"], "cited")
         self.assertEqual(payload["freshness_dimension_id"], "tca")
         self.assertFalse(payload["order_submission_enabled"])
+
+    def test_zero_notional_repair_endpoint_retries_route_tca_deadlock(self) -> None:
+        class _Deadlock:
+            sqlstate = "40P01"
+
+            def __str__(self) -> str:
+                return "deadlock detected"
+
+        status_payload = {
+            "active_revision": "torghut-00320",
+            "freshness_carry_ledger": _freshness_carry_ledger_for_test("tca"),
+            "profit_freshness_frontier": {
+                "frontier_id": "profit-freshness-frontier:test",
+                "capital_posture": {
+                    "capital_state": "zero_notional",
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "capital_behavior_changed": False,
+                },
+                "selected_zero_notional_repairs": [
+                    {
+                        "lot_id": "profit-freshness-repair-lot:tca",
+                        "candidate_id": "candidate-b",
+                        "hypothesis_id": "H-AMZN",
+                        "blocked_dimension": "tca_fill_quality",
+                        "zero_notional_action": "recompute_route_tca_and_fill_quality",
+                        "before_refs": ["execution_tca:AMZN"],
+                        "paper_notional_limit": "0",
+                        "live_notional_limit": "0",
+                        "state": "selected_zero_notional_repair",
+                    }
+                ],
+            },
+        }
+
+        with (
+            patch("app.main.trading_status", return_value=status_payload),
+            patch("app.main.time.sleep") as sleep,
+            patch(
+                "app.main.refresh_execution_tca_metrics",
+                side_effect=[
+                    OperationalError("UPDATE execution_tca_metrics", {}, _Deadlock()),
+                    {
+                        "selected": 1,
+                        "refreshed": 1,
+                        "dry_run": False,
+                        "limit": 250,
+                        "account_label": "paper",
+                    },
+                ],
+            ) as refresh,
+        ):
+            response = self.client.post(
+                "/trading/profit-freshness/zero-notional-repair"
+                "?action=recompute_route_tca_and_fill_quality&execute=true"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["execution_state"], "executed")
+        self.assertEqual(payload["command_exit_code"], 0)
+        self.assertEqual(payload["after_refs"], ["execution_tca_metrics"])
+        self.assertEqual(payload["runner_result"]["retry_attempts"], 1)
+        self.assertEqual(
+            payload["runner_result"]["retry_reasons"],
+            ["route_tca_recompute_retryable:OperationalError"],
+        )
+        self.assertFalse(payload["order_submission_enabled"])
+        self.assertEqual(refresh.call_count, 2)
+        sleep.assert_called_once()
 
     def test_zero_notional_repair_endpoint_executes_drift_replay(self) -> None:
         status_payload = {

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -46,6 +46,7 @@ from app.main import (
     _merge_external_paper_route_target_plan,
     _readiness_dependency_cache_key,
     _readiness_dependency_checks,
+    _retryable_tca_recompute_error,
     _route_continuity_packet_for_proof_floor,
     _route_claim_symbols,
     app,
@@ -7347,6 +7348,103 @@ class TestTradingApi(TestCase):
         self.assertFalse(payload["order_submission_enabled"])
         self.assertEqual(refresh.call_count, 2)
         sleep.assert_called_once()
+
+    def test_retryable_tca_recompute_error_classifies_db_retries(self) -> None:
+        class _SerializationFailure:
+            pgcode = "40001"
+
+        self.assertFalse(
+            _retryable_tca_recompute_error(ValueError("deadlock detected"))
+        )
+        self.assertTrue(
+            _retryable_tca_recompute_error(
+                OperationalError(
+                    "UPDATE execution_tca_metrics",
+                    {},
+                    _SerializationFailure(),
+                )
+            )
+        )
+        self.assertTrue(
+            _retryable_tca_recompute_error(
+                OperationalError(
+                    "deadlock detected",
+                    {},
+                    Exception("database busy"),
+                )
+            )
+        )
+        self.assertTrue(
+            _retryable_tca_recompute_error(
+                OperationalError(
+                    "serialization failure",
+                    {},
+                    Exception("database busy"),
+                )
+            )
+        )
+
+    def test_zero_notional_repair_endpoint_fails_closed_on_route_tca_error(
+        self,
+    ) -> None:
+        class _PermissionDenied:
+            def __str__(self) -> str:
+                return "permission denied"
+
+        status_payload = {
+            "active_revision": "torghut-00320",
+            "freshness_carry_ledger": _freshness_carry_ledger_for_test("tca"),
+            "profit_freshness_frontier": {
+                "frontier_id": "profit-freshness-frontier:test",
+                "capital_posture": {
+                    "capital_state": "zero_notional",
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "capital_behavior_changed": False,
+                },
+                "selected_zero_notional_repairs": [
+                    {
+                        "lot_id": "profit-freshness-repair-lot:tca",
+                        "candidate_id": "candidate-b",
+                        "hypothesis_id": "H-AMZN",
+                        "blocked_dimension": "tca_fill_quality",
+                        "zero_notional_action": "recompute_route_tca_and_fill_quality",
+                        "before_refs": ["execution_tca:AMZN"],
+                        "paper_notional_limit": "0",
+                        "live_notional_limit": "0",
+                        "state": "selected_zero_notional_repair",
+                    }
+                ],
+            },
+        }
+
+        with (
+            patch("app.main.trading_status", return_value=status_payload),
+            patch(
+                "app.main.refresh_execution_tca_metrics",
+                side_effect=OperationalError(
+                    "UPDATE execution_tca_metrics",
+                    {},
+                    _PermissionDenied(),
+                ),
+            ) as refresh,
+        ):
+            response = self.client.post(
+                "/trading/profit-freshness/zero-notional-repair"
+                "?action=recompute_route_tca_and_fill_quality&execute=true"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["execution_state"], "runner_failed")
+        self.assertEqual(payload["command_exit_code"], 1)
+        self.assertEqual(payload["after_refs"], [])
+        self.assertEqual(
+            payload["blocked_reasons"],
+            ["route_tca_recompute_failed:OperationalError"],
+        )
+        self.assertEqual(payload["runner_result"]["retry_attempts"], 0)
+        self.assertEqual(refresh.call_count, 1)
 
     def test_zero_notional_repair_endpoint_executes_drift_replay(self) -> None:
         status_payload = {


### PR DESCRIPTION
## Summary

- Retries retryable Postgres deadlocks and serialization failures during zero-notional route/TCA recompute.
- Keeps the repair fail-closed after bounded retries with order submission disabled and max notional unchanged.
- Adds an endpoint regression for a live-shaped `40P01` deadlock followed by a successful TCA refresh.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'zero_notional_repair_endpoint_retries_route_tca_deadlock or zero_notional_repair_endpoint_can_select_queued_route_tca_action' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_tca.py -q`
- `cd services/torghut && uv run --frozen ruff format app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
