### PR TITLE
chore(torghut): promote image 08b1839b

### DIFF
--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: materialize-targets
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -135,7 +135,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+                  value: sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-05T15:43:51Z"
+        client.knative.dev/updateTimestamp: "2026-06-05T16:11:10Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
           ports:
             - name: http1
               containerPort: 8181
@@ -533,11 +533,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-290-gd3d14bd38
+              value: v0.596.0-295-g08b1839b9
             - name: TORGHUT_COMMIT
-              value: d3d14bd38b6cd4394a399820963a7b3c755e8a35
+              value: 08b1839b97165c6616e6e2211b40b90d12e3e486
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+              value: sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-05T15:43:51Z"
+        client.knative.dev/updateTimestamp: "2026-06-05T16:11:10Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
           ports:
             - name: http1
               containerPort: 8181
@@ -395,11 +395,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-290-gd3d14bd38
+              value: v0.596.0-295-g08b1839b9
             - name: TORGHUT_COMMIT
-              value: d3d14bd38b6cd4394a399820963a7b3c755e8a35
+              value: 08b1839b97165c6616e6e2211b40b90d12e3e486
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+              value: sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -87,7 +87,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+                  value: sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -123,7 +123,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -195,6 +195,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+                  value: sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: d3d14bd38b6cd4394a399820963a7b3c755e8a35
+            value: 08b1839b97165c6616e6e2211b40b90d12e3e486
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+            value: sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f6caf91269f3f1f15c90994d51e2c79550da63021e8383cb692bc1c6869cd693
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `08b1839b97165c6616e6e2211b40b90d12e3e486`
- Image tag: `08b1839b`
- Image digest: `sha256:ef927074f1e222b8b09b5ac2ee36c51c777e947d88cf2da32ac8947edcd063df`