### PR TITLE
fix(torghut): harden proof read timeout paths

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -138,6 +138,7 @@ class TradeDecision(Base, CreatedAtMixin):
             "symbol",
             "created_at",
         ),
+        Index("ix_trade_decisions_created_id", "created_at", "id"),
         Index(
             "uq_trade_decisions_account_decision_hash",
             "alpaca_account_label",
@@ -1561,6 +1562,12 @@ class RejectedSignalOutcomeEvent(Base, TimestampMixin):
             "event_ts",
         ),
         Index(
+            "ix_rejected_signal_events_account_event_created",
+            "account_label",
+            "event_ts",
+            "created_at",
+        ),
+        Index(
             "ix_rejected_signal_outcome_events_reason",
             "reject_reason",
         ),
@@ -1806,6 +1813,16 @@ class StrategyRuntimeLedgerBucket(Base, TimestampMixin):
             "ix_strategy_runtime_ledger_buckets_account_stage_ended",
             "account_label",
             "observed_stage",
+            "bucket_ended_at",
+            "created_at",
+        ),
+        Index(
+            "ix_runtime_ledger_bucket_audit_lookup",
+            "hypothesis_id",
+            "candidate_id",
+            "observed_stage",
+            "account_label",
+            "strategy_family",
             "bucket_ended_at",
             "created_at",
         ),

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from threading import Lock
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
@@ -123,6 +123,16 @@ _CERTIFICATE_EVIDENCE_WINDOW_LIMIT = _CERTIFICATE_EVIDENCE_PER_HYPOTHESIS_LIMIT
 _CERTIFICATE_EVIDENCE_RUNTIME_LEDGER_LIMIT = 16
 _PROMOTION_SCALAR_COUNT_LIMIT = _PROMOTION_TABLE_COUNT_SCAN_LIMIT
 _PROMOTION_PORTFOLIO_SAMPLE_LIMIT = _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT
+
+
+class _PortfolioPromotionRow(NamedTuple):
+    status: str
+    portfolio_candidate_id: str
+    source_candidate_ids_json: Any
+    target_net_pnl_per_day: Decimal
+    objective_scorecard_json: Any
+
+
 _RUNTIME_WINDOW_IMPORT_CONTINUITY_READY_STATES = frozenset(
     {
         "signals_present",
@@ -408,7 +418,7 @@ def _runtime_window_import_health_gate_inputs(
 
 
 def _autoresearch_portfolio_current_oracle_passed(
-    row: AutoresearchPortfolioCandidate,
+    row: AutoresearchPortfolioCandidate | _PortfolioPromotionRow,
 ) -> bool:
     scorecard = row.objective_scorecard_json
     if not isinstance(scorecard, Mapping):
@@ -3951,13 +3961,26 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, Any]:
     truncated_counts: list[str] = []
     try:
         _maybe_set_runtime_ledger_status_statement_timeout(session)
-        portfolio_rows = list(
-            session.execute(
-                select(AutoresearchPortfolioCandidate)
+        portfolio_rows = [
+            _PortfolioPromotionRow(
+                status=str(row.status),
+                portfolio_candidate_id=str(row.portfolio_candidate_id),
+                source_candidate_ids_json=row.source_candidate_ids_json,
+                target_net_pnl_per_day=cast(Decimal, row.target_net_pnl_per_day),
+                objective_scorecard_json=row.objective_scorecard_json,
+            )
+            for row in session.execute(
+                select(
+                    AutoresearchPortfolioCandidate.status,
+                    AutoresearchPortfolioCandidate.portfolio_candidate_id,
+                    AutoresearchPortfolioCandidate.source_candidate_ids_json,
+                    AutoresearchPortfolioCandidate.target_net_pnl_per_day,
+                    AutoresearchPortfolioCandidate.objective_scorecard_json,
+                )
                 .order_by(AutoresearchPortfolioCandidate.created_at.desc())
                 .limit(_PROMOTION_PORTFOLIO_SAMPLE_LIMIT + 1)
-            ).scalars()
-        )
+            ).all()
+        ]
     except SQLAlchemyError as exc:
         logger.warning(
             "Failed to load profit promotion portfolio rows error=%s",

--- a/services/torghut/migrations/versions/0052_proof_read_timeout_indexes.py
+++ b/services/torghut/migrations/versions/0052_proof_read_timeout_indexes.py
@@ -1,0 +1,84 @@
+"""Add proof read timeout indexes.
+
+Revision ID: 0052_proof_read_timeout_indexes
+Revises: 0051_paper_route_source_activity_latest_index
+Create Date: 2026-06-05 01:35:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0052_proof_read_timeout_indexes"
+down_revision = "0051_paper_route_source_activity_latest_index"
+branch_labels = None
+depends_on = None
+
+_INDEXES: tuple[tuple[str, str, str], ...] = (
+    (
+        "ix_runtime_ledger_bucket_audit_lookup",
+        "strategy_runtime_ledger_buckets",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_runtime_ledger_bucket_audit_lookup
+ON strategy_runtime_ledger_buckets (
+  hypothesis_id,
+  candidate_id,
+  observed_stage,
+  account_label,
+  strategy_family,
+  bucket_ended_at DESC,
+  created_at DESC
+)
+""",
+    ),
+    (
+        "ix_rejected_signal_events_account_event_created",
+        "rejected_signal_outcome_events",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_rejected_signal_events_account_event_created
+ON rejected_signal_outcome_events (
+  account_label,
+  event_ts DESC,
+  created_at DESC
+)
+""",
+    ),
+    (
+        "ix_trade_decisions_created_id",
+        "trade_decisions",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_trade_decisions_created_id
+ON trade_decisions (
+  created_at DESC,
+  id
+)
+""",
+    ),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    with op.get_context().autocommit_block():
+        for _index_name, table_name, create_sql in _INDEXES:
+            if not inspector.has_table(table_name):
+                continue
+            op.execute(sa.text(create_sql))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    with op.get_context().autocommit_block():
+        for index_name, table_name, _create_sql in reversed(_INDEXES):
+            if not inspector.has_table(table_name):
+                continue
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))

--- a/services/torghut/tests/test_proof_read_timeout_indexes_migration.py
+++ b/services/torghut/tests/test_proof_read_timeout_indexes_migration.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0052_proof_read_timeout_indexes.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0052", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0052")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestProofReadTimeoutIndexesMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(module.revision, "0052_proof_read_timeout_indexes")
+        self.assertEqual(
+            module.down_revision,
+            "0051_paper_route_source_activity_latest_index",
+        )
+
+    def test_index_names_fit_postgres_identifier_limit(self) -> None:
+        module = _load_migration_module()
+
+        for index_name, _table_name, _create_sql in module._INDEXES:
+            self.assertLessEqual(len(index_name), 63, index_name)
+
+    def test_upgrade_adds_concurrent_timeout_indexes(self) -> None:
+        module = _load_migration_module()
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "get_context") as get_context,
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.upgrade()
+
+        get_context.return_value.autocommit_block.assert_called_once_with()
+        executed_sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+        self.assertIn("CREATE INDEX CONCURRENTLY IF NOT EXISTS", executed_sql)
+        self.assertIn("ix_runtime_ledger_bucket_audit_lookup", executed_sql)
+        self.assertIn("ix_rejected_signal_events_account_event_created", executed_sql)
+        self.assertIn("ix_trade_decisions_created_id", executed_sql)
+
+    def test_downgrade_drops_concurrent_timeout_indexes(self) -> None:
+        module = _load_migration_module()
+        bind = MagicMock()
+        bind.dialect.name = "postgresql"
+        inspector = MagicMock()
+        inspector.has_table.return_value = True
+
+        with (
+            patch.object(module.op, "get_bind", return_value=bind),
+            patch.object(module.op, "get_context") as get_context,
+            patch.object(module, "inspect", return_value=inspector),
+            patch.object(module.op, "execute") as execute,
+        ):
+            module.downgrade()
+
+        get_context.return_value.autocommit_block.assert_called_once_with()
+        executed_sql = "\n".join(str(call.args[0]) for call in execute.call_args_list)
+        self.assertIn("DROP INDEX CONCURRENTLY IF EXISTS", executed_sql)
+        self.assertIn("ix_runtime_ledger_bucket_audit_lookup", executed_sql)
+        self.assertIn("ix_rejected_signal_events_account_event_created", executed_sql)
+        self.assertIn("ix_trade_decisions_created_id", executed_sql)

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -4871,6 +4871,27 @@ class TestSubmissionCouncil(TestCase):
                 for statement in statements
             )
         )
+        portfolio_statements = [
+            statement
+            for statement in statements
+            if "FROM autoresearch_portfolio_candidates" in statement
+        ]
+        self.assertTrue(portfolio_statements)
+        self.assertTrue(
+            any(
+                "autoresearch_portfolio_candidates.status" in statement
+                for statement in portfolio_statements
+            )
+        )
+        self.assertFalse(
+            any("payload_json" in statement for statement in portfolio_statements)
+        )
+        self.assertFalse(
+            any(
+                "optimizer_report_json" in statement
+                for statement in portfolio_statements
+            )
+        )
 
     def test_load_profit_promotion_counts_fail_closed_when_portfolio_scan_truncated(
         self,


### PR DESCRIPTION
## Summary

- Add concurrent Postgres indexes for live proof-read timeout paths: runtime-ledger bucket audits, rejected-signal outcome readback, and recent trade-decision joins.
- Keep Torghut ORM index metadata aligned with the new migration head `0052_proof_read_timeout_indexes`.
- Change profit-promotion status counts to scan scalar portfolio columns instead of hydrating large portfolio payload JSON.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/models/entities.py app/trading/submission_council.py tests/test_submission_council.py tests/test_proof_read_timeout_indexes_migration.py migrations/versions/0052_proof_read_timeout_indexes.py`
- `uv run --frozen pytest tests/test_proof_read_timeout_indexes_migration.py -q`
- `uv run --frozen pytest tests/test_submission_council.py -q -k "load_profit_promotion_counts"`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_proof_read_timeout_indexes_migration.py -q`
- `uv run --frozen python -m compileall app`
- `uv run --frozen ruff check app tests scripts migrations`
- `git diff --check`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report= tests/test_submission_council.py tests/test_proof_read_timeout_indexes_migration.py -q`
- `uv run --frozen python -m coverage xml -o coverage.xml --fail-under=0`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

Applies Alembic migration `0052_proof_read_timeout_indexes`; no API behavior change and no promotion-gate relaxation.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
