### PR TITLE
ci(agents): drop unrelated product triggers

### DIFF
--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -7,55 +7,26 @@ permissions:
 on:
   pull_request:
     paths:
-      - 'apps/froussard/src/**'
       - 'bun.lock'
       - 'package.json'
       - 'argocd/applications/argo-workflows/**'
       - 'argocd/applications/agents/**'
-      - 'argocd/applications/facteur/**'
-      - 'argocd/applications/froussard/**'
-      - 'argocd/applications/graf/**'
-      - 'argocd/applications/traefik/values.yaml'
-      - 'argocd/applications/torghut/**'
       - 'charts/agents/**'
       - 'docs/agents/**'
       - 'docs/autonomous-codex-design.md'
-      - 'docs/graf-codex-research.md'
       - 'docs/runbooks/codex-docker.md'
       - 'docs/runbooks/kafka-broker-storage-recovery.md'
-      - 'docs/torghut/whitepaper-research-workflow.md'
-      - 'docs/torghut/design-system/v5/12-dspy-framework-adoption-for-quant-llm-autonomous-trading-2026-02-25.md'
-      - 'packages/bumba/**'
       - 'packages/agent-contracts/**'
       - 'packages/codex/**'
       - 'packages/cx-tools/**'
-      - 'packages/design/**'
-      - 'packages/discord/**'
       - 'packages/otel/**'
       - 'packages/scripts/src/agents/**'
-      - 'packages/scripts/src/shared/**'
+      - 'packages/scripts/src/shared/cli.ts'
+      - 'packages/scripts/src/shared/docker.ts'
+      - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/__tests__/docker.test.ts'
       - 'packages/temporal-bun-sdk/**'
-      - 'proto/proompteng/facteur/v1/contract.proto'
       - 'services/agents/**'
-      - 'services/bumba/**'
-      - 'services/facteur/README.md'
-      - 'services/facteur/cmd/**'
-      - 'services/facteur/config/**'
-      - 'services/facteur/internal/**'
-      - 'services/graf/src/main/kotlin/**'
-      - 'services/graf/src/test/kotlin/**'
-      - 'services/graf/README.md'
-      - 'services/graf/build.gradle.kts'
-      - 'services/torghut/app/main.py'
-      - 'services/torghut/app/config.py'
-      - 'services/torghut/app/trading/llm/**'
-      - 'services/torghut/app/whitepapers/**'
-      - 'services/torghut/scripts/run_dspy_workflow.py'
-      - 'services/torghut/tests/test_live_config_manifest_contract.py'
-      - 'services/torghut/tests/test_llm_dspy_workflow.py'
-      - 'services/torghut/tests/test_run_dspy_workflow.py'
-      - 'services/torghut/tests/test_whitepaper_api.py'
-      - 'services/torghut/tests/test_whitepaper_workflow.py'
       - 'scripts/agents/**'
       - 'scripts/download_crd_schema.py'
       - '.github/workflows/agents-build-push.yml'
@@ -66,55 +37,26 @@ on:
     branches:
       - main
     paths:
-      - 'apps/froussard/src/**'
       - 'bun.lock'
       - 'package.json'
       - 'argocd/applications/argo-workflows/**'
       - 'argocd/applications/agents/**'
-      - 'argocd/applications/facteur/**'
-      - 'argocd/applications/froussard/**'
-      - 'argocd/applications/graf/**'
-      - 'argocd/applications/traefik/values.yaml'
-      - 'argocd/applications/torghut/**'
       - 'charts/agents/**'
       - 'docs/agents/**'
       - 'docs/autonomous-codex-design.md'
-      - 'docs/graf-codex-research.md'
       - 'docs/runbooks/codex-docker.md'
       - 'docs/runbooks/kafka-broker-storage-recovery.md'
-      - 'docs/torghut/whitepaper-research-workflow.md'
-      - 'docs/torghut/design-system/v5/12-dspy-framework-adoption-for-quant-llm-autonomous-trading-2026-02-25.md'
-      - 'packages/bumba/**'
       - 'packages/agent-contracts/**'
       - 'packages/codex/**'
       - 'packages/cx-tools/**'
-      - 'packages/design/**'
-      - 'packages/discord/**'
       - 'packages/otel/**'
       - 'packages/scripts/src/agents/**'
-      - 'packages/scripts/src/shared/**'
+      - 'packages/scripts/src/shared/cli.ts'
+      - 'packages/scripts/src/shared/docker.ts'
+      - 'packages/scripts/src/shared/git.ts'
+      - 'packages/scripts/src/shared/__tests__/docker.test.ts'
       - 'packages/temporal-bun-sdk/**'
-      - 'proto/proompteng/facteur/v1/contract.proto'
       - 'services/agents/**'
-      - 'services/bumba/**'
-      - 'services/facteur/README.md'
-      - 'services/facteur/cmd/**'
-      - 'services/facteur/config/**'
-      - 'services/facteur/internal/**'
-      - 'services/graf/src/main/kotlin/**'
-      - 'services/graf/src/test/kotlin/**'
-      - 'services/graf/README.md'
-      - 'services/graf/build.gradle.kts'
-      - 'services/torghut/app/main.py'
-      - 'services/torghut/app/config.py'
-      - 'services/torghut/app/trading/llm/**'
-      - 'services/torghut/app/whitepapers/**'
-      - 'services/torghut/scripts/run_dspy_workflow.py'
-      - 'services/torghut/tests/test_live_config_manifest_contract.py'
-      - 'services/torghut/tests/test_llm_dspy_workflow.py'
-      - 'services/torghut/tests/test_run_dspy_workflow.py'
-      - 'services/torghut/tests/test_whitepaper_api.py'
-      - 'services/torghut/tests/test_whitepaper_workflow.py'
       - 'scripts/agents/**'
       - 'scripts/download_crd_schema.py'
       - '.github/workflows/agents-build-push.yml'
@@ -236,19 +178,17 @@ jobs:
       - name: Install dependencies
         run: >-
           bun install --frozen-lockfile --ignore-scripts
-          --filter @proompteng/source
           --filter @proompteng/agentctl
-          --filter @proompteng/bumba
           --filter @proompteng/codex
           --filter @proompteng/cx-tools
-          --filter @proompteng/design
-          --filter @proompteng/discord
           --filter @proompteng/agents
           --filter @proompteng/otel
           --filter @proompteng/scripts
           --filter @proompteng/temporal-bun-sdk
 
       - name: Run Agents script unit tests
+        env:
+          AGENTS_CI_SKIP_CROSS_PRODUCT_BOUNDARIES: 'true'
         run: |
           bun test \
             packages/scripts/src/agents/__tests__/build-image.test.ts \

--- a/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
+++ b/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
@@ -78,6 +78,22 @@ describe('classifyAgentsImageMode', () => {
     expect(result.matchedPaths).toEqual([])
   })
 
+  it('reuses the published image for non-Agents product package changes', () => {
+    const result = classifyAgentsImageMode([
+      'apps/froussard/src/app.tsx',
+      'packages/bumba/src/index.ts',
+      'packages/design/src/index.ts',
+      'packages/discord/src/index.ts',
+      'services/bumba/src/main.ts',
+      'services/facteur/internal/server.go',
+      'services/graf/src/main/kotlin/App.kt',
+      'services/torghut/app/main.py',
+    ])
+    expect(result.mode).toBe('reuse-published-image')
+    expect(result.needsLocalAgentsImage).toBe(false)
+    expect(result.matchedPaths).toEqual([])
+  })
+
   it('builds a local image when bun.lock changes', () => {
     const result = classifyAgentsImageMode(['bun.lock'])
     expect(result.mode).toBe('build-local-image')
@@ -159,6 +175,11 @@ describe('agents-ci workflow local Agents image build', () => {
   it('keeps Agents CI detached from Jangar service and GitOps paths', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 
+    expect(workflow).not.toContain('apps/froussard/src/**')
+    expect(workflow).not.toContain('argocd/applications/facteur/**')
+    expect(workflow).not.toContain('argocd/applications/froussard/**')
+    expect(workflow).not.toContain('argocd/applications/graf/**')
+    expect(workflow).not.toContain('argocd/applications/torghut/**')
     expect(workflow).not.toContain('services/jangar/**')
     expect(workflow).not.toContain('argocd/applications/jangar/**')
     expect(workflow).not.toContain('docs/jangar/application-architecture.md')
@@ -166,6 +187,17 @@ describe('agents-ci workflow local Agents image build', () => {
     expect(workflow).not.toContain('packages/scripts/src/jangar/verify-deployment.ts')
     expect(workflow).not.toContain('--filter @proompteng/jangar')
     expect(workflow).not.toContain('packages/scripts/src/jangar/__tests__/release-contract.test.ts')
+    expect(workflow).not.toContain('packages/bumba/**')
+    expect(workflow).not.toContain('packages/design/**')
+    expect(workflow).not.toContain('packages/discord/**')
+    expect(workflow).not.toContain('services/bumba/**')
+    expect(workflow).not.toContain('services/facteur/')
+    expect(workflow).not.toContain('services/graf/')
+    expect(workflow).not.toContain('services/torghut/')
+    expect(workflow).not.toContain('--filter @proompteng/source')
+    expect(workflow).not.toContain('--filter @proompteng/bumba')
+    expect(workflow).not.toContain('--filter @proompteng/design')
+    expect(workflow).not.toContain('--filter @proompteng/discord')
   })
 
   it('keeps Agents image publication detached from Jangar-only source changes', () => {

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -17,6 +17,10 @@ import {
   isTransientKubectlError,
 } from '../smoke-agents'
 
+const skipCrossProductBoundaryTests = process.env.AGENTS_CI_SKIP_CROSS_PRODUCT_BOUNDARIES === 'true'
+const crossProductDescribe = skipCrossProductBoundaryTests ? describe.skip : describe
+const crossProductIt = skipCrossProductBoundaryTests ? it.skip : it
+
 describe('buildHelmArgs', () => {
   it('applies chart deployment image repository, tag, and empty digest overrides', () => {
     const valuesFile = resolve(process.cwd(), 'scripts/agents/values-ci.yaml')
@@ -529,7 +533,7 @@ describe('scheduled AgentRun templates', () => {
     expect(objectAt(env, 'AGENTS_SWARM_REQUIREMENT_MAX_ACTIVE_PER_SWARM')).toBeUndefined()
   })
 
-  it('keeps Facteur Codex dispatch behind the Agents AgentRun API boundary', () => {
+  crossProductIt('keeps Facteur Codex dispatch behind the Agents AgentRun API boundary', () => {
     const kustomization = readFileSync(
       resolve(process.cwd(), 'argocd/applications/facteur/overlays/cluster/kustomization.yaml'),
       'utf8',
@@ -594,7 +598,7 @@ describe('scheduled AgentRun templates', () => {
   })
 })
 
-describe('autonomous trader provider', () => {
+crossProductDescribe('autonomous trader provider', () => {
   it('registers autotrader as its own product app without Synthesis desired-state co-ownership', () => {
     const product = readYamlObjects('argocd/applicationsets/product.yaml')[0]
     const generators = objectAt(objectAt(product, 'spec'), 'generators') as Record<string, unknown>[]

--- a/packages/scripts/src/agents/resolve-agents-image-mode.ts
+++ b/packages/scripts/src/agents/resolve-agents-image-mode.ts
@@ -8,11 +8,7 @@ const LOCAL_IMAGE_PREFIXES = [
   'packages/agent-contracts/',
   'packages/temporal-bun-sdk/',
   'packages/codex/',
-  'packages/design/',
-  'packages/bumba/',
-  'packages/discord/',
   'packages/cx-tools/',
-  'services/bumba/',
 ]
 
 const LOCAL_IMAGE_EXACT_PATHS = new Set([


### PR DESCRIPTION
## Summary

- Restricts `agents-ci` path filters to Agents-owned chart, GitOps, service, scripts, and real shared runtime/image inputs.
- Removes unrelated product triggers and install filters for Torghut, Froussard, Facteur, Graf, Bumba, Design, Discord, and Source.
- Keeps cross-product boundary tests available outside Agents CI while skipping them in the Agents workflow.
- Updates the Agents image-mode classifier so unrelated product changes reuse the published Agents image.

## Related Issues

None

## Testing

- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/agents-ci.yml`
- `bun test packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `AGENTS_CI_SKIP_CROSS_PRODUCT_BOUNDARIES=true bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `AGENTS_CI_SKIP_CROSS_PRODUCT_BOUNDARIES=true bun test packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/__tests__/resolve-published-agents-images.test.ts packages/scripts/src/agents/__tests__/agentrun-ingestion-mitigation.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents test`
- `scripts/agents/validate-agents.sh`
- `bunx oxfmt --check packages/scripts/src/agents/resolve-agents-image-mode.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
