### PR TITLE
fix(torghut): aggregate pair runtime ledger candidates

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -963,6 +963,7 @@ def _runtime_ledger_bucket_payload(
         "account_label": row.account_label,
         "runtime_strategy_name": row.runtime_strategy_name,
         "strategy_family": row.strategy_family,
+        "symbol": payload_json.get("symbol"),
         "fill_count": row.fill_count,
         "decision_count": row.decision_count,
         "submitted_order_count": row.submitted_order_count,
@@ -1013,6 +1014,210 @@ def _runtime_ledger_bucket_payload(
         "cost_basis_counts": payload_json.get("cost_basis_counts") or {},
         "blockers": row.blockers_json or [],
     }
+
+
+_RUNTIME_LEDGER_BUCKET_INT_TOTAL_KEYS = (
+    "fill_count",
+    "decision_count",
+    "submitted_order_count",
+    "cancelled_order_count",
+    "rejected_order_count",
+    "unfilled_order_count",
+    "closed_trade_count",
+    "open_position_count",
+)
+_RUNTIME_LEDGER_BUCKET_DECIMAL_TOTAL_KEYS = (
+    "filled_notional",
+    "gross_strategy_pnl",
+    "cost_amount",
+    "net_strategy_pnl_after_costs",
+)
+_RUNTIME_LEDGER_BUCKET_COUNT_MAP_KEYS = (
+    "execution_policy_hash_counts",
+    "cost_model_hash_counts",
+    "lineage_hash_counts",
+    "cost_basis_counts",
+    "source_row_counts",
+)
+_RUNTIME_LEDGER_BUCKET_SEQUENCE_KEYS = (
+    "source_refs",
+    "source_window_ids",
+    "trade_decision_ids",
+    "execution_ids",
+    "execution_tca_metric_ids",
+    "execution_order_event_ids",
+    "source_offsets",
+)
+_RUNTIME_LEDGER_BUCKET_COMMON_TEXT_KEYS = (
+    "source_materialization",
+    "authority_class",
+    "authority_reason",
+    "pnl_derivation",
+)
+
+
+def _runtime_ledger_candidate_group_key(
+    payload: Mapping[str, object],
+) -> tuple[str, str, str, str, str, str, str, str, str]:
+    return (
+        _safe_text(payload.get("hypothesis_id")) or "",
+        _safe_text(payload.get("candidate_id")) or "",
+        _safe_text(payload.get("run_id")) or "",
+        _safe_text(payload.get("bucket_started_at")) or "",
+        _safe_text(payload.get("bucket_ended_at")) or "",
+        _safe_text(payload.get("observed_stage")) or "",
+        _safe_text(payload.get("account_label")) or "",
+        _safe_text(payload.get("runtime_strategy_name")) or "",
+        _safe_text(payload.get("strategy_family")) or "",
+    )
+
+
+def _runtime_ledger_bucket_symbol(payload: Mapping[str, object]) -> str | None:
+    symbol = _safe_text(payload.get("symbol"))
+    return symbol.upper() if symbol is not None else None
+
+
+def _runtime_ledger_latest_payloads_per_symbol(
+    payloads: Sequence[dict[str, object]],
+) -> list[dict[str, object]]:
+    no_symbol = [
+        payload
+        for payload in payloads
+        if _runtime_ledger_bucket_symbol(payload) is None
+    ]
+    if no_symbol:
+        return [dict(no_symbol[0])]
+    by_symbol: dict[str, dict[str, object]] = {}
+    for payload in payloads:
+        symbol = _runtime_ledger_bucket_symbol(payload)
+        if symbol is None or symbol in by_symbol:
+            continue
+        by_symbol[symbol] = dict(payload)
+    return list(by_symbol.values())
+
+
+def _runtime_ledger_merge_count_maps(
+    payloads: Sequence[Mapping[str, object]],
+    key: str,
+) -> dict[str, int]:
+    merged: dict[str, int] = {}
+    for payload in payloads:
+        value = payload.get(key)
+        if not isinstance(value, Mapping):
+            continue
+        for raw_name, raw_count in cast(Mapping[object, object], value).items():
+            name = str(raw_name or "").strip()
+            count = _safe_int(raw_count)
+            if not name or count <= 0:
+                continue
+            merged[name] = merged.get(name, 0) + count
+    return dict(sorted(merged.items()))
+
+
+def _runtime_ledger_unique_sequence(
+    payloads: Sequence[Mapping[str, object]],
+    key: str,
+) -> list[object]:
+    values: list[object] = []
+    seen: set[str] = set()
+    for payload in payloads:
+        raw_values = payload.get(key)
+        if not isinstance(raw_values, Sequence) or isinstance(
+            raw_values, (str, bytes, bytearray)
+        ):
+            continue
+        for value in cast(Sequence[object], raw_values):
+            marker = json.dumps(value, sort_keys=True, default=str)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            values.append(value)
+    return values
+
+
+def _runtime_ledger_common_text(
+    payloads: Sequence[Mapping[str, object]],
+    key: str,
+) -> str | None:
+    values = sorted(
+        {
+            value
+            for payload in payloads
+            if (value := _safe_text(payload.get(key))) is not None
+        }
+    )
+    return values[0] if len(values) == 1 else None
+
+
+def _runtime_ledger_aggregate_candidate_payloads(
+    payloads: Sequence[dict[str, object]],
+) -> dict[str, object]:
+    selected = _runtime_ledger_latest_payloads_per_symbol(payloads)
+    if len(selected) <= 1:
+        return dict(selected[0]) if selected else {}
+
+    aggregate = dict(selected[0])
+    symbols = sorted(
+        symbol
+        for payload in selected
+        if (symbol := _runtime_ledger_bucket_symbol(payload)) is not None
+    )
+    for key in _RUNTIME_LEDGER_BUCKET_INT_TOTAL_KEYS:
+        aggregate[key] = sum(_safe_int(payload.get(key)) for payload in selected)
+    for key in _RUNTIME_LEDGER_BUCKET_DECIMAL_TOTAL_KEYS:
+        aggregate[key] = _decimal_text(
+            sum(
+                (
+                    _safe_decimal(payload.get(key)) or Decimal("0")
+                    for payload in selected
+                ),
+                Decimal("0"),
+            ),
+        )
+    filled_notional = _safe_decimal(aggregate.get("filled_notional")) or Decimal("0")
+    net_pnl = _safe_decimal(aggregate.get("net_strategy_pnl_after_costs")) or Decimal(
+        "0"
+    )
+    aggregate["post_cost_expectancy_bps"] = (
+        _decimal_text(net_pnl / filled_notional * Decimal("10000"))
+        if filled_notional > 0
+        else None
+    )
+    for key in _RUNTIME_LEDGER_BUCKET_COUNT_MAP_KEYS:
+        merged = _runtime_ledger_merge_count_maps(selected, key)
+        if merged:
+            aggregate[key] = merged
+    for key in _RUNTIME_LEDGER_BUCKET_SEQUENCE_KEYS:
+        merged_sequence = _runtime_ledger_unique_sequence(selected, key)
+        if merged_sequence:
+            aggregate[key] = merged_sequence
+    aggregate_blockers = [
+        blocker
+        for payload in selected
+        for blocker in (
+            [
+                str(item).strip()
+                for item in cast(Sequence[object], payload.get("blockers") or [])
+                if str(item).strip()
+            ]
+            + runtime_ledger_promotion_source_authority_blockers(payload)
+        )
+    ]
+    aggregate["blockers"] = _normalize_reason_codes(aggregate_blockers)
+    aggregate["symbol"] = symbols[0] if len(symbols) == 1 else None
+    aggregate["symbols"] = symbols
+    aggregate["runtime_ledger_bucket_aggregation"] = (
+        "portfolio_window_from_symbol_buckets"
+    )
+    aggregate["runtime_ledger_aggregate_bucket_count"] = len(selected)
+    aggregate["runtime_ledger_aggregate_symbols"] = symbols
+    for key in _RUNTIME_LEDGER_BUCKET_COMMON_TEXT_KEYS:
+        common_value = _runtime_ledger_common_text(selected, key)
+        if common_value is not None:
+            aggregate[key] = common_value
+        else:
+            aggregate.pop(key, None)
+    return aggregate
 
 
 _RUNTIME_LEDGER_SOURCE_EVIDENCE_KEYS = (
@@ -2825,8 +3030,10 @@ def _load_runtime_ledger_repair_candidates(
         _rollback_runtime_ledger_status_session(session)
         return []
 
-    candidates: list[dict[str, object]] = []
-    seen: set[tuple[str, str, str, str, str]] = set()
+    payload_groups: dict[
+        tuple[str, str, str, str, str, str, str, str, str],
+        list[dict[str, object]],
+    ] = {}
     for row in rows:
         payload = _runtime_ledger_bucket_payload(row)
         if (
@@ -2835,17 +3042,17 @@ def _load_runtime_ledger_repair_candidates(
             and _safe_int(payload.get("closed_trade_count")) <= 0
         ):
             continue
-        manifest = manifests.get(row.hypothesis_id) or {}
-        candidate_key = (
-            str(payload.get("hypothesis_id") or ""),
-            str(payload.get("candidate_id") or ""),
-            str(payload.get("run_id") or ""),
-            str(payload.get("bucket_started_at") or ""),
-            str(payload.get("bucket_ended_at") or ""),
-        )
-        if candidate_key in seen:
+        payload_groups.setdefault(
+            _runtime_ledger_candidate_group_key(payload),
+            [],
+        ).append(payload)
+
+    candidates: list[dict[str, object]] = []
+    for payloads in payload_groups.values():
+        payload = _runtime_ledger_aggregate_candidate_payloads(payloads)
+        if not payload:
             continue
-        seen.add(candidate_key)
+        manifest = manifests.get(_safe_text(payload.get("hypothesis_id")) or "") or {}
         reason_codes = _runtime_ledger_repair_reason_codes(
             payload,
             manifest=manifest,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
@@ -56,6 +57,9 @@ from app.trading.submission_council import (
     _maybe_set_runtime_ledger_status_statement_timeout,
     _metric_window_activity_reason_codes,
     _rollback_runtime_ledger_status_session,
+    _runtime_ledger_aggregate_candidate_payloads,
+    _runtime_ledger_latest_payloads_per_symbol,
+    _runtime_ledger_merge_count_maps,
     _runtime_ledger_paper_probation_candidates,
     _runtime_ledger_repair_reason_codes,
     _runtime_ledger_repair_score,
@@ -65,6 +69,7 @@ from app.trading.submission_council import (
     _runtime_ledger_paper_probation_import_plan,
     _runtime_ledger_source_collection_candidates,
     _runtime_ledger_source_collection_target_progress_payload,
+    _runtime_ledger_unique_sequence,
     build_hypothesis_runtime_summary,
     build_live_submission_gate_payload,
     load_quant_evidence_status,
@@ -2297,6 +2302,207 @@ class TestSubmissionCouncil(TestCase):
             target["safe_evidence_collection_path"][0],
             "materialize_runtime_ledger_source_window_refs",
         )
+
+    def test_runtime_ledger_candidate_aggregation_helpers_fail_closed(self) -> None:
+        self.assertEqual(
+            _runtime_ledger_latest_payloads_per_symbol(
+                [
+                    {"symbol": "AAPL", "marker": "newest-aapl"},
+                    {"symbol": "AAPL", "marker": "older-aapl"},
+                ]
+            ),
+            [{"symbol": "AAPL", "marker": "newest-aapl"}],
+        )
+        self.assertEqual(
+            _runtime_ledger_latest_payloads_per_symbol(
+                [
+                    {"symbol": "AAPL", "marker": "symbol-bucket"},
+                    {"marker": "portfolio-bucket"},
+                ]
+            ),
+            [{"marker": "portfolio-bucket"}],
+        )
+        self.assertEqual(
+            _runtime_ledger_merge_count_maps(
+                [
+                    {"counts": "not-a-map"},
+                    {"counts": {"": 3, "zero": 0, "policy": "2"}},
+                ],
+                "counts",
+            ),
+            {"policy": 2},
+        )
+        self.assertEqual(
+            _runtime_ledger_unique_sequence(
+                [
+                    {"items": "not-a-sequence"},
+                    {
+                        "items": [
+                            {"topic": "fills", "offset": 1},
+                            {"topic": "fills", "offset": 1},
+                        ]
+                    },
+                    {"items": [{"topic": "fills", "offset": 2}]},
+                ],
+                "items",
+            ),
+            [{"topic": "fills", "offset": 1}, {"topic": "fills", "offset": 2}],
+        )
+        self.assertEqual(_runtime_ledger_aggregate_candidate_payloads([]), {})
+
+    def test_runtime_ledger_repair_candidates_aggregate_same_window_symbol_buckets(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        window_start = datetime(2026, 6, 5, 15, 13, 23, tzinfo=timezone.utc)
+        window_end = datetime(2026, 6, 5, 20, 6, tzinfo=timezone.utc)
+        registry_items = [
+            {
+                "hypothesis_id": "H-PAIRS-01",
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                "strategy_family": "microbar_cross_sectional_pairs",
+                "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+            }
+        ]
+
+        with session_local() as session:
+            session.add_all(
+                [
+                    StrategyRuntimeLedgerBucket(
+                        run_id="hpairs-friday-window",
+                        candidate_id="c88421d619759b2cfaa6f4d0",
+                        hypothesis_id="H-PAIRS-01",
+                        observed_stage="paper",
+                        bucket_started_at=window_start,
+                        bucket_ended_at=window_end,
+                        account_label="TORGHUT_SIM",
+                        runtime_strategy_name="microbar-cross-sectional-pairs-v1",
+                        strategy_family="microbar_cross_sectional_pairs",
+                        fill_count=16,
+                        decision_count=4,
+                        submitted_order_count=8,
+                        cancelled_order_count=0,
+                        rejected_order_count=0,
+                        unfilled_order_count=0,
+                        closed_trade_count=13,
+                        open_position_count=0,
+                        filled_notional=Decimal("149316.19255257"),
+                        gross_strategy_pnl=Decimal("-742.50905543"),
+                        cost_amount=Decimal("9.76"),
+                        net_strategy_pnl_after_costs=Decimal("-752.26905543"),
+                        post_cost_expectancy_bps=Decimal("-50.38094279"),
+                        ledger_schema_version="torghut.exact_replay_ledger.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy": 8},
+                        cost_model_hash_counts={"cost": 8},
+                        lineage_hash_counts={"lineage": 8},
+                        blockers_json=[],
+                        payload_json={
+                            "symbol": "AAPL",
+                            "source_refs": ["postgres:executions:aapl"],
+                            "source_offsets": [
+                                {
+                                    "topic": "torghut.trade-updates.v1",
+                                    "partition": 0,
+                                    "offset": 100,
+                                }
+                            ],
+                            "pnl_derivation": "execution_reconstruction",
+                        },
+                        created_at=window_end + timedelta(minutes=1),
+                        updated_at=window_end + timedelta(minutes=1),
+                    ),
+                    StrategyRuntimeLedgerBucket(
+                        run_id="hpairs-friday-window",
+                        candidate_id="c88421d619759b2cfaa6f4d0",
+                        hypothesis_id="H-PAIRS-01",
+                        observed_stage="paper",
+                        bucket_started_at=window_start,
+                        bucket_ended_at=window_end,
+                        account_label="TORGHUT_SIM",
+                        runtime_strategy_name="microbar-cross-sectional-pairs-v1",
+                        strategy_family="microbar_cross_sectional_pairs",
+                        fill_count=6,
+                        decision_count=3,
+                        submitted_order_count=9,
+                        cancelled_order_count=0,
+                        rejected_order_count=0,
+                        unfilled_order_count=0,
+                        closed_trade_count=4,
+                        open_position_count=0,
+                        filled_notional=Decimal("74055.97138900"),
+                        gross_strategy_pnl=Decimal("876.38483500"),
+                        cost_amount=Decimal("1.42"),
+                        net_strategy_pnl_after_costs=Decimal("874.96483500"),
+                        post_cost_expectancy_bps=Decimal("118.14912675"),
+                        ledger_schema_version="torghut.exact_replay_ledger.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy": 9},
+                        cost_model_hash_counts={"cost": 9},
+                        lineage_hash_counts={"lineage": 9},
+                        blockers_json=[],
+                        payload_json={
+                            "symbol": "AMZN",
+                            "source_refs": ["postgres:executions:amzn"],
+                            "source_offsets": [
+                                {
+                                    "topic": "torghut.trade-updates.v1",
+                                    "partition": 0,
+                                    "offset": 101,
+                                }
+                            ],
+                            "pnl_derivation": "execution_reconstruction",
+                        },
+                        created_at=window_end + timedelta(minutes=2),
+                        updated_at=window_end + timedelta(minutes=2),
+                    ),
+                ]
+            )
+            session.commit()
+
+            candidates = _load_runtime_ledger_repair_candidates(
+                session,
+                registry_items=registry_items,
+                limit=5,
+            )
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate["fill_count"], 22)
+        self.assertEqual(candidate["submitted_order_count"], 17)
+        self.assertEqual(candidate["closed_trade_count"], 17)
+        self.assertEqual(candidate["filled_notional"], "223372.16394157")
+        self.assertEqual(candidate["net_strategy_pnl_after_costs"], "122.69577957")
+        runtime_bucket = cast(Mapping[str, object], candidate["runtime_ledger_bucket"])
+        self.assertEqual(
+            runtime_bucket["runtime_ledger_bucket_aggregation"],
+            "portfolio_window_from_symbol_buckets",
+        )
+        self.assertEqual(runtime_bucket["runtime_ledger_aggregate_bucket_count"], 2)
+        self.assertEqual(
+            runtime_bucket["runtime_ledger_aggregate_symbols"], ["AAPL", "AMZN"]
+        )
+
+        source_candidates = _runtime_ledger_source_collection_candidates(candidates)
+        self.assertEqual(len(source_candidates), 1)
+        self.assertFalse(
+            source_candidates[0]["source_collection_profit_target_candidate"]
+        )
+        self.assertEqual(
+            source_candidates[0]["source_collection_priority"],
+            "source_window_evidence_collection",
+        )
+        plan = _runtime_ledger_paper_probation_import_plan(source_candidates)
+        self.assertEqual(plan["source_collection_profit_target_count"], 0)
+        self.assertEqual(plan["targets"][0]["max_notional"], "0")
 
     def test_htsmom_runtime_candidate_alias_unlocks_paper_probation_only(
         self,


### PR DESCRIPTION
## Summary

- Aggregate same-run/window runtime-ledger buckets before building Torghut repair candidates so H-PAIRS cannot be scored from one symbol leg.
- Preserve the newest no-symbol portfolio bucket when present, otherwise keep the newest bucket per symbol and aggregate fills, orders, costs, PnL, refs, offsets, and blockers.
- Add regression coverage for the Friday-shaped H-PAIRS case where AMZN was positive but AAPL offset most of the portfolio PnL.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_submission_council.py -k "runtime_ledger_repair_candidates or source_collection_replay_bucket or source_collection_bucket_without_account or runtime_ledger_source_collection or live_gate_surfaces_runtime_ledger_profit_target"`
- `uv run --frozen pytest tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen python -m compileall app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen coverage run -m pytest tests/test_submission_council.py`
- `uv run --frozen coverage xml -o coverage.xml` (writes XML; exits nonzero on global 70% floor because this is a one-file slice)
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref HEAD`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
