### PR TITLE
fix(registry): expand registry pvc capacity

### DIFF
--- a/argocd/applications/registry/pvc.yaml
+++ b/argocd/applications/registry/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: rook-ceph-block
   resources:
     requests:
-      storage: 1Ti
+      storage: 2Ti


### PR DESCRIPTION
## Summary

- Expands the registry PVC request from `1Ti` to `2Ti`.
- Matches the live `registry-data` resize that restored registry headroom after image pushes exhausted the volume.
- Keeps GitOps desired state aligned with the current registry capacity.

## Related Issues

None

## Testing

- `bun run lint:argocd -- argocd/applications/registry/pvc.yaml`
- `git diff --check`
- Live readback: `kubectl -n registry get pvc registry-data -o wide` reported `CAPACITY 2Ti`.
- Live readback: `kubectl -n registry exec deploy/registry -- df -h /var/lib/registry` reported `/dev/rbd21 2.0T 1007.7G 1008.1G 50% /var/lib/registry`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
