### PR TITLE
fix(torghut): keep source collection out of proof imports

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -10871,7 +10871,6 @@ def build_paper_route_target_plan_payload(
                 )
             else:
                 source_targets = observed_strategy_source_targets
-            runtime_window_import_plan = source_targets
     runtime_import_readiness = _as_mapping(
         runtime_window_import_plan.get("session_readiness")
     )
@@ -11364,21 +11363,6 @@ def build_paper_route_evidence_audit(
             )
         else:
             source_targets = observed_strategy_source_targets
-        runtime_window_import_plan = source_targets
-        observed_source_targets = _as_mapping_items(
-            runtime_window_import_plan.get("targets")
-        )
-        runtime_window_import_target_audits = (
-            [
-                cached_target_audit(
-                    target,
-                    error_source="paper_route_observed_strategy_source_target_audit",
-                )
-                for target in observed_source_targets
-            ]
-            if run_full_runtime_import_audit
-            else _deferred_runtime_window_target_audits(observed_source_targets)
-        )
     runtime_window_import_audit = _runtime_window_import_audit(
         next_targets=runtime_window_import_plan,
         target_audits=target_audits,
@@ -11394,8 +11378,13 @@ def build_paper_route_evidence_audit(
     )
     summary_target_audits: Sequence[Mapping[str, object]]
     summary_target_audit_source: str
+    runtime_window_import_source_collection_only = (
+        _runtime_window_import_plan_is_source_collection_only(
+            runtime_window_import_plan
+        )
+    )
     if (
-        _as_mapping_items(observed_strategy_source_targets.get("targets"))
+        runtime_window_import_source_collection_only
         and runtime_window_import_target_audits
     ):
         summary_target_audits = runtime_window_import_target_audits
@@ -11580,9 +11569,7 @@ def build_paper_route_evidence_audit(
                 runtime_window_import_plan.get("source")
             ),
             "runtime_window_import_source_collection_only": (
-                _runtime_window_import_plan_is_source_collection_only(
-                    runtime_window_import_plan
-                )
+                runtime_window_import_source_collection_only
             ),
             "runtime_window_import_account_contamination_state": _safe_text(
                 _as_mapping(

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -164,6 +164,21 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "handoff",
     "promotion_gate",
 )
+SOURCE_COLLECTION_ONLY_PLAN_SOURCES = frozenset(
+    {
+        "paper_route_observed_strategy_source_collection",
+        "paper_route_prioritized_source_collection",
+    }
+)
+MATERIALIZABLE_SOURCE_ROW_COUNT_KEYS = frozenset(
+    {
+        "trade_decisions",
+        "executions",
+        "execution_tca_metrics",
+        "execution_order_events",
+        "order_feed_source_windows",
+    }
+)
 RUNTIME_WINDOW_TARGET_PLAN_DEFERRED_REASONS = frozenset(
     (
         "runtime_window_target_plan_window_not_closed",
@@ -793,10 +808,16 @@ def _runtime_window_target_plan_target_truthy(value: object) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes"}
 
 
-def _runtime_window_target_plan_positive_mapping_count(value: object) -> bool:
+def _runtime_window_target_plan_positive_mapping_count(
+    value: object,
+    *,
+    allowed_keys: frozenset[str] | None = None,
+) -> bool:
     if not isinstance(value, Mapping):
         return False
-    for raw_count in value.values():
+    for raw_key, raw_count in value.items():
+        if allowed_keys is not None and str(raw_key or "").strip() not in allowed_keys:
+            continue
         try:
             if int(str(raw_count or "0")) > 0:
                 return True
@@ -825,15 +846,20 @@ def _runtime_window_source_collection_target_has_materializable_lineage(
         return True
     if _as_text(target.get("authority_class")) is not None:
         return True
-    if _runtime_window_target_plan_positive_mapping_count(
-        target.get("source_row_counts")
-    ):
-        return True
+    for key in ("source_row_counts", "runtime_ledger_source_row_counts"):
+        if _runtime_window_target_plan_positive_mapping_count(
+            target.get(key),
+            allowed_keys=MATERIALIZABLE_SOURCE_ROW_COUNT_KEYS,
+        ):
+            return True
     source_refs = [
         ref
         for ref in _as_text_list(target.get("source_refs"))
         if "strategy_runtime_ledger_buckets" not in ref
     ]
+    source_ref = _as_text(target.get("source_ref"))
+    if source_ref and "strategy_runtime_ledger_buckets" not in source_ref:
+        source_refs.append(source_ref)
     return bool(source_refs)
 
 
@@ -852,6 +878,34 @@ def _runtime_window_source_collection_target_allowed(
     ):
         return False
     return True
+
+
+def _runtime_window_target_plan_is_source_collection_only(
+    plan: Mapping[str, Any],
+) -> bool:
+    source = str(plan.get("source") or "").strip()
+    if source in SOURCE_COLLECTION_ONLY_PLAN_SOURCES:
+        return True
+    targets = _runtime_window_plan_target_items(plan)
+    return bool(targets) and all(
+        str(target.get("source_kind") or "").strip()
+        == "runtime_ledger_source_collection_candidate"
+        for target in targets
+    )
+
+
+def _runtime_window_target_plan_without_paper_route_source_collection_only(
+    plan: Mapping[str, Any],
+    *,
+    paper_route_evidence_payload: bool,
+) -> dict[str, Any]:
+    candidate_plan = _as_dict(plan)
+    if (
+        paper_route_evidence_payload
+        and _runtime_window_target_plan_is_source_collection_only(candidate_plan)
+    ):
+        return {}
+    return candidate_plan
 
 
 def _runtime_window_target_plan_source_collection_targets(
@@ -905,6 +959,15 @@ def _runtime_window_target_plan_with_live_gate_source_collection(
     plan: Mapping[str, Any],
 ) -> dict[str, Any]:
     merged_plan = dict(plan)
+    paper_route_evidence_payload = (
+        str(payload.get("schema_version") or "").strip()
+        == "torghut.paper-route-evidence.v1"
+    )
+    if (
+        paper_route_evidence_payload
+        and not _runtime_window_target_plan_is_source_collection_only(merged_plan)
+    ):
+        return merged_plan
     if (
         str(merged_plan.get("purpose") or "").strip()
         == "latest_closed_session_paper_route_runtime_window_import"
@@ -998,13 +1061,38 @@ def _latest_closed_runtime_window_target_plan_from_payload(
 def _runtime_window_target_plan_from_payload(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
-    paper_route_plan = _as_dict(payload.get("next_paper_route_runtime_window_targets"))
-    latest_closed_plan = _latest_closed_runtime_window_target_plan_from_payload(payload)
     paper_route_evidence_payload = (
         str(payload.get("schema_version") or "").strip()
         == "torghut.paper-route-evidence.v1"
     )
-    direct_plan = _as_dict(payload.get("runtime_window_import_plan"))
+    paper_route_plan = (
+        _runtime_window_target_plan_without_paper_route_source_collection_only(
+            _as_dict(payload.get("next_paper_route_runtime_window_targets")),
+            paper_route_evidence_payload=paper_route_evidence_payload,
+        )
+    )
+    clean_after_discard_plan = (
+        _runtime_window_target_plan_without_paper_route_source_collection_only(
+            _as_dict(
+                payload.get(
+                    "next_clean_paper_route_runtime_window_targets_after_discard"
+                )
+            ),
+            paper_route_evidence_payload=paper_route_evidence_payload,
+        )
+    )
+    latest_closed_plan = (
+        _runtime_window_target_plan_without_paper_route_source_collection_only(
+            _latest_closed_runtime_window_target_plan_from_payload(payload),
+            paper_route_evidence_payload=paper_route_evidence_payload,
+        )
+    )
+    direct_plan = (
+        _runtime_window_target_plan_without_paper_route_source_collection_only(
+            _as_dict(payload.get("runtime_window_import_plan")),
+            paper_route_evidence_payload=paper_route_evidence_payload,
+        )
+    )
     if paper_route_evidence_payload:
         plan = next(
             (
@@ -1012,16 +1100,7 @@ def _runtime_window_target_plan_from_payload(
                 for candidate_plan in (
                     latest_closed_plan,
                     direct_plan,
-                    _as_dict(
-                        payload.get(
-                            "next_clean_paper_route_runtime_window_targets_after_discard"
-                        )
-                    ),
-                    _as_dict(
-                        payload.get(
-                            "observed_strategy_source_runtime_window_import_plan"
-                        )
-                    ),
+                    clean_after_discard_plan,
                     paper_route_plan,
                 )
                 if _runtime_window_plan_target_items(candidate_plan)
@@ -1033,26 +1112,39 @@ def _runtime_window_target_plan_from_payload(
     source_runtime_window_plan = _as_dict(
         payload.get("source_runtime_window_import_plan")
     )
-    if not plan and _runtime_window_plan_target_items(source_runtime_window_plan):
+    if (
+        not plan
+        and not paper_route_evidence_payload
+        and _runtime_window_plan_target_items(source_runtime_window_plan)
+    ):
         plan = source_runtime_window_plan
     if not plan:
         if direct_plan:
             plan = direct_plan
         else:
             gate = _as_dict(payload.get("live_submission_gate"))
-            gate_plan = _as_dict(gate.get("runtime_ledger_paper_probation_import_plan"))
+            gate_plan = (
+                _runtime_window_target_plan_without_paper_route_source_collection_only(
+                    _as_dict(gate.get("runtime_ledger_paper_probation_import_plan")),
+                    paper_route_evidence_payload=paper_route_evidence_payload,
+                )
+            )
             if gate_plan:
                 plan = gate_plan
             else:
-                top_level_gate_plan = _as_dict(
-                    payload.get("runtime_ledger_paper_probation_import_plan")
+                top_level_gate_plan = _runtime_window_target_plan_without_paper_route_source_collection_only(
+                    _as_dict(payload.get("runtime_ledger_paper_probation_import_plan")),
+                    paper_route_evidence_payload=paper_route_evidence_payload,
                 )
                 if top_level_gate_plan:
                     plan = top_level_gate_plan
                 elif paper_route_plan:
                     plan = paper_route_plan
                 else:
-                    plan = _as_dict(payload)
+                    plan = _runtime_window_target_plan_without_paper_route_source_collection_only(
+                        payload,
+                        paper_route_evidence_payload=paper_route_evidence_payload,
+                    )
     plan = _runtime_window_target_plan_with_live_gate_source_collection(
         payload=payload,
         plan=plan,
@@ -2735,6 +2827,75 @@ def _run_runtime_window_source_window_repair(
     return payload
 
 
+def _runtime_window_source_collection_materialization_blocked_result(
+    *,
+    target: RuntimeWindowImportTarget,
+    candidate_id: str,
+    manifest_path: Path,
+    window_start: datetime,
+    window_end: datetime,
+    window_selection: str,
+) -> dict[str, Any] | None:
+    if target.source_kind != "runtime_ledger_source_collection_candidate":
+        return None
+    if _runtime_window_import_needs_source_window_repair(target):
+        return None
+    target_metadata = _as_dict(target.target_metadata)
+    if _runtime_window_source_collection_target_has_materializable_lineage(
+        target_metadata
+    ):
+        return None
+    reason_codes = _as_text_list(target_metadata.get("source_collection_reason_codes"))
+    blocker_codes = list(
+        dict.fromkeys(
+            [
+                "runtime_ledger_source_collection_materialization_missing",
+                *reason_codes,
+            ]
+        )
+    )
+    next_action = (
+        _as_text(target_metadata.get("source_collection_next_action"))
+        or "materialize_runtime_ledger_source_window_refs"
+    )
+    proof_blockers = [
+        {
+            "blocker": blocker,
+            "hypothesis_id": target.hypothesis_id,
+            "candidate_id": candidate_id,
+            "observed_stage": target.observed_stage,
+            "window_start": _utc_iso(window_start),
+            "window_end": _utc_iso(window_end),
+            "source_collection_next_action": next_action,
+            "remediation": (
+                "Materialize concrete source refs, source window ids, execution ids, "
+                "or order-event/TCA source counts before runtime-window import."
+            ),
+        }
+        for blocker in blocker_codes
+    ]
+    return {
+        "status": "blocked",
+        "reason": "runtime_ledger_source_collection_materialization_required",
+        "window_start": _utc_iso(window_start),
+        "window_end": _utc_iso(window_end),
+        "window_selection": window_selection,
+        "hypothesis_id": target.hypothesis_id,
+        "candidate_id": candidate_id,
+        "strategy_name": target.strategy_name,
+        "account_label": target.account_label,
+        "source_account_label": target.source_account_label or target.account_label,
+        "source_dsn_env": target.source_dsn_env,
+        "target_dsn_env": target.target_dsn_env,
+        "source_kind": target.source_kind,
+        "artifact_refs": [str(manifest_path), *target.artifact_refs],
+        "target_metadata": target_metadata,
+        "proof_status": "blocked",
+        "proof_blockers": proof_blockers,
+        "summary": None,
+    }
+
+
 def _run_runtime_window_import_target(
     *,
     args: argparse.Namespace,
@@ -2829,6 +2990,18 @@ def _run_runtime_window_import_target(
     )
     if blocked_result is not None:
         return blocked_result
+    source_collection_materialization_blocked = (
+        _runtime_window_source_collection_materialization_blocked_result(
+            target=target,
+            candidate_id=candidate_id,
+            manifest_path=manifest_path,
+            window_start=window_start,
+            window_end=window_end,
+            window_selection=window_selection,
+        )
+    )
+    if source_collection_materialization_blocked is not None:
+        return source_collection_materialization_blocked
     delay_depth_report_ref = _runtime_manifest_delay_depth_stress_report_ref(
         target=target,
         runtime_manifest=runtime_manifest,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -10944,66 +10944,45 @@ class TestPaperRouteEvidenceAudit(TestCase):
             )
 
         runtime_plan = payload["runtime_window_import_plan"]
-        self.assertEqual(
-            runtime_plan["source"], "paper_route_observed_strategy_source_collection"
-        )
+        self.assertEqual(runtime_plan["source"], "paper_route_evidence_audit")
         self.assertEqual(runtime_plan["target_count"], 1)
-        self.assertTrue(runtime_plan["session_readiness"]["import_ready"])
-        self.assertTrue(runtime_plan["runtime_window_import_handoff"]["import_ready"])
-        self.assertTrue(
-            runtime_plan["runtime_window_import_handoff"][
-                "source_collection_authorized"
-            ]
-        )
-        self.assertTrue(
-            runtime_plan["runtime_window_import_handoff"]["source_collection_only"]
-        )
-        self.assertFalse(
-            runtime_plan["runtime_window_import_handoff"][
-                "canary_collection_authorized"
-            ]
-        )
         self.assertEqual(
             runtime_plan["account_contamination_readiness"]["state"],
-            "contaminated_window_discarded",
-        )
-        self.assertIn(
-            "paper_route_account_contamination_detected",
-            runtime_plan["account_contamination_readiness"]["blockers"],
+            "clean",
         )
         self.assertEqual(
             runtime_plan["runtime_window_import_health_gate"]["blocked_target_count"],
             0,
         )
         target = runtime_plan["targets"][0]
-        self.assertEqual(target["candidate_id"], "candidate-tsmom")
-        self.assertEqual(target["hypothesis_id"], "H-TSMOM-LIQ-01")
-        self.assertEqual(target["runtime_strategy_name"], "intraday-tsmom-profit-v3")
-        self.assertEqual(target["source_account_label"], "TORGHUT_SIM")
-        self.assertEqual(
+        self.assertEqual(target["candidate_id"], "candidate-hpairs")
+        self.assertEqual(target["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(target["strategy_name"], target_strategy.name)
+        self.assertEqual(target["source_kind"], "paper_route_probe_runtime_observed")
+        self.assertFalse(target["promotion_allowed"])
+        self.assertNotEqual(
             target["source_kind"], "runtime_ledger_source_collection_candidate"
         )
-        self.assertTrue(target["source_collection_authorized"])
-        self.assertFalse(target["promotion_allowed"])
-        self.assertNotIn("paper_route_probe_symbols", target)
-        self.assertEqual(target["dependency_quorum_decision"], "allow")
-        self.assertEqual(target["continuity_ok"], "true")
-        self.assertEqual(target["drift_ok"], "false")
-        self.assertTrue(target["runtime_window_import_health_gate"]["ready"])
-        self.assertEqual(target["runtime_window_import_health_gate_blockers"], [])
+        source_plan = payload["source_runtime_window_import_plan"]
         self.assertEqual(
-            target["runtime_window_import_promotion_blockers"],
-            ["drift_checks_not_ok"],
+            source_plan["source"], "paper_route_observed_strategy_source_collection"
         )
         self.assertEqual(
-            target["observed_from_contaminated_target"]["strategy_name"],
+            source_plan["account_contamination_readiness"]["state"],
+            "contaminated_window_discarded",
+        )
+        self.assertIn(
+            "paper_route_account_contamination_detected",
+            source_plan["account_contamination_readiness"]["blockers"],
+        )
+        self.assertEqual(source_plan["targets"][0]["candidate_id"], "candidate-tsmom")
+        self.assertEqual(
+            source_plan["targets"][0]["observed_from_contaminated_target"][
+                "strategy_name"
+            ],
             "intraday-tsmom-profit-v3",
         )
         self.assertEqual(payload["targets"][0]["candidate_id"], "candidate-tsmom")
-        self.assertEqual(
-            payload["source_runtime_window_import_plan"]["source"],
-            "paper_route_observed_strategy_source_collection",
-        )
 
     def test_evidence_selects_observed_strategy_source_collection_plan(self) -> None:
         generated_at = datetime(2026, 6, 2, 22, 30, tzinfo=timezone.utc)
@@ -11202,61 +11181,40 @@ class TestPaperRouteEvidenceAudit(TestCase):
             next_plan["targets"][0]["final_promotion_blockers"],
         )
         runtime_plan = payload["runtime_window_import_plan"]
-        self.assertEqual(
-            runtime_plan["source"], "paper_route_observed_strategy_source_collection"
-        )
-        self.assertTrue(runtime_plan["session_readiness"]["import_ready"])
-        self.assertTrue(runtime_plan["runtime_window_import_handoff"]["import_ready"])
-        self.assertTrue(
-            runtime_plan["runtime_window_import_handoff"][
-                "source_collection_authorized"
-            ]
-        )
-        self.assertTrue(
-            runtime_plan["runtime_window_import_handoff"]["source_collection_only"]
-        )
-        self.assertFalse(
-            runtime_plan["runtime_window_import_handoff"][
-                "canary_collection_authorized"
-            ]
-        )
+        self.assertEqual(runtime_plan["source"], "paper_route_evidence_audit")
         self.assertEqual(
             runtime_plan["runtime_window_import_health_gate"]["blocked_target_count"],
             0,
         )
         self.assertEqual(
             runtime_plan["account_contamination_readiness"]["state"],
+            "clean",
+        )
+        self.assertEqual(runtime_plan["targets"][0]["candidate_id"], "candidate-hpairs")
+        self.assertEqual(
+            runtime_plan["targets"][0]["selected_by"],
+            "paper_route_evidence_audit",
+        )
+        self.assertFalse(runtime_plan["targets"][0]["promotion_allowed"])
+        self.assertEqual(
+            payload["source_runtime_window_import_plan"]["source"],
+            "paper_route_observed_strategy_source_collection",
+        )
+        self.assertEqual(
+            payload["source_runtime_window_import_plan"][
+                "account_contamination_readiness"
+            ]["state"],
             "contaminated_window_discarded",
         )
         self.assertIn(
             "foreign_order_events_present",
-            runtime_plan["account_contamination_readiness"]["blockers"],
-        )
-        self.assertEqual(runtime_plan["targets"][0]["candidate_id"], "candidate-tsmom")
-        self.assertEqual(
-            runtime_plan["targets"][0]["selected_by"],
-            "paper_route_observed_strategy_source_collection",
+            payload["source_runtime_window_import_plan"][
+                "account_contamination_readiness"
+            ]["blockers"],
         )
         self.assertEqual(
-            runtime_plan["targets"][0]["dependency_quorum_decision"], "allow"
-        )
-        self.assertEqual(runtime_plan["targets"][0]["continuity_ok"], "true")
-        self.assertEqual(runtime_plan["targets"][0]["drift_ok"], "false")
-        self.assertTrue(
-            runtime_plan["targets"][0]["runtime_window_import_health_gate"]["ready"]
-        )
-        self.assertEqual(
-            runtime_plan["targets"][0]["runtime_window_import_health_gate_blockers"],
-            [],
-        )
-        self.assertFalse(runtime_plan["targets"][0]["promotion_allowed"])
-        self.assertIn(
-            "runtime_ledger_source_collection_only",
-            runtime_plan["targets"][0]["final_promotion_blockers"],
-        )
-        self.assertEqual(
-            payload["source_runtime_window_import_plan"]["source"],
-            "paper_route_observed_strategy_source_collection",
+            payload["source_runtime_window_import_plan"]["targets"][0]["candidate_id"],
+            "candidate-tsmom",
         )
         self.assertEqual(
             payload["observed_strategy_source_runtime_window_import_plan"]["source"],
@@ -11275,35 +11233,34 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             payload["summary"]["runtime_window_import_plan_source"],
-            "paper_route_observed_strategy_source_collection",
+            "paper_route_evidence_audit",
         )
         summary = payload["summary"]
-        self.assertTrue(summary["runtime_window_import_source_collection_only"])
+        self.assertFalse(summary["runtime_window_import_source_collection_only"])
         self.assertEqual(
             summary["runtime_window_import_account_contamination_state"],
-            "contaminated_window_discarded",
+            "clean",
         )
-        self.assertIn(
-            "foreign_order_events_present",
-            summary["runtime_window_import_account_contamination_blockers"],
+        self.assertEqual(
+            summary["runtime_window_import_account_contamination_blockers"], []
         )
         self.assertEqual(
             summary["summary_target_audit_source"],
-            "runtime_window_import_target_audits",
+            "paper_route_source_target_audits",
         )
         self.assertEqual(summary["source_plan_target_with_source_activity_count"], 0)
-        self.assertEqual(summary["target_with_source_activity_count"], 1)
+        self.assertEqual(summary["target_with_source_activity_count"], 0)
         self.assertEqual(summary["target_with_runtime_ledger_count"], 0)
         self.assertEqual(
-            summary["runtime_window_import_target_with_source_activity_count"], 1
+            summary["runtime_window_import_target_with_source_activity_count"], 0
         )
-        self.assertEqual(summary["readback"]["source_decisions_present_count"], 1)
-        self.assertEqual(summary["readback"]["submitted_lifecycle_present_count"], 1)
-        self.assertEqual(summary["readback"]["fills_or_executions_present_count"], 1)
-        self.assertEqual(summary["readback"]["source_refs_present_count"], 1)
-        self.assertNotIn("source_decisions_missing", summary["blockers"])
-        self.assertNotIn("source_executions_missing", summary["blockers"])
-        self.assertNotIn("source_tca_missing", summary["blockers"])
+        self.assertEqual(summary["readback"]["source_decisions_present_count"], 0)
+        self.assertEqual(summary["readback"]["submitted_lifecycle_present_count"], 0)
+        self.assertEqual(summary["readback"]["fills_or_executions_present_count"], 0)
+        self.assertEqual(summary["readback"]["source_refs_present_count"], 0)
+        self.assertIn("source_decisions_missing", summary["blockers"])
+        self.assertIn("source_executions_missing", summary["blockers"])
+        self.assertIn("source_tca_missing", summary["blockers"])
         self.assertIn("runtime_ledger_bucket_missing", summary["blockers"])
 
     def test_observed_strategy_source_collection_plan_limits_targets(self) -> None:

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -4,6 +4,7 @@ import argparse
 from datetime import datetime, timezone
 from decimal import Decimal
 import json
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -363,6 +364,308 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
         )
         self.assertTrue(target.target_metadata["source_collection_authorized"])
         self.assertNotIn("paper_route_probe_symbols", target.target_metadata)
+
+    def test_source_collection_materializable_lineage_rejects_aggregate_only_bucket_count(
+        self,
+    ) -> None:
+        self.assertFalse(
+            renew._runtime_window_source_collection_target_has_materializable_lineage(
+                {
+                    "source_kind": "runtime_ledger_source_collection_candidate",
+                    "source_row_counts": {"strategy_runtime_ledger_buckets": 1},
+                    "source_refs": ["postgres:strategy_runtime_ledger_buckets"],
+                }
+            )
+        )
+
+    def test_source_collection_materializable_lineage_accepts_concrete_source_count(
+        self,
+    ) -> None:
+        for row_count_key in (
+            "trade_decisions",
+            "executions",
+            "execution_tca_metrics",
+            "execution_order_events",
+            "order_feed_source_windows",
+        ):
+            with self.subTest(row_count_key=row_count_key):
+                self.assertTrue(
+                    renew._runtime_window_source_collection_target_has_materializable_lineage(
+                        {
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                            "source_row_counts": {
+                                "strategy_runtime_ledger_buckets": 1,
+                                row_count_key: 1,
+                            },
+                        }
+                    )
+                )
+
+    def test_paper_route_evidence_payload_skips_source_only_proof_plans(
+        self,
+    ) -> None:
+        plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "runtime_window_import_plan": {
+                    "source": "paper_route_prioritized_source_collection",
+                    "target_count": 6,
+                    "targets": [
+                        {
+                            "candidate_id": "stale-source-candidate",
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                            "window_start": "2026-05-13T17:00:00+00:00",
+                            "window_end": "2026-05-13T17:30:00+00:00",
+                        }
+                    ],
+                },
+                "observed_strategy_source_runtime_window_import_plan": {
+                    "source": "paper_route_observed_strategy_source_collection",
+                    "targets": [
+                        {
+                            "candidate_id": "observed-source-candidate",
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                        }
+                    ],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "source": "paper_route_evidence_audit",
+                    "purpose": "next_session_paper_route_runtime_window_evidence_collection",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "current-hpairs-candidate",
+                            "strategy_name": ("microbar-cross-sectional-pairs-v1"),
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "window_start": "2026-06-05T13:30:00+00:00",
+                            "window_end": "2026-06-05T20:00:00+00:00",
+                        }
+                    ],
+                },
+                "live_submission_gate": {
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "candidate_id": "gate-source-candidate",
+                                "source_kind": (
+                                    "runtime_ledger_source_collection_candidate"
+                                ),
+                            }
+                        ],
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(plan["source"], "paper_route_evidence_audit")
+        self.assertEqual(len(plan["targets"]), 1)
+        self.assertEqual(plan["targets"][0]["candidate_id"], "current-hpairs-candidate")
+        self.assertNotIn("merged_live_submission_gate_source_collection", plan)
+
+    def test_paper_route_evidence_payload_does_not_fallback_to_gate_source_collection(
+        self,
+    ) -> None:
+        plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "runtime_window_import_plan": {
+                    "source": "paper_route_prioritized_source_collection",
+                    "targets": [
+                        {
+                            "candidate_id": "direct-source-candidate",
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                        }
+                    ],
+                },
+                "live_submission_gate": {
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "candidate_id": "gate-source-candidate",
+                                "source_kind": (
+                                    "runtime_ledger_source_collection_candidate"
+                                ),
+                            }
+                        ],
+                    },
+                },
+                "runtime_ledger_paper_probation_import_plan": {
+                    "source_collection_target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "top-level-source-candidate",
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertNotIn("targets", plan)
+        self.assertEqual(plan["schema_version"], "torghut.paper-route-evidence.v1")
+
+    def test_paper_route_evidence_payload_skips_source_only_fallback_slots(
+        self,
+    ) -> None:
+        latest_closed_plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "latest_closed_runtime_window_import_selection": {
+                    "selected": True,
+                    "state": "selected",
+                    "source_backed_evidence_present": True,
+                    "clean_window_importable": True,
+                },
+                "latest_closed_paper_route_runtime_window_targets": {
+                    "source": "paper_route_prioritized_source_collection",
+                    "session_readiness": {"import_ready": True},
+                    "targets": [
+                        {
+                            "candidate_id": "latest-closed-source-only",
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                        }
+                    ],
+                },
+                "runtime_window_import_plan": {
+                    "source": "paper_route_evidence_audit",
+                    "targets": [
+                        {
+                            "candidate_id": "direct-paper-proof",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                        }
+                    ],
+                },
+            }
+        )
+        self.assertEqual(
+            latest_closed_plan["targets"][0]["candidate_id"], "direct-paper-proof"
+        )
+
+        clean_after_discard_plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "next_clean_paper_route_runtime_window_targets_after_discard": {
+                    "source": "paper_route_observed_strategy_source_collection",
+                    "targets": [
+                        {
+                            "candidate_id": "clean-after-discard-source-only",
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                        }
+                    ],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "source": "paper_route_evidence_audit",
+                    "targets": [
+                        {
+                            "candidate_id": "next-paper-proof",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                        }
+                    ],
+                },
+            }
+        )
+        self.assertEqual(
+            clean_after_discard_plan["targets"][0]["candidate_id"],
+            "next-paper-proof",
+        )
+
+        source_only_plan = renew._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "next_paper_route_runtime_window_targets": {
+                    "source": "paper_route_prioritized_source_collection",
+                    "targets": [
+                        {
+                            "candidate_id": "next-paper-source-only",
+                            "source_kind": (
+                                "runtime_ledger_source_collection_candidate"
+                            ),
+                        }
+                    ],
+                },
+            }
+        )
+        self.assertEqual(
+            source_only_plan["schema_version"], "torghut.paper-route-evidence.v1"
+        )
+        self.assertNotIn("targets", source_only_plan)
+
+    def test_aggregate_only_source_collection_target_blocks_before_import(
+        self,
+    ) -> None:
+        target = renew.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="c88421d619759b2cfaa6f4d0",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            target_dsn_env="SIM_DB_DSN",
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+            source_kind="runtime_ledger_source_collection_candidate",
+            delay_adjusted_depth_stress_report_ref="",
+            window_start="2026-05-13T17:00:00+00:00",
+            window_end="2026-05-13T17:30:00+00:00",
+            target_metadata={
+                "source_row_counts": {"strategy_runtime_ledger_buckets": 1},
+                "source_collection_reason_codes": [
+                    "runtime_window_source_activity_missing"
+                ],
+            },
+        )
+        args = argparse.Namespace(runtime_window_target_plan_settlement_seconds=0)
+
+        with (
+            patch.object(
+                renew,
+                "_read_runtime_window_manifest",
+                return_value={"candidate_id": "c88421d619759b2cfaa6f4d0"},
+            ),
+            patch.object(renew.subprocess, "run") as run,
+        ):
+            result = renew._run_runtime_window_import_target(
+                args=args,
+                target=target,
+                manifest={},
+                run_id="test-run",
+                manifest_path=Path("manifest.yaml"),
+                window_start=datetime(2026, 5, 13, 17, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 13, 17, 30, tzinfo=timezone.utc),
+                now=datetime(2026, 5, 13, 21, tzinfo=timezone.utc),
+            )
+
+        run.assert_not_called()
+        self.assertEqual(
+            result["reason"],
+            "runtime_ledger_source_collection_materialization_required",
+        )
+        self.assertEqual(result["proof_status"], "blocked")
+        blockers = [blocker["blocker"] for blocker in result["proof_blockers"]]
+        self.assertIn(
+            "runtime_ledger_source_collection_materialization_missing", blockers
+        )
+        self.assertIn("runtime_window_source_activity_missing", blockers)
 
     def test_target_plan_payload_prefers_selected_latest_closed_import_plan(
         self,

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1128,7 +1128,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             plan["targets"][0]["window_start"], "2026-05-26T13:30:00+00:00"
         )
 
-    def test_runtime_window_target_plan_payload_prefers_selected_runtime_import_plan(
+    def test_runtime_window_target_plan_payload_skips_source_only_runtime_import_plan(
         self,
     ) -> None:
         plan = renewal._runtime_window_target_plan_from_payload(
@@ -1158,6 +1158,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 },
                 "next_paper_route_runtime_window_targets": {
                     "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "source": "paper_route_evidence_audit",
                     "target_count": 1,
                     "targets": [
                         {
@@ -1179,11 +1180,9 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             }
         )
 
-        self.assertEqual(
-            plan["source"], "paper_route_observed_strategy_source_collection"
-        )
-        self.assertEqual(plan["targets"][0]["candidate_id"], "cand-selected-source")
-        self.assertNotIn(
+        self.assertEqual(plan["source"], "paper_route_evidence_audit")
+        self.assertEqual(plan["targets"][0]["candidate_id"], "cand-contaminated-next")
+        self.assertIn(
             "paper_route_account_contamination_detected",
             plan["targets"][0]["candidate_blockers"],
         )
@@ -1469,7 +1468,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             ["H-SOURCE-COLLECTION", "H-PAPER-ROUTE"],
         )
 
-    def test_runtime_window_target_plan_payload_keeps_sim_gate_source_collection(
+    def test_runtime_window_target_plan_payload_does_not_merge_sim_gate_source_collection(
         self,
     ) -> None:
         plan = renewal._runtime_window_target_plan_from_payload(
@@ -1477,6 +1476,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 "schema_version": "torghut.paper-route-evidence.v1",
                 "next_paper_route_runtime_window_targets": {
                     "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "source": "paper_route_evidence_audit",
                     "target_count": 1,
                     "targets": [
                         {
@@ -1518,16 +1518,13 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             }
         )
 
-        self.assertTrue(plan["merged_live_submission_gate_source_collection"])
-        self.assertEqual(plan["source_collection_target_count"], 1)
-        self.assertEqual(plan["paper_route_target_count"], 1)
-        self.assertEqual(plan["target_count"], 2)
+        self.assertNotIn("merged_live_submission_gate_source_collection", plan)
+        self.assertEqual(plan["source"], "paper_route_evidence_audit")
+        self.assertEqual(plan["target_count"], 1)
         self.assertEqual(
             [target["hypothesis_id"] for target in plan["targets"]],
-            ["H-SOURCE-COLLECTION", "H-PAPER-ROUTE"],
+            ["H-PAPER-ROUTE"],
         )
-        self.assertFalse(plan["targets"][0]["promotion_allowed"])
-        self.assertFalse(plan["targets"][0]["final_promotion_allowed"])
 
     def test_runtime_window_target_plan_skips_aggregate_replay_source_collection(
         self,


### PR DESCRIPTION
## Summary

- Keeps paper-route source-collection plans as sidecar diagnostics instead of replacing `runtime_window_import_plan`.
- Makes renewal skip source-collection-only plans for paper-route evidence proof-job selection, including live-gate fallback plans.
- Blocks aggregate-only `runtime_ledger_source_collection_candidate` targets before import when they only have ledger-bucket counts and no concrete source refs or source row evidence.
- Adds regressions for stale source-only proof plan selection, aggregate-only materializability, and observed source-collection sidecar behavior.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
