### PR TITLE
fix(torghut): respect paper route plan source confirmations

### DIFF
--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -328,11 +328,15 @@ def _candidate_materialization_plans(
 
 def _materialization_plan_from_payload(
     payload: Mapping[str, Any],
+    *,
+    selected_plan_sources: set[str] | None = None,
 ) -> tuple[dict[str, Any], str | None]:
     best_plan: dict[str, Any] = {}
     best_source: str | None = None
     best_score = (-1, -1, -1, -1_000_000)
     for source, plan in _candidate_materialization_plans(payload):
+        if selected_plan_sources and source not in selected_plan_sources:
+            continue
         if not paper_route_target_plan_targets(plan):
             continue
         score = _plan_materialization_score(plan)
@@ -421,6 +425,9 @@ def _fetch_plan_url_payload(
 def _load_plan(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
     plan_file = cast(Path | None, args.plan_json)
     plan_url = _safe_text(args.plan_url)
+    selected_plan_sources = _confirmed_selected_plan_sources(
+        getattr(args, "confirm_selected_plan_source", None)
+    )
     if plan_file is None and plan_url is None:
         raise ValueError("paper_route_target_plan_source_required")
     if plan_file is not None and plan_url is not None:
@@ -428,7 +435,10 @@ def _load_plan(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]
 
     if plan_file is not None:
         payload = _load_json_file(plan_file)
-        plan, selected_plan = _materialization_plan_from_payload(payload)
+        plan, selected_plan = _materialization_plan_from_payload(
+            payload,
+            selected_plan_sources=selected_plan_sources,
+        )
         if not plan:
             plan = payload
         return (
@@ -449,7 +459,10 @@ def _load_plan(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]
     load_error = _safe_text(payload.get("load_error"))
     if load_error:
         raise ValueError(load_error)
-    plan, selected_plan = _materialization_plan_from_payload(payload)
+    plan, selected_plan = _materialization_plan_from_payload(
+        payload,
+        selected_plan_sources=selected_plan_sources,
+    )
     if not plan:
         raise ValueError("paper_route_target_plan_missing")
     return (

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -1427,6 +1427,75 @@ def test_dynamic_plan_selection_prefers_latest_closed_plan_before_next_window() 
     )
 
 
+def test_commit_dynamic_source_allowlist_selects_active_next_window_over_closed_latest(
+    monkeypatch: pytest.MonkeyPatch,
+    sqlite_dsn: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = {
+        "latest_closed_paper_route_runtime_window_targets": _plan(
+            _hpairs_target(
+                source_plan_ref="paper-route-plan:latest-closed",
+                window_start="2026-05-31T13:30:00+00:00",
+                window_end="2026-05-31T20:00:00+00:00",
+            )
+        ),
+        "next_paper_route_runtime_window_targets": _plan(
+            _hpairs_target(
+                target_notional="75000",
+                source_plan_ref="paper-route-plan:next-window",
+                window_start="2026-06-01T13:30:00+00:00",
+                window_end="2026-06-01T20:00:00+00:00",
+            )
+        ),
+    }
+    monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
+
+    exit_code, report = _run_cli(
+        [
+            "--plan-url",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--database-dsn-env",
+            "DB_DSN",
+            "--max-notional",
+            "75000",
+            "--commit",
+            "--allow-dynamic-target-plan",
+            "--skip-unless-active-target-window",
+            "--now-utc",
+            "2026-06-01T14:00:00+00:00",
+            "--confirm-account-label",
+            "TORGHUT_SIM",
+            "--confirm-dsn-env",
+            "DB_DSN",
+            "--confirm-hypothesis-id",
+            "H-PAIRS-01",
+            "--confirm-runtime-strategy-name",
+            "microbar-cross-sectional-pairs-v1",
+            "--confirm-selected-plan-source",
+            "next_paper_route_runtime_window_targets",
+            "--confirm-target-count-min",
+            "1",
+            "--confirm-max-notional",
+            "75000",
+            "--operator-confirmation",
+            cli.OPERATOR_CONFIRMATION,
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert report["plan_source"]["selected_plan"] == (
+        "next_paper_route_runtime_window_targets"
+    )
+    assert report["target_plan_refs"] == ["paper-route-plan:next-window"]
+    assert report["target_window_check"]["active"] is True
+    assert report["skipped"] is False
+    assert report["materialized"] is True
+    assert report["blockers"] == []
+    assert _count_decisions(sqlite_dsn) == 2
+
+
 def test_commit_dynamic_next_window_plan_blocks_when_confirmed_target_is_absent(
     monkeypatch: pytest.MonkeyPatch,
     sqlite_dsn: str,


### PR DESCRIPTION
## Summary

- Filters dynamic paper-route materialization candidates through the operator-confirmed plan-source allowlist before scoring.
- Prevents a closed/latest plan from winning selection when the active next-window source is the only confirmed source.
- Adds a regression test for URL payloads containing both a closed latest plan and an active next-window plan under commit materialization.

## Related Issues

None

## Testing

- `uv run --frozen ruff check scripts/materialize_bounded_paper_route_targets.py tests/test_materialize_bounded_paper_route_targets.py`
- `git diff --check`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
