### PR TITLE
fix(torghut): default authorized source import windows

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -2149,7 +2149,7 @@ def _bounded_source_collection_probe_window(
         return window_start, window_end, False
     if not bool(candidate.get("source_collection_candidate")):
         return window_start, window_end, False
-    if not bool(candidate.get("bounded_evidence_collection_authorized")):
+    if not bool(candidate.get("source_collection_authorized")):
         return window_start, window_end, False
 
     now = datetime.now(timezone.utc)

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -2471,7 +2471,46 @@ class TestSubmissionCouncil(TestCase):
         window_end = datetime.fromisoformat(cast(str, target["window_end"]))
         self.assertEqual(window_end - window_start, timedelta(hours=6, minutes=30))
 
-    def test_source_collection_probe_window_does_not_default_without_bounded_authority(
+    def test_source_collection_import_target_defaults_without_bounded_submit(
+        self,
+    ) -> None:
+        plan = _runtime_ledger_paper_probation_import_plan(
+            [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "account": "TORGHUT_SIM",
+                    "source_collection_candidate": True,
+                    "source_collection_authorized": True,
+                    "bounded_evidence_collection_authorized": False,
+                    "source_collection_reason_codes": [
+                        "runtime_ledger_source_window_missing",
+                    ],
+                    "reason_codes": [
+                        "runtime_ledger_source_window_missing",
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        self.assertTrue(target["source_collection_authorized"])
+        self.assertFalse(target["bounded_evidence_collection_authorized"])
+        self.assertTrue(target["runtime_ledger_source_collection_window_defaulted"])
+        self.assertEqual(
+            target["runtime_ledger_source_collection_window_source"],
+            "current_regular_session_bounded_source_collection_default",
+        )
+        self.assertEqual(
+            target["paper_route_probe_window_start"], target["window_start"]
+        )
+        self.assertEqual(target["paper_route_probe_window_end"], target["window_end"])
+
+    def test_source_collection_probe_window_does_not_default_without_source_authority(
         self,
     ) -> None:
         self.assertEqual(
@@ -2484,6 +2523,26 @@ class TestSubmissionCouncil(TestCase):
                 }
             ),
             (None, None, False),
+        )
+
+    def test_source_collection_probe_window_defaults_with_source_authority_only(
+        self,
+    ) -> None:
+        window_start, window_end, defaulted = _bounded_source_collection_probe_window(
+            {
+                "source_collection_candidate": True,
+                "source_collection_authorized": True,
+                "bounded_evidence_collection_authorized": False,
+            }
+        )
+
+        self.assertTrue(defaulted)
+        self.assertIsNotNone(window_start)
+        self.assertIsNotNone(window_end)
+        self.assertEqual(
+            datetime.fromisoformat(cast(str, window_end))
+            - datetime.fromisoformat(cast(str, window_start)),
+            timedelta(hours=6, minutes=30),
         )
 
     def test_runtime_ledger_source_collection_allows_unclosed_or_losing_activity(


### PR DESCRIPTION
## Summary

- Default runtime-window import bounds for source-collection-authorized targets even when bounded submit is not authorized.
- Keep non-source and source-unauthorized candidates fail-closed with missing windows.
- Add helper-level and exported import-plan regressions for the live blank-window target shape.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py && uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q -k 'source_collection_target or runtime_ledger_source_collection_import_plan or evidence_audit_surfaces_source_collection'`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q -k 'source_collection or runtime_window_import'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_paper_route_evidence.py -q -k 'source_collection_probe_window or source_collection_target_defaults_current_session_window or source_collection_target or runtime_ledger_source_collection_import_plan or evidence_audit_surfaces_source_collection' --cov=app --cov-report=xml:coverage.xml --cov-fail-under=0 && GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
