### PR TITLE
fix(torghut): respect target notional for paper-route sizing

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1699,12 +1699,19 @@ def _paper_route_probe_symbol_quantities(
         fallback_quantity = _safe_decimal(target.get(field))
         if fallback_quantity > 0:
             break
-    if fallback_quantity <= 0 and normalized_symbols:
-        # The bounded source materializer requires an explicit quantity per leg.
-        # H-PAIRS collection is capped independently by the target notional and
-        # simple-pipeline risk clamps; use the minimum integer probe leg so the
-        # materializer can create auditable source decisions instead of
-        # silently producing a zero-decision packet.
+    target_notional = Decimal("0")
+    for field in (
+        "target_notional",
+        "paper_route_probe_target_notional",
+        "paper_route_probe_effective_max_notional",
+        "bounded_evidence_collection_max_notional",
+        "paper_route_probe_next_session_max_notional",
+        "max_notional",
+    ):
+        target_notional = _safe_decimal(target.get(field))
+        if target_notional > 0:
+            break
+    if fallback_quantity <= 0 and normalized_symbols and target_notional <= 0:
         fallback_quantity = Decimal("1")
 
     if fallback_quantity > 0:
@@ -2576,6 +2583,10 @@ def _next_paper_route_runtime_window_targets(
             or runtime_strategy_name
             or strategy_name
             or "",
+            "target_notional": next_notional,
+            "paper_route_probe_target_notional": next_notional,
+            "paper_route_probe_next_session_max_notional": next_notional,
+            "paper_route_probe_effective_max_notional": next_notional,
         }
         pair_balance_required = _target_requires_balanced_pair_probe(
             pair_balance_target
@@ -2970,7 +2981,9 @@ def _next_paper_route_runtime_window_targets(
                 )
             ),
             "paper_route_probe_symbol_quantity_source": (
-                "target_plan_explicit_or_min_integer_probe"
+                "target_plan_explicit_quantity"
+                if pair_symbol_quantities
+                else "target_notional_runtime_sizing"
             ),
             "paper_route_probe_pair_balance_required": pair_balance_required,
             "paper_route_probe_pair_balance_state": pair_balance_state,

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -35,6 +35,7 @@ PAPER_ROUTE_MATERIALIZATION_FINAL_PROMOTION_BLOCKERS = (
     "paper_route_runtime_ledger_import_pending",
 )
 PAPER_ROUTE_MATERIALIZATION_HPAIRS_HYPOTHESIS_ID = "H-PAIRS-01"
+PAPER_ROUTE_TARGET_NOTIONAL_SOURCE_DECISION_SEED_QTY = Decimal("1")
 
 
 def _to_str_map(value: object) -> dict[str, Any]:
@@ -450,6 +451,20 @@ def _target_symbol_quantities(target: Mapping[str, Any]) -> dict[str, Decimal]:
     return quantities
 
 
+def _target_source_decision_quantities(
+    target: Mapping[str, Any],
+) -> dict[str, Decimal]:
+    quantities = _target_symbol_quantities(target)
+    if quantities:
+        return quantities
+    if _target_notional(target) <= 0:
+        return {}
+    return {
+        symbol: PAPER_ROUTE_TARGET_NOTIONAL_SOURCE_DECISION_SEED_QTY
+        for symbol in _target_symbol_actions(target)
+    }
+
+
 def _target_notional(target: Mapping[str, Any]) -> Decimal:
     return _positive_decimal_from_fields(
         target,
@@ -557,7 +572,6 @@ def _target_identity_blockers(identity: Mapping[str, Any]) -> list[str]:
         "account_label",
         "source_plan_ref",
         "target_notional",
-        "target_quantity",
         "bounded_collection_stage",
     )
     blockers = [
@@ -565,7 +579,6 @@ def _target_identity_blockers(identity: Mapping[str, Any]) -> list[str]:
         for field in required
         if not _safe_text(identity.get(field))
         or (field == "target_notional" and _safe_decimal(identity.get(field)) <= 0)
-        or (field == "target_quantity" and _safe_decimal(identity.get(field)) <= 0)
     ]
     if (
         _safe_text(identity.get("account_label"))
@@ -629,7 +642,7 @@ def _target_materialization_blockers(
     missing_quantity_symbols = sorted(
         symbol for symbol in actions if symbol not in quantities
     )
-    if missing_quantity_symbols:
+    if missing_quantity_symbols and target_notional <= 0:
         blockers.append("paper_route_target_symbol_quantities_missing")
     return sorted(dict.fromkeys(blockers))
 
@@ -751,6 +764,15 @@ def _paper_route_decision_payload(
     decision_strategy_id = _safe_text(identity.get("strategy_id")) or _safe_text(
         identity.get("runtime_strategy_name")
     )
+    explicit_symbol_quantities = _target_symbol_quantities(target)
+    quantity_source = (
+        "target_plan_explicit_quantity"
+        if symbol in explicit_symbol_quantities
+        else "target_notional_runtime_sizing_seed"
+    )
+    target_notional_sizing_required = (
+        target_notional > 0 and symbol not in explicit_symbol_quantities
+    )
     source_decision_metadata: dict[str, Any] = {
         "mode": "paper_route_target_plan_source_decision",
         "source": PAPER_ROUTE_MATERIALIZATION_SOURCE,
@@ -777,17 +799,18 @@ def _paper_route_decision_payload(
         "qty": _decimal_text(quantity),
         "target_quantity": _decimal_text(quantity),
         "target_notional": _decimal_text(target_notional),
+        "target_quantity_source": quantity_source,
+        "target_notional_sizing_required": target_notional_sizing_required,
         "paper_route_probe_next_session_max_notional": _decimal_text(target_notional),
         "paper_route_probe_effective_max_notional": _decimal_text(target_notional),
         "paper_route_probe_window_start": identity.get("window_start"),
         "paper_route_probe_window_end": identity.get("window_end"),
         "paper_route_probe_symbols": sorted(_target_symbol_actions(target)),
         "paper_route_probe_symbol_actions": _target_symbol_actions(target),
+        "paper_route_probe_symbol_quantity_source": quantity_source,
         "paper_route_probe_symbol_quantities": {
             item_symbol: _decimal_text(item_quantity)
-            for item_symbol, item_quantity in sorted(
-                _target_symbol_quantities(target).items()
-            )
+            for item_symbol, item_quantity in sorted(explicit_symbol_quantities.items())
         },
         "bounded_collection_stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
         "bounded_evidence_collection_authorized": True,
@@ -862,6 +885,8 @@ def _paper_route_decision_payload(
         "qty": _decimal_text(quantity),
         "target_quantity": _decimal_text(quantity),
         "target_notional": _decimal_text(target_notional),
+        "target_quantity_source": quantity_source,
+        "target_notional_sizing_required": target_notional_sizing_required,
         "bounded_collection_stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
         "bounded_evidence_collection_max_notional": _safe_text(
             target.get("bounded_evidence_collection_max_notional")
@@ -879,6 +904,8 @@ def _paper_route_decision_payload(
             "side": action,
             "qty": _decimal_text(quantity),
             "target_notional": _decimal_text(target_notional),
+            "target_quantity_source": quantity_source,
+            "target_notional_sizing_required": target_notional_sizing_required,
             "order_type": "market",
             "time_in_force": "day",
             "live_capital_routing_enabled": False,
@@ -918,6 +945,8 @@ def _paper_route_decision_payload(
             "source_plan_ref": identity.get("source_plan_ref"),
             "target_notional": _decimal_text(target_notional),
             "target_quantity": _decimal_text(quantity),
+            "target_quantity_source": quantity_source,
+            "target_notional_sizing_required": target_notional_sizing_required,
             "bounded_collection_stage": PAPER_ROUTE_MATERIALIZATION_STAGE,
             "promotion_allowed": False,
             "final_authority_ok": False,
@@ -992,7 +1021,7 @@ def materialize_bounded_paper_route_target_plan(
 
         target_notional = _safe_decimal(identity.get("target_notional"))
         for symbol, action in _target_symbol_actions(target).items():
-            quantity = _target_symbol_quantities(target)[symbol]
+            quantity = _target_source_decision_quantities(target)[symbol]
             payload = _paper_route_decision_payload(
                 target=target,
                 identity=identity,

--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -244,9 +244,7 @@ def _target_bounded_materialization_authorized(target: Mapping[str, Any]) -> boo
 
 def _target_materialization_score(target: Mapping[str, Any]) -> tuple[int, int, int]:
     materializable_shape = int(
-        bool(_target_symbol_actions(target))
-        and _target_notional(target) > 0
-        and _target_quantity(target) > 0
+        bool(_target_symbol_actions(target)) and _target_notional(target) > 0
     )
     bounded_authorized = int(
         _target_bounded_materialization_authorized(target) and materializable_shape
@@ -294,7 +292,9 @@ def _candidate_materialization_plans(
         ),
         (
             "latest_closed_paper_route_runtime_window_targets",
-            _to_str_map(payload.get("latest_closed_paper_route_runtime_window_targets")),
+            _to_str_map(
+                payload.get("latest_closed_paper_route_runtime_window_targets")
+            ),
         ),
         (
             "next_paper_route_runtime_window_targets",
@@ -864,7 +864,7 @@ def _safety_blockers(
             blockers.append(
                 f"paper_route_materialization_target_{index}_target_notional_exceeds_max"
             )
-        if _safe_decimal(summary.get("target_quantity")) <= 0:
+        if _safe_decimal(summary.get("target_quantity")) <= 0 and target_notional <= 0:
             blockers.append(
                 f"paper_route_materialization_target_{index}_target_quantity_missing"
             )

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -1211,7 +1211,10 @@ def test_commit_dynamic_next_window_plan_at_configured_notional_skips_before_ope
 ) -> None:
     payload = {
         "next_paper_route_runtime_window_targets": _plan(
-            _hpairs_target(target_notional="75000")
+            _hpairs_target(
+                target_notional="75000",
+                paper_route_probe_symbol_quantities={},
+            )
         ),
     }
     monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
@@ -1272,7 +1275,10 @@ def test_commit_dynamic_next_window_plan_at_configured_notional_writes_when_open
 ) -> None:
     payload = {
         "next_paper_route_runtime_window_targets": _plan(
-            _hpairs_target(target_notional="75000")
+            _hpairs_target(
+                target_notional="75000",
+                paper_route_probe_symbol_quantities={},
+            )
         ),
     }
     monkeypatch.setattr(cli, "_fetch_plan_url_payload", lambda *_, **__: payload)
@@ -1846,7 +1852,7 @@ def test_paper_route_target_plan_missing_dsn_live_capital_mode_and_empty_plan_ar
     assert "paper_route_materialization_target_plan_targets_missing" in blockers
 
 
-def test_paper_route_target_plan_rejects_exceeded_notional_missing_quantity_and_missing_actions(
+def test_paper_route_target_plan_rejects_exceeded_notional_and_missing_actions(
     tmp_path: Path,
     sqlite_dsn: str,
     capsys: pytest.CaptureFixture[str],
@@ -1873,7 +1879,6 @@ def test_paper_route_target_plan_rejects_exceeded_notional_missing_quantity_and_
     assert (
         "paper_route_materialization_target_0_target_notional_exceeds_max" in blockers
     )
-    assert "paper_route_materialization_target_0_target_quantity_missing" in blockers
     assert "paper_route_materialization_target_0_symbol_actions_missing" in blockers
     assert _count_decisions(sqlite_dsn) == 0
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
@@ -806,6 +806,22 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
 
         self.assertEqual(quantities, {"AAPL": "0.5", "AMZN": "0.7"})
+
+    def test_probe_symbol_quantities_do_not_seed_notional_authoritative_targets(
+        self,
+    ) -> None:
+        quantities = _paper_route_probe_symbol_quantities(
+            {
+                "target_notional": "75000",
+                "paper_route_probe_symbol_actions": {
+                    "AAPL": "buy",
+                    "AMZN": "sell",
+                },
+            },
+            ["AAPL", "AMZN"],
+        )
+
+        self.assertEqual(quantities, {})
 
     def test_non_pair_probe_symbol_actions_default_to_buy(self) -> None:
         actions = _paper_route_probe_symbol_actions(
@@ -3159,7 +3175,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target = plan["targets"][0]
             self.assertEqual(
                 target["paper_route_probe_symbol_quantities"],
-                {"AAPL": "1", "AMZN": "1"},
+                {},
+            )
+            self.assertEqual(target["paper_route_probe_target_quantity"], "0")
+            self.assertEqual(
+                target["paper_route_probe_symbol_quantity_source"],
+                "target_notional_runtime_sizing",
             )
             self.assertFalse(target["promotion_allowed"])
             self.assertFalse(target["final_promotion_allowed"])
@@ -3170,10 +3191,26 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 generated_at=generated_at,
                 bounded_notional_limit=Decimal("25"),
             )
+            decision_payloads = [
+                row.decision_json
+                for row in session.execute(select(TradeDecision)).scalars().all()
+            ]
 
         self.assertEqual(materialized["materialized_decision_count"], 2)
         self.assertEqual(materialized["route_submission_count"], 2)
         self.assertEqual(materialized["blocked_target_count"], 0)
+        self.assertEqual(len(decision_payloads), 2)
+        for decision_payload in decision_payloads:
+            self.assertEqual(
+                decision_payload["target_quantity_source"],
+                "target_notional_runtime_sizing_seed",
+            )
+            self.assertTrue(decision_payload["target_notional_sizing_required"])
+            source_metadata = decision_payload["params"][
+                "paper_route_target_plan_source_decision"
+            ]
+            self.assertEqual(source_metadata["paper_route_probe_symbol_quantities"], {})
+            self.assertTrue(source_metadata["target_notional_sizing_required"])
         self.assertFalse(materialized["promotion_allowed"])
         self.assertFalse(materialized["final_promotion_allowed"])
         self.assertFalse(materialized["live_capital_routing_enabled"])

--- a/services/torghut/tests/test_paper_route_target_plan.py
+++ b/services/torghut/tests/test_paper_route_target_plan.py
@@ -24,6 +24,7 @@ from app.trading.paper_route_target_plan import (
     _paper_route_source_materialization_blockers,
     _target_identity_keys,
     _target_plan_selection_score,
+    _target_source_decision_quantities,
     _target_source_decision_ready,
     _truthy,
     materialize_bounded_paper_route_target_plan,
@@ -131,11 +132,108 @@ def _plan(*targets: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def test_materializer_accepts_notional_authoritative_target_without_quantities(
+    db_session: Session,
+) -> None:
+    target = _hpairs_target(
+        paper_route_probe_symbol_quantities={},
+        target_symbol_quantities={},
+        symbol_quantities={},
+        target_quantity="",
+        target_notional="20",
+    )
+
+    result = materialize_bounded_paper_route_target_plan(
+        db_session,
+        _plan(target),
+        generated_at=datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+        bounded_notional_limit=Decimal("20"),
+    )
+    decisions = db_session.execute(select(TradeDecision)).scalars().all()
+
+    assert result["materialized_decision_count"] == 2
+    assert result["blocked_target_count"] == 0
+    assert len(decisions) == 2
+    for decision in decisions:
+        payload = decision.decision_json
+        assert payload["qty"] == "1"
+        assert payload["target_quantity_source"] == (
+            "target_notional_runtime_sizing_seed"
+        )
+        assert payload["target_notional_sizing_required"] is True
+        metadata = payload["params"]["paper_route_target_plan_source_decision"]
+        assert metadata["paper_route_probe_symbol_quantities"] == {}
+        assert metadata["paper_route_probe_symbol_quantity_source"] == (
+            "target_notional_runtime_sizing_seed"
+        )
+        assert metadata["target_notional_sizing_required"] is True
+
+
+def test_materializer_preserves_explicit_quantities_without_runtime_sizing(
+    db_session: Session,
+) -> None:
+    target = _hpairs_target(
+        target_notional="20",
+        paper_route_probe_symbol_quantities={
+            "AAPL": "0.25",
+            "AMZN": "0.75",
+        },
+    )
+
+    result = materialize_bounded_paper_route_target_plan(
+        db_session,
+        _plan(target),
+        generated_at=datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+        bounded_notional_limit=Decimal("20"),
+    )
+    decisions = db_session.execute(select(TradeDecision)).scalars().all()
+
+    assert result["materialized_decision_count"] == 2
+    assert result["blocked_target_count"] == 0
+    assert {
+        decision.symbol: decision.decision_json["qty"] for decision in decisions
+    } == {
+        "AAPL": "0.25",
+        "AMZN": "0.75",
+    }
+    for decision in decisions:
+        payload = decision.decision_json
+        assert payload["target_quantity_source"] == "target_plan_explicit_quantity"
+        assert payload["target_notional_sizing_required"] is False
+        metadata = payload["params"]["paper_route_target_plan_source_decision"]
+        assert metadata["paper_route_probe_symbol_quantities"] == {
+            "AAPL": "0.25",
+            "AMZN": "0.75",
+        }
+        assert (
+            metadata["paper_route_probe_symbol_quantity_source"]
+            == "target_plan_explicit_quantity"
+        )
+        assert metadata["target_notional_sizing_required"] is False
+
+
 def test_materialization_truthy_helper_accepts_numeric_and_text_readiness() -> None:
     assert _truthy(1) is True
     assert _truthy(0) is False
     assert _truthy("true") is True
     assert _truthy("false") is False
+
+
+def test_target_source_decision_quantities_fail_closed_without_quantity_or_notional() -> (
+    None
+):
+    assert (
+        _target_source_decision_quantities(
+            _hpairs_target(
+                paper_route_probe_symbol_quantities={},
+                target_symbol_quantities={},
+                symbol_quantities={},
+                target_quantity="",
+                target_notional="0",
+            )
+        )
+        == {}
+    )
 
 
 def test_target_source_decision_readiness_accepts_text_truth() -> None:


### PR DESCRIPTION
## Summary

- Stops H-PAIRS target plans from publishing fake one-share quantities when positive target notional is the actual sizing authority.
- Lets the bounded paper-route materializer accept notional-authoritative targets without explicit symbol quantities, while marking seed decisions as runtime-notional-sized.
- Keeps explicit symbol quantities on the explicit path and updates dynamic plan scoring so notional-only next-window plans are selectable.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_paper_route_target_plan.py tests/test_materialize_bounded_paper_route_targets.py tests/test_simple_pipeline.py`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml:coverage.xml tests/test_paper_route_evidence.py tests/test_paper_route_target_plan.py tests/test_materialize_bounded_paper_route_targets.py tests/test_simple_pipeline.py && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py app/trading/paper_route_target_plan.py scripts/materialize_bounded_paper_route_targets.py tests/test_paper_route_evidence.py tests/test_paper_route_target_plan.py tests/test_materialize_bounded_paper_route_targets.py && uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall app && uv run --frozen python scripts/check_migration_graph.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
