### PR TITLE
fix(torghut): enforce bounded paper proof authority

### DIFF
--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -48,6 +48,7 @@ spec:
                     --expected-account-label TORGHUT_SIM \
                     --trading-mode paper \
                     --paper-base-url https://paper-api.alpaca.markets \
+                    --database-dsn-env SIM_DB_DSN \
                     --max-gross-market-value 100000 \
                     --max-position-count 25 \
                     --extended-hours-limit \
@@ -64,6 +65,28 @@ spec:
                     secretKeyRef:
                       name: torghut-db-app
                       key: uri
+                - name: TORGHUT_SIM_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: host
+                - name: TORGHUT_SIM_DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: port
+                - name: TORGHUT_SIM_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: username
+                - name: TORGHUT_SIM_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: password
+                - name: SIM_DB_DSN
+                  value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: APCA_API_KEY_ID
                   valueFrom:
                     secretKeyRef:

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -44,6 +44,7 @@ from ..quote_quality import (
     _status,
     assess_signal_quote_quality,
 )
+from ..quantity_rules import quantize_qty_for_symbol, resolve_quantity_resolution
 from ..proof_floor import build_profitability_proof_floor_receipt
 from ..runtime_decision_authority import (
     BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
@@ -1287,6 +1288,45 @@ def _paper_route_probe_entry_metadata(
     if _target_bool(probe_metadata.get("profit_proof_eligible")) is True:
         return None
     return probe_metadata
+
+
+def _target_notional_sizing_audit_from_params(
+    params: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    direct = _mapping_value(params.get("paper_route_target_notional_sizing"))
+    if (
+        direct is not None
+        and _safe_text(direct.get("sizing_source")) == "target_notional"
+    ):
+        return direct
+    for key in (
+        "paper_route_target_plan_source_decision",
+        "paper_route_target_plan",
+        "paper_route_probe",
+        "simple_lane",
+    ):
+        metadata = _mapping_value(params.get(key))
+        if metadata is None:
+            continue
+        audit = _mapping_value(metadata.get("paper_route_target_notional_sizing"))
+        if (
+            audit is not None
+            and _safe_text(audit.get("sizing_source")) == "target_notional"
+        ):
+            return audit
+    return None
+
+
+def _bounded_collection_decision_requires_target_notional_sizing(
+    params: Mapping[str, Any],
+) -> bool:
+    source_decision_mode = normalize_source_decision_mode(
+        params.get("source_decision_mode")
+    )
+    return (
+        source_decision_mode == BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+        and _target_bool(params.get("profit_proof_eligible")) is True
+    )
 
 
 def _bounded_paper_route_collection_entry_metadata(
@@ -4084,6 +4124,267 @@ class SimpleTradingPipeline(TradingPipeline):
         )
 
     @staticmethod
+    def _decision_quote_snapshot_for_target_sizing(
+        decision: StrategyDecision,
+    ) -> dict[str, Any] | None:
+        normalized_symbol = decision.symbol.strip().upper()
+        snapshot = _quote_snapshot_from_mapping(
+            decision.params,
+            symbol=normalized_symbol,
+        )
+        if snapshot is not None:
+            return dict(snapshot)
+        price = _decimal_from_mapping(
+            decision.params,
+            ("price", "reference_price", "mid", "mid_price"),
+        )
+        bid = _decimal_from_mapping(
+            decision.params,
+            ("imbalance_bid_px", "bid", "bid_px", "bid_price"),
+        )
+        ask = _decimal_from_mapping(
+            decision.params,
+            ("imbalance_ask_px", "ask", "ask_px", "ask_price"),
+        )
+        spread = _decimal_from_mapping(
+            decision.params,
+            ("imbalance_spread", "spread"),
+        )
+        if price is None and bid is not None and ask is not None and ask >= bid:
+            price = (bid + ask) / Decimal("2")
+        if price is None and bid is None and ask is None:
+            return None
+        return {
+            "symbol": normalized_symbol,
+            "price": str(price) if price is not None else None,
+            "bid": str(bid) if bid is not None else None,
+            "ask": str(ask) if ask is not None else None,
+            "spread": str(spread) if spread is not None else None,
+            "source": "decision_executable_quote",
+            "quote_source": "decision_executable_quote",
+        }
+
+    def _bounded_collection_target_sizing_payload(
+        self,
+        *,
+        decision: StrategyDecision,
+        metadata: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        normalized_symbol = decision.symbol.strip().upper()
+        target = dict(metadata)
+        if _quote_snapshot_from_mapping(target, symbol=normalized_symbol) is None:
+            snapshot = self._decision_quote_snapshot_for_target_sizing(decision)
+            if snapshot is not None:
+                target["price_snapshot"] = snapshot
+        return target
+
+    @staticmethod
+    def _apply_bounded_collection_target_sizing_audit(
+        decision: StrategyDecision,
+        *,
+        audit: Mapping[str, Any],
+        qty: Decimal,
+        action: Literal["buy", "sell"] | None = None,
+        price_params: Mapping[str, Any] | None = None,
+    ) -> StrategyDecision:
+        params = dict(decision.params)
+        if price_params:
+            params.update(dict(price_params))
+        audit_payload = dict(audit)
+        params["paper_route_target_notional_sizing"] = audit_payload
+
+        reference_price = _optional_decimal(audit_payload.get("reference_price"))
+        notional = qty * reference_price if reference_price is not None else None
+        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
+        simple_lane["final_qty"] = str(qty)
+        simple_lane["paper_route_target_notional_sizing"] = audit_payload
+        simple_lane["target_source_notional_sized"] = (
+            _safe_text(audit_payload.get("sizing_source")) == "target_notional"
+        )
+        if notional is not None:
+            simple_lane["notional"] = str(notional)
+        params["simple_lane"] = simple_lane
+
+        for key in (
+            "paper_route_target_plan_source_decision",
+            "paper_route_target_plan",
+            "paper_route_probe",
+        ):
+            metadata = _mapping_value(params.get(key))
+            if metadata is None:
+                continue
+            updated_metadata = dict(metadata)
+            updated_metadata["paper_route_target_notional_sizing"] = audit_payload
+            updated_metadata["target_source_notional_sized"] = (
+                _safe_text(audit_payload.get("sizing_source")) == "target_notional"
+            )
+            params[key] = updated_metadata
+
+        update: dict[str, Any] = {"qty": qty, "params": params}
+        if action is not None:
+            update["action"] = action
+        return decision.model_copy(update=update)
+
+    def _bounded_collection_target_notional_sized_decision(
+        self,
+        *,
+        decision: StrategyDecision,
+        strategy: Strategy,
+        positions: list[dict[str, Any]],
+    ) -> tuple[StrategyDecision, str | None]:
+        if self._paper_route_probe_exit_metadata(decision) is not None:
+            return decision, None
+
+        metadata = _bounded_paper_route_collection_entry_metadata(decision.params)
+        if metadata is None:
+            if not _bounded_collection_decision_requires_target_notional_sizing(
+                decision.params
+            ):
+                return decision, None
+            audit = {
+                "schema_version": "torghut.paper-route-target-notional-sizing.v1",
+                "symbol": decision.symbol.strip().upper(),
+                "action": decision.action,
+                "sizing_source": "missing",
+                "requested_qty": str(decision.qty),
+                "resolved_qty": str(decision.qty),
+                "blockers": ["bounded_paper_route_target_metadata_missing"],
+            }
+            updated = self._apply_bounded_collection_target_sizing_audit(
+                decision,
+                audit=audit,
+                qty=decision.qty,
+            )
+            return updated, "bounded_paper_route_target_notional_sizing_missing"
+
+        target = self._bounded_collection_target_sizing_payload(
+            decision=decision,
+            metadata=metadata,
+        )
+        normalized_symbol = decision.symbol.strip().upper()
+        target_symbols = sorted(_target_symbols(target))
+        if normalized_symbol not in target_symbols:
+            target_symbols.append(normalized_symbol)
+        symbol_quantities = _target_probe_symbol_quantities(target, target_symbols)
+        requested_qty = symbol_quantities.get(normalized_symbol) or decision.qty
+        action: Literal["buy", "sell"] = (
+            "sell" if str(decision.action).strip().lower() == "sell" else "buy"
+        )
+        action = _target_probe_symbol_actions(target, target_symbols).get(
+            normalized_symbol,
+            action,
+        )
+        max_notional = _target_probe_cap(target)
+        if max_notional is None or max_notional <= 0:
+            audit = {
+                "schema_version": "torghut.paper-route-target-notional-sizing.v1",
+                "symbol": normalized_symbol,
+                "action": action,
+                "sizing_source": "missing",
+                "requested_qty": str(requested_qty),
+                "resolved_qty": str(decision.qty),
+                "symbols": target_symbols,
+                "blockers": ["bounded_paper_route_target_notional_cap_missing"],
+            }
+            updated = self._apply_bounded_collection_target_sizing_audit(
+                decision,
+                audit=audit,
+                qty=decision.qty,
+                action=action,
+            )
+            return updated, "bounded_paper_route_target_notional_sizing_missing"
+
+        quantity_resolution = self._paper_route_target_quantity_resolution(
+            target=target,
+            symbol=normalized_symbol,
+            symbols=target_symbols,
+            action=action,
+            requested_qty=requested_qty,
+            symbol_quantities=symbol_quantities,
+            max_notional=max_notional,
+            event_ts=decision.event_ts,
+            timeframe=decision.timeframe,
+        )
+        if quantity_resolution is None:
+            audit = {
+                "schema_version": "torghut.paper-route-target-notional-sizing.v1",
+                "symbol": normalized_symbol,
+                "action": action,
+                "sizing_source": "missing",
+                "requested_qty": str(requested_qty),
+                "resolved_qty": str(decision.qty),
+                "target_notional": str(max_notional),
+                "symbols": target_symbols,
+                "blockers": ["paper_route_target_notional_qty_below_min_step"],
+            }
+            updated = self._apply_bounded_collection_target_sizing_audit(
+                decision,
+                audit=audit,
+                qty=decision.qty,
+                action=action,
+            )
+            return updated, "bounded_paper_route_target_notional_sizing_missing"
+
+        audit = dict(quantity_resolution.audit)
+        if _safe_text(audit.get("sizing_source")) != "target_notional":
+            updated = self._apply_bounded_collection_target_sizing_audit(
+                decision,
+                audit=audit,
+                qty=quantity_resolution.qty,
+                action=action,
+                price_params=quantity_resolution.price_params,
+            )
+            return updated, "bounded_paper_route_target_notional_sizing_missing"
+
+        position_qty = position_qty_for_symbol(positions, normalized_symbol)
+        broker_resolution = resolve_quantity_resolution(
+            normalized_symbol,
+            action=action,
+            global_enabled=settings.trading_fractional_equities_enabled,
+            allow_shorts=settings.trading_allow_shorts,
+            position_qty=position_qty,
+            requested_qty=quantity_resolution.qty,
+        )
+        broker_qty = quantize_qty_for_symbol(
+            normalized_symbol,
+            quantity_resolution.qty,
+            fractional_equities_enabled=broker_resolution.fractional_allowed,
+        )
+        if broker_qty <= 0:
+            blockers = list(cast(list[Any], audit.get("blockers") or []))
+            blockers.append("paper_route_target_notional_broker_qty_below_min_step")
+            audit["blockers"] = list(dict.fromkeys(str(item) for item in blockers))
+            audit["broker_quantity_resolution"] = broker_resolution.to_payload()
+            updated = self._apply_bounded_collection_target_sizing_audit(
+                decision,
+                audit=audit,
+                qty=decision.qty,
+                action=action,
+                price_params=quantity_resolution.price_params,
+            )
+            return updated, "bounded_paper_route_target_notional_sizing_missing"
+
+        reference_price = _optional_decimal(audit.get("reference_price"))
+        audit["target_notional_resolved_qty"] = audit.get("resolved_qty")
+        audit["target_notional_resolved_notional"] = audit.get("resolved_notional")
+        audit["broker_quantity_resolution"] = broker_resolution.to_payload()
+        audit["broker_quantity_adjusted"] = broker_qty != quantity_resolution.qty
+        audit["broker_resolved_qty"] = str(broker_qty)
+        audit["resolved_qty"] = str(broker_qty)
+        if reference_price is not None:
+            audit["broker_resolved_notional"] = str(broker_qty * reference_price)
+            audit["resolved_notional"] = str(broker_qty * reference_price)
+
+        updated = self._apply_bounded_collection_target_sizing_audit(
+            decision,
+            audit=audit,
+            qty=broker_qty,
+            action=action,
+            price_params=quantity_resolution.price_params,
+        )
+        return updated, None
+
+    @staticmethod
     def _paper_route_decision_requires_executable_quote(
         decision: StrategyDecision,
     ) -> bool:
@@ -4645,6 +4946,24 @@ class SimpleTradingPipeline(TradingPipeline):
                     log_template="Simple-lane decision rejected strategy_id=%s symbol=%s reason=%s",
                 )
                 return None
+        decision, bounded_target_sizing_reject_reason = (
+            self._bounded_collection_target_notional_sized_decision(
+                decision=decision,
+                strategy=strategy,
+                positions=positions,
+            )
+        )
+        self.executor.update_decision_params(session, decision_row, decision.params)
+        self.executor.sync_decision_state(session, decision_row, decision)
+        if bounded_target_sizing_reject_reason is not None:
+            self._record_decision_rejection(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+                reasons=[bounded_target_sizing_reject_reason],
+                log_template="Simple-lane decision rejected strategy_id=%s symbol=%s reason=%s",
+            )
+            return None
         proof_floor = self._profitability_proof_floor(session=session)
         proof_floor_block_reason = self._proof_floor_submission_block_reason(
             proof_floor
@@ -4700,8 +5019,71 @@ class SimpleTradingPipeline(TradingPipeline):
             )
             or Decimal("0"),
         )
+        target_notional_sizing = _target_notional_sizing_audit_from_params(
+            decision.params
+        )
+        expected_target_qty = (
+            _optional_decimal(target_notional_sizing.get("resolved_qty"))
+            if target_notional_sizing is not None
+            else None
+        )
+        if (
+            target_notional_sizing is not None
+            and expected_target_qty is not None
+            and expected_target_qty > 0
+            and preparation.approved
+            and preparation.reject_reason is None
+            and preparation.decision.qty != expected_target_qty
+        ):
+            adjusted_audit = dict(target_notional_sizing)
+            blockers = list(cast(list[Any], adjusted_audit.get("blockers") or []))
+            blockers.append("bounded_paper_route_target_qty_changed_by_precheck")
+            adjusted_audit["blockers"] = list(
+                dict.fromkeys(str(item) for item in blockers)
+            )
+            adjusted_audit["precheck_resolved_qty"] = str(preparation.decision.qty)
+            adjusted_audit["precheck_expected_target_qty"] = str(expected_target_qty)
+            rejected_decision = self._apply_bounded_collection_target_sizing_audit(
+                preparation.decision,
+                audit=adjusted_audit,
+                qty=preparation.decision.qty,
+                action=(
+                    "sell"
+                    if str(preparation.decision.action).strip().lower() == "sell"
+                    else "buy"
+                ),
+            )
+            self.executor.update_decision_params(
+                session,
+                decision_row,
+                rejected_decision.params,
+            )
+            self.executor.sync_decision_state(session, decision_row, rejected_decision)
+            self._record_decision_rejection(
+                session=session,
+                decision=rejected_decision,
+                decision_row=decision_row,
+                reasons=[
+                    "bounded_paper_route_target_notional_sizing_changed_by_precheck"
+                ],
+                log_template="Simple-lane decision rejected strategy_id=%s symbol=%s reason=%s",
+            )
+            return None
+        prepared_for_alignment = preparation.decision
+        if target_notional_sizing is not None:
+            prepared_action: Literal["buy", "sell"] = (
+                "sell"
+                if str(preparation.decision.action).strip().lower() == "sell"
+                else "buy"
+            )
+            prepared_for_alignment = self._apply_bounded_collection_target_sizing_audit(
+                preparation.decision,
+                audit=target_notional_sizing,
+                qty=preparation.decision.qty,
+                action=prepared_action,
+            )
         prepared_decision = self._align_prechecked_paper_route_probe_cap(
-            preparation.decision
+            prepared_for_alignment
         )
         self.executor.sync_decision_state(session, decision_row, prepared_decision)
         if preparation.diagnostics:
@@ -7129,18 +7511,29 @@ class SimpleTradingPipeline(TradingPipeline):
     ) -> StrategyDecision | None:
         cap = _optional_decimal(context.get("max_notional"))
         price = self._paper_route_probe_reference_price(decision)
-        if cap is None or cap <= 0 or price is None or price <= 0:
-            return None
-
-        capped_qty = (cap / price).quantize(
-            _PAPER_ROUTE_PROBE_QTY_STEP,
-            rounding=ROUND_DOWN,
-        )
-        if capped_qty <= 0:
+        if price is None or price <= 0:
             return None
         target_source_authorized = bool(context.get("target_source_authorized"))
-        if decision.qty > 0 and not target_source_authorized:
-            capped_qty = min(decision.qty, capped_qty)
+        target_notional_sizing = _target_notional_sizing_audit_from_params(
+            decision.params
+        )
+        if (
+            target_source_authorized
+            and target_notional_sizing is not None
+            and decision.qty > 0
+        ):
+            capped_qty = decision.qty
+        else:
+            if cap is None or cap <= 0:
+                return None
+            capped_qty = (cap / price).quantize(
+                _PAPER_ROUTE_PROBE_QTY_STEP,
+                rounding=ROUND_DOWN,
+            )
+            if capped_qty <= 0:
+                return None
+            if decision.qty > 0 and not target_source_authorized:
+                capped_qty = min(decision.qty, capped_qty)
 
         capped_notional = capped_qty * price
         params = dict(decision.params)
@@ -7150,8 +7543,12 @@ class SimpleTradingPipeline(TradingPipeline):
         simple_lane["paper_route_probe_cap_applied"] = True
         if target_source_authorized:
             simple_lane["target_source_notional_sized"] = True
+        if target_notional_sizing is not None:
+            simple_lane["paper_route_target_notional_sizing"] = dict(
+                target_notional_sizing
+            )
         params["simple_lane"] = simple_lane
-        params["paper_route_probe"] = {
+        paper_route_probe = {
             **dict(context),
             "reference_price": str(price),
             "capped_qty": str(capped_qty),
@@ -7159,6 +7556,11 @@ class SimpleTradingPipeline(TradingPipeline):
             "capital_stage": str(proof_floor.get("capital_state") or "zero_notional"),
             "target_source_notional_sized": target_source_authorized,
         }
+        if target_notional_sizing is not None:
+            paper_route_probe["paper_route_target_notional_sizing"] = dict(
+                target_notional_sizing
+            )
+        params["paper_route_probe"] = paper_route_probe
         _merge_paper_route_probe_lineage(
             params,
             _paper_route_probe_lineage_from_params(params),

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import time
 from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
@@ -14,9 +15,10 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import Any, Protocol, cast
 
-from sqlalchemy import select
+from sqlalchemy import create_engine, select
+from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from app.alpaca_client import TorghutAlpacaClient
 from app.config import settings
@@ -96,6 +98,14 @@ def _parse_args() -> argparse.Namespace:
         help="Alpaca paper endpoint to use; kept explicit to avoid inheriting live URLs.",
     )
     parser.add_argument(
+        "--database-dsn-env",
+        default="DB_DSN",
+        help=(
+            "Environment variable containing the database DSN for persisted "
+            "flatten lineage and position snapshots. Defaults to DB_DSN."
+        ),
+    )
+    parser.add_argument(
         "--max-gross-market-value",
         default=str(DEFAULT_MAX_GROSS_MARKET_VALUE),
         help="Refuse to submit flatten orders above this absolute market value.",
@@ -163,6 +173,41 @@ def _decimal(value: object, *, default: Decimal = Decimal("0")) -> Decimal:
         return Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError):
         return default
+
+
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
+
+
+def _session_factory_from_env(
+    dsn_env: str,
+) -> tuple[sessionmaker[Session], Engine | None, str]:
+    resolved_env = dsn_env.strip() or "DB_DSN"
+    if resolved_env == "DB_DSN":
+        return SessionLocal, None, resolved_env
+    dsn = os.getenv(resolved_env)
+    if not dsn:
+        raise RuntimeError(
+            f"paper_account_flatten_database_dsn_env_missing:{resolved_env}"
+        )
+    engine = create_engine(_sqlalchemy_dsn(dsn), pool_pre_ping=True, future=True)
+    return (
+        sessionmaker(
+            bind=engine,
+            autoflush=False,
+            expire_on_commit=False,
+            future=True,
+        ),
+        engine,
+        resolved_env,
+    )
 
 
 def _position_qty(position: Mapping[str, Any]) -> Decimal:
@@ -928,40 +973,50 @@ def main() -> int:
     )
     client = TorghutAlpacaClient(paper=True, base_url=str(args.paper_base_url or ""))
     firewall = OrderFirewall(client)
-    lineage_context = SessionLocal() if args.persist_lineage else nullcontext(None)
-    with lineage_context as lineage_session:
-        payload = flatten_paper_account_positions(
-            client=firewall,
-            account_label=str(args.account_label or ""),
-            expected_account_label=str(args.expected_account_label or ""),
-            trading_mode=str(args.trading_mode or ""),
-            apply=bool(args.apply),
-            max_gross_market_value=max_gross_market_value,
-            max_position_count=max(0, int(args.max_position_count)),
-            extended_hours_limit=bool(args.extended_hours_limit),
-            limit_away_bps=limit_away_bps,
-            wait_flat_seconds=max(0.0, float(args.wait_flat_seconds or 0.0)),
-            poll_seconds=max(0.1, float(args.poll_seconds or DEFAULT_POLL_SECONDS)),
-            persist_lineage=bool(args.persist_lineage),
-            lineage_session=cast(Session | None, lineage_session),
+    session_factory, session_engine, database_dsn_env = _session_factory_from_env(
+        str(args.database_dsn_env or "DB_DSN")
+    )
+    try:
+        lineage_context = (
+            session_factory() if args.persist_lineage else nullcontext(None)
         )
-    if args.persist_snapshot:
-        if (
-            payload["trading_mode"] == "paper"
-            and payload["account_label"] == payload["expected_account_label"]
-        ):
-            with SessionLocal() as session:
-                snapshot = snapshot_account_and_positions(
-                    session,
-                    cast(Any, firewall),
-                    str(args.account_label or ""),
-                )
-            payload["position_snapshot_id"] = str(snapshot.id)
-            payload["position_snapshot_as_of"] = snapshot.as_of.isoformat()
-        else:
-            payload["position_snapshot_skipped"] = (
-                "paper_account_label_or_mode_guard_failed"
+        with lineage_context as lineage_session:
+            payload = flatten_paper_account_positions(
+                client=firewall,
+                account_label=str(args.account_label or ""),
+                expected_account_label=str(args.expected_account_label or ""),
+                trading_mode=str(args.trading_mode or ""),
+                apply=bool(args.apply),
+                max_gross_market_value=max_gross_market_value,
+                max_position_count=max(0, int(args.max_position_count)),
+                extended_hours_limit=bool(args.extended_hours_limit),
+                limit_away_bps=limit_away_bps,
+                wait_flat_seconds=max(0.0, float(args.wait_flat_seconds or 0.0)),
+                poll_seconds=max(0.1, float(args.poll_seconds or DEFAULT_POLL_SECONDS)),
+                persist_lineage=bool(args.persist_lineage),
+                lineage_session=cast(Session | None, lineage_session),
             )
+        payload["database_dsn_env"] = database_dsn_env
+        if args.persist_snapshot:
+            if (
+                payload["trading_mode"] == "paper"
+                and payload["account_label"] == payload["expected_account_label"]
+            ):
+                with session_factory() as session:
+                    snapshot = snapshot_account_and_positions(
+                        session,
+                        cast(Any, firewall),
+                        str(args.account_label or ""),
+                    )
+                payload["position_snapshot_id"] = str(snapshot.id)
+                payload["position_snapshot_as_of"] = snapshot.as_of.isoformat()
+            else:
+                payload["position_snapshot_skipped"] = (
+                    "paper_account_label_or_mode_guard_failed"
+                )
+    finally:
+        if session_engine is not None:
+            session_engine.dispose()
     if args.json:
         print(json.dumps(payload, sort_keys=True))
     else:

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -951,6 +951,8 @@ class TestFlattenPaperAccountPositions(TestCase):
             "paper",
             "--paper-base-url",
             "https://paper-api.alpaca.markets",
+            "--database-dsn-env",
+            "SIM_DB_DSN",
             "--max-gross-market-value",
             "1234.56",
             "--max-position-count",
@@ -975,6 +977,7 @@ class TestFlattenPaperAccountPositions(TestCase):
         self.assertEqual(args.expected_account_label, "TORGHUT_SIM")
         self.assertEqual(args.trading_mode, "paper")
         self.assertEqual(args.paper_base_url, "https://paper-api.alpaca.markets")
+        self.assertEqual(args.database_dsn_env, "SIM_DB_DSN")
         self.assertEqual(args.max_gross_market_value, "1234.56")
         self.assertEqual(args.max_position_count, 3)
         self.assertTrue(args.extended_hours_limit)
@@ -985,6 +988,33 @@ class TestFlattenPaperAccountPositions(TestCase):
         self.assertTrue(args.persist_lineage)
         self.assertTrue(args.apply)
         self.assertTrue(args.json)
+
+    def test_database_dsn_normalization_and_missing_env_guard(self) -> None:
+        self.assertEqual(
+            flatten_script._sqlalchemy_dsn("postgresql+psycopg://u:p@host/db"),
+            "postgresql+psycopg://u:p@host/db",
+        )
+        self.assertEqual(
+            flatten_script._sqlalchemy_dsn("postgres://u:p@host/db"),
+            "postgresql+psycopg://u:p@host/db",
+        )
+        self.assertEqual(
+            flatten_script._sqlalchemy_dsn("postgresql://u:p@host/db"),
+            "postgresql+psycopg://u:p@host/db",
+        )
+        self.assertEqual(
+            flatten_script._sqlalchemy_dsn("sqlite+pysqlite:///:memory:"),
+            "sqlite+pysqlite:///:memory:",
+        )
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "paper_account_flatten_database_dsn_env_missing:SIM_DB_DSN",
+            ),
+        ):
+            flatten_script._session_factory_from_env("SIM_DB_DSN")
 
     def test_main_outputs_json_and_returns_clean_status(self) -> None:
         client = FakeFlattenClient()
@@ -1056,6 +1086,50 @@ class TestFlattenPaperAccountPositions(TestCase):
             "2026-05-31T06:35:00+00:00",
         )
         snapshot_account.assert_called_once()
+
+    def test_main_uses_database_dsn_env_for_snapshot_persistence(self) -> None:
+        client = FakeFlattenClient()
+        snapshot = SimpleNamespace(
+            id="sim-snapshot-1",
+            as_of=datetime(2026, 6, 5, 1, 30, tzinfo=timezone.utc),
+        )
+        argv = [
+            "flatten_paper_account_positions.py",
+            "--account-label",
+            "TORGHUT_SIM",
+            "--expected-account-label",
+            "TORGHUT_SIM",
+            "--trading-mode",
+            "paper",
+            "--database-dsn-env",
+            "SIM_DB_DSN",
+            "--persist-snapshot",
+            "--json",
+        ]
+
+        with (
+            patch.dict("os.environ", {"SIM_DB_DSN": "sqlite+pysqlite:///:memory:"}),
+            patch.object(sys, "argv", argv),
+            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(
+                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+            ),
+            patch.object(
+                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+            ) as snapshot_account,
+            redirect_stdout(StringIO()) as output,
+        ):
+            exit_code = flatten_script.main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["database_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(payload["position_snapshot_id"], "sim-snapshot-1")
+        snapshot_session = snapshot_account.call_args.args[0]
+        self.assertEqual(
+            str(snapshot_session.get_bind().url),
+            "sqlite+pysqlite:///:memory:",
+        )
 
     def test_main_skips_snapshot_persistence_when_guard_fails(self) -> None:
         client = FakeFlattenClient()

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1261,6 +1261,21 @@ class TestLiveConfigManifestContract(TestCase):
             value_from.get("secretKeyRef"),
             {"name": "torghut-db-app", "key": "uri"},
         )
+        for name, key in (
+            ("TORGHUT_SIM_DB_HOST", "host"),
+            ("TORGHUT_SIM_DB_PORT", "port"),
+            ("TORGHUT_SIM_DB_USER", "username"),
+            ("TORGHUT_SIM_DB_PASSWORD", "password"),
+        ):
+            ref = cast(Mapping[str, object], env[name].get("valueFrom", {}))
+            self.assertEqual(
+                ref.get("secretKeyRef"),
+                {"name": "torghut-db-app", "key": key},
+            )
+        self.assertEqual(
+            env["SIM_DB_DSN"].get("value"),
+            "postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default",
+        )
         self.assertEqual(env["TRADING_MODE"].get("value"), "paper")
         self.assertEqual(env["TRADING_ACCOUNT_LABEL"].get("value"), "TORGHUT_SIM")
         self.assertEqual(env["TRADING_KILL_SWITCH_ENABLED"].get("value"), "false")
@@ -1271,6 +1286,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--expected-account-label TORGHUT_SIM", args)
         self.assertIn("--trading-mode paper", args)
         self.assertIn("--paper-base-url https://paper-api.alpaca.markets", args)
+        self.assertIn("--database-dsn-env SIM_DB_DSN", args)
         self.assertIn("--max-gross-market-value 100000", args)
         self.assertNotIn("--max-gross-market-value 2500", args)
         self.assertIn("--max-position-count 25", args)

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -85,6 +85,7 @@ from app.trading.scheduler.simple_pipeline import (
     _target_probe_action,
     _target_probe_symbol_notional_budget,
     _target_probe_window,
+    _target_notional_sizing_audit_from_params,
     _target_truthy,
 )
 from app.trading.scheduler.pipeline_helpers import (
@@ -3951,6 +3952,575 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(params.get("price_snapshot", {}).get("bid"), "190.10")
         self.assertEqual(row.status, "planned")
 
+    def test_bounded_collection_target_source_enforces_target_notional_broker_sizing(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 4, 14, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_allow_shorts = True
+        config.settings.trading_simple_max_notional_per_order = 100000.0
+        config.settings.trading_simple_max_notional_per_symbol = 100000.0
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded target strategy",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("100000"),
+        )
+        target_metadata = {
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "hypothesis_id": "H-PAIRS-01",
+            "account_label": "TORGHUT_SIM",
+            "observed_stage": "paper",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_symbol_actions": {
+                "AAPL": "buy",
+                "AMZN": "sell",
+            },
+            "paper_route_probe_symbol_quantities": {
+                "AAPL": "1",
+                "AMZN": "1",
+            },
+            "paper_route_probe_next_session_max_notional": "75000",
+            "bounded_evidence_collection_authorized": True,
+            "bounded_live_paper_collection_authorized": True,
+            "evidence_collection_ok": True,
+            "source_decision_readiness": {"ready": True, "blockers": []},
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+        }
+        decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AMZN",
+            event_ts=now,
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("1"),
+            rationale="bounded paper-route target source",
+            params={
+                "paper_route_target_plan": target_metadata,
+                "source_decision_mode": (
+                    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+                ),
+                "profit_proof_eligible": True,
+            },
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(
+                Decimal("250"),
+                spread=Decimal("0.02"),
+                bid=Decimal("250"),
+                ask=Decimal("250.02"),
+            ),
+        )
+
+        with self.session_local() as session:
+            session.add(strategy)
+            session.commit()
+            row = pipeline.executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "TORGHUT_SIM",
+            )
+
+            prepared = pipeline._prepare_decision_for_submission(
+                session=session,
+                decision=decision,
+                decision_row=row,
+                strategy=strategy,
+                account={
+                    "equity": "200000",
+                    "cash": "200000",
+                    "buying_power": "200000",
+                },
+                positions=[],
+            )
+            session.refresh(row)
+            row_json = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], row_json["params"])
+            sizing = cast(dict[str, Any], params["paper_route_target_notional_sizing"])
+            simple_lane = cast(dict[str, Any], params["simple_lane"])
+            source_metadata = cast(dict[str, Any], params["paper_route_target_plan"])
+
+        self.assertIsNotNone(prepared)
+        assert prepared is not None
+        prepared_decision, _snapshot = prepared
+        self.assertEqual(prepared_decision.action, "sell")
+        self.assertEqual(prepared_decision.qty, Decimal("150"))
+        self.assertEqual(sizing["sizing_source"], "target_notional")
+        self.assertEqual(sizing["symbol_notional_budget"], "37500.0")
+        self.assertEqual(sizing["broker_resolved_qty"], "150")
+        self.assertEqual(sizing["resolved_qty"], "150")
+        self.assertEqual(
+            sizing["broker_quantity_resolution"]["reason"],
+            "sell_short_increasing_integer_only",
+        )
+        self.assertFalse(sizing["broker_quantity_resolution"]["fractional_allowed"])
+        self.assertEqual(simple_lane["final_qty"], "150")
+        self.assertTrue(simple_lane["target_source_notional_sized"])
+        self.assertEqual(
+            source_metadata["paper_route_target_notional_sizing"]["resolved_qty"],
+            "150",
+        )
+        self.assertEqual(row.status, "planned")
+
+    def test_bounded_collection_target_source_rejects_precheck_qty_clamp(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 4, 14, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_allow_shorts = True
+        config.settings.trading_simple_max_notional_per_order = 1000.0
+        config.settings.trading_simple_max_notional_per_symbol = 100000.0
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded target strategy",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("100000"),
+        )
+        target_metadata = {
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "hypothesis_id": "H-PAIRS-01",
+            "account_label": "TORGHUT_SIM",
+            "observed_stage": "paper",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_symbol_actions": {
+                "AAPL": "buy",
+                "AMZN": "sell",
+            },
+            "paper_route_probe_symbol_quantities": {
+                "AAPL": "1",
+                "AMZN": "1",
+            },
+            "paper_route_probe_next_session_max_notional": "75000",
+            "bounded_evidence_collection_authorized": True,
+            "bounded_live_paper_collection_authorized": True,
+            "evidence_collection_ok": True,
+            "source_decision_readiness": {"ready": True, "blockers": []},
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+        }
+        decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AMZN",
+            event_ts=now,
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("1"),
+            rationale="bounded paper-route target source",
+            params={
+                "paper_route_target_plan": target_metadata,
+                "source_decision_mode": (
+                    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+                ),
+                "profit_proof_eligible": True,
+            },
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(
+                Decimal("250"),
+                spread=Decimal("0.02"),
+                bid=Decimal("250"),
+                ask=Decimal("250.02"),
+            ),
+        )
+
+        with self.session_local() as session:
+            session.add(strategy)
+            session.commit()
+            row = pipeline.executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "TORGHUT_SIM",
+            )
+
+            prepared = pipeline._prepare_decision_for_submission(
+                session=session,
+                decision=decision,
+                decision_row=row,
+                strategy=strategy,
+                account={
+                    "equity": "200000",
+                    "cash": "200000",
+                    "buying_power": "200000",
+                },
+                positions=[],
+            )
+            session.refresh(row)
+            row_json = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], row_json["params"])
+            sizing = cast(dict[str, Any], params["paper_route_target_notional_sizing"])
+
+        self.assertIsNone(prepared)
+        self.assertEqual(row.status, "rejected")
+        self.assertEqual(
+            row_json["reject_reason_atomic"],
+            ["bounded_paper_route_target_notional_sizing_changed_by_precheck"],
+        )
+        self.assertEqual(sizing["resolved_qty"], "150")
+        self.assertEqual(sizing["precheck_resolved_qty"], "4")
+        self.assertIn(
+            "bounded_paper_route_target_qty_changed_by_precheck",
+            sizing["blockers"],
+        )
+
+    def test_bounded_collection_target_source_rejects_missing_target_sizing(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 4, 14, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_allow_shorts = True
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded target strategy",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("100000"),
+        )
+        target_metadata = {
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "hypothesis_id": "H-PAIRS-01",
+            "account_label": "TORGHUT_SIM",
+            "observed_stage": "paper",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_symbol_actions": {
+                "AAPL": "buy",
+                "AMZN": "sell",
+            },
+            "paper_route_probe_symbol_quantities": {
+                "AAPL": "1",
+                "AMZN": "1",
+            },
+            "bounded_evidence_collection_authorized": True,
+            "bounded_live_paper_collection_authorized": True,
+            "evidence_collection_ok": True,
+            "source_decision_readiness": {"ready": True, "blockers": []},
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+        }
+        decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AMZN",
+            event_ts=now,
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("1"),
+            rationale="bounded paper-route target source",
+            params={
+                "paper_route_target_plan": target_metadata,
+                "source_decision_mode": (
+                    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+                ),
+                "profit_proof_eligible": True,
+            },
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(
+                Decimal("250"),
+                spread=Decimal("0.02"),
+                bid=Decimal("250"),
+                ask=Decimal("250.02"),
+            ),
+        )
+
+        with self.session_local() as session:
+            session.add(strategy)
+            session.commit()
+            row = pipeline.executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "TORGHUT_SIM",
+            )
+
+            prepared = pipeline._prepare_decision_for_submission(
+                session=session,
+                decision=decision,
+                decision_row=row,
+                strategy=strategy,
+                account={
+                    "equity": "200000",
+                    "cash": "200000",
+                    "buying_power": "200000",
+                },
+                positions=[],
+            )
+            session.refresh(row)
+            row_json = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], row_json["params"])
+            sizing = cast(dict[str, Any], params["paper_route_target_notional_sizing"])
+
+        self.assertIsNone(prepared)
+        self.assertEqual(row.status, "rejected")
+        self.assertEqual(
+            row_json["reject_reason_atomic"],
+            ["bounded_paper_route_target_notional_sizing_missing"],
+        )
+        self.assertEqual(
+            sizing["blockers"],
+            ["bounded_paper_route_target_notional_cap_missing"],
+        )
+
+    def test_bounded_collection_target_sizing_helper_fail_closed_branches(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 4, 14, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_allow_shorts = True
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded target strategy",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("100000"),
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        direct_quote_decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="direct quote fallback",
+            params={
+                "price": Decimal("100"),
+                "imbalance_bid_px": Decimal("99.99"),
+                "imbalance_ask_px": Decimal("100.01"),
+                "imbalance_spread": Decimal("0.02"),
+            },
+        )
+        direct_quote = SimpleTradingPipeline._decision_quote_snapshot_for_target_sizing(
+            direct_quote_decision
+        )
+        assert direct_quote is not None
+        self.assertEqual(direct_quote["price"], "100")
+        self.assertIsNone(
+            SimpleTradingPipeline._decision_quote_snapshot_for_target_sizing(
+                direct_quote_decision.model_copy(update={"params": {}})
+            )
+        )
+
+        nested_audit = {"sizing_source": "target_notional", "resolved_qty": "3"}
+        self.assertEqual(
+            _target_notional_sizing_audit_from_params(
+                {"simple_lane": {"paper_route_target_notional_sizing": nested_audit}}
+            ),
+            nested_audit,
+        )
+
+        base_params = {
+            "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
+            "profit_proof_eligible": True,
+        }
+        missing_metadata_decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="missing bounded target metadata",
+            params=base_params,
+        )
+        sized, reason = pipeline._bounded_collection_target_notional_sized_decision(
+            decision=missing_metadata_decision,
+            strategy=strategy,
+            positions=[],
+        )
+        self.assertEqual(reason, "bounded_paper_route_target_notional_sizing_missing")
+        self.assertEqual(
+            sized.params["paper_route_target_notional_sizing"]["blockers"],
+            ["bounded_paper_route_target_metadata_missing"],
+        )
+
+        def bounded_decision(
+            *,
+            symbol: str,
+            action: Literal["buy", "sell"],
+            target: Mapping[str, Any],
+            params_extra: Mapping[str, Any] | None = None,
+        ) -> StrategyDecision:
+            return StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol=symbol,
+                event_ts=now,
+                timeframe="1Min",
+                action=action,
+                qty=Decimal("1"),
+                rationale="bounded target helper branch",
+                params={
+                    **base_params,
+                    "paper_route_target_plan": dict(target),
+                    **dict(params_extra or {}),
+                },
+            )
+
+        appended_symbol_decision = bounded_decision(
+            symbol="AAPL",
+            action="buy",
+            target={
+                "paper_route_probe_next_session_max_notional": "1000",
+                "price_snapshot": {"symbol": "AAPL", "ask": "100", "bid": "99.99"},
+            },
+        )
+        sized, reason = pipeline._bounded_collection_target_notional_sized_decision(
+            decision=appended_symbol_decision,
+            strategy=strategy,
+            positions=[],
+        )
+        self.assertIsNone(reason)
+        self.assertEqual(
+            sized.params["paper_route_target_notional_sizing"]["symbols"], ["AAPL"]
+        )
+
+        missing_price_decision = bounded_decision(
+            symbol="AAPL",
+            action="buy",
+            target={
+                "paper_route_probe_symbols": ["AAPL"],
+                "paper_route_probe_next_session_max_notional": "1000",
+            },
+        )
+        sized, reason = pipeline._bounded_collection_target_notional_sized_decision(
+            decision=missing_price_decision,
+            strategy=strategy,
+            positions=[],
+        )
+        self.assertEqual(reason, "bounded_paper_route_target_notional_sizing_missing")
+        self.assertEqual(
+            sized.params["paper_route_target_notional_sizing"]["blockers"],
+            ["paper_route_target_notional_price_missing"],
+        )
+
+        tiny_target_decision = bounded_decision(
+            symbol="AAPL",
+            action="buy",
+            target={
+                "paper_route_probe_symbols": ["AAPL"],
+                "paper_route_probe_next_session_max_notional": "0.00001",
+                "price_snapshot": {"symbol": "AAPL", "ask": "100", "bid": "99.99"},
+            },
+        )
+        sized, reason = pipeline._bounded_collection_target_notional_sized_decision(
+            decision=tiny_target_decision,
+            strategy=strategy,
+            positions=[],
+        )
+        self.assertEqual(reason, "bounded_paper_route_target_notional_sizing_missing")
+        self.assertEqual(
+            sized.params["paper_route_target_notional_sizing"]["blockers"],
+            ["paper_route_target_notional_qty_below_min_step"],
+        )
+
+        broker_zero_decision = bounded_decision(
+            symbol="AMZN",
+            action="sell",
+            target={
+                "paper_route_probe_symbols": ["AMZN"],
+                "paper_route_probe_symbol_actions": {"AMZN": "sell"},
+                "paper_route_probe_next_session_max_notional": "50",
+                "price_snapshot": {"symbol": "AMZN", "bid": "100", "ask": "100.01"},
+            },
+        )
+        sized, reason = pipeline._bounded_collection_target_notional_sized_decision(
+            decision=broker_zero_decision,
+            strategy=strategy,
+            positions=[],
+        )
+        self.assertEqual(reason, "bounded_paper_route_target_notional_sizing_missing")
+        self.assertIn(
+            "paper_route_target_notional_broker_qty_below_min_step",
+            sized.params["paper_route_target_notional_sizing"]["blockers"],
+        )
+
     def test_paper_route_target_price_only_snapshot_refreshes_executable_quote(
         self,
     ) -> None:
@@ -4084,6 +4654,20 @@ class TestTradingPipeline(TestCase):
                     "account_label": "TORGHUT_SIM",
                     "observed_stage": "paper",
                     "source_kind": "paper_route_probe_runtime_observed",
+                    "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "paper_route_probe_symbols": ["AAPL"],
+                    "paper_route_probe_symbol_quantities": {"AAPL": "1"},
+                    "paper_route_probe_next_session_max_notional": "250",
+                    "bounded_evidence_collection_authorized": True,
+                    "bounded_live_paper_collection_authorized": True,
+                    "evidence_collection_ok": True,
+                    "source_decision_readiness": {"ready": True, "blockers": []},
+                    "promotion_allowed": False,
+                    "final_promotion_allowed": False,
+                    "final_promotion_authorized": False,
                 },
                 "source_decision_mode": BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE,
                 "profit_proof_eligible": True,


### PR DESCRIPTION
## Summary

- Adds `--database-dsn-env` to `flatten_paper_account_positions.py` and wires the paper flatten CronJob to persist TORGHUT_SIM flatten proof into `SIM_DB_DSN`.
- Enforces bounded paper-route collection target sizing before submission: profit-proof-eligible bounded decisions must have auditable target metadata, cap, and quote-backed target-notional sizing.
- Applies broker quantity rules to target-sized legs so fractional buys can remain fractional while short-increasing sell legs are whole-share, and rejects bounded decisions if simple-risk clamps the target quantity.
- Preserves `paper_route_target_notional_sizing` through nested source metadata, `simple_lane`, and proof-floor probe metadata so runtime proof can inspect the actual source-backed sizing.
- Adds regression coverage for SIM flatten DB persistence plus the H-PAIRS one-share leakage, missing target sizing, precheck clamp, and fail-closed helper branches.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py -k 'flatten'`
- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'bounded_collection_target_source'`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'bounded_collection_target_source or materialized_target_plan_source_decisions or bounded_hpairs_target_source_records_decisions_and_executions or paper_route_target_executable_quote_reaches_submit_eligibility or paper_route_target_price_only_snapshot_refreshes_executable_quote'`
- `uv run --frozen pytest tests/test_trading_pipeline.py`
- `uv run --frozen python -m coverage run -m pytest tests/test_trading_pipeline.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen python -m coverage xml -o coverage.xml` wrote `coverage.xml`; the focused local run reports total coverage below the project-wide fail-under, as expected without the full CI shard suite.
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` -> changed-line coverage `200/201 (99.50%)`.
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
