### PR TITLE
fix(torghut): refresh sim tca before primary backlog

### DIFF
--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -69,18 +69,18 @@ spec:
                 - |
                   set -euo pipefail
                   cd /app
-                  echo "stage=refresh_execution_tca_metrics dsn_env=DB_DSN started_at=$(date -Iseconds)"
+                  echo "stage=refresh_execution_tca_metrics dsn_env=SIM_DB_DSN account=TORGHUT_SIM started_at=$(date -Iseconds)"
                   /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
-                    --dsn-env DB_DSN \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
                     --older-than-seconds 900 \
                     --batch-size 1000 \
                     --max-batches 5 \
                     --apply \
                     --json
-                  echo "stage=refresh_execution_tca_metrics dsn_env=SIM_DB_DSN account=TORGHUT_SIM started_at=$(date -Iseconds)"
+                  echo "stage=refresh_execution_tca_metrics dsn_env=DB_DSN started_at=$(date -Iseconds)"
                   /opt/venv/bin/python scripts/refresh_execution_tca_metrics.py \
-                    --dsn-env SIM_DB_DSN \
-                    --account-label TORGHUT_SIM \
+                    --dsn-env DB_DSN \
                     --older-than-seconds 900 \
                     --batch-size 1000 \
                     --max-batches 5 \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1223,6 +1223,8 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--dsn-env DB_DSN", args)
         self.assertIn("--dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
+        self.assertLess(args.index("dsn_env=SIM_DB_DSN"), args.index("dsn_env=DB_DSN"))
+        self.assertLess(args.index("--dsn-env SIM_DB_DSN"), args.index("--dsn-env DB_DSN"))
         self.assertIn("--older-than-seconds 900", args)
         self.assertIn("--batch-size 1000", args)
         self.assertIn("--max-batches 5", args)


### PR DESCRIPTION
## Summary

- Reorders the Torghut execution TCA refresh CronJob so the `SIM_DB_DSN` / `TORGHUT_SIM` pass runs before the slower primary `DB_DSN` backlog pass.
- Keeps the primary TCA refresh in the same five-minute CronJob after the SIM evidence lane is refreshed.
- Adds a manifest contract assertion that SIM refresh remains ordered before primary refresh.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k execution_tca_refresh -q`
- `bun run lint:argocd -- argocd/applications/torghut/execution-tca-refresh-cronjob.yaml`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Cluster readback before this fix showed `torghut-execution-tca-refresh-29677270` spent `2026-06-05T05:10:01Z` to `2026-06-05T05:16:25Z` on primary `DB_DSN` before reaching the SIM pass.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
