### PR TITLE
fix(torghut): verify flatten target-plan readback

### DIFF
--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -43,6 +43,15 @@ spec:
                 - |
                   set -euo pipefail
                   cd /app
+                  target_plan_readback_args=()
+                  if /opt/venv/bin/python scripts/flatten_paper_account_positions.py --help \
+                    | grep -q -- '--target-plan-readback-url'; then
+                    target_plan_readback_args=(
+                      --target-plan-readback-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan
+                      --target-plan-readback-timeout-seconds 10
+                      --require-target-plan-readback-clean
+                    )
+                  fi
                   /opt/venv/bin/python scripts/flatten_paper_account_positions.py \
                     --account-label TORGHUT_SIM \
                     --expected-account-label TORGHUT_SIM \
@@ -56,6 +65,7 @@ spec:
                     --wait-flat-seconds 120 \
                     --poll-seconds 10 \
                     --persist-snapshot \
+                    "${target_plan_readback_args[@]}" \
                     --persist-lineage \
                     --apply \
                     --json

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -8,6 +8,8 @@ import hashlib
 import json
 import os
 import time
+import urllib.error
+import urllib.request
 from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -45,6 +47,9 @@ FLATTEN_CLOSE_DECISION_SCHEMA_VERSION = (
 LINEAGE_LINKED_STATUS = "linked_source_lineage"
 LINEAGE_UNLINKED_STATUS = "unlinked_no_source_lineage"
 LINEAGE_PERSIST_FAILED_STATUS = "lineage_persist_failed"
+TARGET_PLAN_READBACK_SCHEMA_VERSION = (
+    "torghut.paper-account-flatten-target-plan-readback.v1"
+)
 
 
 class PaperFlattenClient(Protocol):
@@ -155,6 +160,29 @@ def _parse_args() -> argparse.Namespace:
         help="Persist a fresh PositionSnapshot after the flatten attempt for runtime-window readiness gates.",
     )
     parser.add_argument(
+        "--target-plan-readback-url",
+        default="",
+        help=(
+            "Optional /trading/paper-route-target-plan URL to read after snapshot "
+            "persistence so the job output proves whether the clean-window baseline "
+            "gate sees the snapshot."
+        ),
+    )
+    parser.add_argument(
+        "--target-plan-readback-timeout-seconds",
+        type=float,
+        default=10.0,
+        help="HTTP timeout for --target-plan-readback-url.",
+    )
+    parser.add_argument(
+        "--require-target-plan-readback-clean",
+        action="store_true",
+        help=(
+            "Return non-zero when target-plan readback is requested but the matching "
+            "paper-route clean-window baseline is not clean and source-auditable."
+        ),
+    )
+    parser.add_argument(
         "--persist-lineage",
         action="store_true",
         help=(
@@ -184,6 +212,228 @@ def _sqlalchemy_dsn(dsn: str) -> str:
     if text.startswith("postgresql://"):
         return text.replace("postgresql://", "postgresql+psycopg://", 1)
     return text
+
+
+def _as_mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_sequence(value: object) -> Sequence[object]:
+    if isinstance(value, str | bytes):
+        return []
+    return value if isinstance(value, Sequence) else []
+
+
+def _safe_text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _readback_blockers(value: object) -> list[str]:
+    blockers: list[str] = []
+    for item in _as_sequence(value):
+        text = _safe_text(item)
+        if text and text not in blockers:
+            blockers.append(text)
+    return blockers
+
+
+def _target_plan_readback_plans(
+    payload: Mapping[str, Any],
+) -> list[tuple[str, Mapping[str, Any]]]:
+    plans: list[tuple[str, Mapping[str, Any]]] = [("top_level", payload)]
+    for key in (
+        "next_paper_route_runtime_window_targets",
+        "runtime_window_import_plan",
+        "next_clean_paper_route_runtime_window_targets_after_discard",
+    ):
+        plan = _as_mapping(payload.get(key))
+        if plan:
+            plans.append((key, plan))
+    return plans
+
+
+def _target_plan_readback_targets(
+    payload: Mapping[str, Any],
+) -> tuple[str, Mapping[str, Any], list[Mapping[str, Any]]]:
+    fallback_plan_name = "top_level"
+    fallback_plan = payload
+    for plan_name, plan in _target_plan_readback_plans(payload):
+        targets = [
+            item
+            for item in (_as_mapping(raw) for raw in _as_sequence(plan.get("targets")))
+            if item
+        ]
+        if targets:
+            return plan_name, plan, targets
+        fallback_plan_name = plan_name
+        fallback_plan = plan
+    return fallback_plan_name, fallback_plan, []
+
+
+def _target_plan_target_account_label(target: Mapping[str, Any]) -> str:
+    for key in (
+        "account_label",
+        "source_account_label",
+        "paper_route_account_label",
+        "runtime_account_label",
+    ):
+        text = _safe_text(target.get(key))
+        if text:
+            return text
+    return ""
+
+
+def _target_plan_target_matches_account(
+    target: Mapping[str, Any],
+    account_label: str,
+) -> bool:
+    normalized_account = account_label.strip().upper()
+    if not normalized_account:
+        return True
+    return _target_plan_target_account_label(target).upper() == normalized_account
+
+
+def _target_plan_baseline_readback(
+    target: Mapping[str, Any],
+) -> dict[str, object]:
+    baseline = _as_mapping(target.get("paper_route_clean_window_baseline_state"))
+    blockers = _readback_blockers(
+        target.get("paper_route_clean_window_baseline_blockers")
+    )
+    if not blockers:
+        blockers = _readback_blockers(baseline.get("blockers"))
+    state = _safe_text(baseline.get("state")) or _safe_text(
+        target.get("paper_route_clean_window_state")
+    )
+    return {
+        "candidate_id": _safe_text(target.get("candidate_id")),
+        "account_label": _target_plan_target_account_label(target),
+        "window_start": _safe_text(target.get("window_start")),
+        "window_end": _safe_text(target.get("window_end")),
+        "state": state or "unknown",
+        "snapshot_id": _safe_text(baseline.get("snapshot_id")),
+        "snapshot_as_of": _safe_text(baseline.get("snapshot_as_of")),
+        "source_auditable": bool(baseline.get("source_auditable")),
+        "blockers": blockers,
+    }
+
+
+def read_target_plan_clean_window_readback(
+    *,
+    url: str,
+    account_label: str,
+    snapshot_id: str | None,
+    timeout_seconds: float,
+) -> dict[str, object]:
+    normalized_url = url.strip()
+    base_payload: dict[str, object] = {
+        "schema_version": TARGET_PLAN_READBACK_SCHEMA_VERSION,
+        "url": normalized_url,
+        "account_label": account_label,
+        "position_snapshot_id": snapshot_id,
+        "state": "not_requested",
+        "http_status": None,
+        "plan_source": None,
+        "target_count": 0,
+        "matching_target_count": 0,
+        "clean_matching_target_count": 0,
+        "persisted_snapshot_seen": False,
+        "clean_window_baseline_readiness": {},
+        "targets": [],
+        "blockers": [],
+    }
+    if not normalized_url:
+        return base_payload
+
+    try:
+        request = urllib.request.Request(
+            normalized_url,
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(
+            request,
+            timeout=max(0.1, float(timeout_seconds or 0.1)),
+        ) as response:
+            http_status = int(getattr(response, "status", 200))
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        return {
+            **base_payload,
+            "state": "blocked",
+            "http_status": int(exc.code),
+            "error": str(exc.reason or exc),
+            "blockers": ["paper_route_target_plan_readback_http_error"],
+        }
+    except (OSError, TimeoutError, ValueError, urllib.error.URLError) as exc:
+        return {
+            **base_payload,
+            "state": "blocked",
+            "error": str(exc),
+            "blockers": ["paper_route_target_plan_readback_failed"],
+        }
+
+    try:
+        decoded = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return {
+            **base_payload,
+            "state": "blocked",
+            "http_status": http_status,
+            "error": str(exc),
+            "blockers": ["paper_route_target_plan_readback_json_invalid"],
+        }
+    if not isinstance(decoded, Mapping):
+        return {
+            **base_payload,
+            "state": "blocked",
+            "http_status": http_status,
+            "blockers": ["paper_route_target_plan_readback_payload_invalid"],
+        }
+
+    plan_source, plan, targets = _target_plan_readback_targets(decoded)
+    matching_targets = [
+        target
+        for target in targets
+        if _target_plan_target_matches_account(target, account_label)
+    ]
+    readback_targets = [
+        _target_plan_baseline_readback(target) for target in matching_targets
+    ]
+    clean_targets = [
+        target
+        for target in readback_targets
+        if target.get("state") == "clean" and not target.get("blockers")
+    ]
+    persisted_snapshot_seen = bool(
+        snapshot_id
+        and any(target.get("snapshot_id") == snapshot_id for target in readback_targets)
+    )
+    summary = _as_mapping(plan.get("clean_window_baseline_readiness"))
+    blockers = _readback_blockers(summary.get("blockers"))
+    for target in readback_targets:
+        for blocker in _readback_blockers(target.get("blockers")):
+            if blocker not in blockers:
+                blockers.append(blocker)
+    if not matching_targets:
+        blockers.append("paper_route_target_plan_readback_target_missing")
+    if matching_targets and len(clean_targets) != len(matching_targets):
+        blockers.append("paper_route_target_plan_clean_window_baseline_not_clean")
+    if snapshot_id and matching_targets and not persisted_snapshot_seen:
+        blockers.append("paper_route_target_plan_readback_snapshot_id_mismatch")
+    blockers = sorted(dict.fromkeys(blockers))
+    return {
+        **base_payload,
+        "state": "clean" if matching_targets and not blockers else "blocked",
+        "http_status": http_status,
+        "plan_source": plan_source,
+        "target_count": len(targets),
+        "matching_target_count": len(matching_targets),
+        "clean_matching_target_count": len(clean_targets),
+        "persisted_snapshot_seen": persisted_snapshot_seen,
+        "clean_window_baseline_readiness": dict(summary),
+        "targets": readback_targets,
+        "blockers": blockers,
+    }
 
 
 def _session_factory_from_env(
@@ -1014,6 +1264,25 @@ def main() -> int:
                 payload["position_snapshot_skipped"] = (
                     "paper_account_label_or_mode_guard_failed"
                 )
+        if args.target_plan_readback_url or args.require_target_plan_readback_clean:
+            readback = read_target_plan_clean_window_readback(
+                url=str(args.target_plan_readback_url or ""),
+                account_label=str(args.account_label or ""),
+                snapshot_id=(
+                    str(payload["position_snapshot_id"])
+                    if payload.get("position_snapshot_id")
+                    else None
+                ),
+                timeout_seconds=max(
+                    0.1,
+                    float(args.target_plan_readback_timeout_seconds or 0.1),
+                ),
+            )
+            payload["target_plan_readback"] = readback
+            payload["target_plan_readback_required_clean"] = bool(
+                args.require_target_plan_readback_clean
+            )
+            payload["target_plan_readback_clean"] = readback.get("state") == "clean"
     finally:
         if session_engine is not None:
             session_engine.dispose()
@@ -1024,7 +1293,13 @@ def main() -> int:
             f"status={payload['status']} positions={payload['position_count']} "
             f"submitted={payload['submitted_order_count']} blockers={','.join(payload['blockers'])}"
         )
-    return 0 if payload["status"] in TERMINAL_CLEAN_STATUSES else 2
+    if payload["status"] not in TERMINAL_CLEAN_STATUSES:
+        return 2
+    if bool(payload.get("target_plan_readback_required_clean")) and not bool(
+        payload.get("target_plan_readback_clean")
+    ):
+        return 3
+    return 0
 
 
 if __name__ == "__main__":

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -134,6 +134,36 @@ class FakeSessionContext:
         return None
 
 
+class FakeHttpResponse:
+    def __init__(self, payload: object, status: int = 200) -> None:
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self) -> "FakeHttpResponse":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class FakeBytesResponse:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self.body = body
+        self.status = status
+
+    def __enter__(self) -> "FakeBytesResponse":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.body
+
+
 def _memory_session() -> Session:
     engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
     Base.metadata.create_all(engine)
@@ -965,6 +995,11 @@ class TestFlattenPaperAccountPositions(TestCase):
             "--poll-seconds",
             "3",
             "--persist-snapshot",
+            "--target-plan-readback-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--target-plan-readback-timeout-seconds",
+            "2",
+            "--require-target-plan-readback-clean",
             "--persist-lineage",
             "--apply",
             "--json",
@@ -985,6 +1020,12 @@ class TestFlattenPaperAccountPositions(TestCase):
         self.assertEqual(args.wait_flat_seconds, 45)
         self.assertEqual(args.poll_seconds, 3)
         self.assertTrue(args.persist_snapshot)
+        self.assertEqual(
+            args.target_plan_readback_url,
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+        )
+        self.assertEqual(args.target_plan_readback_timeout_seconds, 2)
+        self.assertTrue(args.require_target_plan_readback_clean)
         self.assertTrue(args.persist_lineage)
         self.assertTrue(args.apply)
         self.assertTrue(args.json)
@@ -1086,6 +1127,268 @@ class TestFlattenPaperAccountPositions(TestCase):
             "2026-05-31T06:35:00+00:00",
         )
         snapshot_account.assert_called_once()
+
+    def test_target_plan_readback_proves_clean_matching_snapshot(self) -> None:
+        target_plan = {
+            "schema_version": "torghut.paper-route-target-plan.v1",
+            "next_paper_route_runtime_window_targets": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "clean_window_baseline_readiness": {
+                    "state": "clean",
+                    "blockers": [],
+                },
+                "targets": [
+                    {
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "window_start": "2026-06-05T13:30:00+00:00",
+                        "window_end": "2026-06-05T20:00:00+00:00",
+                        "paper_route_clean_window_baseline_state": {
+                            "state": "clean",
+                            "snapshot_id": "snapshot-1",
+                            "snapshot_as_of": "2026-06-05T13:16:00+00:00",
+                            "source_auditable": True,
+                            "blockers": [],
+                        },
+                        "paper_route_clean_window_baseline_blockers": [],
+                    }
+                ],
+            },
+        }
+
+        with patch.object(
+            flatten_script.urllib.request,
+            "urlopen",
+            return_value=FakeHttpResponse(target_plan),
+        ):
+            readback = flatten_script.read_target_plan_clean_window_readback(
+                url="http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+                account_label="TORGHUT_SIM",
+                snapshot_id="snapshot-1",
+                timeout_seconds=2,
+            )
+
+        self.assertEqual(readback["state"], "clean")
+        self.assertEqual(
+            readback["plan_source"], "next_paper_route_runtime_window_targets"
+        )
+        self.assertEqual(readback["matching_target_count"], 1)
+        self.assertEqual(readback["clean_matching_target_count"], 1)
+        self.assertTrue(readback["persisted_snapshot_seen"])
+        self.assertEqual(readback["blockers"], [])
+
+    def test_target_plan_readback_fail_closed_edge_cases(self) -> None:
+        self.assertEqual(flatten_script._as_sequence("not-a-list"), [])
+        self.assertEqual(
+            flatten_script._target_plan_readback_targets({"targets": []}),
+            ("top_level", {"targets": []}, []),
+        )
+        self.assertEqual(flatten_script._target_plan_target_account_label({}), "")
+        self.assertTrue(flatten_script._target_plan_target_matches_account({}, ""))
+
+        not_requested = flatten_script.read_target_plan_clean_window_readback(
+            url="",
+            account_label="TORGHUT_SIM",
+            snapshot_id=None,
+            timeout_seconds=1,
+        )
+        self.assertEqual(not_requested["state"], "not_requested")
+
+        http_error = flatten_script.urllib.error.HTTPError(
+            "http://torghut-sim",
+            503,
+            "service unavailable",
+            hdrs=None,
+            fp=None,
+        )
+        with patch.object(
+            flatten_script.urllib.request,
+            "urlopen",
+            side_effect=http_error,
+        ):
+            readback = flatten_script.read_target_plan_clean_window_readback(
+                url="http://torghut-sim",
+                account_label="TORGHUT_SIM",
+                snapshot_id=None,
+                timeout_seconds=1,
+            )
+        self.assertEqual(readback["http_status"], 503)
+        self.assertEqual(
+            readback["blockers"], ["paper_route_target_plan_readback_http_error"]
+        )
+
+        with patch.object(
+            flatten_script.urllib.request,
+            "urlopen",
+            side_effect=OSError("connection refused"),
+        ):
+            readback = flatten_script.read_target_plan_clean_window_readback(
+                url="http://torghut-sim",
+                account_label="TORGHUT_SIM",
+                snapshot_id=None,
+                timeout_seconds=1,
+            )
+        self.assertEqual(
+            readback["blockers"], ["paper_route_target_plan_readback_failed"]
+        )
+
+        with patch.object(
+            flatten_script.urllib.request,
+            "urlopen",
+            return_value=FakeBytesResponse(b"{"),
+        ):
+            readback = flatten_script.read_target_plan_clean_window_readback(
+                url="http://torghut-sim",
+                account_label="TORGHUT_SIM",
+                snapshot_id=None,
+                timeout_seconds=1,
+            )
+        self.assertEqual(
+            readback["blockers"], ["paper_route_target_plan_readback_json_invalid"]
+        )
+
+        with patch.object(
+            flatten_script.urllib.request,
+            "urlopen",
+            return_value=FakeHttpResponse(["not", "a", "mapping"]),
+        ):
+            readback = flatten_script.read_target_plan_clean_window_readback(
+                url="http://torghut-sim",
+                account_label="TORGHUT_SIM",
+                snapshot_id=None,
+                timeout_seconds=1,
+            )
+        self.assertEqual(
+            readback["blockers"], ["paper_route_target_plan_readback_payload_invalid"]
+        )
+
+        target_only_blocker_plan = {
+            "targets": [
+                {
+                    "candidate_id": "candidate-1",
+                    "account_label": "TORGHUT_SIM",
+                    "paper_route_clean_window_baseline_state": {
+                        "state": "blocked",
+                        "blockers": ["target_only_clean_window_blocker"],
+                    },
+                }
+            ],
+            "clean_window_baseline_readiness": {"state": "unknown", "blockers": []},
+        }
+        with patch.object(
+            flatten_script.urllib.request,
+            "urlopen",
+            return_value=FakeHttpResponse(target_only_blocker_plan),
+        ):
+            readback = flatten_script.read_target_plan_clean_window_readback(
+                url="http://torghut-sim",
+                account_label="TORGHUT_SIM",
+                snapshot_id=None,
+                timeout_seconds=1,
+            )
+        self.assertIn("target_only_clean_window_blocker", readback["blockers"])
+        self.assertIn(
+            "paper_route_target_plan_clean_window_baseline_not_clean",
+            readback["blockers"],
+        )
+
+        with patch.object(
+            flatten_script.urllib.request,
+            "urlopen",
+            return_value=FakeHttpResponse(
+                {"targets": [{"candidate_id": "other", "account_label": "OTHER"}]}
+            ),
+        ):
+            readback = flatten_script.read_target_plan_clean_window_readback(
+                url="http://torghut-sim",
+                account_label="TORGHUT_SIM",
+                snapshot_id=None,
+                timeout_seconds=1,
+            )
+        self.assertEqual(
+            readback["blockers"], ["paper_route_target_plan_readback_target_missing"]
+        )
+
+    def test_required_target_plan_readback_blocks_when_baseline_still_pending(
+        self,
+    ) -> None:
+        client = FakeFlattenClient()
+        snapshot = SimpleNamespace(
+            id="snapshot-1",
+            as_of=datetime(2026, 6, 5, 13, 16, tzinfo=timezone.utc),
+        )
+        target_plan = {
+            "schema_version": "torghut.paper-route-target-plan.v1",
+            "next_paper_route_runtime_window_targets": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "clean_window_baseline_readiness": {
+                    "state": "clean_window_required",
+                    "blockers": ["paper_route_clean_window_baseline_snapshot_pending"],
+                },
+                "targets": [
+                    {
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_clean_window_baseline_state": {
+                            "state": "pending_until_clean_window_baseline",
+                            "blockers": [
+                                "paper_route_clean_window_baseline_snapshot_pending"
+                            ],
+                        },
+                    }
+                ],
+            },
+        }
+        argv = [
+            "flatten_paper_account_positions.py",
+            "--account-label",
+            "TORGHUT_SIM",
+            "--expected-account-label",
+            "TORGHUT_SIM",
+            "--trading-mode",
+            "paper",
+            "--persist-snapshot",
+            "--target-plan-readback-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--require-target-plan-readback-clean",
+            "--json",
+        ]
+
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(
+                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+            ),
+            patch.object(
+                flatten_script, "SessionLocal", return_value=FakeSessionContext()
+            ),
+            patch.object(
+                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+            ),
+            patch.object(
+                flatten_script.urllib.request,
+                "urlopen",
+                return_value=FakeHttpResponse(target_plan),
+            ),
+            redirect_stdout(StringIO()) as output,
+        ):
+            exit_code = flatten_script.main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 3)
+        self.assertTrue(payload["target_plan_readback_required_clean"])
+        self.assertFalse(payload["target_plan_readback_clean"])
+        readback = payload["target_plan_readback"]
+        self.assertEqual(readback["state"], "blocked")
+        self.assertIn(
+            "paper_route_clean_window_baseline_snapshot_pending",
+            readback["blockers"],
+        )
+        self.assertIn(
+            "paper_route_target_plan_clean_window_baseline_not_clean",
+            readback["blockers"],
+        )
 
     def test_main_uses_database_dsn_env_for_snapshot_persistence(self) -> None:
         client = FakeFlattenClient()

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1324,6 +1324,15 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--wait-flat-seconds 120", args)
         self.assertIn("--poll-seconds 10", args)
         self.assertIn("--persist-snapshot", args)
+        self.assertIn("target_plan_readback_args=()", args)
+        self.assertIn("--target-plan-readback-url", args)
+        self.assertIn(
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            args,
+        )
+        self.assertIn("--target-plan-readback-timeout-seconds 10", args)
+        self.assertIn("--require-target-plan-readback-clean", args)
+        self.assertIn('"${target_plan_readback_args[@]}"', args)
         self.assertIn("--persist-lineage", args)
         self.assertIn("--apply", args)
         self.assertIn("--json", args)


### PR DESCRIPTION
## Summary

- Adds optional target-plan readback to `flatten_paper_account_positions.py` after snapshot persistence.
- Fails the flatten job with exit code 3 when `--require-target-plan-readback-clean` is set and target-plan still reports the clean-window baseline as blocked.
- Wires `torghut-paper-account-flatten` to use the readback flags against `torghut-sim`, guarded by `--help` so old images do not receive unknown flags during release skew.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account -q`
- `uv run --frozen ruff format --check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`
- Live readback from `torghut-sim-01209` at 2026-06-05T13:00Z confirmed current target-plan still has `paper_route_clean_window_baseline_snapshot_pending` before the 13:15Z baseline window.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
