### PR TITLE
fix(torghut): rank replays with lob reality gap stress

### DIFF
--- a/services/torghut/app/trading/discovery/replay_ledger_ranker.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_ranker.py
@@ -10,7 +10,11 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, cast
 
+from app.trading.discovery.lob_reality_gap_stress import (
+    extract_lob_reality_gap_stress,
+)
 from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
+from app.trading.models import SignalEnvelope
 from app.trading.runtime_ledger import RuntimeLedgerBucket, build_runtime_ledger_buckets
 
 EXACT_REPLAY_LEDGER_RANKING_SCHEMA_VERSION = "torghut.exact-replay-ledger-ranking.v1"
@@ -209,6 +213,11 @@ class ReplayLedgerCandidateRanking:
     execution_quality_penalty_bps: Decimal
     execution_quality_penalty_amount: Decimal
     execution_quality_adjusted_window_net_pnl_per_day: Decimal
+    lob_reality_gap_stress: Mapping[str, object]
+    lob_reality_gap_blockers: tuple[str, ...]
+    lob_reality_gap_penalty_bps: Decimal
+    lob_reality_gap_penalty_amount: Decimal
+    replay_quality_adjusted_window_net_pnl_per_day: Decimal
 
     def to_payload(self) -> dict[str, object]:
         return {
@@ -281,6 +290,13 @@ class ReplayLedgerCandidateRanking:
             ),
             "execution_quality_adjusted_window_net_pnl_per_day": str(
                 self.execution_quality_adjusted_window_net_pnl_per_day
+            ),
+            "lob_reality_gap_stress": _payload_object(self.lob_reality_gap_stress),
+            "lob_reality_gap_blockers": list(self.lob_reality_gap_blockers),
+            "lob_reality_gap_penalty_bps": str(self.lob_reality_gap_penalty_bps),
+            "lob_reality_gap_penalty_amount": str(self.lob_reality_gap_penalty_amount),
+            "replay_quality_adjusted_window_net_pnl_per_day": str(
+                self.replay_quality_adjusted_window_net_pnl_per_day
             ),
         }
 
@@ -379,6 +395,18 @@ def rank_replay_ledger_payload(
         total_net - execution_quality_penalty_amount,
         Decimal(window_weekday_count),
     )
+    lob_reality_gap_stress = _lob_reality_gap_stress_summary(rows)
+    lob_reality_gap_penalty_bps = cast(
+        Decimal, lob_reality_gap_stress["effective_replay_rank_penalty_bps"]
+    )
+    lob_reality_gap_penalty_amount = _safe_divide(
+        total_filled_notional * lob_reality_gap_penalty_bps,
+        Decimal("10000"),
+    )
+    replay_quality_adjusted_window_net_pnl_per_day = _safe_divide(
+        total_net - execution_quality_penalty_amount - lob_reality_gap_penalty_amount,
+        Decimal(window_weekday_count),
+    )
     blockers = _promotion_blockers(
         payload=payload,
         rows=rows,
@@ -468,6 +496,15 @@ def rank_replay_ledger_payload(
         execution_quality_penalty_amount=execution_quality_penalty_amount,
         execution_quality_adjusted_window_net_pnl_per_day=(
             execution_quality_adjusted_window_net_pnl_per_day
+        ),
+        lob_reality_gap_stress=lob_reality_gap_stress,
+        lob_reality_gap_blockers=tuple(
+            cast(tuple[str, ...], lob_reality_gap_stress["lob_reality_gap_blockers"])
+        ),
+        lob_reality_gap_penalty_bps=lob_reality_gap_penalty_bps,
+        lob_reality_gap_penalty_amount=lob_reality_gap_penalty_amount,
+        replay_quality_adjusted_window_net_pnl_per_day=(
+            replay_quality_adjusted_window_net_pnl_per_day
         ),
     )
 
@@ -925,6 +962,89 @@ def _execution_quality_summary(
     }
 
 
+def _lob_reality_gap_stress_summary(
+    rows: Sequence[Mapping[str, object]],
+) -> Mapping[str, object]:
+    signal_rows = _lob_signal_rows(rows)
+    warnings: list[str] = []
+    if not signal_rows:
+        warnings.append("missing_lob_reality_gap_rows")
+        stress_payload: dict[str, object] = {
+            "schema_version": "torghut.lob-reality-gap-stress.v2",
+            "status": "preview_only_lob_reality_gap_stress_ranking",
+            "source_papers": [],
+            "row_count": 0,
+            "replay_rank_penalty_bps": 0.0,
+            "warnings": list(warnings),
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_authority_ok": False,
+        }
+    else:
+        stress_payload = extract_lob_reality_gap_stress(signal_rows).to_payload()
+        warnings.extend(_string_list(stress_payload.get("warnings")))
+
+    warning_penalty_bps = Decimal(len(warnings)) * Decimal("2")
+    raw_penalty_bps = _decimal(stress_payload.get("replay_rank_penalty_bps"))
+    effective_penalty_bps = (raw_penalty_bps or Decimal("0")) + warning_penalty_bps
+    blockers = tuple(f"lob_reality_gap_{warning}" for warning in _dedupe(warnings))
+    return {
+        **stress_payload,
+        "lob_reality_gap_blockers": blockers,
+        "lob_reality_gap_warning_penalty_bps": warning_penalty_bps,
+        "effective_replay_rank_penalty_bps": effective_penalty_bps,
+    }
+
+
+def _lob_signal_rows(
+    rows: Sequence[Mapping[str, object]],
+) -> tuple[SignalEnvelope, ...]:
+    signals: list[SignalEnvelope] = []
+    for index, row in enumerate(rows):
+        event_ts = _row_event_ts(row)
+        symbol = _text(row.get("symbol"))
+        if event_ts is None or not symbol:
+            continue
+        signals.append(
+            SignalEnvelope(
+                event_ts=event_ts,
+                symbol=symbol,
+                timeframe=_text(row.get("timeframe")) or None,
+                ingest_ts=_row_ingest_ts(row),
+                seq=index,
+                source=_text(row.get("source")) or "exact_replay_ledger",
+                payload={str(key): value for key, value in row.items()},
+            )
+        )
+    return tuple(signals)
+
+
+def _row_event_ts(row: Mapping[str, object]) -> datetime | None:
+    for key in (
+        "event_ts",
+        "executed_at",
+        "timestamp",
+        "created_at",
+        "submitted_at",
+        "filled_at",
+    ):
+        if (parsed := _parse_window_datetime(row.get(key))) is not None:
+            return parsed
+    return None
+
+
+def _row_ingest_ts(row: Mapping[str, object]) -> datetime | None:
+    for key in ("ingest_ts", "ingested_at", "observed_at"):
+        if (parsed := _parse_window_datetime(row.get(key))) is not None:
+            return parsed
+    return None
+
+
 def _daily_bucket_ranges(
     start: datetime,
     end: datetime,
@@ -1209,9 +1329,11 @@ def _dedupe(values: Sequence[str]) -> list[str]:
 
 def _ranking_sort_key(candidate: ReplayLedgerCandidateRanking) -> tuple[object, ...]:
     return (
+        -candidate.replay_quality_adjusted_window_net_pnl_per_day,
         -candidate.execution_quality_adjusted_window_net_pnl_per_day,
         -candidate.window_net_pnl_per_day,
         -candidate.total_net_pnl_after_costs,
+        candidate.lob_reality_gap_penalty_bps,
         candidate.execution_quality_penalty_bps,
         candidate.best_day_share,
         candidate.max_drawdown,

--- a/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
+++ b/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
@@ -327,6 +327,12 @@ def _target_replay_window_metadata(
             "execution_quality_adjusted_window_net_pnl_per_day",
             "replay_execution_quality_adjusted_window_net_pnl_per_day",
         ),
+        ("lob_reality_gap_penalty_bps", "replay_lob_reality_gap_penalty_bps"),
+        ("lob_reality_gap_penalty_amount", "replay_lob_reality_gap_penalty_amount"),
+        (
+            "replay_quality_adjusted_window_net_pnl_per_day",
+            "replay_quality_adjusted_window_net_pnl_per_day",
+        ),
     ):
         if (value := best_candidate.get(source_key)) is not None:
             metadata[target_key] = value
@@ -335,11 +341,13 @@ def _target_replay_window_metadata(
         ("cost_lineage", "replay_cost_lineage"),
         ("capacity_warning_counts", "replay_capacity_warning_counts"),
         ("execution_quality", "replay_execution_quality"),
+        ("lob_reality_gap_stress", "replay_lob_reality_gap_stress"),
     ):
         if isinstance(value := best_candidate.get(source_key), Mapping):
             metadata[target_key] = dict(cast(Mapping[str, Any], value))
     for source_key, target_key in (
         ("execution_quality_blockers", "replay_execution_quality_blockers"),
+        ("lob_reality_gap_blockers", "replay_lob_reality_gap_blockers"),
     ):
         values = _string_list(best_candidate.get(source_key))
         if values:

--- a/services/torghut/tests/test_replay_ledger_ranker.py
+++ b/services/torghut/tests/test_replay_ledger_ranker.py
@@ -123,6 +123,40 @@ def _with_execution_quality(
     return rows
 
 
+def _with_lob_reality_gap_evidence(
+    rows: list[dict[str, object]],
+    *,
+    fragile: bool = False,
+) -> list[dict[str, object]]:
+    event_cycle = ("add", "trade", "cancel")
+    for index, row in enumerate(rows):
+        if fragile:
+            row["bid"] = str(100 + Decimal(index) * Decimal("0.12"))
+            row["ask"] = str(Decimal(str(row["bid"])) + Decimal("0.02"))
+            row["bid_size"] = "950"
+            row["ask_size"] = "50"
+            row["round_trip_latency_ms"] = "2"
+            row["trade_direction"] = "buy"
+            row["trade_size"] = "900"
+            row["odd_lot_bid_size"] = "4" if index else "80"
+            row["odd_lot_ask_size"] = "3" if index else "82"
+            row["off_exchange_trade"] = index > 0
+            row["lob_event_type"] = "cancel_replace" if index > 0 else "trade"
+        else:
+            row["bid"] = "99.99"
+            row["ask"] = "100.01"
+            row["bid_size"] = "510" if index % 2 == 0 else "500"
+            row["ask_size"] = "500" if index % 2 == 0 else "510"
+            row["round_trip_latency_ms"] = str(Decimal("1.0") + Decimal(index) / 10)
+            row["trade_direction"] = "buy" if index % 2 == 0 else "sell"
+            row["trade_size"] = "8"
+            row["odd_lot_bid_size"] = "40"
+            row["odd_lot_ask_size"] = "42"
+            row["off_exchange_trade"] = False
+            row["lob_event_type"] = event_cycle[index % len(event_cycle)]
+    return rows
+
+
 def _payload(
     candidate_id: str,
     rows: list[dict[str, object]],
@@ -400,6 +434,126 @@ def test_ranker_penalizes_missing_closing_auction_mechanism_evidence(
     }.issubset(set(missing["execution_quality_blockers"]))
     assert Decimal(str(missing["execution_quality_penalty_bps"])) > Decimal("0")
     assert missing["promotion_status"] == "blocked_pending_runtime_promotion_proof"
+
+
+def test_ranker_discounts_fragile_lob_reality_gap_candidates(
+    tmp_path: Path,
+) -> None:
+    stable = _payload(
+        "stable-lob-lower-raw-pnl",
+        _with_lob_reality_gap_evidence(
+            _with_execution_quality(
+                _round_trip(
+                    day=18,
+                    symbol="NVDA",
+                    qty="1000",
+                    buy_price="100",
+                    sell_price="100.90",
+                    prefix="stable-lob",
+                ),
+                order_type="limit",
+                shortfall_bps="1",
+                limit_fill_probability="0.82",
+                queue_position="0.15",
+                opportunity_cost_bps="2",
+                price_improvement_bps="3",
+            ),
+            fragile=False,
+        ),
+    )
+    fragile_raw_winner = _payload(
+        "fragile-lob-higher-raw-pnl",
+        _with_lob_reality_gap_evidence(
+            _with_execution_quality(
+                _round_trip(
+                    day=18,
+                    symbol="NVDA",
+                    qty="1000",
+                    buy_price="100",
+                    sell_price="101.00",
+                    prefix="fragile-lob",
+                ),
+                order_type="limit",
+                shortfall_bps="1",
+                limit_fill_probability="0.82",
+                queue_position="0.15",
+                opportunity_cost_bps="2",
+                price_improvement_bps="3",
+            ),
+            fragile=True,
+        ),
+    )
+    stable_path = tmp_path / "stable.json"
+    fragile_path = tmp_path / "fragile.json"
+    stable_path.write_text(json.dumps(stable))
+    fragile_path.write_text(json.dumps(fragile_raw_winner))
+
+    report = build_replay_ledger_ranking_report(
+        [stable_path, fragile_path],
+        policy=ReplayLedgerRankingPolicy(
+            target_net_pnl_per_day=Decimal("1"),
+            min_window_weekday_count=1,
+            min_avg_filled_notional_per_day=Decimal("1"),
+            max_best_day_share=Decimal("1.0"),
+            max_gross_exposure_pct_equity=Decimal("1000.0"),
+            start_equity=Decimal("100000000"),
+        ),
+    )
+    top = report["candidates"][0]
+    fragile = report["candidates"][1]
+
+    assert top["candidate_id"] == "stable-lob-lower-raw-pnl"
+    assert fragile["candidate_id"] == "fragile-lob-higher-raw-pnl"
+    assert Decimal(str(fragile["window_net_pnl_per_day"])) > Decimal(
+        str(top["window_net_pnl_per_day"])
+    )
+    assert Decimal(str(fragile["lob_reality_gap_penalty_bps"])) > Decimal(
+        str(top["lob_reality_gap_penalty_bps"])
+    )
+    assert Decimal(
+        str(top["replay_quality_adjusted_window_net_pnl_per_day"])
+    ) > Decimal(str(fragile["replay_quality_adjusted_window_net_pnl_per_day"]))
+    assert "arxiv-2603.24137" in {
+        item["source_id"] for item in fragile["lob_reality_gap_stress"]["source_papers"]
+    }
+    assert fragile["lob_reality_gap_stress"]["promotion_authority"] is False
+
+
+def test_lob_reality_gap_summary_fails_closed_without_signal_rows() -> None:
+    summary = ranker._lob_reality_gap_stress_summary(
+        [{"symbol": "NVDA", "executed_at": "bad-date"}]
+    )
+
+    assert summary["row_count"] == 0
+    assert summary["promotion_authority"] is False
+    assert summary["effective_replay_rank_penalty_bps"] == Decimal("2")
+    assert summary["lob_reality_gap_blockers"] == (
+        "lob_reality_gap_missing_lob_reality_gap_rows",
+    )
+
+
+def test_lob_signal_rows_use_fallback_timestamps_and_ingest_fields() -> None:
+    signals = ranker._lob_signal_rows(
+        [
+            {
+                "symbol": "NVDA",
+                "submitted_at": "2026-05-18T14:31:00Z",
+                "ingested_at": "2026-05-18T14:31:01Z",
+                "source": "historical_lob_replay",
+                "timeframe": "1m",
+            },
+            {
+                "symbol": "",
+                "executed_at": "2026-05-18T14:32:00Z",
+            },
+        ]
+    )
+
+    assert len(signals) == 1
+    assert signals[0].event_ts == datetime(2026, 5, 18, 14, 31, tzinfo=timezone.utc)
+    assert signals[0].ingest_ts == datetime(2026, 5, 18, 14, 31, 1, tzinfo=timezone.utc)
+    assert signals[0].source == "historical_lob_replay"
+    assert signals[0].timeframe == "1m"
 
 
 def test_ranker_blocks_replay_only_and_over_equity_artifacts() -> None:

--- a/services/torghut/tests/test_replay_runtime_window_plan.py
+++ b/services/torghut/tests/test_replay_runtime_window_plan.py
@@ -194,6 +194,10 @@ def test_handoff_builds_non_promotional_runtime_window_target(
     )
     assert target["replay_execution_quality_penalty_bps"] != "0"
     assert "replay_execution_quality_adjusted_window_net_pnl_per_day" in target
+    assert target["replay_lob_reality_gap_penalty_bps"] != "0"
+    assert "replay_lob_reality_gap_stress" in target
+    assert "replay_lob_reality_gap_blockers" in target
+    assert "replay_quality_adjusted_window_net_pnl_per_day" in target
     assert target["hypothesis_id"] == "H-PAIRS-01"
     assert target["strategy_family"] == "microbar_cross_sectional_pairs"
     assert target["strategy_name"] == "microbar-cross-sectional-pairs-v1"


### PR DESCRIPTION
## Summary

- Adds LOB reality-gap stress scoring to exact replay ledger candidate ranking.
- Discounts raw replay winners by fragility penalties before they feed runtime evidence collection.
- Carries the LOB stress payload, blockers, and replay-quality-adjusted PnL into runtime window targets.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_replay_ledger_ranker.py tests/test_replay_runtime_window_plan.py -q`
- `uv run --frozen ruff format --check app/trading/discovery/replay_ledger_ranker.py app/trading/discovery/replay_runtime_window_plan.py tests/test_replay_ledger_ranker.py tests/test_replay_runtime_window_plan.py`
- `uv run --frozen ruff check app/trading/discovery/replay_ledger_ranker.py app/trading/discovery/replay_runtime_window_plan.py tests/test_replay_ledger_ranker.py tests/test_replay_runtime_window_plan.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
