### PR TITLE
fix(torghut): align source materialization evidence

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -104,6 +104,15 @@ DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.loca
 DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL = (
     "http://torghut-sim.torghut.svc.cluster.local"
 )
+MATERIALIZABLE_SOURCE_ROW_COUNT_KEYS = frozenset(
+    {
+        "trade_decisions",
+        "executions",
+        "execution_tca_metrics",
+        "execution_order_events",
+        "order_feed_source_windows",
+    }
+)
 RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet.json"
 RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
 RUNTIME_LEDGER_PROOF_PACKET_ARTIFACT_PREFIX = "runtime-ledger-proof-packets/{run_id}"
@@ -10235,11 +10244,17 @@ def _target_is_runtime_ledger_source_collection(
     )
 
 
-def _positive_mapping_count(value: object) -> bool:
+def _positive_mapping_count(
+    value: object,
+    *,
+    allowed_keys: frozenset[str] | None = None,
+) -> bool:
     if not isinstance(value, Mapping):
         return False
-    typed_value = cast(Mapping[str, object], value)
-    for raw_count in typed_value.values():
+    typed_value = cast(Mapping[object, object], value)
+    for raw_key, raw_count in typed_value.items():
+        if allowed_keys is not None and str(raw_key or "").strip() not in allowed_keys:
+            continue
         if _safe_int(raw_count) > 0:
             return True
     return False
@@ -10263,13 +10278,20 @@ def _source_collection_target_has_materializable_lineage(
         return True
     if _safe_text(target.get("authority_class")) is not None:
         return True
-    if _positive_mapping_count(target.get("source_row_counts")):
-        return True
+    for key in ("source_row_counts", "runtime_ledger_source_row_counts"):
+        if _positive_mapping_count(
+            target.get(key),
+            allowed_keys=MATERIALIZABLE_SOURCE_ROW_COUNT_KEYS,
+        ):
+            return True
     source_refs = [
         ref
         for ref in _unique_text_items(target.get("source_refs"))
         if "strategy_runtime_ledger_buckets" not in ref
     ]
+    source_ref = _safe_text(target.get("source_ref"))
+    if source_ref is not None and "strategy_runtime_ledger_buckets" not in source_ref:
+        source_refs.append(source_ref)
     return bool(source_refs)
 
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -6809,13 +6809,38 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 {"execution_order_events": "2"}
             )
         )
+        self.assertFalse(
+            paper_route_evidence._positive_mapping_count(
+                {"strategy_runtime_ledger_buckets": "2"},
+                allowed_keys=paper_route_evidence.MATERIALIZABLE_SOURCE_ROW_COUNT_KEYS,
+            )
+        )
+        aggregate_only_target = {
+            **base_target,
+            "source_row_counts": {"strategy_runtime_ledger_buckets": 1},
+            "runtime_ledger_source_row_counts": {"strategy_runtime_ledger_buckets": 1},
+            "source_refs": ["postgres:strategy_runtime_ledger_buckets:bucket-1"],
+            "source_ref": "postgres:strategy_runtime_ledger_buckets:bucket-1",
+        }
+        self.assertFalse(
+            paper_route_evidence._source_collection_target_has_materializable_lineage(
+                aggregate_only_target
+            )
+        )
+        self.assertFalse(
+            paper_route_evidence._source_collection_import_target_allowed(
+                aggregate_only_target
+            )
+        )
 
         for lineage in (
             {"source_window_ids": ["window-1"]},
             {"source_materialization": "execution_order_events"},
             {"authority_class": "event_sourced_runtime_ledger_profit_proof"},
             {"source_row_counts": {"execution_order_events": 2}},
+            {"runtime_ledger_source_row_counts": {"execution_order_events": 2}},
             {"source_refs": ["postgres:execution_order_events:event-1"]},
+            {"source_ref": "postgres:execution_order_events:event-1"},
         ):
             target = {**base_target, **lineage}
 


### PR DESCRIPTION
## Summary

- Align paper-route source-collection lineage detection with the renewal/import materializable table allowlist.
- Reject aggregate-only `strategy_runtime_ledger_buckets` row counts and refs as import-authoritative source lineage.
- Preserve concrete materializable lineage from source windows, executions, order events, TCA rows, runtime source row counts, and singular concrete source refs.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_source_collection_import_allows_aggregate_replay_with_materializable_lineage -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml:coverage.xml tests/test_paper_route_evidence.py tests/test_renew_latest_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff check app tests scripts migrations`
- `cd services/torghut && uv run --frozen python -m compileall app`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
