### PR TITLE
fix(registry): expand image storage capacity

### DIFF
--- a/argocd/applications/registry/pvc.yaml
+++ b/argocd/applications/registry/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: rook-ceph-block
   resources:
     requests:
-      storage: 1Ti
+      storage: 2Ti


### PR DESCRIPTION
## Summary

- Expands the in-cluster registry PVC request from `1Ti` to `2Ti`.
- Matches the emergency live PVC expansion already applied to unblock Torghut image pushes.
- Keeps the registry capacity change in GitOps so Argo does not carry hidden drift.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl get pvc registry-data -n registry -o wide` showed capacity `2Ti` after live expansion.
- `kubectl exec -n registry deploy/registry -- df -h /var/lib/registry` showed mounted filesystem size `2.0T` with about `1008G` free.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
