### PR TITLE
fix(torghut): unblock pre-session flatten proof

### DIFF
--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -50,6 +50,7 @@ spec:
                       --target-plan-readback-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan?runtime_window_import_audit=deferred
                       --target-plan-readback-timeout-seconds 10
                       --require-target-plan-readback-clean
+                      --allow-pending-clean-window-baseline-readback
                     )
                   fi
                   /opt/venv/bin/python scripts/flatten_paper_account_positions.py \

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -183,6 +183,15 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--allow-pending-clean-window-baseline-readback",
+        action="store_true",
+        help=(
+            "Allow the explicit pre-session pending clean-window baseline state when "
+            "this cleanup job runs before the baseline window can be evaluated. Dirty, "
+            "missing, stale, or unreadable readbacks still fail when clean readback is required."
+        ),
+    )
+    parser.add_argument(
         "--persist-lineage",
         action="store_true",
         help=(
@@ -316,6 +325,33 @@ def _target_plan_baseline_readback(
         "source_auditable": bool(baseline.get("source_auditable")),
         "blockers": blockers,
     }
+
+
+def _target_plan_readback_pending_clean_window_baseline_only(
+    readback: Mapping[str, object],
+) -> bool:
+    if _safe_text(readback.get("state")) != "blocked":
+        return False
+    if int(readback.get("matching_target_count") or 0) <= 0:
+        return False
+    targets = [_as_mapping(target) for target in _as_sequence(readback.get("targets"))]
+    if not targets:
+        return False
+    allowed_readback_blockers = {
+        "paper_route_clean_window_baseline_snapshot_pending",
+        "paper_route_target_plan_clean_window_baseline_not_clean",
+        "paper_route_target_plan_readback_snapshot_id_mismatch",
+    }
+    if set(_readback_blockers(readback.get("blockers"))) - allowed_readback_blockers:
+        return False
+    for target in targets:
+        if _safe_text(target.get("state")) != "pending_until_clean_window_baseline":
+            return False
+        if set(_readback_blockers(target.get("blockers"))) != {
+            "paper_route_clean_window_baseline_snapshot_pending"
+        }:
+            return False
+    return True
 
 
 def _readback_datetime(value: object) -> datetime | None:
@@ -1333,6 +1369,12 @@ def main() -> int:
                 args.require_target_plan_readback_clean
             )
             payload["target_plan_readback_clean"] = readback.get("state") == "clean"
+            payload["target_plan_readback_pending_clean_window_baseline_allowed"] = (
+                bool(args.allow_pending_clean_window_baseline_readback)
+                and _target_plan_readback_pending_clean_window_baseline_only(
+                    _as_mapping(readback)
+                )
+            )
     finally:
         if session_engine is not None:
             session_engine.dispose()
@@ -1347,6 +1389,7 @@ def main() -> int:
         return 2
     if bool(payload.get("target_plan_readback_required_clean")) and not bool(
         payload.get("target_plan_readback_clean")
+        or payload.get("target_plan_readback_pending_clean_window_baseline_allowed")
     ):
         return 3
     return 0

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -1482,6 +1482,259 @@ class TestFlattenPaperAccountPositions(TestCase):
             readback["blockers"],
         )
 
+    def test_required_target_plan_readback_allows_pre_session_pending_baseline(
+        self,
+    ) -> None:
+        client = FakeFlattenClient()
+        snapshot = SimpleNamespace(
+            id="snapshot-1",
+            as_of=datetime(2026, 6, 5, 13, 6, tzinfo=timezone.utc),
+        )
+        target_plan = {
+            "schema_version": "torghut.paper-route-target-plan.v1",
+            "next_paper_route_runtime_window_targets": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "clean_window_baseline_readiness": {
+                    "state": "clean_window_required",
+                    "blockers": ["paper_route_clean_window_baseline_snapshot_pending"],
+                },
+                "targets": [
+                    {
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "window_start": "2026-06-05T13:30:00+00:00",
+                        "window_end": "2026-06-05T20:00:00+00:00",
+                        "paper_route_clean_window_baseline_state": {
+                            "state": "pending_until_clean_window_baseline",
+                            "blockers": [
+                                "paper_route_clean_window_baseline_snapshot_pending"
+                            ],
+                        },
+                    }
+                ],
+            },
+        }
+        argv = [
+            "flatten_paper_account_positions.py",
+            "--account-label",
+            "TORGHUT_SIM",
+            "--expected-account-label",
+            "TORGHUT_SIM",
+            "--trading-mode",
+            "paper",
+            "--persist-snapshot",
+            "--target-plan-readback-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--require-target-plan-readback-clean",
+            "--allow-pending-clean-window-baseline-readback",
+            "--json",
+        ]
+
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(
+                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+            ),
+            patch.object(
+                flatten_script, "SessionLocal", return_value=FakeSessionContext()
+            ),
+            patch.object(
+                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+            ),
+            patch.object(
+                flatten_script.urllib.request,
+                "urlopen",
+                return_value=FakeHttpResponse(target_plan),
+            ),
+            redirect_stdout(StringIO()) as output,
+        ):
+            exit_code = flatten_script.main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["target_plan_readback_required_clean"])
+        self.assertFalse(payload["target_plan_readback_clean"])
+        self.assertTrue(
+            payload["target_plan_readback_pending_clean_window_baseline_allowed"]
+        )
+        self.assertIn(
+            "paper_route_clean_window_baseline_snapshot_pending",
+            payload["target_plan_readback"]["blockers"],
+        )
+
+    def test_pending_baseline_allowance_still_fails_dirty_readback(self) -> None:
+        client = FakeFlattenClient()
+        snapshot = SimpleNamespace(
+            id="snapshot-1",
+            as_of=datetime(2026, 6, 5, 13, 16, tzinfo=timezone.utc),
+        )
+        target_plan = {
+            "schema_version": "torghut.paper-route-target-plan.v1",
+            "next_paper_route_runtime_window_targets": {
+                "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                "clean_window_baseline_readiness": {
+                    "state": "clean_window_required",
+                    "blockers": ["paper_route_account_pre_session_snapshot_stale"],
+                },
+                "targets": [
+                    {
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "account_label": "TORGHUT_SIM",
+                        "window_start": "2026-06-05T13:30:00+00:00",
+                        "window_end": "2026-06-05T20:00:00+00:00",
+                        "paper_route_clean_window_baseline_state": {
+                            "state": "blocked",
+                            "blockers": [
+                                "paper_route_account_pre_session_snapshot_stale"
+                            ],
+                        },
+                    }
+                ],
+            },
+        }
+        argv = [
+            "flatten_paper_account_positions.py",
+            "--account-label",
+            "TORGHUT_SIM",
+            "--expected-account-label",
+            "TORGHUT_SIM",
+            "--trading-mode",
+            "paper",
+            "--persist-snapshot",
+            "--target-plan-readback-url",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "--require-target-plan-readback-clean",
+            "--allow-pending-clean-window-baseline-readback",
+            "--json",
+        ]
+
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(
+                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+            ),
+            patch.object(
+                flatten_script, "SessionLocal", return_value=FakeSessionContext()
+            ),
+            patch.object(
+                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+            ),
+            patch.object(
+                flatten_script.urllib.request,
+                "urlopen",
+                return_value=FakeHttpResponse(target_plan),
+            ),
+            redirect_stdout(StringIO()) as output,
+        ):
+            exit_code = flatten_script.main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 3)
+        self.assertTrue(payload["target_plan_readback_required_clean"])
+        self.assertFalse(payload["target_plan_readback_clean"])
+        self.assertFalse(
+            payload["target_plan_readback_pending_clean_window_baseline_allowed"]
+        )
+        self.assertIn(
+            "paper_route_account_pre_session_snapshot_stale",
+            payload["target_plan_readback"]["blockers"],
+        )
+
+    def test_pending_baseline_allowance_predicate_fails_closed_edges(self) -> None:
+        self.assertFalse(
+            flatten_script._target_plan_readback_pending_clean_window_baseline_only(
+                {
+                    "state": "clean",
+                    "matching_target_count": 1,
+                    "targets": [
+                        {
+                            "state": "pending_until_clean_window_baseline",
+                            "blockers": [
+                                "paper_route_clean_window_baseline_snapshot_pending"
+                            ],
+                        }
+                    ],
+                    "blockers": [
+                        "paper_route_clean_window_baseline_snapshot_pending",
+                        "paper_route_target_plan_clean_window_baseline_not_clean",
+                    ],
+                }
+            )
+        )
+        self.assertFalse(
+            flatten_script._target_plan_readback_pending_clean_window_baseline_only(
+                {
+                    "state": "blocked",
+                    "matching_target_count": 0,
+                    "targets": [
+                        {
+                            "state": "pending_until_clean_window_baseline",
+                            "blockers": [
+                                "paper_route_clean_window_baseline_snapshot_pending"
+                            ],
+                        }
+                    ],
+                    "blockers": [
+                        "paper_route_clean_window_baseline_snapshot_pending",
+                        "paper_route_target_plan_clean_window_baseline_not_clean",
+                    ],
+                }
+            )
+        )
+        self.assertFalse(
+            flatten_script._target_plan_readback_pending_clean_window_baseline_only(
+                {
+                    "state": "blocked",
+                    "matching_target_count": 1,
+                    "targets": [],
+                    "blockers": [
+                        "paper_route_clean_window_baseline_snapshot_pending",
+                        "paper_route_target_plan_clean_window_baseline_not_clean",
+                    ],
+                }
+            )
+        )
+        self.assertFalse(
+            flatten_script._target_plan_readback_pending_clean_window_baseline_only(
+                {
+                    "state": "blocked",
+                    "matching_target_count": 1,
+                    "targets": [
+                        {
+                            "state": "blocked",
+                            "blockers": [
+                                "paper_route_clean_window_baseline_snapshot_pending"
+                            ],
+                        }
+                    ],
+                    "blockers": [
+                        "paper_route_clean_window_baseline_snapshot_pending",
+                        "paper_route_target_plan_clean_window_baseline_not_clean",
+                    ],
+                }
+            )
+        )
+        self.assertFalse(
+            flatten_script._target_plan_readback_pending_clean_window_baseline_only(
+                {
+                    "state": "blocked",
+                    "matching_target_count": 1,
+                    "targets": [
+                        {
+                            "state": "pending_until_clean_window_baseline",
+                            "blockers": ["paper_route_account_pre_session_not_flat"],
+                        }
+                    ],
+                    "blockers": [
+                        "paper_route_clean_window_baseline_snapshot_pending",
+                        "paper_route_target_plan_clean_window_baseline_not_clean",
+                    ],
+                }
+            )
+        )
+
     def test_main_uses_database_dsn_env_for_snapshot_persistence(self) -> None:
         client = FakeFlattenClient()
         snapshot = SimpleNamespace(

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1342,6 +1342,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertIn("--target-plan-readback-timeout-seconds 10", args)
         self.assertIn("--require-target-plan-readback-clean", args)
+        self.assertIn("--allow-pending-clean-window-baseline-readback", args)
         self.assertIn('"${target_plan_readback_args[@]}"', args)
         self.assertIn("--persist-lineage", args)
         self.assertIn("--apply", args)


### PR DESCRIPTION
## Summary

- Added an explicit `--allow-pending-clean-window-baseline-readback` opt-in for the paper-account flatten producer.
- Kept `--require-target-plan-readback-clean` fail-closed for dirty, stale, missing, unreadable, and target-missing readbacks.
- Wired the Torghut paper-account flatten CronJob to tolerate only the pre-session pending-baseline state and added manifest/test coverage for that contract.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py -k "target_plan_readback or pending_baseline_allowance" -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k paper_account_flatten -q`
- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py --cov --cov-branch --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen python -m compileall scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
