### PR TITLE
fix(torghut): honor terminal order lifecycle state

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -662,6 +662,18 @@ def _order_lifecycle_blockers(
         for row in lifecycle_rows
         if row.event_type in _REJECTED_ORDER_EVENTS and row.order_id is not None
     }
+    unfilled_order_ids = {
+        row.order_id
+        for row in lifecycle_rows
+        if row.event_type in _UNFILLED_ORDER_EVENTS and row.order_id is not None
+    }
+    terminal_order_ids = (
+        fill_lifecycle_order_ids
+        | fill_order_ids
+        | cancelled_order_ids
+        | rejected_order_ids
+        | unfilled_order_ids
+    )
     if any(row.order_id is None for row in usable_fills):
         blockers.append("fill_order_linkage_missing")
     if any(row.order_id is None for row in fill_lifecycle_rows):
@@ -670,17 +682,13 @@ def _order_lifecycle_blockers(
         blockers.append("fill_order_submission_missing")
     if fill_order_ids - fill_lifecycle_order_ids:
         blockers.append("order_feed_lifecycle_missing")
-    if (
-        submitted_order_ids
-        - fill_lifecycle_order_ids
-        - cancelled_order_ids
-        - rejected_order_ids
-    ):
+    unresolved_submitted_order_ids = submitted_order_ids - terminal_order_ids
+    if unfilled_order_count > 0:
+        blockers.append("unfilled_order_present")
+    elif unresolved_submitted_order_ids and not usable_fills:
         blockers.append("unfilled_order_present")
     if rejected_order_count > 0:
         blockers.append("rejected_order_present")
-    if unfilled_order_count > 0:
-        blockers.append("unfilled_order_present")
 
     if not usable_fills or any(
         row.execution_policy_hash is None for row in usable_fills

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -1652,6 +1652,25 @@ def test_source_authority_unfilled_order_keeps_realized_expectancy_blocked() -> 
             "cost_model_hash": "broker-cost-v1",
             "lineage_hash": "lineage",
         },
+        {
+            "event_type": "order_unfilled",
+            "executed_at": _ts(8),
+            "decision_id": "decision-stale",
+            "order_id": "order-stale",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+            "execution_order_event_id": "event-unfilled-stale",
+            "source_window_id": "window-stale",
+            "source_topic": "alpaca.trade_updates",
+            "source_partition": 0,
+            "source_offset": 11,
+            "execution_policy_hash": "policy",
+            "cost_model_hash": "broker-cost-v1",
+            "lineage_hash": "lineage",
+        },
     ]
 
     bucket = build_runtime_ledger_buckets(
@@ -1667,6 +1686,57 @@ def test_source_authority_unfilled_order_keeps_realized_expectancy_blocked() -> 
     assert (
         bucket.diagnostic_closed_trade_expectancy_bps == bucket.post_cost_expectancy_bps
     )
+
+
+def test_source_authority_extra_submitted_order_does_not_block_closed_trip() -> None:
+    rows = [
+        *_source_authority_lifecycle_rows(),
+        {
+            "event_type": "decision",
+            "executed_at": _ts(6),
+            "decision_id": "decision-pending-terminal",
+            "order_id": "order-pending-terminal",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+            "execution_policy_hash": "policy",
+            "cost_model_hash": "broker-cost-v1",
+            "lineage_hash": "lineage",
+        },
+        {
+            "event_type": "order_submitted",
+            "executed_at": _ts(7),
+            "decision_id": "decision-pending-terminal",
+            "order_id": "order-pending-terminal",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+            "execution_order_event_id": "event-new-pending-terminal",
+            "source_window_id": "window-pending-terminal",
+            "source_topic": "alpaca.trade_updates",
+            "source_partition": 0,
+            "source_offset": 10,
+            "execution_policy_hash": "policy",
+            "cost_model_hash": "broker-cost-v1",
+            "lineage_hash": "lineage",
+        },
+    ]
+
+    bucket = build_runtime_ledger_buckets(
+        rows,
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.closed_trade_count == 1
+    assert bucket.open_position_count == 0
+    assert bucket.unfilled_order_count == 0
+    assert "unfilled_order_present" not in bucket.blockers
+    assert bucket.post_cost_expectancy_bps is not None
 
 
 def test_source_authority_open_position_blocks_final_expectancy() -> None:


### PR DESCRIPTION
## Summary

- Corrects runtime-ledger order lifecycle proof so explicit terminal `order_unfilled`/`expired` events still block promotion, while closed profitable buckets are no longer blocked by coarse submitted-minus-fill heuristics when no unresolved order is present.
- Adds regression coverage for both explicit unfilled source-authority orders and extra submitted lifecycle rows on an otherwise closed source-backed round trip.
- Keeps zero-fill submitted-only ledgers strict so truly unresolved orders still fail proof.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen pytest tests/test_runtime_ledger.py -q`
- `uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests -q`
- `uv run --frozen python scripts/check_migration_graph.py`
- `git diff --check`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
