### PR TITLE
fix(torghut): accept post-window flat snapshot readback

### DIFF
--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -318,11 +318,44 @@ def _target_plan_baseline_readback(
     }
 
 
+def _readback_datetime(value: object) -> datetime | None:
+    text = _safe_text(value)
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _snapshot_after_matching_target_windows(
+    *,
+    snapshot_as_of: str | None,
+    readback_targets: Sequence[Mapping[str, object]],
+) -> bool:
+    snapshot_time = _readback_datetime(snapshot_as_of)
+    if snapshot_time is None or not readback_targets:
+        return False
+    saw_window_end = False
+    for target in readback_targets:
+        window_end = _readback_datetime(target.get("window_end"))
+        if window_end is None:
+            return False
+        saw_window_end = True
+        if snapshot_time <= window_end:
+            return False
+    return saw_window_end
+
+
 def read_target_plan_clean_window_readback(
     *,
     url: str,
     account_label: str,
     snapshot_id: str | None,
+    snapshot_as_of: str | None = None,
     timeout_seconds: float,
 ) -> dict[str, object]:
     normalized_url = url.strip()
@@ -331,6 +364,7 @@ def read_target_plan_clean_window_readback(
         "url": normalized_url,
         "account_label": account_label,
         "position_snapshot_id": snapshot_id,
+        "position_snapshot_as_of": snapshot_as_of,
         "state": "not_requested",
         "http_status": None,
         "plan_source": None,
@@ -338,6 +372,7 @@ def read_target_plan_clean_window_readback(
         "matching_target_count": 0,
         "clean_matching_target_count": 0,
         "persisted_snapshot_seen": False,
+        "persisted_snapshot_after_target_window": False,
         "clean_window_baseline_readiness": {},
         "targets": [],
         "blockers": [],
@@ -408,6 +443,10 @@ def read_target_plan_clean_window_readback(
         snapshot_id
         and any(target.get("snapshot_id") == snapshot_id for target in readback_targets)
     )
+    persisted_snapshot_after_target_window = _snapshot_after_matching_target_windows(
+        snapshot_as_of=snapshot_as_of,
+        readback_targets=readback_targets,
+    )
     summary = _as_mapping(plan.get("clean_window_baseline_readiness"))
     blockers = _readback_blockers(summary.get("blockers"))
     for target in readback_targets:
@@ -418,7 +457,12 @@ def read_target_plan_clean_window_readback(
         blockers.append("paper_route_target_plan_readback_target_missing")
     if matching_targets and len(clean_targets) != len(matching_targets):
         blockers.append("paper_route_target_plan_clean_window_baseline_not_clean")
-    if snapshot_id and matching_targets and not persisted_snapshot_seen:
+    if (
+        snapshot_id
+        and matching_targets
+        and not persisted_snapshot_seen
+        and not persisted_snapshot_after_target_window
+    ):
         blockers.append("paper_route_target_plan_readback_snapshot_id_mismatch")
     blockers = sorted(dict.fromkeys(blockers))
     return {
@@ -430,6 +474,7 @@ def read_target_plan_clean_window_readback(
         "matching_target_count": len(matching_targets),
         "clean_matching_target_count": len(clean_targets),
         "persisted_snapshot_seen": persisted_snapshot_seen,
+        "persisted_snapshot_after_target_window": persisted_snapshot_after_target_window,
         "clean_window_baseline_readiness": dict(summary),
         "targets": readback_targets,
         "blockers": blockers,
@@ -1271,6 +1316,11 @@ def main() -> int:
                 snapshot_id=(
                     str(payload["position_snapshot_id"])
                     if payload.get("position_snapshot_id")
+                    else None
+                ),
+                snapshot_as_of=(
+                    str(payload["position_snapshot_as_of"])
+                    if payload.get("position_snapshot_as_of")
                     else None
                 ),
                 timeout_seconds=max(

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -1175,9 +1175,67 @@ class TestFlattenPaperAccountPositions(TestCase):
         self.assertEqual(readback["matching_target_count"], 1)
         self.assertEqual(readback["clean_matching_target_count"], 1)
         self.assertTrue(readback["persisted_snapshot_seen"])
+        self.assertFalse(readback["persisted_snapshot_after_target_window"])
+        self.assertEqual(readback["blockers"], [])
+
+    def test_target_plan_readback_accepts_post_window_flat_snapshot(self) -> None:
+        target_plan = {
+            "schema_version": "torghut.paper-route-target-plan.v1",
+            "next_paper_route_runtime_window_targets": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "clean_window_baseline_readiness": {
+                    "state": "clean",
+                    "blockers": [],
+                },
+                "targets": [
+                    {
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "window_start": "2026-06-05T13:30:00+00:00",
+                        "window_end": "2026-06-05T20:00:00+00:00",
+                        "paper_route_clean_window_baseline_state": {
+                            "state": "clean",
+                            "snapshot_id": "pre-session-snapshot",
+                            "snapshot_as_of": "2026-06-05T13:29:54+00:00",
+                            "source_auditable": True,
+                            "blockers": [],
+                        },
+                        "paper_route_clean_window_baseline_blockers": [],
+                    }
+                ],
+            },
+        }
+
+        with patch.object(
+            flatten_script.urllib.request,
+            "urlopen",
+            return_value=FakeHttpResponse(target_plan),
+        ):
+            readback = flatten_script.read_target_plan_clean_window_readback(
+                url="http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+                account_label="TORGHUT_SIM",
+                snapshot_id="post-close-snapshot",
+                snapshot_as_of="2026-06-05T20:09:35+00:00",
+                timeout_seconds=2,
+            )
+
+        self.assertEqual(readback["state"], "clean")
+        self.assertEqual(readback["matching_target_count"], 1)
+        self.assertEqual(readback["clean_matching_target_count"], 1)
+        self.assertFalse(readback["persisted_snapshot_seen"])
+        self.assertTrue(readback["persisted_snapshot_after_target_window"])
         self.assertEqual(readback["blockers"], [])
 
     def test_target_plan_readback_fail_closed_edge_cases(self) -> None:
+        self.assertIsNone(flatten_script._readback_datetime("not-a-timestamp"))
+        self.assertEqual(
+            flatten_script._readback_datetime("2026-06-05T20:00:00"),
+            datetime(2026, 6, 5, 20, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            flatten_script._readback_datetime("2026-06-05T20:00:00Z"),
+            datetime(2026, 6, 5, 20, 0, tzinfo=timezone.utc),
+        )
         self.assertEqual(flatten_script._as_sequence("not-a-list"), [])
         self.assertEqual(
             flatten_script._target_plan_readback_targets({"targets": []}),
@@ -1307,6 +1365,40 @@ class TestFlattenPaperAccountPositions(TestCase):
             )
         self.assertEqual(
             readback["blockers"], ["paper_route_target_plan_readback_target_missing"]
+        )
+
+        with patch.object(
+            flatten_script.urllib.request,
+            "urlopen",
+            return_value=FakeHttpResponse(
+                {
+                    "targets": [
+                        {
+                            "candidate_id": "candidate-1",
+                            "account_label": "TORGHUT_SIM",
+                            "window_start": "2026-06-05T13:30:00+00:00",
+                            "window_end": "2026-06-05T20:00:00+00:00",
+                            "paper_route_clean_window_baseline_state": {
+                                "state": "clean",
+                                "snapshot_id": "other-snapshot",
+                                "source_auditable": True,
+                                "blockers": [],
+                            },
+                        }
+                    ]
+                }
+            ),
+        ):
+            readback = flatten_script.read_target_plan_clean_window_readback(
+                url="http://torghut-sim",
+                account_label="TORGHUT_SIM",
+                snapshot_id="snapshot-1",
+                snapshot_as_of="2026-06-05T13:16:00+00:00",
+                timeout_seconds=1,
+            )
+        self.assertIn(
+            "paper_route_target_plan_readback_snapshot_id_mismatch",
+            readback["blockers"],
         )
 
     def test_required_target_plan_readback_blocks_when_baseline_still_pending(


### PR DESCRIPTION
## Summary

- Accept a persisted post-window flat position snapshot during required paper-account flatten target-plan readback.
- Keep fail-closed behavior for target-plan errors, missing matching targets, non-clean baselines, and stale/pre-window snapshot mismatches.
- Add regression coverage for both the post-window-flat acceptance path and the stale mismatch blocker.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format --check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py`
- `cd services/torghut && uv run --frozen ruff check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py`
- `cd services/torghut && uv run --frozen pytest tests/test_flatten_paper_account_positions.py -q`
- `cd services/torghut && rm -f .coverage coverage.xml && uv run --frozen coverage run -m pytest tests/test_flatten_paper_account_positions.py -q && uv run --frozen coverage xml --fail-under=0 && GITHUB_BASE_REF=main uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
