### PR TITLE
chore(torghut): promote image 962899d4

### DIFF
--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: materialize-targets
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -134,7 +134,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+                  value: sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-05T08:18:09Z"
+        client.knative.dev/updateTimestamp: "2026-06-05T08:49:39Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
           ports:
             - name: http1
               containerPort: 8181
@@ -531,11 +531,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-229-g43bf6dbd5
+              value: v0.596.0-233-g962899d41
             - name: TORGHUT_COMMIT
-              value: 43bf6dbd5cc3c2b0b3fdcd6cdf2a7728bb891ce6
+              value: 962899d41b25bdaac596ddab268d1ba64753b44e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+              value: sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-05T08:18:09Z"
+        client.knative.dev/updateTimestamp: "2026-06-05T08:49:39Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
           ports:
             - name: http1
               containerPort: 8181
@@ -395,11 +395,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-229-g43bf6dbd5
+              value: v0.596.0-233-g962899d41
             - name: TORGHUT_COMMIT
-              value: 43bf6dbd5cc3c2b0b3fdcd6cdf2a7728bb891ce6
+              value: 962899d41b25bdaac596ddab268d1ba64753b44e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+              value: sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -87,7 +87,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+                  value: sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -123,7 +123,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -195,6 +195,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+                  value: sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: 43bf6dbd5cc3c2b0b3fdcd6cdf2a7728bb891ce6
+            value: 962899d41b25bdaac596ddab268d1ba64753b44e
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+            value: sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7394e70eb91d94ad2fe9049e687c7f807f54f7615b025863399b96e84f14b5d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `962899d41b25bdaac596ddab268d1ba64753b44e`
- Image tag: `962899d4`
- Image digest: `sha256:65c4ba450c3d06b109d4be2b72fbedd0463f33ddc19f05b3846e2442ee64055e`
- Migration change detected under `services/torghut/migrations/**`
- Added `do-not-automerge`; manual DB migration approval required before merge