### PR TITLE
fix(torghut): refresh sim tca before runtime import

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -22,8 +22,9 @@ The empirical workflow depends on the namespace-local sealed secret
 workflow submissions in `torghut` do not rely on manual secret copies from `argo-workflows`.
 
 The `torghut-empirical-promotion-renewal` CronJob is also the scheduled runtime-ledger proof packet conductor for the
-paper-route proof lane. It first runs `renew_latest_empirical_promotion_jobs.py` with the sim
-`/trading/paper-route-evidence?target_limit=5` target plan/evidence payload, then runs
+paper-route proof lane. It first repairs sim source-window lineage, refreshes sim execution TCA rows from `SIM_DB_DSN`,
+then runs `renew_latest_empirical_promotion_jobs.py` with the sim
+`/trading/paper-route-evidence?target_limit=5` target plan/evidence payload, and finally runs
 `assemble_runtime_ledger_proof_packet.py` in explicit
 `authority` mode and uploads the packet under `runtime-ledger-proof-packets/{run_id}`. The scheduled packet uses the
 final authority thresholds: 20 runtime-ledger trading days, $10,000 total post-cost net PnL, $500/day post-cost net PnL,

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -57,6 +57,14 @@ spec:
                     --backfill-execution-events \
                     --apply \
                     --json
+                  /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --older-than-seconds 0 \
+                    --batch-size 1000 \
+                    --max-batches 5 \
+                    --apply \
+                    --json
                   /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \

--- a/services/torghut/scripts/refresh_execution_tca_metrics.py
+++ b/services/torghut/scripts/refresh_execution_tca_metrics.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Any
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
 
 from app.db import SessionLocal
 from app.trading.tca import refresh_execution_tca_metrics
@@ -15,6 +20,11 @@ from app.trading.tca import refresh_execution_tca_metrics
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Refresh stale execution_tca_metrics rows from persisted executions.",
+    )
+    parser.add_argument(
+        "--dsn-env",
+        default="DB_DSN",
+        help="Environment variable containing the database DSN to refresh.",
     )
     parser.add_argument("--account-label", type=str, default=None)
     parser.add_argument(
@@ -34,6 +44,39 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
+
+
+def _session_factory(args: argparse.Namespace) -> tuple[Any, Engine | None]:
+    dsn_env = str(args.dsn_env or "DB_DSN").strip() or "DB_DSN"
+    if dsn_env == "DB_DSN":
+        return SessionLocal, None
+
+    dsn = os.environ.get(dsn_env)
+    if not dsn:
+        raise SystemExit(f"missing DSN env var: {dsn_env}")
+
+    engine = create_engine(_sqlalchemy_dsn(dsn), pool_pre_ping=True, future=True)
+    return (
+        sessionmaker(
+            bind=engine,
+            autoflush=False,
+            autocommit=False,
+            expire_on_commit=False,
+            future=True,
+        ),
+        engine,
+    )
+
+
 def _payload(
     *, args: argparse.Namespace, started_at: datetime, batches: list[dict[str, Any]]
 ) -> dict[str, Any]:
@@ -42,6 +85,7 @@ def _payload(
     return {
         "status": "ok",
         "apply": bool(args.apply),
+        "dsn_env": args.dsn_env,
         "account_label": args.account_label,
         "older_than_seconds": max(0, int(args.older_than_seconds)),
         "batch_size": max(1, min(int(args.batch_size), 5000)),
@@ -61,24 +105,29 @@ def main() -> int:
     batch_size = max(1, min(int(args.batch_size), 5000))
     max_batches = max(1, int(args.max_batches))
     batches: list[dict[str, Any]] = []
+    session_factory, engine = _session_factory(args)
 
-    with SessionLocal() as session:
-        for _ in range(max_batches):
-            batch = refresh_execution_tca_metrics(
-                session,
-                account_label=args.account_label,
-                stale_before=stale_before,
-                limit=batch_size,
-                dry_run=not bool(args.apply),
-            )
-            batches.append(batch)
-            if args.apply:
-                session.commit()
-            else:
-                session.rollback()
-                break
-            if int(batch.get("selected") or 0) < batch_size:
-                break
+    try:
+        with session_factory() as session:
+            for _ in range(max_batches):
+                batch = refresh_execution_tca_metrics(
+                    session,
+                    account_label=args.account_label,
+                    stale_before=stale_before,
+                    limit=batch_size,
+                    dry_run=not bool(args.apply),
+                )
+                batches.append(batch)
+                if args.apply:
+                    session.commit()
+                else:
+                    session.rollback()
+                    break
+                if int(batch.get("selected") or 0) < batch_size:
+                    break
+    finally:
+        if engine is not None:
+            engine.dispose()
 
     payload = _payload(args=args, started_at=started_at, batches=batches)
     print(

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1854,7 +1854,15 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--account-label TORGHUT_REPLAY", args)
         self.assertIn("--backfill-execution-events", args)
         self.assertEqual(args.count("scripts/repair_order_feed_source_windows.py"), 2)
-        self.assertEqual(args.count("--dsn-env SIM_DB_DSN"), 2)
+        self.assertIn("scripts/refresh_execution_tca_metrics.py", args)
+        self.assertIn("--older-than-seconds 0", args)
+        self.assertIn("--max-batches 5", args)
+        self.assertEqual(args.count("scripts/refresh_execution_tca_metrics.py"), 1)
+        self.assertEqual(args.count("--dsn-env SIM_DB_DSN"), 3)
+        self.assertLess(
+            args.index("scripts/refresh_execution_tca_metrics.py"),
+            args.index("scripts/renew_latest_empirical_promotion_jobs.py"),
+        )
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "

--- a/services/torghut/tests/test_refresh_execution_tca_metrics_script.py
+++ b/services/torghut/tests/test_refresh_execution_tca_metrics_script.py
@@ -2,11 +2,20 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import sys
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from scripts import refresh_execution_tca_metrics as script
+
+
+class _FakeEngine:
+    def __init__(self) -> None:
+        self.dispose_calls = 0
+
+    def dispose(self) -> None:
+        self.dispose_calls += 1
 
 
 class _FakeSession:
@@ -28,6 +37,20 @@ class _FakeSession:
 
 
 class TestRefreshExecutionTcaMetricsScript(TestCase):
+    def test_sqlalchemy_dsn_normalizes_postgres_url_variants(self) -> None:
+        self.assertEqual(
+            script._sqlalchemy_dsn("postgresql+psycopg://user:pass@db/torghut"),
+            "postgresql+psycopg://user:pass@db/torghut",
+        )
+        self.assertEqual(
+            script._sqlalchemy_dsn("postgresql://user:pass@db/torghut"),
+            "postgresql+psycopg://user:pass@db/torghut",
+        )
+        self.assertEqual(
+            script._sqlalchemy_dsn("sqlite:///tmp/torghut.db"),
+            "sqlite:///tmp/torghut.db",
+        )
+
     def test_main_defaults_to_dry_run_and_rolls_back(self) -> None:
         fake_session = _FakeSession()
         stdout = io.StringIO()
@@ -123,3 +146,82 @@ class TestRefreshExecutionTcaMetricsScript(TestCase):
         self.assertEqual(refresh.call_args.kwargs["account_label"], "paper")
         self.assertEqual(refresh.call_args.kwargs["limit"], 2)
         self.assertEqual(refresh.call_args.kwargs["dry_run"], False)
+
+    def test_main_can_refresh_non_default_dsn_env(self) -> None:
+        fake_engine = _FakeEngine()
+        fake_session = _FakeSession()
+        stdout = io.StringIO()
+        session_factory = Mock(return_value=fake_session)
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "refresh_execution_tca_metrics.py",
+                    "--dsn-env",
+                    "SIM_DB_DSN",
+                    "--account-label",
+                    "TORGHUT_SIM",
+                    "--json",
+                ],
+            ),
+            patch.dict(
+                os.environ,
+                {"SIM_DB_DSN": "postgres://user:pass@db:5432/torghut_sim_default"},
+            ),
+            patch.object(script, "create_engine", return_value=fake_engine) as create,
+            patch.object(script, "sessionmaker", return_value=session_factory) as make,
+            patch.object(
+                script,
+                "refresh_execution_tca_metrics",
+                return_value={
+                    "selected": 3,
+                    "refreshed": 0,
+                    "dry_run": True,
+                    "limit": 1000,
+                    "account_label": "TORGHUT_SIM",
+                    "stale_before": "2026-06-05T00:00:00+00:00",
+                },
+            ) as refresh,
+            patch("sys.stdout", stdout),
+        ):
+            exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(payload["account_label"], "TORGHUT_SIM")
+        create.assert_called_once_with(
+            "postgresql+psycopg://user:pass@db:5432/torghut_sim_default",
+            pool_pre_ping=True,
+            future=True,
+        )
+        make.assert_called_once_with(
+            bind=fake_engine,
+            autoflush=False,
+            autocommit=False,
+            expire_on_commit=False,
+            future=True,
+        )
+        session_factory.assert_called_once_with()
+        self.assertEqual(fake_engine.dispose_calls, 1)
+        refresh.assert_called_once()
+        self.assertEqual(refresh.call_args.kwargs["account_label"], "TORGHUT_SIM")
+
+    def test_main_rejects_missing_non_default_dsn_env(self) -> None:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "refresh_execution_tca_metrics.py",
+                    "--dsn-env",
+                    "SIM_DB_DSN",
+                    "--json",
+                ],
+            ),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            with self.assertRaisesRegex(SystemExit, "missing DSN env var: SIM_DB_DSN"):
+                script.main()


### PR DESCRIPTION
## Summary

- Added `--dsn-env` to `scripts/refresh_execution_tca_metrics.py` so scheduled TCA refreshes can run against `SIM_DB_DSN` instead of the default DB session.
- Updated `torghut-empirical-promotion-renewal` to refresh `TORGHUT_SIM` execution TCA after source-window repair and before runtime-window import.
- Hardened the script and manifest contract tests, and documented the renewal conductor sequence.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_refresh_execution_tca_metrics_script.py tests/test_live_config_manifest_contract.py -k 'refresh_execution_tca_metrics or empirical_promotion_renewal_imports_authoritative_live_paper_plan_and_sim_db'`
- `uv run --frozen ruff format --check scripts/refresh_execution_tca_metrics.py tests/test_refresh_execution_tca_metrics_script.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/refresh_execution_tca_metrics.py tests/test_refresh_execution_tca_metrics_script.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_refresh_execution_tca_metrics_script.py tests/test_live_config_manifest_contract.py`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
