### PR TITLE
fix(torghut): confirm latest closed materializer plans

### DIFF
--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -65,7 +65,7 @@ spec:
                     --confirm-dsn-env SIM_DB_DSN \
                     --confirm-hypothesis-id H-PAIRS-01 \
                     --confirm-runtime-strategy-name microbar-cross-sectional-pairs-v1 \
-                    --confirm-selected-plan-source live_submission_gate.runtime_ledger_paper_probation_import_plan,runtime_ledger_paper_probation_import_plan,next_paper_route_runtime_window_targets,next_clean_paper_route_runtime_window_targets_after_discard \
+                    --confirm-selected-plan-source live_submission_gate.runtime_ledger_paper_probation_import_plan,runtime_ledger_paper_probation_import_plan,latest_closed_paper_route_runtime_window_targets,next_paper_route_runtime_window_targets,next_clean_paper_route_runtime_window_targets_after_discard \
                     --confirm-target-count-min 1 \
                     --confirm-max-notional 75000 \
                     --operator-confirmation MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1539,6 +1539,7 @@ class TestLiveConfigManifestContract(TestCase):
             "--confirm-selected-plan-source "
             "live_submission_gate.runtime_ledger_paper_probation_import_plan,"
             "runtime_ledger_paper_probation_import_plan,"
+            "latest_closed_paper_route_runtime_window_targets,"
             "next_paper_route_runtime_window_targets,"
             "next_clean_paper_route_runtime_window_targets_after_discard",
             args,


### PR DESCRIPTION
## Summary

- Adds `latest_closed_paper_route_runtime_window_targets` to the bounded paper-route materializer CronJob's confirmed dynamic plan sources.
- Keeps the CronJob fail-closed while aligning its allow-list with the deployed materializer's latest-closed plan selection.
- Extends the live config manifest contract test so the GitOps confirmation list cannot silently drift again.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q -k bounded_paper_route_target_materialization_cronjob_is_sim_only`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
