### PR TITLE
fix(torghut): default source collection import windows

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -66,6 +66,7 @@ from .runtime_strategy_resolution import (
     explicit_runtime_strategy_name_or_family_harness,
     strategy_names_from_strategy_id,
 )
+from .session_context import regular_session_close_utc_for, regular_session_open_utc_for
 from .tca import build_tca_gate_inputs
 
 
@@ -2129,6 +2130,36 @@ def _runtime_ledger_source_collection_source_dsn_env(
     )
 
 
+def _bounded_source_collection_probe_window(
+    candidate: Mapping[str, object],
+) -> tuple[str | None, str | None, bool]:
+    window_start = _safe_text(
+        candidate.get("bucket_started_at")
+        or candidate.get("window_start")
+        or candidate.get("source_window_start")
+        or candidate.get("paper_route_probe_window_start")
+    )
+    window_end = _safe_text(
+        candidate.get("bucket_ended_at")
+        or candidate.get("window_end")
+        or candidate.get("source_window_end")
+        or candidate.get("paper_route_probe_window_end")
+    )
+    if window_start is not None and window_end is not None:
+        return window_start, window_end, False
+    if not bool(candidate.get("source_collection_candidate")):
+        return window_start, window_end, False
+    if not bool(candidate.get("bounded_evidence_collection_authorized")):
+        return window_start, window_end, False
+
+    now = datetime.now(timezone.utc)
+    return (
+        regular_session_open_utc_for(now).isoformat(),
+        regular_session_close_utc_for(now).isoformat(),
+        True,
+    )
+
+
 def _runtime_ledger_paper_probation_import_plan(
     candidates: Sequence[Mapping[str, object]],
 ) -> dict[str, object]:
@@ -2150,8 +2181,9 @@ def _runtime_ledger_paper_probation_import_plan(
             derived_strategy_name_from_strategy_id(strategy_id),
         )
         account_label = _safe_text(candidate.get("account")) or "TORGHUT_SIM"
-        window_start = _safe_text(candidate.get("bucket_started_at"))
-        window_end = _safe_text(candidate.get("bucket_ended_at"))
+        window_start, window_end, defaulted_source_collection_window = (
+            _bounded_source_collection_probe_window(candidate)
+        )
         source_manifest_ref = _safe_text(candidate.get("source_manifest_ref")) or (
             _hypothesis_manifest_ref(hypothesis_id)
         )
@@ -2358,6 +2390,8 @@ def _runtime_ledger_paper_probation_import_plan(
         if source_collection:
             target.update(
                 {
+                    "paper_route_probe_window_start": window_start or "",
+                    "paper_route_probe_window_end": window_end or "",
                     "source_collection_priority": (
                         _safe_text(candidate.get("source_collection_priority"))
                         or "source_window_evidence_collection"
@@ -2423,6 +2457,15 @@ def _runtime_ledger_paper_probation_import_plan(
                     "final_promotion_requires_live_paper_runtime_proof": True,
                 }
             )
+            if defaulted_source_collection_window:
+                target.update(
+                    {
+                        "runtime_ledger_source_collection_window_defaulted": True,
+                        "runtime_ledger_source_collection_window_source": (
+                            "current_regular_session_bounded_source_collection_default"
+                        ),
+                    }
+                )
         if bucket_ref:
             target["runtime_ledger_bucket_ref"] = bucket_ref
         targets.append(target)

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -42,6 +42,7 @@ from app.trading.submission_council import (
     _PROMOTION_PORTFOLIO_READY_SCAN_LIMIT,
     _PROMOTION_TABLE_COUNT_SCAN_LIMIT,
     _QUANT_HEALTH_CACHE,
+    _bounded_source_collection_probe_window,
     _certificate_evidence_authority_score,
     _certificate_evidence_selection_key,
     _coerce_aware_datetime,
@@ -2422,6 +2423,68 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(target["source_dsn_env"], "SIM_DB_DSN")
         self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
         self.assertEqual(target["source_account_label"], "TORGHUT_SIM")
+
+    def test_bounded_source_collection_target_defaults_current_session_window(
+        self,
+    ) -> None:
+        plan = _runtime_ledger_paper_probation_import_plan(
+            [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "account": "TORGHUT_SIM",
+                    "source_collection_candidate": True,
+                    "source_collection_authorized": True,
+                    "source_collection_profit_target_candidate": True,
+                    "bounded_evidence_collection_authorized": True,
+                    "bounded_evidence_collection_max_notional": "75000",
+                    "source_collection_reason_codes": [
+                        "runtime_ledger_source_window_missing",
+                    ],
+                    "reason_codes": [
+                        "runtime_ledger_source_window_missing",
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["skipped_target_count"], 0)
+        self.assertEqual(plan["source_collection_target_count"], 1)
+        self.assertEqual(plan["source_collection_profit_target_count"], 1)
+        target = plan["targets"][0]
+        self.assertTrue(target["source_collection_authorized"])
+        self.assertTrue(target["runtime_ledger_source_collection_window_defaulted"])
+        self.assertEqual(
+            target["runtime_ledger_source_collection_window_source"],
+            "current_regular_session_bounded_source_collection_default",
+        )
+        self.assertEqual(
+            target["paper_route_probe_window_start"], target["window_start"]
+        )
+        self.assertEqual(target["paper_route_probe_window_end"], target["window_end"])
+
+        window_start = datetime.fromisoformat(cast(str, target["window_start"]))
+        window_end = datetime.fromisoformat(cast(str, target["window_end"]))
+        self.assertEqual(window_end - window_start, timedelta(hours=6, minutes=30))
+
+    def test_source_collection_probe_window_does_not_default_without_bounded_authority(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _bounded_source_collection_probe_window({}), (None, None, False)
+        )
+        self.assertEqual(
+            _bounded_source_collection_probe_window(
+                {
+                    "source_collection_candidate": True,
+                }
+            ),
+            (None, None, False),
+        )
 
     def test_runtime_ledger_source_collection_allows_unclosed_or_losing_activity(
         self,


### PR DESCRIPTION
## Summary

- Default bounded runtime-ledger source-collection import targets without bucket windows to the current regular-session window.
- Expose the same window on `paper_route_probe_window_start` and `paper_route_probe_window_end` so the post-close audit can find today’s source decisions, executions, order-feed rows, and TCA.
- Keep fail-closed behavior for non-source-collection and unbounded source-collection targets.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py && uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q -k 'source_collection_target or runtime_ledger_source_collection_import_plan or evidence_audit_surfaces_source_collection'`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q -k 'source_collection or runtime_window_import'`
- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py -q -k 'source_collection or runtime_window'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
