### PR TITLE
fix(torghut): prefer explicit tca policy hashes

### DIFF
--- a/services/torghut/app/trading/tca.py
+++ b/services/torghut/app/trading/tca.py
@@ -326,22 +326,13 @@ def _repair_execution_tca_cost_lineage(
     else:
         source_fields["explicit_cost"] = cost_source_field
 
-    execution_policy_hashes = _hash_candidates(
-        source_payloads,
-        hash_keys=_EXECUTION_POLICY_HASH_KEYS,
-        payload_keys=_EXECUTION_POLICY_PAYLOAD_KEYS,
+    execution_policy_hashes = _execution_policy_hash_candidates(
+        source_payloads=source_payloads,
+        decision=decision,
+        decision_payload=decision_payload,
+        execution=execution,
+        source_fields=source_fields,
     )
-    if len(execution_policy_hashes) == 0:
-        decision_policy_hash = _decision_execution_policy_hash(
-            decision=decision,
-            decision_payload=decision_payload,
-            execution=execution,
-        )
-        if decision_policy_hash is not None:
-            execution_policy_hashes.add(decision_policy_hash)
-            source_fields["execution_policy_hash"] = (
-                "trade_decisions.decision_json+executions.order_fields"
-            )
     if len(execution_policy_hashes) == 0:
         blockers.append("execution_policy_hash_missing")
     elif len(execution_policy_hashes) > 1:
@@ -450,7 +441,9 @@ def _lineage_source_payloads(
         payloads.append(payload)
         if depth <= 0:
             return
-        for nested in payload.values():
+        for item_key, nested in payload.items():
+            if str(item_key) == "source_fields":
+                continue
             if isinstance(nested, Mapping):
                 append_payload(cast(Mapping[object, object], nested), depth=depth - 1)
 
@@ -639,6 +632,63 @@ def _decision_execution_policy_hash(
     return _stable_payload_digest(
         {key: value for key, value in policy_payload.items() if value is not None}
     )
+
+
+def _execution_policy_hash_candidates(
+    *,
+    source_payloads: Collection[Mapping[str, object]],
+    decision: TradeDecision | None,
+    decision_payload: Mapping[str, object],
+    execution: Execution,
+    source_fields: dict[str, object],
+) -> set[str]:
+    explicit_hashes = _hash_candidates(
+        source_payloads,
+        hash_keys=_EXECUTION_POLICY_HASH_KEYS,
+        payload_keys=(),
+    )
+    if explicit_hashes:
+        if len(explicit_hashes) == 1:
+            source_fields["execution_policy_hash"] = (
+                _existing_lineage_source_field(source_payloads, "execution_policy_hash")
+                or "execution_policy_hash"
+            )
+        return explicit_hashes
+
+    payload_hashes = _hash_candidates(
+        source_payloads,
+        hash_keys=(),
+        payload_keys=_EXECUTION_POLICY_PAYLOAD_KEYS,
+    )
+    if payload_hashes:
+        if len(payload_hashes) == 1:
+            source_fields["execution_policy_hash"] = "execution_policy_payload"
+        return payload_hashes
+
+    decision_policy_hash = _decision_execution_policy_hash(
+        decision=decision,
+        decision_payload=decision_payload,
+        execution=execution,
+    )
+    if decision_policy_hash is None:
+        return set()
+    source_fields["execution_policy_hash"] = (
+        "trade_decisions.decision_json+executions.order_fields"
+    )
+    return {decision_policy_hash}
+
+
+def _existing_lineage_source_field(
+    payloads: Collection[Mapping[str, object]], key: str
+) -> object | None:
+    for payload in payloads:
+        source_fields = payload.get("source_fields")
+        if not isinstance(source_fields, Mapping):
+            continue
+        source_field = cast(Mapping[object, object], source_fields).get(key)
+        if source_field is not None:
+            return source_field
+    return None
 
 
 def _hash_candidates(

--- a/services/torghut/tests/test_execution_tca.py
+++ b/services/torghut/tests/test_execution_tca.py
@@ -404,6 +404,49 @@ class TestExecutionTcaCostLineage(TestCase):
             "trade_decisions.decision_json+executions.order_fields",
         )
 
+    def test_upsert_prefers_explicit_policy_hash_over_nested_policy_payloads(
+        self,
+    ) -> None:
+        with self.session_local() as session:
+            strategy = self._insert_strategy(session)
+            decision = self._insert_decision(
+                session,
+                strategy,
+                decision_hash="explicit-policy-decision",
+                execution_policy={"version": "decision-policy", "max_bps": "12"},
+            )
+            execution = self._insert_execution(
+                session,
+                decision,
+                order_id="explicit-policy-order",
+                raw_order={
+                    "commission": "0.02",
+                    "execution_policy": {
+                        "version": "raw-order-policy",
+                        "limit_offset_bps": "2",
+                    },
+                },
+                execution_audit_json={
+                    "execution_policy_hash": "policy-explicit",
+                    "execution_policy": {
+                        "version": "audit-policy",
+                        "limit_offset_bps": "1",
+                    },
+                },
+            )
+
+            upsert_execution_tca_metric(session, execution)
+            session.flush()
+            lineage = self._lineage(execution)
+
+        self.assertEqual(lineage["status"], "source_backed")
+        self.assertEqual(lineage["blockers"], [])
+        self.assertEqual(lineage["execution_policy_hash"], "policy-explicit")
+        self.assertEqual(
+            lineage["source_fields"]["execution_policy_hash"],
+            "execution_policy_hash",
+        )
+
     def test_upsert_blocks_ambiguous_policy_and_cost_model_hashes(self) -> None:
         with self.session_local() as session:
             strategy = self._insert_strategy(session)


### PR DESCRIPTION
## Summary

- Prefer persisted explicit execution policy hashes when repairing TCA runtime-ledger cost lineage.
- Keep conflicting explicit policy hashes fail-closed as ambiguous.
- Skip repaired lineage `source_fields` metadata during source-payload recursion so refreshes stay idempotent.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_execution_tca.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "execution_policy_hash or build_realized_strategy_pnl_rows_keeps_probe_exit_with_source_entry or query_timestamps_filters_to_execution_eligible_decisions"`
- `uv run --frozen ruff format --check app/trading/tca.py tests/test_execution_tca.py`
- `uv run --frozen ruff check app/trading/tca.py tests/test_execution_tca.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
