### PR TITLE
chore(analysis): promote image 50ba63e38c29

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 2d53bd06e6fe1f74c2d39bdffcc381c1e626d2a7
+    newTag: 50ba63e38c29dcfbbed2a090e9ae62040db2c493


### PR DESCRIPTION
## Summary

- Promotes `argocd/applications/analysis` to `registry.ide-newton.ts.net/lab/analysis:50ba63e38c29dcfbbed2a090e9ae62040db2c493`.
- Keeps rollout in lab GitOps by changing only the analysis kustomize image tag.
- Uses the self-hosted analysis image publish workflow output.

## Related Issues

None

## Testing

- `/Users/gregkonush/github.com/analysis/scripts/verify-analysis-image.sh 50ba63e38c29dcfbbed2a090e9ae62040db2c493`
- `kubectl kustomize argocd/applications/analysis`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
