### PR TITLE
fix(torghut): default source import target windows

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -9753,6 +9753,34 @@ def _source_collection_import_target_allowed(target: Mapping[str, Any]) -> bool:
     return True
 
 
+def _runtime_ledger_source_collection_import_window(
+    target: Mapping[str, Any],
+    *,
+    generated_at: datetime,
+) -> tuple[str, str, bool]:
+    window_start = _safe_text(
+        target.get("window_start")
+        or target.get("source_window_start")
+        or target.get("bucket_started_at")
+        or target.get("paper_route_probe_window_start")
+    )
+    window_end = _safe_text(
+        target.get("window_end")
+        or target.get("source_window_end")
+        or target.get("bucket_ended_at")
+        or target.get("paper_route_probe_window_end")
+    )
+    if window_start is not None and window_end is not None:
+        return window_start, window_end, False
+    if not _target_is_runtime_ledger_source_collection(target):
+        return window_start or "", window_end or "", False
+    if not _truthy_plan_value(target.get("source_collection_authorized")):
+        return window_start or "", window_end or "", False
+
+    session_start, session_end = _next_regular_equities_session_window(generated_at)
+    return session_start.isoformat(), session_end.isoformat(), True
+
+
 def _target_bounded_collection_notional(target: Mapping[str, Any]) -> str:
     for key in (
         "target_notional",
@@ -9807,6 +9835,8 @@ def _runtime_window_import_target_metadata(
 
 def _sanitized_runtime_ledger_source_collection_target(
     target: Mapping[str, Any],
+    *,
+    generated_at: datetime,
 ) -> dict[str, object]:
     strategy_name = _safe_text(target.get("strategy_name"))
     strategy_id = _safe_text(target.get("strategy_id"))
@@ -9847,6 +9877,17 @@ def _sanitized_runtime_ledger_source_collection_target(
     bounded_evidence_collection_authorized = (
         bounded_evidence_collection_requested and _safe_decimal(bounded_notional) > 0
     )
+    window_start, window_end, source_collection_window_defaulted = (
+        _runtime_ledger_source_collection_import_window(
+            target, generated_at=generated_at
+        )
+    )
+    paper_route_probe_window_start = (
+        _safe_text(target.get("paper_route_probe_window_start")) or window_start
+    )
+    paper_route_probe_window_end = (
+        _safe_text(target.get("paper_route_probe_window_end")) or window_end
+    )
     final_promotion_blockers = _unique_text_items(
         target.get("final_promotion_blockers")
     ) or list(RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS)
@@ -9873,8 +9914,10 @@ def _sanitized_runtime_ledger_source_collection_target(
         "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref")) or "",
         "source_manifest_ref": _safe_text(target.get("source_manifest_ref")) or "",
         "source_kind": source_kind,
-        "window_start": _safe_text(target.get("window_start")) or "",
-        "window_end": _safe_text(target.get("window_end")) or "",
+        "window_start": window_start,
+        "window_end": window_end,
+        "paper_route_probe_window_start": paper_route_probe_window_start,
+        "paper_route_probe_window_end": paper_route_probe_window_end,
         "paper_probation_authorized": False,
         "paper_probation_authorization_scope": "",
         "paper_probation_satisfied_for_bounded_live_paper_collection": False,
@@ -9951,6 +9994,11 @@ def _sanitized_runtime_ledger_source_collection_target(
             or target.get("final_promotion_authorized")
         ),
     }
+    if source_collection_window_defaulted:
+        sanitized["runtime_ledger_source_collection_window_defaulted"] = True
+        sanitized["runtime_ledger_source_collection_window_default_source"] = (
+            "current_regular_session_source_collection_import_default"
+        )
     for key in (
         "source_collection_priority",
         "source_collection_profit_target_net_pnl_after_costs",
@@ -10046,9 +10094,11 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
     plan: Mapping[str, Any],
     live_submission_gate: Mapping[str, Any],
     target_limit: int,
+    generated_at: datetime | None = None,
 ) -> dict[str, object]:
     if not _live_gate_has_source_collection_pending(live_submission_gate):
         return {}
+    resolved_generated_at = generated_at or datetime.now(timezone.utc)
     limit = max(0, target_limit)
     candidate_targets: list[dict[str, object]] = []
 
@@ -10057,7 +10107,10 @@ def _runtime_ledger_source_collection_import_plan_for_payload(
             return
         if not _source_collection_import_target_allowed(target):
             return
-        sanitized = _sanitized_runtime_ledger_source_collection_target(target)
+        sanitized = _sanitized_runtime_ledger_source_collection_target(
+            target,
+            generated_at=resolved_generated_at,
+        )
         candidate_targets.append(sanitized)
 
     def target_key(
@@ -10273,6 +10326,7 @@ def _observed_strategy_source_collection_target(
     observed_strategy_name: str,
     observed_count: int,
     contaminated_target: Mapping[str, Any],
+    generated_at: datetime,
 ) -> dict[str, object] | None:
     hypothesis_id = _safe_text(candidate.get("hypothesis_id"))
     candidate_id = _safe_text(candidate.get("candidate_id"))
@@ -10364,7 +10418,10 @@ def _observed_strategy_source_collection_target(
             "reason": "paper_route_account_contamination_strategy_observed",
         },
     }
-    return _sanitized_runtime_ledger_source_collection_target(target)
+    return _sanitized_runtime_ledger_source_collection_target(
+        target,
+        generated_at=generated_at,
+    )
 
 
 def _runtime_window_import_plan_metadata(plan: Mapping[str, Any]) -> dict[str, object]:
@@ -10416,6 +10473,7 @@ def _observed_strategy_source_collection_import_plan(
     live_submission_gate: Mapping[str, Any],
     candidate_plans: Sequence[Mapping[str, Any]],
     target_limit: int,
+    generated_at: datetime | None = None,
 ) -> dict[str, object]:
     if not _live_gate_has_source_collection_pending(live_submission_gate):
         return {}
@@ -10424,6 +10482,7 @@ def _observed_strategy_source_collection_import_plan(
     )
     if not candidates_by_strategy:
         return {}
+    resolved_generated_at = generated_at or datetime.now(timezone.utc)
     limit = max(0, target_limit)
     targets: list[dict[str, object]] = []
     skipped_targets: list[dict[str, object]] = []
@@ -10475,6 +10534,7 @@ def _observed_strategy_source_collection_import_plan(
                     observed_strategy_name=observed_strategy_name,
                     observed_count=observed_count,
                     contaminated_target=contaminated_target,
+                    generated_at=resolved_generated_at,
                 )
                 if target is None:
                     skipped_targets.append(
@@ -10545,6 +10605,7 @@ def build_paper_route_target_plan_payload(
             plan=plan,
             live_submission_gate=live_submission_gate,
             target_limit=target_limit,
+            generated_at=resolved_generated_at,
         )
     )
     targets = _as_mapping_items(plan.get("targets"))[: max(0, target_limit)]
@@ -10690,6 +10751,7 @@ def build_paper_route_target_plan_payload(
                     next_targets,
                 ),
                 target_limit=target_limit,
+                generated_at=resolved_generated_at,
             )
         )
         if _as_mapping_items(observed_strategy_source_targets.get("targets")):
@@ -10970,6 +11032,7 @@ def build_paper_route_evidence_audit(
             plan=plan,
             live_submission_gate=live_submission_gate,
             target_limit=effective_target_limit,
+            generated_at=resolved_generated_at,
         )
     )
     target_plan_source = _safe_text(
@@ -11147,6 +11210,7 @@ def build_paper_route_evidence_audit(
             raw_next_targets,
         ),
         target_limit=effective_target_limit,
+        generated_at=resolved_generated_at,
     )
     if _as_mapping_items(observed_strategy_source_targets.get("targets")):
         if _source_collection_import_plan_has_profit_target(source_targets):

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -6417,6 +6417,114 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(target["final_promotion_allowed"])
         self.assertTrue(target["stripped_source_promotion_authority"])
 
+    def test_source_collection_import_plan_defaults_authorized_blank_window_target(
+        self,
+    ) -> None:
+        live_gate = {
+            "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+            "runtime_ledger_paper_probation_import_plan": {
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "candidate-hpairs",
+                        "observed_stage": "paper",
+                        "strategy_family": "microbar_pairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "account_label": "TORGHUT_SIM",
+                        "source_account_label": "TORGHUT_SIM",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "account_stage_runtime_identity": {
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            )
+                        },
+                        "window_start": "",
+                        "window_end": "",
+                        "paper_route_probe_window_start": None,
+                        "paper_route_probe_window_end": None,
+                        "source_collection_authorized": True,
+                    }
+                ],
+            },
+        }
+
+        plan = paper_route_evidence._runtime_ledger_source_collection_import_plan_for_payload(
+            plan=live_gate["runtime_ledger_paper_probation_import_plan"],
+            live_submission_gate=live_gate,
+            target_limit=5,
+            generated_at=datetime(2026, 6, 5, 16, 45, tzinfo=timezone.utc),
+        )
+
+        target = plan["targets"][0]
+        self.assertEqual(target["window_start"], "2026-06-05T13:30:00+00:00")
+        self.assertEqual(target["window_end"], "2026-06-05T20:00:00+00:00")
+        self.assertEqual(
+            target["paper_route_probe_window_start"],
+            "2026-06-05T13:30:00+00:00",
+        )
+        self.assertEqual(
+            target["paper_route_probe_window_end"],
+            "2026-06-05T20:00:00+00:00",
+        )
+        self.assertTrue(target["runtime_ledger_source_collection_window_defaulted"])
+        self.assertEqual(
+            target["runtime_ledger_source_collection_window_default_source"],
+            "current_regular_session_source_collection_import_default",
+        )
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+
+    def test_source_collection_import_plan_does_not_default_unauthorized_target(
+        self,
+    ) -> None:
+        live_gate = {
+            "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+            "runtime_ledger_paper_probation_import_plan": {
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "candidate-hpairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "window_start": "",
+                        "window_end": "",
+                    }
+                ],
+            },
+        }
+
+        plan = paper_route_evidence._runtime_ledger_source_collection_import_plan_for_payload(
+            plan=live_gate["runtime_ledger_paper_probation_import_plan"],
+            live_submission_gate=live_gate,
+            target_limit=5,
+            generated_at=datetime(2026, 6, 5, 16, 45, tzinfo=timezone.utc),
+        )
+
+        target = plan["targets"][0]
+        self.assertEqual(target["window_start"], "")
+        self.assertEqual(target["window_end"], "")
+        self.assertEqual(target["paper_route_probe_window_start"], "")
+        self.assertEqual(target["paper_route_probe_window_end"], "")
+        self.assertNotIn("runtime_ledger_source_collection_window_defaulted", target)
+
+    def test_source_collection_import_window_does_not_default_non_source_target(
+        self,
+    ) -> None:
+        window_start, window_end, defaulted = (
+            paper_route_evidence._runtime_ledger_source_collection_import_window(
+                {
+                    "window_start": "",
+                    "window_end": "",
+                },
+                generated_at=datetime(2026, 6, 5, 16, 45, tzinfo=timezone.utc),
+            )
+        )
+
+        self.assertEqual(window_start, "")
+        self.assertEqual(window_end, "")
+        self.assertFalse(defaulted)
+
     def test_source_collection_import_plan_preserves_bounded_authorized_notional(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Defaults authorized runtime-ledger source-collection import targets with blank windows to the current regular-session window in the paper-route evidence target-plan sanitizer.
- Carries `paper_route_probe_window_start/end` and explicit default markers into sanitized source-collection targets so `/trading/paper-route-target-plan` can hand off importable windows.
- Keeps promotion authority fail-closed: unauthorized or non-source targets do not get defaulted, and promotion fields remain false.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q -k 'source_collection_import_plan_defaults_authorized_blank_window_target or source_collection_import_plan_does_not_default_unauthorized_target or source_collection_import_window_does_not_default_non_source_target'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q -k 'source_collection_target or runtime_ledger_source_collection_import_plan or source_collection_import_plan or evidence_audit_surfaces_source_collection or paper_route_target_plan'`
- `uv run --frozen pytest tests/test_trading_api.py -q -k 'paper_route_target_plan or runtime_window_import_plan or source_runtime_window_import_plan'`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q -k 'source_collection or runtime_window_import'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q --cov=app.trading.paper_route_evidence --cov-report=xml --cov-fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref HEAD`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
