### PR TITLE
fix(torghut): scope evidence probe from bounded target

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1365,6 +1365,18 @@ def _paper_route_probe_summary(
     }
 
 
+def _paper_route_probe_scope_plan(
+    primary_plan: Mapping[str, Any],
+    *candidate_plans: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if _target_plan_probe_scope_symbols(primary_plan):
+        return primary_plan
+    for candidate_plan in candidate_plans:
+        if _target_plan_probe_scope_symbols(candidate_plan):
+            return candidate_plan
+    return primary_plan
+
+
 def _target_plan_probe_scope_symbols(target_plan: Mapping[str, Any]) -> list[str]:
     symbols: list[str] = []
     for target in _as_mapping_items(target_plan.get("targets")):
@@ -10536,16 +10548,17 @@ def build_paper_route_target_plan_payload(
         )
     )
     targets = _as_mapping_items(plan.get("targets"))[: max(0, target_limit)]
+    target_plan_source = _safe_text(
+        live_submission_gate.get("paper_route_target_plan_source")
+    ) or _target_plan_source(plan)
+    target_plan_error = _safe_text(
+        live_submission_gate.get("paper_route_target_plan_error")
+    )
     probe = _paper_route_probe_summary(
         route_reacquisition_book,
         target_plan=plan,
-        target_plan_source=_safe_text(
-            live_submission_gate.get("paper_route_target_plan_source")
-        )
-        or _target_plan_source(plan),
-        target_plan_error=_safe_text(
-            live_submission_gate.get("paper_route_target_plan_error")
-        ),
+        target_plan_source=target_plan_source,
+        target_plan_error=target_plan_error,
     )
     next_targets = _next_paper_route_runtime_window_targets(
         session=session,
@@ -10555,6 +10568,26 @@ def build_paper_route_target_plan_payload(
         generated_at=resolved_generated_at,
         target_account_audit_available=target_account_audit_available,
     )
+    scoped_probe_plan = (
+        _paper_route_probe_scope_plan(plan, next_targets)
+        if target_plan_source == "external_target_plan_url"
+        else plan
+    )
+    if scoped_probe_plan is not plan:
+        probe = _paper_route_probe_summary(
+            route_reacquisition_book,
+            target_plan=scoped_probe_plan,
+            target_plan_source=target_plan_source,
+            target_plan_error=target_plan_error,
+        )
+        next_targets = _next_paper_route_runtime_window_targets(
+            session=session,
+            targets=targets,
+            probe=probe,
+            live_submission_gate=live_submission_gate,
+            generated_at=resolved_generated_at,
+            target_account_audit_available=target_account_audit_available,
+        )
     runtime_window_import_plan = next_targets
     next_clean_after_discard_targets: Mapping[str, Any] = {}
     latest_closed_targets: Mapping[str, Any] = {}
@@ -10939,16 +10972,17 @@ def build_paper_route_evidence_audit(
             target_limit=effective_target_limit,
         )
     )
+    target_plan_source = _safe_text(
+        live_submission_gate.get("paper_route_target_plan_source")
+    ) or _target_plan_source(plan)
+    target_plan_error = _safe_text(
+        live_submission_gate.get("paper_route_target_plan_error")
+    )
     probe = _paper_route_probe_summary(
         route_reacquisition_book,
         target_plan=plan,
-        target_plan_source=_safe_text(
-            live_submission_gate.get("paper_route_target_plan_source")
-        )
-        or _target_plan_source(plan),
-        target_plan_error=_safe_text(
-            live_submission_gate.get("paper_route_target_plan_error")
-        ),
+        target_plan_source=target_plan_source,
+        target_plan_error=target_plan_error,
     )
     target_audit_cache: dict[tuple[object, ...], dict[str, object]] = {}
 
@@ -10978,13 +11012,6 @@ def build_paper_route_evidence_audit(
             target_audit_cache[cache_key] = audit
         return audit
 
-    target_audits = [
-        cached_target_audit(
-            target,
-            error_source="paper_route_source_target_audit",
-        )
-        for target in targets
-    ]
     next_targets = _next_paper_route_runtime_window_targets(
         session=session,
         targets=targets,
@@ -10993,6 +11020,33 @@ def build_paper_route_evidence_audit(
         generated_at=resolved_generated_at,
         target_account_audit_available=target_account_audit_available,
     )
+    scoped_probe_plan = (
+        _paper_route_probe_scope_plan(plan, next_targets)
+        if target_plan_source == "external_target_plan_url"
+        else plan
+    )
+    if scoped_probe_plan is not plan:
+        probe = _paper_route_probe_summary(
+            route_reacquisition_book,
+            target_plan=scoped_probe_plan,
+            target_plan_source=target_plan_source,
+            target_plan_error=target_plan_error,
+        )
+        next_targets = _next_paper_route_runtime_window_targets(
+            session=session,
+            targets=targets,
+            probe=probe,
+            live_submission_gate=live_submission_gate,
+            generated_at=resolved_generated_at,
+            target_account_audit_available=target_account_audit_available,
+        )
+    target_audits = [
+        cached_target_audit(
+            target,
+            error_source="paper_route_source_target_audit",
+        )
+        for target in targets
+    ]
     closed_window_start, closed_window_end = (
         _latest_closed_regular_equities_session_window(resolved_generated_at)
     )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -5442,6 +5442,212 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target["paper_route_probe_scope_authority"], "strategy_universe"
         )
 
+    def test_external_source_collection_plan_scopes_probe_from_next_target(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="microbar-cross-sectional-pairs-v1",
+                    description="source collection strategy",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_notional_per_trade=Decimal("31590"),
+                )
+            )
+            session.commit()
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": True,
+                    "reason": "non_live_mode",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "paper_route_target_plan_source": "external_target_plan_url",
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": True,
+                    "continuity_reason": "signal_continuity_nominal",
+                    "drift_ok": True,
+                    "drift_reason": "drift_live_promotion_eligible",
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.paper-route-target-plan.v1",
+                        "target_count": 1,
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "runtime_strategy_name": (
+                                    "microbar-cross-sectional-pairs-v1"
+                                ),
+                                "strategy_lookup_names": [
+                                    "microbar-cross-sectional-pairs-v1"
+                                ],
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": (
+                                    "runtime_ledger_source_collection_candidate"
+                                ),
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                                "source_collection_authorized": True,
+                                "source_collection_authorization_scope": (
+                                    "source_window_evidence_collection_only"
+                                ),
+                                "bounded_evidence_collection_authorized": True,
+                                "bounded_evidence_collection_scope": (
+                                    "paper_route_probe_next_session_only"
+                                ),
+                                "bounded_evidence_collection_max_notional": "75000",
+                                "paper_route_probe_effective_max_notional": "75000",
+                                "paper_route_probe_next_session_max_notional": "75000",
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "75000",
+                                "selected_by": "runtime_ledger_source_collection",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": "75000",
+                        "next_session_max_notional": "75000",
+                        "eligible_symbol_count": 3,
+                        "eligible_symbols": ["AAPL", "AMZN", "INTC"],
+                        "active_symbols": ["AAPL", "AMZN", "INTC"],
+                        "blocking_reasons": [],
+                    },
+                },
+                generated_at=generated_at,
+                target_account_audit_available=False,
+            )
+
+        probe = payload["paper_route_probe"]
+        self.assertEqual(probe["target_plan_source"], "external_target_plan_url")
+        self.assertTrue(probe["target_plan_scope_applied"])
+        self.assertEqual(probe["target_plan_scope_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(probe["eligible_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(probe["out_of_scope_symbols"], ["INTC"])
+        self.assertNotIn(
+            "external_target_plan_probe_symbols_missing",
+            probe["blocking_reasons"],
+        )
+        next_target = payload["next_paper_route_runtime_window_targets"]["targets"][0]
+        self.assertEqual(next_target["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(
+            next_target["paper_route_probe_scope_authority"], "strategy_universe"
+        )
+
+    def test_external_source_collection_target_plan_payload_scopes_probe(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="microbar-cross-sectional-pairs-v1",
+                    description="source collection strategy",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_notional_per_trade=Decimal("31590"),
+                )
+            )
+            session.commit()
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate={
+                    "allowed": True,
+                    "reason": "non_live_mode",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "paper_route_target_plan_source": "external_target_plan_url",
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": True,
+                    "continuity_reason": "signal_continuity_nominal",
+                    "drift_ok": True,
+                    "drift_reason": "drift_live_promotion_eligible",
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.paper-route-target-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "runtime_strategy_name": (
+                                    "microbar-cross-sectional-pairs-v1"
+                                ),
+                                "strategy_lookup_names": [
+                                    "microbar-cross-sectional-pairs-v1"
+                                ],
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": (
+                                    "runtime_ledger_source_collection_candidate"
+                                ),
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                "source_collection_authorized": True,
+                                "bounded_evidence_collection_authorized": True,
+                                "bounded_evidence_collection_scope": (
+                                    "paper_route_probe_next_session_only"
+                                ),
+                                "bounded_evidence_collection_max_notional": "75000",
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "75000",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": "75000",
+                        "next_session_max_notional": "75000",
+                        "eligible_symbols": ["AAPL", "AMZN", "INTC"],
+                        "active_symbols": ["AAPL", "AMZN", "INTC"],
+                        "blocking_reasons": [],
+                    },
+                },
+                generated_at=generated_at,
+                include_runtime_window_import_audit=False,
+                target_account_audit_available=False,
+            )
+
+        probe = payload["paper_route_probe"]
+        self.assertTrue(probe["target_plan_scope_applied"])
+        self.assertEqual(probe["target_plan_scope_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(probe["eligible_symbols"], ["AAPL", "AMZN"])
+        next_target = payload["next_paper_route_runtime_window_targets"]["targets"][0]
+        self.assertEqual(next_target["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+
+    def test_probe_scope_plan_falls_back_to_primary_without_symbols(self) -> None:
+        primary = {"targets": [{"candidate_id": "source-only"}]}
+
+        self.assertIs(
+            paper_route_evidence._paper_route_probe_scope_plan(
+                primary,
+                {"targets": [{"candidate_id": "also-source-only"}]},
+            ),
+            primary,
+        )
+
     def test_live_target_plan_preserves_source_collection_targets_when_audit_unavailable(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Scope the paper-route evidence probe from a derived bounded next-session target when the external target-plan source only exposes source-collection targets.
- Rebuild the next-window target plan after that scoped probe is available so downstream audits use the same AAPL/AMZN envelope.
- Add a regression for the live failure shape where the external provider lacks explicit probe symbols but the strategy universe resolves the bounded target.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_trading_paper_route_evidence_resolves_target_plan_strategy_universe tests/test_trading_api.py::TestTradingApi::test_external_paper_route_target_preserves_live_symbol_envelope tests/test_trading_api.py::TestTradingApi::test_paper_route_target_plan_payload_prefers_selected_top_level_targets -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
