### PR TITLE
fix(torghut): net lifecycle fills from executions

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -4187,12 +4187,24 @@ def _source_activity_lifecycle_summary(
         )
     net_filled_qty_by_symbol: dict[str, Decimal] = {}
     fill_event_rows = [row for row in order_event_rows if _order_event_is_fill(row)]
+    filled_execution_rows = [
+        row for row in execution_rows if _safe_decimal(row.filled_qty) > 0
+    ]
     execution_side_by_id: dict[object, str] = {
         row.id: (_safe_text(row.side) or "")
         for row in execution_rows
         if _safe_text(row.side) is not None
     }
-    if fill_event_rows:
+    if filled_execution_rows:
+        for row in filled_execution_rows:
+            symbol = (_safe_text(row.symbol) or "missing").upper()
+            qty = _safe_decimal(row.filled_qty)
+            side = (_safe_text(row.side) or "").lower()
+            signed_qty = -qty if side in {"sell", "short"} else qty
+            net_filled_qty_by_symbol[symbol] = (
+                net_filled_qty_by_symbol.get(symbol, Decimal("0")) + signed_qty
+            )
+    elif fill_event_rows:
         for row in fill_event_rows:
             symbol = (_safe_text(row.symbol) or "missing").upper()
             signed_qty = _order_event_signed_filled_qty(
@@ -4203,17 +4215,6 @@ def _source_activity_lifecycle_summary(
                 net_filled_qty_by_symbol[symbol] = (
                     net_filled_qty_by_symbol.get(symbol, Decimal("0")) + signed_qty
                 )
-    else:
-        for row in execution_rows:
-            qty = _safe_decimal(row.filled_qty)
-            if qty <= 0:
-                continue
-            symbol = (_safe_text(row.symbol) or "missing").upper()
-            side = (_safe_text(row.side) or "").lower()
-            signed_qty = -qty if side in {"sell", "short"} else qty
-            net_filled_qty_by_symbol[symbol] = (
-                net_filled_qty_by_symbol.get(symbol, Decimal("0")) + signed_qty
-            )
     open_symbols = sorted(
         symbol
         for symbol, qty in net_filled_qty_by_symbol.items()

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import uuid
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
@@ -9992,6 +9993,148 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertNotIn(
             "source_closed_round_trip_missing",
             source_activity["source_lifecycle_blockers"],
+        )
+
+    def test_source_lifecycle_nets_final_execution_qty_when_order_feed_is_cumulative(
+        self,
+    ) -> None:
+        event_at = datetime(2026, 6, 5, 15, 14, tzinfo=timezone.utc)
+        buy_execution_id = uuid.uuid4()
+        sell_execution_id = uuid.uuid4()
+        buy_decision_id = uuid.uuid4()
+        sell_decision_id = uuid.uuid4()
+        buy_execution = Execution(
+            id=buy_execution_id,
+            trade_decision_id=buy_decision_id,
+            alpaca_account_label="TORGHUT_SIM",
+            alpaca_order_id="cumulative-buy-order",
+            client_order_id="cumulative-buy-client",
+            symbol="AAPL",
+            side="buy",
+            order_type="limit",
+            time_in_force="day",
+            submitted_qty=Decimal("119.7394"),
+            filled_qty=Decimal("119.7394"),
+            avg_fill_price=Decimal("313.10"),
+            status="filled",
+            raw_order={},
+            created_at=event_at,
+            updated_at=event_at,
+            last_update_at=event_at,
+        )
+        sell_execution = Execution(
+            id=sell_execution_id,
+            trade_decision_id=sell_decision_id,
+            alpaca_account_label="TORGHUT_SIM",
+            alpaca_order_id="cumulative-sell-order",
+            client_order_id="cumulative-sell-client",
+            symbol="AAPL",
+            side="sell",
+            order_type="limit",
+            time_in_force="day",
+            submitted_qty=Decimal("119.7394"),
+            filled_qty=Decimal("119.7394"),
+            avg_fill_price=Decimal("308.12"),
+            status="filled",
+            raw_order={},
+            created_at=event_at + timedelta(minutes=1),
+            updated_at=event_at + timedelta(minutes=1),
+            last_update_at=event_at + timedelta(minutes=1),
+        )
+        cumulative_buy_events = [
+            ExecutionOrderEvent(
+                event_fingerprint=f"cumulative-buy-{index}",
+                source_topic="trade_updates",
+                source_partition=0,
+                source_offset=100 + index,
+                alpaca_account_label="TORGHUT_SIM",
+                event_ts=event_at + timedelta(seconds=index),
+                symbol="AAPL",
+                alpaca_order_id=buy_execution.alpaca_order_id,
+                client_order_id=buy_execution.client_order_id,
+                event_type=event_type,
+                status=status,
+                qty=Decimal("119.7394"),
+                filled_qty=filled_qty,
+                filled_qty_delta=filled_qty_delta,
+                raw_event={},
+                execution_id=buy_execution_id,
+                trade_decision_id=buy_decision_id,
+                created_at=event_at + timedelta(seconds=index),
+            )
+            for index, (event_type, status, filled_qty, filled_qty_delta) in enumerate(
+                (
+                    ("partial_fill", "partially_filled", Decimal("83"), None),
+                    ("fill", "filled", Decimal("119.7394"), None),
+                    ("partial_fill", "partially_filled", Decimal("83.7394"), None),
+                    (
+                        "fill",
+                        "filled",
+                        Decimal("119.7394"),
+                        Decimal("119.7394"),
+                    ),
+                ),
+                start=1,
+            )
+        ]
+        sell_event = ExecutionOrderEvent(
+            event_fingerprint="cumulative-sell-fill",
+            source_topic="trade_updates",
+            source_partition=0,
+            source_offset=200,
+            alpaca_account_label="TORGHUT_SIM",
+            event_ts=event_at + timedelta(minutes=1),
+            symbol="AAPL",
+            alpaca_order_id=sell_execution.alpaca_order_id,
+            client_order_id=sell_execution.client_order_id,
+            event_type="fill",
+            status="filled",
+            qty=Decimal("119.7394"),
+            filled_qty=Decimal("119.7394"),
+            filled_qty_delta=None,
+            raw_event={},
+            execution_id=sell_execution_id,
+            trade_decision_id=sell_decision_id,
+            created_at=event_at + timedelta(minutes=1),
+        )
+
+        lifecycle = paper_route_evidence._source_activity_lifecycle_summary(
+            execution_rows=[buy_execution, sell_execution],
+            order_event_rows=[*cumulative_buy_events, sell_event],
+            tca_rows=[],
+        )
+        fallback_lifecycle = paper_route_evidence._source_activity_lifecycle_summary(
+            execution_rows=[],
+            order_event_rows=[
+                ExecutionOrderEvent(
+                    event_fingerprint="event-only-sell-fill",
+                    source_topic="trade_updates",
+                    source_partition=0,
+                    source_offset=300,
+                    alpaca_account_label="TORGHUT_SIM",
+                    event_ts=event_at,
+                    symbol="AAPL",
+                    alpaca_order_id="event-only-sell-order",
+                    client_order_id="event-only-sell-client",
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    filled_qty_delta=None,
+                    raw_event={"side": "sell"},
+                    created_at=event_at,
+                )
+            ],
+            tca_rows=[],
+        )
+
+        self.assertEqual(lifecycle["net_filled_qty_by_symbol"], {"AAPL": "0"})
+        self.assertEqual(lifecycle["open_symbols_after_source_fills"], [])
+        self.assertTrue(lifecycle["closed_round_trip_evidence"])
+        self.assertNotIn("source_close_missing", lifecycle["blockers"])
+        self.assertEqual(
+            fallback_lifecycle["net_filled_qty_by_symbol"],
+            {"AAPL": "-1"},
         )
 
     def test_hpairs_collection_blocks_missing_lifecycle_costs_and_flatten(


### PR DESCRIPTION
## Summary

- Net paper-route source lifecycle quantities from linked final execution fills when execution rows are present, preventing cumulative order-feed partial/fill events from reopening closed positions.
- Keep order-feed events as required lifecycle/source evidence and retain order-event netting only as the fallback when no filled execution rows exist.
- Add regression coverage for cumulative partial-fill events plus duplicate fill events, matching the live AAPL source-lifecycle blocker mode.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k 'source_lifecycle_nets_final_execution_qty_when_order_feed_is_cumulative or post_window_flatten_closeout or source_activity_signs_order_feed_fills_from_linked_execution_side or source_activity_is_bound_to_target_window_end' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python -m compileall app scripts tests`
- `cd services/torghut && rm -f .coverage coverage.xml && uv run --frozen coverage run -m pytest tests/test_paper_route_evidence.py -q && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 && rm -f coverage.xml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
