### PR TITLE
ci(torghut): decouple core release dependencies

### DIFF
--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -12,9 +12,9 @@ on:
       - 'packages/scripts/src/torghut/**'
       - '!packages/scripts/src/torghut/__tests__/**'
       - '!packages/scripts/src/torghut/**/*.test.ts'
-      - 'packages/scripts/src/shared/**'
-      - 'package.json'
-      - 'bun.lock'
+      - 'packages/scripts/src/shared/cli.ts'
+      - 'packages/scripts/src/shared/docker.ts'
+      - 'packages/scripts/src/shared/git.ts'
       - '.github/workflows/torghut-build-push.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -6,38 +6,28 @@ on:
     paths:
       - 'services/torghut/**'
       - 'packages/scripts/src/torghut/**'
-      - 'packages/scripts/src/shared/**'
+      - 'packages/scripts/src/shared/cli.ts'
+      - 'packages/scripts/src/shared/docker.ts'
+      - 'packages/scripts/src/shared/git.ts'
       - '.github/workflows/torghut-ci.yml'
       - '.github/workflows/torghut-build-push.yaml'
       - '.github/workflows/torghut-deploy-automerge.yml'
       - '.github/workflows/torghut-post-deploy-verify.yml'
       - '.github/workflows/torghut-release.yml'
-      - '.github/workflows/torghut-ta-build-push.yaml'
-      - '.github/workflows/torghut-ta-release.yml'
-      - '.github/workflows/torghut-ws-build-push.yaml'
-      - '.github/workflows/torghut-ws-release.yml'
       - 'argocd/applications/torghut/**'
-      - 'argocd/applications/torghut-options/**'
-      - 'package.json'
-      - 'bun.lock'
   pull_request:
     paths:
       - 'services/torghut/**'
       - 'packages/scripts/src/torghut/**'
-      - 'packages/scripts/src/shared/**'
+      - 'packages/scripts/src/shared/cli.ts'
+      - 'packages/scripts/src/shared/docker.ts'
+      - 'packages/scripts/src/shared/git.ts'
       - '.github/workflows/torghut-ci.yml'
       - '.github/workflows/torghut-build-push.yaml'
       - '.github/workflows/torghut-deploy-automerge.yml'
       - '.github/workflows/torghut-post-deploy-verify.yml'
       - '.github/workflows/torghut-release.yml'
-      - '.github/workflows/torghut-ta-build-push.yaml'
-      - '.github/workflows/torghut-ta-release.yml'
-      - '.github/workflows/torghut-ws-build-push.yaml'
-      - '.github/workflows/torghut-ws-release.yml'
       - 'argocd/applications/torghut/**'
-      - 'argocd/applications/torghut-options/**'
-      - 'package.json'
-      - 'bun.lock'
   workflow_dispatch:
 
 permissions:
@@ -123,10 +113,10 @@ jobs:
 
           service=false
           manifests=false
-          if matches_any '^(services/torghut/|packages/scripts/src/torghut/|packages/scripts/src/shared/|\.github/workflows/torghut-(ci|build-push|deploy-automerge|post-deploy-verify|release|ta-build-push|ta-release|ws-build-push|ws-release)\.yml$|\.github/workflows/torghut-build-push\.yaml$|package\.json$|bun\.lock$)'; then
+          if matches_any '^(services/torghut/|packages/scripts/src/torghut/|packages/scripts/src/shared/(cli|docker|git)\.ts$|\.github/workflows/torghut-(ci|deploy-automerge|post-deploy-verify|release)\.yml$|\.github/workflows/torghut-build-push\.yaml$)'; then
             service=true
           fi
-          if matches_any '^argocd/applications/(torghut|torghut-options)/'; then
+          if matches_any '^argocd/applications/torghut/'; then
             manifests=true
           fi
 

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -65,8 +65,6 @@ jobs:
             'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
             'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
             'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml'
-            'argocd/applications/torghut-options/catalog/deployment.yaml'
-            'argocd/applications/torghut-options/enricher/deployment.yaml'
           )
 
           contains() {

--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - 'argocd/applications/torghut/**'
-      - 'argocd/applications/torghut-options/**'
   workflow_dispatch:
     inputs:
       expected_revision:
@@ -109,7 +108,7 @@ jobs:
             git fetch --no-tags --depth=200 origin main
           fi
 
-          for app in torghut torghut-options; do
+          for app in torghut; do
             kubectl annotate application "${app}" -n argocd argocd.argoproj.io/refresh=hard --overwrite
           done
 
@@ -125,7 +124,7 @@ jobs:
             git cat-file -e "${revision}^{commit}" >/dev/null 2>&1
           }
 
-          for app in torghut torghut-options; do
+          for app in torghut; do
             for attempt in $(seq 1 90); do
               STATUS="$(kubectl get application "${app}" -n argocd -o jsonpath='{.status.sync.status} {.status.health.status} {.status.sync.revision} {.status.operationState.phase} {.status.operationState.syncResult.revision} {.status.history[-1].revision}')"
               SYNC_STATUS="$(echo "${STATUS}" | awk '{print $1}')"
@@ -176,10 +175,6 @@ jobs:
                   echo "Torghut Argo health is Degraded after sync; continuing to runtime safety checks"
                   break
                 fi
-                if [ "${app}" = 'torghut-options' ] && [ "${HEALTH_STATUS}" = 'Degraded' ] && [ "${OPERATION_PHASE}" = 'Succeeded' ]; then
-                  echo "Torghut options Argo health is Degraded after sync; continuing to explicit workload rollout checks"
-                  break
-                fi
               fi
 
               if [ "${attempt}" -eq 90 ]; then
@@ -190,11 +185,6 @@ jobs:
               sleep 10
             done
           done
-
-          kubectl rollout status deployment/torghut-ws -n torghut --timeout=10m
-          kubectl rollout status deployment/torghut-options-catalog -n torghut --timeout=10m
-          kubectl rollout status deployment/torghut-options-enricher -n torghut --timeout=10m
-          kubectl rollout status deployment/torghut-ws-options -n torghut --timeout=10m
 
           set +e
           KNSVC_READY="$(kubectl get ksvc torghut -n torghut -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2> /tmp/torghut-ksvc-ready.err)"
@@ -404,11 +394,6 @@ jobs:
             http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
             "${EVIDENCE_DIR}/torghut-sim-paper-route-evidence.json" \
             "Torghut sim /trading/paper-route-evidence"
-          fetch_json_2xx \
-            http://torghut-ws.torghut.svc.cluster.local/readyz \
-            "${EVIDENCE_DIR}/torghut-ws-ready.json" \
-            "Torghut ws /readyz"
-
           export TORGHUT_REVENUE_REPAIR_DIGEST="${EVIDENCE_DIR}/torghut-revenue-repair-digest.json"
           export TORGHUT_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-status.json"
           export TORGHUT_READYZ_HTTP_STATUS
@@ -552,12 +537,10 @@ jobs:
           fi
 
           git checkout --quiet HEAD^ -- \
-            argocd/applications/torghut \
-            argocd/applications/torghut-options
+            argocd/applications/torghut
 
           if git diff --quiet HEAD -- \
-            argocd/applications/torghut \
-            argocd/applications/torghut-options; then
+            argocd/applications/torghut; then
             echo "No rollback diff detected"
             echo "should_rollback=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -645,7 +628,6 @@ jobs:
           delete-branch: true
           add-paths: |
             argocd/applications/torghut
-            argocd/applications/torghut-options
           body: |
             ## Summary
             Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -110,14 +110,14 @@ jobs:
                   git diff --name-only "${SOURCE_SHA}..${MAIN_HEAD}" -- \
                     services/torghut \
                     packages/scripts/src/torghut \
-                    packages/scripts/src/shared \
+                    packages/scripts/src/shared/cli.ts \
+                    packages/scripts/src/shared/docker.ts \
+                    packages/scripts/src/shared/git.ts \
                     .github/workflows/torghut-build-push.yaml \
                     .github/workflows/torghut-ci.yml \
                     .github/workflows/torghut-deploy-automerge.yml \
                     .github/workflows/torghut-post-deploy-verify.yml \
-                    .github/workflows/torghut-release.yml \
-                    package.json \
-                    bun.lock
+                    .github/workflows/torghut-release.yml
                 )"
                 if [ -n "${TORGHUT_CHANGES}" ]; then
                   echo "Skipping stale workflow_run promotion for ${SOURCE_SHA}; newer Torghut build inputs changed:"
@@ -261,9 +261,7 @@ jobs:
             argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml \
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml \
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml \
-            argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml \
-            argocd/applications/torghut-options/catalog/deployment.yaml \
-            argocd/applications/torghut-options/enricher/deployment.yaml; then
+            argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -306,8 +304,6 @@ jobs:
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
             argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
-            argocd/applications/torghut-options/catalog/deployment.yaml
-            argocd/applications/torghut-options/enricher/deployment.yaml
           body: |
             ## Summary
             Promote Torghut image into GitOps manifests.
@@ -353,8 +349,6 @@ jobs:
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut/tigerbeetle-smoke-job.yaml
             argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
-            argocd/applications/torghut-options/catalog/deployment.yaml
-            argocd/applications/torghut-options/enricher/deployment.yaml
           body: |
             ## Summary
             Promote Torghut image into GitOps manifests.

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -50,8 +50,6 @@ const torghutArm64ImageChecks: ManifestCheck[] = [
     path: 'argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml',
     selectorPath: ['spec', 'templates', 0],
   },
-  { path: 'argocd/applications/torghut-options/catalog/deployment.yaml', selectorPath: ['spec', 'template', 'spec'] },
-  { path: 'argocd/applications/torghut-options/enricher/deployment.yaml', selectorPath: ['spec', 'template', 'spec'] },
 ]
 
 const getAtPath = (root: unknown, selectorPath: Array<string | number>): JsonRecord => {

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -10,14 +10,6 @@ const agentsCiClusterRbac = readFileSync(
   new URL('../../../../../argocd/applications/agents-ci/runner-rbac-cluster.yaml', import.meta.url),
   'utf8',
 )
-const optionsTaConfigmap = readFileSync(
-  new URL('../../../../../argocd/applications/torghut-options/ta/configmap.yaml', import.meta.url),
-  'utf8',
-)
-const optionsTaFlinkDeployment = readFileSync(
-  new URL('../../../../../argocd/applications/torghut-options/ta/flinkdeployment.yaml', import.meta.url),
-  'utf8',
-)
 
 describe('torghut post-deploy verifier workflow', () => {
   it('does not skip Knative Service readiness when the runner lacks RBAC', () => {
@@ -36,14 +28,10 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('[ "${OPERATION_PHASE}" = \'Succeeded\' ]')
   })
 
-  it('continues past degraded Torghut options Argo health only with explicit workload rollout checks', () => {
-    expect(workflow).toContain(
-      'Torghut options Argo health is Degraded after sync; continuing to explicit workload rollout checks',
-    )
-    expect(workflow).toContain('[ "${app}" = \'torghut-options\' ]')
-    expect(workflow).toContain('kubectl rollout status deployment/torghut-options-catalog -n torghut --timeout=10m')
-    expect(workflow).toContain('kubectl rollout status deployment/torghut-options-enricher -n torghut --timeout=10m')
-    expect(workflow).toContain('kubectl rollout status deployment/torghut-ws-options -n torghut --timeout=10m')
+  it('keeps options and websocket deployments out of core Torghut post-deploy verification', () => {
+    expect(workflow).not.toContain('torghut-options')
+    expect(workflow).not.toContain('kubectl rollout status deployment/torghut-ws')
+    expect(workflow).not.toContain('http://torghut-ws.torghut.svc.cluster.local/readyz')
   })
 
   it('delegates readyz acceptance to the revenue repair evidence validator', () => {
@@ -98,7 +86,8 @@ describe('torghut post-deploy verifier workflow', () => {
 
   it('requests Argo refresh before polling deployed revisions', () => {
     expect(workflow).toContain('argocd.argoproj.io/refresh=hard --overwrite')
-    expect(workflow).toContain('for app in torghut torghut-options; do')
+    expect(workflow).toContain('for app in torghut; do')
+    expect(workflow).not.toContain('for app in torghut torghut-options; do')
   })
 
   it('grants the ARC runner read access to Torghut Knative Service readiness', () => {
@@ -111,14 +100,6 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(agentsCiClusterRbac).toContain('agents-ci-runner-argocd-application-refresh')
     expect(agentsCiClusterRbac).toContain('argoproj.io')
     expect(agentsCiClusterRbac).toContain('patch')
-  })
-
-  it('rotates the options TA Kafka transactional client prefix with the restart nonce', () => {
-    expect(optionsTaFlinkDeployment).toContain('restartNonce: 9')
-    expect(optionsTaConfigmap).toContain('TA_KAFKA_TRANSACTION_TIMEOUT_MS: "120000"')
-    expect(optionsTaConfigmap).toContain('TA_CLIENT_ID: "torghut-options-ta-r8"')
-    expect(optionsTaConfigmap).toContain('TA_GROUP_ID: "torghut-options-ta-2026-03-08"')
-    expect(optionsTaFlinkDeployment).toContain('value: EXACTLY_ONCE')
   })
 
   it('closes superseded automatic rollback pull requests after successful verification', () => {

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -217,6 +217,44 @@ spec:
   }
 }
 
+type UpdateOptions = Parameters<typeof __private.updateTorghutManifests>[0]
+
+const updateOptionsForFixture = (
+  fixture: ReturnType<typeof createFixture>,
+  overrides: Partial<UpdateOptions> = {},
+): UpdateOptions => ({
+  imageName: 'registry.ide-newton.ts.net/lab/torghut',
+  digest: 'sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+  version: 'v0.600.0',
+  commit: '1234567890abcdef1234567890abcdef12345678',
+  rolloutTimestamp: '2026-02-21T04:00:00Z',
+  manifestPath: relative(repoRoot, fixture.serviceManifestPath),
+  simulationManifestPath: relative(repoRoot, fixture.simulationServiceManifestPath),
+  migrationManifestPath: relative(repoRoot, fixture.migrationManifestPath),
+  historicalSimulationWorkflowManifestPath: relative(repoRoot, fixture.historicalWorkflowManifestPath),
+  empiricalPromotionWorkflowManifestPath: relative(repoRoot, fixture.empiricalWorkflowManifestPath),
+  whitepaperAutoresearchWorkflowManifestPath: relative(repoRoot, fixture.whitepaperAutoresearchWorkflowManifestPath),
+  analysisRuntimeReadyManifestPath: relative(repoRoot, fixture.analysisRuntimeReadyManifestPath),
+  analysisActivityManifestPath: relative(repoRoot, fixture.analysisActivityManifestPath),
+  analysisTeardownManifestPath: relative(repoRoot, fixture.analysisTeardownManifestPath),
+  analysisArtifactManifestPath: relative(repoRoot, fixture.analysisArtifactManifestPath),
+  empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
+  empiricalPromotionRenewalManifestPath: relative(repoRoot, fixture.empiricalPromotionRenewalManifestPath),
+  executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
+  orderFeedSourceWindowRepairManifestPath: relative(repoRoot, fixture.orderFeedSourceWindowRepairManifestPath),
+  paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
+  boundedPaperRouteTargetMaterializationManifestPath: relative(
+    repoRoot,
+    fixture.boundedPaperRouteTargetMaterializationManifestPath,
+  ),
+  whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
+  tigerBeetleSmokeManifestPath: relative(repoRoot, fixture.tigerBeetleSmokeManifestPath),
+  tigerBeetleJournalOrderEventsManifestPath: relative(repoRoot, fixture.tigerBeetleJournalOrderEventsManifestPath),
+  optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
+  optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),
+  ...overrides,
+})
+
 describe('update-manifests', () => {
   it('keeps workflow template postgres password injection logic in repo', () => {
     const historicalWorkflowManifest = readFileSync(
@@ -259,40 +297,7 @@ describe('update-manifests', () => {
 
   it('updates service and migration image digest, rollout timestamp, and metadata env values', () => {
     const fixture = createFixture()
-    const result = __private.updateTorghutManifests({
-      imageName: 'registry.ide-newton.ts.net/lab/torghut',
-      digest: 'sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
-      version: 'v0.600.0',
-      commit: '1234567890abcdef1234567890abcdef12345678',
-      rolloutTimestamp: '2026-02-21T04:00:00Z',
-      manifestPath: relative(repoRoot, fixture.serviceManifestPath),
-      simulationManifestPath: relative(repoRoot, fixture.simulationServiceManifestPath),
-      migrationManifestPath: relative(repoRoot, fixture.migrationManifestPath),
-      historicalSimulationWorkflowManifestPath: relative(repoRoot, fixture.historicalWorkflowManifestPath),
-      empiricalPromotionWorkflowManifestPath: relative(repoRoot, fixture.empiricalWorkflowManifestPath),
-      whitepaperAutoresearchWorkflowManifestPath: relative(
-        repoRoot,
-        fixture.whitepaperAutoresearchWorkflowManifestPath,
-      ),
-      analysisRuntimeReadyManifestPath: relative(repoRoot, fixture.analysisRuntimeReadyManifestPath),
-      analysisActivityManifestPath: relative(repoRoot, fixture.analysisActivityManifestPath),
-      analysisTeardownManifestPath: relative(repoRoot, fixture.analysisTeardownManifestPath),
-      analysisArtifactManifestPath: relative(repoRoot, fixture.analysisArtifactManifestPath),
-      empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
-      empiricalPromotionRenewalManifestPath: relative(repoRoot, fixture.empiricalPromotionRenewalManifestPath),
-      executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
-      orderFeedSourceWindowRepairManifestPath: relative(repoRoot, fixture.orderFeedSourceWindowRepairManifestPath),
-      paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
-      boundedPaperRouteTargetMaterializationManifestPath: relative(
-        repoRoot,
-        fixture.boundedPaperRouteTargetMaterializationManifestPath,
-      ),
-      whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
-      tigerBeetleSmokeManifestPath: relative(repoRoot, fixture.tigerBeetleSmokeManifestPath),
-      tigerBeetleJournalOrderEventsManifestPath: relative(repoRoot, fixture.tigerBeetleJournalOrderEventsManifestPath),
-      optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
-      optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),
-    })
+    const result = __private.updateTorghutManifests(updateOptionsForFixture(fixture))
 
     const serviceManifest = readFileSync(fixture.serviceManifestPath, 'utf8')
     const simulationServiceManifest = readFileSync(fixture.simulationServiceManifestPath, 'utf8')
@@ -380,15 +385,37 @@ describe('update-manifests', () => {
     ).toBe(2)
     for (const manifest of [optionsCatalogManifest, optionsEnricherManifest]) {
       expect(manifest).toContain(
-        'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+        'image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111',
       )
-      expect(manifest).toContain('value: v0.600.0')
-      expect(manifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+      expect(manifest).toContain('value: old-version')
+      expect(manifest).toContain('value: old-commit')
     }
     expect(result.changed).toBe(true)
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
+    expect(result.changedPaths.length).toBe(19)
+
+    rmSync(fixture.dir, { recursive: true, force: true })
+  })
+
+  it('updates options manifests only when explicitly included', () => {
+    const fixture = createFixture()
+    const result = __private.updateTorghutManifests(
+      updateOptionsForFixture(fixture, {
+        includeOptionsManifests: true,
+      }),
+    )
+    const optionsCatalogManifest = readFileSync(fixture.optionsCatalogManifestPath, 'utf8')
+    const optionsEnricherManifest = readFileSync(fixture.optionsEnricherManifestPath, 'utf8')
+
+    for (const manifest of [optionsCatalogManifest, optionsEnricherManifest]) {
+      expect(manifest).toContain(
+        'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
+      )
+      expect(manifest).toContain('value: v0.600.0')
+      expect(manifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    }
     expect(result.changedPaths.length).toBe(21)
 
     rmSync(fixture.dir, { recursive: true, force: true })
@@ -396,40 +423,12 @@ describe('update-manifests', () => {
 
   it('returns changed=false when manifests already match requested state', () => {
     const fixture = createFixture()
-    const options = {
-      imageName: 'registry.ide-newton.ts.net/lab/torghut',
+    const options = updateOptionsForFixture(fixture, {
       digest: 'sha256:ef4a4f754c30705019667f7aa6c89ca95b8ca4f2f1539ca0f8ce62d56a4be63c',
       version: 'v0.601.0',
       commit: 'abcdefabcdefabcdefabcdefabcdefabcdefabcd',
       rolloutTimestamp: '2026-02-21T05:00:00Z',
-      manifestPath: relative(repoRoot, fixture.serviceManifestPath),
-      simulationManifestPath: relative(repoRoot, fixture.simulationServiceManifestPath),
-      migrationManifestPath: relative(repoRoot, fixture.migrationManifestPath),
-      historicalSimulationWorkflowManifestPath: relative(repoRoot, fixture.historicalWorkflowManifestPath),
-      empiricalPromotionWorkflowManifestPath: relative(repoRoot, fixture.empiricalWorkflowManifestPath),
-      whitepaperAutoresearchWorkflowManifestPath: relative(
-        repoRoot,
-        fixture.whitepaperAutoresearchWorkflowManifestPath,
-      ),
-      analysisRuntimeReadyManifestPath: relative(repoRoot, fixture.analysisRuntimeReadyManifestPath),
-      analysisActivityManifestPath: relative(repoRoot, fixture.analysisActivityManifestPath),
-      analysisTeardownManifestPath: relative(repoRoot, fixture.analysisTeardownManifestPath),
-      analysisArtifactManifestPath: relative(repoRoot, fixture.analysisArtifactManifestPath),
-      empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
-      empiricalPromotionRenewalManifestPath: relative(repoRoot, fixture.empiricalPromotionRenewalManifestPath),
-      executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
-      orderFeedSourceWindowRepairManifestPath: relative(repoRoot, fixture.orderFeedSourceWindowRepairManifestPath),
-      paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
-      boundedPaperRouteTargetMaterializationManifestPath: relative(
-        repoRoot,
-        fixture.boundedPaperRouteTargetMaterializationManifestPath,
-      ),
-      whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
-      tigerBeetleSmokeManifestPath: relative(repoRoot, fixture.tigerBeetleSmokeManifestPath),
-      tigerBeetleJournalOrderEventsManifestPath: relative(repoRoot, fixture.tigerBeetleJournalOrderEventsManifestPath),
-      optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
-      optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),
-    }
+    })
 
     __private.updateTorghutManifests(options)
     const second = __private.updateTorghutManifests(options)

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -67,6 +67,7 @@ type UpdateManifestsOptions = {
   whitepaperSemanticBackfillManifestPath?: string
   tigerBeetleSmokeManifestPath?: string
   tigerBeetleJournalOrderEventsManifestPath?: string
+  includeOptionsManifests?: boolean
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
 }
@@ -98,6 +99,7 @@ type CliOptions = {
   whitepaperSemanticBackfillManifestPath?: string
   tigerBeetleSmokeManifestPath?: string
   tigerBeetleJournalOrderEventsManifestPath?: string
+  includeOptionsManifests?: boolean
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
 }
@@ -377,22 +379,26 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.tigerBeetleJournalOrderEventsManifestPath ?? defaultTigerBeetleJournalOrderEventsManifestPath,
     'torghut-tigerbeetle-journal-order-events image reference',
   )
-  const optionsCatalog = updateVersionedDeploymentManifest(
-    options,
-    options.optionsCatalogManifestPath ?? defaultOptionsCatalogManifestPath,
-    'torghut-options-catalog',
-    'TORGHUT_OPTIONS_VERSION',
-    'TORGHUT_OPTIONS_COMMIT',
-    'torghut-options-catalog image reference',
-  )
-  const optionsEnricher = updateVersionedDeploymentManifest(
-    options,
-    options.optionsEnricherManifestPath ?? defaultOptionsEnricherManifestPath,
-    'torghut-options-enricher',
-    'TORGHUT_OPTIONS_VERSION',
-    'TORGHUT_OPTIONS_COMMIT',
-    'torghut-options-enricher image reference',
-  )
+  const optionalResults = options.includeOptionsManifests
+    ? [
+        updateVersionedDeploymentManifest(
+          options,
+          options.optionsCatalogManifestPath ?? defaultOptionsCatalogManifestPath,
+          'torghut-options-catalog',
+          'TORGHUT_OPTIONS_VERSION',
+          'TORGHUT_OPTIONS_COMMIT',
+          'torghut-options-catalog image reference',
+        ),
+        updateVersionedDeploymentManifest(
+          options,
+          options.optionsEnricherManifestPath ?? defaultOptionsEnricherManifestPath,
+          'torghut-options-enricher',
+          'TORGHUT_OPTIONS_VERSION',
+          'TORGHUT_OPTIONS_COMMIT',
+          'torghut-options-enricher image reference',
+        ),
+      ]
+    : []
   const changedPaths = [
     service,
     simulationService,
@@ -413,8 +419,7 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     whitepaperSemanticBackfill,
     tigerBeetleSmoke,
     tigerBeetleJournalOrderEvents,
-    optionsCatalog,
-    optionsEnricher,
+    ...optionalResults,
   ]
     .filter((entry) => entry.changed)
     .map((entry) => entry.manifestPath)
@@ -460,9 +465,15 @@ Options:
   --whitepaper-semantic-backfill-manifest-path <path>
   --tigerbeetle-smoke-manifest-path <path>
   --tigerbeetle-journal-order-events-manifest-path <path>
+  --include-options-manifests
   --options-catalog-manifest-path <path>
   --options-enricher-manifest-path <path>`)
       process.exit(0)
+    }
+
+    if (arg === '--include-options-manifests') {
+      options.includeOptionsManifests = true
+      continue
     }
 
     if (!arg.startsWith('--')) {
@@ -557,6 +568,9 @@ Options:
       case '--tigerbeetle-journal-order-events-manifest-path':
         options.tigerBeetleJournalOrderEventsManifestPath = value
         break
+      case '--include-options-manifests':
+        options.includeOptionsManifests = true
+        break
       case '--options-catalog-manifest-path':
         options.optionsCatalogManifestPath = value
         break
@@ -570,6 +584,8 @@ Options:
 
   return options
 }
+
+const parseBooleanEnv = (value: string | undefined): boolean => value === '1' || value?.toLowerCase() === 'true'
 
 const main = (cliOptions?: CliOptions) => {
   const parsed = cliOptions ?? parseArgs(process.argv.slice(2))
@@ -630,6 +646,8 @@ const main = (cliOptions?: CliOptions) => {
     tigerBeetleJournalOrderEventsManifestPath:
       parsed.tigerBeetleJournalOrderEventsManifestPath ??
       process.env.TORGHUT_TIGERBEETLE_JOURNAL_ORDER_EVENTS_MANIFEST_PATH,
+    includeOptionsManifests:
+      parsed.includeOptionsManifests ?? parseBooleanEnv(process.env.TORGHUT_INCLUDE_OPTIONS_MANIFESTS),
     optionsCatalogManifestPath: parsed.optionsCatalogManifestPath ?? process.env.TORGHUT_OPTIONS_CATALOG_MANIFEST_PATH,
     optionsEnricherManifestPath:
       parsed.optionsEnricherManifestPath ?? process.env.TORGHUT_OPTIONS_ENRICHER_MANIFEST_PATH,


### PR DESCRIPTION
## Summary

- Decouples core Torghut CI/build/release triggers from `torghut-options`, TA/WS release workflow files, root lockfile/package-only changes, and broad shared-script changes.
- Narrows Torghut shared script triggers to the exact helper files imported by Torghut release/build scripts: `cli.ts`, `docker.ts`, and `git.ts`.
- Makes Torghut manifest promotion update options catalog/enricher only with explicit `--include-options-manifests` opt-in.
- Reduces `torghut-post-deploy-verify` to core `torghut` Argo, `torghut`/`torghut-sim` Knative readiness, and Torghut HTTP evidence; options/WS stay in their separate lanes.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `cd services/torghut && uv run --frozen pytest tests/test_torghut_release_workflow_manifest_paths.py -q`
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `git diff --check`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/torghut-ci.yml .github/workflows/torghut-build-push.yaml .github/workflows/torghut-release.yml .github/workflows/torghut-deploy-automerge.yml .github/workflows/torghut-post-deploy-verify.yml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
