### PR TITLE
fix(torghut): carry execution quality remediation into guided sweeps

### DIFF
--- a/services/torghut/app/trading/discovery/replay_ledger_guided_search.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_guided_search.py
@@ -29,6 +29,65 @@ _BREADTH_PARAMETER_KEYS = (
 _MAX_BREADTH_FACTOR = Decimal("4")
 _MAX_TOP_N = 12
 _MAX_ENTRY_COUNT = 12
+_EXECUTION_QUALITY_EVIDENCE_FIELDS_BY_BLOCKER = {
+    "order_type_mix_evidence_incomplete": (
+        "selected_order_type",
+        "submitted_order_type",
+        "fill_order_type",
+    ),
+    "fill_order_type_evidence_incomplete": (
+        "submitted_order_type",
+        "fill_order_type",
+        "fill_order_id",
+    ),
+    "execution_shortfall_evidence_incomplete": (
+        "route_tca_bps",
+        "execution_shortfall_bps",
+        "arrival_shortfall_bps",
+    ),
+    "limit_fill_probability_evidence_incomplete": (
+        "limit_fill_probability",
+        "survival_fill_probability",
+        "fill_probability",
+    ),
+    "queue_position_survival_evidence_incomplete": (
+        "queue_position",
+        "queue_ahead_qty",
+        "time_to_fill_seconds",
+    ),
+    "price_improvement_evidence_incomplete": (
+        "price_improvement_bps",
+        "realized_price_improvement_bps",
+    ),
+    "nonfill_opportunity_cost_evidence_incomplete": (
+        "nonfill_opportunity_cost_bps",
+        "missed_fill_opportunity_cost_bps",
+    ),
+    "limit_fill_rate_below_execution_quality_floor": (
+        "limit_fill_probability",
+        "limit_fill_rate",
+        "order_type_ablation",
+    ),
+    "execution_shortfall_bps_above_quality_floor": (
+        "route_tca_bps",
+        "execution_shortfall_bps",
+        "order_type_ablation",
+    ),
+    "nonfill_opportunity_cost_bps_above_quality_floor": (
+        "nonfill_opportunity_cost_bps",
+        "missed_fill_opportunity_cost_bps",
+        "order_type_ablation",
+    ),
+}
+_DEFAULT_EXECUTION_QUALITY_EVIDENCE_FIELDS = (
+    "route_tca_bps",
+    "selected_order_type",
+    "fill_order_type",
+    "limit_fill_probability",
+    "queue_position",
+    "price_improvement_bps",
+    "nonfill_opportunity_cost_bps",
+)
 
 
 @dataclass(frozen=True)
@@ -57,7 +116,8 @@ def apply_replay_ledger_remediation_guidance(
         return ReplayLedgerGuidedSweep(sweep_config=payload, applied_actions=())
 
     blockers = _search_blockers(remediation_report)
-    if not blockers:
+    execution_quality_blockers = _execution_quality_blockers(remediation_report)
+    if not blockers and not execution_quality_blockers:
         return ReplayLedgerGuidedSweep(sweep_config=payload, applied_actions=())
 
     policy = _policy_from_report(remediation_report)
@@ -96,6 +156,13 @@ def apply_replay_ledger_remediation_guidance(
         )
         actions.append("window")
 
+    execution_quality_remediations = _execution_quality_remediations(
+        remediation_report,
+        execution_quality_blockers=execution_quality_blockers,
+    )
+    if execution_quality_blockers:
+        actions.append("execution_quality")
+
     if actions:
         metadata = _mapping(payload.get("metadata"))
         metadata["replay_ledger_guided_search"] = {
@@ -103,6 +170,14 @@ def apply_replay_ledger_remediation_guidance(
             "source_candidate_id": _string(remediation_report.get("candidate_id")),
             "status": _string(remediation_report.get("status")),
             "blockers": sorted(blockers),
+            "execution_quality_blockers": sorted(execution_quality_blockers),
+            "execution_quality_remediations": execution_quality_remediations,
+            "required_replay_evidence_fields": _required_execution_quality_fields(
+                execution_quality_blockers
+            ),
+            "execution_quality_authority": (
+                "research_ranking_only_final_promotion_still_requires_runtime_ledger"
+            ),
             "applied_actions": list(actions),
             "parameter_changes": parameter_changes,
             "metric_snapshot": dict(
@@ -182,6 +257,55 @@ def _search_blockers(remediation_report: Mapping[str, Any]) -> set[str]:
     blockers.discard("replay_artifact_only_not_live")
     blockers.discard("exact_replay_ledger_candidate_missing")
     return blockers
+
+
+def _execution_quality_blockers(remediation_report: Mapping[str, Any]) -> set[str]:
+    return set(_string_list(remediation_report.get("execution_quality_blockers")))
+
+
+def _execution_quality_remediations(
+    remediation_report: Mapping[str, Any],
+    *,
+    execution_quality_blockers: set[str],
+) -> list[dict[str, Any]]:
+    if not execution_quality_blockers:
+        return []
+    remediations: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in (
+        *_mapping_sequence(remediation_report.get("recommended_search_actions")),
+        *_mapping_sequence(remediation_report.get("blocker_remediations")),
+    ):
+        blocker = _string(item.get("blocker"))
+        if blocker not in execution_quality_blockers:
+            continue
+        action = _string(item.get("action"))
+        dedupe_key = (blocker, action)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        remediations.append(
+            {
+                "blocker": blocker,
+                "action": action,
+                "reason": _string(item.get("reason")),
+                "parameter_hints": list(_string_list(item.get("parameter_hints"))),
+            }
+        )
+    return remediations
+
+
+def _required_execution_quality_fields(
+    execution_quality_blockers: set[str],
+) -> list[str]:
+    fields: set[str] = set()
+    for blocker in execution_quality_blockers:
+        fields.update(
+            _EXECUTION_QUALITY_EVIDENCE_FIELDS_BY_BLOCKER.get(
+                blocker, _DEFAULT_EXECUTION_QUALITY_EVIDENCE_FIELDS
+            )
+        )
+    return sorted(fields)
 
 
 def _policy_from_report(remediation_report: Mapping[str, Any]) -> dict[str, str]:

--- a/services/torghut/tests/test_replay_ledger_guided_search.py
+++ b/services/torghut/tests/test_replay_ledger_guided_search.py
@@ -104,6 +104,101 @@ class TestReplayLedgerGuidedSearch(TestCase):
         self.assertFalse(result.applied)
         self.assertEqual(result.sweep_config, {"parameters": {"top_n": ["2"]}})
 
+    def test_execution_quality_blockers_are_carried_into_guided_metadata(
+        self,
+    ) -> None:
+        result = apply_replay_ledger_remediation_guidance(
+            sweep_config={
+                "parameters": {"top_n": ["2"]},
+                "metadata": {"existing": "kept"},
+            },
+            remediation_report={
+                "status": "blocked_pending_runtime_promotion_proof",
+                "candidate_id": "candidate-execution-quality",
+                "promotion_blockers": ["replay_artifact_only_not_live"],
+                "runtime_ledger_blockers": [],
+                "execution_quality_blockers": [
+                    "execution_shortfall_evidence_incomplete",
+                    "queue_position_survival_evidence_incomplete",
+                ],
+                "recommended_search_actions": [
+                    {
+                        "blocker": "execution_shortfall_evidence_incomplete",
+                        "action": "collect_route_tca_shortfall_evidence",
+                        "reason": "route TCA/shortfall is required before execution quality can influence collection",
+                        "parameter_hints": [
+                            "route_tca_bps",
+                            "execution_shortfall_bps",
+                        ],
+                    },
+                    {
+                        "blocker": "queue_position_survival_evidence_incomplete",
+                        "action": "collect_queue_position_survival_fill_curve_evidence",
+                        "reason": "queue-position/time-to-fill evidence is missing for limit-order candidates",
+                        "parameter_hints": [
+                            "queue_position",
+                            "queue_ahead_qty",
+                        ],
+                    },
+                ],
+                "metric_snapshot": {
+                    "execution_quality_penalty_bps": "12.5",
+                },
+            },
+        )
+
+        self.assertTrue(result.applied)
+        self.assertEqual(result.applied_actions, ("execution_quality",))
+        self.assertEqual(result.sweep_config["parameters"], {"top_n": ["2"]})
+        self.assertEqual(result.sweep_config["metadata"]["existing"], "kept")
+        metadata = result.sweep_config["metadata"]["replay_ledger_guided_search"]
+        self.assertEqual(metadata["blockers"], [])
+        self.assertEqual(
+            metadata["execution_quality_blockers"],
+            [
+                "execution_shortfall_evidence_incomplete",
+                "queue_position_survival_evidence_incomplete",
+            ],
+        )
+        self.assertEqual(
+            metadata["execution_quality_authority"],
+            "research_ranking_only_final_promotion_still_requires_runtime_ledger",
+        )
+        self.assertEqual(
+            metadata["required_replay_evidence_fields"],
+            [
+                "arrival_shortfall_bps",
+                "execution_shortfall_bps",
+                "queue_ahead_qty",
+                "queue_position",
+                "route_tca_bps",
+                "time_to_fill_seconds",
+            ],
+        )
+        self.assertEqual(
+            metadata["execution_quality_remediations"],
+            [
+                {
+                    "blocker": "execution_shortfall_evidence_incomplete",
+                    "action": "collect_route_tca_shortfall_evidence",
+                    "reason": "route TCA/shortfall is required before execution quality can influence collection",
+                    "parameter_hints": [
+                        "route_tca_bps",
+                        "execution_shortfall_bps",
+                    ],
+                },
+                {
+                    "blocker": "queue_position_survival_evidence_incomplete",
+                    "action": "collect_queue_position_survival_fill_curve_evidence",
+                    "reason": "queue-position/time-to-fill evidence is missing for limit-order candidates",
+                    "parameter_hints": [
+                        "queue_position",
+                        "queue_ahead_qty",
+                    ],
+                },
+            ],
+        )
+
     def test_window_blocker_is_recorded_without_guessing_dates(self) -> None:
         result = apply_replay_ledger_remediation_guidance(
             sweep_config={"parameters": {"entry_cooldown_seconds": ["600"]}},


### PR DESCRIPTION
## Summary

- Carries replay-ledger `execution_quality_blockers` into guided follow-up sweep metadata instead of dropping them when no breadth/risk/window blocker is present.
- Records execution-quality remediations and required replay evidence fields for route TCA, order type, queue/fill, price-improvement, and nonfill opportunity-cost follow-up collection.
- Keeps execution-quality metadata explicitly non-authoritative: promotion still requires runtime-ledger/live-paper proof and existing gates.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_replay_ledger_guided_search.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_replay_ledger_ranker.py -q -k 'execution_quality or rank_replay_ledgers_cli'`
- `cd services/torghut && uv run --frozen pytest tests/test_run_strategy_factory_v2.py::TestRunStrategyFactoryV2::test_run_strategy_factory_v2_applies_replay_ledger_guidance_before_frontier -q`
- `cd services/torghut && uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q -k 'remediation'`
- `cd services/torghut && uv run --frozen pytest tests/test_replay_ledger_guided_search.py tests/test_replay_ledger_ranker.py -q -k 'guided or execution_quality or rank_replay_ledgers_cli'`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/replay_ledger_guided_search.py tests/test_replay_ledger_guided_search.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/replay_ledger_guided_search.py tests/test_replay_ledger_guided_search.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
