### PR TITLE
fix(torghut): defer pre-import evidence audits

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6202,6 +6202,13 @@ def trading_paper_route_evidence(
         le=MAX_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
         description="Maximum number of paper-route targets to audit.",
     ),
+    full_audit: bool = Query(
+        False,
+        description=(
+            "Force full source/runtime-ledger audits before the runtime window "
+            "is import-ready."
+        ),
+    ),
 ) -> JSONResponse:
     """Return target-by-target paper-route evidence collection status."""
 
@@ -6273,6 +6280,7 @@ def trading_paper_route_evidence(
             route_reacquisition_book=route_reacquisition_book,
             lookback_hours=lookback_hours,
             target_limit=target_limit,
+            include_runtime_window_import_audit=True if full_audit else None,
             target_account_audit_available=_paper_route_target_account_audit_available(
                 cast(Mapping[str, Any], live_submission_gate)
             ),

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -11006,6 +11006,7 @@ def build_paper_route_evidence_audit(
     generated_at: datetime | None = None,
     lookback_hours: int = DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
     target_limit: int = DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+    include_runtime_window_import_audit: bool | None = True,
     target_account_audit_available: bool = True,
 ) -> dict[str, object]:
     """Build a target-by-target audit for paper-route evidence collection."""
@@ -11103,41 +11104,51 @@ def build_paper_route_evidence_audit(
             generated_at=resolved_generated_at,
             target_account_audit_available=target_account_audit_available,
         )
-    target_audits = [
-        cached_target_audit(
-            target,
-            error_source="paper_route_source_target_audit",
-        )
-        for target in targets
-    ]
-    closed_window_start, closed_window_end = (
-        _latest_closed_regular_equities_session_window(resolved_generated_at)
+    next_import_readiness = _as_mapping(next_targets.get("session_readiness"))
+    next_import_handoff = _as_mapping(next_targets.get("runtime_window_import_handoff"))
+    next_import_ready = bool(
+        next_import_readiness.get("import_ready")
+        or next_import_handoff.get("import_ready")
     )
-    latest_closed_targets = _next_paper_route_runtime_window_targets(
-        session=session,
-        targets=targets,
-        probe=probe,
-        live_submission_gate=live_submission_gate,
-        generated_at=resolved_generated_at,
-        require_clean_pre_session=False,
-        window_start=closed_window_start,
-        window_end=closed_window_end,
-        purpose="latest_closed_session_paper_route_runtime_window_import",
-        target_account_audit_available=target_account_audit_available,
+    run_full_runtime_import_audit = (
+        next_import_ready
+        if include_runtime_window_import_audit is None
+        else include_runtime_window_import_audit
     )
-    next_target_audits = [
-        cached_target_audit(
-            target,
-            error_source="paper_route_next_target_audit",
-        )
-        for target in _as_mapping_items(next_targets.get("targets"))
-    ]
+    runtime_window_import_audit_mode = (
+        "full" if run_full_runtime_import_audit else "deferred_until_import_ready"
+    )
+    target_audits = (
+        [
+            cached_target_audit(
+                target,
+                error_source="paper_route_source_target_audit",
+            )
+            for target in targets
+        ]
+        if run_full_runtime_import_audit
+        else _deferred_runtime_window_target_audits(targets)
+    )
     raw_next_targets: Mapping[str, Any] = next_targets
+    next_target_audits = (
+        [
+            cached_target_audit(
+                target,
+                error_source="paper_route_next_target_audit",
+            )
+            for target in _as_mapping_items(next_targets.get("targets"))
+        ]
+        if run_full_runtime_import_audit
+        else _deferred_runtime_window_target_audits(
+            _as_mapping_items(next_targets.get("targets"))
+        )
+    )
     raw_next_target_audits: list[dict[str, object]] = next_target_audits
     runtime_window_import_plan = next_targets
     runtime_window_import_target_audits = next_target_audits
     source_targets: Mapping[str, Any] = source_collection_import_plan
     observed_strategy_source_targets: Mapping[str, Any] = {}
+    latest_closed_targets: Mapping[str, Any] = {}
     next_clean_after_discard_targets: Mapping[str, Any] = {}
     latest_closed_runtime_window_import_selection = (
         _runtime_window_import_candidate_selection(
@@ -11146,62 +11157,86 @@ def build_paper_route_evidence_audit(
             selected=False,
         )
     )
-    latest_closed_runtime_window_import_plan = _runtime_window_import_plan_for_audit(
-        latest_closed_targets=latest_closed_targets,
-        next_targets=next_targets,
-    )
-    if latest_closed_runtime_window_import_plan is latest_closed_targets:
-        latest_closed_target_audits = [
-            cached_target_audit(
-                target,
-                error_source="paper_route_runtime_window_import_target_audit",
-            )
-            for target in _as_mapping_items(latest_closed_targets.get("targets"))
-        ]
-        latest_closed_importable = (
-            _target_audits_have_importable_source_backed_runtime_window_import_evidence(
-                latest_closed_target_audits
-            )
+
+    if run_full_runtime_import_audit:
+        closed_window_start, closed_window_end = (
+            _latest_closed_regular_equities_session_window(resolved_generated_at)
+        )
+        latest_closed_targets = _next_paper_route_runtime_window_targets(
+            session=session,
+            targets=targets,
+            probe=probe,
+            live_submission_gate=live_submission_gate,
+            generated_at=resolved_generated_at,
+            require_clean_pre_session=False,
+            window_start=closed_window_start,
+            window_end=closed_window_end,
+            purpose="latest_closed_session_paper_route_runtime_window_import",
+            target_account_audit_available=target_account_audit_available,
         )
         latest_closed_runtime_window_import_selection = (
             _runtime_window_import_candidate_selection(
                 latest_closed_targets=latest_closed_targets,
-                latest_closed_target_audits=latest_closed_target_audits,
-                selected=latest_closed_importable,
+                latest_closed_target_audits=[],
+                selected=False,
             )
         )
-        if latest_closed_importable:
-            runtime_window_import_plan = latest_closed_targets
-            runtime_window_import_target_audits = latest_closed_target_audits
-        elif _runtime_window_import_candidate_discard_blockers(
-            latest_closed_target_audits
-        ):
-            followup_window_start, followup_window_end = (
-                _following_regular_equities_session_window(closed_window_end)
+        latest_closed_runtime_window_import_plan = (
+            _runtime_window_import_plan_for_audit(
+                latest_closed_targets=latest_closed_targets,
+                next_targets=next_targets,
             )
-            next_clean_after_discard_targets = _next_paper_route_runtime_window_targets(
-                session=session,
-                targets=targets,
-                probe=probe,
-                live_submission_gate=live_submission_gate,
-                generated_at=resolved_generated_at,
-                window_start=followup_window_start,
-                window_end=followup_window_end,
-                purpose=(
-                    "next_clean_session_paper_route_runtime_window_collection_after_discard"
-                ),
-                target_account_audit_available=target_account_audit_available,
-            )
-            runtime_window_import_plan = next_clean_after_discard_targets
-            runtime_window_import_target_audits = [
+        )
+        if latest_closed_runtime_window_import_plan is latest_closed_targets:
+            latest_closed_target_audits = [
                 cached_target_audit(
                     target,
                     error_source="paper_route_runtime_window_import_target_audit",
                 )
-                for target in _as_mapping_items(
-                    runtime_window_import_plan.get("targets")
-                )
+                for target in _as_mapping_items(latest_closed_targets.get("targets"))
             ]
+            latest_closed_importable = _target_audits_have_importable_source_backed_runtime_window_import_evidence(
+                latest_closed_target_audits
+            )
+            latest_closed_runtime_window_import_selection = (
+                _runtime_window_import_candidate_selection(
+                    latest_closed_targets=latest_closed_targets,
+                    latest_closed_target_audits=latest_closed_target_audits,
+                    selected=latest_closed_importable,
+                )
+            )
+            if latest_closed_importable:
+                runtime_window_import_plan = latest_closed_targets
+                runtime_window_import_target_audits = latest_closed_target_audits
+            elif _runtime_window_import_candidate_discard_blockers(
+                latest_closed_target_audits
+            ):
+                followup_window_start, followup_window_end = (
+                    _following_regular_equities_session_window(closed_window_end)
+                )
+                next_clean_after_discard_targets = _next_paper_route_runtime_window_targets(
+                    session=session,
+                    targets=targets,
+                    probe=probe,
+                    live_submission_gate=live_submission_gate,
+                    generated_at=resolved_generated_at,
+                    window_start=followup_window_start,
+                    window_end=followup_window_end,
+                    purpose=(
+                        "next_clean_session_paper_route_runtime_window_collection_after_discard"
+                    ),
+                    target_account_audit_available=target_account_audit_available,
+                )
+                runtime_window_import_plan = next_clean_after_discard_targets
+                runtime_window_import_target_audits = [
+                    cached_target_audit(
+                        target,
+                        error_source="paper_route_runtime_window_import_target_audit",
+                    )
+                    for target in _as_mapping_items(
+                        runtime_window_import_plan.get("targets")
+                    )
+                ]
     observed_strategy_source_targets = _observed_strategy_source_collection_import_plan(
         live_submission_gate=live_submission_gate,
         candidate_plans=(
@@ -11221,13 +11256,20 @@ def build_paper_route_evidence_audit(
         else:
             source_targets = observed_strategy_source_targets
         runtime_window_import_plan = source_targets
-        runtime_window_import_target_audits = [
-            cached_target_audit(
-                target,
-                error_source="paper_route_observed_strategy_source_target_audit",
-            )
-            for target in _as_mapping_items(runtime_window_import_plan.get("targets"))
-        ]
+        observed_source_targets = _as_mapping_items(
+            runtime_window_import_plan.get("targets")
+        )
+        runtime_window_import_target_audits = (
+            [
+                cached_target_audit(
+                    target,
+                    error_source="paper_route_observed_strategy_source_target_audit",
+                )
+                for target in observed_source_targets
+            ]
+            if run_full_runtime_import_audit
+            else _deferred_runtime_window_target_audits(observed_source_targets)
+        )
     runtime_window_import_audit = _runtime_window_import_audit(
         next_targets=runtime_window_import_plan,
         target_audits=target_audits,
@@ -11305,6 +11347,7 @@ def build_paper_route_evidence_audit(
     return {
         "schema_version": PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION,
         "generated_at": _isoformat(resolved_generated_at),
+        "runtime_window_import_audit_mode": runtime_window_import_audit_mode,
         "window": {
             "lookback_hours": effective_lookback_hours,
             "requested_lookback_hours": lookback_hours,
@@ -11616,6 +11659,7 @@ def build_paper_route_evidence_audit(
                 "blockers": summary_blockers,
             },
             "runtime_window_import_audit_state": runtime_window_import_audit["state"],
+            "runtime_window_import_audit_mode": runtime_window_import_audit_mode,
             "hpairs_zero_activity_diagnostics": hpairs_zero_activity_diagnostics,
             "blockers": summary_blockers,
         },

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -2042,6 +2042,68 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target_account_audit_available=target_account_audit_available,
         )
 
+    def _build_basic_paper_route_evidence(
+        self,
+        session: Session,
+        *,
+        generated_at: datetime,
+        include_runtime_window_import_audit: bool | None = True,
+    ) -> dict[str, object]:
+        return build_paper_route_evidence_audit(
+            session,
+            live_submission_gate={
+                "allowed": False,
+                "reason": "paper_route_probe_only",
+                "blocked_reasons": [],
+                "promotion_eligible_total": 0,
+                "dependency_quorum_decision": "allow",
+                "continuity_ok": True,
+                "continuity_reason": "signal_continuity_nominal",
+                "drift_ok": True,
+                "drift_reason": "drift_live_promotion_eligible",
+                "runtime_ledger_paper_probation_import_plan": {
+                    "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "candidate-pre-session",
+                            "observed_stage": "paper",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                            "account_label": "TORGHUT_REPLAY",
+                            "source_kind": "durable_runtime_ledger_bucket",
+                            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+                            "dataset_snapshot_ref": "dataset://paper-route",
+                            "paper_probation_authorized": True,
+                            "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+                            "promotion_allowed": False,
+                            "final_promotion_authorized": False,
+                            "max_notional": "0",
+                        }
+                    ],
+                },
+            },
+            route_reacquisition_book={
+                "schema_version": "torghut.route-reacquisition-book.v1",
+                "state": "repair_only",
+                "summary": {
+                    "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                    "paper_route_probe_active_symbols": [],
+                },
+                "paper_route_probe": {
+                    "configured_enabled": True,
+                    "active": False,
+                    "next_session_max_notional": "25",
+                    "eligible_symbol_count": 2,
+                    "eligible_symbols": ["AAPL", "AMZN"],
+                    "blocking_reasons": ["market_session_closed"],
+                },
+            },
+            generated_at=generated_at,
+            include_runtime_window_import_audit=include_runtime_window_import_audit,
+        )
+
     def test_target_plan_can_defer_full_runtime_window_audit(self) -> None:
         generated_at = datetime(2026, 5, 26, 12, tzinfo=timezone.utc)
         with Session(self.engine) as session:
@@ -2142,6 +2204,57 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "source_executions_missing",
                 "source_tca_missing",
             ],
+        )
+
+    def test_paper_route_evidence_auto_defers_full_audit_until_import_ready(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 26, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            with patch(
+                "app.trading.paper_route_evidence._target_audit",
+                side_effect=AssertionError("full evidence audit should defer"),
+            ):
+                payload = self._build_basic_paper_route_evidence(
+                    session,
+                    generated_at=generated_at,
+                    include_runtime_window_import_audit=None,
+                )
+
+        self.assertEqual(
+            payload["runtime_window_import_audit_mode"],
+            "deferred_until_import_ready",
+        )
+        self.assertEqual(
+            payload["summary"]["runtime_window_import_audit_mode"],
+            "deferred_until_import_ready",
+        )
+        self.assertEqual(
+            payload["runtime_window_import_audit"]["state"],
+            "waiting_for_session_open",
+        )
+        self.assertIn(
+            "runtime_window_import_audit_deferred_until_import_ready",
+            payload["targets"][0]["source_activity"]["missing_reasons"],
+        )
+
+    def test_paper_route_evidence_auto_runs_full_audit_when_import_ready(self) -> None:
+        generated_at = datetime(2026, 5, 26, 22, 30, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            payload = self._build_basic_paper_route_evidence(
+                session,
+                generated_at=generated_at,
+                include_runtime_window_import_audit=None,
+            )
+
+        self.assertEqual(payload["runtime_window_import_audit_mode"], "full")
+        self.assertEqual(
+            payload["summary"]["runtime_window_import_audit_mode"],
+            "full",
+        )
+        self.assertNotIn(
+            "runtime_window_import_audit_deferred_until_import_ready",
+            payload["runtime_window_import_audit"]["blockers"],
         )
 
     def test_evidence_audit_records_target_db_timeout_as_fail_closed_blocker(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -9384,7 +9384,7 @@ class TestTradingApi(TestCase):
                 ),
             ):
                 response = self.client.get(
-                    "/trading/paper-route-evidence?lookback_hours=24&target_limit=1"
+                    "/trading/paper-route-evidence?lookback_hours=24&target_limit=1&full_audit=true"
                 )
             self.assertEqual(response.status_code, 200)
             payload = response.json()
@@ -9393,6 +9393,7 @@ class TestTradingApi(TestCase):
             )
             self.assertEqual(payload["window"]["lookback_hours"], 24)
             self.assertEqual(payload["window"]["target_limit"], 1)
+            self.assertEqual(payload["runtime_window_import_audit_mode"], "full")
             self.assertEqual(payload["summary"]["target_count"], 1)
             self.assertEqual(payload["summary"]["target_with_runtime_ledger_count"], 1)
             self.assertEqual(payload["summary"]["target_with_source_activity_count"], 0)
@@ -10994,13 +10995,28 @@ class TestTradingApi(TestCase):
                         "schema_version": "torghut.paper-route-evidence.v1",
                         "summary": {"target_count": 1},
                     },
-                ),
+                ) as evidence_builder,
             ):
                 response = self.client.get("/trading/paper-route-evidence")
 
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(active_sessions, 0)
-            self.assertEqual(response.json()["summary"]["target_count"], 1)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(active_sessions, 0)
+                self.assertEqual(response.json()["summary"]["target_count"], 1)
+                self.assertIsNone(
+                    evidence_builder.call_args.kwargs[
+                        "include_runtime_window_import_audit"
+                    ]
+                )
+
+                response = self.client.get(
+                    "/trading/paper-route-evidence?full_audit=true"
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertTrue(
+                    evidence_builder.call_args.kwargs[
+                        "include_runtime_window_import_audit"
+                    ]
+                )
         finally:
             settings.trading_paper_route_target_plan_url = original_target_plan_url
             if original_scheduler is None:


### PR DESCRIPTION
## Summary

- Add an auto-deferred mode for `/trading/paper-route-evidence` so pre-import readbacks do not run full source/runtime-ledger audits before the session is import-ready.
- Preserve full evidence diagnostics with `full_audit=true` and automatic full mode once the runtime window is ready for import.
- Surface `runtime_window_import_audit_mode` in the evidence payload and summary for proof automation readback.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app/main.py app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -q -k "paper_route_evidence_auto_defers_full_audit_until_import_ready or paper_route_evidence_auto_runs_full_audit_when_import_ready or target_plan_can_defer_full_runtime_window_audit or target_plan_auto_runs_full_runtime_window_audit_when_import_ready or paper_route_evidence_releases_db_session_before_external_plan_fetch"`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
