### PR TITLE
fix(torghut): keep materializer on next-window plans

### DIFF
--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -65,7 +65,7 @@ spec:
                     --confirm-dsn-env SIM_DB_DSN \
                     --confirm-hypothesis-id H-PAIRS-01 \
                     --confirm-runtime-strategy-name microbar-cross-sectional-pairs-v1 \
-                    --confirm-selected-plan-source live_submission_gate.runtime_ledger_paper_probation_import_plan,runtime_ledger_paper_probation_import_plan,latest_closed_paper_route_runtime_window_targets,next_paper_route_runtime_window_targets,next_clean_paper_route_runtime_window_targets_after_discard \
+                    --confirm-selected-plan-source live_submission_gate.runtime_ledger_paper_probation_import_plan,runtime_ledger_paper_probation_import_plan,next_paper_route_runtime_window_targets,next_clean_paper_route_runtime_window_targets_after_discard \
                     --confirm-target-count-min 1 \
                     --confirm-max-notional 75000 \
                     --operator-confirmation MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1539,9 +1539,12 @@ class TestLiveConfigManifestContract(TestCase):
             "--confirm-selected-plan-source "
             "live_submission_gate.runtime_ledger_paper_probation_import_plan,"
             "runtime_ledger_paper_probation_import_plan,"
-            "latest_closed_paper_route_runtime_window_targets,"
             "next_paper_route_runtime_window_targets,"
             "next_clean_paper_route_runtime_window_targets_after_discard",
+            args,
+        )
+        self.assertNotIn(
+            "latest_closed_paper_route_runtime_window_targets",
             args,
         )
         self.assertIn("--confirm-target-count-min 1", args)


### PR DESCRIPTION
## Summary

- Removes `latest_closed_paper_route_runtime_window_targets` from the live bounded paper-route materializer source allowlist.
- Keeps the production CronJob constrained to probation/next-window materialization sources so closed-window plans cannot win selection.
- Updates the live manifest contract test to assert the closed/latest source stays out of the allowlist.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q -k bounded_paper_route`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `git diff --check`
- `bun run lint:argocd`
- `uv run --frozen pyright --project pyrightconfig.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
