### PR TITLE
fix(torghut): isolate bounded paper proof account

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -575,16 +575,81 @@ def _bounded_sim_collection_reserves_account(
     return bool(_BOUNDED_SIM_COLLECTION_RESERVATION_BLOCKERS.intersection(blockers))
 
 
-def _target_requires_bounded_sim_collection_gate(target: Mapping[str, Any]) -> bool:
+def _target_owns_bounded_sim_collection_account(target: Mapping[str, Any]) -> bool:
     hypothesis_id = _safe_text(target.get("hypothesis_id"))
     candidate_id = _safe_text(target.get("candidate_id"))
-    account_label = _safe_text(target.get("account_label"))
     family_tokens = _target_strategy_family_tokens(target)
     return (
         hypothesis_id == "H-PAIRS-01"
         or candidate_id == "c88421d619759b2cfaa6f4d0"
-        or account_label == _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL
         or any("microbar_cross_sectional_pairs" in token for token in family_tokens)
+    )
+
+
+def _target_runtime_account_matches(
+    target: Mapping[str, Any],
+    *,
+    account_label: str | None,
+) -> bool:
+    normalized_account = _safe_text(account_label)
+    if not normalized_account:
+        return False
+    labels = set(_lineage_text_values(target.get("account_label")))
+    for key in (
+        "execution_account_label",
+        "runtime_account_label",
+        "paper_account_label",
+        "paper_route_runtime_account_label",
+    ):
+        labels.update(_lineage_text_values(target.get(key)))
+    identity = target.get("account_stage_runtime_identity")
+    if isinstance(identity, Mapping):
+        identity_mapping = cast(Mapping[str, Any], identity)
+        labels.update(_lineage_text_values(identity_mapping.get("account_label")))
+        for key in (
+            "execution_account_label",
+            "runtime_account_label",
+            "paper_account_label",
+            "paper_route_runtime_account_label",
+        ):
+            labels.update(_lineage_text_values(identity_mapping.get(key)))
+    return normalized_account in labels
+
+
+def _target_active_in_window(target: Mapping[str, Any], now: datetime) -> bool:
+    window = _target_probe_window(target)
+    if window is None:
+        return False
+    window_start, window_end = window
+    return window_start <= now < window_end
+
+
+def _target_plan_has_active_bounded_sim_collection_owner(
+    targets: Sequence[Mapping[str, Any]],
+    *,
+    account_label: str | None,
+    now: datetime,
+) -> bool:
+    for target in targets:
+        if not _target_owns_bounded_sim_collection_account(target):
+            continue
+        if not _target_runtime_account_matches(target, account_label=account_label):
+            continue
+        if not _bounded_sim_collection_reserves_account(
+            target,
+            account_label=account_label,
+        ):
+            continue
+        if _target_active_in_window(target, now):
+            return True
+    return False
+
+
+def _target_requires_bounded_sim_collection_gate(target: Mapping[str, Any]) -> bool:
+    account_label = _safe_text(target.get("account_label"))
+    return (
+        _target_owns_bounded_sim_collection_account(target)
+        or account_label == _BOUNDED_SIM_COLLECTION_ACCOUNT_LABEL
     )
 
 
@@ -5671,6 +5736,11 @@ class SimpleTradingPipeline(TradingPipeline):
         normalized_allowed = {
             symbol.strip().upper() for symbol in allowed_symbols if symbol.strip()
         }
+        bounded_sim_owner_active = _target_plan_has_active_bounded_sim_collection_owner(
+            target_plan_targets,
+            account_label=self.account_label,
+            now=now,
+        )
         decisions: list[StrategyDecision] = []
         seen: set[tuple[str, str, str, str]] = set()
         for raw_target in target_plan_targets:
@@ -5683,6 +5753,24 @@ class SimpleTradingPipeline(TradingPipeline):
                 ),
                 account_label=self.account_label,
             )
+            if (
+                bounded_sim_owner_active
+                and _target_runtime_account_matches(
+                    target,
+                    account_label=self.account_label,
+                )
+                and not _target_owns_bounded_sim_collection_account(target)
+            ):
+                logger.warning(
+                    "Skipping paper-route target source collection because bounded "
+                    "H-PAIRS evidence collection owns account=%s hypothesis_id=%s "
+                    "candidate_id=%s runtime_strategy_name=%s",
+                    self.account_label,
+                    _safe_text(target.get("hypothesis_id")),
+                    _safe_text(target.get("candidate_id")),
+                    _safe_text(target.get("runtime_strategy_name")),
+                )
+                continue
             if _target_requires_bounded_sim_collection_gate(target):
                 collection_blockers = _bounded_sim_collection_blockers(
                     target,
@@ -6020,9 +6108,6 @@ class SimpleTradingPipeline(TradingPipeline):
             return False
         if not target_symbols:
             return False
-        normalized_allowed = {
-            symbol.strip().upper() for symbol in allowed_symbols if symbol.strip()
-        }
         for target in target_plan_targets:
             if not _target_requires_bounded_sim_collection_gate(target):
                 continue
@@ -6031,16 +6116,9 @@ class SimpleTradingPipeline(TradingPipeline):
                 account_label=self.account_label,
             ):
                 continue
-            window = _target_probe_window(target)
-            if window is None:
-                continue
-            window_start, window_end = window
-            if now < window_start or now >= window_end:
-                continue
-            symbols = _target_symbols(target) & target_symbols
-            if normalized_allowed:
-                symbols = {symbol for symbol in symbols if symbol in normalized_allowed}
-            if symbols:
+            if _target_owns_bounded_sim_collection_account(
+                target
+            ) and _target_active_in_window(target, now):
                 return True
         return False
 

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -20,8 +20,10 @@ from app.trading.scheduler.simple_pipeline import (
     _quote_snapshot_reference_price,
     _quote_snapshot_matches_symbol,
     _target_metadata_quote_snapshot,
+    _target_active_in_window,
     _target_probe_symbol_notional_budget,
     _target_probe_symbol_quantities,
+    _target_runtime_account_matches,
     _target_symbols,
 )
 from app.trading.runtime_window_import import (
@@ -1616,6 +1618,97 @@ def test_source_collection_authorization_emits_bounded_lineage_decisions_without
         settings.trading_allow_shorts = allow_shorts_before
 
 
+def test_hpairs_owner_skips_other_source_collection_targets_for_same_paper_account(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    allow_shorts_before = settings.trading_allow_shorts
+    try:
+        settings.trading_mode = "paper"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_allow_shorts = True
+        now = datetime(2026, 6, 2, 18, 0, tzinfo=timezone.utc)
+        hpairs_target = _bounded_hpairs_target(
+            paper_route_probe_window_start="2026-06-02T13:30:00+00:00",
+            paper_route_probe_window_end="2026-06-02T20:00:00+00:00",
+            paper_route_probe_next_session_max_notional="75000",
+            paper_route_probe_symbol_actions={"AAPL": "buy", "AMZN": "sell"},
+            paper_route_probe_symbol_quantities={"AAPL": "120.1614", "AMZN": "1"},
+        )
+        tsmom_target = _bounded_hpairs_target(
+            hypothesis_id="H-TSMOM-LIQ-01",
+            candidate_id="ca4e6e3c7d639e3363dc5860",
+            strategy_family="intraday_tsmom_consistent",
+            strategy_name="intraday-tsmom-profit-v3",
+            runtime_strategy_name="intraday-tsmom-profit-v3",
+            source_manifest_ref="config/trading/hypotheses/h-tsmom-liq-01.json",
+            paper_route_probe_symbols=["NVDA", "INTC"],
+            paper_route_probe_pair_balance_state="not_required",
+            paper_route_probe_window_start="2026-06-02T13:30:00+00:00",
+            paper_route_probe_window_end="2026-06-02T20:00:00+00:00",
+            paper_route_probe_next_session_max_notional="75000",
+            paper_route_probe_symbol_actions={"NVDA": "buy", "INTC": "buy"},
+            paper_route_probe_symbol_quantities={"NVDA": "1", "INTC": "34.6997"},
+        )
+        hpairs_strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="H-PAIRS proof owner",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        tsmom_strategy = Strategy(
+            name="intraday-tsmom-profit-v3",
+            description="non-owner source collection target",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["NVDA", "INTC"],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "TORGHUT_SIM"
+        pipeline.price_fetcher = SimpleNamespace(
+            fetch_market_snapshot=lambda signal: MarketSnapshot(
+                symbol=signal.symbol,
+                as_of=signal.event_ts,
+                price=Decimal("100"),
+                spread=Decimal("0"),
+                source="fixture",
+                bid=Decimal("100"),
+                ask=Decimal("100"),
+            )
+        )
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+            {"AAPL", "AMZN", "NVDA", "INTC"},
+            None,
+            [hpairs_target, tsmom_target],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[hpairs_strategy, tsmom_strategy],
+            allowed_symbols={"AAPL", "AMZN", "NVDA", "INTC"},
+            positions=[],
+            session=None,
+        )
+
+        assert {decision.symbol for decision in decisions} == {"AAPL", "AMZN"}
+        assert {
+            decision.params["paper_route_target_plan_source_decision"]["hypothesis_id"]
+            for decision in decisions
+        } == {"H-PAIRS-01"}
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_allow_shorts = allow_shorts_before
+
+
 def test_stale_unfilled_hpairs_closeout_does_not_block_retry_with_source_lineage(
     monkeypatch,
 ) -> None:
@@ -2004,6 +2097,9 @@ def test_contaminated_bounded_window_still_reserves_paper_account(monkeypatch) -
         assert pipeline._paper_route_target_plan_reserves_account(
             allowed_symbols={"AAPL", "AMZN"},
         )
+        assert pipeline._paper_route_target_plan_reserves_account(
+            allowed_symbols={"NVDA", "INTC"},
+        )
     finally:
         settings.trading_mode = trading_mode_before
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
@@ -2058,6 +2154,23 @@ def test_target_account_audit_unavailable_still_reserves_paper_account(
     finally:
         settings.trading_mode = trading_mode_before
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+
+
+def test_target_runtime_account_and_window_helpers_cover_identity_edges() -> None:
+    target = {
+        "account_label": "OTHER",
+        "account_stage_runtime_identity": {
+            "account_label": "PA3SX7FYNUTF",
+            "runtime_account_label": "TORGHUT_SIM",
+        },
+    }
+
+    assert not _target_runtime_account_matches(target, account_label="")
+    assert _target_runtime_account_matches(target, account_label="TORGHUT_SIM")
+    assert not _target_active_in_window(
+        target,
+        datetime(2026, 6, 1, 18, 0, tzinfo=timezone.utc),
+    )
 
 
 def test_target_plan_fetch_error_reserves_configured_paper_account(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -13475,7 +13475,9 @@ class TestTradingPipeline(TestCase):
                 )
             )
             setattr(pipeline, "_is_market_session_open", lambda _now: True)
-            self.assertFalse(
+            # An active bounded H-PAIRS owner reserves the whole paper account,
+            # not just symbols that overlap the candidate target.
+            self.assertTrue(
                 pipeline._paper_route_target_plan_reserves_account(
                     allowed_symbols={"MSFT"}
                 )


### PR DESCRIPTION
## Summary

- Reserves `TORGHUT_SIM` at the account level while an active H-PAIRS bounded paper proof target owns the evidence window.
- Skips non-owner external target-plan source collection targets for the same paper account during that H-PAIRS window, preventing TSMOM-style contamination.
- Adds regressions for same-account non-owner source target suppression and non-overlapping-symbol reservation.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_target_plan_reservation_rejects_unusable_targets`
- `uv run --frozen pytest tests/test_simple_pipeline.py -k 'hpairs_owner_skips or contaminated_bounded_window'`
- `uv run --frozen pytest tests/test_simple_pipeline.py`
- `COVERAGE_FILE=.coverage.local uv run --frozen pytest tests/test_simple_pipeline.py tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_target_plan_reservation_rejects_unusable_targets --cov --cov-branch --cov-fail-under=0 --cov-report=xml`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
