### PR TITLE
fix(torghut): block late paper-route entries

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -4213,6 +4213,86 @@ class SimpleTradingPipeline(TradingPipeline):
         return target
 
     @staticmethod
+    def _bounded_collection_exit_window_elapsed(
+        *,
+        decision: StrategyDecision,
+        metadata: Mapping[str, Any],
+    ) -> tuple[datetime, datetime] | None:
+        exit_due_at = _parse_target_datetime(metadata.get("exit_due_at"))
+        if exit_due_at is None:
+            return None
+        event_ts = decision.event_ts
+        if event_ts.tzinfo is None:
+            event_ts = event_ts.replace(tzinfo=timezone.utc)
+        event_ts = event_ts.astimezone(timezone.utc)
+        if event_ts < exit_due_at:
+            return None
+        return event_ts, exit_due_at
+
+    @staticmethod
+    def _apply_bounded_collection_exit_window_audit(
+        decision: StrategyDecision,
+        *,
+        event_ts: datetime,
+        exit_due_at: datetime,
+    ) -> StrategyDecision:
+        reason = "bounded_paper_route_target_exit_window_elapsed"
+        audit = {
+            "schema_version": "torghut.bounded-paper-route-exit-window.v1",
+            "state": "rejected",
+            "reason": reason,
+            "symbol": decision.symbol.strip().upper(),
+            "action": decision.action,
+            "event_ts": event_ts.isoformat(),
+            "exit_due_at": exit_due_at.isoformat(),
+            "source_decision_mode": (
+                BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+            ),
+        }
+        params = dict(decision.params)
+        params["bounded_paper_route_target_exit_window"] = audit
+        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
+        simple_lane["bounded_paper_route_target_exit_window"] = audit
+        params["simple_lane"] = simple_lane
+
+        for key in (
+            "paper_route_target_plan_source_decision",
+            "paper_route_target_plan",
+            "paper_route_probe",
+        ):
+            metadata = _mapping_value(params.get(key))
+            if metadata is None:
+                continue
+            updated_metadata = dict(metadata)
+            updated_metadata["bounded_paper_route_target_exit_window"] = audit
+            params[key] = updated_metadata
+
+        return decision.model_copy(update={"params": params})
+
+    def _bounded_collection_exit_window_guarded_decision(
+        self,
+        decision: StrategyDecision,
+    ) -> tuple[StrategyDecision, str | None]:
+        if self._paper_route_probe_exit_metadata(decision) is not None:
+            return decision, None
+        metadata = _bounded_paper_route_collection_entry_metadata(decision.params)
+        if metadata is None:
+            return decision, None
+        elapsed = self._bounded_collection_exit_window_elapsed(
+            decision=decision,
+            metadata=metadata,
+        )
+        if elapsed is None:
+            return decision, None
+        event_ts, exit_due_at = elapsed
+        updated = self._apply_bounded_collection_exit_window_audit(
+            decision,
+            event_ts=event_ts,
+            exit_due_at=exit_due_at,
+        )
+        return updated, "bounded_paper_route_target_exit_window_elapsed"
+
+    @staticmethod
     def _apply_bounded_collection_target_sizing_audit(
         decision: StrategyDecision,
         *,
@@ -4290,6 +4370,12 @@ class SimpleTradingPipeline(TradingPipeline):
                 qty=decision.qty,
             )
             return updated, "bounded_paper_route_target_notional_sizing_missing"
+
+        exit_guarded_decision, exit_window_reason = (
+            self._bounded_collection_exit_window_guarded_decision(decision)
+        )
+        if exit_window_reason is not None:
+            return exit_guarded_decision, exit_window_reason
 
         target = self._bounded_collection_target_sizing_payload(
             decision=decision,
@@ -4958,6 +5044,20 @@ class SimpleTradingPipeline(TradingPipeline):
         account: dict[str, str],
         positions: list[dict[str, Any]],
     ) -> tuple[StrategyDecision, Optional[MarketSnapshot]] | None:
+        decision, bounded_exit_window_reject_reason = (
+            self._bounded_collection_exit_window_guarded_decision(decision)
+        )
+        if bounded_exit_window_reject_reason is not None:
+            self.executor.update_decision_params(session, decision_row, decision.params)
+            self.executor.sync_decision_state(session, decision_row, decision)
+            self._record_decision_rejection(
+                session=session,
+                decision=decision,
+                decision_row=decision_row,
+                reasons=[bounded_exit_window_reject_reason],
+                log_template="Simple-lane decision rejected strategy_id=%s symbol=%s reason=%s",
+            )
+            return None
         decision, snapshot = self._ensure_decision_price(
             decision, signal_price=decision.params.get("price")
         )

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -681,11 +681,21 @@ def _source_decision_target_notional_sizing_summary(
     rows: Sequence[Mapping[str, object]],
 ) -> dict[str, object]:
     source_row_count = len(rows)
+    paper_route_probe_exit_identifiers = _paper_route_probe_exit_identifiers(rows)
+    sizing_required_rows = [
+        row
+        for row in rows
+        if not _source_row_is_paper_route_probe_exit_or_linked(
+            row,
+            paper_route_probe_exit_identifiers=paper_route_probe_exit_identifiers,
+        )
+    ]
+    sizing_required_row_count = len(sizing_required_rows)
     audits: list[dict[str, object]] = []
     authoritative_count = 0
     non_authoritative_source_counts: dict[str, int] = {}
     blocker_counts: dict[str, int] = {}
-    for row in rows:
+    for row in sizing_required_rows:
         audit = _source_decision_target_notional_sizing_audit(row)
         if audit is None:
             continue
@@ -706,10 +716,10 @@ def _source_decision_target_notional_sizing_summary(
         or mode_counts.get("bounded_paper_route_collection", 0) > 0
         or any(
             _first_text(row, "paper_route_probe_target_notional", "target_notional")
-            for row in rows
+            for row in sizing_required_rows
         )
     )
-    missing_count = max(source_row_count - len(audits), 0)
+    missing_count = max(sizing_required_row_count - len(audits), 0)
     blockers: list[str] = []
     if requires_target_notional_sizing and missing_count:
         blockers.append("paper_route_target_notional_sizing_missing")
@@ -718,6 +728,10 @@ def _source_decision_target_notional_sizing_summary(
     blockers.extend(blocker_counts)
     return {
         "source_row_count": source_row_count,
+        "target_notional_sizing_required_source_row_count": (sizing_required_row_count),
+        "excluded_paper_route_probe_exit_row_count": (
+            source_row_count - sizing_required_row_count
+        ),
         "audit_count": len(audits),
         "authoritative_target_notional_sizing_count": authoritative_count,
         "missing_target_notional_sizing_count": (

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1423,6 +1423,55 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
         )
 
+    def test_target_notional_sizing_summary_excludes_paper_route_exits(
+        self,
+    ) -> None:
+        summary = _source_decision_target_notional_sizing_summary(
+            [
+                {
+                    "trade_decision_id": "entry-decision",
+                    "source_decision_mode": "bounded_paper_route_collection",
+                    "paper_route_probe_target_notional": "150",
+                    "decision_json": {
+                        "params": {
+                            "source_decision_mode": ("bounded_paper_route_collection"),
+                            "paper_route_target_notional_sizing": {
+                                "sizing_source": "target_notional",
+                                "blockers": [],
+                            },
+                        }
+                    },
+                },
+                {
+                    "trade_decision_id": "exit-decision",
+                    "source_decision_mode": "route_acquisition_probe",
+                    "decision_json": {
+                        "params": {
+                            "source_decision_mode": "route_acquisition_probe",
+                            "paper_route_probe_exit": {
+                                "mode": "paper_route_exit",
+                                "source": "filled_paper_route_probe_executions",
+                            },
+                        }
+                    },
+                },
+                {
+                    "trade_decision_id": "exit-decision",
+                    "execution_id": "exit-execution",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+            ]
+        )
+
+        self.assertTrue(summary["requires_target_notional_sizing"])
+        self.assertEqual(summary["source_row_count"], 3)
+        self.assertEqual(summary["target_notional_sizing_required_source_row_count"], 1)
+        self.assertEqual(summary["excluded_paper_route_probe_exit_row_count"], 2)
+        self.assertEqual(summary["audit_count"], 1)
+        self.assertEqual(summary["authoritative_target_notional_sizing_count"], 1)
+        self.assertEqual(summary["missing_target_notional_sizing_count"], 0)
+        self.assertEqual(summary["blockers"], [])
+
     def test_runtime_rows_fail_closed_on_non_authoritative_target_notional_sizing(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4346,6 +4346,142 @@ class TestTradingPipeline(TestCase):
             ["bounded_paper_route_target_notional_cap_missing"],
         )
 
+    def test_bounded_collection_target_source_rejects_entry_after_exit_window(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 6, 5, 19, 52, tzinfo=timezone.utc)
+        exit_due_at = datetime(2026, 6, 5, 19, 45, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_allow_shorts = True
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description="bounded target strategy",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("100000"),
+        )
+        target_metadata = {
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "hypothesis_id": "H-PAIRS-01",
+            "account_label": "TORGHUT_SIM",
+            "observed_stage": "paper",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_symbol_actions": {
+                "AAPL": "buy",
+                "AMZN": "sell",
+            },
+            "paper_route_probe_symbol_quantities": {
+                "AAPL": "1",
+                "AMZN": "1",
+            },
+            "paper_route_probe_next_session_max_notional": "75000",
+            "bounded_evidence_collection_authorized": True,
+            "bounded_live_paper_collection_authorized": True,
+            "evidence_collection_ok": True,
+            "source_decision_readiness": {"ready": True, "blockers": []},
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "exit_due_at": exit_due_at.isoformat(),
+        }
+        decision = StrategyDecision(
+            strategy_id=str(strategy.id),
+            symbol="AAPL",
+            event_ts=now,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="bounded paper-route target source after exit",
+            params={
+                "paper_route_target_plan": target_metadata,
+                "source_decision_mode": (
+                    BOUNDED_PAPER_ROUTE_COLLECTION_SOURCE_DECISION_MODE
+                ),
+                "profit_proof_eligible": True,
+            },
+        )
+        price_fetcher = FakePriceFetcher(
+            Decimal("250"),
+            spread=Decimal("0.02"),
+            bid=Decimal("250"),
+            ask=Decimal("250.02"),
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+            price_fetcher=price_fetcher,
+        )
+
+        with self.session_local() as session:
+            session.add(strategy)
+            session.commit()
+            row = pipeline.executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "TORGHUT_SIM",
+            )
+
+            prepared = pipeline._prepare_decision_for_submission(
+                session=session,
+                decision=decision,
+                decision_row=row,
+                strategy=strategy,
+                account={
+                    "equity": "200000",
+                    "cash": "200000",
+                    "buying_power": "200000",
+                },
+                positions=[],
+            )
+            session.refresh(row)
+            row_json = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], row_json["params"])
+            exit_window = cast(
+                dict[str, Any],
+                params["bounded_paper_route_target_exit_window"],
+            )
+            target_plan = cast(dict[str, Any], params["paper_route_target_plan"])
+
+        self.assertIsNone(prepared)
+        self.assertEqual(row.status, "rejected")
+        self.assertEqual(
+            row_json["reject_reason_atomic"],
+            ["bounded_paper_route_target_exit_window_elapsed"],
+        )
+        self.assertEqual(price_fetcher.snapshot_requests, 0)
+        self.assertEqual(
+            exit_window["reason"], "bounded_paper_route_target_exit_window_elapsed"
+        )
+        self.assertEqual(exit_window["event_ts"], now.isoformat())
+        self.assertEqual(exit_window["exit_due_at"], exit_due_at.isoformat())
+        self.assertEqual(
+            target_plan["bounded_paper_route_target_exit_window"], exit_window
+        )
+
     def test_bounded_collection_target_sizing_helper_fail_closed_branches(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Prevent bounded paper-route target-source entries from submitting at or after the target `exit_due_at`; they now reject with `bounded_paper_route_target_exit_window_elapsed` before quote fetching and persist an audit payload.
- Keep paper-route closeout exits and their linked lifecycle rows out of the importer target-notional sizing-required denominator, so position-based exits no longer create false `paper_route_target_notional_sizing_missing` blockers.
- Add focused regressions for the late-entry rejection and closeout-exit sizing summary.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'target_notional_sizing_summary' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k 'bounded_collection_target_source_rejects_entry_after_exit_window or bounded_collection_target_source_enforces_target_notional_broker_sizing or bounded_collection_target_source_rejects_missing_target_sizing' -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall -q app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend scheduler/importer behavior only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
