### PR TITLE
fix(torghut): gate deferred source diagnostics

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -7126,13 +7126,15 @@ def _hpairs_zero_activity_reason_flags(
     ).lower()
     audit_state = (_safe_text(runtime_window_import_audit.get("state")) or "").lower()
     import_ready = bool(runtime_window_import_audit.get("import_ready"))
-    window_import_ready = import_ready or audit_state in {
-        "import_due_source_activity_missing",
-        "import_due_runtime_ledger_missing",
-        "import_due_runtime_ledger_not_materialized",
-        "runtime_ledger_imported_but_not_evidence_grade",
-        "window_closed_import_ready",
-    }
+    window_import_ready = (
+        import_ready
+        or audit_state.startswith("import_due_")
+        or audit_state
+        in {
+            "runtime_ledger_imported_but_not_evidence_grade",
+            "window_closed_import_ready",
+        }
+    )
     no_market_window = not window_import_ready and (
         bool(
             {
@@ -7214,22 +7216,25 @@ def _hpairs_zero_activity_reason_flags(
         "import_due_runtime_ledger_missing",
         "import_due_runtime_ledger_not_materialized",
     }
-    source_decisions_missing = hpairs_target_count > 0 and hpairs_decision_count <= 0
+    source_decisions_missing = (
+        window_import_ready and hpairs_target_count > 0 and hpairs_decision_count <= 0
+    )
     source_executions_missing = hpairs_decision_count > 0 and (
         hpairs_submitted_order_count <= 0 or "source_executions_missing" in normalized
     )
     source_tca_missing = hpairs_submitted_order_count > 0 and (
         hpairs_tca_sample_count <= 0 or "source_tca_missing" in normalized
     )
-    runtime_ledger_bucket_missing = (
-        hpairs_decision_count > 0 and hpairs_runtime_bucket_count <= 0
-    ) or bool(
-        {
-            "runtime_ledger_bucket_missing",
-            "runtime_ledger_source_bucket_missing",
-            "runtime_ledger_evidence_grade_bucket_missing",
-        }
-        & normalized
+    runtime_ledger_bucket_missing = window_import_ready and (
+        (hpairs_decision_count > 0 and hpairs_runtime_bucket_count <= 0)
+        or bool(
+            {
+                "runtime_ledger_bucket_missing",
+                "runtime_ledger_source_bucket_missing",
+                "runtime_ledger_evidence_grade_bucket_missing",
+            }
+            & normalized
+        )
     )
     source_lineage_mismatch = bool(
         {
@@ -7255,6 +7260,28 @@ def _hpairs_zero_activity_reason_flags(
         "source_tca_missing": source_tca_missing,
         "runtime_ledger_bucket_missing": runtime_ledger_bucket_missing,
     }
+
+
+def _hpairs_zero_activity_visible_blockers(
+    blockers: Sequence[str],
+    *,
+    reason_flags: Mapping[str, bool],
+) -> list[str]:
+    gated_blockers = {
+        "source_decisions_missing": "source_decisions_missing",
+        "source_executions_missing": "source_executions_missing",
+        "source_tca_missing": "source_tca_missing",
+        "runtime_ledger_bucket_missing": "runtime_ledger_bucket_missing",
+        "runtime_ledger_source_bucket_missing": "runtime_ledger_bucket_missing",
+        "runtime_ledger_evidence_grade_bucket_missing": "runtime_ledger_bucket_missing",
+    }
+    visible: list[str] = []
+    for blocker in blockers:
+        flag_name = gated_blockers.get(blocker)
+        if flag_name is not None and not bool(reason_flags.get(flag_name)):
+            continue
+        visible.append(blocker)
+    return visible
 
 
 def _hpairs_zero_activity_state(reason_flags: Mapping[str, bool]) -> str:
@@ -7461,7 +7488,10 @@ def _hpairs_zero_activity_diagnostics(
         "generated_at": _isoformat(generated_at),
         "state": _hpairs_zero_activity_state(reason_flags),
         "reason_flags": reason_flags,
-        "blockers": blockers,
+        "blockers": _hpairs_zero_activity_visible_blockers(
+            blockers,
+            reason_flags=reason_flags,
+        ),
         "counts": {
             "hpairs_target_count": hpairs_target_count,
             "hpairs_skipped_target_count": len(skipped_targets),

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -7919,6 +7919,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(diagnostics["counts"]["hpairs_symbol_count"], 2)
         self.assertEqual(diagnostics["counts"]["hpairs_decision_count"], 0)
         self.assertIn("market_session_closed", diagnostics["blockers"])
+        self.assertNotIn("source_decisions_missing", diagnostics["blockers"])
+        self.assertNotIn("runtime_ledger_bucket_missing", diagnostics["blockers"])
         self.assertNotIn("c88421d619759b2cfaa6f4d0", diagnostics["blockers"])
         self.assertNotIn("H-PAIRS-01", diagnostics["blockers"])
         self.assertNotIn("AAPL", diagnostics["blockers"])
@@ -7931,10 +7933,10 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(stage_diagnostics["source_executions_present"])
         self.assertFalse(stage_diagnostics["source_tca_present"])
         self.assertFalse(stage_diagnostics["runtime_ledger_buckets_present"])
-        self.assertIn("source_decisions_missing", stage_diagnostics["blockers"])
+        self.assertNotIn("source_decisions_missing", stage_diagnostics["blockers"])
         self.assertNotIn("source_executions_missing", stage_diagnostics["blockers"])
         self.assertNotIn("source_tca_missing", stage_diagnostics["blockers"])
-        self.assertIn("runtime_ledger_bucket_missing", stage_diagnostics["blockers"])
+        self.assertNotIn("runtime_ledger_bucket_missing", stage_diagnostics["blockers"])
 
     def test_hpairs_zero_activity_reason_flags_distinguish_source_stages(
         self,
@@ -7955,6 +7957,49 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(no_decisions["source_executions_missing"])
         self.assertFalse(no_decisions["source_tca_missing"])
         self.assertTrue(no_decisions["runtime_ledger_bucket_missing"])
+
+        generic_import_due_state = _hpairs_zero_activity_reason_flags(
+            blockers=["source_decisions_missing", "runtime_ledger_bucket_missing"],
+            probe={"configured_enabled": True},
+            runtime_window_import_audit={"state": "import_due_flatten_handoff_missing"},
+            hpairs_target_count=1,
+            hpairs_symbol_count=2,
+            hpairs_source_decision_ready_count=1,
+            hpairs_decision_count=0,
+            hpairs_submitted_order_count=0,
+            hpairs_tca_sample_count=0,
+            hpairs_runtime_bucket_count=0,
+        )
+        self.assertTrue(generic_import_due_state["source_decisions_missing"])
+        self.assertTrue(generic_import_due_state["runtime_ledger_bucket_missing"])
+
+        deferred_settlement_window = _hpairs_zero_activity_reason_flags(
+            blockers=[
+                "paper_route_session_settlement_pending",
+                "source_decisions_missing",
+                "runtime_ledger_bucket_missing",
+            ],
+            probe={"configured_enabled": True},
+            runtime_window_import_audit={
+                "session_state": "window_closed_settlement_pending",
+                "state": "window_closed_settlement_pending",
+                "import_ready": False,
+            },
+            hpairs_target_count=1,
+            hpairs_symbol_count=2,
+            hpairs_source_decision_ready_count=1,
+            hpairs_decision_count=0,
+            hpairs_submitted_order_count=0,
+            hpairs_tca_sample_count=0,
+            hpairs_runtime_bucket_count=0,
+        )
+        self.assertTrue(deferred_settlement_window["no_market_window"])
+        self.assertFalse(deferred_settlement_window["source_decisions_missing"])
+        self.assertFalse(deferred_settlement_window["runtime_ledger_bucket_missing"])
+        self.assertEqual(
+            _hpairs_zero_activity_state(deferred_settlement_window),
+            "no_market_window",
+        )
 
         decisions_without_execution = _hpairs_zero_activity_reason_flags(
             blockers=[],


### PR DESCRIPTION
## Summary

- Gate H-PAIRS zero-activity source-decision and runtime-ledger missing flags on runtime-window import readiness.
- Filter top-level H-PAIRS diagnostic blockers through the same deferred-window reason flags so settlement-pending windows do not report stale source-missing blockers.
- Keep import-due and import-ready states fail-closed by preserving missing-source/runtime-ledger blockers once runtime-window import is actually due.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -q -k 'hpairs_zero_activity'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
