### PR TITLE
fix(torghut): harden paper proof source authority

### DIFF
--- a/services/torghut/app/trading/discovery/replay_ledger_ranker.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_ranker.py
@@ -26,6 +26,12 @@ _LIVE_PROMOTION_AUTHORITIES = frozenset(
 )
 _EXECUTION_QUALITY_SOURCE_PAPERS = (
     {
+        "source_id": "arxiv-2601.17247",
+        "url": "https://arxiv.org/abs/2601.17247",
+        "title": "Learning Market Making with Closing Auctions",
+        "mechanism": "closing_auction_projection_clearing_price_terminal_inventory_path",
+    },
+    {
         "source_id": "rof-rfaf049",
         "url": "https://doi.org/10.1093/rof/rfaf049",
         "title": "Retail Limit Orders",
@@ -95,6 +101,36 @@ _LIMIT_FILL_PROBABILITY_FIELDS = (
     "fill_probability",
     "estimated_limit_fill_probability",
     "survival_fill_probability",
+)
+_CLOSING_WINDOW_FIELDS = (
+    "closing_window",
+    "is_closing_window",
+    "close_window",
+    "late_session_window",
+)
+_CLOSING_AUCTION_FIELDS = (
+    "closing_auction",
+    "is_closing_auction",
+    "closing_auction_participation",
+    "close_auction",
+)
+_CLOSING_AUCTION_PROJECTION_FIELDS = (
+    "closing_auction_projection",
+    "closing_auction_projected_price",
+    "closing_auction_projected_imbalance",
+    "projected_closing_auction_price",
+)
+_CLOSING_AUCTION_CLEARING_PRICE_FIELDS = (
+    "closing_auction_clearing_price",
+    "closing_auction_reference_price",
+    "closing_auction_match_price",
+    "closing_price",
+)
+_TERMINAL_INVENTORY_PATH_FIELDS = (
+    "terminal_inventory_path",
+    "terminal_inventory_qty",
+    "terminal_position_qty",
+    "terminal_inventory_gap_share",
 )
 
 
@@ -755,6 +791,23 @@ def _execution_quality_summary(
         for row in rows
         if (value := _first_decimal(row, _LIMIT_FILL_PROBABILITY_FIELDS)) is not None
     ]
+    closing_window_sample_count = sum(
+        1 for row in rows if _first_evidence(row, _CLOSING_WINDOW_FIELDS)
+    )
+    closing_auction_sample_count = sum(
+        1 for row in rows if _first_evidence(row, _CLOSING_AUCTION_FIELDS)
+    )
+    closing_auction_projection_sample_count = sum(
+        1 for row in rows if _first_evidence(row, _CLOSING_AUCTION_PROJECTION_FIELDS)
+    )
+    closing_auction_clearing_price_sample_count = sum(
+        1
+        for row in rows
+        if _first_evidence(row, _CLOSING_AUCTION_CLEARING_PRICE_FIELDS)
+    )
+    terminal_inventory_path_sample_count = sum(
+        1 for row in rows if _first_evidence(row, _TERMINAL_INVENTORY_PATH_FIELDS)
+    )
     filled_status_count = sum(1 for row in rows if _row_has_fill_status(row))
     blockers: list[str] = []
     penalty_bps = Decimal("0")
@@ -782,6 +835,21 @@ def _execution_quality_summary(
     if limit_order_count > 0 and not opportunity_cost_samples:
         blockers.append("nonfill_opportunity_cost_evidence_incomplete")
         penalty_bps += Decimal("2")
+    if submitted_rows and closing_window_sample_count == 0:
+        blockers.append("closing_window_evidence_incomplete")
+        penalty_bps += Decimal("4")
+    if submitted_rows and closing_auction_sample_count == 0:
+        blockers.append("closing_auction_evidence_incomplete")
+        penalty_bps += Decimal("4")
+    if submitted_rows and closing_auction_projection_sample_count == 0:
+        blockers.append("closing_auction_projection_evidence_incomplete")
+        penalty_bps += Decimal("6")
+    if submitted_rows and closing_auction_clearing_price_sample_count == 0:
+        blockers.append("closing_auction_clearing_price_evidence_incomplete")
+        penalty_bps += Decimal("6")
+    if fill_rows and terminal_inventory_path_sample_count == 0:
+        blockers.append("terminal_inventory_path_evidence_incomplete")
+        penalty_bps += Decimal("6")
     limit_fill_rate = (
         _safe_divide(Decimal(limit_fill_count), Decimal(limit_order_count))
         if limit_order_count > 0
@@ -810,8 +878,12 @@ def _execution_quality_summary(
             "requires_exact_replay": True,
             "requires_route_tca": True,
             "requires_order_lifecycle_fill_evidence": True,
+            "requires_closing_auction_mechanism_evidence": True,
+            "requires_terminal_inventory_path_evidence": True,
             "requires_runtime_ledger": True,
             "rejects_model_fill_probability_as_fill_authority": True,
+            "rejects_closing_auction_projection_as_price_authority": True,
+            "rejects_terminal_inventory_path_as_position_authority": True,
             "rejects_adjusted_pnl_as_promotion_authority": True,
         },
         "submitted_order_count": len(submitted_rows),
@@ -834,6 +906,15 @@ def _execution_quality_summary(
         "queue_position_sample_count": queue_position_sample_count,
         "limit_fill_probability_sample_count": len(limit_fill_probability_samples),
         "avg_limit_fill_probability": _average_decimal(limit_fill_probability_samples),
+        "closing_window_sample_count": closing_window_sample_count,
+        "closing_auction_sample_count": closing_auction_sample_count,
+        "closing_auction_projection_sample_count": (
+            closing_auction_projection_sample_count
+        ),
+        "closing_auction_clearing_price_sample_count": (
+            closing_auction_clearing_price_sample_count
+        ),
+        "terminal_inventory_path_sample_count": terminal_inventory_path_sample_count,
         "execution_quality_blockers": tuple(_dedupe(blockers)),
         "execution_quality_penalty_bps": penalty_bps,
         "execution_quality_penalty_amount": penalty_amount,
@@ -926,6 +1007,29 @@ def _first_decimal(
         if value is not None:
             return value
     return None
+
+
+def _first_evidence(row: Mapping[str, object], fields: Sequence[str]) -> bool:
+    for field in fields:
+        if _evidence_present(row.get(field)):
+            return True
+    return False
+
+
+def _evidence_present(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, Decimal):
+        return True
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, Mapping):
+        return bool(cast(Mapping[object, object], value))
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return bool(cast(Sequence[object], value))
+    return bool(str(value).strip())
 
 
 def _decimal(value: object) -> Decimal | None:

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1326,6 +1326,29 @@ def _runtime_import_materialization_metadata_blockers(
         blockers.append(
             "runtime_window_import_source_execution_materialization_missing"
         )
+    target_notional_sizing_required_count = _int(
+        observation.get("paper_route_target_notional_sizing_required_count")
+    )
+    if target_notional_sizing_required_count > 0:
+        target_notional_sizing_authoritative_count = _int(
+            observation.get("paper_route_target_notional_sizing_authoritative_count")
+        )
+        target_notional_sizing_missing_count = _int(
+            observation.get("paper_route_target_notional_sizing_missing_count")
+        )
+        target_notional_sizing_non_authoritative_count = _int(
+            observation.get(
+                "paper_route_target_notional_sizing_non_authoritative_count"
+            )
+        )
+        if (
+            target_notional_sizing_missing_count > 0
+            or target_notional_sizing_authoritative_count
+            < target_notional_sizing_required_count
+        ):
+            blockers.append("paper_route_target_notional_sizing_missing")
+        if target_notional_sizing_non_authoritative_count > 0:
+            blockers.append("paper_route_target_notional_sizing_not_authoritative")
 
     source_materializations = _text_list(
         observation.get("runtime_ledger_source_materializations")
@@ -1555,6 +1578,10 @@ def _runtime_import_materialization_summary(
         "runtime_ledger_source_bucket_profit_proof_count": 0,
         "runtime_ledger_durable_bucket_profit_proof_count": 0,
         "runtime_ledger_artifact_tca_row_count": 0,
+        "paper_route_target_notional_sizing_required_count": 0,
+        "paper_route_target_notional_sizing_authoritative_count": 0,
+        "paper_route_target_notional_sizing_missing_count": 0,
+        "paper_route_target_notional_sizing_non_authoritative_count": 0,
     }
     for item in items:
         summary = _mapping(item.get("summary"))
@@ -1609,6 +1636,10 @@ def _runtime_import_materialization_summary(
             "runtime_ledger_source_bucket_profit_proof_count",
             "runtime_ledger_durable_bucket_profit_proof_count",
             "runtime_ledger_artifact_tca_row_count",
+            "paper_route_target_notional_sizing_required_count",
+            "paper_route_target_notional_sizing_authoritative_count",
+            "paper_route_target_notional_sizing_missing_count",
+            "paper_route_target_notional_sizing_non_authoritative_count",
         ):
             counts[key] += _int(observation.get(key))
         if observation.get("authoritative") is not True:

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -663,6 +663,75 @@ def _source_decision_profit_proof_flag(row: Mapping[str, object]) -> bool | None
     return _first_bool(row, "profit_proof_eligible", "post_cost_promotion_eligible")
 
 
+def _source_decision_target_notional_sizing_audit(
+    row: Mapping[str, object],
+) -> dict[str, object] | None:
+    for payload in _source_decision_priority_payloads(row):
+        audit = _as_mapping(payload.get("paper_route_target_notional_sizing"))
+        if audit:
+            return {str(key): value for key, value in audit.items()}
+        simple_lane = _as_mapping(payload.get("simple_lane"))
+        audit = _as_mapping(simple_lane.get("paper_route_target_notional_sizing"))
+        if audit:
+            return {str(key): value for key, value in audit.items()}
+    return None
+
+
+def _source_decision_target_notional_sizing_summary(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    source_row_count = len(rows)
+    audits: list[dict[str, object]] = []
+    authoritative_count = 0
+    non_authoritative_source_counts: dict[str, int] = {}
+    blocker_counts: dict[str, int] = {}
+    for row in rows:
+        audit = _source_decision_target_notional_sizing_audit(row)
+        if audit is None:
+            continue
+        audits.append(audit)
+        sizing_source = _text_or_none(audit.get("sizing_source")) or "missing"
+        if sizing_source == "target_notional":
+            authoritative_count += 1
+        else:
+            non_authoritative_source_counts[sizing_source] = (
+                non_authoritative_source_counts.get(sizing_source, 0) + 1
+            )
+        for blocker in _metadata_text_list(audit.get("blockers")):
+            blocker_counts[blocker] = blocker_counts.get(blocker, 0) + 1
+
+    mode_counts = _source_decision_mode_counts(rows)
+    requires_target_notional_sizing = (
+        bool(audits)
+        or mode_counts.get("bounded_paper_route_collection", 0) > 0
+        or any(
+            _first_text(row, "paper_route_probe_target_notional", "target_notional")
+            for row in rows
+        )
+    )
+    missing_count = max(source_row_count - len(audits), 0)
+    blockers: list[str] = []
+    if requires_target_notional_sizing and missing_count:
+        blockers.append("paper_route_target_notional_sizing_missing")
+    if non_authoritative_source_counts:
+        blockers.append("paper_route_target_notional_sizing_not_authoritative")
+    blockers.extend(blocker_counts)
+    return {
+        "source_row_count": source_row_count,
+        "audit_count": len(audits),
+        "authoritative_target_notional_sizing_count": authoritative_count,
+        "missing_target_notional_sizing_count": (
+            missing_count if requires_target_notional_sizing else 0
+        ),
+        "non_authoritative_sizing_source_counts": dict(
+            sorted(non_authoritative_source_counts.items())
+        ),
+        "sizing_blocker_counts": dict(sorted(blocker_counts.items())),
+        "requires_target_notional_sizing": requires_target_notional_sizing,
+        "blockers": list(dict.fromkeys(blockers)),
+    }
+
+
 def _source_row_is_paper_route_probe_exit(row: Mapping[str, object]) -> bool:
     for payload in _source_decision_priority_payloads(row):
         metadata = _as_mapping(payload.get("paper_route_probe_exit"))
@@ -2415,6 +2484,10 @@ def _runtime_ledger_tca_materialization_metadata(
     authoritative_bucket_count = 0
     source_execution_materialized_count = 0
     execution_reconstruction_count = 0
+    target_notional_sizing_required_count = 0
+    target_notional_sizing_authoritative_count = 0
+    target_notional_sizing_missing_count = 0
+    target_notional_sizing_non_authoritative_count = 0
     authority_reasons: list[str] = []
     pnl_derivations: list[str] = []
     source_materializations: list[str] = []
@@ -2449,6 +2522,25 @@ def _runtime_ledger_tca_materialization_metadata(
         )
         if source_materialization is not None:
             source_materializations.append(source_materialization)
+        target_notional_sizing = _as_mapping(
+            row.get("paper_route_target_notional_sizing")
+            or bucket_payload.get("paper_route_target_notional_sizing")
+        )
+        if target_notional_sizing.get("requires_target_notional_sizing"):
+            target_notional_sizing_required_count += 1
+            target_notional_sizing_authoritative_count += _nonnegative_int(
+                target_notional_sizing.get("authoritative_target_notional_sizing_count")
+            )
+            target_notional_sizing_missing_count += _nonnegative_int(
+                target_notional_sizing.get("missing_target_notional_sizing_count")
+            )
+            target_notional_sizing_non_authoritative_count += sum(
+                _nonnegative_int(value)
+                for value in _as_mapping(
+                    target_notional_sizing.get("non_authoritative_sizing_source_counts")
+                ).values()
+            )
+            blockers.extend(_metadata_text_list(target_notional_sizing.get("blockers")))
         if runtime_ledger_promotion_source_authority_present(bucket_payload):
             source_execution_materialized_count += 1
         if authority_reason == "execution_reconstruction_not_runtime_ledger_proof":
@@ -2470,6 +2562,18 @@ def _runtime_ledger_tca_materialization_metadata(
         ),
         "runtime_ledger_execution_reconstruction_bucket_count": (
             execution_reconstruction_count
+        ),
+        "paper_route_target_notional_sizing_required_count": (
+            target_notional_sizing_required_count
+        ),
+        "paper_route_target_notional_sizing_authoritative_count": (
+            target_notional_sizing_authoritative_count
+        ),
+        "paper_route_target_notional_sizing_missing_count": (
+            target_notional_sizing_missing_count
+        ),
+        "paper_route_target_notional_sizing_non_authoritative_count": (
+            target_notional_sizing_non_authoritative_count
         ),
         "runtime_ledger_materialization_authority_reasons": sorted(
             dict.fromkeys(authority_reasons)
@@ -4179,6 +4283,9 @@ def _runtime_source_context_for_bucket(
         "source_decision_profit_proof_eligible": (
             _source_decision_rows_profit_proof_eligible(source_rows)
         ),
+        "paper_route_target_notional_sizing": (
+            _source_decision_target_notional_sizing_summary(source_rows)
+        ),
         "equity_denominator": _runtime_ledger_equity_denominator_from_rows(source_rows),
     }
 
@@ -4769,6 +4876,12 @@ def _build_realized_strategy_pnl_rows(
         source_decision_profit_proof_eligible = bool(
             source_context["source_decision_profit_proof_eligible"]
         )
+        target_notional_sizing = cast(
+            dict[str, object], source_context["paper_route_target_notional_sizing"]
+        )
+        target_notional_sizing_blockers = _metadata_text_list(
+            target_notional_sizing.get("blockers")
+        )
         source_refs = cast(list[str], source_context["source_refs"])
         source_row_counts = cast(dict[str, int], source_context["source_row_counts"])
         trade_decision_ids = cast(list[str], source_context["trade_decision_ids"])
@@ -4877,6 +4990,23 @@ def _build_realized_strategy_pnl_rows(
                     row["promotion_blocker"] = (
                         SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER
                     )
+                row["runtime_ledger_bucket"] = bucket_payload
+        if target_notional_sizing.get("requires_target_notional_sizing"):
+            row["paper_route_target_notional_sizing"] = target_notional_sizing
+            if isinstance(bucket_payload, Mapping):
+                bucket_payload = {
+                    **dict(bucket_payload),
+                    "paper_route_target_notional_sizing": target_notional_sizing,
+                }
+                if target_notional_sizing_blockers:
+                    blockers = list(bucket_payload.get("blockers") or [])
+                    for blocker in target_notional_sizing_blockers:
+                        if blocker not in blockers:
+                            blockers.append(blocker)
+                    bucket_payload["blockers"] = blockers
+                    row["runtime_ledger_blockers"] = blockers
+                    row["post_cost_promotion_eligible"] = False
+                    row["promotion_blocker"] = target_notional_sizing_blockers[0]
                 row["runtime_ledger_bucket"] = bucket_payload
         if isinstance(bucket_payload, Mapping):
             bucket_payload = _with_runtime_ledger_source_authority_context(

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1370,6 +1370,52 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["authority_blockers"],
         )
 
+    def test_authority_packet_rejects_non_authoritative_target_notional_sizing(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        runtime_observation = cast(
+            dict[str, object],
+            cast(dict[str, object], runtime_import["imports"][0])["summary"],
+        )["runtime_observation"]
+        assert isinstance(runtime_observation, dict)
+        runtime_observation.update(
+            {
+                "paper_route_target_notional_sizing_required_count": 1,
+                "paper_route_target_notional_sizing_authoritative_count": 0,
+                "paper_route_target_notional_sizing_missing_count": 1,
+                "paper_route_target_notional_sizing_non_authoritative_count": 1,
+            }
+        )
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="authority",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["final_authority_ok"], result)
+        self.assertIn(
+            "paper_route_target_notional_sizing_missing",
+            result["authority_blockers"],
+        )
+        self.assertIn(
+            "paper_route_target_notional_sizing_not_authoritative",
+            result["authority_blockers"],
+        )
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertEqual(
+            materialization["paper_route_target_notional_sizing_required_count"],
+            1,
+        )
+        self.assertEqual(
+            materialization["paper_route_target_notional_sizing_missing_count"],
+            1,
+        )
+
     def test_source_offsets_accept_mapping_and_skip_invalid_or_duplicate_values(
         self,
     ) -> None:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -62,6 +62,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _source_activity_missing_summary,
     _source_backed_fill_lifecycle_rows,
     _source_backed_order_lifecycle_rows,
+    _source_decision_target_notional_sizing_summary,
     _source_decision_mode,
     _source_decision_mode_counts,
     _source_decision_rows_profit_proof_eligible,
@@ -1366,6 +1367,111 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             _runtime_ledger_bucket_profit_proof_blockers(bucket),
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+    def test_target_notional_sizing_summary_requires_authoritative_runtime_audit(
+        self,
+    ) -> None:
+        summary = _source_decision_target_notional_sizing_summary(
+            [
+                {
+                    "source_decision_mode": "bounded_paper_route_collection",
+                    "paper_route_probe_target_notional": "150",
+                    "decision_json": {
+                        "paper_route_target_notional_sizing": {
+                            "sizing_source": "target_notional",
+                            "blockers": [],
+                        }
+                    },
+                },
+                {
+                    "source_decision_mode": "bounded_paper_route_collection",
+                    "paper_route_probe_target_notional": "150",
+                },
+                {
+                    "source_decision_mode": "bounded_paper_route_collection",
+                    "paper_route_probe_target_notional": "150",
+                    "decision_json": {
+                        "paper_route_target_notional_sizing": {
+                            "sizing_source": "max_notional",
+                            "blockers": [
+                                "paper_route_target_notional_qty_below_min_step"
+                            ],
+                        }
+                    },
+                },
+            ]
+        )
+
+        self.assertTrue(summary["requires_target_notional_sizing"])
+        self.assertEqual(summary["audit_count"], 2)
+        self.assertEqual(summary["authoritative_target_notional_sizing_count"], 1)
+        self.assertEqual(summary["missing_target_notional_sizing_count"], 1)
+        self.assertEqual(
+            summary["non_authoritative_sizing_source_counts"],
+            {"max_notional": 1},
+        )
+        self.assertEqual(
+            summary["sizing_blocker_counts"],
+            {"paper_route_target_notional_qty_below_min_step": 1},
+        )
+        self.assertEqual(
+            summary["blockers"],
+            [
+                "paper_route_target_notional_sizing_missing",
+                "paper_route_target_notional_sizing_not_authoritative",
+                "paper_route_target_notional_qty_below_min_step",
+            ],
+        )
+
+    def test_runtime_rows_fail_closed_on_non_authoritative_target_notional_sizing(
+        self,
+    ) -> None:
+        decision_rows, order_rows, execution_rows = _source_backed_runtime_split_rows()
+        for row in decision_rows:
+            row["source_decision_mode"] = "bounded_paper_route_collection"
+            row["paper_route_probe_target_notional"] = "150"
+            row["decision_json"] = {
+                "source_decision_mode": "bounded_paper_route_collection",
+                "paper_route_probe_target_notional": "150",
+                "paper_route_target_notional_sizing": {
+                    "sizing_source": "max_notional",
+                    "blockers": ["paper_route_target_notional_qty_below_min_step"],
+                },
+            }
+
+        rows = _build_realized_strategy_pnl_rows(
+            execution_rows,
+            decision_lifecycle_rows=decision_rows,
+            order_lifecycle_rows=order_rows,
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 2)
+        for row in rows:
+            self.assertFalse(row["post_cost_promotion_eligible"])
+            self.assertIn("promotion_blocker", row)
+        rows_with_sizing = [
+            row for row in rows if "paper_route_target_notional_sizing" in row
+        ]
+        self.assertTrue(rows_with_sizing)
+        for row in rows_with_sizing:
+            self.assertIn(
+                "paper_route_target_notional_sizing_not_authoritative",
+                row["runtime_ledger_blockers"],
+            )
+            self.assertIn(
+                "paper_route_target_notional_qty_below_min_step",
+                row["runtime_ledger_blockers"],
+            )
+            sizing = row["paper_route_target_notional_sizing"]
+            self.assertEqual(sizing["authoritative_target_notional_sizing_count"], 0)
+            self.assertEqual(
+                sizing["non_authoritative_sizing_source_counts"],
+                {"max_notional": 2},
+            )
+            bucket = row["runtime_ledger_bucket"]
+            assert isinstance(bucket, dict)
+            self.assertEqual(bucket["paper_route_target_notional_sizing"], sizing)
 
     def test_runtime_ledger_tca_refs_accept_readback_aliases(self) -> None:
         readback_alias_bucket = _complete_runtime_ledger_bucket(
@@ -7375,16 +7481,25 @@ class TestImportHypothesisRuntimeWindows(TestCase):
     def test_build_realized_strategy_pnl_rows_keeps_probe_exit_with_source_entry(
         self,
     ) -> None:
+        target_notional_sizing_json = {
+            "sizing_source": "target_notional",
+            "target_notional": "100",
+            "reference_price": "100",
+            "computed_qty": "1",
+            "blockers": [],
+        }
         entry_decision_json = {
             "params": {
                 "source_decision_mode": "bounded_paper_route_collection",
                 "profit_proof_eligible": True,
                 "account": {"equity": "10000"},
+                "paper_route_target_notional_sizing": target_notional_sizing_json,
             }
         }
         exit_decision_json = {
             "params": {
                 "source_decision_mode": "route_acquisition_probe",
+                "paper_route_target_notional_sizing": target_notional_sizing_json,
                 "paper_route_probe_exit": {
                     "mode": "paper_route_exit",
                     "source": "filled_paper_route_probe_executions",
@@ -7400,6 +7515,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             "params": {
                 "source_decision_mode": "route_acquisition_probe",
                 "profit_proof_eligible": False,
+                "paper_route_target_notional_sizing": target_notional_sizing_json,
             }
         }
 

--- a/services/torghut/tests/test_replay_ledger_ranker.py
+++ b/services/torghut/tests/test_replay_ledger_ranker.py
@@ -93,12 +93,25 @@ def _with_execution_quality(
     queue_position: str | None = None,
     opportunity_cost_bps: str | None = None,
     price_improvement_bps: str | None = None,
+    include_closing_auction_evidence: bool = True,
 ) -> list[dict[str, object]]:
     for row in rows:
         if row.get("event_type") in {"order_submitted", "fill"}:
             row["order_type"] = order_type
             row["execution_shortfall_bps"] = shortfall_bps
             row["fill_status"] = "filled"
+            if include_closing_auction_evidence:
+                row["closing_window"] = "late_session_close"
+                row["closing_auction"] = True
+                row["closing_auction_projection"] = {
+                    "projected_imbalance_shares": "12500",
+                    "projected_clearing_price": "100.42",
+                }
+                row["closing_auction_clearing_price"] = "100.44"
+                row["terminal_inventory_path"] = [
+                    {"minutes_to_close": 10, "qty": "1000"},
+                    {"minutes_to_close": 0, "qty": "0"},
+                ]
             if limit_fill_probability is not None:
                 row["limit_fill_probability"] = limit_fill_probability
             if queue_position is not None:
@@ -307,6 +320,86 @@ def test_ranker_uses_market_limit_queue_execution_quality_for_adjusted_ranking(
     assert Decimal(
         str(top["execution_quality_adjusted_window_net_pnl_per_day"])
     ) > Decimal(str(raw_winner["execution_quality_adjusted_window_net_pnl_per_day"]))
+
+
+def test_ranker_penalizes_missing_closing_auction_mechanism_evidence(
+    tmp_path: Path,
+) -> None:
+    complete = _payload(
+        "complete-closing-auction-evidence",
+        _with_execution_quality(
+            _round_trip(
+                day=18,
+                symbol="NVDA",
+                qty="1000",
+                buy_price="100",
+                sell_price="100.80",
+                prefix="complete-closing",
+            ),
+            order_type="limit",
+            shortfall_bps="1",
+            limit_fill_probability="0.80",
+            queue_position="0.20",
+            opportunity_cost_bps="2",
+            price_improvement_bps="3",
+        ),
+    )
+    missing_mechanism = _payload(
+        "missing-closing-auction-evidence",
+        _with_execution_quality(
+            _round_trip(
+                day=18,
+                symbol="NVDA",
+                qty="1000",
+                buy_price="100",
+                sell_price="100.82",
+                prefix="missing-closing",
+            ),
+            order_type="limit",
+            shortfall_bps="1",
+            limit_fill_probability="0.80",
+            queue_position="0.20",
+            opportunity_cost_bps="2",
+            price_improvement_bps="3",
+            include_closing_auction_evidence=False,
+        ),
+    )
+    complete_path = tmp_path / "complete.json"
+    missing_path = tmp_path / "missing.json"
+    complete_path.write_text(json.dumps(complete))
+    missing_path.write_text(json.dumps(missing_mechanism))
+
+    report = build_replay_ledger_ranking_report(
+        [complete_path, missing_path],
+        policy=ReplayLedgerRankingPolicy(
+            target_net_pnl_per_day=Decimal("1"),
+            min_window_weekday_count=1,
+            min_avg_filled_notional_per_day=Decimal("1"),
+            max_best_day_share=Decimal("1.0"),
+            max_gross_exposure_pct_equity=Decimal("1000.0"),
+            start_equity=Decimal("100000000"),
+        ),
+    )
+    top = report["candidates"][0]
+    missing = report["candidates"][1]
+
+    assert top["candidate_id"] == "complete-closing-auction-evidence"
+    assert top["execution_quality"]["closing_window_sample_count"] == 4
+    assert top["execution_quality"]["closing_auction_sample_count"] == 4
+    assert top["execution_quality"]["closing_auction_projection_sample_count"] == 4
+    assert top["execution_quality"]["closing_auction_clearing_price_sample_count"] == 4
+    assert top["execution_quality"]["terminal_inventory_path_sample_count"] == 4
+    assert "closing_window_evidence_incomplete" not in top["execution_quality_blockers"]
+    assert missing["candidate_id"] == "missing-closing-auction-evidence"
+    assert {
+        "closing_window_evidence_incomplete",
+        "closing_auction_evidence_incomplete",
+        "closing_auction_projection_evidence_incomplete",
+        "closing_auction_clearing_price_evidence_incomplete",
+        "terminal_inventory_path_evidence_incomplete",
+    }.issubset(set(missing["execution_quality_blockers"]))
+    assert Decimal(str(missing["execution_quality_penalty_bps"])) > Decimal("0")
+    assert missing["promotion_status"] == "blocked_pending_runtime_promotion_proof"
 
 
 def test_ranker_blocks_replay_only_and_over_equity_artifacts() -> None:


### PR DESCRIPTION
## Summary

- Requires source-backed runtime-window imports to carry authoritative target-notional sizing audits before they can satisfy promotion authority.
- Carries target-notional sizing counts and blockers into runtime-ledger proof packet materialization summaries.
- Adds closing-auction and terminal-inventory mechanism evidence to replay ledger ranking so projection-only evidence is penalized rather than trusted.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_replay_ledger_ranker.py tests/test_import_hypothesis_runtime_windows.py -k 'target_notional_sizing or non_authoritative_target_notional or closing_auction or terminal_inventory' tests/test_assemble_runtime_ledger_proof_packet.py -k 'target_notional_sizing or aggregate_only_runtime_import_materialization' -q`
- `uv run --frozen pytest tests/test_replay_ledger_ranker.py -q`
- `uv run --frozen ruff format --check app/trading/discovery/replay_ledger_ranker.py scripts/import_hypothesis_runtime_windows.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_replay_ledger_ranker.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check app/trading/discovery/replay_ledger_ranker.py scripts/import_hypothesis_runtime_windows.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_replay_ledger_ranker.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
