### PR TITLE
fix(torghut): skip replay source seeds without lineage

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1059,7 +1059,9 @@ def _paper_route_execution_readiness_next_action(
     account_pre_session_state: Mapping[str, Any],
     collection_authorized: bool,
 ) -> str:
-    blocker_set = set(collection_blockers) | set(evidence_blockers) | set(import_blockers)
+    blocker_set = (
+        set(collection_blockers) | set(evidence_blockers) | set(import_blockers)
+    )
     pre_session_state = _safe_text(account_pre_session_state.get("state"))
     if "paper_route_session_window_not_open" in blocker_set:
         if "paper_route_clean_window_baseline_snapshot_pending" in blocker_set:
@@ -1098,7 +1100,11 @@ def _paper_route_execution_readiness_state(
         return "ready_for_runtime_window_import"
     if import_ready and not import_blockers:
         return "window_closed_import_ready"
-    if collection_authorized and evidence_collection_ok and session_state == "collecting_session_evidence":
+    if (
+        collection_authorized
+        and evidence_collection_ok
+        and session_state == "collecting_session_evidence"
+    ):
         return "ready_for_bounded_collection"
     if session_state == "waiting_for_session_open":
         return "waiting_for_session_open"
@@ -1123,14 +1129,18 @@ def _paper_route_execution_readiness_contract(
     clean_window_baseline_state = _as_mapping(
         target.get("paper_route_clean_window_baseline_state")
     )
-    session_state = _safe_text(target.get("paper_route_session_readiness_state")) or "unknown"
+    session_state = (
+        _safe_text(target.get("paper_route_session_readiness_state")) or "unknown"
+    )
     collection_blockers = _unique_text_items(
         target.get("paper_route_session_collection_blockers")
     )
     evidence_blockers = _unique_text_items(
         target.get("bounded_evidence_collection_blockers")
     )
-    import_blockers = _unique_text_items(target.get("paper_route_session_import_blockers"))
+    import_blockers = _unique_text_items(
+        target.get("paper_route_session_import_blockers")
+    )
     source_decision_ready = bool(source_readiness.get("ready"))
     evidence_collection_ok = bool(target.get("evidence_collection_ok"))
     collection_authorized = bool(target.get("bounded_evidence_collection_authorized"))
@@ -1185,7 +1195,9 @@ def _paper_route_execution_readiness_contract(
                 "required_after": _safe_text(
                     account_pre_session_state.get("required_after")
                 ),
-                "blockers": _unique_text_items(account_pre_session_state.get("blockers")),
+                "blockers": _unique_text_items(
+                    account_pre_session_state.get("blockers")
+                ),
             },
             "clean_window_baseline": {
                 "state": _safe_text(clean_window_baseline_state.get("state")),
@@ -9713,7 +9725,7 @@ def _source_collection_target_has_bounded_bucket_materialization_seed(
 
 
 def _source_collection_import_target_allowed(target: Mapping[str, Any]) -> bool:
-    """Reject replay buckets that have neither real lineage nor bounded materialization coordinates."""
+    """Reject replay buckets that have no source lineage to materialize."""
 
     account_label = _safe_text(target.get("account_label"))
     source_account_label = (
@@ -9724,9 +9736,6 @@ def _source_collection_import_target_allowed(target: Mapping[str, Any]) -> bool:
         and source_account_label == "TORGHUT_REPLAY"
         and _safe_text(target.get("source_dsn_env")) == "DB_DSN"
         and not _source_collection_target_has_materializable_lineage(target)
-        and not _source_collection_target_has_bounded_bucket_materialization_seed(
-            target
-        )
     ):
         return False
     return True

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -143,7 +143,10 @@ class TestPaperRouteEvidenceAudit(TestCase):
             ),
             "wait_for_settlement_before_import",
         )
-        self.assertEqual(next_action(session_state="paper_route_custom_state"), "inspect_paper_route_readiness")
+        self.assertEqual(
+            next_action(session_state="paper_route_custom_state"),
+            "inspect_paper_route_readiness",
+        )
 
     def test_execution_readiness_state_preserves_blocked_and_unknown_states(
         self,
@@ -5897,6 +5900,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         "source_collection_next_action": (
                             "materialize_runtime_ledger_source_window_refs"
                         ),
+                        "source_row_counts": {"execution_order_events": 2},
                         "runtime_ledger_bucket_ref": (
                             "strategy_runtime_ledger_buckets:run-1:start:end"
                         ),
@@ -5940,6 +5944,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         "source_collection_next_action": (
                             "materialize_runtime_ledger_source_window_refs"
                         ),
+                        "source_row_counts": {"execution_order_events": 2},
                         "runtime_ledger_bucket_ref": (
                             "strategy_runtime_ledger_buckets:run-1:start:end"
                         ),
@@ -6035,7 +6040,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
 
         self.assertEqual(plan, {})
 
-    def test_source_collection_import_keeps_bounded_bucket_seed_without_authority(
+    def test_source_collection_import_skips_bounded_bucket_seed_without_lineage(
         self,
     ) -> None:
         live_gate = {
@@ -6085,37 +6090,32 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target_limit=5,
         )
 
-        self.assertEqual(plan["target_count"], 1)
-        target = plan["targets"][0]
-        self.assertEqual(target["candidate_id"], "bounded-replay-seed")
-        self.assertEqual(target["account_label"], "TORGHUT_REPLAY")
-        self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")
-        self.assertEqual(target["source_dsn_env"], "DB_DSN")
-        self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
-        self.assertEqual(target["window_start"], "2026-05-13T17:00:00+00:00")
-        self.assertEqual(target["window_end"], "2026-05-13T17:30:00+00:00")
-        self.assertEqual(
-            target["runtime_ledger_bucket_ref"],
-            (
+        self.assertEqual(plan, {})
+        raw_target = {
+            "runtime_ledger_bucket_ref": (
                 "strategy_runtime_ledger_buckets:"
                 "rt-ledger-vwap-cap-safe-20260512-20260521-c88421d6:"
                 "2026-05-13T17:00:00+00:00:"
                 "2026-05-13T17:30:00+00:00"
             ),
-        )
-        self.assertEqual(target["max_notional"], "0")
-        self.assertFalse(target["promotion_allowed"])
-        self.assertFalse(target["final_promotion_allowed"])
-        self.assertFalse(target["live_capital_authorized"])
+            "window_start": "2026-05-13T17:00:00+00:00",
+            "window_end": "2026-05-13T17:30:00+00:00",
+            "account_label": "TORGHUT_REPLAY",
+            "source_account_label": "TORGHUT_REPLAY",
+            "source_dsn_env": "DB_DSN",
+        }
         self.assertFalse(
             paper_route_evidence._source_collection_target_has_materializable_lineage(
-                target
+                raw_target
             )
         )
         self.assertTrue(
             paper_route_evidence._source_collection_target_has_bounded_bucket_materialization_seed(
-                target
+                raw_target
             )
+        )
+        self.assertFalse(
+            paper_route_evidence._source_collection_import_target_allowed(raw_target)
         )
 
     def test_source_collection_import_allows_aggregate_replay_with_materializable_lineage(


### PR DESCRIPTION
## Summary

- Reject TORGHUT_REPLAY source-collection targets that only carry a runtime-ledger bucket/window seed and no materializable source lineage.
- Keep valid profit-target source-collection candidates ranked first when they include source row lineage.
- Update paper-route evidence regression coverage for seed-only replay rejection.

## Related Issues

None

## Testing

- uv sync --frozen --extra dev
- uv run --frozen pytest tests/test_paper_route_evidence.py -q
- uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q -k 'source_collection or runtime_window_target_plan'
- uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py
- uv run --frozen pyright --project pyrightconfig.json
- uv run --frozen pyright --project pyrightconfig.alpha.json
- uv run --frozen pyright --project pyrightconfig.scripts.json
- uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py -q --cov=app --cov-branch --cov-report=xml --cov-fail-under=0
- uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main
- git diff --check

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
