### PR TITLE
fix(torghut): reserve paper account during baseline wait

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -134,6 +134,10 @@ _BOUNDED_SIM_COLLECTION_BLOCKER_FIELDS = (
 _BOUNDED_SIM_COLLECTION_RESERVATION_BLOCKERS = frozenset(
     {
         "paper_route_target_account_audit_unavailable",
+        "paper_route_account_pre_session_snapshot_missing",
+        "paper_route_account_pre_session_snapshot_stale",
+        "paper_route_account_window_start_snapshot_missing",
+        "paper_route_clean_window_baseline_snapshot_pending",
         "paper_route_account_contamination_detected",
         "unlinked_order_events_present",
     }

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -2156,6 +2156,54 @@ def test_target_account_audit_unavailable_still_reserves_paper_account(
         settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
 
 
+def test_pending_clean_window_baseline_still_reserves_paper_account(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    try:
+        settings.trading_mode = "paper"
+        settings.trading_simple_paper_route_probe_enabled = True
+        now = datetime(2026, 6, 5, 13, 45, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            paper_route_probe_window_start="2026-06-05T13:30:00+00:00",
+            paper_route_probe_window_end="2026-06-05T20:00:00+00:00",
+            evidence_collection_ok=False,
+            canary_collection_authorized=False,
+            bounded_evidence_collection_authorized=False,
+            bounded_live_paper_collection_authorized=False,
+            bounded_evidence_collection_blockers=[
+                "paper_route_clean_window_baseline_snapshot_pending",
+            ],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "TORGHUT_SIM"
+        pipeline._is_market_session_open = lambda _now: True
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+            {"AAPL", "AMZN"},
+            None,
+            [target],
+        )
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        blockers = _bounded_sim_collection_blockers(
+            target,
+            account_label="TORGHUT_SIM",
+        )
+
+        assert "bounded_sim_collection_evidence_collection_not_ready" in blockers
+        assert "paper_route_clean_window_baseline_snapshot_pending" in blockers
+        assert pipeline._paper_route_target_plan_reserves_account(
+            allowed_symbols={"NVDA", "INTC"},
+        )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+
+
 def test_target_runtime_account_and_window_helpers_cover_identity_edges() -> None:
     target = {
         "account_label": "OTHER",


### PR DESCRIPTION
## Summary

- Reserves the bounded Torghut SIM paper account while the clean-window baseline snapshot is still pending.
- Treats pre-session/window-start snapshot blockers as account-reservation blockers so normal simple-lane strategies cannot contaminate the proof window.
- Adds a regression test for an active H-PAIRS target whose source decision is ready but collection authorization is still waiting on the clean baseline.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_simple_pipeline.py -k 'pending_clean_window_baseline or target_account_audit_unavailable_still_reserves_paper_account or target_plan_fetch_error_reserves_configured_paper_account'`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py`
- `uv run --frozen pytest tests/test_simple_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
