### PR TITLE
fix(torghut): materialize sim paper route targets

### DIFF
--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -52,7 +52,7 @@ spec:
                     exit 0
                   fi
                   /opt/venv/bin/python scripts/materialize_bounded_paper_route_targets.py \
-                    --plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan \
+                    --plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan \
                     --plan-url-timeout-seconds 45 \
                     --plan-url-attempts 3 \
                     --database-dsn-env SIM_DB_DSN \

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -705,6 +705,14 @@ def _paper_route_source_materialization_blockers(
     )
     if mode != BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE:
         blockers.append("paper_route_source_decision_mode_missing")
+    expected_decision_strategy_id = _safe_text(
+        identity.get("strategy_id")
+    ) or _safe_text(identity.get("runtime_strategy_name"))
+    observed_decision_strategy_id = _safe_text(payload_mapping.get("strategy_id"))
+    if expected_decision_strategy_id and (
+        observed_decision_strategy_id != expected_decision_strategy_id
+    ):
+        blockers.append("paper_route_source_decision_strategy_id_missing")
     if not bool(payload_mapping.get("final_promotion_allowed") is False) or not bool(
         params.get("final_promotion_allowed") is False
     ):
@@ -740,6 +748,9 @@ def _paper_route_decision_payload(
     generated_at: datetime,
 ) -> dict[str, Any]:
     source_decision_mode = BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+    decision_strategy_id = _safe_text(identity.get("strategy_id")) or _safe_text(
+        identity.get("runtime_strategy_name")
+    )
     source_decision_metadata: dict[str, Any] = {
         "mode": "paper_route_target_plan_source_decision",
         "source": PAPER_ROUTE_MATERIALIZATION_SOURCE,
@@ -837,6 +848,7 @@ def _paper_route_decision_payload(
         "observed_stage": "paper",
         "hypothesis_id": identity.get("hypothesis_id"),
         "candidate_id": identity.get("candidate_id"),
+        "strategy_id": decision_strategy_id,
         "runtime_strategy_name": identity.get("runtime_strategy_name"),
         "strategy_name": identity.get("strategy_name"),
         "account_label": identity.get("account_label"),

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1526,7 +1526,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertIn(
             "--plan-url "
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
             args,
         )
         self.assertIn("--plan-url-timeout-seconds 45", args)

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.models import Base, Strategy, TradeDecision
+from app.trading.models import StrategyDecision
 from app.trading.paper_route_target_plan import (
     materialize_bounded_paper_route_target_plan,
 )
@@ -28,6 +29,7 @@ def _hpairs_target(**overrides: object) -> dict[str, Any]:
     target: dict[str, Any] = {
         "hypothesis_id": "H-PAIRS-01",
         "candidate_id": "c88421d619759b2cfaa6f4d0",
+        "strategy_id": "microbar_cross_sectional_pairs_v1@research",
         "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
         "strategy_name": "microbar-cross-sectional-pairs-v1",
         "account_label": "TORGHUT_SIM",
@@ -204,6 +206,26 @@ def _count_decisions(dsn: str) -> int:
         engine.dispose()
 
 
+def _decision_payloads(dsn: str) -> list[dict[str, Any]]:
+    engine = create_engine(dsn, future=True)
+    try:
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            rows = (
+                session.execute(
+                    select(TradeDecision).order_by(
+                        TradeDecision.created_at.asc(),
+                        TradeDecision.symbol.asc(),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            return [dict(row.decision_json) for row in rows]
+    finally:
+        engine.dispose()
+
+
 def _run_cli(
     argv: list[str], capsys: pytest.CaptureFixture[str]
 ) -> tuple[int, dict[str, Any]]:
@@ -334,6 +356,59 @@ def test_commit_writes_only_for_torghut_sim_with_explicit_confirmations(
     assert payload["route_submission_count"] == 2
     assert payload["blockers"] == []
     assert _count_decisions(sqlite_dsn) == 2
+
+
+def test_materializer_repairs_existing_payloads_missing_executable_strategy_id(
+    in_memory_session: Session,
+) -> None:
+    plan = _plan(_hpairs_target())
+    first = materialize_bounded_paper_route_target_plan(
+        in_memory_session,
+        plan,
+        generated_at=datetime(2026, 6, 1, 13, 35, tzinfo=timezone.utc),
+        bounded_notional_limit=Decimal("25"),
+    )
+    in_memory_session.commit()
+    assert first["materialized_decision_count"] == 2
+
+    rows = (
+        in_memory_session.execute(
+            select(TradeDecision).order_by(TradeDecision.symbol.asc())
+        )
+        .scalars()
+        .all()
+    )
+    for row in rows:
+        broken_payload = dict(row.decision_json)
+        broken_payload.pop("strategy_id", None)
+        row.decision_json = broken_payload
+    in_memory_session.commit()
+
+    repaired = materialize_bounded_paper_route_target_plan(
+        in_memory_session,
+        plan,
+        generated_at=datetime(2026, 6, 1, 13, 40, tzinfo=timezone.utc),
+        bounded_notional_limit=Decimal("25"),
+    )
+    in_memory_session.commit()
+
+    assert repaired["existing_decision_count"] == 2
+    assert repaired["repaired_decision_count"] == 2
+    assert repaired["blockers"] == []
+    repaired_rows = (
+        in_memory_session.execute(
+            select(TradeDecision).order_by(TradeDecision.symbol.asc())
+        )
+        .scalars()
+        .all()
+    )
+    decisions = [
+        StrategyDecision.model_validate(row.decision_json) for row in repaired_rows
+    ]
+    assert {decision.symbol: decision.strategy_id for decision in decisions} == {
+        "AAPL": "microbar_cross_sectional_pairs_v1@research",
+        "AMZN": "microbar_cross_sectional_pairs_v1@research",
+    }
 
 
 def test_commit_rejects_missing_account_and_dsn_confirmation(
@@ -536,6 +611,16 @@ def test_cli_preserves_existing_paper_route_target_plan_materialization_semantic
     assert payload["materialization"]["promotion_allowed"] is False
     assert payload["materialization"]["final_promotion_allowed"] is False
     assert payload["materialization"]["live_capital_routing_enabled"] is False
+    decisions = [
+        StrategyDecision.model_validate(item) for item in _decision_payloads(sqlite_dsn)
+    ]
+    assert {decision.symbol: decision.action for decision in decisions} == {
+        "AAPL": "buy",
+        "AMZN": "sell",
+    }
+    assert {decision.strategy_id for decision in decisions} == {
+        "microbar_cross_sectional_pairs_v1@research"
+    }
 
 
 def test_paper_route_target_plan_json_and_scalar_helpers_preserve_report_encoding_edges() -> (


### PR DESCRIPTION
## Summary

- Point the bounded paper-route materialization CronJob at the `torghut-sim` target-plan endpoint so it selects the current bounded H-PAIRS AAPL/AMZN target instead of stale live-provider source-collection rows.
- Add executable top-level `strategy_id` to materialized paper-route source decision payloads so the simple scheduler can validate them as `StrategyDecision` rows.
- Repair previously materialized planned rows that are missing executable `strategy_id` on the next materializer pass without relaxing promotion, live-capital, or runtime-ledger proof gates.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app/trading/paper_route_target_plan.py tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/trading/paper_route_target_plan.py tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py tests/test_live_config_manifest_contract.py -k 'materializer_repairs or cli_preserves or bounded_paper_route_target_materialization or dynamic_plan_prefers_materializable_next_window or source_allowlist_selects_active_next_window' -q`
- `uv run --frozen pytest tests/test_materialize_bounded_paper_route_targets.py -q`
- `uv run --frozen pytest tests/test_simple_pipeline.py -k source_collection_target_defaults_current_session_probe_contract -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- Runtime dry-run against `http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan` selected `next_paper_route_runtime_window_targets` with one open H-PAIRS target and two route submissions.
- One bounded `TORGHUT_SIM` materialization run committed two planned AAPL/AMZN source decisions; downstream scheduler logs showed the previous live image skipped them because executable `strategy_id` was missing, which this PR fixes.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
