### PR TITLE
chore(agents): promote images 4a010a93

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 5af13821
-  digest: sha256:114d950041cb11ffa81533d4fe34a3a69bed1acbc8effaf7bb79e97edefbbbaa
+  tag: 4a010a93
+  digest: sha256:149ad97c4ae40ea651123d3f190a68003dba4ff0a6a073398b0d3adcca98bd4a
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 5af13821
-    digest: sha256:a3e15f3a8b8c6c3a60dbb683e81ce79248fb92a50022532eeabac17379d3d0a0
+    tag: 4a010a93
+    digest: sha256:2ac77605ac90c2a8301fe50facb242adc13d9563487d084694b4f61e7e4687a5
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 5af138213ec76114bac24c219c4fe81e9e5572e5
-      AGENTS_GITOPS_REVISION: 5af138213ec76114bac24c219c4fe81e9e5572e5
-      AGENTS_SOURCE_CI_RUN_ID: "26862462160"
+      AGENTS_SOURCE_HEAD_SHA: 4a010a937bc9fbe6405d310eee1bc5a8204e4cd8
+      AGENTS_GITOPS_REVISION: 4a010a937bc9fbe6405d310eee1bc5a8204e4cd8
+      AGENTS_SOURCE_CI_RUN_ID: "26999079708"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:a3e15f3a8b8c6c3a60dbb683e81ce79248fb92a50022532eeabac17379d3d0a0
-      AGENTS_SERVING_BUILD_COMMIT: 5af138213ec76114bac24c219c4fe81e9e5572e5
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:a3e15f3a8b8c6c3a60dbb683e81ce79248fb92a50022532eeabac17379d3d0a0
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:2ac77605ac90c2a8301fe50facb242adc13d9563487d084694b4f61e7e4687a5
+      AGENTS_SERVING_BUILD_COMMIT: 4a010a937bc9fbe6405d310eee1bc5a8204e4cd8
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:2ac77605ac90c2a8301fe50facb242adc13d9563487d084694b4f61e7e4687a5
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 5af13821
-    digest: sha256:5621e17a05af2360632c896cea36d5e67c9f39d2b1abdcd13b7682f743126787
+    tag: 4a010a93
+    digest: sha256:ba27e25e5aed4c331e4e931e29663546cfabb28eb7276e0ee905005fd8287174
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 5af13821
-    digest: sha256:114d950041cb11ffa81533d4fe34a3a69bed1acbc8effaf7bb79e97edefbbbaa
+    tag: 4a010a93
+    digest: sha256:149ad97c4ae40ea651123d3f190a68003dba4ff0a6a073398b0d3adcca98bd4a
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `4a010a937bc9fbe6405d310eee1bc5a8204e4cd8`
- Image tag: `4a010a93`
- Agents build run: `26999079708`
- Promotion source: `workflow_run`