### PR TITLE
fix(torghut): harden paper route proof reads

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -817,6 +817,27 @@ def _rollback_paper_route_audit_session(session: Session) -> None:
         logger.warning("Failed to roll back paper-route evidence session")
 
 
+def _paper_route_audit_db_unavailable_blockers(error_source: str) -> list[str]:
+    return _unique_text_items(
+        [
+            PAPER_ROUTE_EVIDENCE_DB_UNAVAILABLE_BLOCKER,
+            _paper_route_audit_error_source_blocker(error_source),
+        ]
+    )
+
+
+def _rollback_after_paper_route_audit_error(
+    session: Session,
+    *,
+    source: str,
+    exc: SQLAlchemyError,
+) -> None:
+    logger.warning(
+        "Paper route audit query unavailable source=%s error=%s", source, exc
+    )
+    _rollback_paper_route_audit_session(session)
+
+
 def _execution_activity_timestamp() -> Any:
     return func.coalesce(
         Execution.order_feed_last_event_ts,
@@ -5344,12 +5365,47 @@ def _account_contamination_audit(
     )
     if symbol_filters:
         stmt = stmt.where(ExecutionOrderEvent.symbol.in_(symbol_filters))
-    _maybe_set_paper_route_audit_statement_timeout(session)
-    rows = list(
-        session.execute(
-            stmt.order_by(order_event_activity_ts.desc()).limit(500)
-        ).scalars()
-    )
+    error_source = "paper_route_account_contamination"
+    try:
+        _maybe_set_paper_route_audit_statement_timeout(session)
+        rows = list(
+            session.execute(
+                stmt.order_by(order_event_activity_ts.desc()).limit(500)
+            ).scalars()
+        )
+    except SQLAlchemyError as exc:
+        _rollback_after_paper_route_audit_error(session, source=error_source, exc=exc)
+        return {
+            "schema_version": "torghut.paper-route-account-contamination-audit.v1",
+            "scope": "target_window_account_symbol_order_events",
+            "state": "target_account_audit_unavailable",
+            "account_label": account_label,
+            "symbols": symbol_filters,
+            "window_start": _isoformat(window_start),
+            "window_end": _isoformat(window_end),
+            "contaminated": None,
+            "order_event_count": 0,
+            "unlinked_order_event_count": 0,
+            "foreign_linked_order_event_count": 0,
+            "target_linked_order_event_count": 0,
+            "client_order_id_count": 0,
+            "sample_client_order_ids": [],
+            "symbol_counts": {},
+            "event_type_counts": {},
+            "status_counts": {},
+            "foreign_strategy_counts": {},
+            "last_event_at": None,
+            "reason": "account_contamination_db_unavailable",
+            "blockers": _paper_route_audit_db_unavailable_blockers(error_source),
+            "sample_order_event_refs": [],
+            "source_audit_blockers": [
+                PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER
+            ],
+            "db_load_error": _paper_route_audit_error_payload(
+                error_source=error_source,
+                error=exc,
+            ),
+        }
     target_linked_rows: list[ExecutionOrderEvent] = []
     foreign_linked_rows: list[ExecutionOrderEvent] = []
     unlinked_rows: list[ExecutionOrderEvent] = []
@@ -5539,31 +5595,48 @@ def _account_window_start_snapshot_audit(
     if not required:
         return base_payload
 
-    _maybe_set_paper_route_audit_statement_timeout(session)
-    before_snapshot = session.execute(
-        select(PositionSnapshot)
-        .where(PositionSnapshot.alpaca_account_label == account_label)
-        .where(PositionSnapshot.as_of <= window_start)
-        .order_by(PositionSnapshot.as_of.desc())
-        .limit(1)
-    ).scalar_one_or_none()
-    after_snapshot = None
-    if before_snapshot is None:
+    error_source = "paper_route_account_window_start_snapshot"
+    try:
         _maybe_set_paper_route_audit_statement_timeout(session)
-        after_snapshot = session.execute(
+        before_snapshot = session.execute(
             select(PositionSnapshot)
             .where(PositionSnapshot.alpaca_account_label == account_label)
-            .where(PositionSnapshot.as_of > window_start)
-            .where(
-                PositionSnapshot.as_of
-                <= window_start
-                + timedelta(
-                    seconds=PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS
-                )
-            )
-            .order_by(PositionSnapshot.as_of.asc())
+            .where(PositionSnapshot.as_of <= window_start)
+            .order_by(PositionSnapshot.as_of.desc())
             .limit(1)
         ).scalar_one_or_none()
+        after_snapshot = None
+        if before_snapshot is None:
+            _maybe_set_paper_route_audit_statement_timeout(session)
+            after_snapshot = session.execute(
+                select(PositionSnapshot)
+                .where(PositionSnapshot.alpaca_account_label == account_label)
+                .where(PositionSnapshot.as_of > window_start)
+                .where(
+                    PositionSnapshot.as_of
+                    <= window_start
+                    + timedelta(
+                        seconds=PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS
+                    )
+                )
+                .order_by(PositionSnapshot.as_of.asc())
+                .limit(1)
+            ).scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        _rollback_after_paper_route_audit_error(session, source=error_source, exc=exc)
+        return {
+            **base_payload,
+            "state": "blocked",
+            "flat": False,
+            "blockers": _paper_route_audit_db_unavailable_blockers(error_source),
+            "source_audit_blockers": [
+                PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER
+            ],
+            "db_load_error": _paper_route_audit_error_payload(
+                error_source=error_source,
+                error=exc,
+            ),
+        }
 
     snapshot = before_snapshot or after_snapshot
     if snapshot is None:
@@ -5675,14 +5748,31 @@ def _account_pre_session_snapshot_audit(
         }
 
     snapshot_cutoff = min(generated_at, window_start)
-    _maybe_set_paper_route_audit_statement_timeout(session)
-    snapshot = session.execute(
-        select(PositionSnapshot)
-        .where(PositionSnapshot.alpaca_account_label == account_label)
-        .where(PositionSnapshot.as_of <= snapshot_cutoff)
-        .order_by(PositionSnapshot.as_of.desc())
-        .limit(1)
-    ).scalar_one_or_none()
+    error_source = "paper_route_account_pre_session_snapshot"
+    try:
+        _maybe_set_paper_route_audit_statement_timeout(session)
+        snapshot = session.execute(
+            select(PositionSnapshot)
+            .where(PositionSnapshot.alpaca_account_label == account_label)
+            .where(PositionSnapshot.as_of <= snapshot_cutoff)
+            .order_by(PositionSnapshot.as_of.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        _rollback_after_paper_route_audit_error(session, source=error_source, exc=exc)
+        return {
+            **base_payload,
+            "state": "blocked",
+            "flat": False,
+            "blockers": _paper_route_audit_db_unavailable_blockers(error_source),
+            "source_audit_blockers": [
+                PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER
+            ],
+            "db_load_error": _paper_route_audit_error_payload(
+                error_source=error_source,
+                error=exc,
+            ),
+        }
     if snapshot is None:
         return {
             **base_payload,
@@ -5916,14 +6006,33 @@ def _account_window_close_snapshot_audit(
             "zero_open_position_evidence": True,
         }
 
-    snapshot = session.execute(
-        select(PositionSnapshot)
-        .where(PositionSnapshot.alpaca_account_label == account_label)
-        .where(PositionSnapshot.as_of >= window_end)
-        .where(PositionSnapshot.as_of <= generated_at)
-        .order_by(PositionSnapshot.as_of.desc())
-        .limit(1)
-    ).scalar_one_or_none()
+    error_source = "paper_route_account_window_close_snapshot"
+    try:
+        _maybe_set_paper_route_audit_statement_timeout(session)
+        snapshot = session.execute(
+            select(PositionSnapshot)
+            .where(PositionSnapshot.alpaca_account_label == account_label)
+            .where(PositionSnapshot.as_of >= window_end)
+            .where(PositionSnapshot.as_of <= generated_at)
+            .order_by(PositionSnapshot.as_of.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        _rollback_after_paper_route_audit_error(session, source=error_source, exc=exc)
+        return {
+            **base_payload,
+            "state": "blocked",
+            "flat": False,
+            "zero_open_position_evidence": False,
+            "blockers": _paper_route_audit_db_unavailable_blockers(error_source),
+            "source_audit_blockers": [
+                PAPER_ROUTE_TARGET_ACCOUNT_AUDIT_UNAVAILABLE_BLOCKER
+            ],
+            "db_load_error": _paper_route_audit_error_payload(
+                error_source=error_source,
+                error=exc,
+            ),
+        }
     if snapshot is None:
         return {
             **base_payload,

--- a/services/torghut/migrations/versions/0053_paper_route_proof_read_indexes.py
+++ b/services/torghut/migrations/versions/0053_paper_route_proof_read_indexes.py
@@ -1,0 +1,97 @@
+"""Add paper route proof read indexes.
+
+Revision ID: 0053_paper_route_proof_read_indexes
+Revises: 0052_proof_read_timeout_indexes
+Create Date: 2026-06-05 18:05:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+revision = "0053_paper_route_proof_read_indexes"
+down_revision = "0052_proof_read_timeout_indexes"
+branch_labels = None
+depends_on = None
+
+_INDEXES: tuple[tuple[str, str, str], ...] = (
+    (
+        "ix_position_snapshots_account_as_of_desc",
+        "position_snapshots",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_position_snapshots_account_as_of_desc
+ON position_snapshots (
+  alpaca_account_label,
+  as_of DESC
+)
+""",
+    ),
+    (
+        "ix_execution_order_events_account_symbol_activity_desc",
+        "execution_order_events",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_execution_order_events_account_symbol_activity_desc
+ON execution_order_events (
+  alpaca_account_label,
+  symbol,
+  (COALESCE(event_ts, created_at)) DESC,
+  trade_decision_id
+)
+WHERE symbol IS NOT NULL
+""",
+    ),
+    (
+        "ix_executions_account_symbol_activity_desc",
+        "executions",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_executions_account_symbol_activity_desc
+ON executions (
+  alpaca_account_label,
+  symbol,
+  (COALESCE(order_feed_last_event_ts, last_update_at, updated_at, created_at)) DESC,
+  trade_decision_id
+)
+""",
+    ),
+    (
+        "ix_execution_tca_account_symbol_computed_desc",
+        "execution_tca_metrics",
+        """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_execution_tca_account_symbol_computed_desc
+ON execution_tca_metrics (
+  alpaca_account_label,
+  symbol,
+  computed_at DESC,
+  trade_decision_id
+)
+WHERE alpaca_account_label IS NOT NULL
+""",
+    ),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    with op.get_context().autocommit_block():
+        for _index_name, table_name, create_sql in _INDEXES:
+            if not inspector.has_table(table_name):
+                continue
+            op.execute(sa.text(create_sql))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if getattr(getattr(bind, "dialect", None), "name", "") != "postgresql":
+        return
+    inspector = inspect(bind)
+    with op.get_context().autocommit_block():
+        for index_name, table_name, _create_sql in reversed(_INDEXES):
+            if not inspector.has_table(table_name):
+                continue
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}"))

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -33,8 +33,10 @@ from app.trading.paper_route_evidence import (
     PAPER_ROUTE_SOURCE_ACTIVITY_REF_LIMIT,
     PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT,
     RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
+    _account_contamination_audit,
     _account_contamination_reason,
     _account_pre_session_snapshot_audit,
+    _account_window_close_snapshot_audit,
     _account_window_start_snapshot_audit,
     _balanced_pair_probe_symbol_actions,
     _hpairs_round_trip_identity_blockers,
@@ -2458,6 +2460,157 @@ class TestPaperRouteEvidenceAudit(TestCase):
         blockers = set(audit["readiness"]["blockers"])
         self.assertIn("paper_route_evidence_db_unavailable", blockers)
         self.assertIn("paper_route_source_target_audit_db_unavailable", blockers)
+
+    def test_account_contamination_query_timeout_fails_closed(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            with patch.object(
+                session, "execute", side_effect=SQLAlchemyError("statement timeout")
+            ):
+                audit = _account_contamination_audit(
+                    session,
+                    account_label="TORGHUT_SIM",
+                    symbols=["AAPL", "AMZN"],
+                    window_start=window_start,
+                    window_end=window_end,
+                    strategy_lookup_names=["paper-route-candidate-v1"],
+                    candidate_id="candidate-timeout",
+                    hypothesis_id="H-TIMEOUT",
+                    require_source_lineage=True,
+                )
+
+        self.assertEqual(audit["state"], "target_account_audit_unavailable")
+        self.assertIsNone(audit["contaminated"])
+        self.assertEqual(audit["reason"], "account_contamination_db_unavailable")
+        self.assertEqual(audit["order_event_count"], 0)
+        self.assertIn("paper_route_evidence_db_unavailable", audit["blockers"])
+        self.assertIn(
+            "paper_route_account_contamination_db_unavailable", audit["blockers"]
+        )
+        self.assertEqual(
+            audit["db_load_error"]["source"], "paper_route_account_contamination"
+        )
+        self.assertEqual(
+            audit["db_load_error"]["blocker"],
+            "paper_route_account_contamination_db_unavailable",
+        )
+
+    def test_account_window_start_snapshot_query_timeout_fails_closed(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            with patch.object(
+                session, "execute", side_effect=SQLAlchemyError("statement timeout")
+            ):
+                audit = _account_window_start_snapshot_audit(
+                    session,
+                    account_label="TORGHUT_SIM",
+                    symbols=["AAPL"],
+                    window_start=window_start,
+                    generated_at=window_start,
+                )
+
+        self.assertEqual(audit["state"], "blocked")
+        self.assertFalse(audit["flat"])
+        self.assertIn("paper_route_evidence_db_unavailable", audit["blockers"])
+        self.assertIn(
+            "paper_route_account_window_start_snapshot_db_unavailable",
+            audit["blockers"],
+        )
+        self.assertEqual(
+            audit["db_load_error"]["source"],
+            "paper_route_account_window_start_snapshot",
+        )
+
+    def test_account_window_start_fallback_snapshot_timeout_fails_closed(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            first_read = SimpleNamespace(scalar_one_or_none=lambda: None)
+            with patch.object(
+                session,
+                "execute",
+                side_effect=[first_read, SQLAlchemyError("statement timeout")],
+            ):
+                audit = _account_window_start_snapshot_audit(
+                    session,
+                    account_label="TORGHUT_SIM",
+                    symbols=["AAPL"],
+                    window_start=window_start,
+                    generated_at=window_start,
+                )
+
+        self.assertEqual(audit["state"], "blocked")
+        self.assertFalse(audit["flat"])
+        self.assertIn(
+            "paper_route_account_window_start_snapshot_db_unavailable",
+            audit["blockers"],
+        )
+        self.assertEqual(
+            audit["db_load_error"]["source"],
+            "paper_route_account_window_start_snapshot",
+        )
+
+    def test_account_pre_session_snapshot_query_timeout_fails_closed(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        generated_at = window_start - timedelta(minutes=5)
+
+        with Session(self.engine) as session:
+            with patch.object(
+                session, "execute", side_effect=SQLAlchemyError("statement timeout")
+            ):
+                audit = _account_pre_session_snapshot_audit(
+                    session,
+                    account_label="TORGHUT_SIM",
+                    symbols=["AAPL"],
+                    generated_at=generated_at,
+                    window_start=window_start,
+                    window_end=window_end,
+                )
+
+        self.assertEqual(audit["state"], "blocked")
+        self.assertFalse(audit["flat"])
+        self.assertIn("paper_route_evidence_db_unavailable", audit["blockers"])
+        self.assertIn(
+            "paper_route_account_pre_session_snapshot_db_unavailable",
+            audit["blockers"],
+        )
+        self.assertEqual(
+            audit["db_load_error"]["source"],
+            "paper_route_account_pre_session_snapshot",
+        )
+
+    def test_account_window_close_snapshot_query_timeout_fails_closed(self) -> None:
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        generated_at = window_end + timedelta(minutes=30)
+
+        with Session(self.engine) as session:
+            with patch.object(
+                session, "execute", side_effect=SQLAlchemyError("statement timeout")
+            ):
+                audit = _account_window_close_snapshot_audit(
+                    session,
+                    account_label="TORGHUT_SIM",
+                    symbols=["AAPL"],
+                    window_end=window_end,
+                    generated_at=generated_at,
+                )
+
+        self.assertEqual(audit["state"], "blocked")
+        self.assertFalse(audit["flat"])
+        self.assertFalse(audit["zero_open_position_evidence"])
+        self.assertIn("paper_route_evidence_db_unavailable", audit["blockers"])
+        self.assertIn(
+            "paper_route_account_window_close_snapshot_db_unavailable",
+            audit["blockers"],
+        )
+        self.assertEqual(
+            audit["db_load_error"]["source"],
+            "paper_route_account_window_close_snapshot",
+        )
 
     def test_normalized_open_positions_handles_flat_short_and_implicit_market_value(
         self,


### PR DESCRIPTION
## Summary

- Adds fail-closed handling for paper-route account contamination and position snapshot proof reads when Postgres times out or returns an audit query error.
- Adds source-specific DB-unavailable blockers and error payloads so target plans remain blocked instead of returning 500/503 during proof assembly.
- Adds concurrent Postgres indexes for the account snapshot, order-event, execution, and TCA read patterns used by paper-route proof endpoints.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py migrations/versions/0053_paper_route_proof_read_indexes.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py migrations/versions/0053_paper_route_proof_read_indexes.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q -k 'account_contamination_query_timeout or account_window_start_snapshot_query_timeout or account_window_start_fallback_snapshot_timeout or account_pre_session_snapshot_query_timeout or account_window_close_snapshot_query_timeout'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q -k 'account_contamination or account_window_start_snapshot or account_pre_session or window_close_snapshot or clean_window_baseline or source_activity_db_unavailable or deferred_runtime_window'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python scripts/check_migration_graph.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main` after focused coverage run; changed app lines were `36/36` covered.

## Screenshots (if applicable)

N/A

## Breaking Changes

Adds Alembic migration `0053_paper_route_proof_read_indexes` with concurrent Postgres indexes. No API or schema contract break.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
