### PR TITLE
fix(torghut): refresh sim execution tca on fast cron

### DIFF
--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -40,6 +40,28 @@ spec:
                     secretKeyRef:
                       name: torghut-db-app
                       key: uri
+                - name: TORGHUT_SIM_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: host
+                - name: TORGHUT_SIM_DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: port
+                - name: TORGHUT_SIM_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: username
+                - name: TORGHUT_SIM_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: password
+                - name: SIM_DB_DSN
+                  value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
               command:
                 - /bin/bash
                 - -lc
@@ -47,7 +69,18 @@ spec:
                 - |
                   set -euo pipefail
                   cd /app
+                  echo "stage=refresh_execution_tca_metrics dsn_env=DB_DSN started_at=$(date -Iseconds)"
                   /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
+                    --dsn-env DB_DSN \
+                    --older-than-seconds 900 \
+                    --batch-size 1000 \
+                    --max-batches 5 \
+                    --apply \
+                    --json
+                  echo "stage=refresh_execution_tca_metrics dsn_env=SIM_DB_DSN account=TORGHUT_SIM started_at=$(date -Iseconds)"
+                  /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
                     --older-than-seconds 900 \
                     --batch-size 1000 \
                     --max-batches 5 \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1201,13 +1201,33 @@ class TestLiveConfigManifestContract(TestCase):
             value_from.get("secretKeyRef"),
             {"name": "torghut-db-app", "key": "uri"},
         )
+        self.assertEqual(
+            env["SIM_DB_DSN"].get("value"),
+            "postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@"
+            "$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default",
+        )
+        for name, key in {
+            "TORGHUT_SIM_DB_HOST": "host",
+            "TORGHUT_SIM_DB_PORT": "port",
+            "TORGHUT_SIM_DB_USER": "username",
+            "TORGHUT_SIM_DB_PASSWORD": "password",
+        }.items():
+            value_from = cast(Mapping[str, object], env[name].get("valueFrom", {}))
+            self.assertEqual(
+                value_from.get("secretKeyRef"),
+                {"name": "torghut-db-app", "key": key},
+            )
 
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/refresh_execution_tca_metrics.py", args)
+        self.assertIn("--dsn-env DB_DSN", args)
+        self.assertIn("--dsn-env SIM_DB_DSN", args)
+        self.assertIn("--account-label TORGHUT_SIM", args)
         self.assertIn("--older-than-seconds 900", args)
         self.assertIn("--batch-size 1000", args)
         self.assertIn("--max-batches 5", args)
         self.assertIn("--apply", args)
+        self.assertEqual(args.count("scripts/refresh_execution_tca_metrics.py"), 2)
 
     def test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account(
         self,


### PR DESCRIPTION
## Summary

- Extends the fast `torghut-execution-tca-refresh` CronJob to refresh both the primary `DB_DSN` and `SIM_DB_DSN`.
- Scopes the sim refresh to `TORGHUT_SIM` so paper-route executions in `torghut_sim_default` get TCA rows without waiting for slower renewal jobs.
- Updates the live manifest contract test to assert the sim database secret wiring and the two refresh invocations.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k execution_tca_refresh -q`
- `bun run lint:argocd -- argocd/applications/torghut/execution-tca-refresh-cronjob.yaml`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
