### PR TITLE
fix(torghut): prefer fresh closeout runtime ledger imports

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -1282,11 +1282,30 @@ def build_observed_runtime_buckets(
             )
         )
 
-    def row_computed_at_is_in_import_window(row: _NormalizedTcaRow) -> bool:
+    def time_is_in_import_window(value: datetime) -> bool:
         return any(
-            bucket_start <= row.computed_at < bucket_end
+            bucket_start <= value < bucket_end
             for bucket_start, bucket_end, _ in bucket_ranges
         )
+
+    def row_import_bucketed_at(row: _NormalizedTcaRow) -> datetime:
+        if time_is_in_import_window(row.computed_at):
+            return row.computed_at
+        if time_is_in_import_window(row.bucketed_at):
+            return row.bucketed_at
+        interval = _runtime_ledger_payload_interval(row.runtime_ledger_bucket)
+        if interval is None:
+            return row.bucketed_at
+        interval_start, interval_end = interval
+        overlapping_ranges = [
+            (bucket_start, bucket_end)
+            for bucket_start, bucket_end, _ in bucket_ranges
+            if interval_start < bucket_end and interval_end > bucket_start
+        ]
+        if not overlapping_ranges:
+            return row.bucketed_at
+        last_start, last_end = overlapping_ranges[-1]
+        return max(last_start, last_end - timedelta(microseconds=1))
 
     buckets: list[ObservedRuntimeBucket] = []
     for bucket_start, bucket_end, market_session_count in bucket_ranges:
@@ -1299,11 +1318,7 @@ def build_observed_runtime_buckets(
         bucket_tca = [
             row
             for row in normalized_tca_rows
-            if (
-                bucket_start <= row.computed_at < bucket_end
-                if row_computed_at_is_in_import_window(row)
-                else bucket_start <= row.bucketed_at < bucket_end
-            )
+            if bucket_start <= row_import_bucketed_at(row) < bucket_end
         ]
         runtime_ledger_decision_count = sum(
             _observation_int(row.runtime_ledger_bucket.get("decision_count"))

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -536,6 +536,111 @@ class TestRuntimeWindowImport(TestCase):
             runtime_payloads[0]["source_window_ids"], ["source-window-late-close"]
         )
 
+    def test_build_observed_runtime_buckets_assigns_post_window_closeout_to_import_window(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc),
+                    datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+                    6,
+                )
+            ],
+            decision_times=[],
+            execution_times=[],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 6, 1, 14, 5, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("25"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        bucket_started_at="2026-06-01T13:41:00+00:00",
+                        bucket_ended_at="2026-06-01T14:05:00.000001+00:00",
+                        source_window_start="2026-06-01T13:41:00+00:00",
+                        source_window_end="2026-06-01T14:05:00.000001+00:00",
+                        source_window_ids=[
+                            "source-window-entry",
+                            "source-window-closeout",
+                        ],
+                        execution_ids=["execution-entry", "execution-closeout"],
+                        trade_decision_ids=["decision-entry", "decision-closeout"],
+                        execution_order_event_ids=[
+                            "event-fill-entry",
+                            "event-fill-closeout",
+                        ],
+                        source_offsets=[
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 41,
+                            },
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 42,
+                            },
+                        ],
+                    ),
+                    **_runtime_pnl_basis(),
+                }
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        self.assertEqual(len(buckets), 1)
+        self.assertEqual(buckets[0].payload_json["tca_row_count"], 1)
+        runtime_payloads = buckets[0].payload_json["runtime_ledger_buckets"]
+        self.assertEqual(len(runtime_payloads), 1)
+        self.assertEqual(
+            runtime_payloads[0]["source_window_ids"],
+            ["source-window-entry", "source-window-closeout"],
+        )
+
+    def test_build_observed_runtime_buckets_ignores_out_of_window_tca_rows(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc),
+                    datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+                    6,
+                )
+            ],
+            decision_times=[],
+            execution_times=[],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 6, 1, 14, 5, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("25"),
+                    **_runtime_pnl_basis(),
+                },
+                {
+                    "computed_at": datetime(2026, 6, 1, 14, 5, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("25"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        bucket_started_at="2026-06-01T14:10:00+00:00",
+                        bucket_ended_at="2026-06-01T14:11:00+00:00",
+                        source_window_start="2026-06-01T14:10:00+00:00",
+                        source_window_end="2026-06-01T14:11:00+00:00",
+                    ),
+                    **_runtime_pnl_basis(),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        self.assertEqual(len(buckets), 1)
+        self.assertEqual(buckets[0].payload_json["tca_row_count"], 0)
+        self.assertEqual(buckets[0].trade_count, 0)
+
     def test_build_observed_runtime_buckets_quarantines_simulation_report_pnl(
         self,
     ) -> None:
@@ -1873,6 +1978,122 @@ class TestRuntimeWindowImport(TestCase):
         self.assertIn(
             "source_decision_mode_not_profit_proof_eligible",
             ledger_rows[0].blockers_json,
+        )
+        self.assertNotIn("runtime_ledger_readback_source", ledger_rows[0].payload_json)
+
+    def test_persist_observed_runtime_windows_prefers_post_window_closeout_over_stale_readback(
+        self,
+    ) -> None:
+        def source_buckets():
+            return build_observed_runtime_buckets(
+                bucket_ranges=[
+                    (
+                        datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc),
+                        datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+                        6,
+                    )
+                ],
+                decision_times=[],
+                execution_times=[],
+                tca_rows=[
+                    {
+                        "computed_at": datetime(
+                            2026, 6, 1, 13, 55, tzinfo=timezone.utc
+                        ),
+                        "abs_slippage_bps": Decimal("1"),
+                        "post_cost_expectancy_bps": None,
+                        "runtime_ledger_bucket": _runtime_ledger_bucket(
+                            bucket_started_at="2026-06-01T13:41:00+00:00",
+                            bucket_ended_at="2026-06-01T13:55:00.000001+00:00",
+                            source_window_start="2026-06-01T13:41:00+00:00",
+                            source_window_end="2026-06-01T13:55:00.000001+00:00",
+                            runtime_ledger_readback_source=(
+                                "strategy_runtime_ledger_buckets"
+                            ),
+                            source_window_ids=["source-window-entry"],
+                            execution_ids=["execution-entry"],
+                            trade_decision_ids=["decision-entry"],
+                            execution_order_event_ids=["event-fill-entry"],
+                            fill_count=1,
+                            closed_trade_count=0,
+                            open_position_count=1,
+                            filled_notional="100",
+                            net_strategy_pnl_after_costs="0",
+                        ),
+                        **_runtime_pnl_basis(),
+                    },
+                    {
+                        "computed_at": datetime(
+                            2026, 6, 1, 14, 5, tzinfo=timezone.utc
+                        ),
+                        "abs_slippage_bps": Decimal("1"),
+                        "post_cost_expectancy_bps": Decimal("25"),
+                        "runtime_ledger_bucket": _runtime_ledger_bucket(
+                            bucket_started_at="2026-06-01T13:41:00+00:00",
+                            bucket_ended_at="2026-06-01T14:05:00.000001+00:00",
+                            source_window_start="2026-06-01T13:41:00+00:00",
+                            source_window_end="2026-06-01T14:05:00.000001+00:00",
+                            source_window_ids=[
+                                "source-window-entry",
+                                "source-window-closeout",
+                            ],
+                            execution_ids=[
+                                "execution-entry",
+                                "execution-closeout",
+                            ],
+                            trade_decision_ids=[
+                                "decision-entry",
+                                "decision-closeout",
+                            ],
+                            execution_order_event_ids=[
+                                "event-fill-entry",
+                                "event-fill-closeout",
+                            ],
+                            closed_trade_count=1,
+                            open_position_count=0,
+                            filled_notional="200",
+                            net_strategy_pnl_after_costs="0.50",
+                        ),
+                        **_runtime_pnl_basis(),
+                    },
+                ],
+                continuity_ok=True,
+                drift_ok=True,
+                dependency_quorum_decision="allow",
+            )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-post-window-closeout",
+                candidate_id="cand-post-window-closeout",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=source_buckets(),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "runtime_ledger_profit_proof_present": False,
+                },
+            )
+            session.commit()
+            ledger_rows = (
+                session.execute(select(StrategyRuntimeLedgerBucket)).scalars().all()
+            )
+
+        self.assertEqual(
+            summary["runtime_materialization_target"]["runtime_ledger_bucket_count"],
+            1,
+        )
+        self.assertEqual(len(ledger_rows), 1)
+        self.assertEqual(ledger_rows[0].closed_trade_count, 1)
+        self.assertEqual(ledger_rows[0].open_position_count, 0)
+        self.assertEqual(ledger_rows[0].filled_notional, Decimal("200"))
+        self.assertEqual(
+            ledger_rows[0].bucket_ended_at.replace(tzinfo=timezone.utc),
+            datetime(2026, 6, 1, 14, 5, 0, 1, tzinfo=timezone.utc),
         )
         self.assertNotIn("runtime_ledger_readback_source", ledger_rows[0].payload_json)
 


### PR DESCRIPTION
## Summary

- Assign source-backed runtime-ledger rows that close just after the regular-session import window to the last overlapping import bucket instead of dropping them.
- Prevent stale `strategy_runtime_ledger_buckets` readback rows from surviving when a fresh execution/order-feed reconstruction overlaps the same proof window.
- Add regression coverage for post-window closeout assignment, out-of-window exclusion, and stale readback replacement.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen pytest tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py -q`
- `uv run --frozen pytest tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m compileall app scripts tests -q`
- `uv run --frozen python scripts/check_migration_graph.py`
- `git diff --check`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
