### PR TITLE
fix(torghut): submit capped source collection decisions

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -5036,39 +5036,46 @@ class SimpleTradingPipeline(TradingPipeline):
             and preparation.decision.qty != expected_target_qty
         ):
             adjusted_audit = dict(target_notional_sizing)
-            blockers = list(cast(list[Any], adjusted_audit.get("blockers") or []))
-            blockers.append("bounded_paper_route_target_qty_changed_by_precheck")
-            adjusted_audit["blockers"] = list(
-                dict.fromkeys(str(item) for item in blockers)
+            adjusted_audit.setdefault(
+                "target_notional_resolved_qty",
+                adjusted_audit.get("resolved_qty"),
+            )
+            adjusted_audit.setdefault(
+                "target_notional_resolved_notional",
+                adjusted_audit.get("resolved_notional"),
+            )
+            adjusted_audit["precheck_quantity_adjusted"] = True
+            adjusted_audit["precheck_adjustment_reason"] = (
+                "risk_precheck_capped_quantity"
             )
             adjusted_audit["precheck_resolved_qty"] = str(preparation.decision.qty)
             adjusted_audit["precheck_expected_target_qty"] = str(expected_target_qty)
-            rejected_decision = self._apply_bounded_collection_target_sizing_audit(
-                preparation.decision,
-                audit=adjusted_audit,
-                qty=preparation.decision.qty,
-                action=(
-                    "sell"
-                    if str(preparation.decision.action).strip().lower() == "sell"
-                    else "buy"
-                ),
+            reference_price = _optional_decimal(adjusted_audit.get("reference_price"))
+            if reference_price is not None:
+                adjusted_audit["precheck_resolved_notional"] = str(
+                    preparation.decision.qty * reference_price
+                )
+                adjusted_audit["precheck_expected_target_notional"] = str(
+                    expected_target_qty * reference_price
+                )
+                adjusted_audit["resolved_notional"] = str(
+                    preparation.decision.qty * reference_price
+                )
+            adjusted_audit["resolved_qty"] = str(preparation.decision.qty)
+            simple_lane_precheck = _mapping_value(
+                preparation.decision.params.get("simple_lane")
             )
-            self.executor.update_decision_params(
-                session,
-                decision_row,
-                rejected_decision.params,
-            )
-            self.executor.sync_decision_state(session, decision_row, rejected_decision)
-            self._record_decision_rejection(
-                session=session,
-                decision=rejected_decision,
-                decision_row=decision_row,
-                reasons=[
-                    "bounded_paper_route_target_notional_sizing_changed_by_precheck"
-                ],
-                log_template="Simple-lane decision rejected strategy_id=%s symbol=%s reason=%s",
-            )
-            return None
+            if simple_lane_precheck is not None:
+                for key in (
+                    "capped_by_order",
+                    "capped_by_symbol",
+                    "capped_by_buying_power",
+                ):
+                    if key in simple_lane_precheck:
+                        adjusted_audit[f"precheck_{key}"] = bool(
+                            simple_lane_precheck.get(key)
+                        )
+            target_notional_sizing = adjusted_audit
         prepared_for_alignment = preparation.decision
         if target_notional_sizing is not None:
             prepared_action: Literal["buy", "sell"] = (

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4091,7 +4091,7 @@ class TestTradingPipeline(TestCase):
         )
         self.assertEqual(row.status, "planned")
 
-    def test_bounded_collection_target_source_rejects_precheck_qty_clamp(
+    def test_bounded_collection_target_source_submits_precheck_qty_clamp(
         self,
     ) -> None:
         from app import config
@@ -4206,18 +4206,22 @@ class TestTradingPipeline(TestCase):
             params = cast(dict[str, Any], row_json["params"])
             sizing = cast(dict[str, Any], params["paper_route_target_notional_sizing"])
 
-        self.assertIsNone(prepared)
-        self.assertEqual(row.status, "rejected")
+        self.assertIsNotNone(prepared)
+        assert prepared is not None
+        prepared_decision, _snapshot = prepared
+        self.assertEqual(prepared_decision.qty, Decimal("4"))
+        self.assertEqual(row.status, "planned")
         self.assertEqual(
-            row_json["reject_reason_atomic"],
-            ["bounded_paper_route_target_notional_sizing_changed_by_precheck"],
+            Decimal(str(sizing["target_notional_resolved_qty"])), Decimal("150")
         )
-        self.assertEqual(sizing["resolved_qty"], "150")
+        self.assertEqual(Decimal(str(sizing["resolved_qty"])), Decimal("4"))
+        self.assertTrue(sizing["precheck_quantity_adjusted"])
+        self.assertEqual(
+            sizing["precheck_adjustment_reason"], "risk_precheck_capped_quantity"
+        )
         self.assertEqual(sizing["precheck_resolved_qty"], "4")
-        self.assertIn(
-            "bounded_paper_route_target_qty_changed_by_precheck",
-            sizing["blockers"],
-        )
+        self.assertEqual(sizing["precheck_expected_target_qty"], "150")
+        self.assertTrue(sizing["precheck_capped_by_order"])
 
     def test_bounded_collection_target_source_rejects_missing_target_sizing(
         self,


### PR DESCRIPTION
## Summary

- Change bounded paper-route source collection so broker precheck quantity caps no longer hard-reject otherwise valid target-notional decisions.
- Preserve the original target-notional quantity/notional in the audit payload while recording the broker-valid submitted quantity and the cap reason.
- Update the regression test that previously enforced the zero-source-activity behavior.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'bounded_collection_target_source_enforces_target_notional_broker_sizing or bounded_collection_target_source_submits_precheck_qty_clamp or bounded_hpairs_target_source_records_decisions_and_executions'`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'bounded_collection_target_source or bounded_hpairs_target_source_records_decisions_and_executions or paper_route_target_source_decisions_guard_paths_and_dedupes or paper_route_target_source_decisions_skip_symbols_with_open_exposure or paper_route_target_source_allows_flat_repaired_strategy_exposure'`
- `uv run --frozen pytest tests/test_simple_pipeline.py -q -k 'target_source_decisions_size_default_quantities_from_target_notional or target_source_decisions_skip_target_notional_below_min_step or target_source_decisions_fail_closed_without_target_notional_price'`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
