### PR TITLE
fix(torghut): mark observed source imports as repair only

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -9522,13 +9522,42 @@ def _runtime_window_import_plan_metadata(plan: Mapping[str, Any]) -> dict[str, o
     for key in (
         "session_window",
         "session_readiness",
+        "collection_session_readiness",
         "runtime_window_import_handoff",
         "runtime_window_import_health_gate",
         "source_decision_readiness",
+        "target_account_audit_readiness",
+        "account_pre_session_readiness",
+        "clean_window_baseline_readiness",
+        "account_contamination_readiness",
     ):
         value = _as_mapping(plan.get(key))
         if value:
             metadata[key] = dict(value)
+    return metadata
+
+
+def _source_collection_runtime_import_metadata(
+    plan: Mapping[str, Any],
+) -> dict[str, object]:
+    metadata = _runtime_window_import_plan_metadata(plan)
+    handoff = dict(_as_mapping(metadata.get("runtime_window_import_handoff")))
+    if handoff:
+        handoff.update(
+            {
+                "evidence_collection_ok": True,
+                "source_collection_authorized": True,
+                "source_collection_only": True,
+                "canary_collection_authorized": False,
+                "bounded_live_paper_collection_authorized": False,
+                "capital_promotion_allowed": False,
+                "promotion_allowed": False,
+                "final_promotion_authorized": False,
+                "final_promotion_allowed": False,
+                "promotion_gate": "runtime_ledger_source_collection_only",
+            }
+        )
+        metadata["runtime_window_import_handoff"] = handoff
     return metadata
 
 
@@ -9620,6 +9649,7 @@ def _observed_strategy_source_collection_import_plan(
                 targets.append(target)
     if not targets:
         return {}
+    metadata = _source_collection_runtime_import_metadata(selected_plan or {})
     return {
         "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
         "source": "paper_route_observed_strategy_source_collection",
@@ -9635,7 +9665,7 @@ def _observed_strategy_source_collection_import_plan(
         "final_promotion_authorized": False,
         "final_promotion_allowed": False,
         "target_count": len(targets),
-        **_runtime_window_import_plan_metadata(selected_plan or {}),
+        **metadata,
         "paper_probation_target_count": 0,
         "source_collection_target_count": len(targets),
         "skipped_target_count": len(skipped_targets),
@@ -9997,6 +10027,20 @@ def build_paper_route_target_plan_payload(
             "runtime_window_import_audit_mode": runtime_window_import_audit_mode,
             "runtime_window_import_audit_blockers": _unique_text_items(
                 runtime_window_import_audit.get("blockers")
+            ),
+            "runtime_window_import_source_collection_only": _safe_text(
+                runtime_window_import_plan.get("source")
+            )
+            == "paper_route_observed_strategy_source_collection",
+            "runtime_window_import_account_contamination_state": _safe_text(
+                _as_mapping(
+                    runtime_window_import_plan.get("account_contamination_readiness")
+                ).get("state")
+            ),
+            "runtime_window_import_account_contamination_blockers": _unique_text_items(
+                _as_mapping(
+                    runtime_window_import_plan.get("account_contamination_readiness")
+                ).get("blockers")
             ),
             "skipped_target_count": _safe_int(next_targets.get("skipped_target_count")),
             "promotion_authority": {
@@ -10396,6 +10440,20 @@ def build_paper_route_evidence_audit(
             ),
             "runtime_window_import_plan_source": _safe_text(
                 runtime_window_import_plan.get("source")
+            ),
+            "runtime_window_import_source_collection_only": _safe_text(
+                runtime_window_import_plan.get("source")
+            )
+            == "paper_route_observed_strategy_source_collection",
+            "runtime_window_import_account_contamination_state": _safe_text(
+                _as_mapping(
+                    runtime_window_import_plan.get("account_contamination_readiness")
+                ).get("state")
+            ),
+            "runtime_window_import_account_contamination_blockers": _unique_text_items(
+                _as_mapping(
+                    runtime_window_import_plan.get("account_contamination_readiness")
+                ).get("blockers")
             ),
             "summary_target_count": len(summary_target_audits),
             "summary_target_audit_source": summary_target_audit_source,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -9840,6 +9840,27 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(runtime_plan["target_count"], 1)
         self.assertTrue(runtime_plan["session_readiness"]["import_ready"])
         self.assertTrue(runtime_plan["runtime_window_import_handoff"]["import_ready"])
+        self.assertTrue(
+            runtime_plan["runtime_window_import_handoff"][
+                "source_collection_authorized"
+            ]
+        )
+        self.assertTrue(
+            runtime_plan["runtime_window_import_handoff"]["source_collection_only"]
+        )
+        self.assertFalse(
+            runtime_plan["runtime_window_import_handoff"][
+                "canary_collection_authorized"
+            ]
+        )
+        self.assertEqual(
+            runtime_plan["account_contamination_readiness"]["state"],
+            "contaminated_window_discarded",
+        )
+        self.assertIn(
+            "paper_route_account_contamination_detected",
+            runtime_plan["account_contamination_readiness"]["blockers"],
+        )
         self.assertEqual(
             runtime_plan["runtime_window_import_health_gate"]["blocked_target_count"],
             0,
@@ -10076,9 +10097,30 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertTrue(runtime_plan["session_readiness"]["import_ready"])
         self.assertTrue(runtime_plan["runtime_window_import_handoff"]["import_ready"])
+        self.assertTrue(
+            runtime_plan["runtime_window_import_handoff"][
+                "source_collection_authorized"
+            ]
+        )
+        self.assertTrue(
+            runtime_plan["runtime_window_import_handoff"]["source_collection_only"]
+        )
+        self.assertFalse(
+            runtime_plan["runtime_window_import_handoff"][
+                "canary_collection_authorized"
+            ]
+        )
         self.assertEqual(
             runtime_plan["runtime_window_import_health_gate"]["blocked_target_count"],
             0,
+        )
+        self.assertEqual(
+            runtime_plan["account_contamination_readiness"]["state"],
+            "contaminated_window_discarded",
+        )
+        self.assertIn(
+            "foreign_order_events_present",
+            runtime_plan["account_contamination_readiness"]["blockers"],
         )
         self.assertEqual(runtime_plan["targets"][0]["candidate_id"], "candidate-tsmom")
         self.assertEqual(
@@ -10126,6 +10168,15 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "paper_route_observed_strategy_source_collection",
         )
         summary = payload["summary"]
+        self.assertTrue(summary["runtime_window_import_source_collection_only"])
+        self.assertEqual(
+            summary["runtime_window_import_account_contamination_state"],
+            "contaminated_window_discarded",
+        )
+        self.assertIn(
+            "foreign_order_events_present",
+            summary["runtime_window_import_account_contamination_blockers"],
+        )
         self.assertEqual(
             summary["summary_target_audit_source"],
             "runtime_window_import_target_audits",


### PR DESCRIPTION
## Summary

- Mark observed-strategy source-collection imports from contaminated paper-route windows as repair-only/source-collection-only in the runtime import handoff.
- Preserve selected-plan readiness metadata, including account contamination summaries, so operators and proof packets can see why a window was rejected for clean collection.
- Add regression coverage that source-collection repair imports keep import authority while clean canary/bounded collection and promotion remain disabled.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "observed_strategy_source_collection"`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py -k "observed_strategy_source_collection or runtime_window_target_plan"`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -k "selected_import_plan_health_gate"`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
