### PR TITLE
fix(torghut): include verified post-window closeouts

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -14,7 +14,7 @@ from collections import Counter
 from collections.abc import Generator, Mapping, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 from zoneinfo import ZoneInfo
 
 from sqlalchemy import create_engine, func, or_, select, text
@@ -58,6 +58,7 @@ from .session_context import is_regular_equities_session_date
 
 
 logger = logging.getLogger(__name__)
+TModelRow = TypeVar("TModelRow")
 
 
 def _paper_route_evidence_query_timeout_ms() -> int:
@@ -94,6 +95,9 @@ PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_STALE_SECONDS = 900
 PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS = 300
 PAPER_ROUTE_ACCOUNT_PRE_SESSION_READINESS_SECONDS = 900
 PAPER_ROUTE_ACCOUNT_CLOSE_SNAPSHOT_STALE_SECONDS = 3600
+PAPER_ROUTE_POST_WINDOW_CLOSEOUT_LOOKAHEAD_SECONDS = (
+    PAPER_ROUTE_ACCOUNT_CLOSE_SNAPSHOT_STALE_SECONDS
+)
 HPAIRS_REQUIRED_PAPER_ROUTE_SYMBOLS = ("AAPL", "AMZN")
 PAPER_ROUTE_TARGET_PLAN_ENDPOINT = "/trading/paper-route-target-plan"
 DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.local"
@@ -3809,6 +3813,285 @@ def _trade_decision_is_paper_route_closeout(row: TradeDecision) -> bool:
     return _safe_text(metadata.get("mode")) == "paper_route_exit"
 
 
+def _trade_decision_action(row: TradeDecision) -> str | None:
+    payload = _as_mapping(row.decision_json)
+    params = _as_mapping(payload.get("params"))
+    return _safe_text(payload.get("action")) or _safe_text(params.get("action"))
+
+
+def _source_decision_lineage_missing_or_matches(
+    row: TradeDecision,
+    *,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+) -> bool:
+    if candidate_id is not None:
+        candidate_values = _source_lineage_values(
+            row.decision_json,
+            SOURCE_LINEAGE_CANDIDATE_KEYS,
+        )
+        if candidate_values and candidate_id not in candidate_values:
+            return False
+    if hypothesis_id is not None:
+        hypothesis_values = _source_lineage_values(
+            row.decision_json,
+            SOURCE_LINEAGE_HYPOTHESIS_KEYS,
+        )
+        if hypothesis_values and hypothesis_id not in hypothesis_values:
+            return False
+    return True
+
+
+def _open_symbol_qtys_from_lifecycle(
+    lifecycle_summary: Mapping[str, object],
+) -> dict[str, Decimal]:
+    net_by_symbol = _as_mapping(lifecycle_summary.get("net_filled_qty_by_symbol"))
+    open_qtys: dict[str, Decimal] = {}
+    for symbol, raw_qty in net_by_symbol.items():
+        normalized_symbol = _safe_text(symbol)
+        qty = _safe_decimal(raw_qty)
+        if normalized_symbol and qty != 0:
+            open_qtys[normalized_symbol.upper()] = qty
+    return open_qtys
+
+
+def _post_window_action_offsets_open_qty(
+    row: TradeDecision,
+    *,
+    open_qtys: Mapping[str, Decimal],
+) -> bool:
+    symbol = (_safe_text(row.symbol) or "").upper()
+    open_qty = _safe_decimal(open_qtys.get(symbol))
+    if open_qty == 0:
+        return False
+    action = (_trade_decision_action(row) or "").lower()
+    if open_qty > 0:
+        return action in {"sell", "short"}
+    return action in {"buy", "cover"}
+
+
+def _trade_decision_is_post_window_closeout_candidate(
+    row: TradeDecision,
+    *,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+    open_qtys: Mapping[str, Decimal],
+) -> bool:
+    mode = _trade_decision_source_decision_mode(row)
+    if not source_decision_mode_is_profit_proof_eligible(mode):
+        return False
+    if not _source_decision_lineage_missing_or_matches(
+        row,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+    ):
+        return False
+    return _post_window_action_offsets_open_qty(row, open_qtys=open_qtys)
+
+
+def _unique_model_rows_by_id(rows: Sequence[TModelRow]) -> list[TModelRow]:
+    unique_rows: list[TModelRow] = []
+    seen: set[object] = set()
+    for row in rows:
+        row_id = getattr(row, "id", None)
+        if row_id is None:
+            unique_rows.append(row)
+            continue
+        if row_id in seen:
+            continue
+        seen.add(row_id)
+        unique_rows.append(row)
+    return unique_rows
+
+
+def _post_window_closeout_source_rows(
+    session: Session,
+    *,
+    strategy_ids: Sequence[object],
+    account_label: str | None,
+    symbol_filters: Sequence[str],
+    window_end: datetime,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+    lifecycle_summary: Mapping[str, object],
+) -> tuple[
+    list[TradeDecision],
+    list[Execution],
+    list[ExecutionOrderEvent],
+    list[ExecutionTCAMetric],
+    list[OrderFeedSourceWindow],
+]:
+    open_qtys = _open_symbol_qtys_from_lifecycle(lifecycle_summary)
+    if not open_qtys or not strategy_ids:
+        return [], [], [], [], []
+
+    closeout_cutoff = window_end + timedelta(
+        seconds=PAPER_ROUTE_POST_WINDOW_CLOSEOUT_LOOKAHEAD_SECONDS
+    )
+    candidate_symbols = sorted(
+        set(open_qtys) & {item.upper() for item in symbol_filters}
+    )
+    if not candidate_symbols:
+        return [], [], [], [], []
+
+    stmt = (
+        select(TradeDecision)
+        .options(selectinload(TradeDecision.strategy))
+        .where(TradeDecision.strategy_id.in_(strategy_ids))
+        .where(TradeDecision.created_at > window_end)
+        .where(TradeDecision.created_at <= closeout_cutoff)
+        .where(TradeDecision.symbol.in_(candidate_symbols))
+        .order_by(TradeDecision.created_at.asc(), TradeDecision.id.asc())
+        .limit(PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT)
+    )
+    if account_label:
+        stmt = stmt.where(TradeDecision.alpaca_account_label == account_label)
+
+    _maybe_set_paper_route_audit_statement_timeout(session)
+    candidate_rows = [
+        row
+        for row in session.execute(stmt).scalars().all()
+        if _trade_decision_is_post_window_closeout_candidate(
+            row,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            open_qtys=open_qtys,
+        )
+    ]
+    if not candidate_rows:
+        return [], [], [], [], []
+
+    candidate_ids = [row.id for row in candidate_rows]
+    execution_activity_ts = _execution_activity_timestamp()
+    execution_stmt = (
+        select(Execution)
+        .where(Execution.trade_decision_id.in_(candidate_ids))
+        .where(execution_activity_ts > window_end)
+        .where(execution_activity_ts <= closeout_cutoff)
+        .where(Execution.filled_qty > 0)
+        .order_by(execution_activity_ts.asc(), Execution.id.asc())
+        .limit(PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT)
+    )
+    if account_label:
+        execution_stmt = execution_stmt.where(
+            Execution.alpaca_account_label == account_label
+        )
+    execution_stmt = execution_stmt.where(Execution.symbol.in_(candidate_symbols))
+
+    _maybe_set_paper_route_audit_statement_timeout(session)
+    execution_rows = list(session.execute(execution_stmt).scalars().all())
+    if not execution_rows:
+        return [], [], [], [], []
+
+    execution_decision_ids = {
+        row.trade_decision_id for row in execution_rows if row.trade_decision_id
+    }
+    execution_ids = [row.id for row in execution_rows]
+    order_event_activity_ts = _order_event_activity_timestamp()
+    order_event_stmt = (
+        select(ExecutionOrderEvent)
+        .where(
+            or_(
+                ExecutionOrderEvent.trade_decision_id.in_(candidate_ids),
+                ExecutionOrderEvent.execution_id.in_(execution_ids),
+            )
+        )
+        .where(order_event_activity_ts > window_end)
+        .where(order_event_activity_ts <= closeout_cutoff)
+        .order_by(order_event_activity_ts.asc(), ExecutionOrderEvent.id.asc())
+        .limit(PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT)
+    )
+    if account_label:
+        order_event_stmt = order_event_stmt.where(
+            ExecutionOrderEvent.alpaca_account_label == account_label
+        )
+    order_event_stmt = order_event_stmt.where(
+        ExecutionOrderEvent.symbol.in_(candidate_symbols)
+    )
+
+    _maybe_set_paper_route_audit_statement_timeout(session)
+    order_event_rows = list(session.execute(order_event_stmt).scalars().all())
+    if not order_event_rows:
+        return [], [], [], [], []
+
+    fill_event_decision_ids = {
+        row.trade_decision_id
+        for row in order_event_rows
+        if row.trade_decision_id and _order_event_has_complete_fill_lifecycle(row)
+    }
+    tca_stmt = (
+        select(ExecutionTCAMetric)
+        .where(
+            or_(
+                ExecutionTCAMetric.trade_decision_id.in_(candidate_ids),
+                ExecutionTCAMetric.execution_id.in_(execution_ids),
+            )
+        )
+        .order_by(ExecutionTCAMetric.computed_at.asc(), ExecutionTCAMetric.id.asc())
+        .limit(PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT)
+    )
+    if account_label:
+        tca_stmt = tca_stmt.where(
+            ExecutionTCAMetric.alpaca_account_label == account_label
+        )
+    tca_stmt = tca_stmt.where(ExecutionTCAMetric.symbol.in_(candidate_symbols))
+
+    _maybe_set_paper_route_audit_statement_timeout(session)
+    tca_rows = list(session.execute(tca_stmt).scalars().all())
+    tca_decision_ids = {
+        row.trade_decision_id for row in tca_rows if row.trade_decision_id
+    }
+    eligible_decision_ids = (
+        execution_decision_ids & fill_event_decision_ids & tca_decision_ids
+    )
+    if not eligible_decision_ids:
+        return [], [], [], [], []
+
+    eligible_decision_rows = [
+        row for row in candidate_rows if row.id in eligible_decision_ids
+    ]
+    eligible_execution_rows = [
+        row for row in execution_rows if row.trade_decision_id in eligible_decision_ids
+    ]
+    eligible_order_event_rows = [
+        row
+        for row in order_event_rows
+        if row.trade_decision_id in eligible_decision_ids
+        or row.execution_id in {execution.id for execution in eligible_execution_rows}
+    ]
+    eligible_tca_rows = [
+        row
+        for row in tca_rows
+        if row.trade_decision_id in eligible_decision_ids
+        or row.execution_id in {execution.id for execution in eligible_execution_rows}
+    ]
+    source_window_ids = sorted(
+        {
+            row.source_window_id
+            for row in eligible_order_event_rows
+            if row.source_window_id is not None
+        }
+    )
+    source_window_rows: list[OrderFeedSourceWindow] = []
+    if source_window_ids:
+        _maybe_set_paper_route_audit_statement_timeout(session)
+        source_window_rows = list(
+            session.execute(
+                select(OrderFeedSourceWindow)
+                .where(OrderFeedSourceWindow.id.in_(source_window_ids))
+                .order_by(OrderFeedSourceWindow.window_ended_at.asc())
+                .limit(PAPER_ROUTE_SOURCE_ACTIVITY_ROW_LIMIT)
+            ).scalars()
+        )
+    return (
+        eligible_decision_rows,
+        eligible_execution_rows,
+        eligible_order_event_rows,
+        eligible_tca_rows,
+        source_window_rows,
+    )
+
+
 def _source_closeout_fillability_summary(
     *,
     decision_rows: Sequence[TradeDecision],
@@ -4984,6 +5267,71 @@ def _strategy_source_activity(
                 raw_decision_count=raw_decision_count,
                 lineage_matched_decision_count=len(decision_rows),
             )
+    post_window_closeout_decision_rows: list[TradeDecision] = []
+    post_window_closeout_execution_rows: list[Execution] = []
+    post_window_closeout_order_event_rows: list[ExecutionOrderEvent] = []
+    post_window_closeout_tca_rows: list[ExecutionTCAMetric] = []
+    post_window_closeout_source_window_rows: list[OrderFeedSourceWindow] = []
+    initial_lifecycle_summary = _source_activity_lifecycle_summary(
+        execution_rows=execution_rows,
+        order_event_rows=order_event_rows,
+        tca_rows=tca_rows,
+    )
+    if (
+        order_event_rows
+        and tca_rows
+        and _open_symbol_qtys_from_lifecycle(initial_lifecycle_summary)
+    ):
+        try:
+            (
+                post_window_closeout_decision_rows,
+                post_window_closeout_execution_rows,
+                post_window_closeout_order_event_rows,
+                post_window_closeout_tca_rows,
+                post_window_closeout_source_window_rows,
+            ) = _post_window_closeout_source_rows(
+                session,
+                strategy_ids=strategy_ids,
+                account_label=account_label,
+                symbol_filters=symbol_filters,
+                window_end=window_end,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                lifecycle_summary=initial_lifecycle_summary,
+            )
+        except SQLAlchemyError as exc:
+            _rollback_after_source_activity_error(
+                session,
+                source="post_window_closeout_source_rows",
+                exc=exc,
+            )
+            return _unavailable_source_activity(
+                strategy_name=strategy_name,
+                strategy_lookup_names=strategy_filters,
+                account_label=account_label,
+                symbols=symbol_filters,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                require_source_lineage=require_source_lineage,
+                source="post_window_closeout_source_rows",
+                missing_reason="source_closeout_readback_unavailable",
+                raw_decision_count=raw_decision_count,
+                lineage_matched_decision_count=len(decision_rows),
+            )
+    if post_window_closeout_decision_rows:
+        decision_rows = _unique_model_rows_by_id(
+            [*decision_rows, *post_window_closeout_decision_rows]
+        )
+        execution_rows = _unique_model_rows_by_id(
+            [*execution_rows, *post_window_closeout_execution_rows]
+        )
+        order_event_rows = _unique_model_rows_by_id(
+            [*order_event_rows, *post_window_closeout_order_event_rows]
+        )
+        tca_rows = _unique_model_rows_by_id([*tca_rows, *post_window_closeout_tca_rows])
+        source_window_rows = _unique_model_rows_by_id(
+            [*source_window_rows, *post_window_closeout_source_window_rows]
+        )
     decision_count = len(decision_rows)
     execution_count = len(execution_rows)
     tca_sample_count = len(tca_rows)
@@ -5207,6 +5555,17 @@ def _strategy_source_activity(
             materialized_unsubmitted_decision_count
         ),
         "materialized_unsubmitted_reasons": materialized_unsubmitted_reasons,
+        "post_window_closeout_decision_count": len(post_window_closeout_decision_rows),
+        "post_window_closeout_execution_count": len(
+            post_window_closeout_execution_rows
+        ),
+        "post_window_closeout_order_event_count": len(
+            post_window_closeout_order_event_rows
+        ),
+        "post_window_closeout_tca_count": len(post_window_closeout_tca_rows),
+        "post_window_closeout_source_window_count": len(
+            post_window_closeout_source_window_rows
+        ),
         "source_decision_mode_counts": _source_decision_mode_counts(decision_rows),
         "execution_count": execution_count,
         "linked_execution_count": execution_count,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -8773,6 +8773,665 @@ class TestPaperRouteEvidenceAudit(TestCase):
             payload["targets"][0]["readiness"]["evidence_collection_blockers"],
         )
 
+    def test_source_activity_includes_verified_post_window_flatten_closeout(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 6, 5, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 5, 20, tzinfo=timezone.utc)
+        entry_at = window_start + timedelta(hours=6, minutes=20)
+        close_at = window_end + timedelta(minutes=5)
+        strategy_name = "post-window-flatten-closeout"
+        candidate_id = "c88421d619759b2cfaa6f4d0"
+        hypothesis_id = "H-PAIRS-01"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="post-window flatten closeout fixture",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            entry_decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": candidate_id,
+                    "hypothesis_id": hypothesis_id,
+                    "params": {
+                        "source_candidate_ids": [candidate_id],
+                        "source_hypothesis_ids": [hypothesis_id],
+                        "source_decision_mode": "bounded_paper_route_collection",
+                    },
+                },
+                rationale="post-window flatten entry fixture",
+                status="filled",
+                created_at=entry_at,
+                executed_at=entry_at,
+            )
+            close_decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "sell",
+                    "qty": "1",
+                    "params": {
+                        "source_decision_mode": "bounded_paper_route_collection",
+                        "profit_proof_eligible": True,
+                    },
+                },
+                rationale="post-window account flatten fixture",
+                status="filled",
+                created_at=close_at,
+                executed_at=close_at,
+            )
+            session.add_all([entry_decision, close_decision])
+            session.flush()
+
+            def add_filled_lifecycle(
+                *,
+                decision: TradeDecision,
+                side: str,
+                event_at: datetime,
+                source_offset: int,
+            ) -> None:
+                execution = Execution(
+                    trade_decision_id=decision.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    alpaca_order_id=f"post-window-closeout-{source_offset}",
+                    client_order_id=f"post-window-closeout-client-{source_offset}",
+                    symbol="AAPL",
+                    side=side,
+                    order_type="limit",
+                    time_in_force="day",
+                    submitted_qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("100"),
+                    status="filled",
+                    raw_order={},
+                    created_at=event_at,
+                    updated_at=event_at,
+                    last_update_at=event_at,
+                    order_feed_last_event_ts=event_at,
+                )
+                session.add(execution)
+                session.flush()
+                source_window = OrderFeedSourceWindow(
+                    consumer_group="torghut-order-feed",
+                    source_topic="trade_updates",
+                    source_partition=0,
+                    alpaca_account_label="TORGHUT_SIM",
+                    assignment_mode="group",
+                    collector_identity="test-order-feed",
+                    source_revision="alpaca_trade_updates_v1",
+                    window_started_at=event_at,
+                    window_ended_at=event_at,
+                    start_offset=source_offset,
+                    end_offset=source_offset,
+                    consumed_count=1,
+                    inserted_count=1,
+                    status="inserted",
+                    status_reason="linked_execution_and_decision",
+                    payload_json={
+                        "source_ref": {
+                            "topic": "trade_updates",
+                            "partition": 0,
+                            "offset": source_offset,
+                        },
+                        "source_coverage_complete": True,
+                        "promotion_authority_eligible": False,
+                    },
+                )
+                session.add(source_window)
+                session.flush()
+                session.add(
+                    ExecutionOrderEvent(
+                        event_fingerprint=f"post-window-closeout-{source_offset}",
+                        source_topic="trade_updates",
+                        source_partition=0,
+                        source_offset=source_offset,
+                        alpaca_account_label="TORGHUT_SIM",
+                        feed_seq=source_offset,
+                        event_ts=event_at,
+                        symbol="AAPL",
+                        alpaca_order_id=execution.alpaca_order_id,
+                        client_order_id=execution.client_order_id,
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        filled_qty_delta=Decimal("1"),
+                        avg_fill_price=Decimal("100"),
+                        raw_event={
+                            "event": "fill",
+                            "order": {
+                                "id": execution.alpaca_order_id,
+                                "client_order_id": execution.client_order_id,
+                                "symbol": "AAPL",
+                                "status": "filled",
+                                "qty": "1",
+                                "filled_qty": "1",
+                                "filled_avg_price": "100",
+                            },
+                        },
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        source_window_id=source_window.id,
+                        created_at=event_at,
+                    )
+                )
+                signed_qty = Decimal("-1") if side == "sell" else Decimal("1")
+                session.add(
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        side=side,
+                        arrival_price=Decimal("100"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=signed_qty,
+                        slippage_bps=Decimal("0"),
+                        shortfall_notional=Decimal("0"),
+                        realized_shortfall_bps=Decimal("0"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=event_at,
+                        created_at=event_at,
+                        updated_at=event_at,
+                    )
+                )
+
+            add_filled_lifecycle(
+                decision=entry_decision,
+                side="buy",
+                event_at=entry_at,
+                source_offset=501,
+            )
+            add_filled_lifecycle(
+                decision=close_decision,
+                side="sell",
+                event_at=close_at,
+                source_offset=502,
+            )
+            session.commit()
+
+            source_activity = _strategy_source_activity(
+                session,
+                strategy_name=strategy_name,
+                account_label="TORGHUT_SIM",
+                symbols=["AAPL"],
+                window_start=window_start,
+                window_end=window_end,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                require_source_lineage=True,
+            )
+
+        lifecycle = source_activity["source_lifecycle"]
+        self.assertEqual(source_activity["decision_count"], 2)
+        self.assertEqual(source_activity["execution_count"], 2)
+        self.assertEqual(source_activity["post_window_closeout_decision_count"], 1)
+        self.assertEqual(source_activity["post_window_closeout_execution_count"], 1)
+        self.assertEqual(source_activity["post_window_closeout_order_event_count"], 1)
+        self.assertEqual(source_activity["post_window_closeout_tca_count"], 1)
+        self.assertEqual(lifecycle["net_filled_qty_by_symbol"], {"AAPL": "0"})
+        self.assertEqual(lifecycle["open_symbols_after_source_fills"], [])
+        self.assertTrue(lifecycle["closed_round_trip_evidence"])
+        self.assertNotIn(
+            "source_close_missing",
+            source_activity["source_lifecycle_blockers"],
+        )
+        self.assertNotIn(
+            "source_closed_round_trip_missing",
+            source_activity["source_lifecycle_blockers"],
+        )
+
+    def test_post_window_closeout_candidate_helpers_fail_closed(self) -> None:
+        candidate_id = "candidate-closeout"
+        hypothesis_id = "H-CLOSEOUT"
+        eligible_decision = TradeDecision(
+            alpaca_account_label="TORGHUT_SIM",
+            symbol="AAPL",
+            timeframe="1Sec",
+            decision_json={
+                "action": "sell",
+                "params": {
+                    "source_decision_mode": "bounded_paper_route_collection",
+                    "source_candidate_ids": ["other-candidate"],
+                    "source_hypothesis_ids": [hypothesis_id],
+                },
+            },
+            rationale="candidate helper fixture",
+            status="filled",
+        )
+        hypothesis_mismatch = TradeDecision(
+            alpaca_account_label="TORGHUT_SIM",
+            symbol="AAPL",
+            timeframe="1Sec",
+            decision_json={
+                "action": "sell",
+                "params": {
+                    "source_decision_mode": "bounded_paper_route_collection",
+                    "source_candidate_ids": [candidate_id],
+                    "source_hypothesis_ids": ["other-hypothesis"],
+                },
+            },
+            rationale="hypothesis helper fixture",
+            status="filled",
+        )
+        ineligible_mode = TradeDecision(
+            alpaca_account_label="TORGHUT_SIM",
+            symbol="AAPL",
+            timeframe="1Sec",
+            decision_json={
+                "action": "sell",
+                "params": {"source_decision_mode": "replay"},
+            },
+            rationale="mode helper fixture",
+            status="filled",
+        )
+        short_cover = TradeDecision(
+            alpaca_account_label="TORGHUT_SIM",
+            symbol="AAPL",
+            timeframe="1Sec",
+            decision_json={"action": "buy"},
+            rationale="short cover helper fixture",
+            status="filled",
+        )
+        unknown_symbol = TradeDecision(
+            alpaca_account_label="TORGHUT_SIM",
+            symbol="MSFT",
+            timeframe="1Sec",
+            decision_json={"action": "sell"},
+            rationale="unknown symbol helper fixture",
+            status="filled",
+        )
+
+        self.assertFalse(
+            paper_route_evidence._source_decision_lineage_missing_or_matches(
+                eligible_decision,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+            )
+        )
+        self.assertFalse(
+            paper_route_evidence._source_decision_lineage_missing_or_matches(
+                hypothesis_mismatch,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+            )
+        )
+        self.assertFalse(
+            paper_route_evidence._post_window_action_offsets_open_qty(
+                unknown_symbol,
+                open_qtys={"AAPL": Decimal("1")},
+            )
+        )
+        self.assertTrue(
+            paper_route_evidence._post_window_action_offsets_open_qty(
+                short_cover,
+                open_qtys={"AAPL": Decimal("-1")},
+            )
+        )
+        self.assertFalse(
+            paper_route_evidence._trade_decision_is_post_window_closeout_candidate(
+                ineligible_mode,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                open_qtys={"AAPL": Decimal("1")},
+            )
+        )
+        self.assertFalse(
+            paper_route_evidence._trade_decision_is_post_window_closeout_candidate(
+                eligible_decision,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                open_qtys={"AAPL": Decimal("1")},
+            )
+        )
+        row_without_id = SimpleNamespace(id=None, value="raw")
+        first_row = SimpleNamespace(id="same-id", value="first")
+        duplicate_row = SimpleNamespace(id="same-id", value="duplicate")
+        self.assertEqual(
+            paper_route_evidence._unique_model_rows_by_id(
+                [row_without_id, first_row, duplicate_row]
+            ),
+            [row_without_id, first_row],
+        )
+
+    def test_post_window_closeout_source_rows_require_complete_refs(self) -> None:
+        window_end = datetime(2026, 6, 5, 20, tzinfo=timezone.utc)
+        close_at = window_end + timedelta(minutes=5)
+        lifecycle_summary = {"net_filled_qty_by_symbol": {"AAPL": "1"}}
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="post-window-closeout-incomplete-refs",
+                description="post-window closeout incomplete refs fixture",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_end,
+                updated_at=window_end,
+            )
+            session.add(strategy)
+            session.flush()
+
+            self.assertEqual(
+                paper_route_evidence._post_window_closeout_source_rows(
+                    session,
+                    strategy_ids=[],
+                    account_label="TORGHUT_SIM",
+                    symbol_filters=["AAPL"],
+                    window_end=window_end,
+                    candidate_id="candidate-closeout",
+                    hypothesis_id="H-CLOSEOUT",
+                    lifecycle_summary=lifecycle_summary,
+                ),
+                ([], [], [], [], []),
+            )
+            self.assertEqual(
+                paper_route_evidence._post_window_closeout_source_rows(
+                    session,
+                    strategy_ids=[strategy.id],
+                    account_label="TORGHUT_SIM",
+                    symbol_filters=["MSFT"],
+                    window_end=window_end,
+                    candidate_id="candidate-closeout",
+                    hypothesis_id="H-CLOSEOUT",
+                    lifecycle_summary=lifecycle_summary,
+                ),
+                ([], [], [], [], []),
+            )
+
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "sell",
+                    "params": {
+                        "source_decision_mode": "bounded_paper_route_collection",
+                    },
+                },
+                rationale="post-window closeout incomplete refs fixture",
+                status="filled",
+                created_at=close_at,
+                executed_at=close_at,
+            )
+            session.add(decision)
+            session.flush()
+
+            self.assertEqual(
+                paper_route_evidence._post_window_closeout_source_rows(
+                    session,
+                    strategy_ids=[strategy.id],
+                    account_label="TORGHUT_SIM",
+                    symbol_filters=["AAPL"],
+                    window_end=window_end,
+                    candidate_id="candidate-closeout",
+                    hypothesis_id="H-CLOSEOUT",
+                    lifecycle_summary=lifecycle_summary,
+                ),
+                ([], [], [], [], []),
+            )
+
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="post-window-incomplete-order",
+                client_order_id="post-window-incomplete-client",
+                symbol="AAPL",
+                side="sell",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=close_at,
+                updated_at=close_at,
+                last_update_at=close_at,
+                order_feed_last_event_ts=close_at,
+            )
+            session.add(execution)
+            session.flush()
+
+            self.assertEqual(
+                paper_route_evidence._post_window_closeout_source_rows(
+                    session,
+                    strategy_ids=[strategy.id],
+                    account_label="TORGHUT_SIM",
+                    symbol_filters=["AAPL"],
+                    window_end=window_end,
+                    candidate_id="candidate-closeout",
+                    hypothesis_id="H-CLOSEOUT",
+                    lifecycle_summary=lifecycle_summary,
+                ),
+                ([], [], [], [], []),
+            )
+
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="post-window-incomplete-fill",
+                    source_topic="trade_updates",
+                    source_partition=0,
+                    source_offset=900,
+                    alpaca_account_label="TORGHUT_SIM",
+                    feed_seq=900,
+                    event_ts=close_at,
+                    symbol="AAPL",
+                    alpaca_order_id=execution.alpaca_order_id,
+                    client_order_id=execution.client_order_id,
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    filled_qty_delta=Decimal("1"),
+                    avg_fill_price=Decimal("100"),
+                    raw_event={
+                        "event": "fill",
+                        "order": {
+                            "id": execution.alpaca_order_id,
+                            "client_order_id": execution.client_order_id,
+                            "symbol": "AAPL",
+                            "status": "filled",
+                            "qty": "1",
+                            "filled_qty": "1",
+                            "filled_avg_price": "100",
+                        },
+                    },
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    created_at=close_at,
+                )
+            )
+            session.flush()
+
+            self.assertEqual(
+                paper_route_evidence._post_window_closeout_source_rows(
+                    session,
+                    strategy_ids=[strategy.id],
+                    account_label="TORGHUT_SIM",
+                    symbol_filters=["AAPL"],
+                    window_end=window_end,
+                    candidate_id="candidate-closeout",
+                    hypothesis_id="H-CLOSEOUT",
+                    lifecycle_summary=lifecycle_summary,
+                ),
+                ([], [], [], [], []),
+            )
+
+    def test_source_activity_closeout_query_timeout_fails_closed(self) -> None:
+        window_start = datetime(2026, 6, 5, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 5, 20, tzinfo=timezone.utc)
+        event_at = window_start + timedelta(hours=6)
+        candidate_id = "candidate-closeout-timeout"
+        hypothesis_id = "H-CLOSEOUT-TIMEOUT"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="post-window-closeout-timeout",
+                description="post-window closeout timeout fixture",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": candidate_id,
+                    "hypothesis_id": hypothesis_id,
+                    "params": {
+                        "source_decision_mode": "bounded_paper_route_collection",
+                        "source_candidate_ids": [candidate_id],
+                        "source_hypothesis_ids": [hypothesis_id],
+                    },
+                },
+                rationale="post-window closeout timeout entry fixture",
+                status="filled",
+                created_at=event_at,
+                executed_at=event_at,
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="post-window-timeout-entry-order",
+                client_order_id="post-window-timeout-entry-client",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=event_at,
+                updated_at=event_at,
+                last_update_at=event_at,
+                order_feed_last_event_ts=event_at,
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="post-window-timeout-entry-fill",
+                    source_topic="trade_updates",
+                    source_partition=0,
+                    source_offset=901,
+                    alpaca_account_label="TORGHUT_SIM",
+                    feed_seq=901,
+                    event_ts=event_at,
+                    symbol="AAPL",
+                    alpaca_order_id=execution.alpaca_order_id,
+                    client_order_id=execution.client_order_id,
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    filled_qty_delta=Decimal("1"),
+                    avg_fill_price=Decimal("100"),
+                    raw_event={
+                        "event": "fill",
+                        "order": {
+                            "id": execution.alpaca_order_id,
+                            "client_order_id": execution.client_order_id,
+                            "symbol": "AAPL",
+                            "status": "filled",
+                            "qty": "1",
+                            "filled_qty": "1",
+                            "filled_avg_price": "100",
+                        },
+                    },
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    created_at=event_at,
+                )
+            )
+            session.add(
+                ExecutionTCAMetric(
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    side="buy",
+                    arrival_price=Decimal("100"),
+                    avg_fill_price=Decimal("100"),
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("1"),
+                    slippage_bps=Decimal("0"),
+                    shortfall_notional=Decimal("0"),
+                    realized_shortfall_bps=Decimal("0"),
+                    churn_qty=Decimal("0"),
+                    churn_ratio=Decimal("0"),
+                    computed_at=event_at,
+                    created_at=event_at,
+                    updated_at=event_at,
+                )
+            )
+            session.commit()
+
+            with (
+                patch(
+                    "app.trading.paper_route_evidence._post_window_closeout_source_rows",
+                    side_effect=SQLAlchemyError("statement timeout"),
+                ),
+                patch.object(session, "rollback", wraps=session.rollback) as rollback,
+            ):
+                source_activity = _strategy_source_activity(
+                    session,
+                    strategy_name=strategy.name,
+                    account_label="TORGHUT_SIM",
+                    symbols=["AAPL"],
+                    window_start=window_start,
+                    window_end=window_end,
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                    require_source_lineage=True,
+                )
+
+        self.assertEqual(rollback.call_count, 1)
+        self.assertTrue(source_activity["missing"])
+        self.assertTrue(source_activity["query_unavailable"])
+        self.assertEqual(
+            source_activity["unavailable_source"],
+            "post_window_closeout_source_rows",
+        )
+        self.assertEqual(
+            source_activity["missing_reasons"],
+            ["source_closeout_readback_unavailable"],
+        )
+        self.assertEqual(source_activity["raw_decision_count"], 1)
+        self.assertEqual(source_activity["lineage_matched_decision_count"], 1)
+
     def test_source_activity_uses_order_feed_event_time_for_execution_window(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Admit verified post-window flatten closeouts into Torghut paper-route source activity when they offset an open target-window symbol.
- Require filled execution, complete order-event lifecycle, source-window refs, and TCA refs before a post-window closeout can clear source-close blockers.
- Preserve the existing target-window bound for unrelated post-window source activity.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k 'post_window_flatten_closeout or source_activity_is_bound_to_target_window_end or hpairs_source_activity_surfaces_unfilled_closeout_fillability or source_activity_uses_order_feed_event_time_for_execution_window' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
