### PR TITLE
chore(torghut): promote image d2ef3f06

### DIFF
--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: materialize-targets
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -135,7 +135,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+                  value: sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-06T02:51:57Z"
+        client.knative.dev/updateTimestamp: "2026-06-06T03:34:14Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
           ports:
             - name: http1
               containerPort: 8181
@@ -533,11 +533,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-353-g1bcf508ff
+              value: v0.596.0-355-gd2ef3f06b
             - name: TORGHUT_COMMIT
-              value: 1bcf508ff1202b865c9f4fe2f4b571cad6a9155b
+              value: d2ef3f06bdae68418ff6eef207c90f8d8807938a
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+              value: sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-06-06T02:51:57Z"
+        client.knative.dev/updateTimestamp: "2026-06-06T03:34:14Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -31,7 +31,7 @@ spec:
           securityContext:
             seccompProfile:
               type: Unconfined
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
           ports:
             - name: http1
               containerPort: 8181
@@ -395,11 +395,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.596.0-353-g1bcf508ff
+              value: v0.596.0-355-gd2ef3f06b
             - name: TORGHUT_COMMIT
-              value: 1bcf508ff1202b865c9f4fe2f4b571cad6a9155b
+              value: d2ef3f06bdae68418ff6eef207c90f8d8807938a
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+              value: sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -30,7 +30,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-live
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -87,7 +87,7 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+                  value: sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
                 - name: PYTHONUNBUFFERED
                   value: "1"
 ---
@@ -123,7 +123,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: journal-order-events-sim
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
               imagePullPolicy: IfNotPresent
               securityContext:
                 seccompProfile:
@@ -195,6 +195,6 @@ spec:
                 - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
                   value: "false"
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+                  value: sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
                 - name: PYTHONUNBUFFERED
                   value: "1"

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: smoke
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
           imagePullPolicy: IfNotPresent
           securityContext:
             seccompProfile:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,7 +159,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash
@@ -182,9 +182,9 @@ spec:
           - name: TRADING_STRATEGY_CONFIG_PATH
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_COMMIT
-            value: 1bcf508ff1202b865c9f4fe2f4b571cad6a9155b
+            value: d2ef3f06bdae68418ff6eef207c90f8d8807938a
           - name: TORGHUT_IMAGE_DIGEST
-            value: sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+            value: sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f76b7a89d44110eefa77bcd01c83eaf904f60811e510aba6adcbcf767dd6044d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- Promote Torghut image `d2ef3f06` built from source commit `d2ef3f06bdae68418ff6eef207c90f8d8807938a`.
- Pin both Torghut GitOps manifests to image digest `sha256:cfe1d52834e6906f04378abf4da4be90182f0f8e78ae0fe26fed54d0a5062b1c`.
- Roll forward the deployed fix for closeout runtime-ledger import-window precedence.

## Related Issues

None

## Testing

- `torghut-build-push` run `27051357185` completed successfully and uploaded the release contract.
- `torghut-release` run `27051437191` completed successfully and generated this manifest promotion.

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
