### PR TITLE
fix(torghut): derive probe symbols from clean baseline

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6427,10 +6427,17 @@ def _paper_route_target_account_audit_available(
     )
 
 
-def _paper_route_target_plan_probe_symbols(plan: Mapping[str, Any]) -> list[str]:
+def _paper_route_probe_symbol_values_from_mapping(
+    target: Mapping[str, Any],
+) -> list[str]:
     symbols: list[str] = []
-    for target in _paper_route_target_plan_targets(plan):
-        raw_symbols = target.get("paper_route_probe_symbols")
+    for field in (
+        "paper_route_probe_symbols",
+        "paper_route_probe_raw_target_symbols",
+        "symbols",
+        "target_symbols",
+    ):
+        raw_symbols = target.get(field)
         if isinstance(raw_symbols, str):
             values: Sequence[object] = raw_symbols.split(",")
         elif isinstance(raw_symbols, Sequence) and not isinstance(
@@ -6444,6 +6451,45 @@ def _paper_route_target_plan_probe_symbols(plan: Mapping[str, Any]) -> list[str]
             symbol = str(item).strip().upper()
             if symbol and symbol not in symbols:
                 symbols.append(symbol)
+    for field in (
+        "paper_route_probe_symbol_actions",
+        "symbol_actions",
+        "target_symbol_actions",
+    ):
+        raw_actions = target.get(field)
+        if not isinstance(raw_actions, Mapping):
+            continue
+        for item in cast(Mapping[object, object], raw_actions):
+            symbol = str(item).strip().upper()
+            if symbol and symbol not in symbols:
+                symbols.append(symbol)
+    return symbols
+
+
+def _paper_route_target_plan_probe_symbols(plan: Mapping[str, Any]) -> list[str]:
+    symbols: list[str] = []
+    for target in _paper_route_target_plan_targets(plan):
+        for symbol in _paper_route_probe_symbol_values_from_mapping(target):
+            if symbol not in symbols:
+                symbols.append(symbol)
+        for field in (
+            "paper_route_clean_window_baseline_state",
+            "clean_window_baseline_state",
+        ):
+            state = target.get(field)
+            if not isinstance(state, Mapping):
+                continue
+            typed_state = cast(Mapping[str, Any], state)
+            for symbol in _paper_route_probe_symbol_values_from_mapping(typed_state):
+                if symbol not in symbols:
+                    symbols.append(symbol)
+            source_audit = typed_state.get("source_audit")
+            if isinstance(source_audit, Mapping):
+                for symbol in _paper_route_probe_symbol_values_from_mapping(
+                    cast(Mapping[str, Any], source_audit)
+                ):
+                    if symbol not in symbols:
+                        symbols.append(symbol)
     return symbols
 
 

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -57,7 +57,7 @@ def paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, A
     return mapping_items(plan.get("targets"))
 
 
-def _target_probe_symbol_values(target: Mapping[str, Any]) -> set[str]:
+def _probe_symbol_values_from_mapping(payload: Mapping[str, Any]) -> set[str]:
     symbols: set[str] = set()
     for field in (
         "paper_route_probe_symbols",
@@ -65,7 +65,7 @@ def _target_probe_symbol_values(target: Mapping[str, Any]) -> set[str]:
         "symbols",
         "target_symbols",
     ):
-        raw_symbols = target.get(field)
+        raw_symbols = payload.get(field)
         if isinstance(raw_symbols, str):
             values: Sequence[object] = raw_symbols.split(",")
         elif isinstance(raw_symbols, Sequence) and not isinstance(
@@ -84,13 +84,29 @@ def _target_probe_symbol_values(target: Mapping[str, Any]) -> set[str]:
         "symbol_actions",
         "target_symbol_actions",
     ):
-        raw_actions = target.get(field)
+        raw_actions = payload.get(field)
         if not isinstance(raw_actions, Mapping):
             continue
         for raw_symbol in cast(Mapping[object, object], raw_actions):
             symbol = str(raw_symbol).strip().upper()
             if symbol:
                 symbols.add(symbol)
+    return symbols
+
+
+def _target_probe_symbol_values(target: Mapping[str, Any]) -> set[str]:
+    symbols = _probe_symbol_values_from_mapping(target)
+    for field in (
+        "paper_route_clean_window_baseline_state",
+        "clean_window_baseline_state",
+    ):
+        state = _to_str_map(target.get(field))
+        if not state:
+            continue
+        symbols.update(_probe_symbol_values_from_mapping(state))
+        source_audit = _to_str_map(state.get("source_audit"))
+        if source_audit:
+            symbols.update(_probe_symbol_values_from_mapping(source_audit))
     return symbols
 
 

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -220,7 +220,7 @@ def _safe_text(value: object) -> str | None:
     return text or None
 
 
-def _target_symbols(target: Mapping[str, Any]) -> set[str]:
+def _symbols_from_mapping(target: Mapping[str, Any]) -> set[str]:
     symbols: set[str] = set()
     for field in (
         "paper_route_probe_symbols",
@@ -252,6 +252,24 @@ def _target_symbols(target: Mapping[str, Any]) -> set[str]:
         for raw_symbol in cast(Mapping[object, object], raw_actions):
             if symbol := str(raw_symbol).strip().upper():
                 symbols.add(symbol)
+
+    return symbols
+
+
+def _target_symbols(target: Mapping[str, Any]) -> set[str]:
+    symbols = _symbols_from_mapping(target)
+    for field in (
+        "paper_route_clean_window_baseline_state",
+        "clean_window_baseline_state",
+    ):
+        state = target.get(field)
+        if not isinstance(state, Mapping):
+            continue
+        typed_state = cast(Mapping[str, Any], state)
+        symbols.update(_symbols_from_mapping(typed_state))
+        source_audit = typed_state.get("source_audit")
+        if isinstance(source_audit, Mapping):
+            symbols.update(_symbols_from_mapping(cast(Mapping[str, Any], source_audit)))
 
     execution_source_key = target.get("paper_route_execution_source_key")
     if isinstance(execution_source_key, Mapping):

--- a/services/torghut/tests/test_paper_route_target_plan.py
+++ b/services/torghut/tests/test_paper_route_target_plan.py
@@ -297,6 +297,27 @@ def test_target_plan_payload_keeps_top_level_plan_when_it_has_probe_symbols() ->
     assert paper_route_target_plan_probe_symbols(plan) == {"AAPL", "AMZN"}
 
 
+def test_target_plan_probe_symbols_accept_clean_window_baseline_state() -> None:
+    plan = {
+        "schema_version": "torghut.paper-route-target-plan.v1",
+        "target_count": 1,
+        "targets": [
+            {
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "paper_route_clean_window_baseline_state": {
+                    "symbols": [" aapl "],
+                    "source_audit": {
+                        "symbols": ["AMZN"],
+                    },
+                },
+            }
+        ],
+    }
+
+    assert paper_route_target_plan_probe_symbols(plan) == {"AAPL", "AMZN"}
+
+
 def test_fresh_hpairs_target_materializes_bounded_collection_source_decisions(
     db_session: Session,
 ) -> None:

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -767,6 +767,19 @@ def test_target_symbols_accept_action_and_execution_source_fields() -> None:
     ) == {"AAPL", "AMZN"}
 
 
+def test_target_symbols_accept_clean_window_baseline_symbol_evidence() -> None:
+    assert _target_symbols(
+        {
+            "paper_route_clean_window_baseline_state": {
+                "symbols": [" aapl "],
+                "source_audit": {
+                    "symbols": ["AMZN"],
+                },
+            },
+        }
+    ) == {"AAPL", "AMZN"}
+
+
 def _routeability_decision(
     *,
     symbol: str = "AAPL",

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -11648,6 +11648,28 @@ class TestTradingApi(TestCase):
             {},
         )
 
+    def test_status_probe_symbols_accept_clean_window_baseline_state(self) -> None:
+        plan = {
+            "schema_version": "torghut.paper-route-target-plan.v1",
+            "target_count": 1,
+            "targets": [
+                {
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "paper_route_clean_window_baseline_state": {
+                        "symbols": [" aapl "],
+                        "source_audit": {
+                            "symbols": ["AMZN"],
+                        },
+                    },
+                }
+            ],
+        }
+
+        self.assertEqual(
+            main_module._paper_route_target_plan_probe_symbols(plan),
+            ["AAPL", "AMZN"],
+        )
+
     def test_fetch_paper_route_target_plan_url_rejects_invalid_url(self) -> None:
         self.assertEqual(
             _fetch_paper_route_target_plan_url(


### PR DESCRIPTION
## Summary

- Derives paper-route probe symbols from nested clean-window baseline evidence when target-plan payloads do not carry top-level probe symbols.
- Keeps shared target-plan extraction, simple-pipeline source decisions, and `/trading/status` route-acquisition probe summaries aligned.
- Adds regressions for the live blocker shape where `paper_route_clean_window_baseline_state.symbols` carries AAPL/AMZN.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_target_plan.py app/trading/scheduler/simple_pipeline.py app/main.py tests/test_paper_route_target_plan.py tests/test_simple_pipeline.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_paper_route_target_plan.py -q`
- `uv run --frozen pytest tests/test_simple_pipeline.py -q`
- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_status_probe_symbols_accept_clean_window_baseline_state tests/test_trading_api.py::TestTradingApi::test_fetch_paper_route_target_plan_url_validates_response tests/test_trading_api.py::TestTradingApi::test_shared_paper_route_target_plan_helpers_validate_response -q`
- `uv run --frozen ruff check app/trading/paper_route_target_plan.py app/trading/scheduler/simple_pipeline.py app/main.py tests/test_paper_route_target_plan.py tests/test_simple_pipeline.py tests/test_trading_api.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
