### PR TITLE
fix(torghut): count post-close tca for source windows

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -17,9 +17,10 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, cast
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import create_engine, func, select, text
+from sqlalchemy import create_engine, func, or_, select, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.sql.elements import ColumnElement
 
 from ..config import settings
 from ..models import (
@@ -4329,6 +4330,11 @@ def _source_activity_account_diagnostics(
                 last_activity_at=last_activity_at,
             )
 
+        tca_activity_ts = func.coalesce(
+            TradeDecision.created_at,
+            Execution.created_at,
+            ExecutionTCAMetric.computed_at,
+        )
         tca_stmt = (
             select(
                 ExecutionTCAMetric.alpaca_account_label,
@@ -4336,10 +4342,15 @@ def _source_activity_account_diagnostics(
                 func.count(ExecutionTCAMetric.id),
                 func.max(ExecutionTCAMetric.computed_at),
             )
+            .outerjoin(
+                TradeDecision,
+                ExecutionTCAMetric.trade_decision_id == TradeDecision.id,
+            )
+            .outerjoin(Execution, ExecutionTCAMetric.execution_id == Execution.id)
             .outerjoin(Strategy, ExecutionTCAMetric.strategy_id == Strategy.id)
             .where(ExecutionTCAMetric.alpaca_account_label.in_(account_labels))
-            .where(ExecutionTCAMetric.computed_at >= window_start)
-            .where(ExecutionTCAMetric.computed_at <= window_end)
+            .where(tca_activity_ts >= window_start)
+            .where(tca_activity_ts <= window_end)
             .group_by(ExecutionTCAMetric.alpaca_account_label, Strategy.name)
         )
         if symbol_filters:
@@ -4848,18 +4859,17 @@ def _strategy_source_activity(
                     raw_decision_count=raw_decision_count,
                     lineage_matched_decision_count=len(decision_rows),
                 )
+    execution_ids = [row.id for row in execution_rows]
     tca_rows: list[ExecutionTCAMetric] = []
+    tca_source_filters: list[ColumnElement[bool]] = []
     if decision_ids:
-        tca_stmt = (
-            select(ExecutionTCAMetric)
-            .join(Strategy, ExecutionTCAMetric.strategy_id == Strategy.id)
-            .where(Strategy.name.in_(strategy_filters))
-            .where(ExecutionTCAMetric.computed_at >= window_start)
-            .where(ExecutionTCAMetric.computed_at <= window_end)
-        )
-        tca_stmt = tca_stmt.where(
+        tca_source_filters.append(
             ExecutionTCAMetric.trade_decision_id.in_(decision_ids)
         )
+    if execution_ids:
+        tca_source_filters.append(ExecutionTCAMetric.execution_id.in_(execution_ids))
+    if tca_source_filters:
+        tca_stmt = select(ExecutionTCAMetric).where(or_(*tca_source_filters))
         if account_label:
             tca_stmt = tca_stmt.where(
                 ExecutionTCAMetric.alpaca_account_label == account_label
@@ -5015,7 +5025,7 @@ def _strategy_source_activity(
     if execution_count <= 0 and not quote_quality_only_rejects:
         missing_reasons.append("source_executions_missing")
     missing_reasons.extend(materialized_unsubmitted_reasons)
-    if decision_reject_blockers:
+    if decision_reject_blockers and execution_count <= 0:
         missing_reasons.extend(decision_reject_blockers)
     if (
         tca_sample_count <= 0

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -7462,6 +7462,258 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 0,
             )
 
+    def test_runtime_window_import_audit_counts_post_close_tca_for_mixed_source_activity(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        strategy_name = "mixed-source-post-close-tca"
+        candidate_id = "candidate-mixed-source-post-close-tca"
+
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="mixed source post-close TCA fixture",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            for index, side in enumerate(("buy", "sell")):
+                event_at = window_start + timedelta(minutes=10 + index)
+                decision = TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    timeframe="1Sec",
+                    decision_json={
+                        "action": side,
+                        "qty": "1",
+                        "candidate_id": candidate_id,
+                        "hypothesis_id": "H-PAIRS-01",
+                    },
+                    rationale="mixed source filled decision",
+                    status="filled",
+                    created_at=event_at,
+                    executed_at=event_at,
+                )
+                session.add(decision)
+                session.flush()
+                execution = Execution(
+                    trade_decision_id=decision.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    alpaca_order_id=f"mixed-source-order-{index}",
+                    client_order_id=f"mixed-source-{side}-aapl-{index}",
+                    symbol="AAPL",
+                    side=side,
+                    order_type="limit",
+                    time_in_force="day",
+                    submitted_qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("100"),
+                    status="filled",
+                    raw_order={},
+                    created_at=event_at,
+                    updated_at=event_at,
+                    last_update_at=event_at,
+                )
+                session.add(execution)
+                session.flush()
+                session.add(
+                    ExecutionOrderEvent(
+                        event_fingerprint=f"mixed-source-fill-{index}",
+                        source_topic="trade_updates",
+                        source_partition=0,
+                        source_offset=300 + index,
+                        alpaca_account_label="TORGHUT_SIM",
+                        feed_seq=300 + index,
+                        event_ts=event_at,
+                        symbol="AAPL",
+                        alpaca_order_id=f"mixed-source-order-{index}",
+                        client_order_id=f"mixed-source-{side}-aapl-{index}",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        filled_qty_delta=Decimal("1"),
+                        filled_notional_delta=Decimal("100"),
+                        avg_fill_price=Decimal("100"),
+                        raw_event={
+                            "event": "fill",
+                            "side": side,
+                            "order": {
+                                "id": f"mixed-source-order-{index}",
+                                "client_order_id": f"mixed-source-{side}-aapl-{index}",
+                                "symbol": "AAPL",
+                                "side": side,
+                                "status": "filled",
+                            },
+                        },
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        created_at=event_at,
+                    )
+                )
+                session.add(
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        side=side,
+                        arrival_price=Decimal("100"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=Decimal("-1") if side == "sell" else Decimal("1"),
+                        slippage_bps=Decimal("0"),
+                        shortfall_notional=Decimal("0"),
+                        realized_shortfall_bps=Decimal("0"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=window_end + timedelta(minutes=45 + index),
+                        created_at=window_end + timedelta(minutes=45 + index),
+                        updated_at=window_end + timedelta(minutes=45 + index),
+                    )
+                )
+
+            session.add(
+                TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    timeframe="1Sec",
+                    decision_json={
+                        "action": "buy",
+                        "qty": "1",
+                        "candidate_id": candidate_id,
+                        "hypothesis_id": "H-PAIRS-01",
+                        "reject_reason_atomic": ["broker_submit_failed"],
+                    },
+                    rationale="mixed source rejected decision",
+                    status="rejected",
+                    created_at=window_start + timedelta(minutes=12),
+                )
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
+            self._add_flat_account_close_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_end=window_end,
+            )
+            session.commit()
+
+            target = {
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": candidate_id,
+                "observed_stage": "paper",
+                "strategy_family": "microbar_pairs",
+                "strategy_name": strategy_name,
+                "runtime_strategy_name": strategy_name,
+                "account_label": "TORGHUT_SIM",
+                "source_account_label": "TORGHUT_SIM",
+                "window_start": window_start.isoformat(),
+                "window_end": window_end.isoformat(),
+                "paper_route_probe_symbols": ["AAPL"],
+            }
+            probe = {
+                "configured_enabled": True,
+                "active": True,
+                "eligible_symbol_count": 1,
+            }
+            source_activity = paper_route_evidence._strategy_source_activity(
+                session,
+                strategy_name=strategy_name,
+                strategy_lookup_names=[strategy_name],
+                account_label="TORGHUT_SIM",
+                symbols=["AAPL"],
+                window_start=window_start,
+                window_end=window_end,
+                candidate_id=candidate_id,
+                hypothesis_id="H-PAIRS-01",
+                require_source_lineage=True,
+            )
+            account_diagnostics = (
+                paper_route_evidence._source_activity_account_diagnostics(
+                    session,
+                    target=target,
+                    probe=probe,
+                    strategy_lookup_names=[strategy_name],
+                    window_start=window_start,
+                    window_end=window_end,
+                )
+            )
+            import_audit = paper_route_evidence._runtime_window_import_audit(
+                next_targets={
+                    "target_count": 1,
+                    "source": "paper_route_evidence_audit",
+                    "session_readiness": {
+                        "state": "window_closed_import_ready",
+                        "import_ready": True,
+                        "import_blockers": [],
+                    },
+                    "targets": [target],
+                },
+                target_audits=[
+                    {
+                        "target": target,
+                        "source_activity": source_activity,
+                        "runtime_ledger": {
+                            "bucket_count": 0,
+                            "evidence_grade_bucket_count": 0,
+                        },
+                        "promotion_decisions": {"decision_count": 1},
+                    }
+                ],
+                next_target_audits=[
+                    {
+                        "target": target,
+                        "source_activity": source_activity,
+                        "account_close_state": {
+                            "zero_open_position_evidence": True,
+                            "blockers": [],
+                        },
+                        "account_contamination": {"blockers": []},
+                        "account_state": {"blockers": []},
+                        "runtime_ledger": {
+                            "bucket_count": 0,
+                            "evidence_grade_bucket_count": 0,
+                        },
+                        "promotion_decisions": {"decision_count": 1},
+                    }
+                ],
+            )
+
+        self.assertFalse(source_activity["missing"])
+        self.assertEqual(source_activity["tca_sample_count"], 2)
+        self.assertEqual(source_activity["explicit_cost_tca_count"], 2)
+        self.assertIn(
+            "source_reject_broker_submit_failed",
+            source_activity["source_decision_reject_blockers"],
+        )
+        self.assertEqual(
+            account_diagnostics["account_summaries"][0][
+                "target_strategy_tca_sample_count"
+            ],
+            2,
+        )
+        self.assertEqual(import_audit["state"], "import_due_runtime_ledger_missing")
+        self.assertNotIn(
+            "paper_route_source_activity_missing", import_audit["blockers"]
+        )
+        self.assertNotIn(
+            "source_reject_broker_submit_failed",
+            import_audit["blockers"],
+        )
+
     def test_runtime_window_import_audit_reports_observed_source_blockers_without_session_readiness(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Count execution TCA rows by the source decision/execution window instead of post-close `computed_at`, so settlement refreshes count for the session they repair.
- Let mixed filled/rejected source windows remain source-present when fills and cost rows exist; rejected decisions stay diagnostic instead of blocking runtime-ledger materialization.
- Add a regression covering post-close TCA refresh rows plus mixed filled/rejected source activity.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_evidence or paper_route_target_plan' -q`
- `cd services/torghut && rm -f .coverage coverage.xml && uv run --frozen coverage run -m pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_runtime_window_import_audit_counts_post_close_tca_for_mixed_source_activity tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_runtime_window_import_audit_tracks_missing_and_non_grade_ledger tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_runtime_window_import_audit_explains_quote_rejected_source_activity -q && uv run --frozen coverage xml --fail-under=0 && GITHUB_BASE_REF=main uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
