### PR TITLE
fix(torghut): raise hpairs paper route sizing cap

### DIFF
--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -57,7 +57,7 @@ spec:
                     --plan-url-attempts 3 \
                     --database-dsn-env SIM_DB_DSN \
                     --account-label TORGHUT_SIM \
-                    --max-notional 75000 \
+                    --max-notional 1000000 \
                     --commit \
                     --allow-dynamic-target-plan \
                     --skip-unless-active-target-window \
@@ -67,7 +67,7 @@ spec:
                     --confirm-runtime-strategy-name microbar-cross-sectional-pairs-v1 \
                     --confirm-selected-plan-source live_submission_gate.runtime_ledger_paper_probation_import_plan,runtime_ledger_paper_probation_import_plan,next_paper_route_runtime_window_targets,next_clean_paper_route_runtime_window_targets_after_discard \
                     --confirm-target-count-min 1 \
-                    --confirm-max-notional 75000 \
+                    --confirm-max-notional 1000000 \
                     --operator-confirmation MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS
               env:
                 - name: TORGHUT_SIM_DB_HOST

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -130,7 +130,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "75000"
+              value: "1000000"
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
               value: http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -133,7 +133,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "75000"
+              value: "1000000"
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
             - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL

--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -432,8 +432,8 @@ data:
         base_timeframe: "1Sec"
         universe_type: microbar_cross_sectional_pairs_v1
         universe_symbols: ["AAPL", "AMZN"]
-        max_notional_per_trade: 75000
-        max_position_pct_equity: 6.0
+        max_notional_per_trade: 1000000
+        max_position_pct_equity: 10.0
         params:
           entry_minute_after_open: "60"
           exit_minute_after_open: "120"
@@ -442,7 +442,7 @@ data:
           selection_mode: "continuation"
           top_n: "1"
           min_cross_section_continuation_rank: "0.55"
-          max_gross_exposure_pct_equity: "4.0"
+          max_gross_exposure_pct_equity: "10.0"
           max_pair_legs: "2"
           max_entries_per_session: "1"
           entry_cooldown_seconds: "600"

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -2991,6 +2991,8 @@ def _next_paper_route_runtime_window_targets(
             "paper_route_probe_missing_strategy_universe_symbols": (
                 missing_strategy_universe_symbols
             ),
+            "target_notional": next_notional,
+            "paper_route_probe_target_notional": next_notional,
             "paper_route_probe_next_session_max_notional": next_notional,
             "paper_route_probe_effective_max_notional": next_notional,
             "paper_route_probe_window_start": _isoformat(window_start),

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -29,6 +29,7 @@ _LIVE_EXECUTION_CHIP_TECH_UNIVERSE = _RESEARCHED_CHIP_TECH_UNIVERSE
 _QUOTE_COVERED_PAPER_STRATEGY_UNIVERSE = ("AAPL", "AMZN", "INTC", "NVDA")
 _CHIP_UNIVERSE_SYMBOLS = set(_RESEARCHED_CHIP_TECH_UNIVERSE)
 _LIVE_EXECUTION_CHIP_UNIVERSE_SYMBOLS = set(_LIVE_EXECUTION_CHIP_TECH_UNIVERSE)
+_HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL = "1000000"
 
 
 def _repo_root() -> Path:
@@ -480,14 +481,14 @@ class TestLiveConfigManifestContract(TestCase):
                 self.assertEqual(name, "microbar-cross-sectional-pairs-v1")
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_notional_per_trade"),
-                    Decimal("75000"),
+                    Decimal(_HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL),
                 )
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_position_pct_equity"),
-                    Decimal("6.0"),
+                    Decimal("10.0"),
                 )
                 self.assertEqual(params.get("position_isolation_mode"), "per_strategy")
-                self.assertEqual(params.get("max_gross_exposure_pct_equity"), "4.0")
+                self.assertEqual(params.get("max_gross_exposure_pct_equity"), "10.0")
                 self.assertEqual(params.get("max_pair_legs"), "2")
                 self.assertEqual(params.get("top_n"), "1")
                 self.assertEqual(
@@ -690,7 +691,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
-            "75000",
+            _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL,
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_URL"),
@@ -1534,7 +1535,9 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--plan-url-attempts 3", args)
         self.assertIn("--database-dsn-env SIM_DB_DSN", args)
         self.assertIn("--account-label TORGHUT_SIM", args)
-        self.assertIn("--max-notional 75000", args)
+        self.assertIn(
+            f"--max-notional {_HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL}", args
+        )
         self.assertIn("--commit", args)
         self.assertIn("--allow-dynamic-target-plan", args)
         self.assertIn("--skip-unless-active-target-window", args)
@@ -1558,7 +1561,10 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertIn("--confirm-target-count-min 1", args)
-        self.assertIn("--confirm-max-notional 75000", args)
+        self.assertIn(
+            f"--confirm-max-notional {_HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL}",
+            args,
+        )
         self.assertIn(
             "--operator-confirmation MATERIALIZE_BOUNDED_TORGHUT_SIM_PAPER_ROUTE_TARGETS",
             args,
@@ -1570,6 +1576,48 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn("--capital-promotion-allowed", args)
         self.assertNotIn("--final-authority-ok", args)
         self.assertNotIn("PA3SX7FYNUTF", args)
+
+    def test_hpairs_bounded_paper_collection_notional_contract_is_aligned(
+        self,
+    ) -> None:
+        live_env = _load_torghut_knative_env()
+        sim_env = _load_knative_env(
+            "argocd/applications/torghut/knative-service-sim.yaml"
+        )
+        _, materializer_container = _load_cronjob_container(
+            "argocd/applications/torghut/"
+            "bounded-paper-route-target-materialization-cronjob.yaml"
+        )
+        args = "\n".join(str(item) for item in materializer_container.get("args", []))
+        strategies = {
+            str(strategy.get("name")): strategy
+            for strategy in _load_torghut_strategy_catalog()
+        }
+        hpairs = strategies["microbar-cross-sectional-pairs-v1"]
+
+        self.assertEqual(
+            live_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
+            _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL,
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
+            _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL,
+        )
+        self.assertIn(
+            f"--max-notional {_HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL}", args
+        )
+        self.assertIn(
+            f"--confirm-max-notional {_HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL}",
+            args,
+        )
+        self.assertEqual(
+            _strategy_decimal(hpairs, "max_notional_per_trade"),
+            Decimal(_HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL),
+        )
+        self.assertEqual(
+            _strategy_decimal(hpairs, "max_position_pct_equity"), Decimal("10.0")
+        )
+        self.assertEqual(_params(hpairs).get("max_gross_exposure_pct_equity"), "10.0")
 
     def test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim(
         self,
@@ -2240,7 +2288,8 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertFalse(_manifest_bool(env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
         self.assertTrue(_manifest_bool(env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED"))
         self.assertEqual(
-            env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"), "75000"
+            env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
+            _HPAIRS_BOUNDED_PAPER_COLLECTION_MAX_NOTIONAL,
         )
         self.assertTrue(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
         self.assertEqual(env.get("TRADING_ALPACA_QUOTE_FEED"), "iex")

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -4282,6 +4282,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(target["max_notional"], "0")
         self.assertEqual(target["paper_route_probe_symbols"], ["AAPL"])
+        self.assertEqual(target["target_notional"], "25")
+        self.assertEqual(target["paper_route_probe_target_notional"], "25")
         self.assertEqual(target["paper_route_probe_next_session_max_notional"], "25")
         self.assertEqual(
             target["source_decision_readiness"]["blockers"],
@@ -4731,6 +4733,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
             [],
         )
         self.assertEqual(target["max_notional"], "0")
+        self.assertEqual(target["target_notional"], "63180")
+        self.assertEqual(target["paper_route_probe_target_notional"], "63180")
         self.assertEqual(target["paper_route_probe_next_session_max_notional"], "63180")
         self.assertEqual(target["paper_route_probe_effective_max_notional"], "63180")
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Raises the bounded H-PAIRS paper-route collection cap from `75,000` to `1,000,000` across the live service env, sim service env, materialization CronJob, and strategy catalog.
- Publishes explicit `target_notional` and `paper_route_probe_target_notional` on next-session paper-route targets while keeping `max_notional` at `0` so live capital promotion remains blocked.
- Adds a manifest contract test that keeps the H-PAIRS bounded collection cap aligned across both services, the materializer, and the strategy config.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_live_config_manifest_contract.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'hpairs_bounded_paper_collection_notional_contract_is_aligned or bounded_paper_route_target_materialization_cronjob_is_sim_only or manifest_simple_lane_profile_is_enforced or sim_manifest_runs_paper_live_signal_profile or enabled_paper_sleeves_are_chip_universe_with_safe_profiles' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'next_paper_route or bounded_evidence_collection' -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py tests/test_paper_route_evidence.py tests/test_materialize_bounded_paper_route_targets.py tests/test_paper_route_target_plan.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_live_config_manifest_contract.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_live_config_manifest_contract.py tests/test_paper_route_evidence.py`
- `uv run --frozen python -m compileall -q app scripts tests`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
