### PR TITLE
fix(torghut): read sim-backed source lineage

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -209,6 +209,12 @@ RUNTIME_LEDGER_SOURCE_COLLECTION_PENDING_BLOCKER = (
 RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND = (
     "runtime_ledger_source_collection_candidate"
 )
+SIM_BACKED_PAPER_ROUTE_SOURCE_KINDS = frozenset(
+    {
+        "paper_route_probe_runtime_observed",
+        RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND,
+    }
+)
 RUNTIME_LEDGER_SOURCE_COLLECTION_HANDOFF = "runtime_ledger_source_collection_import"
 RUNTIME_LEDGER_SOURCE_COLLECTION_SELECTED_BY = "runtime_ledger_source_collection"
 PRIORITIZED_SOURCE_COLLECTION_PLAN_SOURCE = "paper_route_prioritized_source_collection"
@@ -1986,6 +1992,15 @@ def _target_identity(
         strategy_names_from_strategy_id(strategy_id),
         derived_strategy_name_from_strategy_id(strategy_id),
     )
+    account_label = _safe_text(target.get("account_label"))
+    source_kind = _safe_text(target.get("source_kind"))
+    source_dsn_env = _safe_text(target.get("source_dsn_env"))
+    source_account_label = _normalized_sim_backed_source_account_label(
+        account_label=account_label,
+        source_account_label=_safe_text(target.get("source_account_label")),
+        source_dsn_env=source_dsn_env,
+        source_kind=source_kind,
+    )
     return {
         "hypothesis_id": _safe_text(target.get("hypothesis_id")),
         "candidate_id": _safe_text(target.get("candidate_id")),
@@ -1995,10 +2010,10 @@ def _target_identity(
         "strategy_id": strategy_id,
         "runtime_strategy_name": runtime_strategy_name,
         "strategy_lookup_names": strategy_lookup_names,
-        "account_label": _safe_text(target.get("account_label")),
-        "source_account_label": _safe_text(target.get("source_account_label")),
-        "source_kind": _safe_text(target.get("source_kind")),
-        "source_dsn_env": _safe_text(target.get("source_dsn_env")),
+        "account_label": account_label,
+        "source_account_label": source_account_label,
+        "source_kind": source_kind,
+        "source_dsn_env": source_dsn_env,
         "target_dsn_env": _safe_text(target.get("target_dsn_env")),
         "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
         "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref")),
@@ -2015,11 +2030,11 @@ def _target_identity(
             target.get("runtime_ledger_bucket_ref")
         ),
         "account_stage_runtime_identity": {
-            "account_label": _safe_text(target.get("account_label")),
-            "source_account_label": _safe_text(target.get("source_account_label")),
+            "account_label": account_label,
+            "source_account_label": source_account_label,
             "observed_stage": _safe_text(target.get("observed_stage")) or "paper",
             "runtime_strategy_name": runtime_strategy_name,
-            "source_kind": _safe_text(target.get("source_kind")),
+            "source_kind": source_kind,
         },
         "paper_probation_authorized": bool(target.get("paper_probation_authorized")),
         "paper_probation_authorization_scope": _safe_text(
@@ -2810,7 +2825,15 @@ def _next_paper_route_runtime_window_targets(
                 }
             )
             continue
-        source_account_label = _safe_text(target.get("account_label"))
+        source_account_label = _normalized_sim_backed_source_account_label(
+            account_label=PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+            source_account_label=(
+                _safe_text(target.get("source_account_label"))
+                or _safe_text(target.get("account_label"))
+            ),
+            source_dsn_env="SIM_DB_DSN",
+            source_kind="paper_route_probe_runtime_observed",
+        )
         health_gate = _runtime_window_import_health_gate(
             target=target,
             live_submission_gate=live_submission_gate,
@@ -9885,6 +9908,24 @@ def _source_collection_target_has_bounded_bucket_materialization_seed(
     )
 
 
+def _normalized_sim_backed_source_account_label(
+    *,
+    account_label: str | None,
+    source_account_label: str | None,
+    source_dsn_env: str | None,
+    source_kind: str | None,
+) -> str | None:
+    resolved = source_account_label or account_label
+    if (
+        account_label == PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL
+        and resolved == "TORGHUT_REPLAY"
+        and source_dsn_env == "SIM_DB_DSN"
+        and (source_kind or "").strip() in SIM_BACKED_PAPER_ROUTE_SOURCE_KINDS
+    ):
+        return account_label
+    return resolved
+
+
 def _source_collection_import_target_allowed(target: Mapping[str, Any]) -> bool:
     """Reject replay buckets that have no source lineage to materialize."""
 
@@ -10008,12 +10049,17 @@ def _sanitized_runtime_ledger_source_collection_target(
     account_label = (
         _safe_text(target.get("account_label")) or PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL
     )
-    source_account_label = (
-        _safe_text(target.get("source_account_label")) or account_label
-    )
     source_kind = (
         _safe_text(target.get("source_kind"))
         or RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND
+    )
+    source_dsn_env = _safe_text(target.get("source_dsn_env")) or "SIM_DB_DSN"
+    target_dsn_env = _safe_text(target.get("target_dsn_env")) or "SIM_DB_DSN"
+    source_account_label = _normalized_sim_backed_source_account_label(
+        account_label=account_label,
+        source_account_label=_safe_text(target.get("source_account_label")),
+        source_dsn_env=source_dsn_env,
+        source_kind=source_kind,
     )
     bounded_evidence_collection_requested = _truthy_plan_value(
         target.get("bounded_evidence_collection_authorized")
@@ -10058,8 +10104,8 @@ def _sanitized_runtime_ledger_source_collection_target(
             "runtime_strategy_name": runtime_strategy_name,
             "source_kind": source_kind,
         },
-        "source_dsn_env": _safe_text(target.get("source_dsn_env")) or "SIM_DB_DSN",
-        "target_dsn_env": _safe_text(target.get("target_dsn_env")) or "SIM_DB_DSN",
+        "source_dsn_env": source_dsn_env,
+        "target_dsn_env": target_dsn_env,
         "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref")) or "",
         "source_manifest_ref": _safe_text(target.get("source_manifest_ref")) or "",
         "source_kind": source_kind,

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -192,6 +192,15 @@ RUNTIME_WINDOW_TARGET_PLAN_IMPORT_BLOCKED_STATES = frozenset(
         "import_due_source_activity_missing",
     )
 )
+PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
+PAPER_ROUTE_REPLAY_ACCOUNT_LABEL = "TORGHUT_REPLAY"
+SIM_DB_DSN_ENV = "SIM_DB_DSN"
+SIM_BACKED_PAPER_ROUTE_SOURCE_KINDS = frozenset(
+    (
+        "paper_route_probe_runtime_observed",
+        "runtime_ledger_source_collection_candidate",
+    )
+)
 OFFLINE_REPLAY_TRIAGE_CANDIDATE_LIMIT = 5
 HPAIRS_SOURCE_PROOF_CENSUS_STATUS_SCHEMA_VERSION = (
     "torghut.hpairs-source-proof-census-status.v1"
@@ -512,6 +521,24 @@ def _runtime_window_delay_depth_remediation(
     }
 
 
+def _normalized_sim_backed_source_account_label(
+    *,
+    account_label: str,
+    source_account_label: str,
+    source_dsn_env: str,
+    source_kind: str,
+) -> str:
+    resolved = source_account_label or account_label
+    if (
+        account_label == PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL
+        and resolved == PAPER_ROUTE_REPLAY_ACCOUNT_LABEL
+        and source_dsn_env == SIM_DB_DSN_ENV
+        and source_kind.strip() in SIM_BACKED_PAPER_ROUTE_SOURCE_KINDS
+    ):
+        return account_label
+    return resolved
+
+
 @dataclass(frozen=True)
 class RuntimeWindowImportTarget:
     hypothesis_id: str
@@ -534,6 +561,18 @@ class RuntimeWindowImportTarget:
     target_metadata: Mapping[str, Any] | None = None
     source_account_label: str = ""
     target_dsn_env: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "source_account_label",
+            _normalized_sim_backed_source_account_label(
+                account_label=self.account_label,
+                source_account_label=self.source_account_label,
+                source_dsn_env=self.source_dsn_env,
+                source_kind=self.source_kind,
+            ),
+        )
 
 
 def _runtime_window_target_plan_import_blocked_result(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1623,6 +1623,159 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(observation["exact_match_decision_count"], 1)
         self.assertEqual(observation["blockers"], [])
 
+    def test_hpairs_sim_backed_replay_source_label_reads_runtime_lineage(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 6, 5, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 5, 20, 0, tzinfo=timezone.utc)
+        event_at = window_start + timedelta(hours=6, minutes=15)
+        candidate_id = "c88421d619759b2cfaa6f4d0"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="microbar_cross_sectional_pairs_v1",
+                universe_symbols=["AAPL", "AMZN"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "params": {
+                        "lineage": {
+                            "candidate_id": candidate_id,
+                            "hypothesis_id": "H-PAIRS-01",
+                            "source_account_label": "TORGHUT_SIM",
+                        },
+                        "source_decision_mode": "bounded_paper_route_collection",
+                        "profit_proof_eligible": True,
+                    },
+                },
+                rationale="SIM-backed H-PAIRS source lineage",
+                status="filled",
+                created_at=event_at,
+                executed_at=event_at + timedelta(seconds=5),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="sim-backed-lineage-order",
+                client_order_id="sim-backed-lineage-client",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=event_at + timedelta(seconds=10),
+                updated_at=event_at + timedelta(seconds=10),
+                last_update_at=event_at + timedelta(seconds=10),
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionTCAMetric(
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    side="buy",
+                    arrival_price=Decimal("99"),
+                    avg_fill_price=Decimal("100"),
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("1"),
+                    slippage_bps=Decimal("1"),
+                    shortfall_notional=Decimal("0.01"),
+                    realized_shortfall_bps=Decimal("1"),
+                    churn_qty=Decimal("0"),
+                    churn_ratio=Decimal("0"),
+                    computed_at=event_at + timedelta(seconds=20),
+                    created_at=event_at + timedelta(seconds=20),
+                    updated_at=event_at + timedelta(seconds=20),
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": candidate_id,
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "runtime_strategy_name": (
+                                    "microbar-cross-sectional-pairs-v1"
+                                ),
+                                "strategy_lookup_names": [
+                                    "microbar-cross-sectional-pairs-v1"
+                                ],
+                                "account_label": "TORGHUT_SIM",
+                                "source_account_label": "TORGHUT_REPLAY",
+                                "source_dsn_env": "SIM_DB_DSN",
+                                "target_dsn_env": "SIM_DB_DSN",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                                "paper_probation_satisfied_for_bounded_live_paper_collection": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_active_symbols": ["AAPL", "AMZN"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 75000,
+                        "next_session_max_notional": 75000,
+                    },
+                },
+                generated_at=window_end + timedelta(hours=2),
+            )
+
+        source_activity = payload["targets"][0]["source_activity"]
+        self.assertEqual(
+            payload["targets"][0]["target"]["source_account_label"],
+            "TORGHUT_SIM",
+        )
+        self.assertEqual(source_activity["account_label"], "TORGHUT_SIM")
+        self.assertEqual(source_activity["raw_decision_count"], 1)
+        self.assertEqual(source_activity["lineage_matched_decision_count"], 1)
+        self.assertEqual(source_activity["decision_count"], 1)
+        self.assertEqual(source_activity["execution_count"], 1)
+        self.assertEqual(source_activity["tca_sample_count"], 1)
+        self.assertFalse(source_activity["missing"])
+
     def test_evidence_audit_reuses_duplicate_target_window_audits(self) -> None:
         window_start = datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc)
         window_end = window_start + timedelta(hours=1)
@@ -4107,7 +4260,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(handoff["target_dsn_env"], "SIM_DB_DSN")
         target = plan["targets"][0]
         self.assertEqual(target["account_label"], "TORGHUT_SIM")
-        self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(target["source_account_label"], "TORGHUT_SIM")
         self.assertEqual(target["source_dsn_env"], "SIM_DB_DSN")
         self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
         self.assertEqual(target["source_kind"], "paper_route_probe_runtime_observed")
@@ -5996,7 +6149,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "runtime_ledger_source_collection_import",
         )
         self.assertTrue(source_target["source_collection_authorized"])
-        self.assertEqual(source_target["source_account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(source_target["source_account_label"], "TORGHUT_SIM")
         self.assertEqual(source_target["max_notional"], "0")
         self.assertFalse(source_target["promotion_allowed"])
         self.assertFalse(source_target["final_promotion_allowed"])

--- a/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_renew_latest_empirical_promotion_jobs.py
@@ -289,6 +289,40 @@ class TestRenewLatestEmpiricalPromotionJobsRuntimeLedger(TestCase):
             ["runtime_ledger_source_window_missing"],
         )
 
+    def test_sim_backed_runtime_window_target_normalizes_replay_source_label(
+        self,
+    ) -> None:
+        args = argparse.Namespace(
+            runtime_window_target=[
+                json.dumps(
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "observed_stage": "paper",
+                        "strategy_family": "microbar_cross_sectional_pairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "account_label": "TORGHUT_SIM",
+                        "source_account_label": "TORGHUT_REPLAY",
+                        "source_dsn_env": "SIM_DB_DSN",
+                        "target_dsn_env": "SIM_DB_DSN",
+                        "source_kind": "runtime_ledger_source_collection_candidate",
+                        "source_manifest_ref": (
+                            "config/trading/hypotheses/h-pairs-01.json"
+                        ),
+                    }
+                )
+            ],
+            runtime_window_target_plan_required=False,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+        )
+
+        targets = renew._runtime_window_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].source_account_label, "TORGHUT_SIM")
+
     def test_observed_strategy_source_collection_plan_target_parses_for_import(
         self,
     ) -> None:

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -4899,10 +4899,10 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIn("--source-account-label", command)
         self.assertEqual(
             command[command.index("--source-account-label") + 1],
-            "TORGHUT_REPLAY",
+            "TORGHUT_SIM",
         )
         self.assertEqual(payload["account_label"], "TORGHUT_SIM")
-        self.assertEqual(payload["source_account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(payload["source_account_label"], "TORGHUT_SIM")
 
     def test_runtime_window_import_rejects_non_mapping_import_payload(
         self,


### PR DESCRIPTION
## Summary

- Normalize SIM-backed Torghut paper-route targets that still carry `source_account_label=TORGHUT_REPLAY` so runtime evidence reads the actual `TORGHUT_SIM` source lifecycle rows.
- Apply the same normalization in the runtime-window import runner target model so endpoint and import-plan behavior stay aligned.
- Add regressions for live-shape H-PAIRS source lineage under `decision_json.params.lineage` and explicit runtime-window target normalization.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py -k 'sim_backed_replay_source_label or exact_lineage_readback or runtime_window_import_plan or sim_backed_runtime_window_target_normalizes_replay_source_label or explicit_runtime_window_target_preserves_metadata_and_gates or observed_strategy_source_collection_plan_target_parses_for_import' -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall -q app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
