### PR TITLE
fix(torghut): block stale runtime proof packets

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1771,6 +1771,87 @@ def _first_env_text(names: Sequence[str]) -> str:
     return ""
 
 
+def _normalize_image_digest(value: object) -> str:
+    text = _text(value)
+    marker = "sha256:"
+    if marker not in text:
+        return ""
+    return text[text.index(marker) :]
+
+
+def _commit_refs_match(left: str, right: str) -> bool:
+    if not left or not right:
+        return True
+    return left == right or left.startswith(right) or right.startswith(left)
+
+
+def _assembly_code_lineage() -> dict[str, Any]:
+    code_commit = _first_env_text(
+        (
+            "TORGHUT_COMMIT",
+            "TORGHUT_IMAGE_COMMIT",
+            "GIT_COMMIT",
+            "SOURCE_COMMIT",
+            "CODE_COMMIT",
+            "COMMIT_SHA",
+        )
+    )
+    image_digest = _first_env_text(
+        (
+            "TORGHUT_IMAGE_DIGEST",
+            "IMAGE_DIGEST",
+            "CONTAINER_IMAGE_DIGEST",
+            "K_REVISION_IMAGE_DIGEST",
+        )
+    )
+    image = _first_env_text(("TORGHUT_IMAGE", "CONTAINER_IMAGE", "IMAGE"))
+    return {
+        "commit": code_commit,
+        "image": image,
+        "image_digest": image_digest,
+        "commit_available": bool(code_commit),
+        "image_digest_available": bool(image_digest),
+    }
+
+
+def _status_build_code_lineage(status: Mapping[str, Any]) -> dict[str, Any]:
+    build = _mapping(status.get("build"))
+    return {
+        "version": _text(build.get("version")),
+        "commit": _text(build.get("commit")),
+        "image_digest": _text(build.get("image_digest")),
+        "active_revision": _text(build.get("active_revision")),
+        "commit_available": bool(_text(build.get("commit"))),
+        "image_digest_available": bool(_text(build.get("image_digest"))),
+    }
+
+
+def _runtime_code_parity(status: Mapping[str, Any]) -> dict[str, Any]:
+    status_code = _status_build_code_lineage(status)
+    assembly_code = _assembly_code_lineage()
+    status_digest = _normalize_image_digest(status_code.get("image_digest"))
+    assembly_digest = _normalize_image_digest(assembly_code.get("image_digest"))
+    status_commit = _text(status_code.get("commit"))
+    assembly_commit = _text(assembly_code.get("commit"))
+    blockers: list[str] = []
+    if status_digest and assembly_digest and status_digest != assembly_digest:
+        blockers.append("proof_packet_assembly_image_digest_mismatch")
+    if (
+        status_commit
+        and assembly_commit
+        and not _commit_refs_match(status_commit, assembly_commit)
+    ):
+        blockers.append("proof_packet_assembly_commit_mismatch")
+    return {
+        "schema_version": "torghut.runtime-ledger-proof-packet-code-parity.v1",
+        "live_status_build": status_code,
+        "assembly_runtime": assembly_code,
+        "image_digest_parity_checked": bool(status_digest and assembly_digest),
+        "commit_parity_checked": bool(status_commit and assembly_commit),
+        "blockers": blockers,
+    }
+
+
 def _runtime_ledger_immutable_lineage(
     *,
     identity: Mapping[str, object],
@@ -1900,24 +1981,7 @@ def _runtime_ledger_immutable_lineage(
     runtime_strategy = _text(
         identity.get("runtime_strategy_name") or identity.get("strategy_name")
     )
-    code_commit = _first_env_text(
-        (
-            "TORGHUT_IMAGE_COMMIT",
-            "GIT_COMMIT",
-            "SOURCE_COMMIT",
-            "CODE_COMMIT",
-            "COMMIT_SHA",
-        )
-    )
-    image_digest = _first_env_text(
-        (
-            "TORGHUT_IMAGE_DIGEST",
-            "IMAGE_DIGEST",
-            "CONTAINER_IMAGE_DIGEST",
-            "K_REVISION_IMAGE_DIGEST",
-        )
-    )
-    image = _first_env_text(("TORGHUT_IMAGE", "CONTAINER_IMAGE", "IMAGE"))
+    code = _assembly_code_lineage()
     return {
         "schema_version": "torghut.runtime-ledger-proof-packet-lineage.v1",
         "hypothesis_id": _text(identity.get("hypothesis_id")),
@@ -1944,13 +2008,7 @@ def _runtime_ledger_immutable_lineage(
             "metric_window_id_count": len(metric_window_ids),
             "promotion_decision_id_count": len(promotion_decision_ids),
         },
-        "code": {
-            "commit": code_commit,
-            "image": image,
-            "image_digest": image_digest,
-            "commit_available": bool(code_commit),
-            "image_digest_available": bool(image_digest),
-        },
+        "code": code,
     }
 
 
@@ -2066,6 +2124,13 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
             )
         elif blocker == RUNTIME_LEDGER_PROOF_MODE_NOT_AUTHORITY_BLOCKER:
             _extend_unique(actions, ["rerun_proof_packet_in_authority_mode"])
+        elif blocker in {
+            "proof_packet_assembly_image_digest_mismatch",
+            "proof_packet_assembly_commit_mismatch",
+        }:
+            _extend_unique(
+                actions, ["rerun_runtime_window_import_on_current_torghut_image"]
+            )
         elif blocker.startswith("runtime_ledger_") or blocker in {
             "filled_notional_missing",
             "closed_round_trip_missing",
@@ -2229,6 +2294,21 @@ def build_runtime_ledger_proof_packet(
         blockers=live_blockers,
     )
     _extend_unique(blockers, live_blockers)
+
+    runtime_code_parity = _runtime_code_parity(status)
+    runtime_code_parity_blockers = _text_list(runtime_code_parity.get("blockers"))
+    _check(
+        checks,
+        "runtime_code_parity",
+        passed=not runtime_code_parity_blockers,
+        observed=runtime_code_parity,
+        expected=(
+            "proof-packet assembler runtime image and commit match live Torghut "
+            "status when both sides expose build identity"
+        ),
+        blockers=runtime_code_parity_blockers,
+    )
+    _extend_unique(blockers, runtime_code_parity_blockers)
 
     plan = _paper_route_target_plan(paper_route_evidence)
     paper_targets = _paper_route_targets(plan)
@@ -3299,6 +3379,7 @@ def build_runtime_ledger_proof_packet(
                 "materialization": materialization_summary,
                 "lineage": runtime_import_lineage,
             },
+            "runtime_code_parity": runtime_code_parity,
             "completion_live_scale": {
                 "gate_status": live_scale_gate.get("status"),
                 "runtime_ledger_summary": dict(runtime_summary),

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -829,6 +829,54 @@ class TestRuntimeLedgerProofPacket(TestCase):
             ],
         )
 
+    def test_packet_blocks_stale_assembly_image_against_live_status(self) -> None:
+        status = _status()
+        status["build"] = {
+            "version": "v0.596.0-371-gcurrent",
+            "commit": "abc123",
+            "image_digest": "sha256:current",
+            "active_revision": "torghut-01158",
+        }
+
+        with patch.dict(
+            os.environ,
+            {
+                "TORGHUT_COMMIT": "abc123",
+                "TORGHUT_IMAGE_DIGEST": "sha256:stale",
+            },
+            clear=True,
+        ):
+            result = packet.build_runtime_ledger_proof_packet(
+                status,
+                proof_mode="authority",
+                paper_route_evidence=_paper_route_evidence(),
+                runtime_window_import=_runtime_import(),
+                completion_status=_completion(),
+                min_runtime_ledger_net_pnl=Decimal("500"),
+                min_runtime_ledger_daily_net_pnl=Decimal("500"),
+                min_runtime_ledger_trading_days=1,
+                generated_at="2026-05-26T21:05:00+00:00",
+            )
+
+        self.assertFalse(result["ok"], result)
+        self.assertIn(
+            "proof_packet_assembly_image_digest_mismatch",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "rerun_runtime_window_import_on_current_torghut_image",
+            result["required_actions"],
+        )
+        parity = result["checks"]["runtime_code_parity"]
+        self.assertFalse(parity["passed"])
+        self.assertEqual(
+            parity["observed"]["live_status_build"]["image_digest"], "sha256:current"
+        )
+        self.assertEqual(
+            parity["observed"]["assembly_runtime"]["image_digest"], "sha256:stale"
+        )
+        self.assertEqual(result["lineage"]["code"]["commit"], "abc123")
+
     def test_packet_lineage_preserves_runtime_window_readback_refs(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),


### PR DESCRIPTION
## Summary

- Added proof-packet runtime code parity against live `/trading/status` build identity.
- Recorded `TORGHUT_COMMIT` in runtime proof packet lineage.
- Fail closed with explicit stale image or commit blockers and a rerun action when the assembler image does not match the live Torghut image.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
