### PR TITLE
fix(torghut): carry bounded paper probation notional

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -9054,6 +9054,21 @@ def _source_collection_import_target_allowed(target: Mapping[str, Any]) -> bool:
     return True
 
 
+def _target_bounded_collection_notional(target: Mapping[str, Any]) -> str:
+    for key in (
+        "target_notional",
+        "paper_route_probe_target_notional",
+        "paper_route_probe_effective_max_notional",
+        "bounded_evidence_collection_max_notional",
+        "paper_route_probe_next_session_max_notional",
+        "max_notional",
+    ):
+        amount = _safe_decimal(target.get(key))
+        if amount > 0:
+            return _decimal_text(amount)
+    return "0"
+
+
 def _runtime_window_import_target_metadata(
     target: Mapping[str, Any],
 ) -> dict[str, object]:
@@ -9122,6 +9137,17 @@ def _sanitized_runtime_ledger_source_collection_target(
         _safe_text(target.get("source_kind"))
         or RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND
     )
+    bounded_evidence_collection_requested = _truthy_plan_value(
+        target.get("bounded_evidence_collection_authorized")
+    )
+    bounded_notional = (
+        _target_bounded_collection_notional(target)
+        if bounded_evidence_collection_requested
+        else "0"
+    )
+    bounded_evidence_collection_authorized = (
+        bounded_evidence_collection_requested and _safe_decimal(bounded_notional) > 0
+    )
     final_promotion_blockers = _unique_text_items(
         target.get("final_promotion_blockers")
     ) or list(RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS)
@@ -9166,9 +9192,26 @@ def _sanitized_runtime_ledger_source_collection_target(
         ),
         "proof_mode": "probation",
         "evidence_collection_ok": True,
-        "canary_collection_authorized": False,
-        "bounded_live_paper_collection_authorized": False,
-        "bounded_evidence_collection_authorized": False,
+        "canary_collection_authorized": bool(
+            bounded_evidence_collection_authorized
+            and target.get("canary_collection_authorized")
+        ),
+        "bounded_live_paper_collection_authorized": bool(
+            bounded_evidence_collection_authorized
+            and target.get("bounded_live_paper_collection_authorized")
+        ),
+        "bounded_evidence_collection_authorized": (
+            bounded_evidence_collection_authorized
+        ),
+        "bounded_evidence_collection_scope": _safe_text(
+            target.get("bounded_evidence_collection_scope")
+        )
+        or (
+            "paper_route_probe_next_session_only"
+            if bounded_evidence_collection_authorized
+            else ""
+        ),
+        "bounded_evidence_collection_max_notional": bounded_notional,
         "capital_promotion_allowed": False,
         "live_capital_authorized": False,
         "final_authority_ok": False,
@@ -9199,7 +9242,10 @@ def _sanitized_runtime_ledger_source_collection_target(
         or RUNTIME_LEDGER_SOURCE_COLLECTION_SELECTED_BY,
         "selection_reason": _safe_text(target.get("selection_reason"))
         or "positive_activity_needs_source_window_runtime_evidence",
-        "max_notional": "0",
+        "target_notional": bounded_notional,
+        "paper_route_probe_next_session_max_notional": bounded_notional,
+        "paper_route_probe_effective_max_notional": bounded_notional,
+        "max_notional": bounded_notional,
         "stripped_source_promotion_authority": bool(
             target.get("promotion_allowed")
             or target.get("final_promotion_allowed")

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -449,6 +449,45 @@ def _safe_decimal(value: object) -> Decimal | None:
         return None
 
 
+def _decimal_text(value: Decimal) -> str:
+    text = format(value, "f")
+    if "." not in text:
+        return text
+    return text.rstrip("0").rstrip(".") or "0"
+
+
+def _bounded_paper_route_probe_notional() -> Decimal:
+    return max(
+        _safe_decimal(settings.trading_simple_paper_route_probe_max_notional)
+        or Decimal("0"),
+        Decimal("0"),
+    )
+
+
+def _bounded_paper_route_probe_collection_payload(
+    *,
+    authorized: bool,
+) -> dict[str, object]:
+    notional = _bounded_paper_route_probe_notional() if authorized else Decimal("0")
+    bounded_authorized = notional > 0
+    if not bounded_authorized:
+        return {
+            "bounded_evidence_collection_authorized": False,
+            "bounded_evidence_collection_max_notional": "0",
+            "max_notional": "0",
+        }
+    notional_text = _decimal_text(notional)
+    return {
+        "bounded_evidence_collection_authorized": True,
+        "bounded_evidence_collection_scope": "paper_route_probe_next_session_only",
+        "bounded_evidence_collection_max_notional": notional_text,
+        "paper_route_probe_next_session_max_notional": notional_text,
+        "paper_route_probe_effective_max_notional": notional_text,
+        "target_notional": notional_text,
+        "max_notional": notional_text,
+    }
+
+
 def _safe_bool(value: object) -> bool | None:
     if isinstance(value, bool):
         return value
@@ -1849,7 +1888,7 @@ def _runtime_ledger_paper_probation_candidates(
             "final_promotion_allowed": False,
             "paper_probation_reason_codes": [_RUNTIME_LEDGER_PAPER_PROBATION_REASON],
             "paper_probation_target_capital_stage": "shadow",
-            "max_notional": "0",
+            **_bounded_paper_route_probe_collection_payload(authorized=True),
         }
         for candidate in candidates
         if _runtime_ledger_paper_probation_eligible(candidate)
@@ -1904,9 +1943,7 @@ def _runtime_ledger_source_collection_target_progress_payload(
 ) -> dict[str, object]:
     target = _RUNTIME_LEDGER_SOURCE_COLLECTION_PROFIT_TARGET_NET_PNL_AFTER_COSTS
     shortfall = max(target - net_pnl_after_costs, Decimal("0"))
-    progress_ratio = (
-        net_pnl_after_costs / target if target > 0 else Decimal("0")
-    )
+    progress_ratio = net_pnl_after_costs / target if target > 0 else Decimal("0")
     if net_pnl_after_costs > 0:
         required_notional_scale = max(target / net_pnl_after_costs, Decimal("1"))
     else:
@@ -1938,14 +1975,16 @@ def _runtime_ledger_source_collection_profit_target_metadata(
         "source_collection_priority": "source_window_evidence_collection",
     }
     if profit_target_candidate:
-        net_pnl_after_costs = (
-            _safe_decimal(payload.get("net_strategy_pnl_after_costs")) or Decimal("0")
-        )
+        net_pnl_after_costs = _safe_decimal(
+            payload.get("net_strategy_pnl_after_costs")
+        ) or Decimal("0")
         filled_notional = _safe_decimal(payload.get("filled_notional")) or Decimal("0")
         metadata.update(
             {
                 "source_collection_priority": "profit_target_source_materialization",
-                "source_collection_net_strategy_pnl_after_costs": str(net_pnl_after_costs),
+                "source_collection_net_strategy_pnl_after_costs": str(
+                    net_pnl_after_costs
+                ),
                 "source_collection_post_cost_expectancy_bps": str(
                     _safe_decimal(payload.get("post_cost_expectancy_bps"))
                     or Decimal("0")
@@ -1989,6 +2028,11 @@ def _runtime_ledger_source_collection_candidates(
             "capital_promotion_allowed": False,
             "final_authority_ok": False,
             "final_promotion_allowed": False,
+            **_bounded_paper_route_probe_collection_payload(
+                authorized=_runtime_ledger_source_collection_profit_target_candidate(
+                    candidate
+                )
+            ),
             "source_collection_reason_codes": [
                 reason
                 for reason in _normalize_reason_codes(
@@ -2002,7 +2046,6 @@ def _runtime_ledger_source_collection_candidates(
                 )
                 if reason in _RUNTIME_LEDGER_SOURCE_COLLECTION_TRIGGER_REASONS
             ],
-            "max_notional": "0",
         }
         for candidate in candidates
         if _runtime_ledger_source_collection_candidate(candidate)
@@ -2271,6 +2314,9 @@ def _runtime_ledger_paper_probation_import_plan(
             "evidence_collection_ok": True,
             "canary_collection_authorized": paper_probation_satisfied,
             "bounded_live_paper_collection_authorized": paper_probation_satisfied,
+            **_bounded_paper_route_probe_collection_payload(
+                authorized=paper_probation_satisfied or profit_target_source_collection
+            ),
             "capital_promotion_allowed": False,
             "final_authority_ok": False,
             "evidence_collection_stage": "paper",
@@ -2298,7 +2344,6 @@ def _runtime_ledger_paper_probation_import_plan(
                 else "runtime_ledger_paper_probation"
             ),
             "selection_reason": selection_reason,
-            "max_notional": "0",
         }
         if source_collection:
             target.update(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5956,6 +5956,54 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(target["final_promotion_allowed"])
         self.assertTrue(target["stripped_source_promotion_authority"])
 
+    def test_source_collection_import_plan_preserves_bounded_authorized_notional(
+        self,
+    ) -> None:
+        live_gate = {
+            "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+            "runtime_ledger_source_collection_candidates": [
+                {
+                    "hypothesis_id": "H-DIRECT",
+                    "candidate_id": "direct-bounded-source-collection",
+                    "observed_stage": "paper",
+                    "strategy_family": "intraday_tsmom_consistent",
+                    "strategy_name": "intraday-tsmom-profit-v3",
+                    "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                    "account": "TORGHUT_SIM",
+                    "source_account_label": "TORGHUT_SIM",
+                    "source_dsn_env": "SIM_DB_DSN",
+                    "target_dsn_env": "SIM_DB_DSN",
+                    "window_start": "2026-06-02T13:30:00+00:00",
+                    "window_end": "2026-06-02T20:00:00+00:00",
+                    "source_collection_authorized": True,
+                    "source_collection_reason_codes": [
+                        "runtime_ledger_source_collection_pending"
+                    ],
+                    "bounded_evidence_collection_authorized": True,
+                    "bounded_evidence_collection_max_notional": "25",
+                    "target_notional": "25",
+                    "promotion_allowed": True,
+                    "final_promotion_allowed": True,
+                    "max_notional": "25000",
+                }
+            ],
+        }
+
+        plan = paper_route_evidence._runtime_ledger_source_collection_import_plan_for_payload(
+            plan={"targets": []},
+            live_submission_gate=live_gate,
+            target_limit=5,
+        )
+
+        target = plan["targets"][0]
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(target["target_notional"], "25")
+        self.assertEqual(target["bounded_evidence_collection_max_notional"], "25")
+        self.assertEqual(target["max_notional"], "25")
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+        self.assertTrue(target["stripped_source_promotion_authority"])
+
     def test_builder_exports_missing_runtime_window_health_gate_as_blockers(
         self,
     ) -> None:

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -1537,7 +1537,9 @@ class TestSubmissionCouncil(TestCase):
         self.assertFalse(paper_candidates[0]["capital_promotion_allowed"])
         self.assertFalse(paper_candidates[0]["final_authority_ok"])
         self.assertFalse(paper_candidates[0]["final_promotion_allowed"])
-        self.assertEqual(paper_candidates[0]["max_notional"], "0")
+        self.assertTrue(paper_candidates[0]["bounded_evidence_collection_authorized"])
+        self.assertEqual(paper_candidates[0]["target_notional"], "25")
+        self.assertEqual(paper_candidates[0]["max_notional"], "25")
         import_plan = gate["runtime_ledger_paper_probation_import_plan"]
         self.assertIsInstance(import_plan, dict)
         self.assertEqual(
@@ -1593,6 +1595,10 @@ class TestSubmissionCouncil(TestCase):
         self.assertTrue(target["evidence_collection_ok"])
         self.assertTrue(target["canary_collection_authorized"])
         self.assertTrue(target["bounded_live_paper_collection_authorized"])
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(target["target_notional"], "25")
+        self.assertEqual(target["bounded_evidence_collection_max_notional"], "25")
+        self.assertEqual(target["max_notional"], "25")
         self.assertFalse(target["capital_promotion_allowed"])
         self.assertFalse(target["final_authority_ok"])
         self.assertEqual(target["promotion_allowed"], False)
@@ -2157,7 +2163,10 @@ class TestSubmissionCouncil(TestCase):
         self.assertFalse(target["paper_probation_authorized"])
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_allowed"])
-        self.assertEqual(target["max_notional"], "0")
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(target["target_notional"], "25")
+        self.assertEqual(target["bounded_evidence_collection_max_notional"], "25")
+        self.assertEqual(target["max_notional"], "25")
         self.assertEqual(
             target["selection_reason"], "profit_target_source_window_evidence_pending"
         )
@@ -2286,7 +2295,10 @@ class TestSubmissionCouncil(TestCase):
         target = plan["targets"][0]
         self.assertEqual(target["candidate_id"], "ca4e6e3c7d639e3363dc5860")
         self.assertTrue(target["paper_probation_authorized"])
-        self.assertEqual(target["max_notional"], "0")
+        self.assertTrue(target["bounded_evidence_collection_authorized"])
+        self.assertEqual(target["target_notional"], "25")
+        self.assertEqual(target["bounded_evidence_collection_max_notional"], "25")
+        self.assertEqual(target["max_notional"], "25")
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_allowed"])
         self.assertIn(


### PR DESCRIPTION
## Summary

- Carry configured bounded paper-route notional into paper-probation import-plan targets that are already authorized for evidence collection.
- Preserve bounded notional through source-collection target sanitization only when explicit bounded-evidence authorization is present, while stripping any promotion authority.
- Add regressions for paper-probation, profit-target source collection, sanitizer stripping, and bounded materialization compatibility.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_materialize_bounded_paper_route_targets.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'paper_route or bounded'`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council.py app/trading/paper_route_evidence.py tests/test_submission_council.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council.py app/trading/paper_route_evidence.py tests/test_submission_council.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
