### PR TITLE
ci(torghut): decouple agents automerge checks

### DIFF
--- a/.github/workflows/agents-deploy-automerge.yml
+++ b/.github/workflows/agents-deploy-automerge.yml
@@ -7,6 +7,9 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths:
+      - 'argocd/applications/agents/values.yaml'
+      - '.github/workflows/agents-deploy-automerge.yml'
 
 jobs:
   enable:

--- a/.github/workflows/jangar-deploy-automerge.yml
+++ b/.github/workflows/jangar-deploy-automerge.yml
@@ -7,6 +7,10 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths:
+      - 'argocd/applications/jangar/kustomization.yaml'
+      - 'argocd/applications/jangar/deployment.yaml'
+      - '.github/workflows/jangar-deploy-automerge.yml'
 
 jobs:
   enable:

--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -9,6 +9,15 @@ on:
       - ready_for_review
       - labeled
       - unlabeled
+    paths:
+      - 'argocd/applications/proompteng/kustomization.yaml'
+      - 'argocd/applications/synthesis/kustomization.yaml'
+      - 'argocd/applications/bumba/kustomization.yaml'
+      - 'argocd/applications/khoshut/kustomization.yaml'
+      - 'argocd/applications/analysis/kustomization.yaml'
+      - 'argocd/applications/bilig/kustomization.yaml'
+      - 'argocd/applications/olden/kustomization.yaml'
+      - '.github/workflows/release-pr-automerge.yml'
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/symphony-deploy-automerge.yml
+++ b/.github/workflows/symphony-deploy-automerge.yml
@@ -7,6 +7,14 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths:
+      - 'argocd/applications/symphony/kustomization.yaml'
+      - 'argocd/applications/symphony/deployment.patch.yaml'
+      - 'argocd/applications/symphony-jangar/kustomization.yaml'
+      - 'argocd/applications/symphony-jangar/deployment.patch.yaml'
+      - 'argocd/applications/symphony-torghut/kustomization.yaml'
+      - 'argocd/applications/symphony-torghut/deployment.patch.yaml'
+      - '.github/workflows/symphony-deploy-automerge.yml'
 
 jobs:
   enable:

--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -9,6 +9,27 @@ on:
       - ready_for_review
       - labeled
       - unlabeled
+    paths:
+      - 'argocd/applications/torghut/knative-service.yaml'
+      - 'argocd/applications/torghut/knative-service-sim.yaml'
+      - 'argocd/applications/torghut/db-migrations-job.yaml'
+      - 'argocd/applications/torghut/historical-simulation-workflowtemplate.yaml'
+      - 'argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml'
+      - 'argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml'
+      - 'argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml'
+      - 'argocd/applications/torghut/analysis-template-runtime-ready.yaml'
+      - 'argocd/applications/torghut/analysis-template-activity.yaml'
+      - 'argocd/applications/torghut/analysis-template-teardown-clean.yaml'
+      - 'argocd/applications/torghut/analysis-template-artifact-bundle.yaml'
+      - 'argocd/applications/torghut/empirical-jobs-backfill-job.yaml'
+      - 'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml'
+      - 'argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml'
+      - 'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
+      - 'argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml'
+      - 'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
+      - 'argocd/applications/torghut/tigerbeetle-smoke-job.yaml'
+      - 'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml'
+      - '.github/workflows/torghut-deploy-automerge.yml'
 
 permissions:
   contents: write

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - agents-domain
   - postgres-cluster.yaml
   - cnpg-torghut-db-objectbucketclaim.yaml
   - postgres-scheduled-backup.yaml


### PR DESCRIPTION
## Summary

- Add path filters to deploy-automerge pull_request_target workflows so unrelated PRs stop creating skipped Agents, Jangar, Symphony, or generic release checks.
- Remove `agents-domain` from the Torghut GitOps kustomization so the live Torghut app no longer renders Agent, AgentRun, or AgentProvider resources.
- Keep Torghut deploy automerge scoped to Torghut release manifest paths.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "ok #{p}" }' .github/workflows/agents-deploy-automerge.yml .github/workflows/jangar-deploy-automerge.yml .github/workflows/symphony-deploy-automerge.yml .github/workflows/torghut-deploy-automerge.yml .github/workflows/release-pr-automerge.yml argocd/applications/torghut/kustomization.yaml`
- `kustomize build argocd/applications/torghut >/tmp/torghut-kustomize.yaml` and `rg -n "^(kind: (Agent|AgentRun|AgentProvider)|  name: torghut-health-agent|agents\.proompteng\.ai|agents-domain)" /tmp/torghut-kustomize.yaml || true`
- `uv sync --frozen --extra dev` in `services/torghut`
- `uv run --frozen pytest tests/test_torghut_release_workflow_manifest_paths.py -q`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

Torghut no longer deploys the `agents-domain` resources. After this merges and Argo syncs, previously rendered Torghut Agent, AgentRun, and AgentProvider resources are expected to be pruned from the live app ownership set.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
