### PR TITLE
fix(torghut): attach hpairs source proof census

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -41,7 +41,8 @@ spec:
                   cd /app
                   RENEWAL_OUTPUT=/tmp/torghut-empirical-renewal/runtime-window-renewal.json
                   PROOF_PACKET_OUTPUT=/tmp/torghut-empirical-renewal/runtime-ledger-proof-packet.json
-                  mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")"
+                  HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT=/tmp/torghut-empirical-renewal/hpairs-source-proof-census.json
+                  mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")" "$(dirname "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}")"
                   /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
                     --dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
@@ -66,9 +67,19 @@ spec:
                     --max-batches 5 \
                     --apply \
                     --json
+                  /opt/venv/bin/python scripts/audit_hpairs_source_proof_census.py \
+                    --dsn "${SIM_DB_DSN}" \
+                    --hypothesis-id H-PAIRS-01 \
+                    --candidate-id c88421d619759b2cfaa6f4d0 \
+                    --runtime-strategy-name microbar-cross-sectional-pairs-v1 \
+                    --account-label TORGHUT_SIM \
+                    --source-account-label TORGHUT_SIM \
+                    --observed-stage paper \
+                    > "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}"
                   /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
+                    --hpairs-source-proof-census-file "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}" \
                     --runtime-window-import \
                     --runtime-window-target-plan-url 'http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence?target_limit=5' \
                     --runtime-window-target-plan-url-timeout-seconds 45 \
@@ -96,6 +107,7 @@ spec:
                     --timeout-seconds 30 \
                     --proof-mode authority \
                     --runtime-window-import-file "${RENEWAL_OUTPUT}" \
+                    --hpairs-source-proof-census-file "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}" \
                     --min-runtime-ledger-net-pnl 10000 \
                     --min-runtime-ledger-daily-net-pnl 500 \
                     --min-runtime-ledger-trading-days 20 \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -2005,7 +2005,19 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertIn(
-            'mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")"',
+            "HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT=/tmp/torghut-empirical-renewal/hpairs-source-proof-census.json",
+            args,
+        )
+        self.assertIn(
+            'mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")" "$(dirname "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}")"',
+            args,
+        )
+        self.assertIn("scripts/audit_hpairs_source_proof_census.py", args)
+        self.assertIn('--dsn "${SIM_DB_DSN}"', args)
+        self.assertIn("--source-account-label TORGHUT_SIM", args)
+        self.assertIn('> "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}"', args)
+        self.assertIn(
+            '--hpairs-source-proof-census-file "${HPAIRS_SOURCE_PROOF_CENSUS_OUTPUT}"',
             args,
         )
         self.assertIn("scripts/assemble_runtime_ledger_proof_packet.py", args)


### PR DESCRIPTION
## Summary

- Generates a fresh read-only H-PAIRS source-proof census inside the empirical promotion renewal CronJob.
- Passes the census file into `renew_latest_empirical_promotion_jobs.py` so renewal status no longer reports `hpairs_source_proof_census_missing` when the readback is available.
- Passes the same census into `assemble_runtime_ledger_proof_packet.py` while preserving the existing non-authority/fail-closed census semantics.

## Related Issues

None.

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `bun run lint:argocd`
- `scripts/argo-lint.sh`
- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py -k hpairs_source_proof_census -q`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -k hpairs_source_proof_census -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall app scripts tests/test_live_config_manifest_contract.py`
- `uv run --frozen python scripts/check_migration_graph.py`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
