### PR TITLE
fix(torghut): normalize hpairs census dsn

### DIFF
--- a/services/torghut/scripts/audit_hpairs_source_proof_census.py
+++ b/services/torghut/scripts/audit_hpairs_source_proof_census.py
@@ -319,7 +319,7 @@ def load_dsn_rows(
 ) -> CensusSourceRows:
     """Read only the bounded H-PAIRS source rows needed for the census."""
 
-    engine = create_engine(dsn)
+    engine = create_engine(_sqlalchemy_dsn(dsn), pool_pre_ping=True, future=True)
     session_factory = sessionmaker(bind=engine)
     with session_factory() as session:
         return _load_session_rows(
@@ -328,6 +328,17 @@ def load_dsn_rows(
             started_at=started_at,
             ended_at=ended_at,
         )
+
+
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
 
 
 def _load_session_rows(

--- a/services/torghut/tests/test_audit_hpairs_source_proof_census.py
+++ b/services/torghut/tests/test_audit_hpairs_source_proof_census.py
@@ -1303,7 +1303,7 @@ def test_dsn_loader_opens_session_and_delegates(monkeypatch) -> None:  # type: i
         def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
             return None
 
-    monkeypatch.setattr(census, "create_engine", lambda dsn: f"engine:{dsn}")
+    monkeypatch.setattr(census, "create_engine", lambda dsn, **kwargs: f"engine:{dsn}")
     monkeypatch.setattr(census, "sessionmaker", lambda bind: lambda: FakeSession())
     monkeypatch.setattr(census, "_load_session_rows", lambda *args, **kwargs: expected)
 
@@ -1312,6 +1312,57 @@ def test_dsn_loader_opens_session_and_delegates(monkeypatch) -> None:  # type: i
     )
 
     assert rows is expected
+
+
+def test_dsn_loader_sqlalchemy_dsn_uses_installed_psycopg_driver(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    identity = census.CensusIdentity(
+        hypothesis_id=DEFAULT_HPAIRS_HYPOTHESIS_ID,
+        candidate_id=DEFAULT_HPAIRS_CANDIDATE_ID,
+        runtime_strategy_name=DEFAULT_HPAIRS_RUNTIME_STRATEGY,
+        account_label=DEFAULT_HPAIRS_ACCOUNT_LABEL,
+        observed_stage="paper",
+    )
+    captured: dict[str, object] = {}
+
+    class FakeSession:
+        def __enter__(self) -> "FakeSession":
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:  # type: ignore[no-untyped-def]
+            return None
+
+    def fake_create_engine(dsn: str, **kwargs: object) -> str:
+        captured["dsn"] = dsn
+        captured["kwargs"] = kwargs
+        return f"engine:{dsn}"
+
+    monkeypatch.setattr(census, "create_engine", fake_create_engine)
+    monkeypatch.setattr(census, "sessionmaker", lambda bind: lambda: FakeSession())
+    monkeypatch.setattr(
+        census, "_load_session_rows", lambda *args, **kwargs: census.CensusSourceRows()
+    )
+
+    census.load_dsn_rows(
+        "postgresql://user:pass@postgres/torghut",
+        identity=identity,
+        started_at=None,
+        ended_at=None,
+    )
+
+    assert captured["dsn"] == "postgresql+psycopg://user:pass@postgres/torghut"
+    assert captured["kwargs"] == {"pool_pre_ping": True, "future": True}
+    assert (
+        census._sqlalchemy_dsn("postgres://user:pass@postgres/torghut")
+        == "postgresql+psycopg://user:pass@postgres/torghut"
+    )
+    assert (
+        census._sqlalchemy_dsn("postgresql+psycopg://user:pass@postgres/torghut")
+        == "postgresql+psycopg://user:pass@postgres/torghut"
+    )
+    assert (
+        census._sqlalchemy_dsn("sqlite+pysqlite:///:memory:")
+        == "sqlite+pysqlite:///:memory:"
+    )
 
 
 def test_main_reports_read_errors_as_json(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary

- Normalizes H-PAIRS source-proof census SQLAlchemy DSNs to use the installed psycopg3 driver.
- Prevents `postgresql://...` renewal jobs from failing closed with `source_proof_census_read_error` because `psycopg2` is not installed.
- Adds regression coverage for the audit loader and preserves read-only census semantics.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_audit_hpairs_source_proof_census.py -k 'dsn_loader or read_errors' -q`
- `uv run --frozen pytest tests/test_audit_hpairs_source_proof_census.py -q`
- `uv run --frozen pytest tests/test_renew_latest_empirical_promotion_jobs.py -k hpairs_source_proof_census -q`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -k hpairs_source_proof_census -q`
- `uv run --frozen pytest tests/test_audit_hpairs_source_proof_census.py tests/test_renew_latest_empirical_promotion_jobs.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff format --check scripts/audit_hpairs_source_proof_census.py tests/test_audit_hpairs_source_proof_census.py`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall app scripts tests/test_audit_hpairs_source_proof_census.py`
- `uv run --frozen python scripts/check_migration_graph.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
