### PR TITLE
fix(torghut): prefer bounded target plan scope

### DIFF
--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -160,20 +160,45 @@ def _target_plan_selected_identity_match(
     )
 
 
+def _source_collection_marker(value: object) -> bool:
+    text = str(value or "").strip().lower()
+    return "source_collection" in text or "source-window" in text
+
+
+def _target_plan_is_source_collection_only(plan: Mapping[str, Any]) -> bool:
+    if _source_collection_marker(plan.get("purpose")) or _source_collection_marker(
+        plan.get("source")
+    ):
+        return True
+    targets = paper_route_target_plan_targets(plan)
+    if not targets:
+        return False
+    return all(
+        _source_collection_marker(target.get("source_kind"))
+        or _source_collection_marker(target.get("handoff"))
+        or _source_collection_marker(target.get("selected_by"))
+        or _source_collection_marker(
+            target.get("source_collection_authorization_scope")
+        )
+        for target in targets
+    )
+
+
 def _target_plan_selection_score(
     plan: Mapping[str, Any],
     *,
     source_rank: int,
     selected_identity_keys: set[tuple[str, str]],
-) -> tuple[int, int, int, int, int, int]:
+) -> tuple[int, int, int, int, int, int, int]:
     targets = paper_route_target_plan_targets(plan)
     if not targets:
-        return (-1, 0, 0, 0, 0, -source_rank)
+        return (-1, 0, 0, 0, 0, 0, -source_rank)
     probe_symbol_count = sum(
         len(_target_probe_symbol_values(target)) for target in targets
     )
     ready_count = sum(1 for target in targets if _target_source_decision_ready(target))
     return (
+        0 if _target_plan_is_source_collection_only(plan) else 1,
         1
         if _target_plan_selected_identity_match(
             plan,

--- a/services/torghut/tests/test_paper_route_target_plan.py
+++ b/services/torghut/tests/test_paper_route_target_plan.py
@@ -188,7 +188,7 @@ def test_target_plan_selection_score_rejects_empty_plans() -> None:
         {},
         source_rank=3,
         selected_identity_keys=set(),
-    ) == (-1, 0, 0, 0, 0, -3)
+    ) == (-1, 0, 0, 0, 0, 0, -3)
 
 
 def test_target_plan_payload_prefers_nested_plan_with_probe_symbols() -> None:
@@ -223,6 +223,57 @@ def test_target_plan_payload_prefers_nested_plan_with_probe_symbols() -> None:
 
     assert plan["source"] == "paper_route_evidence_audit"
     assert plan["targets"][0]["paper_route_probe_symbols"] == ["AAPL", "AMZN"]
+    assert paper_route_target_plan_probe_symbols(plan) == {"AAPL", "AMZN"}
+
+
+def test_target_plan_payload_prefers_nested_probe_plan_over_source_collection() -> None:
+    payload = {
+        "schema_version": "torghut.paper-route-target-plan.v1",
+        "source": "paper_route_target_plan_endpoint",
+        "purpose": "observed_strategy_runtime_ledger_source_collection_import",
+        "target_count": 1,
+        "targets": [
+            {
+                "hypothesis_id": "H-TSMOM-LIQ-01",
+                "candidate_id": "ca4e6e3c7d639e3363dc5860",
+                "runtime_strategy_name": "intraday-tsmom-profit-v3",
+                "source_kind": "runtime_ledger_source_collection_candidate",
+                "selected_by": "paper_route_observed_strategy_source_collection",
+                "handoff": "runtime_ledger_source_collection_import",
+                "source_collection_authorization_scope": (
+                    "source_window_evidence_collection_only"
+                ),
+            }
+        ],
+        "next_paper_route_runtime_window_targets": {
+            "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+            "source": "paper_route_evidence_audit",
+            "purpose": "next_session_paper_route_runtime_window_evidence_collection",
+            "target_count": 1,
+            "targets": [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "source_kind": "paper_route_probe_runtime_observed",
+                    "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                    "paper_route_probe_symbol_actions": {
+                        "AAPL": "buy",
+                        "AMZN": "sell",
+                    },
+                    "source_decision_readiness": {"ready": True, "blockers": []},
+                }
+            ],
+        },
+    }
+
+    plan = paper_route_target_plan_from_payload(payload)
+
+    assert plan["source"] == "paper_route_evidence_audit"
+    assert (
+        plan["purpose"] == "next_session_paper_route_runtime_window_evidence_collection"
+    )
+    assert plan["targets"][0]["hypothesis_id"] == "H-PAIRS-01"
     assert paper_route_target_plan_probe_symbols(plan) == {"AAPL", "AMZN"}
 
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -11510,12 +11510,14 @@ class TestTradingApi(TestCase):
             }
         )
 
-        self.assertEqual(plan["targets"][0]["candidate_id"], "ca4e6e3c7d639e3363dc5860")
+        self.assertEqual(plan["targets"][0]["candidate_id"], "c88421d619759b2cfaa6f4d0")
         self.assertEqual(
             plan["targets"][0]["selected_by"],
-            "paper_route_observed_strategy_source_collection",
+            "paper_route_evidence_audit",
         )
-        self.assertNotIn("paper_route_probe_symbols", plan["targets"][0])
+        self.assertEqual(
+            plan["targets"][0]["paper_route_probe_symbols"], ["AAPL", "AMZN"]
+        )
 
     def test_paper_route_target_plan_payload_prefers_next_window_over_closed_import(
         self,


### PR DESCRIPTION
## Summary

- Prefer bounded next-session target plans over source-collection/import plans when selecting an external paper-route target-plan payload.
- Prevent observed source-collection targets from suppressing H-PAIRS probe symbols in the paper-route probe scope.
- Add a live-shape regression covering source-collection top-level targets plus nested bounded probe targets.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_target_plan.py -q`
- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_payload_prefers_selected_top_level_targets -q`
- `uv run --frozen pytest tests/test_paper_route_target_plan.py tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_payload_prefers_selected_top_level_targets -q`
- `uv run --frozen ruff check app/trading/paper_route_target_plan.py tests/test_paper_route_target_plan.py`
- `uv run --frozen ruff format --check app/trading/paper_route_target_plan.py tests/test_paper_route_target_plan.py`
- `uv run --frozen ruff check app/trading/paper_route_target_plan.py tests/test_paper_route_target_plan.py tests/test_trading_api.py`
- `uv run --frozen ruff format --check app/trading/paper_route_target_plan.py tests/test_paper_route_target_plan.py tests/test_trading_api.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
