### PR TITLE
fix(torghut): defer target-plan readback audits

### DIFF
--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -47,7 +47,7 @@ spec:
                   if /opt/venv/bin/python scripts/flatten_paper_account_positions.py --help \
                     | grep -q -- '--target-plan-readback-url'; then
                     target_plan_readback_args=(
-                      --target-plan-readback-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan
+                      --target-plan-readback-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan?runtime_window_import_audit=deferred
                       --target-plan-readback-timeout-seconds 10
                       --require-target-plan-readback-clean
                     )

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6288,8 +6288,26 @@ def trading_paper_route_evidence(
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
 
+def _paper_route_target_plan_audit_mode_value(mode: str) -> bool | None:
+    normalized = mode.strip().lower()
+    if normalized == "deferred":
+        return False
+    if normalized == "full":
+        return True
+    return None
+
+
 @app.get("/trading/paper-route-target-plan")
-def trading_paper_route_target_plan() -> JSONResponse:
+def trading_paper_route_target_plan(
+    runtime_window_import_audit: str = Query(
+        "auto",
+        pattern="^(auto|deferred|full)$",
+        description=(
+            "Runtime-window import audit mode. Use deferred for low-latency "
+            "clean-window readback; auto runs full proof audit only when import-ready."
+        ),
+    ),
+) -> JSONResponse:
     """Return the lightweight next-window paper-route target plan."""
 
     scheduler: TradingScheduler | None = getattr(app.state, "trading_scheduler", None)
@@ -6391,7 +6409,9 @@ def trading_paper_route_target_plan() -> JSONResponse:
             route_reacquisition_book=route_reacquisition_book,
             # Keep this provider endpoint bounded; proof-grade runtime import
             # audits run only after the runtime window is import-ready.
-            include_runtime_window_import_audit=None,
+            include_runtime_window_import_audit=_paper_route_target_plan_audit_mode_value(
+                runtime_window_import_audit,
+            ),
             target_account_audit_available=_paper_route_target_account_audit_available(
                 cast(Mapping[str, Any], live_submission_gate)
             ),

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1327,7 +1327,8 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("target_plan_readback_args=()", args)
         self.assertIn("--target-plan-readback-url", args)
         self.assertIn(
-            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/"
+            "paper-route-target-plan?runtime_window_import_audit=deferred",
             args,
         )
         self.assertIn("--target-plan-readback-timeout-seconds 10", args)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -9694,6 +9694,105 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
+    def test_trading_paper_route_target_plan_deferred_query_skips_full_import_audit(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        live_gate = {
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "promotion_eligible_total": 0,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "skipped_target_count": 0,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [
+                    {
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ],
+            },
+        }
+
+        def _assert_deferred_mode(*args: object, **kwargs: object) -> dict[str, object]:
+            self.assertIs(kwargs["include_runtime_window_import_audit"], False)
+            return {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "target_count": 1,
+                "skipped_target_count": 0,
+                "runtime_window_import_audit_mode": "deferred_until_import_ready",
+                "targets": [
+                    {
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        "promotion_allowed": False,
+                        "final_promotion_allowed": False,
+                    }
+                ],
+            }
+
+        self.assertIsNone(main_module._paper_route_target_plan_audit_mode_value("auto"))
+        self.assertIs(
+            main_module._paper_route_target_plan_audit_mode_value("deferred"), False
+        )
+        self.assertIs(
+            main_module._paper_route_target_plan_audit_mode_value("full"), True
+        )
+
+        try:
+            app.state.trading_scheduler = SimpleNamespace(
+                state=SimpleNamespace(market_session_open=False)
+            )
+            with (
+                patch(
+                    "app.main._paper_route_cached_live_submission_gate",
+                    return_value=live_gate,
+                ),
+                patch(
+                    "app.main._merge_external_paper_route_target_plan",
+                    side_effect=lambda gate: dict(gate),
+                ),
+                patch(
+                    "app.main._build_simple_lane_status_payload",
+                    return_value={
+                        "paper_route_probe_enabled": True,
+                        "paper_route_probe_max_notional": "75000",
+                    },
+                ),
+                patch(
+                    "app.main._paper_route_probe_book_from_target_plan",
+                    return_value={},
+                ),
+                patch(
+                    "app.main.build_paper_route_target_plan_payload",
+                    side_effect=_assert_deferred_mode,
+                ),
+            ):
+                response = self.client.get(
+                    "/trading/paper-route-target-plan"
+                    "?runtime_window_import_audit=deferred"
+                )
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(
+                payload["runtime_window_import_audit_mode"],
+                "deferred_until_import_ready",
+            )
+            self.assertEqual(payload["target_count"], 1)
+        finally:
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
     def test_live_paper_route_target_plan_uses_bounded_sim_cached_gate_fast_path(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds an explicit `runtime_window_import_audit` mode to `/trading/paper-route-target-plan`.
- Allows flatten/readback callers to force the low-latency `deferred` target-plan path while preserving the default `auto` behavior for import proof.
- Updates the Torghut paper-account flatten CronJob to use deferred target-plan readback so clean-window proof is not blocked by full source/import diagnostics after settlement.
- Adds API and manifest regression coverage for the new readback mode.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format app/main.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan_deferred_query or paper_route_target_plan_defers_runtime_import_audit' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -k paper_account_flatten -q`
- `cd services/torghut && rm -f .coverage coverage.xml && uv run --frozen coverage run -m pytest tests/test_trading_api.py::TestTradingApi::test_trading_paper_route_target_plan_deferred_query_skips_full_import_audit tests/test_trading_api.py::TestTradingApi::test_trading_paper_route_target_plan_defers_runtime_import_audit tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account -q && uv run --frozen coverage xml --fail-under=0 && GITHUB_BASE_REF=main uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
