### PR TITLE
fix(torghut): carry renewal proof commit lineage

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -148,6 +148,8 @@ spec:
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:ab230606092556bdc1b7f329e6c108750dfa41d054c2b3db0b7530470cbf274d
+                - name: TORGHUT_COMMIT
+                  value: 769d9780df80138a4fb220b2dab35ad7190185fe
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -113,7 +113,7 @@ spec:
     tigerBeetleJournalOrderEventsManifestPath,
   ]) {
     const metadataEnv =
-      path === whitepaperAutoresearchWorkflowManifestPath
+      path === whitepaperAutoresearchWorkflowManifestPath || path === empiricalPromotionRenewalManifestPath
         ? `            - name: TORGHUT_COMMIT
               value: old-commit
 `
@@ -373,6 +373,7 @@ describe('update-manifests', () => {
       expect(manifest).toContain('value: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e')
     }
     expect(whitepaperAutoresearchWorkflowManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
+    expect(empiricalPromotionRenewalManifest).toContain('value: 1234567890abcdef1234567890abcdef12345678')
     expect(
       tigerBeetleJournalOrderEventsManifest.match(
         /image: registry\.ide-newton\.ts\.net\/lab\/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e/g,

--- a/services/torghut/README.md
+++ b/services/torghut/README.md
@@ -361,8 +361,8 @@ Testing rules for the trading core:
   May 13 doc 191 `torghut.source-serving-repair-receipt-ledger.v1` ledger. It binds repair and routeability evidence
   to the source commit, serving build commit, serving image digest, manifest image digest, and required contract
   canaries. Missing or mismatched source-serving proof keeps the ledger in repair-only zero-notional mode; the Torghut
-  release manifest updater now writes `TORGHUT_IMAGE_DIGEST` into live and sim Knative env so runtime payloads can
-  report the promoted digest.
+  release manifest updater now writes `TORGHUT_IMAGE_DIGEST` and `TORGHUT_COMMIT` into runtime/proof surfaces so
+  runtime payloads can report the promoted digest and scheduled proof packets can fail closed on stale code lineage.
 - `GET /trading/status`, `GET /trading/health`, `GET /readyz`, and `GET /trading/consumer-evidence` now expose the
   May 13 doc 192 `torghut.freshness-carry-ledger.v1` ledger. It derives TA signal, TCA, empirical, market-context,
   quant-evidence, and source-serving freshness dimensions from existing status inputs, emits bounded zero-notional

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1953,6 +1953,11 @@ class TestLiveConfigManifestContract(TestCase):
             item.get("name"): item
             for item in cast(list[Mapping[str, object]], container.get("env", []))
         }
+        self.assertRegex(str(env["TORGHUT_COMMIT"].get("value")), r"^[0-9a-f]{40}$")
+        self.assertRegex(
+            str(env["TORGHUT_IMAGE_DIGEST"].get("value")),
+            r"^sha256:[0-9a-f]{64}$",
+        )
         db_dsn = cast(Mapping[str, object], env["DB_DSN"])
         db_value_from = cast(Mapping[str, object], db_dsn.get("valueFrom", {}))
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Add `TORGHUT_COMMIT` to the `torghut-empirical-promotion-renewal` CronJob so scheduled runtime-ledger proof packets expose source commit lineage.
- Extend the Torghut release manifest updater test to prove renewal manifests keep commit metadata updated with image releases.
- Add a live manifest contract assertion and update Torghut docs so proof packet code lineage remains fail-closed, not image-only.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
