### PR TITLE
fix(torghut): import post-window closeouts into runtime ledger

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -78,6 +78,7 @@ EXACT_REPLAY_ARTIFACT_AUTHORITY_BLOCKERS = (
 )
 RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
 RUNTIME_LEDGER_CARRY_IN_LOOKBACK = timedelta(days=5)
+RUNTIME_LEDGER_POST_WINDOW_CLOSEOUT_LOOKAHEAD = timedelta(seconds=3600)
 RUNTIME_LEDGER_FLAT_START_SNAPSHOT_STALE_SECONDS = 900
 RUNTIME_LEDGER_FLAT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS = 300
 RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
@@ -747,6 +748,8 @@ def _source_decision_target_notional_sizing_summary(
 
 
 def _source_row_is_paper_route_probe_exit(row: Mapping[str, object]) -> bool:
+    if _first_bool(row, "post_window_closeout", "runtime_ledger_post_window_closeout"):
+        return True
     for payload in _source_decision_priority_payloads(row):
         metadata = _as_mapping(payload.get("paper_route_probe_exit"))
         if _direct_text(metadata, "mode") == "paper_route_exit":
@@ -1043,6 +1046,327 @@ def _source_row_matches_lineage(
     ):
         return False
     return True
+
+
+def _source_row_lineage_missing_or_matches(
+    row: Mapping[str, object],
+    *,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+) -> bool:
+    if candidate_id is not None:
+        candidate_values = _text_values(row, *SOURCE_LINEAGE_CANDIDATE_KEYS)
+        if candidate_values and candidate_id not in candidate_values:
+            return False
+    if hypothesis_id is not None:
+        hypothesis_values = _text_values(row, *SOURCE_LINEAGE_HYPOTHESIS_KEYS)
+        if hypothesis_values and hypothesis_id not in hypothesis_values:
+            return False
+    return True
+
+
+def _source_row_time_before(
+    row: Mapping[str, object],
+    *,
+    window_end: datetime,
+) -> bool:
+    event_time = _runtime_ledger_row_time(row)
+    return event_time is None or event_time < window_end
+
+
+def _source_row_time_after_window(
+    row: Mapping[str, object],
+    *,
+    window_end: datetime,
+    closeout_end: datetime,
+) -> bool:
+    event_time = _runtime_ledger_row_time(row)
+    return (
+        event_time is not None
+        and event_time > window_end
+        and event_time <= closeout_end
+    )
+
+
+def _runtime_open_qtys_by_symbol_from_execution_rows(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[str, Decimal]:
+    open_qtys: dict[str, Decimal] = {}
+    for row in rows:
+        if not _execution_row_has_fill(row):
+            continue
+        symbol = _runtime_source_row_symbol(row)
+        if symbol is None:
+            continue
+        signed_qty = _execution_signed_qty(
+            side=_first_text(row, "side", "action", "order_side"),
+            qty=_first_positive_decimal(
+                row,
+                "filled_qty",
+                "filled_quantity",
+                "qty",
+                "quantity",
+            ),
+        )
+        if signed_qty == 0:
+            continue
+        open_qtys[symbol] = open_qtys.get(symbol, Decimal("0")) + signed_qty
+    return {symbol: qty for symbol, qty in sorted(open_qtys.items()) if qty != 0}
+
+
+def _source_decision_action_offsets_open_qty(
+    row: Mapping[str, object],
+    *,
+    open_qtys: Mapping[str, Decimal],
+) -> bool:
+    symbol = _runtime_source_row_symbol(row)
+    if symbol is None:
+        return False
+    open_qty = open_qtys.get(symbol, Decimal("0"))
+    if open_qty == 0:
+        return False
+    action = (_first_text(row, "action", "side", "order_side") or "").lower()
+    if open_qty > 0:
+        return action in {"sell", "short", "sell_short"}
+    return action in {"buy", "cover", "buy_to_cover"}
+
+
+def _source_row_decision_ids(row: Mapping[str, object]) -> set[str]:
+    return set(
+        _source_identifier_values(
+            [row],
+            "trade_decision_id",
+            "decision_id",
+            "decision_hash",
+        )
+    )
+
+
+def _source_row_execution_ids(row: Mapping[str, object]) -> set[str]:
+    return set(_source_identifier_values([row], "execution_id"))
+
+
+def _mark_post_window_closeout_source_row(
+    row: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        **dict(row),
+        "post_window_closeout": True,
+        "runtime_ledger_post_window_closeout": True,
+        "runtime_ledger_closeout_reason": "post_window_fill_offsets_window_open_qty",
+    }
+
+
+def _filter_source_rows_for_runtime_window(
+    *,
+    decision_rows: list[dict[str, object]],
+    execution_rows: list[dict[str, object]],
+    order_lifecycle_rows: list[dict[str, object]],
+    window_end: datetime,
+    closeout_end: datetime,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+    require_source_lineage: bool,
+) -> tuple[
+    list[dict[str, object]],
+    list[dict[str, object]],
+    list[dict[str, object]],
+    dict[str, object],
+]:
+    lineaged_decision_rows = [
+        row
+        for row in decision_rows
+        if _source_row_time_before(row, window_end=window_end)
+        and _source_row_matches_lineage(
+            row,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            require_source_lineage=require_source_lineage,
+        )
+    ]
+    lineaged_execution_rows = [
+        row
+        for row in execution_rows
+        if _source_row_time_before(row, window_end=window_end)
+        and _source_row_matches_lineage(
+            row,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            require_source_lineage=require_source_lineage,
+        )
+    ]
+    lineaged_order_rows = [
+        row
+        for row in order_lifecycle_rows
+        if _source_row_time_before(row, window_end=window_end)
+        and _source_row_matches_lineage(
+            row,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            require_source_lineage=require_source_lineage,
+        )
+    ]
+    diagnostics: dict[str, object] = {
+        "post_window_closeout_lookahead_seconds": int(
+            RUNTIME_LEDGER_POST_WINDOW_CLOSEOUT_LOOKAHEAD.total_seconds()
+        ),
+        "post_window_closeout_query_end": closeout_end.isoformat(),
+    }
+    if closeout_end <= window_end:
+        diagnostics.update(
+            {
+                "post_window_closeout_open_qty_by_symbol": {},
+                "post_window_closeout_decision_count": 0,
+                "post_window_closeout_execution_count": 0,
+                "post_window_closeout_order_event_count": 0,
+            }
+        )
+        return (
+            lineaged_decision_rows,
+            lineaged_execution_rows,
+            lineaged_order_rows,
+            diagnostics,
+        )
+
+    open_qtys = _runtime_open_qtys_by_symbol_from_execution_rows(
+        lineaged_execution_rows
+    )
+    diagnostics["post_window_closeout_open_qty_by_symbol"] = {
+        symbol: str(qty) for symbol, qty in open_qtys.items()
+    }
+    if not open_qtys:
+        diagnostics.update(
+            {
+                "post_window_closeout_decision_count": 0,
+                "post_window_closeout_execution_count": 0,
+                "post_window_closeout_order_event_count": 0,
+            }
+        )
+        return (
+            lineaged_decision_rows,
+            lineaged_execution_rows,
+            lineaged_order_rows,
+            diagnostics,
+        )
+
+    closeout_decision_rows = [
+        row
+        for row in decision_rows
+        if _source_row_time_after_window(
+            row,
+            window_end=window_end,
+            closeout_end=closeout_end,
+        )
+        and source_decision_mode_is_profit_proof_eligible(_source_decision_mode(row))
+        and _source_row_lineage_missing_or_matches(
+            row,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+        )
+        and _source_decision_action_offsets_open_qty(row, open_qtys=open_qtys)
+    ]
+    closeout_decision_ids = set[str]()
+    for row in closeout_decision_rows:
+        closeout_decision_ids.update(_source_row_decision_ids(row))
+    if not closeout_decision_ids:
+        diagnostics.update(
+            {
+                "post_window_closeout_decision_count": 0,
+                "post_window_closeout_execution_count": 0,
+                "post_window_closeout_order_event_count": 0,
+            }
+        )
+        return (
+            lineaged_decision_rows,
+            lineaged_execution_rows,
+            lineaged_order_rows,
+            diagnostics,
+        )
+
+    closeout_execution_rows = [
+        row
+        for row in execution_rows
+        if _source_row_time_after_window(
+            row,
+            window_end=window_end,
+            closeout_end=closeout_end,
+        )
+        and _source_row_decision_ids(row) & closeout_decision_ids
+        and _execution_row_has_fill(row)
+        and _execution_query_row_has_tca_ref(row)
+    ]
+    closeout_execution_decision_ids = set[str]()
+    closeout_execution_ids = set[str]()
+    for row in closeout_execution_rows:
+        closeout_execution_decision_ids.update(_source_row_decision_ids(row))
+        closeout_execution_ids.update(_source_row_execution_ids(row))
+
+    closeout_order_rows = [
+        row
+        for row in order_lifecycle_rows
+        if _source_row_time_after_window(
+            row,
+            window_end=window_end,
+            closeout_end=closeout_end,
+        )
+        and (
+            _source_row_decision_ids(row) & closeout_decision_ids
+            or _source_row_execution_ids(row) & closeout_execution_ids
+        )
+        and _source_authority_order_event_row(row)
+    ]
+    fill_order_decision_ids = set[str]()
+    for row in closeout_order_rows:
+        if _runtime_ledger_event_type(row) not in _RUNTIME_LEDGER_FILL_EVENTS:
+            continue
+        fill_order_decision_ids.update(_source_row_decision_ids(row))
+        if _source_row_execution_ids(row) & closeout_execution_ids:
+            fill_order_decision_ids.update(closeout_execution_decision_ids)
+
+    eligible_decision_ids = (
+        closeout_decision_ids
+        & closeout_execution_decision_ids
+        & fill_order_decision_ids
+    )
+    eligible_execution_ids = {
+        execution_id
+        for row in closeout_execution_rows
+        if _source_row_decision_ids(row) & eligible_decision_ids
+        for execution_id in _source_row_execution_ids(row)
+    }
+    eligible_closeout_decision_rows = [
+        _mark_post_window_closeout_source_row(row)
+        for row in closeout_decision_rows
+        if _source_row_decision_ids(row) & eligible_decision_ids
+    ]
+    eligible_closeout_execution_rows = [
+        _mark_post_window_closeout_source_row(row)
+        for row in closeout_execution_rows
+        if _source_row_decision_ids(row) & eligible_decision_ids
+    ]
+    eligible_closeout_order_rows = [
+        _mark_post_window_closeout_source_row(row)
+        for row in closeout_order_rows
+        if (
+            _source_row_decision_ids(row) & eligible_decision_ids
+            or _source_row_execution_ids(row) & eligible_execution_ids
+        )
+    ]
+    diagnostics.update(
+        {
+            "post_window_closeout_decision_count": len(eligible_closeout_decision_rows),
+            "post_window_closeout_execution_count": len(
+                eligible_closeout_execution_rows
+            ),
+            "post_window_closeout_order_event_count": len(eligible_closeout_order_rows),
+        }
+    )
+    return (
+        [*lineaged_decision_rows, *eligible_closeout_decision_rows],
+        [*lineaged_execution_rows, *eligible_closeout_execution_rows],
+        [*lineaged_order_rows, *eligible_closeout_order_rows],
+        diagnostics,
+    )
 
 
 def _runtime_ledger_equity_denominator_from_rows(
@@ -5930,6 +6254,11 @@ def _query_timestamps(
     carry_in_order_lifecycle_rows: list[dict[str, object]] = []
     flat_start_position_snapshot: dict[str, object] | None = None
     carry_in_window_start = window_start - RUNTIME_LEDGER_CARRY_IN_LOOKBACK
+    source_activity_window_end = (
+        window_end + RUNTIME_LEDGER_POST_WINDOW_CLOSEOUT_LOOKAHEAD
+        if allow_authoritative_runtime_ledger_materialization
+        else window_end
+    )
     symbol_filter = _metadata_symbol_list(symbols or ())
     if source_activity_diagnostics is not None:
         source_activity_diagnostics.update(
@@ -5939,6 +6268,7 @@ def _query_timestamps(
                 "source_account_label": source_account_label,
                 "window_start": window_start.isoformat(),
                 "window_end": window_end.isoformat(),
+                "source_activity_window_end": source_activity_window_end.isoformat(),
                 "carry_in_window_start": carry_in_window_start.isoformat(),
                 "carry_in_window_end": window_start.isoformat(),
                 "source_activity_symbol_filter": symbol_filter,
@@ -6004,7 +6334,7 @@ def _query_timestamps(
                     source_query_account_label,
                     list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
                     window_start,
-                    window_end,
+                    source_activity_window_end,
                     *decision_symbol_params,
                 ),
             )
@@ -6017,30 +6347,6 @@ def _query_timestamps(
                 source_activity_diagnostics["decision_rows_before_lineage_filter"] = (
                     len(decision_lifecycle_rows)
                 )
-            decision_lifecycle_rows = [
-                row
-                for row in decision_lifecycle_rows
-                if _source_row_matches_lineage(
-                    row,
-                    candidate_id=candidate_id,
-                    hypothesis_id=hypothesis_id,
-                    require_source_lineage=require_source_lineage,
-                )
-            ]
-            if source_activity_diagnostics is not None:
-                source_activity_diagnostics["decision_rows_after_lineage_filter"] = len(
-                    decision_lifecycle_rows
-                )
-            decision_lifecycle_rows = _attach_source_lineage_context(
-                decision_lifecycle_rows,
-                candidate_id=candidate_id,
-                hypothesis_id=hypothesis_id,
-            )
-            decisions = []
-            for row in decision_lifecycle_rows:
-                computed_at = row.get("computed_at")
-                if isinstance(computed_at, datetime):
-                    decisions.append(computed_at)
             cur.execute(
                 f"""
                 select
@@ -6101,7 +6407,7 @@ def _query_timestamps(
                     source_query_account_label,
                     source_query_account_label,
                     window_start,
-                    window_end,
+                    source_activity_window_end,
                     *execution_symbol_params,
                 ),
             )
@@ -6122,38 +6428,6 @@ def _query_timestamps(
                 ] = sum(
                     1 for row in execution_rows if _execution_query_row_has_tca_ref(row)
                 )
-            execution_rows = [
-                row
-                for row in execution_rows
-                if _source_row_matches_lineage(
-                    row,
-                    candidate_id=candidate_id,
-                    hypothesis_id=hypothesis_id,
-                    require_source_lineage=require_source_lineage,
-                )
-            ]
-            if source_activity_diagnostics is not None:
-                source_activity_diagnostics["execution_rows_after_lineage_filter"] = (
-                    len(execution_rows)
-                )
-                source_activity_diagnostics[
-                    "fill_execution_rows_after_lineage_filter"
-                ] = sum(1 for row in execution_rows if _execution_row_has_fill(row))
-                source_activity_diagnostics[
-                    "execution_tca_rows_after_lineage_filter"
-                ] = sum(
-                    1 for row in execution_rows if _execution_query_row_has_tca_ref(row)
-                )
-            execution_rows = _attach_source_lineage_context(
-                execution_rows,
-                candidate_id=candidate_id,
-                hypothesis_id=hypothesis_id,
-            )
-            executions = []
-            for row in execution_rows:
-                execution_event_at = row.get("execution_event_at")
-                if isinstance(execution_event_at, datetime):
-                    executions.append(execution_event_at)
             cur.execute(
                 f"""
                 select
@@ -6260,7 +6534,7 @@ def _query_timestamps(
                     source_query_account_label,
                     source_account_label,
                     window_start,
-                    window_end,
+                    source_activity_window_end,
                     *order_event_symbol_params,
                 ),
             )
@@ -6280,17 +6554,37 @@ def _query_timestamps(
                     for row in order_lifecycle_rows
                     if _runtime_ledger_event_type(row) in _RUNTIME_LEDGER_FILL_EVENTS
                 )
-            order_lifecycle_rows = [
-                row
-                for row in order_lifecycle_rows
-                if _source_row_matches_lineage(
-                    row,
-                    candidate_id=candidate_id,
-                    hypothesis_id=hypothesis_id,
-                    require_source_lineage=require_source_lineage,
-                )
-            ]
+            (
+                decision_lifecycle_rows,
+                execution_rows,
+                order_lifecycle_rows,
+                post_window_closeout_diagnostics,
+            ) = _filter_source_rows_for_runtime_window(
+                decision_rows=decision_lifecycle_rows,
+                execution_rows=execution_rows,
+                order_lifecycle_rows=order_lifecycle_rows,
+                window_end=window_end,
+                closeout_end=source_activity_window_end,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                require_source_lineage=require_source_lineage,
+            )
             if source_activity_diagnostics is not None:
+                source_activity_diagnostics.update(post_window_closeout_diagnostics)
+                source_activity_diagnostics["decision_rows_after_lineage_filter"] = len(
+                    decision_lifecycle_rows
+                )
+                source_activity_diagnostics["execution_rows_after_lineage_filter"] = (
+                    len(execution_rows)
+                )
+                source_activity_diagnostics[
+                    "fill_execution_rows_after_lineage_filter"
+                ] = sum(1 for row in execution_rows if _execution_row_has_fill(row))
+                source_activity_diagnostics[
+                    "execution_tca_rows_after_lineage_filter"
+                ] = sum(
+                    1 for row in execution_rows if _execution_query_row_has_tca_ref(row)
+                )
                 source_activity_diagnostics[
                     "order_lifecycle_rows_after_lineage_filter"
                 ] = len(order_lifecycle_rows)
@@ -6301,11 +6595,31 @@ def _query_timestamps(
                     for row in order_lifecycle_rows
                     if _runtime_ledger_event_type(row) in _RUNTIME_LEDGER_FILL_EVENTS
                 )
+            decision_lifecycle_rows = _attach_source_lineage_context(
+                decision_lifecycle_rows,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+            )
+            execution_rows = _attach_source_lineage_context(
+                execution_rows,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+            )
             order_lifecycle_rows = _attach_source_lineage_context(
                 order_lifecycle_rows,
                 candidate_id=candidate_id,
                 hypothesis_id=hypothesis_id,
             )
+            decisions = []
+            for row in decision_lifecycle_rows:
+                computed_at = row.get("computed_at")
+                if isinstance(computed_at, datetime):
+                    decisions.append(computed_at)
+            executions = []
+            for row in execution_rows:
+                execution_event_at = row.get("execution_event_at")
+                if isinstance(execution_event_at, datetime):
+                    executions.append(execution_event_at)
             if allow_authoritative_runtime_ledger_materialization:
                 cur.execute(
                     f"""

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -66,6 +66,10 @@ from scripts.import_hypothesis_runtime_windows import (
     _source_decision_mode,
     _source_decision_mode_counts,
     _source_decision_rows_profit_proof_eligible,
+    _source_decision_action_offsets_open_qty,
+    _source_row_lineage_missing_or_matches,
+    _filter_source_rows_for_runtime_window,
+    _runtime_open_qtys_by_symbol_from_execution_rows,
     _source_runtime_ledger_payload_from_row,
     _source_order_feed_payload_delta_fill,
     _required_order_lifecycle_source_row_count,
@@ -1471,6 +1475,88 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(summary["authoritative_target_notional_sizing_count"], 1)
         self.assertEqual(summary["missing_target_notional_sizing_count"], 0)
         self.assertEqual(summary["blockers"], [])
+
+    def test_post_window_closeout_helpers_fail_closed(self) -> None:
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+
+        self.assertFalse(
+            _source_row_lineage_missing_or_matches(
+                {"candidate_id": "other-candidate"},
+                candidate_id="candidate-1",
+                hypothesis_id=None,
+            )
+        )
+        self.assertFalse(
+            _source_row_lineage_missing_or_matches(
+                {"hypothesis_id": "other-hypothesis"},
+                candidate_id=None,
+                hypothesis_id="H-PAIRS-01",
+            )
+        )
+        self.assertEqual(
+            _runtime_open_qtys_by_symbol_from_execution_rows(
+                [
+                    {"symbol": "AAPL", "side": "buy", "filled_qty": "0"},
+                    {
+                        "side": "buy",
+                        "filled_qty": "1",
+                        "avg_fill_price": "100",
+                    },
+                    {
+                        "symbol": "MSFT",
+                        "side": "hold",
+                        "filled_qty": "1",
+                        "avg_fill_price": "100",
+                    },
+                ]
+            ),
+            {},
+        )
+        self.assertFalse(
+            _source_decision_action_offsets_open_qty(
+                {"action": "sell"},
+                open_qtys={"AAPL": Decimal("1")},
+            )
+        )
+        self.assertFalse(
+            _source_decision_action_offsets_open_qty(
+                {"symbol": "AAPL", "action": "sell"},
+                open_qtys={},
+            )
+        )
+        self.assertTrue(
+            _source_decision_action_offsets_open_qty(
+                {"symbol": "AAPL", "action": "buy"},
+                open_qtys={"AAPL": Decimal("-1")},
+            )
+        )
+
+        decisions, executions, order_rows, diagnostics = (
+            _filter_source_rows_for_runtime_window(
+                decision_rows=[
+                    {
+                        "trade_decision_id": "decision-close",
+                        "computed_at": window_end + timedelta(minutes=5),
+                        "symbol": "AAPL",
+                        "action": "sell",
+                        "source_decision_mode": "bounded_paper_route_collection",
+                    }
+                ],
+                execution_rows=[],
+                order_lifecycle_rows=[],
+                window_end=window_end,
+                closeout_end=window_end + timedelta(hours=1),
+                candidate_id="candidate-1",
+                hypothesis_id="H-PAIRS-01",
+                require_source_lineage=True,
+            )
+        )
+
+        self.assertEqual(decisions, [])
+        self.assertEqual(executions, [])
+        self.assertEqual(order_rows, [])
+        self.assertEqual(diagnostics["post_window_closeout_decision_count"], 0)
+        self.assertEqual(diagnostics["post_window_closeout_open_qty_by_symbol"], {})
 
     def test_runtime_rows_fail_closed_on_non_authoritative_target_notional_sizing(
         self,
@@ -8691,6 +8777,298 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertNotIn(
             "order_feed_unlinked_fill_lifecycle_present",
             _source_activity_diagnostics_blockers(diagnostics),
+        )
+
+    def test_query_timestamps_includes_verified_post_window_closeout(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        closeout_at = window_end + timedelta(minutes=5)
+        entry_payload = {
+            "action": "buy",
+            "source_decision_mode": "bounded_paper_route_collection",
+            "candidate_id": "candidate-1",
+            "hypothesis_id": "H-PAIRS-01",
+            "paper_route_target_notional_sizing": {
+                "schema_version": "torghut.paper-route-target-notional-sizing.v1",
+                "sizing_source": "target_notional",
+                "target_notional": "75000",
+                "requested_qty": "1",
+                "resolved_qty": "1",
+                "blockers": [],
+            },
+        }
+        closeout_payload = {
+            "action": "sell",
+            "source_decision_mode": "bounded_paper_route_collection",
+        }
+
+        def decision_row(
+            decision_id: str,
+            created_at: datetime,
+            action_payload: dict[str, object],
+        ) -> tuple[object, ...]:
+            return (
+                decision_id,
+                created_at,
+                "AAPL",
+                "TORGHUT_SIM",
+                "microbar-cross-sectional-pairs-v1",
+                decision_id,
+                action_payload,
+            )
+
+        def execution_row(
+            execution_id: str,
+            decision_id: str,
+            decision_created_at: datetime,
+            event_at: datetime,
+            side: str,
+            qty: str,
+            price: str,
+            payload: dict[str, object],
+            tca_id: str,
+        ) -> tuple[object, ...]:
+            return (
+                execution_id,
+                decision_id,
+                decision_created_at,
+                event_at,
+                event_at,
+                "AAPL",
+                side,
+                Decimal(qty),
+                Decimal(price),
+                Decimal("0.01"),
+                {
+                    "cost_amount": "0.01",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                },
+                {},
+                "TORGHUT_SIM",
+                "microbar-cross-sectional-pairs-v1",
+                decision_id,
+                payload,
+                f"order-{decision_id}",
+                f"client-{decision_id}",
+                "filled",
+                tca_id,
+            )
+
+        def order_event_row(
+            event_id: str,
+            decision_id: str,
+            execution_id: str,
+            event_at: datetime,
+            event_type: str,
+            side: str,
+            qty: str,
+            price: str,
+            payload: dict[str, object],
+            source_offset: int,
+        ) -> tuple[object, ...]:
+            is_fill = event_type == "fill"
+            return (
+                event_id,
+                decision_id,
+                execution_id,
+                event_at,
+                "AAPL",
+                "TORGHUT_SIM",
+                "microbar-cross-sectional-pairs-v1",
+                decision_id,
+                payload,
+                f"order-{decision_id}",
+                f"client-{decision_id}",
+                event_type,
+                "filled" if is_fill else "new",
+                side,
+                Decimal(qty),
+                Decimal(qty) if is_fill else Decimal("0"),
+                Decimal(qty) if is_fill else None,
+                Decimal(price) if is_fill else None,
+                Decimal(qty) * Decimal(price) if is_fill else None,
+                "cumulative_to_delta" if is_fill else None,
+                f"fingerprint-{event_id}",
+                "alpaca.trade_updates",
+                0,
+                source_offset,
+                f"source-window-{event_id}",
+                {},
+                {
+                    "cost_amount": "0.01",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                },
+                {
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                "inserted",
+                None,
+                1,
+                1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                [],
+            )
+
+        cursor = _FakeCursor()
+        cursor._results = [
+            [
+                decision_row(
+                    "decision-buy",
+                    window_start + timedelta(minutes=5),
+                    entry_payload,
+                ),
+                decision_row("decision-close", closeout_at, closeout_payload),
+            ],
+            [
+                execution_row(
+                    "execution-buy",
+                    "decision-buy",
+                    window_start + timedelta(minutes=5),
+                    window_start + timedelta(minutes=5, seconds=2),
+                    "buy",
+                    "1",
+                    "100",
+                    entry_payload,
+                    "tca-buy",
+                ),
+                execution_row(
+                    "execution-close",
+                    "decision-close",
+                    closeout_at,
+                    closeout_at + timedelta(seconds=2),
+                    "sell",
+                    "1",
+                    "101",
+                    closeout_payload,
+                    "tca-close",
+                ),
+            ],
+            [
+                order_event_row(
+                    "new-buy",
+                    "decision-buy",
+                    "execution-buy",
+                    window_start + timedelta(minutes=5, seconds=1),
+                    "new",
+                    "buy",
+                    "1",
+                    "100",
+                    entry_payload,
+                    10,
+                ),
+                order_event_row(
+                    "fill-buy",
+                    "decision-buy",
+                    "execution-buy",
+                    window_start + timedelta(minutes=5, seconds=2),
+                    "fill",
+                    "buy",
+                    "1",
+                    "100",
+                    entry_payload,
+                    11,
+                ),
+                order_event_row(
+                    "new-close",
+                    "decision-close",
+                    "execution-close",
+                    closeout_at + timedelta(seconds=1),
+                    "new",
+                    "sell",
+                    "1",
+                    "101",
+                    closeout_payload,
+                    12,
+                ),
+                order_event_row(
+                    "fill-close",
+                    "decision-close",
+                    "execution-close",
+                    closeout_at + timedelta(seconds=2),
+                    "fill",
+                    "sell",
+                    "1",
+                    "101",
+                    closeout_payload,
+                    13,
+                ),
+            ],
+            [],
+            [],
+            [],
+            [],
+        ]
+        connection = _FakeConnection(cursor)
+        diagnostics: dict[str, object] = {}
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            decisions, executions, tca_rows = _query_timestamps(
+                dsn="postgresql://example",
+                strategy_names=["microbar-cross-sectional-pairs-v1"],
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+                candidate_id="candidate-1",
+                hypothesis_id="H-PAIRS-01",
+                require_source_lineage=True,
+                allow_authoritative_runtime_ledger_materialization=True,
+                source_activity_diagnostics=diagnostics,
+            )
+
+        self.assertEqual(len(cursor.executed), 7)
+        self.assertEqual(
+            cursor.executed[0][1][4],
+            window_end + timedelta(hours=1),
+        )
+        self.assertEqual(
+            cursor.executed[1][1][4],
+            window_end + timedelta(hours=1),
+        )
+        self.assertEqual(
+            cursor.executed[2][1][6],
+            window_end + timedelta(hours=1),
+        )
+        self.assertEqual(len(decisions), 2)
+        self.assertEqual(len(executions), 2)
+        self.assertEqual(diagnostics["post_window_closeout_decision_count"], 1)
+        self.assertEqual(diagnostics["post_window_closeout_execution_count"], 1)
+        self.assertEqual(diagnostics["post_window_closeout_order_event_count"], 2)
+        runtime_rows = [
+            row
+            for row in tca_rows
+            if row.get("post_cost_expectancy_basis") == POST_COST_BASIS_RUNTIME_LEDGER
+        ]
+        self.assertEqual(len(runtime_rows), 1)
+        runtime_row = runtime_rows[0]
+        self.assertTrue(runtime_row["authoritative"])
+        self.assertEqual(runtime_row["runtime_ledger_blockers"], [])
+        bucket = runtime_row["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["closed_trade_count"], 1)
+        self.assertEqual(bucket["open_position_count"], 0)
+        self.assertEqual(
+            bucket["source_window_end"], "2026-03-06T15:05:02.000001+00:00"
+        )
+        self.assertNotIn("unclosed_position", bucket["blockers"])
+        self.assertNotIn(
+            "paper_route_target_notional_sizing_missing",
+            bucket["blockers"],
         )
 
     def test_query_timestamps_uses_source_events_but_materializes_target_account(


### PR DESCRIPTION
## Summary

- Extends authoritative runtime-window source queries with a one-hour post-window closeout lookahead, matching the paper-route account-close proof window.
- Filters post-window rows through a verified closeout predicate: profit-proof source mode, non-conflicting lineage, action offsets the in-window open quantity, filled execution, TCA ref, and source-backed order lifecycle.
- Marks accepted post-window closeout rows as closeout lifecycle rows so they do not create false target-notional sizing blockers while preserving fail-closed behavior for entries.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests -q`
- `git diff --check`
- `uv run --frozen python -m coverage run -m pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen python -m coverage xml -o coverage.xml` wrote XML but exits nonzero on global partial-suite fail-under; XML was consumed by the diff coverage checker.
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main` -> `scripts/import_hypothesis_runtime_windows.py: 109/109 lines covered (100.00%)`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
