### PR TITLE
fix(torghut): default source collection probe windows

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -860,6 +860,18 @@ def _target_probe_window(target: Mapping[str, Any]) -> tuple[datetime, datetime]
     return window_start, window_end
 
 
+def _target_missing_explicit_probe_window(target: Mapping[str, Any]) -> bool:
+    return all(
+        _safe_text(target.get(key)) is None
+        for key in (
+            "paper_route_probe_window_start",
+            "paper_route_probe_window_end",
+            "window_start",
+            "window_end",
+        )
+    )
+
+
 def _target_probe_action(target: Mapping[str, Any]) -> Literal["buy", "sell"]:
     for key in (
         "paper_route_probe_action",
@@ -5893,6 +5905,22 @@ class SimpleTradingPipeline(TradingPipeline):
             normalized["paper_route_probe_symbols"] = sorted(raw_symbols)
         elif raw_symbols and "paper_route_probe_symbols" not in normalized:
             normalized["paper_route_probe_symbols"] = sorted(raw_symbols)
+
+        if (
+            _target_has_bounded_source_collection_authorization(normalized)
+            and _target_probe_window(normalized) is None
+            and _target_missing_explicit_probe_window(normalized)
+        ):
+            now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+            window_start = regular_session_open_utc_for(now)
+            window_end = window_start + timedelta(minutes=_REGULAR_SESSION_MINUTES)
+            normalized["paper_route_probe_window_start"] = window_start.isoformat()
+            normalized["paper_route_probe_window_end"] = window_end.isoformat()
+            normalized.setdefault("paper_route_probe_window_defaulted", True)
+            normalized.setdefault(
+                "paper_route_probe_window_source",
+                "current_regular_session_source_collection_default",
+            )
 
         if not isinstance(normalized.get("source_decision_readiness"), Mapping):
             normalized["source_decision_readiness"] = (

--- a/services/torghut/tests/test_simple_pipeline.py
+++ b/services/torghut/tests/test_simple_pipeline.py
@@ -23,6 +23,7 @@ from app.trading.scheduler.simple_pipeline import (
     _target_active_in_window,
     _target_probe_symbol_notional_budget,
     _target_probe_symbol_quantities,
+    _target_probe_window,
     _target_runtime_account_matches,
     _target_symbols,
 )
@@ -623,6 +624,120 @@ def test_target_source_decisions_size_default_quantities_from_target_notional(
             assert (
                 decision.params["simple_lane"]["paper_route_target_notional_sizing"]
                 == sizing
+            )
+    finally:
+        settings.trading_mode = trading_mode_before
+        settings.trading_simple_paper_route_probe_enabled = probe_enabled_before
+        settings.trading_allow_shorts = allow_shorts_before
+
+
+def test_source_collection_target_defaults_current_session_probe_contract(
+    monkeypatch,
+) -> None:
+    trading_mode_before = settings.trading_mode
+    probe_enabled_before = settings.trading_simple_paper_route_probe_enabled
+    allow_shorts_before = settings.trading_allow_shorts
+    try:
+        settings.trading_mode = "paper"
+        settings.trading_simple_paper_route_probe_enabled = True
+        settings.trading_allow_shorts = True
+        now = datetime(2026, 6, 5, 14, 45, tzinfo=timezone.utc)
+        target = _bounded_hpairs_target(
+            source_kind="runtime_ledger_source_collection_candidate",
+            strategy_id="microbar_cross_sectional_pairs_v1@research",
+            strategy_name="69cf50e3-4815-47c2-b802-1efbaac09ecb",
+            runtime_strategy_name="69cf50e3-4815-47c2-b802-1efbaac09ecb",
+            strategy_lookup_names=[
+                "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                "microbar-cross-sectional-pairs-v1",
+            ],
+            source_collection_authorized=True,
+            source_collection_authorization_scope=(
+                "source_window_evidence_collection_only"
+            ),
+            target_notional="75000",
+            paper_route_probe_next_session_max_notional="75000",
+            bounded_evidence_collection_max_notional="75000",
+        )
+        target.pop("paper_route_probe_symbols")
+        target.pop("source_decision_readiness")
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            description="metadata fixture",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+        pipeline = object.__new__(SimpleTradingPipeline)
+        pipeline.account_label = "TORGHUT_SIM"
+        pipeline.price_fetcher = SimpleNamespace(
+            fetch_market_snapshot=lambda signal: MarketSnapshot(
+                symbol=signal.symbol,
+                as_of=signal.event_ts,
+                price=Decimal("100"),
+                spread=Decimal("0"),
+                source="fixture",
+                bid=Decimal("100"),
+                ask=Decimal("100"),
+            )
+        )
+        pipeline._is_market_session_open = lambda _now: True
+        monkeypatch.setattr(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            lambda account_label=None: now,
+        )
+
+        normalized = pipeline._paper_route_target_with_local_probe_contract(
+            target,
+            strategies=[strategy],
+        )
+        pipeline._external_paper_route_target_probe_symbols_cached = lambda **_kwargs: (
+            _target_symbols(normalized),
+            None,
+            [normalized],
+        )
+
+        assert normalized["paper_route_probe_symbols"] == ["AAPL", "AMZN"]
+        assert normalized["paper_route_probe_window_defaulted"] is True
+        assert normalized["paper_route_probe_window_source"] == (
+            "current_regular_session_source_collection_default"
+        )
+        assert _target_probe_window(normalized) == (
+            datetime(2026, 6, 5, 13, 30, tzinfo=timezone.utc),
+            datetime(2026, 6, 5, 20, 0, tzinfo=timezone.utc),
+        )
+
+        decisions = pipeline._paper_route_target_source_decisions(
+            strategies=[strategy],
+            allowed_symbols={"AAPL", "AMZN"},
+            positions=[],
+            session=None,
+        )
+
+        assert {decision.symbol: decision.qty for decision in decisions} == {
+            "AAPL": Decimal("375.0000"),
+            "AMZN": Decimal("375.0000"),
+        }
+        actions = {
+            decision.symbol: decision.params["simple_lane"][
+                "paper_route_probe_leg_action"
+            ]
+            for decision in decisions
+        }
+        assert actions == {"AAPL": "buy", "AMZN": "sell"}
+        for decision in decisions:
+            metadata = decision.params["paper_route_target_plan_source_decision"]
+            assert metadata["source_collection_authorized"] is True
+            assert metadata["profit_proof_eligible"] is True
+            assert metadata["paper_route_probe_window_start"] == (
+                "2026-06-05T13:30:00+00:00"
+            )
+            assert metadata["paper_route_probe_window_end"] == (
+                "2026-06-05T20:00:00+00:00"
+            )
+            assert decision.params["source_decision_mode"] == (
+                "bounded_paper_route_collection"
             )
     finally:
         settings.trading_mode = trading_mode_before


### PR DESCRIPTION
## Summary

- Default authorized TORGHUT_SIM source-collection targets without explicit probe windows to the current regular-session window.
- Preserve fail-closed behavior for targets with explicit or malformed windows; the default only applies to source-collection-authorized bounded targets.
- Add a regression that reproduces the deployed no-symbol/no-window source target and verifies bounded H-PAIRS source decisions are generated from the local strategy universe.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_simple_pipeline.py`
- `uv run --frozen pytest tests/test_simple_pipeline.py -q`
- `uv run --frozen pytest tests/test_trading_scheduler_safety.py -q -k 'paper_route_source_decisions'`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'paper_route_target_source_decisions or source_decisions_guard_paths or target_source_decisions'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_simple_pipeline.py tests/test_trading_scheduler_safety.py tests/test_trading_pipeline.py -q -k 'source_collection_target_defaults_current_session_probe_contract or target_source_decisions_size_default_quantities_from_target_notional or paper_route_source_decisions or paper_route_target_source_decisions or source_decisions_guard_paths or target_source_decisions' --cov=app --cov-branch --cov-report=xml --cov-fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
