### PR TITLE
fix(torghut): harden sim evidence and paper routing

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -66,6 +66,8 @@ spec:
                   key: password
             - name: DB_DSN
               value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
+            - name: SIM_DB_DSN
+              value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
             - name: TORGHUT_TIGERBEETLE_ENABLED
               value: "true"
             - name: TORGHUT_TIGERBEETLE_REQUIRED

--- a/services/torghut/app/trading/discovery/cluster_lob_features.py
+++ b/services/torghut/app/trading/discovery/cluster_lob_features.py
@@ -35,6 +35,13 @@ HAWKES_EXCITATION_KERNEL_SECONDS = 5.0
 HAWKES_EXCITATION_LOOKBACK_SECONDS = 30.0
 HPAIRS_CLUSTER_LOB_PRIMARY_SOURCES: tuple[Mapping[str, str], ...] = (
     {
+        "source_id": "arxiv-2504.20349",
+        "url": "https://arxiv.org/abs/2504.20349",
+        "title": "ClusterLOB: Enhancing Trading Strategies by Clustering Orders in Limit Order Books",
+        "date": "2025-04-29",
+        "mechanism": "cluster_individual_market_events_into_behavioral_lob_regimes_for_strategy_filtering",
+    },
+    {
         "source_id": "arxiv-2510.08085",
         "url": "https://arxiv.org/abs/2510.08085",
         "title": "A Deterministic Limit Order Book Simulator with Hawkes-Driven Order Flow",
@@ -157,6 +164,9 @@ class ClusterLOBFeatureSet:
             "schema_version": HPAIRS_CLUSTER_LOB_FEATURE_SCHEMA_VERSION,
             "feature_schema_hash": self.feature_schema_hash,
             "status": "preview_only_research_ranking",
+            "source_papers": [
+                dict(item) for item in HPAIRS_CLUSTER_LOB_PRIMARY_SOURCES
+            ],
             "row_count": self.row_count,
             "symbol_count": self.symbol_count,
             "source_fields": list(self.source_fields),

--- a/services/torghut/app/trading/discovery/replay_ledger_ranker.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_ranker.py
@@ -10,8 +10,15 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, cast
 
+from app.trading.discovery.adaptive_market_limit_allocation_stress import (
+    extract_adaptive_market_limit_allocation_stress,
+)
+from app.trading.discovery.cluster_lob_features import extract_cluster_lob_features
 from app.trading.discovery.lob_reality_gap_stress import (
     extract_lob_reality_gap_stress,
+)
+from app.trading.discovery.order_book_observability_stress import (
+    extract_order_book_observability_stress,
 )
 from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
 from app.trading.models import SignalEnvelope
@@ -19,6 +26,9 @@ from app.trading.runtime_ledger import RuntimeLedgerBucket, build_runtime_ledger
 
 EXACT_REPLAY_LEDGER_RANKING_SCHEMA_VERSION = "torghut.exact-replay-ledger-ranking.v1"
 EXECUTION_QUALITY_SCHEMA_VERSION = "torghut.exact-replay-execution-quality.v1"
+EXACT_REPLAY_MICROSTRUCTURE_STRESS_SCHEMA_VERSION = (
+    "torghut.exact-replay-microstructure-stress.v1"
+)
 _LIVE_PROMOTION_AUTHORITIES = frozenset(
     {
         "live",
@@ -217,6 +227,10 @@ class ReplayLedgerCandidateRanking:
     lob_reality_gap_blockers: tuple[str, ...]
     lob_reality_gap_penalty_bps: Decimal
     lob_reality_gap_penalty_amount: Decimal
+    microstructure_stress: Mapping[str, object]
+    microstructure_stress_blockers: tuple[str, ...]
+    microstructure_stress_penalty_bps: Decimal
+    microstructure_stress_penalty_amount: Decimal
     replay_quality_adjusted_window_net_pnl_per_day: Decimal
 
     def to_payload(self) -> dict[str, object]:
@@ -295,6 +309,14 @@ class ReplayLedgerCandidateRanking:
             "lob_reality_gap_blockers": list(self.lob_reality_gap_blockers),
             "lob_reality_gap_penalty_bps": str(self.lob_reality_gap_penalty_bps),
             "lob_reality_gap_penalty_amount": str(self.lob_reality_gap_penalty_amount),
+            "microstructure_stress": _payload_object(self.microstructure_stress),
+            "microstructure_stress_blockers": list(self.microstructure_stress_blockers),
+            "microstructure_stress_penalty_bps": str(
+                self.microstructure_stress_penalty_bps
+            ),
+            "microstructure_stress_penalty_amount": str(
+                self.microstructure_stress_penalty_amount
+            ),
             "replay_quality_adjusted_window_net_pnl_per_day": str(
                 self.replay_quality_adjusted_window_net_pnl_per_day
             ),
@@ -403,8 +425,19 @@ def rank_replay_ledger_payload(
         total_filled_notional * lob_reality_gap_penalty_bps,
         Decimal("10000"),
     )
+    microstructure_stress = _microstructure_stress_summary(rows)
+    microstructure_stress_penalty_bps = cast(
+        Decimal, microstructure_stress["effective_replay_rank_penalty_bps"]
+    )
+    microstructure_stress_penalty_amount = _safe_divide(
+        total_filled_notional * microstructure_stress_penalty_bps,
+        Decimal("10000"),
+    )
     replay_quality_adjusted_window_net_pnl_per_day = _safe_divide(
-        total_net - execution_quality_penalty_amount - lob_reality_gap_penalty_amount,
+        total_net
+        - execution_quality_penalty_amount
+        - lob_reality_gap_penalty_amount
+        - microstructure_stress_penalty_amount,
         Decimal(window_weekday_count),
     )
     blockers = _promotion_blockers(
@@ -503,6 +536,15 @@ def rank_replay_ledger_payload(
         ),
         lob_reality_gap_penalty_bps=lob_reality_gap_penalty_bps,
         lob_reality_gap_penalty_amount=lob_reality_gap_penalty_amount,
+        microstructure_stress=microstructure_stress,
+        microstructure_stress_blockers=tuple(
+            cast(
+                tuple[str, ...],
+                microstructure_stress["microstructure_stress_blockers"],
+            )
+        ),
+        microstructure_stress_penalty_bps=microstructure_stress_penalty_bps,
+        microstructure_stress_penalty_amount=microstructure_stress_penalty_amount,
         replay_quality_adjusted_window_net_pnl_per_day=(
             replay_quality_adjusted_window_net_pnl_per_day
         ),
@@ -1001,6 +1043,131 @@ def _lob_reality_gap_stress_summary(
     }
 
 
+def _microstructure_stress_summary(
+    rows: Sequence[Mapping[str, object]],
+) -> Mapping[str, object]:
+    signal_rows = _lob_signal_rows(rows)
+    warnings: list[str] = []
+    if not signal_rows:
+        warnings.append("missing_microstructure_signal_rows")
+        adaptive_payload: dict[str, object] = {}
+        order_book_payload: dict[str, object] = {}
+        cluster_lob_payload: dict[str, object] = {}
+    else:
+        adaptive_payload = extract_adaptive_market_limit_allocation_stress(
+            signal_rows
+        ).to_payload()
+        order_book_payload = extract_order_book_observability_stress(
+            signal_rows,
+            max_notional=_max_single_fill_notional(rows),
+        ).to_payload()
+        cluster_lob_payload = extract_cluster_lob_features(signal_rows).to_payload()
+        warnings.extend(
+            f"adaptive_market_limit_{warning}"
+            for warning in _string_list(adaptive_payload.get("warnings"))
+        )
+        warnings.extend(
+            f"order_book_observability_{warning}"
+            for warning in _string_list(order_book_payload.get("warnings"))
+        )
+        warnings.extend(
+            f"cluster_lob_{warning}"
+            for warning in _string_list(cluster_lob_payload.get("warnings"))
+        )
+
+    adaptive_penalty_bps = _stress_penalty_bps(adaptive_payload)
+    order_book_penalty_bps = _stress_penalty_bps(order_book_payload)
+    cluster_warning_penalty_bps = Decimal(
+        len(_string_list(cluster_lob_payload.get("warnings")))
+    )
+    warning_penalty_bps = Decimal(len(_dedupe(warnings))) * Decimal("1.5")
+    effective_penalty_bps = min(
+        Decimal("250"),
+        (adaptive_penalty_bps * Decimal("0.5"))
+        + (order_book_penalty_bps * Decimal("0.5"))
+        + cluster_warning_penalty_bps
+        + warning_penalty_bps,
+    )
+    blockers = tuple(
+        f"microstructure_stress_{warning}" for warning in _dedupe(warnings)
+    )
+    return {
+        "schema_version": EXACT_REPLAY_MICROSTRUCTURE_STRESS_SCHEMA_VERSION,
+        "status": "preview_only_exact_replay_microstructure_stress_ranking",
+        "source_papers": _dedupe_source_papers(
+            (
+                adaptive_payload.get("source_papers"),
+                order_book_payload.get("source_papers"),
+                cluster_lob_payload.get("source_papers"),
+            )
+        ),
+        "stress_components": {
+            "adaptive_market_limit_allocation": _payload_object(adaptive_payload),
+            "order_book_observability": _payload_object(order_book_payload),
+            "cluster_lob": _payload_object(cluster_lob_payload),
+        },
+        "adaptive_market_limit_penalty_bps": adaptive_penalty_bps,
+        "order_book_observability_penalty_bps": order_book_penalty_bps,
+        "cluster_lob_warning_penalty_bps": cluster_warning_penalty_bps,
+        "microstructure_warning_penalty_bps": warning_penalty_bps,
+        "effective_replay_rank_penalty_bps": effective_penalty_bps,
+        "warnings": _dedupe(warnings),
+        "microstructure_stress_blockers": blockers,
+        "proof_neutrality": {
+            "research_ranking_only": True,
+            "prefilter_only": True,
+            "promotion_proof": False,
+            "proof_authority": False,
+            "promotion_authority": False,
+            "requires_exact_replay": True,
+            "requires_route_tca": True,
+            "requires_order_lifecycle_fill_evidence": True,
+            "requires_runtime_ledger": True,
+            "rejects_preview_stress_as_promotion_authority": True,
+        },
+        "research_ranking_only": True,
+        "prefilter_only": True,
+        "promotion_proof": False,
+        "proof_authority": False,
+        "promotion_authority": False,
+        "promotion_allowed": False,
+        "final_promotion_allowed": False,
+        "final_authority_ok": False,
+    }
+
+
+def _stress_penalty_bps(payload: Mapping[str, object]) -> Decimal:
+    for key in (
+        "replay_rank_penalty_bps",
+        "effective_replay_rank_penalty_bps",
+    ):
+        value = _decimal(payload.get(key))
+        if value is not None:
+            return max(Decimal("0"), value)
+    ranking_features = _mapping(payload.get("ranking_features"))
+    value = _decimal(ranking_features.get("replay_rank_penalty_bps"))
+    return max(Decimal("0"), value or Decimal("0"))
+
+
+def _dedupe_source_papers(
+    groups: Sequence[object],
+) -> list[Mapping[str, object]]:
+    seen: set[str] = set()
+    papers: list[Mapping[str, object]] = []
+    for group in groups:
+        if not isinstance(group, Sequence) or isinstance(group, (str, bytes)):
+            continue
+        for item in cast(Sequence[object], group):
+            if not isinstance(item, Mapping):
+                continue
+            source_id = _text(cast(Mapping[str, object], item).get("source_id"))
+            if not source_id or source_id in seen:
+                continue
+            seen.add(source_id)
+            papers.append(cast(Mapping[str, object], item))
+    return papers
+
+
 def _lob_signal_rows(
     rows: Sequence[Mapping[str, object]],
 ) -> tuple[SignalEnvelope, ...]:
@@ -1334,6 +1501,7 @@ def _ranking_sort_key(candidate: ReplayLedgerCandidateRanking) -> tuple[object, 
         -candidate.window_net_pnl_per_day,
         -candidate.total_net_pnl_after_costs,
         candidate.lob_reality_gap_penalty_bps,
+        candidate.microstructure_stress_penalty_bps,
         candidate.execution_quality_penalty_bps,
         candidate.best_day_share,
         candidate.max_drawdown,

--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -35,6 +35,7 @@ DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE = (
 DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCES = (
     DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCE,
     "runtime_ledger_paper_probation_import_plan",
+    "latest_closed_paper_route_runtime_window_targets",
     "next_paper_route_runtime_window_targets",
     "next_clean_paper_route_runtime_window_targets_after_discard",
 )
@@ -290,6 +291,10 @@ def _candidate_materialization_plans(
         (
             "runtime_ledger_paper_probation_import_plan",
             _to_str_map(payload.get("runtime_ledger_paper_probation_import_plan")),
+        ),
+        (
+            "latest_closed_paper_route_runtime_window_targets",
+            _to_str_map(payload.get("latest_closed_paper_route_runtime_window_targets")),
         ),
         (
             "next_paper_route_runtime_window_targets",

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -652,6 +652,11 @@ class TestLiveConfigManifestContract(TestCase):
         live_env = _load_torghut_knative_env()
 
         self.assertTrue(_manifest_bool(sim_env, "TRADING_ENABLED"))
+        self.assertEqual(
+            sim_env.get("SIM_DB_DSN"),
+            sim_env.get("DB_DSN"),
+            "sim evidence endpoints must expose SIM_DB_DSN because runtime-window import reads the sim paper-route evidence URL",
+        )
         self.assertEqual(sim_env.get("TRADING_MODE"), "paper")
         self.assertEqual(sim_env.get("TRADING_PIPELINE_MODE"), "simple")
         self.assertTrue(_manifest_bool(sim_env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
@@ -1224,7 +1229,9 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
         self.assertLess(args.index("dsn_env=SIM_DB_DSN"), args.index("dsn_env=DB_DSN"))
-        self.assertLess(args.index("--dsn-env SIM_DB_DSN"), args.index("--dsn-env DB_DSN"))
+        self.assertLess(
+            args.index("--dsn-env SIM_DB_DSN"), args.index("--dsn-env DB_DSN")
+        )
         self.assertIn("--older-than-seconds 900", args)
         self.assertIn("--batch-size 1000", args)
         self.assertIn("--max-batches 5", args)

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -1404,6 +1404,29 @@ def test_dynamic_plan_selection_prefers_sanitized_isolated_hpairs_plan() -> None
     ] == ["c88421d619759b2cfaa6f4d0"]
 
 
+def test_dynamic_plan_selection_prefers_latest_closed_plan_before_next_window() -> None:
+    payload = {
+        "latest_closed_paper_route_runtime_window_targets": _plan(
+            _hpairs_target(source_plan_ref="paper-route-plan:latest-closed")
+        ),
+        "next_paper_route_runtime_window_targets": _plan(
+            _hpairs_target(source_plan_ref="paper-route-plan:next-window")
+        ),
+    }
+
+    plan, selected_plan = cli._materialization_plan_from_payload(payload)
+
+    assert selected_plan == "latest_closed_paper_route_runtime_window_targets"
+    targets = cli.paper_route_target_plan_targets(plan)
+    assert [target["candidate_id"] for target in targets] == [
+        "c88421d619759b2cfaa6f4d0"
+    ]
+    assert targets[0]["source_plan_ref"] == "paper-route-plan:latest-closed"
+    assert "latest_closed_paper_route_runtime_window_targets" in (
+        cli.DEFAULT_DYNAMIC_SELECTED_PLAN_SOURCES
+    )
+
+
 def test_commit_dynamic_next_window_plan_blocks_when_confirmed_target_is_absent(
     monkeypatch: pytest.MonkeyPatch,
     sqlite_dsn: str,

--- a/services/torghut/tests/test_replay_ledger_ranker.py
+++ b/services/torghut/tests/test_replay_ledger_ranker.py
@@ -654,6 +654,48 @@ def test_lob_reality_gap_summary_fails_closed_without_signal_rows() -> None:
     )
 
 
+def test_microstructure_stress_summary_fails_closed_without_signal_rows() -> None:
+    summary = ranker._microstructure_stress_summary(
+        [{"symbol": "NVDA", "executed_at": "bad-date"}]
+    )
+
+    assert summary["source_papers"] == []
+    assert summary["stress_components"] == {
+        "adaptive_market_limit_allocation": {},
+        "order_book_observability": {},
+        "cluster_lob": {},
+    }
+    assert summary["adaptive_market_limit_penalty_bps"] == Decimal("0")
+    assert summary["order_book_observability_penalty_bps"] == Decimal("0")
+    assert summary["cluster_lob_warning_penalty_bps"] == Decimal("0")
+    assert summary["microstructure_warning_penalty_bps"] == Decimal("1.5")
+    assert summary["effective_replay_rank_penalty_bps"] == Decimal("1.5")
+    assert summary["microstructure_stress_blockers"] == (
+        "microstructure_stress_missing_microstructure_signal_rows",
+    )
+    assert summary["promotion_authority"] is False
+    assert summary["proof_authority"] is False
+
+
+def test_microstructure_helpers_cover_nested_penalties_and_source_dedupe() -> None:
+    assert ranker._stress_penalty_bps(
+        {"ranking_features": {"replay_rank_penalty_bps": "-7"}}
+    ) == Decimal("0")
+    assert ranker._stress_penalty_bps(
+        {"ranking_features": {"replay_rank_penalty_bps": "12.5"}}
+    ) == Decimal("12.5")
+
+    papers = ranker._dedupe_source_papers(
+        (
+            "not-a-paper-list",
+            [{"source_id": ""}, "not-a-paper", {"source_id": "paper-a"}],
+            [{"source_id": "paper-a"}, {"source_id": "paper-b"}],
+        )
+    )
+
+    assert [paper["source_id"] for paper in papers] == ["paper-a", "paper-b"]
+
+
 def test_lob_signal_rows_use_fallback_timestamps_and_ingest_fields() -> None:
     signals = ranker._lob_signal_rows(
         [

--- a/services/torghut/tests/test_replay_ledger_ranker.py
+++ b/services/torghut/tests/test_replay_ledger_ranker.py
@@ -157,6 +157,39 @@ def _with_lob_reality_gap_evidence(
     return rows
 
 
+def _with_microstructure_stress_evidence(
+    rows: list[dict[str, object]],
+    *,
+    fragile: bool = False,
+) -> list[dict[str, object]]:
+    for index, row in enumerate(rows):
+        if fragile:
+            row["order_type"] = "market"
+            row["fill_status"] = "filled"
+            row["order_qty"] = "1000"
+            row["fill_qty"] = "1000"
+            row["spread_bps"] = "24"
+            row["order_book_imbalance"] = "-0.70"
+            row["event_type"] = "trade"
+            row["bid_size"] = "20"
+            row["ask_size"] = "980"
+            row.pop("bid", None)
+            row.pop("ask", None)
+        else:
+            row["order_type"] = "limit"
+            row["fill_status"] = "filled"
+            row["order_qty"] = "1000"
+            row["fill_qty"] = "1000"
+            row["spread_bps"] = "2"
+            row["order_book_imbalance"] = "0.25"
+            row["event_type"] = ("add", "trade", "cancel")[index % 3]
+            row["bid"] = "99.99"
+            row["ask"] = "100.01"
+            row["bid_size"] = "600"
+            row["ask_size"] = "500"
+    return rows
+
+
 def _payload(
     candidate_id: str,
     rows: list[dict[str, object]],
@@ -517,6 +550,95 @@ def test_ranker_discounts_fragile_lob_reality_gap_candidates(
         item["source_id"] for item in fragile["lob_reality_gap_stress"]["source_papers"]
     }
     assert fragile["lob_reality_gap_stress"]["promotion_authority"] is False
+
+
+def test_ranker_discounts_microstructure_fragile_candidates(
+    tmp_path: Path,
+) -> None:
+    stable = _payload(
+        "stable-microstructure-lower-raw-pnl",
+        _with_microstructure_stress_evidence(
+            _with_execution_quality(
+                _round_trip(
+                    day=18,
+                    symbol="NVDA",
+                    qty="1000",
+                    buy_price="100",
+                    sell_price="100.90",
+                    prefix="stable-microstructure",
+                ),
+                order_type="limit",
+                shortfall_bps="1",
+                limit_fill_probability="0.82",
+                queue_position="0.15",
+                opportunity_cost_bps="2",
+                price_improvement_bps="3",
+            ),
+            fragile=False,
+        ),
+    )
+    fragile_raw_winner = _payload(
+        "fragile-microstructure-higher-raw-pnl",
+        _with_microstructure_stress_evidence(
+            _with_execution_quality(
+                _round_trip(
+                    day=18,
+                    symbol="NVDA",
+                    qty="1000",
+                    buy_price="100",
+                    sell_price="101.00",
+                    prefix="fragile-microstructure",
+                ),
+                order_type="market",
+                shortfall_bps="1",
+                limit_fill_probability="0.82",
+                queue_position="0.15",
+                opportunity_cost_bps="2",
+                price_improvement_bps="3",
+            ),
+            fragile=True,
+        ),
+    )
+    stable_path = tmp_path / "stable-microstructure.json"
+    fragile_path = tmp_path / "fragile-microstructure.json"
+    stable_path.write_text(json.dumps(stable))
+    fragile_path.write_text(json.dumps(fragile_raw_winner))
+
+    report = build_replay_ledger_ranking_report(
+        [stable_path, fragile_path],
+        policy=ReplayLedgerRankingPolicy(
+            target_net_pnl_per_day=Decimal("1"),
+            min_window_weekday_count=1,
+            min_avg_filled_notional_per_day=Decimal("1"),
+            max_best_day_share=Decimal("1.0"),
+            max_gross_exposure_pct_equity=Decimal("1000.0"),
+            start_equity=Decimal("100000000"),
+        ),
+    )
+    top = report["candidates"][0]
+    fragile = report["candidates"][1]
+
+    assert top["candidate_id"] == "stable-microstructure-lower-raw-pnl"
+    assert fragile["candidate_id"] == "fragile-microstructure-higher-raw-pnl"
+    assert Decimal(str(fragile["window_net_pnl_per_day"])) > Decimal(
+        str(top["window_net_pnl_per_day"])
+    )
+    assert Decimal(str(fragile["microstructure_stress_penalty_bps"])) > Decimal(
+        str(top["microstructure_stress_penalty_bps"])
+    )
+    assert Decimal(
+        str(top["replay_quality_adjusted_window_net_pnl_per_day"])
+    ) > Decimal(str(fragile["replay_quality_adjusted_window_net_pnl_per_day"]))
+    source_ids = {
+        item["source_id"] for item in fragile["microstructure_stress"]["source_papers"]
+    }
+    assert {
+        "arxiv-2504.20349",
+        "arxiv-2507.06345",
+        "arxiv-2605.19584",
+    }.issubset(source_ids)
+    assert fragile["microstructure_stress"]["promotion_authority"] is False
+    assert fragile["microstructure_stress"]["proof_authority"] is False
 
 
 def test_lob_reality_gap_summary_fails_closed_without_signal_rows() -> None:


### PR DESCRIPTION
## Summary

- Exposes `SIM_DB_DSN` on `torghut-sim` and keeps the sim evidence manifest from regressing to a missing source DSN.
- Adds exact-replay microstructure stress into replay ledger ranking so fragile LOB/order-book candidates are downranked before bounded paper collection.
- Lets bounded paper target materialization prefer `latest_closed_paper_route_runtime_window_targets` before next-window plans when the latest closed plan is equally materializable.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_replay_ledger_ranker.py tests/test_cluster_lob_features.py -q`
- `uv run --frozen pytest tests/test_fast_replay.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py tests/test_replay_ledger_ranker.py tests/test_cluster_lob_features.py tests/test_fast_replay.py -q`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q -k 'latest_closed or dynamic_plan_selection'`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen pytest tests/test_replay_ledger_ranker.py -q`
- `uv run --frozen pytest tests/test_replay_ledger_ranker.py tests/test_cluster_lob_features.py tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` after local coverage XML generation; failing file improved to `55/55` changed lines covered.
- `uv run --frozen ruff check app/trading/discovery/replay_ledger_ranker.py app/trading/discovery/cluster_lob_features.py tests/test_replay_ledger_ranker.py tests/test_cluster_lob_features.py tests/test_fast_replay.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen ruff check tests/test_replay_ledger_ranker.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
