### PR TITLE
fix(torghut): rank autoresearch by execution quality

### DIFF
--- a/services/torghut/app/trading/discovery/mlx_proposal_models.py
+++ b/services/torghut/app/trading/discovery/mlx_proposal_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, cast
 
 from app.trading.discovery.autoresearch import ProposalModelPolicy
 from app.trading.discovery.mlx_features import (
@@ -25,15 +25,38 @@ def _float(value: Any) -> float:
         return 0.0
 
 
+def _has_value(value: Any) -> bool:
+    return value not in (None, "")
+
+
+def _sequence_count(value: Any) -> int:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return len(cast(Sequence[object], value))
+    return 0
+
+
 def _candidate_target(row: Mapping[str, Any]) -> float:
     net = _float(row.get("net_pnl_per_day"))
     deployable_lower_bound = deployable_lower_bound_net_pnl_per_day(row)
     deployable_net = (
         float(deployable_lower_bound) if deployable_lower_bound is not None else net
     )
+    if _has_value(row.get("execution_quality_adjusted_window_net_pnl_per_day")):
+        deployable_net = min(
+            deployable_net,
+            _float(row.get("execution_quality_adjusted_window_net_pnl_per_day")),
+        )
     proof_penalty = (
         deployable_lower_bound_missing_count(row) * 1_000.0
         + deployable_proof_failed_gate_count(row) * 1_000.0
+    )
+    execution_quality_penalty = min(
+        max(0.0, _float(row.get("execution_quality_penalty_bps"))) * 5.0,
+        500.0,
+    )
+    execution_quality_blocker_penalty = min(
+        _sequence_count(row.get("execution_quality_blockers")) * 150.0,
+        600.0,
     )
     activity = _float(row.get("active_day_ratio"))
     positive_day_ratio = _float(row.get("positive_day_ratio"))
@@ -73,6 +96,8 @@ def _candidate_target(row: Mapping[str, Any]) -> float:
         - (concentration_penalty * 100.0)
         - (veto_penalty * 250.0)
         - proof_penalty
+        - execution_quality_penalty
+        - execution_quality_blocker_penalty
         - (max(0.0, 1.0 - activity) * 400.0)
         - (max(0.0, 1.0 - positive_day_ratio) * 300.0)
         - (notional_shortfall_penalty * 350.0)

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -327,6 +327,15 @@ def _decimal(value: Any, *, default: Decimal = Decimal("0")) -> Decimal:
         return default
 
 
+def _maybe_decimal(value: Any) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
 def _json_clone(payload: Mapping[str, Any]) -> dict[str, Any]:
     return cast(dict[str, Any], json.loads(json.dumps(payload, default=str)))
 
@@ -1006,6 +1015,22 @@ def _history_record(
     ranking = _mapping(candidate_payload.get("ranking"))
     replay_config = _mapping(candidate_payload.get("replay_config"))
     staged_search = _mapping(candidate_payload.get("staged_search"))
+    exact_replay_ranking = _mapping(
+        candidate_payload.get("exact_replay_ledger_ranking")
+    )
+    execution_quality = _mapping(
+        candidate_payload.get("execution_quality") or scorecard.get("execution_quality")
+    )
+    execution_quality_blockers = [
+        _string(item)
+        for item in cast(
+            list[Any],
+            candidate_payload.get("execution_quality_blockers")
+            or scorecard.get("execution_quality_blockers")
+            or [],
+        )
+        if _string(item)
+    ]
     promotion_readiness = _promotion_readiness_payload(family_plan=family_plan)
     deployable_lower_bound = deployable_lower_bound_net_pnl_per_day(scorecard)
     return {
@@ -1238,6 +1263,27 @@ def _history_record(
             scorecard.get("exact_replay_ledger_artifact_fill_count")
             or candidate_payload.get("exact_replay_ledger_artifact_fill_count")
         ),
+        "exact_replay_ledger_ranking_authority": _string(
+            exact_replay_ranking.get("authority")
+        ),
+        "exact_replay_ledger_ranking_artifact_ref": _string(
+            exact_replay_ranking.get("artifact_ref")
+        ),
+        "execution_quality": execution_quality,
+        "execution_quality_blockers": execution_quality_blockers,
+        "execution_quality_blocker_count": len(execution_quality_blockers),
+        "execution_quality_penalty_bps": _string(
+            candidate_payload.get("execution_quality_penalty_bps")
+            or scorecard.get("execution_quality_penalty_bps")
+        ),
+        "execution_quality_penalty_amount": _string(
+            candidate_payload.get("execution_quality_penalty_amount")
+            or scorecard.get("execution_quality_penalty_amount")
+        ),
+        "execution_quality_adjusted_window_net_pnl_per_day": _string(
+            candidate_payload.get("execution_quality_adjusted_window_net_pnl_per_day")
+            or scorecard.get("execution_quality_adjusted_window_net_pnl_per_day")
+        ),
         "runtime_ledger_pnl_basis": _string(
             scorecard.get("runtime_ledger_pnl_basis")
             or candidate_payload.get("runtime_ledger_pnl_basis")
@@ -1280,6 +1326,9 @@ def _write_results_tsv(path: Path, history: list[dict[str, Any]]) -> None:
         "family_template_id",
         "candidate_id",
         "net_pnl_per_day",
+        "execution_quality_adjusted_window_net_pnl_per_day",
+        "execution_quality_penalty_bps",
+        "execution_quality_blocker_count",
         "active_day_ratio",
         "best_day_share",
         "max_drawdown",
@@ -1298,6 +1347,15 @@ def _write_results_tsv(path: Path, history: list[dict[str, Any]]) -> None:
                     _sanitize_tsv_field(item["family_template_id"]),
                     _sanitize_tsv_field(item["candidate_id"]),
                     _sanitize_tsv_field(item["net_pnl_per_day"]),
+                    _sanitize_tsv_field(
+                        item.get(
+                            "execution_quality_adjusted_window_net_pnl_per_day", ""
+                        )
+                    ),
+                    _sanitize_tsv_field(item.get("execution_quality_penalty_bps", "")),
+                    _sanitize_tsv_field(
+                        item.get("execution_quality_blocker_count", "")
+                    ),
                     _sanitize_tsv_field(item["active_day_ratio"]),
                     _sanitize_tsv_field(item["best_day_share"]),
                     _sanitize_tsv_field(item["max_drawdown"]),
@@ -1313,6 +1371,20 @@ def _write_results_tsv(path: Path, history: list[dict[str, Any]]) -> None:
     path.write_text("\n".join(rows) + "\n", encoding="utf-8")
 
 
+def _research_ranking_net_pnl_per_day(item: Mapping[str, Any]) -> float:
+    base = (
+        _maybe_decimal(item.get("deployable_lower_bound_net_pnl_per_day"))
+        or _maybe_decimal(item.get("net_pnl_per_day"))
+        or Decimal("0")
+    )
+    adjusted = _maybe_decimal(
+        item.get("execution_quality_adjusted_window_net_pnl_per_day")
+    )
+    if adjusted is not None:
+        base = min(base, adjusted)
+    return float(base)
+
+
 def _best_history_record(history: list[dict[str, Any]]) -> dict[str, Any] | None:
     if not history:
         return None
@@ -1322,11 +1394,7 @@ def _best_history_record(history: list[dict[str, Any]]) -> dict[str, Any] | None
             item["status"] != "keep",
             bool(item["hard_vetoes"]),
             int(item["pareto_tier"]),
-            -float(
-                item.get("deployable_lower_bound_net_pnl_per_day")
-                or item["net_pnl_per_day"]
-                or "0"
-            ),
+            -_research_ranking_net_pnl_per_day(item),
             -float(item["net_pnl_per_day"] or "0"),
             -float(item["active_day_ratio"] or "0"),
         ),
@@ -2172,6 +2240,79 @@ def _write_exact_replay_ledger_ranking(
     }
 
 
+_EXACT_REPLAY_EXECUTION_QUALITY_FIELDS = (
+    "artifact_ref",
+    "window_start",
+    "window_end",
+    "execution_quality",
+    "execution_quality_blockers",
+    "execution_quality_penalty_bps",
+    "execution_quality_penalty_amount",
+    "execution_quality_adjusted_window_net_pnl_per_day",
+)
+
+
+def _exact_replay_ranking_by_candidate(
+    ranking_report: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    candidates = cast(list[Any], ranking_report.get("candidates") or [])
+    by_candidate: dict[str, dict[str, Any]] = {}
+    for item in candidates:
+        candidate = _mapping(item)
+        candidate_id = _string(candidate.get("candidate_id"))
+        if candidate_id and candidate_id not in by_candidate:
+            by_candidate[candidate_id] = candidate
+    return by_candidate
+
+
+def _with_exact_replay_execution_quality(
+    candidate_payload: Mapping[str, Any],
+    exact_replay_candidate: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    payload = _json_clone(candidate_payload)
+    if exact_replay_candidate is None:
+        return payload
+    exact_payload = _mapping(exact_replay_candidate)
+    metadata = _mapping(payload.get("exact_replay_ledger_ranking"))
+    for field in _EXACT_REPLAY_EXECUTION_QUALITY_FIELDS:
+        if field in exact_payload:
+            payload[field] = (
+                _json_clone(_mapping(exact_payload[field]))
+                if isinstance(exact_payload[field], Mapping)
+                else exact_payload[field]
+            )
+            metadata[field] = payload[field]
+    if metadata:
+        metadata["authority"] = "research_ranking_only_not_promotion_proof"
+        payload["exact_replay_ledger_ranking"] = metadata
+    return payload
+
+
+def _exact_replay_candidate_for_payload(
+    *,
+    candidate_payload: Mapping[str, Any],
+    by_candidate: Mapping[str, Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    candidate_id = _string(candidate_payload.get("candidate_id"))
+    if not candidate_id:
+        return None
+    exact_candidate = by_candidate.get(candidate_id)
+    if exact_candidate is None:
+        return None
+    payload_refs = {
+        str(Path(ref).expanduser().resolve(strict=False))
+        for ref in _exact_replay_ledger_refs(candidate_payload)
+    }
+    if not payload_refs:
+        return exact_candidate
+    exact_ref = _string(exact_candidate.get("artifact_ref"))
+    if not exact_ref:
+        return None
+    if str(Path(exact_ref).expanduser().resolve(strict=False)) not in payload_refs:
+        return None
+    return exact_candidate
+
+
 def _write_exact_replay_ledger_remediation(
     *,
     run_root: Path,
@@ -2750,9 +2891,24 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 existing=signal_bundle_stats,
             )
             manifest = _refresh_manifest()
+            exact_replay_by_candidate = _exact_replay_ranking_by_candidate(
+                cast(Mapping[str, Any], exact_replay_ledger_ranking["report"])
+            )
             top_candidates = cast(
                 list[dict[str, Any]], frontier_payload.get("top") or []
             )
+            top_candidates = [
+                _with_exact_replay_execution_quality(
+                    candidate,
+                    _exact_replay_candidate_for_payload(
+                        candidate_payload=candidate,
+                        by_candidate=exact_replay_by_candidate,
+                    ),
+                )
+                for candidate in top_candidates
+            ]
+            if top_candidates:
+                frontier_payload = {**frontier_payload, "top": top_candidates}
             keep_candidates = [
                 candidate
                 for candidate in top_candidates

--- a/services/torghut/tests/test_mlx_autoresearch.py
+++ b/services/torghut/tests/test_mlx_autoresearch.py
@@ -205,6 +205,41 @@ class TestMlxAutoresearch(TestCase):
         self.assertLess(optimistic, robust)
         self.assertLess(raw_only, robust)
 
+    def test_candidate_target_penalizes_execution_quality_adjusted_net(
+        self,
+    ) -> None:
+        base = {
+            "net_pnl_per_day": "900",
+            **_proof_metrics("800"),
+            "active_day_ratio": "1",
+            "positive_day_ratio": "1",
+            "avg_filled_notional_per_day": "300000",
+            "required_min_daily_notional": "250000",
+            "best_day_share": "0.10",
+        }
+
+        unadjusted = _candidate_target(base)
+        adjusted = _candidate_target(
+            {
+                **base,
+                "execution_quality_adjusted_window_net_pnl_per_day": "220",
+            }
+        )
+        blocked = _candidate_target(
+            {
+                **base,
+                "execution_quality_adjusted_window_net_pnl_per_day": "220",
+                "execution_quality_penalty_bps": "25",
+                "execution_quality_blockers": [
+                    "market_order_share_high",
+                    "queue_evidence_missing",
+                ],
+            }
+        )
+
+        self.assertLess(adjusted, unadjusted)
+        self.assertLess(blocked, adjusted)
+
     def test_descriptor_inference_covers_side_rank_and_universe_fallbacks(
         self,
     ) -> None:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -1153,6 +1153,239 @@ class TestStrategyAutoresearch(TestCase):
         self.assertEqual(record["staged_full_replay_candidate_budget"], "96")
         self.assertEqual(record["staged_full_replay_candidates_started"], 7)
 
+    def test_history_record_flattens_exact_replay_execution_quality(self) -> None:
+        candidate_payload = runner._with_exact_replay_execution_quality(
+            {
+                "candidate_id": "candidate-1",
+                "hard_vetoes": [],
+                "ranking": {"pareto_tier": 1, "tie_breaker_score": "10"},
+                "objective_scorecard": {"net_pnl_per_day": "700"},
+                "full_window": {},
+                "replay_config": {},
+            },
+            {
+                "candidate_id": "candidate-1",
+                "artifact_ref": "/tmp/candidate-1-exact-replay-ledger.json",
+                "execution_quality": {
+                    "market_order_ratio": "0.8",
+                    "limit_order_ratio": "0.2",
+                },
+                "execution_quality_blockers": [
+                    "market_order_share_high",
+                    "queue_evidence_missing",
+                ],
+                "execution_quality_penalty_bps": "35",
+                "execution_quality_penalty_amount": "17.5",
+                "execution_quality_adjusted_window_net_pnl_per_day": "430",
+            },
+        )
+
+        record = runner._history_record(
+            runner_run_id="run-1",
+            experiment_index=1,
+            family_plan=FamilyAutoresearchPlan(
+                family_template=_family_template(),
+                seed_sweep_config=Path("/tmp/example.yaml"),
+                max_iterations=1,
+                keep_top_candidates=1,
+                frontier_top_n=1,
+                force_keep_top_candidate_if_all_vetoed=True,
+                symbol_prune_iterations=0,
+                symbol_prune_candidates=1,
+                symbol_prune_min_universe_size=2,
+                loss_repair_iterations=0,
+                loss_repair_candidates=1,
+                consistency_repair_iterations=0,
+                consistency_repair_candidates=2,
+                parameter_mutations={},
+                strategy_override_mutations={},
+            ),
+            iteration=1,
+            mutation_label="seed",
+            parent_candidate_id=None,
+            sweep_config_path=Path("/tmp/sweep.yaml"),
+            result_path=Path("/tmp/result.json"),
+            candidate_payload=candidate_payload,
+            rank=1,
+            status="keep",
+            objective_met=False,
+            dataset_snapshot_id="snap-1",
+        )
+
+        self.assertEqual(
+            record["execution_quality"]["market_order_ratio"],
+            "0.8",
+        )
+        self.assertEqual(record["execution_quality_blocker_count"], 2)
+        self.assertEqual(record["execution_quality_penalty_bps"], "35")
+        self.assertEqual(
+            record["execution_quality_adjusted_window_net_pnl_per_day"],
+            "430",
+        )
+        self.assertEqual(
+            record["exact_replay_ledger_ranking_authority"],
+            "research_ranking_only_not_promotion_proof",
+        )
+        self.assertNotIn("promotion_allowed", candidate_payload)
+
+    def test_best_history_record_uses_execution_quality_adjusted_cap(self) -> None:
+        weak_after_execution_quality = {
+            "status": "keep",
+            "hard_vetoes": [],
+            "pareto_tier": 1,
+            "candidate_id": "raw-winner",
+            "net_pnl_per_day": "900",
+            "deployable_lower_bound_net_pnl_per_day": "900",
+            "execution_quality_adjusted_window_net_pnl_per_day": "80",
+            "active_day_ratio": "1",
+        }
+        stronger_after_execution_quality = {
+            "status": "keep",
+            "hard_vetoes": [],
+            "pareto_tier": 1,
+            "candidate_id": "adjusted-winner",
+            "net_pnl_per_day": "300",
+            "deployable_lower_bound_net_pnl_per_day": "300",
+            "execution_quality_adjusted_window_net_pnl_per_day": "260",
+            "active_day_ratio": "1",
+        }
+
+        best = runner._best_history_record(
+            [weak_after_execution_quality, stronger_after_execution_quality]
+        )
+
+        self.assertEqual(best["candidate_id"], "adjusted-winner")
+
+    def test_maybe_decimal_returns_none_for_invalid_values(self) -> None:
+        self.assertIsNone(runner._maybe_decimal("not-a-decimal"))
+
+    def test_exact_replay_ranking_by_candidate_keeps_first_valid_candidate(
+        self,
+    ) -> None:
+        first = {
+            "candidate_id": "candidate-1",
+            "artifact_ref": "/tmp/first.json",
+        }
+        second = {
+            "candidate_id": "candidate-1",
+            "artifact_ref": "/tmp/second.json",
+        }
+
+        by_candidate = runner._exact_replay_ranking_by_candidate(
+            {
+                "candidates": [
+                    "not-a-mapping",
+                    {"candidate_id": ""},
+                    first,
+                    second,
+                ]
+            }
+        )
+
+        self.assertEqual(by_candidate, {"candidate-1": first})
+
+    def test_exact_replay_candidate_match_allows_payload_without_artifact_refs(
+        self,
+    ) -> None:
+        exact_candidate = {
+            "candidate_id": "candidate-1",
+            "artifact_ref": "/tmp/exact.json",
+        }
+
+        self.assertEqual(
+            runner._exact_replay_candidate_for_payload(
+                candidate_payload={"candidate_id": "candidate-1"},
+                by_candidate={"candidate-1": exact_candidate},
+            ),
+            exact_candidate,
+        )
+
+    def test_exact_replay_execution_quality_leaves_payload_without_candidate(
+        self,
+    ) -> None:
+        candidate_payload = {
+            "candidate_id": "candidate-1",
+            "exact_replay_ledger_ranking": {"path": "/tmp/ranking.json"},
+        }
+
+        self.assertEqual(
+            runner._with_exact_replay_execution_quality(candidate_payload, None),
+            candidate_payload,
+        )
+
+    def test_exact_replay_candidate_match_rejects_missing_candidate_id(self) -> None:
+        self.assertIsNone(
+            runner._exact_replay_candidate_for_payload(
+                candidate_payload={
+                    "exact_replay_ledger_artifact_ref": "/tmp/current.json"
+                },
+                by_candidate={
+                    "candidate-1": {
+                        "candidate_id": "candidate-1",
+                        "artifact_ref": "/tmp/current.json",
+                    }
+                },
+            )
+        )
+
+    def test_exact_replay_candidate_match_rejects_unranked_candidate(self) -> None:
+        self.assertIsNone(
+            runner._exact_replay_candidate_for_payload(
+                candidate_payload={"candidate_id": "candidate-1"},
+                by_candidate={},
+            )
+        )
+
+    def test_exact_replay_candidate_match_rejects_missing_exact_artifact(self) -> None:
+        self.assertIsNone(
+            runner._exact_replay_candidate_for_payload(
+                candidate_payload={
+                    "candidate_id": "candidate-1",
+                    "exact_replay_ledger_artifact_ref": "/tmp/current.json",
+                },
+                by_candidate={
+                    "candidate-1": {
+                        "candidate_id": "candidate-1",
+                    }
+                },
+            )
+        )
+
+    def test_exact_replay_candidate_match_returns_matching_artifact(self) -> None:
+        exact_candidate = {
+            "candidate_id": "candidate-1",
+            "artifact_ref": "/tmp/current.json",
+        }
+
+        self.assertEqual(
+            runner._exact_replay_candidate_for_payload(
+                candidate_payload={
+                    "candidate_id": "candidate-1",
+                    "exact_replay_ledger_artifact_refs": ["/tmp/current.json"],
+                },
+                by_candidate={"candidate-1": exact_candidate},
+            ),
+            exact_candidate,
+        )
+
+    def test_exact_replay_candidate_match_requires_artifact_when_present(
+        self,
+    ) -> None:
+        exact_candidate = runner._exact_replay_candidate_for_payload(
+            candidate_payload={
+                "candidate_id": "candidate-1",
+                "exact_replay_ledger_artifact_ref": "/tmp/current.json",
+            },
+            by_candidate={
+                "candidate-1": {
+                    "candidate_id": "candidate-1",
+                    "artifact_ref": "/tmp/stale.json",
+                }
+            },
+        )
+
+        self.assertIsNone(exact_candidate)
+
     def test_materialize_run_replay_tape_writes_bundle_and_receipt(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary

- Threads exact replay execution-quality ranking metadata into autoresearch candidate history and TSV output.
- Uses execution-quality adjusted net PnL as a research-ranking cap for best-history selection and MLX proposal targets.
- Adds artifact-ref matching so stale same-id exact replay artifacts cannot contaminate current candidates.
- Keeps promotion authority unchanged: execution-quality adjusted PnL is ranking metadata only, not proof.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format app/trading/discovery/mlx_proposal_models.py scripts/run_strategy_autoresearch_loop.py tests/test_mlx_autoresearch.py tests/test_strategy_autoresearch.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/mlx_proposal_models.py scripts/run_strategy_autoresearch_loop.py tests/test_mlx_autoresearch.py tests/test_strategy_autoresearch.py`
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_autoresearch.py -k 'persist_run_outputs_surfaces_exact_replay_ledger_ranking or history_record_flattens_staged_search_metadata or exact_replay or execution_quality or best_history_record' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_mlx_autoresearch.py -k 'candidate_target or rank_candidate_descriptors_orders_candidates_from_history_signal' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_replay_ledger_ranker.py -k 'execution_quality or closing_auction' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_autoresearch.py tests/test_mlx_autoresearch.py tests/test_replay_ledger_ranker.py -k 'exact_replay or execution_quality or best_history_record or candidate_target or closing_auction' -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
