### PR TITLE
fix(torghut): hash observed broker order policies

### DIFF
--- a/services/torghut/app/trading/tca.py
+++ b/services/torghut/app/trading/tca.py
@@ -636,6 +636,49 @@ def _decision_execution_policy_hash(
     )
 
 
+def _observed_broker_order_policy_hash(*, execution: Execution) -> str | None:
+    raw_order = _mapping_from_any(execution.raw_order)
+    if not raw_order:
+        return None
+
+    side = _text_from_payload(raw_order, "side")
+    order_type = _text_from_payload(raw_order, "order_type", "type")
+    time_in_force = _text_from_payload(raw_order, "time_in_force")
+    broker_order_id = (
+        _text_from_payload(raw_order, "id")
+        or str(execution.alpaca_order_id or "").strip()
+    )
+    submitted_qty = _text_from_payload(raw_order, "qty")
+    notional = _text_from_payload(raw_order, "notional")
+    if not side or not order_type or not time_in_force or not broker_order_id:
+        return None
+    if not submitted_qty and notional is None:
+        return None
+
+    policy_payload = {
+        "source": "observed_broker_order_execution_policy",
+        "broker": "alpaca",
+        "alpaca_account_label": execution.alpaca_account_label,
+        "alpaca_order_id": broker_order_id,
+        "client_order_id": _text_from_payload(raw_order, "client_order_id")
+        or execution.client_order_id,
+        "symbol": _text_from_payload(raw_order, "symbol") or execution.symbol,
+        "side": side,
+        "order_type": order_type,
+        "time_in_force": time_in_force,
+        "submitted_qty": submitted_qty,
+        "notional": notional,
+        "limit_price": _text_from_payload(raw_order, "limit_price"),
+        "stop_price": _text_from_payload(raw_order, "stop_price"),
+        "extended_hours": raw_order.get("extended_hours"),
+        "order_class": _text_from_payload(raw_order, "order_class"),
+        "position_intent": _text_from_payload(raw_order, "position_intent"),
+    }
+    return _stable_payload_digest(
+        {key: value for key, value in policy_payload.items() if value is not None}
+    )
+
+
 def _execution_policy_hash_candidates(
     *,
     source_payloads: Collection[Mapping[str, object]],
@@ -682,12 +725,17 @@ def _execution_policy_hash_candidates(
         decision_payload=decision_payload,
         execution=execution,
     )
-    if decision_policy_hash is None:
+    if decision_policy_hash is not None:
+        source_fields["execution_policy_hash"] = (
+            "trade_decisions.decision_json+executions.order_fields"
+        )
+        return {decision_policy_hash}
+
+    observed_order_policy_hash = _observed_broker_order_policy_hash(execution=execution)
+    if observed_order_policy_hash is None:
         return set()
-    source_fields["execution_policy_hash"] = (
-        "trade_decisions.decision_json+executions.order_fields"
-    )
-    return {decision_policy_hash}
+    source_fields["execution_policy_hash"] = "executions.raw_order_observed_policy"
+    return {observed_order_policy_hash}
 
 
 def _existing_lineage_source_field(

--- a/services/torghut/tests/test_execution_tca.py
+++ b/services/torghut/tests/test_execution_tca.py
@@ -564,6 +564,64 @@ class TestExecutionTcaCostLineage(TestCase):
             "execution_policy_advisor_payload",
         )
 
+    def test_upsert_uses_observed_broker_order_policy_when_decision_missing(
+        self,
+    ) -> None:
+        with self.session_local() as session:
+            execution = self._insert_execution(
+                session,
+                None,
+                order_id="orphan-broker-order",
+                side="sell",
+                raw_order={
+                    "id": "orphan-broker-order",
+                    "asset_class": "us_equity",
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "type": "limit",
+                    "time_in_force": "day",
+                    "qty": "10",
+                    "limit_price": "99.50",
+                    "commission": "0.02",
+                    "cost_model": {"source": "broker_reported_commission"},
+                },
+            )
+
+            upsert_execution_tca_metric(session, execution)
+            session.flush()
+            lineage = self._lineage(execution)
+
+        self.assertEqual(lineage["status"], "source_backed")
+        self.assertNotIn("execution_policy_hash_missing", lineage["blockers"])
+        self.assertIsInstance(lineage["execution_policy_hash"], str)
+        self.assertEqual(
+            lineage["source_fields"]["execution_policy_hash"],
+            "executions.raw_order_observed_policy",
+        )
+
+    def test_upsert_keeps_orphan_execution_without_broker_policy_blocked(
+        self,
+    ) -> None:
+        with self.session_local() as session:
+            execution = self._insert_execution(
+                session,
+                None,
+                order_id="orphan-missing-policy-order",
+                raw_order={
+                    "id": "orphan-missing-policy-order",
+                    "commission": "0.02",
+                    "cost_model": {"source": "broker_reported_commission"},
+                },
+            )
+
+            upsert_execution_tca_metric(session, execution)
+            session.flush()
+            lineage = self._lineage(execution)
+
+        self.assertEqual(lineage["status"], "blocked")
+        self.assertIn("execution_policy_hash_missing", lineage["blockers"])
+        self.assertIsNone(lineage["execution_policy_hash"])
+
     def test_upsert_blocks_ambiguous_policy_and_cost_model_hashes(self) -> None:
         with self.session_local() as session:
             strategy = self._insert_strategy(session)
@@ -686,7 +744,7 @@ class TestExecutionTcaCostLineage(TestCase):
     def _insert_execution(
         self,
         session: Session,
-        decision: TradeDecision,
+        decision: TradeDecision | None,
         *,
         order_id: str,
         raw_order: dict[str, object],
@@ -694,7 +752,7 @@ class TestExecutionTcaCostLineage(TestCase):
         execution_audit_json: dict[str, object] | None = None,
     ) -> Execution:
         execution = Execution(
-            trade_decision_id=decision.id,
+            trade_decision_id=decision.id if decision is not None else None,
             alpaca_order_id=order_id,
             client_order_id=f"client-{order_id}",
             symbol="AAPL",


### PR DESCRIPTION
## Summary

- Hashes observed broker raw-order policy fields for filled executions that lack a TradeDecision, instead of leaving recoverable broker-restoration fills blocked.
- Keeps orphan executions fail-closed when the raw broker order does not contain core policy fields.
- Adds regression coverage for both source-backed orphan broker orders and missing-policy orphan orders.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_execution_tca.py -q -k 'observed_broker_order_policy or orphan_execution_without_broker_policy or uses_advisor_policy_payload_when_selected_policy_missing or prefers_selected_policy_payload_over_advisor_context or blocks_ambiguous_policy_and_cost_model_hashes'`
- `uv run --frozen pytest tests/test_execution_tca.py -q`
- `uv run --frozen ruff format --check app/trading/tca.py tests/test_execution_tca.py`
- `uv run --frozen ruff check app/trading/tca.py tests/test_execution_tca.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_execution_tca.py -q --cov=app --cov-branch --cov-report=xml --cov-report=term-missing:skip-covered --cov-fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main` (changed-line coverage 91.30%)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
