### PR TITLE
fix(torghut): isolate profit source proof windows

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -204,6 +204,10 @@ RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND = (
 )
 RUNTIME_LEDGER_SOURCE_COLLECTION_HANDOFF = "runtime_ledger_source_collection_import"
 RUNTIME_LEDGER_SOURCE_COLLECTION_SELECTED_BY = "runtime_ledger_source_collection"
+PRIORITIZED_SOURCE_COLLECTION_PLAN_SOURCE = "paper_route_prioritized_source_collection"
+OBSERVED_STRATEGY_SOURCE_COLLECTION_PLAN_SOURCE = (
+    "paper_route_observed_strategy_source_collection"
+)
 RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS = (
     "runtime_ledger_source_collection_only",
     "live_runtime_ledger_required",
@@ -8031,7 +8035,11 @@ def _runtime_window_import_audit(
         not import_ready
         and not import_blockers
         and session_state == "unknown"
-        and plan_source == "paper_route_observed_strategy_source_collection"
+        and plan_source
+        in {
+            OBSERVED_STRATEGY_SOURCE_COLLECTION_PLAN_SOURCE,
+            PRIORITIZED_SOURCE_COLLECTION_PLAN_SOURCE,
+        }
         and current_target_count > 0
         and any(
             count > 0
@@ -9351,28 +9359,82 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
     if not _live_gate_has_source_collection_pending(live_submission_gate):
         return {}
     limit = max(0, target_limit)
-    source_targets: list[dict[str, object]] = []
-    seen_target_keys: set[tuple[str, str, str, str, str]] = set()
+    candidate_targets: list[dict[str, object]] = []
 
     def append_source_target(target: Mapping[str, Any]) -> None:
-        if len(source_targets) >= limit:
-            return
         if not _target_is_runtime_ledger_source_collection(target):
             return
         if not _source_collection_import_target_allowed(target):
             return
         sanitized = _sanitized_runtime_ledger_source_collection_target(target)
+        candidate_targets.append(sanitized)
+
+    def target_key(
+        target: Mapping[str, object],
+    ) -> tuple[str, str, str, str, str]:
+        return (
+            _safe_text(target.get("hypothesis_id")) or "",
+            _safe_text(target.get("candidate_id")) or "",
+            _safe_text(target.get("runtime_strategy_name")) or "",
+            _safe_text(target.get("window_start")) or "",
+            _safe_text(target.get("window_end")) or "",
+        )
+
+    def target_rank(
+        target: Mapping[str, object],
+    ) -> tuple[int, int, int, int, Decimal, Decimal, tuple[str, str, str, str, str]]:
+        profit_target = _truthy_plan_value(
+            target.get("source_collection_profit_target_candidate")
+        )
+        priority = (
+            _safe_text(target.get("source_collection_priority"))
+            == "profit_target_source_materialization"
+        )
+        materialize_next = (
+            _safe_text(target.get("source_collection_next_action"))
+            == "materialize_runtime_ledger_source_window_refs"
+        )
+        if _source_collection_target_has_materializable_lineage(target):
+            materialization_rank = 0
+        elif _source_collection_target_has_bounded_bucket_materialization_seed(target):
+            materialization_rank = 1
+        else:
+            materialization_rank = 2
+        net_pnl = _safe_decimal(
+            target.get("source_collection_net_strategy_pnl_after_costs")
+            or target.get("net_strategy_pnl_after_costs")
+        )
+        filled_notional = _safe_decimal(
+            target.get("source_collection_filled_notional")
+            or target.get("filled_notional")
+        )
+        return (
+            0 if profit_target else 1,
+            0 if priority else 1,
+            0 if materialize_next else 1,
+            materialization_rank,
+            -net_pnl,
+            -filled_notional,
+            target_key(target),
+        )
+
+    source_targets: list[dict[str, object]] = []
+    seen_target_keys: set[tuple[str, str, str, str, str]] = set()
+
+    def append_ranked_target(target: Mapping[str, object]) -> None:
+        if len(source_targets) >= limit:
+            return
         key = (
-            _safe_text(sanitized.get("hypothesis_id")) or "",
-            _safe_text(sanitized.get("candidate_id")) or "",
-            _safe_text(sanitized.get("runtime_strategy_name")) or "",
-            _safe_text(sanitized.get("window_start")) or "",
-            _safe_text(sanitized.get("window_end")) or "",
+            _safe_text(target.get("hypothesis_id")) or "",
+            _safe_text(target.get("candidate_id")) or "",
+            _safe_text(target.get("runtime_strategy_name")) or "",
+            _safe_text(target.get("window_start")) or "",
+            _safe_text(target.get("window_end")) or "",
         )
         if key in seen_target_keys:
             return
         seen_target_keys.add(key)
-        source_targets.append(sanitized)
+        source_targets.append(dict(target))
 
     for target in _as_mapping_items(plan.get("targets")):
         append_source_target(target)
@@ -9380,6 +9442,8 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
         live_submission_gate.get("runtime_ledger_source_collection_candidates")
     ):
         append_source_target(target)
+    for target in sorted(candidate_targets, key=target_rank):
+        append_ranked_target(target)
     if not source_targets:
         return {}
     profit_target_count = sum(
@@ -9408,6 +9472,55 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
         "skipped_target_count": 0,
         "targets": source_targets,
         "skipped_targets": [],
+    }
+
+
+def _source_collection_import_plan_has_profit_target(
+    plan: Mapping[str, Any],
+) -> bool:
+    return any(
+        _truthy_plan_value(target.get("source_collection_profit_target_candidate"))
+        for target in _as_mapping_items(plan.get("targets"))
+    )
+
+
+def _merged_runtime_ledger_source_collection_import_plan(
+    *,
+    plans: Sequence[Mapping[str, Any]],
+    target_limit: int,
+    source: str = PRIORITIZED_SOURCE_COLLECTION_PLAN_SOURCE,
+) -> dict[str, object]:
+    targets: list[Mapping[str, Any]] = []
+    schema_version = ""
+    for plan in plans:
+        if not schema_version:
+            schema_version = _safe_text(plan.get("schema_version")) or ""
+        targets.extend(_as_mapping_items(plan.get("targets")))
+    if not targets:
+        return {}
+    merged = _runtime_ledger_source_collection_import_plan_for_payload(
+        plan={
+            "schema_version": schema_version,
+            "targets": targets,
+        },
+        live_submission_gate={
+            "blocked_reasons": [RUNTIME_LEDGER_SOURCE_COLLECTION_PENDING_BLOCKER],
+        },
+        target_limit=target_limit,
+    )
+    if not merged:
+        return {}
+    merged["source"] = source
+    return merged
+
+
+def _runtime_window_import_plan_is_source_collection_only(
+    plan: Mapping[str, Any],
+) -> bool:
+    source = _safe_text(plan.get("source"))
+    return source in {
+        OBSERVED_STRATEGY_SOURCE_COLLECTION_PLAN_SOURCE,
+        PRIORITIZED_SOURCE_COLLECTION_PLAN_SOURCE,
     }
 
 
@@ -9698,7 +9811,7 @@ def _observed_strategy_source_collection_import_plan(
     metadata = _source_collection_runtime_import_metadata(selected_plan or {})
     return {
         "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
-        "source": "paper_route_observed_strategy_source_collection",
+        "source": OBSERVED_STRATEGY_SOURCE_COLLECTION_PLAN_SOURCE,
         "purpose": "observed_strategy_runtime_ledger_source_collection_import",
         "proof_mode": "probation",
         "evidence_collection_ok": True,
@@ -9868,8 +9981,14 @@ def build_paper_route_target_plan_payload(
             )
         )
         if _as_mapping_items(observed_strategy_source_targets.get("targets")):
-            source_targets = observed_strategy_source_targets
-            runtime_window_import_plan = observed_strategy_source_targets
+            if _source_collection_import_plan_has_profit_target(source_targets):
+                source_targets = _merged_runtime_ledger_source_collection_import_plan(
+                    plans=(source_targets, observed_strategy_source_targets),
+                    target_limit=target_limit,
+                )
+            else:
+                source_targets = observed_strategy_source_targets
+            runtime_window_import_plan = source_targets
     runtime_import_readiness = _as_mapping(
         runtime_window_import_plan.get("session_readiness")
     )
@@ -10074,10 +10193,11 @@ def build_paper_route_target_plan_payload(
             "runtime_window_import_audit_blockers": _unique_text_items(
                 runtime_window_import_audit.get("blockers")
             ),
-            "runtime_window_import_source_collection_only": _safe_text(
-                runtime_window_import_plan.get("source")
-            )
-            == "paper_route_observed_strategy_source_collection",
+            "runtime_window_import_source_collection_only": (
+                _runtime_window_import_plan_is_source_collection_only(
+                    runtime_window_import_plan
+                )
+            ),
             "runtime_window_import_account_contamination_state": _safe_text(
                 _as_mapping(
                     runtime_window_import_plan.get("account_contamination_readiness")
@@ -10290,8 +10410,14 @@ def build_paper_route_evidence_audit(
         target_limit=effective_target_limit,
     )
     if _as_mapping_items(observed_strategy_source_targets.get("targets")):
-        source_targets = observed_strategy_source_targets
-        runtime_window_import_plan = observed_strategy_source_targets
+        if _source_collection_import_plan_has_profit_target(source_targets):
+            source_targets = _merged_runtime_ledger_source_collection_import_plan(
+                plans=(source_targets, observed_strategy_source_targets),
+                target_limit=effective_target_limit,
+            )
+        else:
+            source_targets = observed_strategy_source_targets
+        runtime_window_import_plan = source_targets
         runtime_window_import_target_audits = [
             cached_target_audit(
                 target,
@@ -10487,10 +10613,11 @@ def build_paper_route_evidence_audit(
             "runtime_window_import_plan_source": _safe_text(
                 runtime_window_import_plan.get("source")
             ),
-            "runtime_window_import_source_collection_only": _safe_text(
-                runtime_window_import_plan.get("source")
-            )
-            == "paper_route_observed_strategy_source_collection",
+            "runtime_window_import_source_collection_only": (
+                _runtime_window_import_plan_is_source_collection_only(
+                    runtime_window_import_plan
+                )
+            ),
             "runtime_window_import_account_contamination_state": _safe_text(
                 _as_mapping(
                     runtime_window_import_plan.get("account_contamination_readiness")

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1482,6 +1482,40 @@ def _target_allows_strategy_universe_probe_fallback(
     )
 
 
+def _runtime_window_isolated_account_priority(
+    target: Mapping[str, Any],
+    source_index: int,
+) -> tuple[int, int, int, int, Decimal, Decimal, int]:
+    reason_codes = set(_unique_text_items(target.get("source_collection_reason_codes")))
+    next_action = _safe_text(target.get("source_collection_next_action"))
+    profit_target = (
+        _truthy_plan_value(target.get("source_collection_profit_target_candidate"))
+        or "profit_target_source_materialization" in reason_codes
+    )
+    materialization_target = (
+        next_action == RUNTIME_LEDGER_SOURCE_COLLECTION_SAFE_EVIDENCE_COLLECTION_PATH[0]
+    )
+    source_authorized = _truthy_plan_value(
+        target.get("source_collection_authorized")
+    ) or _truthy_plan_value(target.get("bounded_evidence_collection_authorized"))
+    net_pnl = max(
+        _safe_decimal(
+            target.get("source_collection_profit_target_net_pnl_after_costs")
+        ),
+        _safe_decimal(target.get("source_collection_net_strategy_pnl_after_costs")),
+    )
+    filled_notional = _safe_decimal(target.get("source_collection_filled_notional"))
+    return (
+        0 if profit_target else 1,
+        0 if materialization_target else 1,
+        0 if source_authorized else 1,
+        0 if _target_is_hpairs(target) else 1,
+        -net_pnl,
+        -filled_notional,
+        source_index,
+    )
+
+
 def _strategy_lookup_names_for_target(target: Mapping[str, Any]) -> list[str]:
     strategy_name = _safe_text(target.get("strategy_name"))
     strategy_id = _safe_text(target.get("strategy_id"))
@@ -2167,10 +2201,12 @@ def _next_paper_route_runtime_window_targets(
     skipped_targets: list[dict[str, object]] = []
     planned_keys: set[tuple[object, ...]] = set()
     planned_execution_source_keys: dict[tuple[object, ...], dict[str, object]] = {}
-    planned_account_window_keys: dict[
-        tuple[str, str, str, str, str, str], dict[str, object]
-    ] = {}
-    for target in targets:
+    planned_account_window_keys: dict[tuple[str, str, str], dict[str, object]] = {}
+    prioritized_targets = sorted(
+        enumerate(targets),
+        key=lambda item: _runtime_window_isolated_account_priority(item[1], item[0]),
+    )
+    for source_index, target in prioritized_targets:
         hypothesis_id = _safe_text(target.get("hypothesis_id"))
         candidate_id = _safe_text(target.get("candidate_id"))
         strategy_family = _safe_text(target.get("strategy_family"))
@@ -2310,6 +2346,7 @@ def _next_paper_route_runtime_window_targets(
                     "hypothesis_id": hypothesis_id,
                     "candidate_id": candidate_id,
                     "reason": "next_paper_route_runtime_window_target_not_ready",
+                    "source_plan_index": source_index,
                     "missing_or_blocking_fields": reasons,
                 }
             )
@@ -2395,6 +2432,7 @@ def _next_paper_route_runtime_window_targets(
                     "hypothesis_id": hypothesis_id,
                     "candidate_id": candidate_id,
                     "reason": "paper_route_account_pre_session_not_clean",
+                    "source_plan_index": source_index,
                     "missing_or_blocking_fields": account_pre_session_blockers,
                     "paper_route_account_pre_session_state": (
                         account_pre_session_state
@@ -2422,6 +2460,7 @@ def _next_paper_route_runtime_window_targets(
                     "hypothesis_id": hypothesis_id,
                     "candidate_id": candidate_id,
                     "reason": "duplicate_next_paper_route_runtime_window_target",
+                    "source_plan_index": source_index,
                     "missing_or_blocking_fields": [
                         "duplicate_next_paper_route_runtime_window_target"
                     ],
@@ -2451,6 +2490,7 @@ def _next_paper_route_runtime_window_targets(
                     "reason": (
                         "duplicate_next_paper_route_runtime_window_execution_source"
                     ),
+                    "source_plan_index": source_index,
                     "duplicate_of_hypothesis_id": existing_execution_source.get(
                         "hypothesis_id"
                     ),
@@ -2469,9 +2509,6 @@ def _next_paper_route_runtime_window_targets(
             PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
             account_window_start,
             account_window_end,
-            hypothesis_id or "",
-            candidate_id or "",
-            canonical_strategy_name or "",
         )
         existing_account_window = planned_account_window_keys.get(account_window_key)
         if existing_account_window is not None:
@@ -2479,18 +2516,28 @@ def _next_paper_route_runtime_window_targets(
                 {
                     "hypothesis_id": hypothesis_id,
                     "candidate_id": candidate_id,
-                    "reason": "paper_route_account_window_already_assigned",
+                    "reason": (
+                        "paper_route_account_window_reserved_for_isolated_source_collection"
+                    ),
+                    "source_plan_index": source_index,
                     "duplicate_of_hypothesis_id": existing_account_window.get(
                         "hypothesis_id"
                     ),
                     "duplicate_of_candidate_id": existing_account_window.get(
                         "candidate_id"
                     ),
+                    "duplicate_of_strategy_name": existing_account_window.get(
+                        "strategy_name"
+                    ),
+                    "duplicate_of_runtime_strategy_name": existing_account_window.get(
+                        "runtime_strategy_name"
+                    ),
                     "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
                     "window_start": account_window_start,
                     "window_end": account_window_end,
                     "missing_or_blocking_fields": [
-                        "paper_route_account_window_already_assigned"
+                        "paper_route_account_window_reserved_for_isolated_source_collection",
+                        "paper_route_account_window_already_assigned",
                     ],
                 }
             )
@@ -2584,6 +2631,7 @@ def _next_paper_route_runtime_window_targets(
         planned_target: dict[str, object] = {
             "hypothesis_id": hypothesis_id,
             "candidate_id": candidate_id,
+            "source_plan_index": source_index,
             "observed_stage": "paper",
             "strategy_family": strategy_family,
             "strategy_name": canonical_strategy_name,

--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -242,17 +242,20 @@ def _target_bounded_materialization_authorized(target: Mapping[str, Any]) -> boo
 
 
 def _target_materialization_score(target: Mapping[str, Any]) -> tuple[int, int, int]:
-    bounded_authorized = int(_target_bounded_materialization_authorized(target))
+    materializable_shape = int(
+        bool(_target_symbol_actions(target))
+        and _target_notional(target) > 0
+        and _target_quantity(target) > 0
+    )
+    bounded_authorized = int(
+        _target_bounded_materialization_authorized(target) and materializable_shape
+    )
     return (
+        materializable_shape,
         bounded_authorized,
         int(
             _safe_text(target.get("hypothesis_id"))
             == PAPER_ROUTE_MATERIALIZATION_HPAIRS_HYPOTHESIS_ID
-        ),
-        int(
-            bool(_target_symbol_actions(target))
-            and _target_notional(target) > 0
-            and _target_quantity(target) > 0
         ),
     )
 
@@ -263,13 +266,13 @@ def _plan_materialization_score(plan: Mapping[str, Any]) -> tuple[int, int, int,
     materializable_shape = 0
     targets = paper_route_target_plan_targets(plan)
     for target in targets:
-        target_authorized, target_hpairs, target_shape = _target_materialization_score(
+        target_shape, target_authorized, target_hpairs = _target_materialization_score(
             target
         )
         bounded_authorized += target_authorized
         hpairs += target_hpairs
         materializable_shape += target_shape
-    return (bounded_authorized, hpairs, materializable_shape, len(targets))
+    return (materializable_shape, bounded_authorized, hpairs, -len(targets))
 
 
 def _candidate_materialization_plans(
@@ -323,7 +326,7 @@ def _materialization_plan_from_payload(
 ) -> tuple[dict[str, Any], str | None]:
     best_plan: dict[str, Any] = {}
     best_source: str | None = None
-    best_score = (0, 0, 0, 0)
+    best_score = (-1, -1, -1, -1_000_000)
     for source, plan in _candidate_materialization_plans(payload):
         if not paper_route_target_plan_targets(plan):
             continue

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -1385,6 +1385,25 @@ def test_commit_dynamic_next_window_plan_filters_to_confirmed_hpairs_target(
     assert _count_decisions(sqlite_dsn) == 2
 
 
+def test_dynamic_plan_selection_prefers_sanitized_isolated_hpairs_plan() -> None:
+    payload = {
+        "live_submission_gate": {
+            "runtime_ledger_paper_probation_import_plan": _plan(
+                _tsmom_target(),
+                _hpairs_target(),
+            )
+        },
+        "next_paper_route_runtime_window_targets": _plan(_hpairs_target()),
+    }
+
+    plan, selected_plan = cli._materialization_plan_from_payload(payload)
+
+    assert selected_plan == "next_paper_route_runtime_window_targets"
+    assert [
+        target["candidate_id"] for target in cli.paper_route_target_plan_targets(plan)
+    ] == ["c88421d619759b2cfaa6f4d0"]
+
+
 def test_commit_dynamic_next_window_plan_blocks_when_confirmed_target_is_absent(
     monkeypatch: pytest.MonkeyPatch,
     sqlite_dsn: str,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -10787,11 +10787,15 @@ class TestPaperRouteEvidenceAudit(TestCase):
             )
 
         plan = payload["next_paper_route_runtime_window_targets"]
-        self.assertEqual(plan["target_count"], 2)
-        self.assertEqual(plan["skipped_target_count"], 0)
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["skipped_target_count"], 1)
         first_target = plan["targets"][0]
-        second_target = plan["targets"][1]
-        self.assertEqual(second_target["candidate_id"], "candidate-overlap-pair")
+        skipped_target = plan["skipped_targets"][0]
+        self.assertEqual(skipped_target["candidate_id"], "candidate-overlap-pair")
+        self.assertEqual(
+            skipped_target["reason"],
+            "paper_route_account_window_reserved_for_isolated_source_collection",
+        )
         self.assertEqual(
             first_target["paper_route_account_contamination_state"]["reason"],
             "unlinked_and_foreign_account_order_events_present",
@@ -10800,9 +10804,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(
             contamination_readiness["state"], "contaminated_window_discarded"
         )
-        self.assertEqual(contamination_readiness["target_count"], 2)
-        self.assertEqual(contamination_readiness["contaminated_target_count"], 2)
-        self.assertEqual(contamination_readiness["unlinked_order_event_count"], 15)
+        self.assertEqual(contamination_readiness["target_count"], 1)
+        self.assertEqual(contamination_readiness["contaminated_target_count"], 1)
+        self.assertEqual(contamination_readiness["unlinked_order_event_count"], 10)
         self.assertEqual(contamination_readiness["foreign_linked_order_event_count"], 1)
         sample_refs = contamination_readiness["sample_order_event_refs"]
         self.assertEqual(len(sample_refs), 10)
@@ -11507,7 +11511,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(import_audit["counts"]["selected_target_count"], 1)
         self.assertEqual(import_audit["counts"]["next_runtime_window_target_count"], 1)
 
-    def test_next_paper_route_runtime_window_allows_distinct_account_window_targets(
+    def test_next_paper_route_runtime_window_reserves_account_window_for_one_target(
         self,
     ) -> None:
         window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
@@ -11604,24 +11608,162 @@ class TestPaperRouteEvidenceAudit(TestCase):
             )
 
         next_targets = payload["next_paper_route_runtime_window_targets"]
-        self.assertEqual(next_targets["target_count"], 2)
-        self.assertEqual(next_targets["skipped_target_count"], 0)
+        self.assertEqual(next_targets["target_count"], 1)
+        self.assertEqual(next_targets["skipped_target_count"], 1)
         self.assertEqual(
             next_targets["targets"][0]["candidate_id"], "candidate-paper-alpha"
         )
         self.assertEqual(
-            next_targets["targets"][1]["candidate_id"], "candidate-paper-beta"
+            next_targets["skipped_targets"][0]["candidate_id"], "candidate-paper-beta"
         )
         self.assertEqual(next_targets["targets"][0]["account_label"], "TORGHUT_SIM")
-        self.assertEqual(next_targets["targets"][1]["account_label"], "TORGHUT_SIM")
-        self.assertNotIn(
+        self.assertEqual(
+            next_targets["skipped_targets"][0]["reason"],
+            "paper_route_account_window_reserved_for_isolated_source_collection",
+        )
+        self.assertIn(
             "paper_route_account_window_already_assigned",
-            [str(skipped.get("reason")) for skipped in next_targets["skipped_targets"]],
+            next_targets["skipped_targets"][0]["missing_or_blocking_fields"],
+        )
+        self.assertEqual(
+            next_targets["skipped_targets"][0]["duplicate_of_candidate_id"],
+            "candidate-paper-alpha",
         )
         import_audit = payload["runtime_window_import_audit"]
         self.assertEqual(import_audit["counts"]["source_plan_target_count"], 2)
-        self.assertEqual(import_audit["counts"]["selected_target_count"], 2)
-        self.assertEqual(import_audit["counts"]["next_runtime_window_target_count"], 2)
+        self.assertEqual(import_audit["counts"]["selected_target_count"], 1)
+        self.assertEqual(import_audit["counts"]["next_runtime_window_target_count"], 1)
+
+    def test_next_paper_route_runtime_window_prefers_profit_source_target_for_account_window(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add_all(
+                [
+                    Strategy(
+                        name="intraday-tsmom-profit-v3",
+                        description="raw first paper route target",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols=["NVDA"],
+                        created_at=window_start,
+                        updated_at=window_start,
+                    ),
+                    Strategy(
+                        name="microbar-cross-sectional-pairs-v1",
+                        description="profit source collection target",
+                        enabled=True,
+                        base_timeframe="1Min",
+                        universe_type="static",
+                        universe_symbols=["AAPL", "AMZN"],
+                        created_at=window_start,
+                        updated_at=window_start,
+                    ),
+                ]
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": "2",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-TSMOM-LIQ-01",
+                                "candidate_id": "candidate-tsmom",
+                                "observed_stage": "paper",
+                                "strategy_family": "intraday_tsmom_consistent",
+                                "strategy_name": "intraday-tsmom-profit-v3",
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": "config/trading/hypotheses/h-tsmom-liq-01.json",
+                                "paper_route_probe_symbols": ["NVDA"],
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                                "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+                            },
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-hpairs-profit",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_collection_authorized": True,
+                                "source_collection_reason_codes": [
+                                    "profit_target_source_materialization"
+                                ],
+                                "source_collection_profit_target_candidate": True,
+                                "source_collection_next_action": (
+                                    "materialize_runtime_ledger_source_window_refs"
+                                ),
+                                "source_collection_profit_target_net_pnl_after_costs": "567.44720578",
+                                "source_collection_filled_notional": "127090.02495200",
+                                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                                "paper_route_probe_symbol_actions": {
+                                    "AAPL": "buy",
+                                    "AMZN": "sell",
+                                },
+                                "paper_route_probe_symbol_quantities": {
+                                    "AAPL": "1",
+                                    "AMZN": "1",
+                                },
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                                "paper_probation_satisfied_for_bounded_live_paper_collection": False,
+                            },
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN", "NVDA"],
+                        "paper_route_probe_active_symbols": ["AAPL", "AMZN", "NVDA"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=now,
+            )
+
+        next_targets = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(next_targets["target_count"], 1)
+        self.assertEqual(
+            next_targets["targets"][0]["candidate_id"], "candidate-hpairs-profit"
+        )
+        self.assertEqual(next_targets["targets"][0]["source_plan_index"], 1)
+        self.assertEqual(
+            next_targets["skipped_targets"][0]["candidate_id"], "candidate-tsmom"
+        )
+        self.assertEqual(next_targets["skipped_targets"][0]["source_plan_index"], 0)
+        self.assertEqual(
+            next_targets["skipped_targets"][0]["reason"],
+            "paper_route_account_window_reserved_for_isolated_source_collection",
+        )
 
     def test_runtime_import_audit_counts_selected_targets_not_raw_plan_noise(
         self,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5727,6 +5727,133 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(empty_plan, {})
 
+    def test_source_collection_import_plan_prioritizes_profit_target_before_limit(
+        self,
+    ) -> None:
+        live_gate = {
+            "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+        }
+
+        plan = paper_route_evidence._runtime_ledger_source_collection_import_plan_for_payload(
+            plan={
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "generic-hpairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_collection_authorized": True,
+                    },
+                    {
+                        "hypothesis_id": "H-TSMOM-LIQ-01",
+                        "candidate_id": "generic-tsmom",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_collection_authorized": True,
+                    },
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "generic-hpairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_collection_authorized": True,
+                        "source_collection_priority": (
+                            "profit_target_source_materialization"
+                        ),
+                        "source_collection_profit_target_candidate": True,
+                        "source_collection_net_strategy_pnl_after_costs": (
+                            "567.44720578"
+                        ),
+                        "source_collection_filled_notional": "127090.02495200",
+                        "source_collection_next_action": (
+                            "materialize_runtime_ledger_source_window_refs"
+                        ),
+                        "runtime_ledger_bucket_ref": (
+                            "strategy_runtime_ledger_buckets:run-1:start:end"
+                        ),
+                        "window_start": "2026-06-04T13:30:00+00:00",
+                        "window_end": "2026-06-04T20:00:00+00:00",
+                    },
+                ],
+            },
+            live_submission_gate=live_gate,
+            target_limit=2,
+        )
+
+        self.assertEqual(plan["target_count"], 2)
+        self.assertEqual(plan["source_collection_profit_target_count"], 1)
+        self.assertEqual(plan["targets"][0]["candidate_id"], "generic-hpairs")
+        self.assertTrue(plan["targets"][0]["source_collection_profit_target_candidate"])
+        self.assertEqual(
+            plan["targets"][0]["source_collection_next_action"],
+            "materialize_runtime_ledger_source_window_refs",
+        )
+
+    def test_source_collection_import_plan_merges_profit_target_before_observed(
+        self,
+    ) -> None:
+        source_plan = paper_route_evidence._runtime_ledger_source_collection_import_plan_for_payload(
+            plan={
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "profit-hpairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_collection_authorized": True,
+                        "source_collection_priority": (
+                            "profit_target_source_materialization"
+                        ),
+                        "source_collection_profit_target_candidate": True,
+                        "source_collection_net_strategy_pnl_after_costs": (
+                            "567.44720578"
+                        ),
+                        "source_collection_next_action": (
+                            "materialize_runtime_ledger_source_window_refs"
+                        ),
+                        "runtime_ledger_bucket_ref": (
+                            "strategy_runtime_ledger_buckets:run-1:start:end"
+                        ),
+                        "window_start": "2026-06-04T13:30:00+00:00",
+                        "window_end": "2026-06-04T20:00:00+00:00",
+                    }
+                ],
+            },
+            live_submission_gate={
+                "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+            },
+            target_limit=1,
+        )
+        observed_plan = {
+            "targets": [
+                {
+                    "hypothesis_id": "H-TSMOM-LIQ-01",
+                    "candidate_id": "observed-tsmom",
+                    "strategy_name": "intraday-tsmom-profit-v3",
+                    "source_kind": "runtime_ledger_source_collection_candidate",
+                    "source_collection_authorized": True,
+                    "selected_by": "paper_route_observed_strategy_source_collection",
+                    "window_start": "2026-06-04T13:30:00+00:00",
+                    "window_end": "2026-06-04T20:00:00+00:00",
+                }
+            ],
+        }
+
+        merged = (
+            paper_route_evidence._merged_runtime_ledger_source_collection_import_plan(
+                plans=(source_plan, observed_plan),
+                target_limit=1,
+            )
+        )
+
+        self.assertEqual(merged["source"], "paper_route_prioritized_source_collection")
+        self.assertEqual(merged["target_count"], 1)
+        self.assertEqual(merged["targets"][0]["candidate_id"], "profit-hpairs")
+        self.assertTrue(
+            merged["targets"][0]["source_collection_profit_target_candidate"]
+        )
+
     def test_source_collection_import_plan_skips_aggregate_replay_bucket_without_lineage(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Prioritize runtime-ledger source-collection profit targets before applying paper-route import limits so the H-PAIRS `materialize_runtime_ledger_source_window_refs` path is not dropped.
- Merge observed-strategy source collection with higher-priority profit-materialization targets while preserving probation-only, no-capital promotion authority.
- Reserve each TORGHUT_SIM runtime-window target plan to one account/session authority target so mixed strategy plans are skipped instead of scheduled into the same proof window.
- Tighten bounded materializer plan scoring so sanitized materializable H-PAIRS plans beat larger raw mixed plans.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py scripts/materialize_bounded_paper_route_targets.py tests/test_paper_route_evidence.py tests/test_materialize_bounded_paper_route_targets.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/materialize_bounded_paper_route_targets.py tests/test_paper_route_evidence.py tests/test_materialize_bounded_paper_route_targets.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q -k "runtime_window_target_metadata_defaults_source_collection_blockers"`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `uv run --frozen python -m compileall app`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report= tests/test_paper_route_evidence.py tests/test_materialize_bounded_paper_route_targets.py tests/test_run_empirical_promotion_jobs.py -q -k "not slow"`
- `uv run --frozen python -m coverage xml -o coverage.xml --fail-under=0`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- Simulated the captured live `/trading/paper-route-target-plan` payload and verified the `567.44720578` source-collection profit target becomes the first merged import target.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
