### PR TITLE
fix(torghut): rank selected execution policy lineage

### DIFF
--- a/services/torghut/app/trading/tca.py
+++ b/services/torghut/app/trading/tca.py
@@ -73,9 +73,11 @@ _EXECUTION_POLICY_HASH_KEYS = (
     "execution_policy_sha256",
     "policy_hash",
 )
-_EXECUTION_POLICY_PAYLOAD_KEYS = (
+_EXECUTION_POLICY_PRIMARY_PAYLOAD_KEYS = (
     "execution_policy",
     "execution_policy_context",
+)
+_EXECUTION_POLICY_ADVISORY_PAYLOAD_KEYS = (
     "execution_advisor",
     "_execution_advice_provenance",
 )
@@ -658,11 +660,21 @@ def _execution_policy_hash_candidates(
     payload_hashes = _hash_candidates(
         source_payloads,
         hash_keys=(),
-        payload_keys=_EXECUTION_POLICY_PAYLOAD_KEYS,
+        payload_keys=_EXECUTION_POLICY_PRIMARY_PAYLOAD_KEYS,
     )
     if payload_hashes:
         if len(payload_hashes) == 1:
             source_fields["execution_policy_hash"] = "execution_policy_payload"
+        return payload_hashes
+
+    payload_hashes = _hash_candidates(
+        source_payloads,
+        hash_keys=(),
+        payload_keys=_EXECUTION_POLICY_ADVISORY_PAYLOAD_KEYS,
+    )
+    if payload_hashes:
+        if len(payload_hashes) == 1:
+            source_fields["execution_policy_hash"] = "execution_policy_advisor_payload"
         return payload_hashes
 
     decision_policy_hash = _decision_execution_policy_hash(

--- a/services/torghut/tests/test_execution_tca.py
+++ b/services/torghut/tests/test_execution_tca.py
@@ -447,6 +447,123 @@ class TestExecutionTcaCostLineage(TestCase):
             "execution_policy_hash",
         )
 
+    def test_upsert_prefers_selected_policy_payload_over_advisor_context(
+        self,
+    ) -> None:
+        with self.session_local() as session:
+            strategy = self._insert_strategy(session)
+            decision = self._insert_decision(
+                session,
+                strategy,
+                decision_hash="advisor-context-decision",
+                execution_policy={
+                    "approved": True,
+                    "selected_order_type": "market",
+                    "adaptive": {
+                        "key": "AAPL:range",
+                        "applied": False,
+                        "sample_size": 0,
+                    },
+                },
+                decision_json={
+                    "strategy_id": str(strategy.id),
+                    "symbol": "AAPL",
+                    "action": "buy",
+                    "qty": "10",
+                    "order_type": "market",
+                    "time_in_force": "day",
+                    "submit_path": "direct_alpaca",
+                    "params": {
+                        "price": "100",
+                        "execution_policy": {
+                            "approved": True,
+                            "selected_order_type": "market",
+                            "adaptive": {
+                                "key": "AAPL:range",
+                                "applied": False,
+                                "sample_size": 0,
+                            },
+                        },
+                    },
+                    "execution_advisor": {
+                        "enabled": False,
+                        "applied": False,
+                        "fallback_reason": "advisor_disabled",
+                        "preferred_order_type": None,
+                    },
+                },
+            )
+            execution = self._insert_execution(
+                session,
+                decision,
+                order_id="advisor-context-order",
+                raw_order={
+                    "commission": "0.02",
+                    "cost_model": {"source": "broker_reported_commission"},
+                },
+            )
+
+            upsert_execution_tca_metric(session, execution)
+            session.flush()
+            lineage = self._lineage(execution)
+
+        self.assertEqual(lineage["status"], "source_backed")
+        self.assertNotIn("execution_policy_hash_ambiguous", lineage["blockers"])
+        self.assertIsInstance(lineage["execution_policy_hash"], str)
+        self.assertEqual(
+            lineage["source_fields"]["execution_policy_hash"],
+            "execution_policy_payload",
+        )
+
+    def test_upsert_uses_advisor_policy_payload_when_selected_policy_missing(
+        self,
+    ) -> None:
+        with self.session_local() as session:
+            strategy = self._insert_strategy(session)
+            decision = self._insert_decision(
+                session,
+                strategy,
+                decision_hash="advisor-only-decision",
+                execution_policy=None,
+                decision_json={
+                    "strategy_id": str(strategy.id),
+                    "symbol": "AAPL",
+                    "action": "buy",
+                    "qty": "10",
+                    "order_type": "market",
+                    "time_in_force": "day",
+                    "submit_path": "direct_alpaca",
+                    "params": {"price": "100"},
+                    "execution_advisor": {
+                        "enabled": False,
+                        "applied": False,
+                        "fallback_reason": "advisor_disabled",
+                        "preferred_order_type": None,
+                    },
+                },
+            )
+            execution = self._insert_execution(
+                session,
+                decision,
+                order_id="advisor-only-order",
+                raw_order={
+                    "commission": "0.02",
+                    "cost_model": {"source": "broker_reported_commission"},
+                },
+            )
+
+            upsert_execution_tca_metric(session, execution)
+            session.flush()
+            lineage = self._lineage(execution)
+
+        self.assertEqual(lineage["status"], "source_backed")
+        self.assertNotIn("execution_policy_hash_missing", lineage["blockers"])
+        self.assertIsInstance(lineage["execution_policy_hash"], str)
+        self.assertEqual(
+            lineage["source_fields"]["execution_policy_hash"],
+            "execution_policy_advisor_payload",
+        )
+
     def test_upsert_blocks_ambiguous_policy_and_cost_model_hashes(self) -> None:
         with self.session_local() as session:
             strategy = self._insert_strategy(session)


### PR DESCRIPTION
## Summary

- Rank selected execution policy payloads ahead of advisory/provenance payloads when deriving TCA policy hashes.
- Keep explicit policy hashes as the highest-authority source and preserve ambiguity blockers for conflicting selected policy payloads.
- Add a regression for live-shaped decisions that carry both `execution_policy` and disabled `execution_advisor` context.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_execution_tca.py -q -k 'prefers_selected_policy_payload_over_advisor_context'` (failed before the fix)
- `uv run --frozen pytest tests/test_execution_tca.py -q -k 'prefers_selected_policy_payload_over_advisor_context or blocks_ambiguous_policy_and_cost_model_hashes or prefers_explicit_policy_hash'`
- `uv run --frozen pytest tests/test_execution_tca.py -q`
- `uv run --frozen ruff format --check app/trading/tca.py tests/test_execution_tca.py`
- `uv run --frozen ruff check app/trading/tca.py tests/test_execution_tca.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
