### PR TITLE
fix(torghut): materialize source lifecycle before import

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -1933,6 +1933,8 @@ def repair_order_feed_execution_links(
     *,
     account_label: str | None = None,
     canonical_account_label: str | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
     limit: int = 1000,
 ) -> dict[str, int]:
     """Attach unlinked order-feed lifecycle rows to matching executions.
@@ -1985,6 +1987,16 @@ def repair_order_feed_execution_links(
     )
     if account_label:
         stmt = stmt.where(ExecutionOrderEvent.alpaca_account_label == account_label)
+    if window_start is not None:
+        stmt = stmt.where(
+            func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
+            >= _ensure_aware_utc(window_start)
+        )
+    if window_end is not None:
+        stmt = stmt.where(
+            func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
+            < _ensure_aware_utc(window_end)
+        )
 
     events = session.execute(stmt).scalars().all()
     processed_execution_ids: set[tuple[object, str]] = set()
@@ -2148,6 +2160,8 @@ def repair_order_feed_execution_states(
     session: Session,
     *,
     account_label: str | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
     limit: int = 1000,
 ) -> dict[str, int]:
     """Reapply linked order-feed lifecycle rows to durable executions.
@@ -2175,6 +2189,11 @@ def repair_order_feed_execution_states(
     )
     if account_label:
         stmt = stmt.where(Execution.alpaca_account_label == account_label)
+    activity_ts = _execution_activity_timestamp()
+    if window_start is not None:
+        stmt = stmt.where(activity_ts >= _ensure_aware_utc(window_start))
+    if window_end is not None:
+        stmt = stmt.where(activity_ts < _ensure_aware_utc(window_end))
 
     executions = session.execute(stmt).scalars().all()
     counters = {
@@ -2205,6 +2224,8 @@ def repair_order_feed_fill_deltas(
     session: Session,
     *,
     account_label: str | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
     limit: int = 1000,
 ) -> dict[str, int]:
     """Backfill fill-delta proof fields for already-persisted cumulative fills.
@@ -2242,6 +2263,16 @@ def repair_order_feed_fill_deltas(
     )
     if account_label:
         stmt = stmt.where(ExecutionOrderEvent.alpaca_account_label == account_label)
+    if window_start is not None:
+        stmt = stmt.where(
+            func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
+            >= _ensure_aware_utc(window_start)
+        )
+    if window_end is not None:
+        stmt = stmt.where(
+            func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
+            < _ensure_aware_utc(window_end)
+        )
 
     events = session.execute(stmt).scalars().all()
     counters = {
@@ -2363,6 +2394,8 @@ def backfill_order_feed_events_from_executions(
     session: Session,
     *,
     account_label: str | None = None,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
     limit: int = 1000,
 ) -> dict[str, int]:
     """Materialize bounded order-feed lifecycle rows from durable executions.
@@ -2392,6 +2425,11 @@ def backfill_order_feed_events_from_executions(
     )
     if account_label:
         stmt = stmt.where(Execution.alpaca_account_label == account_label)
+    activity_ts = _execution_activity_timestamp()
+    if window_start is not None:
+        stmt = stmt.where(activity_ts >= _ensure_aware_utc(window_start))
+    if window_end is not None:
+        stmt = stmt.where(activity_ts < _ensure_aware_utc(window_end))
 
     executions = session.execute(stmt).scalars().all()
     counters = {

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -2847,7 +2847,7 @@ def _run_runtime_window_source_window_repair(
         "5000",
         "--max-batches",
         "2",
-        "--source-window-only",
+        "--backfill-execution-events",
         "--json",
     ]
     if (

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -311,6 +311,8 @@ def main() -> int:
                     session,
                     account_label=args.account_label,
                     canonical_account_label=args.canonical_account_label,
+                    window_start=window_start,
+                    window_end=window_end,
                     limit=batch_size,
                 )
             )
@@ -323,6 +325,8 @@ def main() -> int:
                 else repair_order_feed_execution_states(
                     session,
                     account_label=execution_state_account_label,
+                    window_start=window_start,
+                    window_end=window_end,
                     limit=batch_size,
                 )
             )
@@ -330,6 +334,8 @@ def main() -> int:
                 backfill_order_feed_events_from_executions(
                     session,
                     account_label=args.account_label,
+                    window_start=window_start,
+                    window_end=window_end,
                     limit=batch_size,
                 )
                 if execution_event_backfill_enabled and not args.source_window_only
@@ -341,6 +347,8 @@ def main() -> int:
                 else repair_order_feed_fill_deltas(
                     session,
                     account_label=args.account_label,
+                    window_start=window_start,
+                    window_end=window_end,
                     limit=batch_size,
                 )
             )

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -3377,6 +3377,194 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.unlinked_execution_count, 0)
         self.assertEqual(source_window.unlinked_decision_count, 0)
 
+    def test_order_feed_repair_helpers_filter_to_runtime_window(self) -> None:
+        window_start = datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc)
+        window_end = datetime(2026, 2, 1, 10, 30, tzinfo=timezone.utc)
+        inside_ts = datetime(2026, 2, 1, 10, 5, tzinfo=timezone.utc)
+        outside_ts = datetime(2026, 2, 1, 11, 5, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            inside_link_execution = self._seed_execution(
+                session,
+                account_label="PA3SX7FYNUTF",
+                order_id="inside-link-order",
+                client_order_id="inside-link-client",
+            )
+            outside_link_execution = self._seed_execution(
+                session,
+                account_label="PA3SX7FYNUTF",
+                order_id="outside-link-order",
+                client_order_id="outside-link-client",
+            )
+            inside_state_execution = self._seed_execution(
+                session,
+                account_label="PA3SX7FYNUTF",
+                order_id="inside-state-order",
+                client_order_id="inside-state-client",
+            )
+            outside_state_execution = self._seed_execution(
+                session,
+                account_label="PA3SX7FYNUTF",
+                order_id="outside-state-order",
+                client_order_id="outside-state-client",
+            )
+            inside_backfill_execution = self._seed_execution(
+                session,
+                account_label="PA3SX7FYNUTF",
+                order_id="inside-backfill-order",
+                client_order_id="inside-backfill-client",
+            )
+            outside_backfill_execution = self._seed_execution(
+                session,
+                account_label="PA3SX7FYNUTF",
+                order_id="outside-backfill-order",
+                client_order_id="outside-backfill-client",
+            )
+            for execution, ts in (
+                (inside_link_execution, inside_ts),
+                (inside_state_execution, inside_ts),
+                (inside_backfill_execution, inside_ts),
+                (outside_link_execution, outside_ts),
+                (outside_state_execution, outside_ts),
+                (outside_backfill_execution, outside_ts),
+            ):
+                execution.last_update_at = ts
+                execution.status = "filled"
+                execution.filled_qty = Decimal("1")
+                execution.avg_fill_price = Decimal("191.25")
+                execution.raw_order = {
+                    "status": "filled",
+                    "id": execution.alpaca_order_id,
+                }
+                session.add(execution)
+            session.add_all(
+                [
+                    ExecutionOrderEvent(
+                        event_fingerprint="inside-link-event",
+                        source_topic="torghut.trade-updates.v2",
+                        source_partition=0,
+                        source_offset=201,
+                        alpaca_account_label="PA3SX7FYNUTF",
+                        event_ts=inside_ts,
+                        symbol="AAPL",
+                        alpaca_order_id="inside-link-order",
+                        client_order_id="inside-link-client",
+                        event_type="fill",
+                        status="filled",
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("191.25"),
+                        raw_event={"event": "fill"},
+                    ),
+                    ExecutionOrderEvent(
+                        event_fingerprint="outside-link-event",
+                        source_topic="torghut.trade-updates.v2",
+                        source_partition=0,
+                        source_offset=202,
+                        alpaca_account_label="PA3SX7FYNUTF",
+                        event_ts=outside_ts,
+                        symbol="AAPL",
+                        alpaca_order_id="outside-link-order",
+                        client_order_id="outside-link-client",
+                        event_type="fill",
+                        status="filled",
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("191.25"),
+                        raw_event={"event": "fill"},
+                    ),
+                    ExecutionOrderEvent(
+                        event_fingerprint="inside-state-event",
+                        source_topic="torghut.trade-updates.v2",
+                        source_partition=0,
+                        source_offset=203,
+                        alpaca_account_label="PA3SX7FYNUTF",
+                        event_ts=inside_ts,
+                        symbol="AAPL",
+                        alpaca_order_id="inside-state-order",
+                        client_order_id="inside-state-client",
+                        event_type="fill",
+                        status="filled",
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("191.25"),
+                        raw_event={"event": "fill"},
+                        execution_id=inside_state_execution.id,
+                        trade_decision_id=inside_state_execution.trade_decision_id,
+                    ),
+                    ExecutionOrderEvent(
+                        event_fingerprint="outside-state-event",
+                        source_topic="torghut.trade-updates.v2",
+                        source_partition=0,
+                        source_offset=204,
+                        alpaca_account_label="PA3SX7FYNUTF",
+                        event_ts=outside_ts,
+                        symbol="AAPL",
+                        alpaca_order_id="outside-state-order",
+                        client_order_id="outside-state-client",
+                        event_type="fill",
+                        status="filled",
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("191.25"),
+                        raw_event={"event": "fill"},
+                        execution_id=outside_state_execution.id,
+                        trade_decision_id=outside_state_execution.trade_decision_id,
+                    ),
+                ]
+            )
+            session.commit()
+
+            link_result = repair_order_feed_execution_links(
+                session,
+                account_label="PA3SX7FYNUTF",
+                window_start=window_start,
+                window_end=window_end,
+                limit=10,
+            )
+            session.commit()
+            state_result = repair_order_feed_execution_states(
+                session,
+                account_label="PA3SX7FYNUTF",
+                window_start=window_start,
+                window_end=window_end,
+                limit=10,
+            )
+            session.commit()
+            delta_result = repair_order_feed_fill_deltas(
+                session,
+                account_label="PA3SX7FYNUTF",
+                window_start=window_start,
+                window_end=window_end,
+                limit=10,
+            )
+            session.commit()
+            backfill_result = backfill_order_feed_events_from_executions(
+                session,
+                account_label="PA3SX7FYNUTF",
+                window_start=window_start,
+                window_end=window_end,
+                limit=10,
+            )
+            session.commit()
+            outside_link_event = session.scalar(
+                select(ExecutionOrderEvent).where(
+                    ExecutionOrderEvent.event_fingerprint == "outside-link-event"
+                )
+            )
+            outside_backfill_event_count = session.scalar(
+                select(func.count(ExecutionOrderEvent.id)).where(
+                    ExecutionOrderEvent.alpaca_order_id == "outside-backfill-order"
+                )
+            )
+
+        self.assertEqual(link_result["selected"], 1)
+        self.assertEqual(link_result["events_linked"], 1)
+        self.assertEqual(state_result["selected"], 2)
+        self.assertEqual(delta_result["selected"], 2)
+        self.assertEqual(backfill_result["selected"], 1)
+        self.assertEqual(backfill_result["events_created"], 1)
+        self.assertIsNotNone(outside_link_event)
+        assert outside_link_event is not None
+        self.assertIsNone(outside_link_event.execution_id)
+        self.assertEqual(outside_backfill_event_count, 0)
+
     def test_execution_event_backfill_filters_existing_order_feed_lifecycle(
         self,
     ) -> None:

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -203,17 +203,23 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             fake_session,
             account_label=None,
             canonical_account_label=None,
+            window_start=None,
+            window_end=None,
             limit=5000,
         )
         backfill_execution_events.assert_not_called()
         repair_states.assert_called_once_with(
             fake_session,
             account_label=None,
+            window_start=None,
+            window_end=None,
             limit=5000,
         )
         repair_deltas.assert_called_once_with(
             fake_session,
             account_label=None,
+            window_start=None,
+            window_end=None,
             limit=5000,
         )
 
@@ -470,12 +476,36 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(repair_links.call_count, 1)
         self.assertEqual(repair_links.call_args.kwargs["account_label"], "TORGHUT_SIM")
         self.assertIsNone(repair_links.call_args.kwargs["canonical_account_label"])
+        self.assertEqual(
+            repair_links.call_args.kwargs["window_start"].isoformat(),
+            "2026-05-13T17:00:00+00:00",
+        )
+        self.assertEqual(
+            repair_links.call_args.kwargs["window_end"].isoformat(),
+            "2026-05-13T17:30:00+00:00",
+        )
         self.assertEqual(repair_links.call_args.kwargs["limit"], 1000)
         self.assertEqual(repair_states.call_count, 1)
         self.assertEqual(repair_states.call_args.kwargs["account_label"], "TORGHUT_SIM")
+        self.assertEqual(
+            repair_states.call_args.kwargs["window_start"].isoformat(),
+            "2026-05-13T17:00:00+00:00",
+        )
+        self.assertEqual(
+            repair_states.call_args.kwargs["window_end"].isoformat(),
+            "2026-05-13T17:30:00+00:00",
+        )
         self.assertEqual(repair_states.call_args.kwargs["limit"], 1000)
         self.assertEqual(repair_deltas.call_count, 1)
         self.assertEqual(repair_deltas.call_args.kwargs["account_label"], "TORGHUT_SIM")
+        self.assertEqual(
+            repair_deltas.call_args.kwargs["window_start"].isoformat(),
+            "2026-05-13T17:00:00+00:00",
+        )
+        self.assertEqual(
+            repair_deltas.call_args.kwargs["window_end"].isoformat(),
+            "2026-05-13T17:30:00+00:00",
+        )
         self.assertEqual(repair_deltas.call_args.kwargs["limit"], 1000)
 
     def test_main_source_window_only_skips_broader_repairs(self) -> None:
@@ -570,6 +600,10 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                     "LIVE_DSN",
                     "--account-label",
                     "PA3SX7FYNUTF",
+                    "--window-start",
+                    "2026-05-13T17:00:00Z",
+                    "--window-end",
+                    "2026-05-13T17:30:00Z",
                     "--batch-size",
                     "100",
                     "--max-batches",
@@ -650,6 +684,8 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["execution_event_backfill_enabled"], True)
         self.assertIsNone(payload["execution_event_backfill_skip_reason"])
         self.assertEqual(payload["account_label"], "PA3SX7FYNUTF")
+        self.assertEqual(payload["window_start"], "2026-05-13T17:00:00+00:00")
+        self.assertEqual(payload["window_end"], "2026-05-13T17:30:00+00:00")
         self.assertEqual(payload["execution_state_candidates"], 0)
         self.assertEqual(payload["execution_state_executions_updated"], 0)
         self.assertEqual(payload["execution_event_backfill_candidates"], 7)
@@ -662,16 +698,22 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         backfill_execution_events.assert_called_once_with(
             fake_session,
             account_label="PA3SX7FYNUTF",
+            window_start=script._parse_optional_dt("2026-05-13T17:00:00Z"),
+            window_end=script._parse_optional_dt("2026-05-13T17:30:00Z"),
             limit=100,
         )
         repair_states.assert_called_once_with(
             fake_session,
             account_label="PA3SX7FYNUTF",
+            window_start=script._parse_optional_dt("2026-05-13T17:00:00Z"),
+            window_end=script._parse_optional_dt("2026-05-13T17:30:00Z"),
             limit=100,
         )
         repair_deltas.assert_called_once_with(
             fake_session,
             account_label="PA3SX7FYNUTF",
+            window_start=script._parse_optional_dt("2026-05-13T17:00:00Z"),
+            window_end=script._parse_optional_dt("2026-05-13T17:30:00Z"),
             limit=100,
         )
 
@@ -778,6 +820,8 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         repair_states.assert_called_once_with(
             fake_session,
             account_label="TORGHUT_SIM",
+            window_start=None,
+            window_end=None,
             limit=100,
         )
 

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -2932,11 +2932,14 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 {
                     "status": "ok",
                     "apply": True,
-                    "source_window_only": True,
+                    "source_window_only": False,
+                    "backfill_execution_events": True,
+                    "execution_event_backfill_enabled": True,
                     "selected": 2,
                     "source_windows_created": 1,
                     "source_windows_reused": 1,
                     "events_linked": 2,
+                    "execution_event_backfill_events_created": 1,
                 }
             )
         )
@@ -2971,7 +2974,8 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         import_command = run_mock.call_args_list[1].args[0]
         self.assertIn("scripts/repair_order_feed_source_windows.py", repair_command)
         self.assertIn("--apply", repair_command)
-        self.assertIn("--source-window-only", repair_command)
+        self.assertIn("--backfill-execution-events", repair_command)
+        self.assertNotIn("--source-window-only", repair_command)
         self.assertIn("--window-start", repair_command)
         self.assertEqual(
             repair_command[repair_command.index("--window-start") + 1],
@@ -2995,7 +2999,11 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             "TORGHUT_PAPER",
         )
         self.assertEqual(payload["source_window_repair"]["events_linked"], 2)
-        self.assertTrue(payload["source_window_repair"]["source_window_only"])
+        self.assertFalse(payload["source_window_repair"]["source_window_only"])
+        self.assertTrue(payload["source_window_repair"]["backfill_execution_events"])
+        self.assertTrue(
+            payload["source_window_repair"]["execution_event_backfill_enabled"]
+        )
         self.assertEqual(payload["summary"]["source_window_repair"]["events_linked"], 2)
 
     def test_runtime_window_import_audit_only_dry_runs_source_window_repair(
@@ -3049,7 +3057,9 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 {
                     "status": "ok",
                     "apply": False,
-                    "source_window_only": True,
+                    "source_window_only": False,
+                    "backfill_execution_events": True,
+                    "execution_event_backfill_enabled": True,
                     "selected": 2,
                     "source_windows_created": 1,
                     "source_windows_reused": 1,
@@ -3087,13 +3097,15 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(run_mock.call_count, 2)
         repair_command = run_mock.call_args_list[0].args[0]
         import_command = run_mock.call_args_list[1].args[0]
-        self.assertIn("--source-window-only", repair_command)
+        self.assertIn("--backfill-execution-events", repair_command)
+        self.assertNotIn("--source-window-only", repair_command)
         self.assertNotIn("--apply", repair_command)
         self.assertIn("--audit-only", import_command)
         self.assertEqual(payload["status"], "audit_only")
         self.assertEqual(payload["proof_status"], "blocked")
         self.assertFalse(payload["source_window_repair"]["apply"])
-        self.assertTrue(payload["source_window_repair"]["source_window_only"])
+        self.assertFalse(payload["source_window_repair"]["source_window_only"])
+        self.assertTrue(payload["source_window_repair"]["backfill_execution_events"])
         blocker_codes = [item["blocker"] for item in payload["proof_blockers"]]
         self.assertIn("runtime_window_import_audit_only_no_persistence", blocker_codes)
 


### PR DESCRIPTION
## Summary

- Bounds order-feed source-window, execution-link, execution-state, fill-delta, and execution-event backfill repairs to the target runtime import window.
- Runs bounded full lifecycle/source materialization, including execution-event backfill, before importing source-collection runtime-window targets.
- Keeps source-collection proof fail-closed: the importer still blocks unless real source lifecycle, TCA, and runtime-ledger evidence materialize.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'source_window_repair or runtime_window_import_repairs_source_windows or audit_only_dry_runs_source_window_repair' -q`
- `uv run --frozen pytest tests/test_repair_order_feed_source_windows_script.py -q`
- `uv run --frozen pytest tests/test_order_feed.py -k 'repair_helpers_filter_to_runtime_window or backfill_order_feed_events_from_executions' -q`
- `uv run --frozen pytest tests/test_order_feed.py -q`
- `uv run --frozen pytest tests/test_repair_order_feed_source_windows_script.py tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen ruff check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff format --check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen python -m compileall app/trading/order_feed.py scripts/repair_order_feed_source_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_run_empirical_promotion_jobs.py --cov --cov-branch --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
