### PR TITLE
fix(torghut): default blank source import windows

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -2130,6 +2130,28 @@ def _runtime_ledger_source_collection_source_dsn_env(
     )
 
 
+def _runtime_ledger_source_collection_import_candidate(
+    candidate: Mapping[str, object],
+) -> bool:
+    if bool(candidate.get("source_collection_candidate")):
+        return True
+    if bool(candidate.get("source_collection_authorized")):
+        return True
+    if (
+        _safe_text(candidate.get("source_kind"))
+        == _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND
+    ):
+        return True
+    identity = candidate.get("account_stage_runtime_identity")
+    if isinstance(identity, Mapping):
+        identity_mapping = cast(Mapping[str, object], identity)
+        return (
+            _safe_text(identity_mapping.get("source_kind"))
+            == _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND
+        )
+    return False
+
+
 def _bounded_source_collection_probe_window(
     candidate: Mapping[str, object],
 ) -> tuple[str | None, str | None, bool]:
@@ -2147,7 +2169,7 @@ def _bounded_source_collection_probe_window(
     )
     if window_start is not None and window_end is not None:
         return window_start, window_end, False
-    if not bool(candidate.get("source_collection_candidate")):
+    if not _runtime_ledger_source_collection_import_candidate(candidate):
         return window_start, window_end, False
     if not bool(candidate.get("source_collection_authorized")):
         return window_start, window_end, False
@@ -2212,7 +2234,9 @@ def _runtime_ledger_paper_probation_import_plan(
             )
             continue
 
-        source_collection = bool(candidate.get("source_collection_candidate"))
+        source_collection = _runtime_ledger_source_collection_import_candidate(
+            candidate
+        )
         paper_probation_blockers = (
             []
             if source_collection

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -2510,6 +2510,57 @@ class TestSubmissionCouncil(TestCase):
         )
         self.assertEqual(target["paper_route_probe_window_end"], target["window_end"])
 
+    def test_source_collection_import_target_defaults_existing_blank_window_target(
+        self,
+    ) -> None:
+        plan = _runtime_ledger_paper_probation_import_plan(
+            [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "account": "TORGHUT_SIM",
+                    "source_kind": "runtime_ledger_source_collection_candidate",
+                    "account_stage_runtime_identity": {
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                    },
+                    "source_collection_authorized": True,
+                    "window_start": "",
+                    "window_end": "",
+                    "paper_route_probe_window_start": "",
+                    "paper_route_probe_window_end": "",
+                    "bounded_evidence_collection_authorized": False,
+                    "source_collection_reason_codes": [
+                        "runtime_ledger_source_window_missing",
+                    ],
+                    "reason_codes": [
+                        "runtime_ledger_source_window_missing",
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(
+            target["source_kind"], "runtime_ledger_source_collection_candidate"
+        )
+        self.assertTrue(target["source_collection_authorized"])
+        self.assertTrue(target["runtime_ledger_source_collection_window_defaulted"])
+        self.assertEqual(
+            target["runtime_ledger_source_collection_window_source"],
+            "current_regular_session_bounded_source_collection_default",
+        )
+        self.assertNotEqual(target["window_start"], "")
+        self.assertNotEqual(target["window_end"], "")
+        self.assertEqual(
+            target["paper_route_probe_window_start"], target["window_start"]
+        )
+        self.assertEqual(target["paper_route_probe_window_end"], target["window_end"])
+
     def test_source_collection_probe_window_does_not_default_without_source_authority(
         self,
     ) -> None:
@@ -2524,15 +2575,39 @@ class TestSubmissionCouncil(TestCase):
             ),
             (None, None, False),
         )
+        self.assertEqual(
+            _bounded_source_collection_probe_window(
+                {
+                    "source_kind": "runtime_ledger_source_collection_candidate",
+                    "window_start": "",
+                    "window_end": "",
+                }
+            ),
+            (None, None, False),
+        )
+        self.assertEqual(
+            _bounded_source_collection_probe_window(
+                {
+                    "account_stage_runtime_identity": {
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                    },
+                    "window_start": "",
+                    "window_end": "",
+                }
+            ),
+            (None, None, False),
+        )
 
     def test_source_collection_probe_window_defaults_with_source_authority_only(
         self,
     ) -> None:
         window_start, window_end, defaulted = _bounded_source_collection_probe_window(
             {
-                "source_collection_candidate": True,
+                "source_kind": "runtime_ledger_source_collection_candidate",
                 "source_collection_authorized": True,
                 "bounded_evidence_collection_authorized": False,
+                "window_start": "",
+                "window_end": "",
             }
         )
 


### PR DESCRIPTION
## Summary

- Treat source-collection import targets from prior target-plan output as source-collection candidates when they carry source authority or the source-collection source kind.
- Default blank source-collection import windows to the current regular session instead of preserving empty `window_start` / `window_end` fields.
- Add regressions for the deployed live shape: authorized source-collection targets with blank windows and no new bounded submit authority.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q -k 'source_collection_target or runtime_ledger_source_collection_import_plan or evidence_audit_surfaces_source_collection'`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q -k 'source_collection or runtime_window_import'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_submission_council.py -q --cov=app.trading.submission_council --cov-report=xml --cov-fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
