### PR TITLE
fix(torghut): repair source windows before runtime import

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -2298,6 +2298,8 @@ def backfill_order_feed_source_windows(
     session: Session,
     *,
     account_label: str | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
     limit: int = 1000,
 ) -> dict[str, int]:
     """Attach source-window rows to persisted order events that already have offsets.
@@ -2325,6 +2327,16 @@ def backfill_order_feed_source_windows(
     )
     if account_label:
         stmt = stmt.where(ExecutionOrderEvent.alpaca_account_label == account_label)
+    if window_start is not None:
+        stmt = stmt.where(
+            func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
+            >= _ensure_aware_utc(window_start)
+        )
+    if window_end is not None:
+        stmt = stmt.where(
+            func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
+            < _ensure_aware_utc(window_end)
+        )
 
     events = session.execute(stmt).scalars().all()
     counters = {

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -2680,6 +2680,61 @@ def _runtime_window_import_health_gate_args(
     return dependency_quorum_decision, continuity_ok, drift_ok
 
 
+def _runtime_window_import_needs_source_window_repair(
+    target: RuntimeWindowImportTarget,
+) -> bool:
+    target_metadata = _as_dict(target.target_metadata)
+    return (
+        target.source_kind == "runtime_ledger_source_collection_candidate"
+        and _as_text(target_metadata.get("source_collection_next_action"))
+        == "materialize_runtime_ledger_source_window_refs"
+    )
+
+
+def _run_runtime_window_source_window_repair(
+    *,
+    target: RuntimeWindowImportTarget,
+    window_start: datetime,
+    window_end: datetime,
+    audit_only: bool,
+) -> dict[str, Any] | None:
+    if not _runtime_window_import_needs_source_window_repair(target):
+        return None
+    source_account_label = target.source_account_label or target.account_label
+    command = [
+        sys.executable,
+        "scripts/repair_order_feed_source_windows.py",
+        "--dsn-env",
+        target.source_dsn_env,
+        "--account-label",
+        source_account_label,
+        "--window-start",
+        _utc_iso(window_start),
+        "--window-end",
+        _utc_iso(window_end),
+        "--batch-size",
+        "5000",
+        "--max-batches",
+        "2",
+        "--source-window-only",
+        "--json",
+    ]
+    if (
+        target.source_account_label
+        and target.source_account_label != target.account_label
+    ):
+        command.extend(["--canonical-account-label", target.account_label])
+    if not audit_only:
+        command.append("--apply")
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, Mapping):
+        raise RuntimeError("runtime_window_source_window_repair_payload_not_mapping")
+    payload = dict(payload)
+    payload["command"] = " ".join(command[:2] + ["..."])
+    return payload
+
+
 def _run_runtime_window_import_target(
     *,
     args: argparse.Namespace,
@@ -2794,6 +2849,13 @@ def _run_runtime_window_import_target(
             runtime_manifest=runtime_manifest,
         )
     )
+    audit_only = bool(getattr(args, "runtime_window_import_audit_only", False))
+    source_window_repair = _run_runtime_window_source_window_repair(
+        target=target,
+        window_start=window_start,
+        window_end=window_end,
+        audit_only=audit_only,
+    )
     command = [
         sys.executable,
         "scripts/import_hypothesis_runtime_windows.py",
@@ -2839,7 +2901,6 @@ def _run_runtime_window_import_target(
     ]
     if target.target_dsn_env:
         command.extend(["--target-dsn-env", target.target_dsn_env])
-    audit_only = bool(getattr(args, "runtime_window_import_audit_only", False))
     if audit_only:
         command.append("--audit-only")
     for artifact_ref in target.artifact_refs:
@@ -2867,6 +2928,8 @@ def _run_runtime_window_import_target(
     if not isinstance(payload, Mapping):
         raise RuntimeError("runtime_window_import_payload_not_mapping")
     payload = dict(payload)
+    if source_window_repair is not None:
+        payload["source_window_repair"] = source_window_repair
     runtime_observation = _as_dict(payload.get("runtime_observation"))
     source_activity_diagnostics = _as_dict(payload.get("source_activity_diagnostics"))
     if not source_activity_diagnostics and runtime_observation:
@@ -2920,6 +2983,7 @@ def _run_runtime_window_import_target(
         "source_kind": target.source_kind,
         "artifact_refs": [str(manifest_path), *target.artifact_refs],
         "target_metadata": dict(target.target_metadata or {}),
+        "source_window_repair": source_window_repair,
         "source_activity_diagnostics": source_activity_diagnostics,
         "source_activity_diagnostic_blockers": source_activity_diagnostic_blockers,
         "proof_status": "blocked" if proof_blockers else "ok",

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -28,6 +28,13 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--dsn-env", default="DB_DSN")
     parser.add_argument("--account-label", default=None)
     parser.add_argument("--canonical-account-label", default=None)
+    parser.add_argument("--window-start", default=None)
+    parser.add_argument("--window-end", default=None)
+    parser.add_argument(
+        "--source-window-only",
+        action="store_true",
+        help="Only attach source-window rows to existing order-feed events.",
+    )
     parser.add_argument("--batch-size", type=int, default=1000)
     parser.add_argument("--max-batches", type=int, default=1)
     parser.add_argument(
@@ -47,6 +54,18 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _parse_optional_dt(value: object) -> datetime | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def _payload(
     *,
     args: argparse.Namespace,
@@ -54,6 +73,8 @@ def _payload(
     batches: list[dict[str, int]],
     execution_event_backfill_enabled: bool,
     execution_event_backfill_skip_reason: str | None,
+    window_start: datetime | None,
+    window_end: datetime | None,
 ) -> dict[str, Any]:
     totals = {
         "selected": sum(batch["selected"] for batch in batches),
@@ -148,6 +169,9 @@ def _payload(
         "dsn_env": args.dsn_env,
         "account_label": args.account_label,
         "canonical_account_label": args.canonical_account_label,
+        "window_start": window_start.isoformat() if window_start is not None else None,
+        "window_end": window_end.isoformat() if window_end is not None else None,
+        "source_window_only": bool(args.source_window_only),
         "backfill_execution_events": bool(args.backfill_execution_events),
         "execution_event_backfill_enabled": execution_event_backfill_enabled,
         "execution_event_backfill_skip_reason": execution_event_backfill_skip_reason,
@@ -189,9 +213,43 @@ def _empty_execution_event_backfill_batch() -> dict[str, int]:
     }
 
 
+def _empty_execution_link_batch() -> dict[str, int]:
+    return {
+        "selected": 0,
+        "executions_matched": 0,
+        "executions_linked": 0,
+        "decisions_matched": 0,
+        "events_linked": 0,
+        "decision_events_linked": 0,
+        "events_without_execution": 0,
+        "events_without_decision": 0,
+        "account_alias_events_linked": 0,
+    }
+
+
+def _empty_execution_state_batch() -> dict[str, int]:
+    return {
+        "selected": 0,
+        "latest_event_found": 0,
+        "executions_updated": 0,
+        "out_of_order_events_skipped": 0,
+    }
+
+
+def _empty_fill_delta_batch() -> dict[str, int]:
+    return {
+        "selected": 0,
+        "delta_events_repaired": 0,
+        "non_increasing_events_marked": 0,
+        "missing_identity_events_marked": 0,
+    }
+
+
 def _execution_event_backfill_config(
     args: argparse.Namespace,
 ) -> tuple[bool, str | None]:
+    if bool(args.source_window_only) and bool(args.backfill_execution_events):
+        return False, "source_window_only"
     if not bool(args.backfill_execution_events):
         return False, None
 
@@ -228,27 +286,45 @@ def main() -> int:
         execution_event_backfill_enabled,
         execution_event_backfill_skip_reason,
     ) = _execution_event_backfill_config(args)
+    window_start = _parse_optional_dt(args.window_start)
+    window_end = _parse_optional_dt(args.window_end)
+    if (
+        window_start is not None
+        and window_end is not None
+        and window_end <= window_start
+    ):
+        raise SystemExit("window_end_must_be_after_window_start")
     batches: list[dict[str, int]] = []
     with session_factory() as session:
         for _ in range(max_batches):
             source_window_batch = backfill_order_feed_source_windows(
                 session,
                 account_label=args.account_label,
+                window_start=window_start,
+                window_end=window_end,
                 limit=batch_size,
             )
-            execution_link_batch = repair_order_feed_execution_links(
-                session,
-                account_label=args.account_label,
-                canonical_account_label=args.canonical_account_label,
-                limit=batch_size,
+            execution_link_batch = (
+                _empty_execution_link_batch()
+                if args.source_window_only
+                else repair_order_feed_execution_links(
+                    session,
+                    account_label=args.account_label,
+                    canonical_account_label=args.canonical_account_label,
+                    limit=batch_size,
+                )
             )
             execution_state_account_label = (
                 args.canonical_account_label or args.account_label
             )
-            execution_state_batch = repair_order_feed_execution_states(
-                session,
-                account_label=execution_state_account_label,
-                limit=batch_size,
+            execution_state_batch = (
+                _empty_execution_state_batch()
+                if args.source_window_only
+                else repair_order_feed_execution_states(
+                    session,
+                    account_label=execution_state_account_label,
+                    limit=batch_size,
+                )
             )
             execution_event_backfill_batch = (
                 backfill_order_feed_events_from_executions(
@@ -256,13 +332,17 @@ def main() -> int:
                     account_label=args.account_label,
                     limit=batch_size,
                 )
-                if execution_event_backfill_enabled
+                if execution_event_backfill_enabled and not args.source_window_only
                 else _empty_execution_event_backfill_batch()
             )
-            fill_delta_batch = repair_order_feed_fill_deltas(
-                session,
-                account_label=args.account_label,
-                limit=batch_size,
+            fill_delta_batch = (
+                _empty_fill_delta_batch()
+                if args.source_window_only
+                else repair_order_feed_fill_deltas(
+                    session,
+                    account_label=args.account_label,
+                    limit=batch_size,
+                )
             )
             batch = {
                 **source_window_batch,
@@ -353,6 +433,8 @@ def main() -> int:
         batches=batches,
         execution_event_backfill_enabled=execution_event_backfill_enabled,
         execution_event_backfill_skip_reason=execution_event_backfill_skip_reason,
+        window_start=window_start,
+        window_end=window_end,
     )
     print(
         json.dumps(payload, separators=(",", ":"))

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -1449,6 +1449,85 @@ class TestOrderFeed(TestCase):
         )
         self.assertEqual(event.source_window_id, source_window_id)
 
+    def test_backfill_source_windows_filters_by_event_window(self) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            before_event = ExecutionOrderEvent(
+                event_fingerprint="legacy-fill-before-window",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=111,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 9, 59, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                event_type="fill",
+                status="filled",
+                raw_event={"event": "fill"},
+                execution_id=execution.id,
+                trade_decision_id=execution.trade_decision_id,
+            )
+            in_window_event = ExecutionOrderEvent(
+                event_fingerprint="legacy-fill-inside-window",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=112,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 5, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                event_type="fill",
+                status="filled",
+                raw_event={"event": "fill"},
+                execution_id=execution.id,
+                trade_decision_id=execution.trade_decision_id,
+            )
+            after_event = ExecutionOrderEvent(
+                event_fingerprint="legacy-fill-after-window",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=113,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 30, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                event_type="fill",
+                status="filled",
+                raw_event={"event": "fill"},
+                execution_id=execution.id,
+                trade_decision_id=execution.trade_decision_id,
+            )
+            session.add_all([before_event, in_window_event, after_event])
+            session.commit()
+
+            result = backfill_order_feed_source_windows(
+                session,
+                account_label="paper",
+                window_start=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                window_end=datetime(2026, 2, 1, 10, 30, tzinfo=timezone.utc),
+                limit=10,
+            )
+            session.commit()
+            session.refresh(before_event)
+            session.refresh(in_window_event)
+            session.refresh(after_event)
+
+        self.assertEqual(
+            result,
+            {
+                "selected": 1,
+                "source_windows_created": 1,
+                "source_windows_reused": 0,
+                "events_linked": 1,
+            },
+        )
+        self.assertIsNone(before_event.source_window_id)
+        self.assertIsNotNone(in_window_event.source_window_id)
+        self.assertIsNone(after_event.source_window_id)
+
     def test_linking_one_event_keeps_source_window_unlinked_counts_aggregate(
         self,
     ) -> None:

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import sys
+from datetime import timezone
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -37,6 +38,40 @@ class _FakeSessionFactory:
 
 
 class TestRepairOrderFeedSourceWindowsScript(TestCase):
+    def test_parse_optional_dt_handles_empty_and_naive_values(self) -> None:
+        self.assertIsNone(script._parse_optional_dt(" "))
+        parsed = script._parse_optional_dt("2026-05-13T17:00:00")
+        self.assertIsNotNone(parsed)
+        assert parsed is not None
+        self.assertEqual(parsed.tzinfo, timezone.utc)
+        self.assertEqual(parsed.isoformat(), "2026-05-13T17:00:00+00:00")
+
+    def test_main_rejects_invalid_bounded_window(self) -> None:
+        with (
+            patch.dict(os.environ, {"SIM_DSN": "postgresql://example/sim"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "repair_order_feed_source_windows.py",
+                    "--dsn-env",
+                    "SIM_DSN",
+                    "--window-start",
+                    "2026-05-13T17:30:00Z",
+                    "--window-end",
+                    "2026-05-13T17:00:00Z",
+                    "--json",
+                ],
+            ),
+            patch.object(script, "create_engine", return_value=object()),
+            patch.object(script, "sessionmaker") as sessionmaker_mock,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                script.main()
+
+        self.assertEqual(str(raised.exception), "window_end_must_be_after_window_start")
+        sessionmaker_mock.assert_called_once()
+
     def test_main_defaults_to_dry_run_and_rolls_back(self) -> None:
         fake_session = _FakeSession()
         stdout = io.StringIO()
@@ -121,6 +156,7 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(payload["apply"], False)
         self.assertEqual(payload["backfill_execution_events"], False)
+        self.assertEqual(payload["source_window_only"], False)
         self.assertEqual(payload["execution_event_backfill_enabled"], False)
         self.assertIsNone(payload["execution_event_backfill_skip_reason"])
         self.assertEqual(payload["dsn_env"], "TEST_DSN")
@@ -159,6 +195,8 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         backfill.assert_called_once_with(
             fake_session,
             account_label=None,
+            window_start=None,
+            window_end=None,
             limit=5000,
         )
         repair_links.assert_called_once_with(
@@ -250,11 +288,11 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                         "events_without_decision": 0,
                     },
                 ],
-            ) as repair_links,
+            ),
             patch.object(
                 script,
                 "backfill_order_feed_events_from_executions",
-            ) as backfill_execution_events,
+            ),
             patch.object(
                 script,
                 "repair_order_feed_execution_states",
@@ -272,7 +310,7 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                         "out_of_order_events_skipped": 1,
                     },
                 ],
-            ) as repair_states,
+            ),
             patch.object(
                 script,
                 "repair_order_feed_fill_deltas",
@@ -290,7 +328,7 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                         "missing_identity_events_marked": 0,
                     },
                 ],
-            ) as repair_deltas,
+            ),
             patch("sys.stdout", stdout),
         ):
             exit_code = script.main()
@@ -326,18 +364,196 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(fake_session.rollbacks, 0)
         self.assertEqual(backfill.call_count, 2)
         self.assertEqual(backfill.call_args.kwargs["account_label"], "TORGHUT_SIM")
+        self.assertIsNone(backfill.call_args.kwargs["window_start"])
+        self.assertIsNone(backfill.call_args.kwargs["window_end"])
         self.assertEqual(backfill.call_args.kwargs["limit"], 2)
-        self.assertEqual(repair_links.call_count, 2)
+
+    def test_main_passes_bounded_window_to_source_window_backfill(self) -> None:
+        fake_session = _FakeSession()
+        stdout = io.StringIO()
+
+        with (
+            patch.dict(os.environ, {"SIM_DSN": "postgresql://example/sim"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "repair_order_feed_source_windows.py",
+                    "--dsn-env",
+                    "SIM_DSN",
+                    "--account-label",
+                    "TORGHUT_SIM",
+                    "--window-start",
+                    "2026-05-13T17:00:00Z",
+                    "--window-end",
+                    "2026-05-13T17:30:00Z",
+                    "--json",
+                    "--apply",
+                ],
+            ),
+            patch.object(script, "create_engine", return_value=object()),
+            patch.object(
+                script,
+                "sessionmaker",
+                return_value=_FakeSessionFactory(fake_session),
+            ),
+            patch.object(
+                script,
+                "backfill_order_feed_source_windows",
+                return_value={
+                    "selected": 2,
+                    "source_windows_created": 1,
+                    "source_windows_reused": 1,
+                    "events_linked": 2,
+                },
+            ) as backfill,
+            patch.object(
+                script,
+                "repair_order_feed_execution_links",
+                return_value={
+                    "selected": 0,
+                    "executions_matched": 0,
+                    "executions_linked": 0,
+                    "decisions_matched": 0,
+                    "events_linked": 0,
+                    "decision_events_linked": 0,
+                    "events_without_execution": 0,
+                    "events_without_decision": 0,
+                    "account_alias_events_linked": 0,
+                },
+            ) as repair_links,
+            patch.object(
+                script,
+                "repair_order_feed_execution_states",
+                return_value={
+                    "selected": 0,
+                    "latest_event_found": 0,
+                    "executions_updated": 0,
+                    "out_of_order_events_skipped": 0,
+                },
+            ) as repair_states,
+            patch.object(
+                script,
+                "backfill_order_feed_events_from_executions",
+            ) as backfill_execution_events,
+            patch.object(
+                script,
+                "repair_order_feed_fill_deltas",
+                return_value={
+                    "selected": 0,
+                    "delta_events_repaired": 0,
+                    "non_increasing_events_marked": 0,
+                    "missing_identity_events_marked": 0,
+                },
+            ) as repair_deltas,
+            patch("sys.stdout", stdout),
+        ):
+            exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["window_start"], "2026-05-13T17:00:00+00:00")
+        self.assertEqual(payload["window_end"], "2026-05-13T17:30:00+00:00")
+        self.assertEqual(fake_session.commits, 1)
+        self.assertEqual(fake_session.rollbacks, 0)
+        backfill.assert_called_once()
+        self.assertEqual(backfill.call_args.kwargs["account_label"], "TORGHUT_SIM")
+        self.assertEqual(
+            backfill.call_args.kwargs["window_start"].isoformat(),
+            "2026-05-13T17:00:00+00:00",
+        )
+        self.assertEqual(
+            backfill.call_args.kwargs["window_end"].isoformat(),
+            "2026-05-13T17:30:00+00:00",
+        )
+        backfill_execution_events.assert_not_called()
+        self.assertEqual(repair_links.call_count, 1)
         self.assertEqual(repair_links.call_args.kwargs["account_label"], "TORGHUT_SIM")
         self.assertIsNone(repair_links.call_args.kwargs["canonical_account_label"])
-        self.assertEqual(repair_links.call_args.kwargs["limit"], 2)
-        backfill_execution_events.assert_not_called()
-        self.assertEqual(repair_states.call_count, 2)
+        self.assertEqual(repair_links.call_args.kwargs["limit"], 1000)
+        self.assertEqual(repair_states.call_count, 1)
         self.assertEqual(repair_states.call_args.kwargs["account_label"], "TORGHUT_SIM")
-        self.assertEqual(repair_states.call_args.kwargs["limit"], 2)
-        self.assertEqual(repair_deltas.call_count, 2)
+        self.assertEqual(repair_states.call_args.kwargs["limit"], 1000)
+        self.assertEqual(repair_deltas.call_count, 1)
         self.assertEqual(repair_deltas.call_args.kwargs["account_label"], "TORGHUT_SIM")
-        self.assertEqual(repair_deltas.call_args.kwargs["limit"], 2)
+        self.assertEqual(repair_deltas.call_args.kwargs["limit"], 1000)
+
+    def test_main_source_window_only_skips_broader_repairs(self) -> None:
+        fake_session = _FakeSession()
+        stdout = io.StringIO()
+
+        with (
+            patch.dict(os.environ, {"SIM_DSN": "postgresql://example/sim"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "repair_order_feed_source_windows.py",
+                    "--dsn-env",
+                    "SIM_DSN",
+                    "--account-label",
+                    "TORGHUT_SIM",
+                    "--source-window-only",
+                    "--backfill-execution-events",
+                    "--json",
+                    "--apply",
+                    "--batch-size",
+                    "2",
+                ],
+            ),
+            patch.object(script, "create_engine", return_value=object()),
+            patch.object(
+                script,
+                "sessionmaker",
+                return_value=_FakeSessionFactory(fake_session),
+            ),
+            patch.object(
+                script,
+                "backfill_order_feed_source_windows",
+                return_value={
+                    "selected": 2,
+                    "source_windows_created": 1,
+                    "source_windows_reused": 1,
+                    "events_linked": 2,
+                },
+            ) as backfill,
+            patch.object(script, "repair_order_feed_execution_links") as repair_links,
+            patch.object(script, "repair_order_feed_execution_states") as repair_states,
+            patch.object(
+                script,
+                "backfill_order_feed_events_from_executions",
+            ) as backfill_execution_events,
+            patch.object(script, "repair_order_feed_fill_deltas") as repair_deltas,
+            patch("sys.stdout", stdout),
+        ):
+            exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["source_window_only"])
+        self.assertFalse(payload["execution_event_backfill_enabled"])
+        self.assertEqual(
+            payload["execution_event_backfill_skip_reason"], "source_window_only"
+        )
+        self.assertEqual(payload["selected"], 2)
+        self.assertEqual(payload["events_linked"], 2)
+        self.assertEqual(payload["execution_link_candidates"], 0)
+        self.assertEqual(payload["execution_state_candidates"], 0)
+        self.assertEqual(payload["execution_event_backfill_candidates"], 0)
+        self.assertEqual(payload["fill_delta_candidates"], 0)
+        self.assertEqual(fake_session.commits, 1)
+        self.assertEqual(fake_session.rollbacks, 0)
+        backfill.assert_called_once_with(
+            fake_session,
+            account_label="TORGHUT_SIM",
+            window_start=None,
+            window_end=None,
+            limit=2,
+        )
+        repair_links.assert_not_called()
+        repair_states.assert_not_called()
+        backfill_execution_events.assert_not_called()
+        repair_deltas.assert_not_called()
 
     def test_main_backfills_execution_events_when_enabled(self) -> None:
         fake_session = _FakeSession()

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -2884,6 +2884,266 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertFalse(metadata["promotion_allowed"])
         self.assertFalse(metadata["final_promotion_authorized"])
 
+    def test_runtime_window_import_repairs_source_windows_before_source_collection_import(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps(
+                {
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                }
+            ),
+            encoding="utf-8",
+        )
+        window_start = datetime(2026, 5, 13, 17, 0, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 13, 17, 30, tzinfo=timezone.utc)
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="c88421d619759b2cfaa6f4d0",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            target_dsn_env="SIM_DB_DSN",
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            account_label="TORGHUT_SIM",
+            source_account_label="TORGHUT_PAPER",
+            dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            source_manifest_ref=str(hypothesis_path),
+            source_kind="runtime_ledger_source_collection_candidate",
+            delay_adjusted_depth_stress_report_ref="",
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            target_metadata={
+                "source_collection_next_action": (
+                    "materialize_runtime_ledger_source_window_refs"
+                ),
+            },
+        )
+        args = SimpleNamespace(
+            runtime_window_target_plan_settlement_seconds=0,
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_import_audit_only=False,
+        )
+
+        repair_completed = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "status": "ok",
+                    "apply": True,
+                    "source_window_only": True,
+                    "selected": 2,
+                    "source_windows_created": 1,
+                    "source_windows_reused": 1,
+                    "events_linked": 2,
+                }
+            )
+        )
+        import_completed = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "inserted_windows": 1,
+                    "promotion_decision": "blocked",
+                    "source_window_ids": ["window-1", "window-2"],
+                }
+            )
+        )
+
+        with patch.object(
+            renewal.subprocess,
+            "run",
+            side_effect=[repair_completed, import_completed],
+        ) as run_mock:
+            payload = renewal._run_runtime_window_import_target(
+                args=args,
+                target=target,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                window_start=window_start,
+                window_end=window_end,
+                now=datetime(2026, 5, 13, 18, 0, tzinfo=timezone.utc),
+            )
+
+        self.assertEqual(run_mock.call_count, 2)
+        repair_command = run_mock.call_args_list[0].args[0]
+        import_command = run_mock.call_args_list[1].args[0]
+        self.assertIn("scripts/repair_order_feed_source_windows.py", repair_command)
+        self.assertIn("--apply", repair_command)
+        self.assertIn("--source-window-only", repair_command)
+        self.assertIn("--window-start", repair_command)
+        self.assertEqual(
+            repair_command[repair_command.index("--window-start") + 1],
+            "2026-05-13T17:00:00Z",
+        )
+        self.assertEqual(
+            repair_command[repair_command.index("--window-end") + 1],
+            "2026-05-13T17:30:00Z",
+        )
+        self.assertEqual(
+            repair_command[repair_command.index("--account-label") + 1],
+            "TORGHUT_PAPER",
+        )
+        self.assertEqual(
+            repair_command[repair_command.index("--canonical-account-label") + 1],
+            "TORGHUT_SIM",
+        )
+        self.assertIn("scripts/import_hypothesis_runtime_windows.py", import_command)
+        self.assertEqual(
+            import_command[import_command.index("--source-account-label") + 1],
+            "TORGHUT_PAPER",
+        )
+        self.assertEqual(payload["source_window_repair"]["events_linked"], 2)
+        self.assertTrue(payload["source_window_repair"]["source_window_only"])
+        self.assertEqual(payload["summary"]["source_window_repair"]["events_linked"], 2)
+
+    def test_runtime_window_import_audit_only_dry_runs_source_window_repair(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps(
+                {
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                }
+            ),
+            encoding="utf-8",
+        )
+        window_start = datetime(2026, 5, 13, 17, 0, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 13, 17, 30, tzinfo=timezone.utc)
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="c88421d619759b2cfaa6f4d0",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            target_dsn_env="SIM_DB_DSN",
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            account_label="TORGHUT_SIM",
+            source_account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            source_manifest_ref=str(hypothesis_path),
+            source_kind="runtime_ledger_source_collection_candidate",
+            delay_adjusted_depth_stress_report_ref="",
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            target_metadata={
+                "source_collection_next_action": (
+                    "materialize_runtime_ledger_source_window_refs"
+                ),
+            },
+        )
+        args = SimpleNamespace(
+            runtime_window_target_plan_settlement_seconds=0,
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_import_audit_only=True,
+        )
+
+        repair_completed = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "status": "ok",
+                    "apply": False,
+                    "source_window_only": True,
+                    "selected": 2,
+                    "source_windows_created": 1,
+                    "source_windows_reused": 1,
+                    "events_linked": 2,
+                }
+            )
+        )
+        import_completed = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "schema_version": "torghut.runtime-window-import-source-audit.v1",
+                    "audit_only": True,
+                    "would_persist": False,
+                    "promotion_allowed": True,
+                }
+            )
+        )
+
+        with patch.object(
+            renewal.subprocess,
+            "run",
+            side_effect=[repair_completed, import_completed],
+        ) as run_mock:
+            payload = renewal._run_runtime_window_import_target(
+                args=args,
+                target=target,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                window_start=window_start,
+                window_end=window_end,
+                now=datetime(2026, 5, 13, 18, 0, tzinfo=timezone.utc),
+            )
+
+        self.assertEqual(run_mock.call_count, 2)
+        repair_command = run_mock.call_args_list[0].args[0]
+        import_command = run_mock.call_args_list[1].args[0]
+        self.assertIn("--source-window-only", repair_command)
+        self.assertNotIn("--apply", repair_command)
+        self.assertIn("--audit-only", import_command)
+        self.assertEqual(payload["status"], "audit_only")
+        self.assertEqual(payload["proof_status"], "blocked")
+        self.assertFalse(payload["source_window_repair"]["apply"])
+        self.assertTrue(payload["source_window_repair"]["source_window_only"])
+        blocker_codes = [item["blocker"] for item in payload["proof_blockers"]]
+        self.assertIn("runtime_window_import_audit_only_no_persistence", blocker_codes)
+
+    def test_runtime_window_source_window_repair_rejects_non_mapping_payload(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 13, 17, 0, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 13, 17, 30, tzinfo=timezone.utc)
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="c88421d619759b2cfaa6f4d0",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            target_dsn_env="SIM_DB_DSN",
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            account_label="TORGHUT_SIM",
+            source_account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+            source_kind="runtime_ledger_source_collection_candidate",
+            delay_adjusted_depth_stress_report_ref="",
+            window_start=window_start.isoformat(),
+            window_end=window_end.isoformat(),
+            target_metadata={
+                "source_collection_next_action": (
+                    "materialize_runtime_ledger_source_window_refs"
+                ),
+            },
+        )
+
+        with patch.object(
+            renewal.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="[]"),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "runtime_window_source_window_repair_payload_not_mapping",
+            ):
+                renewal._run_runtime_window_source_window_repair(
+                    target=target,
+                    window_start=window_start,
+                    window_end=window_end,
+                    audit_only=False,
+                )
+
     def test_runtime_window_target_metadata_defaults_source_collection_blockers(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds bounded window filters to order-feed source-window backfill so source-window repair can target only the runtime import interval.
- Adds `--source-window-only` mode to the order-feed repair script so the runtime import pre-repair only attaches real source windows and does not run broader execution/link/fill repairs.
- Runs the source-window-only repair before runtime-window imports that explicitly request `materialize_runtime_ledger_source_window_refs`, with audit-only imports kept dry-run and source/target account aliases preserved in the command.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_repair_order_feed_source_windows_script.py tests/test_run_empirical_promotion_jobs.py && uv run --frozen ruff check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_repair_order_feed_source_windows_script.py tests/test_run_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q -k 'source_window_repair or audit_only' && uv run --frozen pytest tests/test_repair_order_feed_source_windows_script.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py -q -k 'backfill_source_windows_filters_by_event_window' && uv run --frozen pytest tests/test_repair_order_feed_source_windows_script.py -q -k 'parse_optional_dt_handles_empty_and_naive_values or rejects_invalid_bounded_window' && uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q -k 'source_window_repair_rejects_non_mapping_payload'`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_run_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check origin/main..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
