### PR TITLE
fix(torghut): require paper-route capacity proof

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -54,6 +54,7 @@ from .runtime_strategy_resolution import (
     runtime_strategy_name_from_strategy_id,
     strategy_names_from_strategy_id,
 )
+from .quantity_rules import quantize_qty_for_symbol, resolve_quantity_resolution
 from .session_context import is_regular_equities_session_date
 
 
@@ -86,6 +87,9 @@ RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION = (
 )
 PAPER_ROUTE_EXECUTION_READINESS_CONTRACT_SCHEMA_VERSION = (
     "torghut.paper-route-execution-readiness-contract.v1"
+)
+PAPER_ROUTE_EXECUTION_CAPACITY_CONTRACT_SCHEMA_VERSION = (
+    "torghut.paper-route-execution-capacity-contract.v1"
 )
 DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
 DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
@@ -798,6 +802,11 @@ def _decimal_text(value: object) -> str:
     return text.rstrip("0").rstrip(".") or "0"
 
 
+def _positive_decimal_or_none(value: object) -> Decimal | None:
+    amount = _safe_decimal(value)
+    return amount if amount > 0 else None
+
+
 def _optional_decimal_text(value: object) -> str | None:
     if value is None:
         return None
@@ -1160,6 +1169,284 @@ def _paper_route_execution_readiness_state(
     return session_state or "unknown"
 
 
+def _target_capacity_notional(target: Mapping[str, object]) -> Decimal:
+    for key in (
+        "target_notional",
+        "paper_route_probe_target_notional",
+        "paper_route_probe_effective_max_notional",
+        "bounded_evidence_collection_max_notional",
+        "paper_route_probe_next_session_max_notional",
+    ):
+        amount = _safe_decimal(target.get(key))
+        if amount > 0:
+            return amount
+    return Decimal("0")
+
+
+def _target_capacity_strategy_max_notional(
+    target: Mapping[str, object],
+) -> Decimal | None:
+    readiness = _as_mapping(target.get("source_decision_readiness"))
+    matched_strategy = _as_mapping(readiness.get("matched_strategy"))
+    return _positive_decimal_or_none(matched_strategy.get("max_notional_per_trade"))
+
+
+def _target_capacity_price_snapshot(
+    target: Mapping[str, object],
+    *,
+    symbol: str,
+) -> dict[str, Any]:
+    snapshots = _as_mapping(target.get("price_snapshots"))
+    for key in (symbol, symbol.upper(), symbol.lower()):
+        snapshot = _as_mapping(snapshots.get(key))
+        if snapshot:
+            return snapshot
+
+    snapshot = _as_mapping(target.get("price_snapshot"))
+    snapshot_symbol = (_safe_text(snapshot.get("symbol")) or "").upper()
+    if snapshot and (not snapshot_symbol or snapshot_symbol == symbol):
+        return snapshot
+    return {}
+
+
+def _price_snapshot_reference_price(
+    snapshot: Mapping[str, object],
+    *,
+    action: str,
+) -> Decimal | None:
+    if action == "buy":
+        preferred = _positive_decimal_or_none(
+            snapshot.get("ask") or snapshot.get("ask_price") or snapshot.get("ap")
+        )
+        if preferred is not None:
+            return preferred
+    if action == "sell":
+        preferred = _positive_decimal_or_none(
+            snapshot.get("bid") or snapshot.get("bid_price") or snapshot.get("bp")
+        )
+        if preferred is not None:
+            return preferred
+
+    for key in ("price", "mid", "mid_price", "midpoint"):
+        amount = _positive_decimal_or_none(snapshot.get(key))
+        if amount is not None:
+            return amount
+    bid = _positive_decimal_or_none(
+        snapshot.get("bid") or snapshot.get("bid_price") or snapshot.get("bp")
+    )
+    ask = _positive_decimal_or_none(
+        snapshot.get("ask") or snapshot.get("ask_price") or snapshot.get("ap")
+    )
+    if bid is not None and ask is not None:
+        return (bid + ask) / Decimal("2")
+    return bid or ask
+
+
+def _target_capacity_symbol_contracts(
+    *,
+    target: Mapping[str, object],
+    symbols: Sequence[str],
+    actions: Mapping[str, str],
+    symbol_budget: Decimal,
+    per_order_cap: Decimal | None,
+    per_symbol_cap: Decimal | None,
+    strategy_cap: Decimal | None,
+) -> tuple[list[dict[str, object]], list[str]]:
+    contracts: list[dict[str, object]] = []
+    blockers: list[str] = []
+    for symbol in symbols:
+        action = actions.get(symbol) or "buy"
+        caps = [symbol_budget]
+        if per_order_cap is not None:
+            caps.append(per_order_cap)
+        if per_symbol_cap is not None:
+            caps.append(per_symbol_cap)
+        if strategy_cap is not None:
+            caps.append(strategy_cap)
+        effective_notional_cap = min(caps) if caps else Decimal("0")
+        snapshot = _target_capacity_price_snapshot(target, symbol=symbol)
+        reference_price = _price_snapshot_reference_price(snapshot, action=action)
+        estimate: dict[str, object] = {
+            "symbol": symbol,
+            "action": action,
+            "target_symbol_notional_budget": _decimal_text(symbol_budget),
+            "effective_symbol_notional_cap": _decimal_text(effective_notional_cap),
+            "reference_price": (
+                _decimal_text(reference_price) if reference_price is not None else None
+            ),
+            "price_snapshot_available": bool(snapshot),
+        }
+        if reference_price is not None and reference_price > 0:
+            requested_qty = effective_notional_cap / reference_price
+            broker_resolution = resolve_quantity_resolution(
+                symbol,
+                action=action,
+                global_enabled=settings.trading_fractional_equities_enabled,
+                allow_shorts=settings.trading_allow_shorts,
+                position_qty=Decimal("0"),
+                requested_qty=requested_qty,
+            )
+            broker_qty = quantize_qty_for_symbol(
+                symbol,
+                requested_qty,
+                fractional_equities_enabled=broker_resolution.fractional_allowed,
+            )
+            estimate["requested_qty"] = _decimal_text(requested_qty)
+            estimate["broker_resolved_qty"] = _decimal_text(broker_qty)
+            estimate["broker_resolved_notional"] = _decimal_text(
+                broker_qty * reference_price
+            )
+            estimate["broker_quantity_resolution"] = broker_resolution.to_payload()
+            if broker_resolution.short_increasing and not settings.trading_allow_shorts:
+                blockers.append("paper_route_execution_capacity_short_sells_disabled")
+            if broker_qty <= 0:
+                blockers.append(
+                    "paper_route_execution_capacity_broker_qty_below_min_step"
+                )
+        contracts.append(estimate)
+    return contracts, blockers
+
+
+def _paper_route_execution_capacity_contract(
+    target: Mapping[str, object],
+) -> dict[str, object]:
+    target_notional = _target_capacity_notional(target)
+    symbols = _unique_text_items(target.get("paper_route_probe_symbols"))
+    actions = {
+        str(symbol).strip().upper(): str(action).strip().lower()
+        for symbol, action in _as_mapping(
+            target.get("paper_route_probe_symbol_actions")
+        ).items()
+        if str(symbol).strip() and str(action).strip().lower() in {"buy", "sell"}
+    }
+    symbol_count = len(symbols)
+    per_order_cap = _positive_decimal_or_none(
+        settings.trading_simple_max_notional_per_order
+    )
+    per_symbol_cap = _positive_decimal_or_none(
+        settings.trading_simple_max_notional_per_symbol
+    )
+    strategy_cap = _target_capacity_strategy_max_notional(target)
+    probe_cap = (
+        _positive_decimal_or_none(
+            target.get("paper_route_probe_effective_max_notional")
+        )
+        or _positive_decimal_or_none(
+            target.get("paper_route_probe_next_session_max_notional")
+        )
+        or _positive_decimal_or_none(
+            settings.trading_simple_paper_route_probe_max_notional
+        )
+    )
+
+    blockers: list[str] = []
+    if target_notional <= 0:
+        blockers.append("paper_route_execution_capacity_target_notional_missing")
+    if not symbols:
+        blockers.append("paper_route_execution_capacity_symbols_missing")
+
+    aggregate_caps = [target_notional] if target_notional > 0 else []
+    if probe_cap is not None:
+        aggregate_caps.append(probe_cap)
+        if target_notional > 0 and probe_cap < target_notional:
+            blockers.append(
+                "paper_route_execution_capacity_probe_cap_below_target_notional"
+            )
+    if symbol_count > 0:
+        if per_order_cap is not None:
+            aggregate_caps.append(per_order_cap * Decimal(symbol_count))
+            if (
+                target_notional > 0
+                and per_order_cap * Decimal(symbol_count) < target_notional
+            ):
+                blockers.append(
+                    "paper_route_execution_capacity_order_cap_below_target_notional"
+                )
+        if per_symbol_cap is not None:
+            aggregate_caps.append(per_symbol_cap * Decimal(symbol_count))
+            if (
+                target_notional > 0
+                and per_symbol_cap * Decimal(symbol_count) < target_notional
+            ):
+                blockers.append(
+                    "paper_route_execution_capacity_symbol_cap_below_target_notional"
+                )
+        if strategy_cap is not None:
+            aggregate_caps.append(strategy_cap * Decimal(symbol_count))
+            if (
+                target_notional > 0
+                and strategy_cap * Decimal(symbol_count) < target_notional
+            ):
+                blockers.append(
+                    "paper_route_execution_capacity_strategy_cap_below_target_notional"
+                )
+
+    effective_collection_cap = min(aggregate_caps) if aggregate_caps else Decimal("0")
+    if target_notional > 0 and effective_collection_cap < target_notional:
+        blockers.append("paper_route_execution_capacity_below_target_notional")
+
+    symbol_budget = (
+        target_notional / Decimal(symbol_count)
+        if target_notional > 0 and symbol_count > 0
+        else Decimal("0")
+    )
+    symbol_contracts, symbol_blockers = _target_capacity_symbol_contracts(
+        target=target,
+        symbols=symbols,
+        actions=actions,
+        symbol_budget=symbol_budget,
+        per_order_cap=per_order_cap,
+        per_symbol_cap=per_symbol_cap,
+        strategy_cap=strategy_cap,
+    )
+    blockers.extend(symbol_blockers)
+    blockers = sorted(dict.fromkeys(blockers))
+    state = "blocked" if blockers else "capacity_ready"
+    capacity_ratio = (
+        effective_collection_cap / target_notional
+        if target_notional > 0
+        else Decimal("0")
+    )
+    return {
+        "schema_version": PAPER_ROUTE_EXECUTION_CAPACITY_CONTRACT_SCHEMA_VERSION,
+        "state": state,
+        "authority": "bounded_paper_route_collection_capacity_only",
+        "target_notional": _decimal_text(target_notional),
+        "effective_collection_notional_cap": _decimal_text(effective_collection_cap),
+        "capacity_ratio_to_target": _decimal_text(capacity_ratio),
+        "blockers": blockers,
+        "symbol_count": symbol_count,
+        "symbols": symbols,
+        "configured_caps": {
+            "paper_route_probe_max_notional": (
+                _decimal_text(probe_cap) if probe_cap is not None else None
+            ),
+            "simple_max_notional_per_order": (
+                _decimal_text(per_order_cap) if per_order_cap is not None else None
+            ),
+            "simple_max_notional_per_symbol": (
+                _decimal_text(per_symbol_cap) if per_symbol_cap is not None else None
+            ),
+            "strategy_max_notional_per_trade": (
+                _decimal_text(strategy_cap) if strategy_cap is not None else None
+            ),
+            "fractional_equities_enabled": (
+                settings.trading_fractional_equities_enabled
+            ),
+            "shorts_enabled": settings.trading_allow_shorts,
+        },
+        "symbol_capacity": symbol_contracts,
+        "price_snapshot_missing_symbols": [
+            item["symbol"]
+            for item in symbol_contracts
+            if not bool(item.get("price_snapshot_available"))
+        ],
+        "proof_boundary": (
+            "capacity_ready_is_not_profit_proof_until_orders_fill_tca_and_runtime_ledger_import"
+        ),
+    }
+
+
 def _paper_route_execution_readiness_contract(
     target: Mapping[str, object],
 ) -> dict[str, object]:
@@ -1169,6 +1456,9 @@ def _paper_route_execution_readiness_contract(
     )
     clean_window_baseline_state = _as_mapping(
         target.get("paper_route_clean_window_baseline_state")
+    )
+    execution_capacity = _as_mapping(
+        target.get("paper_route_execution_capacity_contract")
     )
     session_state = (
         _safe_text(target.get("paper_route_session_readiness_state")) or "unknown"
@@ -1259,6 +1549,19 @@ def _paper_route_execution_readiness_contract(
                 or _safe_text(target.get("paper_route_probe_effective_max_notional"))
                 or "0",
                 "blockers": evidence_blockers,
+            },
+            "execution_capacity": {
+                "state": _safe_text(execution_capacity.get("state")),
+                "target_notional": _safe_text(
+                    execution_capacity.get("target_notional")
+                ),
+                "effective_collection_notional_cap": _safe_text(
+                    execution_capacity.get("effective_collection_notional_cap")
+                ),
+                "capacity_ratio_to_target": _safe_text(
+                    execution_capacity.get("capacity_ratio_to_target")
+                ),
+                "blockers": _unique_text_items(execution_capacity.get("blockers")),
             },
             "runtime_window_import": {
                 "ready": import_ready,
@@ -2894,6 +3197,22 @@ def _next_paper_route_runtime_window_targets(
                 health_gate=health_gate,
             )
         )
+        execution_capacity_contract = _paper_route_execution_capacity_contract(
+            {
+                **pair_balance_target,
+                "source_decision_readiness": source_decision_readiness,
+                "paper_route_probe_symbols": target_probe_symbols,
+                "paper_route_probe_symbol_actions": pair_symbol_actions,
+                "target_notional": next_notional,
+                "paper_route_probe_target_notional": next_notional,
+                "paper_route_probe_effective_max_notional": next_notional,
+                "bounded_evidence_collection_max_notional": next_notional,
+                "paper_route_probe_next_session_max_notional": next_notional,
+            }
+        )
+        execution_capacity_blockers = _unique_text_items(
+            execution_capacity_contract.get("blockers")
+        )
         stale_collection_blockers_cleared_by_current_inputs = (
             _hpairs_stale_collection_blockers_cleared_by_current_inputs(
                 target=pair_balance_target,
@@ -2915,6 +3234,7 @@ def _next_paper_route_runtime_window_targets(
                 ),
                 *_unique_text_items(source_decision_readiness.get("blockers")),
                 *current_collection_prerequisite_blockers,
+                *execution_capacity_blockers,
                 *target_account_audit_blockers,
                 *account_pre_session_blockers,
                 *clean_window_baseline_blockers,
@@ -2973,6 +3293,8 @@ def _next_paper_route_runtime_window_targets(
             "runtime_window_import_promotion_blockers": (
                 health_gate_promotion_blockers
             ),
+            "paper_route_execution_capacity_contract": execution_capacity_contract,
+            "paper_route_execution_capacity_blockers": execution_capacity_blockers,
             "window_start": _isoformat(window_start),
             "window_end": _isoformat(window_end),
             "paper_route_probe_symbols": target_probe_symbols,

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -626,6 +626,7 @@ def _target_materialization_blockers(
     blockers.extend(_hpairs_materialization_blockers(identity))
     blockers.extend(_clean_window_baseline_blockers(target))
     blockers.extend(_source_decision_readiness_blockers(target))
+    blockers.extend(paper_route_target_execution_capacity_blockers(target))
     if not bool(target.get("evidence_collection_ok")):
         blockers.append("paper_route_evidence_collection_gate_not_passed")
     if not bool(target.get("bounded_evidence_collection_authorized")):
@@ -647,10 +648,41 @@ def _target_materialization_blockers(
     return sorted(dict.fromkeys(blockers))
 
 
+def paper_route_target_execution_capacity_blockers(
+    target: Mapping[str, Any],
+) -> list[str]:
+    contract = _to_str_map(target.get("paper_route_execution_capacity_contract"))
+    target_notional = _target_notional(target)
+    explicit_quantities = _target_symbol_quantities(target)
+    if target_notional > 0 and not explicit_quantities and not contract:
+        return ["paper_route_execution_capacity_contract_missing"]
+    if not contract:
+        return []
+
+    blockers: list[str] = []
+    raw_blockers = contract.get("blockers")
+    if isinstance(raw_blockers, Sequence) and not isinstance(
+        raw_blockers, (str, bytes, bytearray)
+    ):
+        blockers.extend(
+            item_text
+            for item in cast(Sequence[object], raw_blockers)
+            if (item_text := _safe_text(item))
+        )
+    state = _safe_text(contract.get("state"))
+    if state != "capacity_ready":
+        blockers.append("paper_route_execution_capacity_not_ready")
+    return sorted({item for item in blockers if item})
+
+
 def _blocked_target_readiness(blockers: Sequence[str]) -> dict[str, Any]:
     blocker_set = {blocker for blocker in blockers if blocker}
     if "paper_route_target_notional_exceeds_bounded_collection_limit" in blocker_set:
         next_action = "reduce_notional"
+    elif any(
+        blocker.startswith("paper_route_execution_capacity") for blocker in blocker_set
+    ):
+        next_action = "repair_execution_capacity_contract"
     elif (
         "paper_route_target_symbol_actions_missing" in blocker_set
         or "paper_route_target_symbol_quantities_missing" in blocker_set
@@ -1174,6 +1206,7 @@ __all__ = [
     "fetch_paper_route_target_plan_url",
     "materialize_bounded_paper_route_target_plan",
     "mapping_items",
+    "paper_route_target_execution_capacity_blockers",
     "paper_route_target_plan_from_payload",
     "paper_route_target_plan_probe_symbols",
     "paper_route_target_plan_targets",

--- a/services/torghut/scripts/materialize_bounded_paper_route_targets.py
+++ b/services/torghut/scripts/materialize_bounded_paper_route_targets.py
@@ -24,6 +24,7 @@ from app.trading.paper_route_target_plan import (
     PAPER_ROUTE_MATERIALIZATION_ACCOUNT_LABEL,
     PAPER_ROUTE_MATERIALIZATION_HPAIRS_HYPOTHESIS_ID,
     materialize_bounded_paper_route_target_plan,
+    paper_route_target_execution_capacity_blockers,
     paper_route_target_plan_targets,
 )
 
@@ -512,6 +513,9 @@ def _target_summaries(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
         actions = _target_symbol_actions(target)
         quantities = _target_symbol_quantities(target)
         target_notional = _target_notional(target)
+        capacity_contract = _to_str_map(
+            target.get("paper_route_execution_capacity_contract")
+        )
         bounded_evidence_collection_authorized = _truthy(
             target.get("bounded_evidence_collection_authorized")
         )
@@ -545,6 +549,10 @@ def _target_summaries(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
                     _target_bounded_materialization_authorized(target)
                 ),
                 "evidence_collection_ok": _truthy(target.get("evidence_collection_ok")),
+                "execution_capacity_state": _safe_text(capacity_contract.get("state")),
+                "execution_capacity_blockers": (
+                    paper_route_target_execution_capacity_blockers(target)
+                ),
                 "symbols": sorted(actions),
                 "symbol_actions": actions,
                 "symbol_quantities": {
@@ -880,6 +888,13 @@ def _safety_blockers(
             blockers.append(
                 f"paper_route_materialization_target_{index}_symbol_actions_missing"
             )
+        for capacity_blocker in cast(
+            Sequence[object], summary.get("execution_capacity_blockers", [])
+        ):
+            if capacity_blocker_text := _safe_text(capacity_blocker):
+                blockers.append(
+                    f"paper_route_materialization_target_{index}_{capacity_blocker_text}"
+                )
 
     blockers.extend(
         _confirmation_blockers(

--- a/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
+++ b/services/torghut/tests/test_materialize_bounded_paper_route_targets.py
@@ -693,11 +693,62 @@ def test_paper_route_target_plan_target_summary_accepts_explicit_quantity_and_sy
             "bounded_evidence_collection_authorized": True,
             "bounded_materialization_authorized": True,
             "evidence_collection_ok": True,
+            "execution_capacity_state": None,
+            "execution_capacity_blockers": [],
             "symbols": ["AAPL", "AMZN"],
             "symbol_actions": {"AAPL": "buy", "AMZN": "sell"},
             "symbol_quantities": {"AAPL": "3", "AMZN": "3"},
         }
     ]
+
+
+def test_paper_route_materializer_blocks_notional_target_missing_capacity_contract() -> (
+    None
+):
+    target = _hpairs_target(
+        paper_route_probe_symbol_quantities={},
+        target_quantity="",
+        paper_route_execution_capacity_contract={},
+    )
+    plan = _plan(target)
+    summaries = cli._target_summaries(plan)
+    args = Namespace(
+        account_label="TORGHUT_SIM",
+        max_notional="20",
+        capital_mode="paper",
+        promotion_allowed=False,
+        final_promotion_allowed=False,
+        final_authority_ok=False,
+        capital_promotion_allowed=False,
+        commit=False,
+        allow_dynamic_target_plan=False,
+        confirm_account_label=None,
+        confirm_dsn_env=None,
+        confirm_hypothesis_id=None,
+        confirm_candidate_id=None,
+        confirm_runtime_strategy_name=None,
+        confirm_target_plan_ref=None,
+        confirm_selected_plan_source=None,
+        confirm_target_count_min=None,
+        operator_confirmation=cli.OPERATOR_CONFIRMATION,
+    )
+
+    blockers = cli._safety_blockers(
+        args=args,
+        plan=plan,
+        plan_source={},
+        summaries=summaries,
+        dsn="sqlite+pysqlite:///:memory:",
+        dsn_env="SIM_DB_DSN",
+    )
+
+    assert summaries[0]["execution_capacity_blockers"] == [
+        "paper_route_execution_capacity_contract_missing"
+    ]
+    assert (
+        "paper_route_materialization_target_0_paper_route_execution_capacity_contract_missing"
+        in blockers
+    )
 
 
 def test_paper_route_materializer_window_datetime_helpers_handle_edge_cases() -> None:
@@ -1214,6 +1265,14 @@ def test_commit_dynamic_next_window_plan_at_configured_notional_skips_before_ope
             _hpairs_target(
                 target_notional="75000",
                 paper_route_probe_symbol_quantities={},
+                paper_route_execution_capacity_contract={
+                    "schema_version": "torghut.paper-route-execution-capacity-contract.v1",
+                    "state": "capacity_ready",
+                    "target_notional": "75000",
+                    "effective_collection_notional_cap": "75000",
+                    "capacity_ratio_to_target": "1",
+                    "blockers": [],
+                },
             )
         ),
     }
@@ -1278,6 +1337,14 @@ def test_commit_dynamic_next_window_plan_at_configured_notional_writes_when_open
             _hpairs_target(
                 target_notional="75000",
                 paper_route_probe_symbol_quantities={},
+                paper_route_execution_capacity_contract={
+                    "schema_version": "torghut.paper-route-execution-capacity-contract.v1",
+                    "state": "capacity_ready",
+                    "target_notional": "75000",
+                    "effective_collection_notional_cap": "75000",
+                    "capacity_ratio_to_target": "1",
+                    "blockers": [],
+                },
             )
         ),
     }

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -2312,6 +2312,342 @@ class TestPaperRouteEvidenceAudit(TestCase):
             1,
         )
 
+    def test_target_plan_exposes_execution_capacity_contract_for_notional_target(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 26, 12, tzinfo=timezone.utc)
+        old_probe_cap = (
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional
+        )
+        old_order_cap = (
+            paper_route_evidence.settings.trading_simple_max_notional_per_order
+        )
+        old_symbol_cap = (
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol
+        )
+        old_fractional = (
+            paper_route_evidence.settings.trading_fractional_equities_enabled
+        )
+        old_shorts = paper_route_evidence.settings.trading_allow_shorts
+        try:
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional = 25.0
+            paper_route_evidence.settings.trading_simple_max_notional_per_order = None
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol = None
+            paper_route_evidence.settings.trading_fractional_equities_enabled = True
+            paper_route_evidence.settings.trading_allow_shorts = True
+            with Session(self.engine) as session:
+                session.add(
+                    Strategy(
+                        name="paper-route-candidate-v1",
+                        description="capacity-ready target source strategy",
+                        enabled=True,
+                        base_timeframe="1Sec",
+                        universe_type="static",
+                        universe_symbols=["AAPL", "AMZN"],
+                        max_notional_per_trade=Decimal("25"),
+                    )
+                )
+                session.commit()
+
+                payload = self._build_basic_paper_route_target_plan(
+                    session,
+                    generated_at=generated_at,
+                )
+        finally:
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional = old_probe_cap
+            paper_route_evidence.settings.trading_simple_max_notional_per_order = (
+                old_order_cap
+            )
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol = (
+                old_symbol_cap
+            )
+            paper_route_evidence.settings.trading_fractional_equities_enabled = (
+                old_fractional
+            )
+            paper_route_evidence.settings.trading_allow_shorts = old_shorts
+
+        target = payload["next_paper_route_runtime_window_targets"]["targets"][0]
+        capacity = target["paper_route_execution_capacity_contract"]
+
+        self.assertEqual(
+            capacity["schema_version"],
+            paper_route_evidence.PAPER_ROUTE_EXECUTION_CAPACITY_CONTRACT_SCHEMA_VERSION,
+        )
+        self.assertEqual(capacity["state"], "capacity_ready")
+        self.assertEqual(capacity["target_notional"], "25")
+        self.assertEqual(capacity["effective_collection_notional_cap"], "25")
+        self.assertEqual(capacity["capacity_ratio_to_target"], "1")
+        self.assertEqual(capacity["blockers"], [])
+        self.assertEqual(
+            capacity["configured_caps"]["paper_route_probe_max_notional"], "25"
+        )
+        self.assertEqual(
+            capacity["configured_caps"]["strategy_max_notional_per_trade"], "25"
+        )
+        self.assertEqual(
+            capacity["price_snapshot_missing_symbols"],
+            ["AAPL", "AMZN"],
+        )
+        readiness = target["paper_route_execution_readiness_contract"]
+        self.assertEqual(
+            readiness["phase_gates"]["execution_capacity"]["state"],
+            "capacity_ready",
+        )
+        self.assertEqual(readiness["phase_gates"]["execution_capacity"]["blockers"], [])
+
+    def test_target_plan_blocks_bounded_collection_when_capacity_cap_is_too_low(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 26, 12, tzinfo=timezone.utc)
+        old_probe_cap = (
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional
+        )
+        old_order_cap = (
+            paper_route_evidence.settings.trading_simple_max_notional_per_order
+        )
+        old_symbol_cap = (
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol
+        )
+        try:
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional = 25.0
+            paper_route_evidence.settings.trading_simple_max_notional_per_order = 10.0
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol = None
+            with Session(self.engine) as session:
+                session.add(
+                    Strategy(
+                        name="paper-route-candidate-v1",
+                        description="capacity-blocked target source strategy",
+                        enabled=True,
+                        base_timeframe="1Sec",
+                        universe_type="static",
+                        universe_symbols=["AAPL", "AMZN"],
+                        max_notional_per_trade=Decimal("25"),
+                    )
+                )
+                session.commit()
+
+                payload = self._build_basic_paper_route_target_plan(
+                    session,
+                    generated_at=generated_at,
+                )
+        finally:
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional = old_probe_cap
+            paper_route_evidence.settings.trading_simple_max_notional_per_order = (
+                old_order_cap
+            )
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol = (
+                old_symbol_cap
+            )
+
+        target = payload["next_paper_route_runtime_window_targets"]["targets"][0]
+        capacity = target["paper_route_execution_capacity_contract"]
+
+        self.assertEqual(capacity["state"], "blocked")
+        self.assertEqual(capacity["effective_collection_notional_cap"], "20")
+        self.assertEqual(capacity["capacity_ratio_to_target"], "0.8")
+        self.assertIn(
+            "paper_route_execution_capacity_order_cap_below_target_notional",
+            capacity["blockers"],
+        )
+        self.assertIn(
+            "paper_route_execution_capacity_below_target_notional",
+            target["bounded_evidence_collection_blockers"],
+        )
+        self.assertFalse(target["evidence_collection_ok"])
+
+    def test_execution_capacity_contract_reports_missing_notional_and_symbols(
+        self,
+    ) -> None:
+        old_probe_cap = (
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional
+        )
+        try:
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional = None
+            capacity = paper_route_evidence._paper_route_execution_capacity_contract({})
+        finally:
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional = old_probe_cap
+
+        self.assertEqual(capacity["state"], "blocked")
+        self.assertEqual(capacity["target_notional"], "0")
+        self.assertEqual(capacity["effective_collection_notional_cap"], "0")
+        self.assertEqual(capacity["capacity_ratio_to_target"], "0")
+        self.assertEqual(capacity["symbol_capacity"], [])
+        self.assertEqual(
+            capacity["blockers"],
+            [
+                "paper_route_execution_capacity_symbols_missing",
+                "paper_route_execution_capacity_target_notional_missing",
+            ],
+        )
+
+    def test_execution_capacity_contract_estimates_broker_quantities_from_quotes(
+        self,
+    ) -> None:
+        old_probe_cap = (
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional
+        )
+        old_order_cap = (
+            paper_route_evidence.settings.trading_simple_max_notional_per_order
+        )
+        old_symbol_cap = (
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol
+        )
+        old_fractional = (
+            paper_route_evidence.settings.trading_fractional_equities_enabled
+        )
+        old_shorts = paper_route_evidence.settings.trading_allow_shorts
+        try:
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional = 30.0
+            paper_route_evidence.settings.trading_simple_max_notional_per_order = 15.0
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol = 10.0
+            paper_route_evidence.settings.trading_fractional_equities_enabled = True
+            paper_route_evidence.settings.trading_allow_shorts = True
+
+            capacity = paper_route_evidence._paper_route_execution_capacity_contract(
+                {
+                    "target_notional": "20",
+                    "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                    "paper_route_probe_symbol_actions": {
+                        "AAPL": "buy",
+                        "AMZN": "sell",
+                    },
+                    "price_snapshots": {
+                        "AAPL": {"ask": "2"},
+                        "AMZN": {"bid": "5"},
+                    },
+                    "source_decision_readiness": {
+                        "matched_strategy": {"max_notional_per_trade": "30"}
+                    },
+                }
+            )
+        finally:
+            paper_route_evidence.settings.trading_simple_paper_route_probe_max_notional = old_probe_cap
+            paper_route_evidence.settings.trading_simple_max_notional_per_order = (
+                old_order_cap
+            )
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol = (
+                old_symbol_cap
+            )
+            paper_route_evidence.settings.trading_fractional_equities_enabled = (
+                old_fractional
+            )
+            paper_route_evidence.settings.trading_allow_shorts = old_shorts
+
+        self.assertEqual(capacity["state"], "capacity_ready")
+        self.assertEqual(capacity["effective_collection_notional_cap"], "20")
+        self.assertEqual(capacity["capacity_ratio_to_target"], "1")
+        self.assertEqual(capacity["blockers"], [])
+        self.assertEqual(
+            capacity["configured_caps"],
+            {
+                "paper_route_probe_max_notional": "30",
+                "simple_max_notional_per_order": "15",
+                "simple_max_notional_per_symbol": "10",
+                "strategy_max_notional_per_trade": "30",
+                "fractional_equities_enabled": True,
+                "shorts_enabled": True,
+            },
+        )
+        aapl_capacity, amzn_capacity = capacity["symbol_capacity"]
+        self.assertEqual(aapl_capacity["reference_price"], "2")
+        self.assertEqual(aapl_capacity["requested_qty"], "5")
+        self.assertEqual(aapl_capacity["broker_resolved_qty"], "5")
+        self.assertEqual(aapl_capacity["broker_resolved_notional"], "10")
+        self.assertEqual(amzn_capacity["reference_price"], "5")
+        self.assertEqual(amzn_capacity["requested_qty"], "2")
+        self.assertEqual(amzn_capacity["broker_resolved_qty"], "2")
+        self.assertEqual(amzn_capacity["broker_resolved_notional"], "10")
+
+    def test_execution_capacity_contract_blocks_short_qty_below_min_step(
+        self,
+    ) -> None:
+        old_fractional = (
+            paper_route_evidence.settings.trading_fractional_equities_enabled
+        )
+        old_shorts = paper_route_evidence.settings.trading_allow_shorts
+        try:
+            paper_route_evidence.settings.trading_fractional_equities_enabled = True
+            paper_route_evidence.settings.trading_allow_shorts = False
+
+            capacity = paper_route_evidence._paper_route_execution_capacity_contract(
+                {
+                    "target_notional": "10",
+                    "paper_route_probe_effective_max_notional": "10",
+                    "paper_route_probe_symbols": ["AMZN"],
+                    "paper_route_probe_symbol_actions": {"AMZN": "sell"},
+                    "price_snapshot": {"symbol": "AMZN", "price": "100"},
+                }
+            )
+        finally:
+            paper_route_evidence.settings.trading_fractional_equities_enabled = (
+                old_fractional
+            )
+            paper_route_evidence.settings.trading_allow_shorts = old_shorts
+
+        self.assertEqual(capacity["state"], "blocked")
+        self.assertEqual(
+            capacity["blockers"],
+            [
+                "paper_route_execution_capacity_broker_qty_below_min_step",
+                "paper_route_execution_capacity_short_sells_disabled",
+            ],
+        )
+        self.assertEqual(capacity["symbol_capacity"][0]["reference_price"], "100")
+        self.assertEqual(capacity["symbol_capacity"][0]["requested_qty"], "0.1")
+        self.assertEqual(capacity["symbol_capacity"][0]["broker_resolved_qty"], "0")
+        self.assertFalse(capacity["configured_caps"]["shorts_enabled"])
+
+    def test_execution_capacity_contract_blocks_probe_and_symbol_caps_below_target(
+        self,
+    ) -> None:
+        old_symbol_cap = (
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol
+        )
+        try:
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol = 10.0
+
+            capacity = paper_route_evidence._paper_route_execution_capacity_contract(
+                {
+                    "target_notional": "25",
+                    "paper_route_probe_effective_max_notional": "20",
+                    "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                    "paper_route_probe_symbol_actions": {
+                        "AAPL": "buy",
+                        "AMZN": "sell",
+                    },
+                }
+            )
+        finally:
+            paper_route_evidence.settings.trading_simple_max_notional_per_symbol = (
+                old_symbol_cap
+            )
+
+        self.assertEqual(capacity["state"], "blocked")
+        self.assertEqual(capacity["effective_collection_notional_cap"], "20")
+        self.assertEqual(capacity["capacity_ratio_to_target"], "0.8")
+        self.assertIn(
+            "paper_route_execution_capacity_probe_cap_below_target_notional",
+            capacity["blockers"],
+        )
+        self.assertIn(
+            "paper_route_execution_capacity_symbol_cap_below_target_notional",
+            capacity["blockers"],
+        )
+        self.assertIn(
+            "paper_route_execution_capacity_below_target_notional",
+            capacity["blockers"],
+        )
+
+    def test_price_snapshot_reference_price_uses_midpoint_when_no_action_quote(
+        self,
+    ) -> None:
+        reference_price = paper_route_evidence._price_snapshot_reference_price(
+            {"bid": "9", "ask": "11"},
+            action="hold",
+        )
+
+        self.assertEqual(reference_price, Decimal("10"))
+
     def test_target_plan_deferred_mode_builds_only_next_window(self) -> None:
         generated_at = datetime(2026, 5, 26, 12, tzinfo=timezone.utc)
         window_purposes: list[str] = []

--- a/services/torghut/tests/test_paper_route_target_plan.py
+++ b/services/torghut/tests/test_paper_route_target_plan.py
@@ -141,6 +141,14 @@ def test_materializer_accepts_notional_authoritative_target_without_quantities(
         symbol_quantities={},
         target_quantity="",
         target_notional="20",
+        paper_route_execution_capacity_contract={
+            "schema_version": "torghut.paper-route-execution-capacity-contract.v1",
+            "state": "capacity_ready",
+            "target_notional": "20",
+            "effective_collection_notional_cap": "20",
+            "capacity_ratio_to_target": "1",
+            "blockers": [],
+        },
     )
 
     result = materialize_bounded_paper_route_target_plan(
@@ -167,6 +175,75 @@ def test_materializer_accepts_notional_authoritative_target_without_quantities(
             "target_notional_runtime_sizing_seed"
         )
         assert metadata["target_notional_sizing_required"] is True
+
+
+def test_materializer_rejects_notional_authoritative_target_without_capacity_contract(
+    db_session: Session,
+) -> None:
+    target = _hpairs_target(
+        paper_route_probe_symbol_quantities={},
+        target_symbol_quantities={},
+        symbol_quantities={},
+        target_quantity="",
+        target_notional="20",
+    )
+
+    result = materialize_bounded_paper_route_target_plan(
+        db_session,
+        _plan(target),
+        generated_at=datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+        bounded_notional_limit=Decimal("20"),
+    )
+    decisions = db_session.execute(select(TradeDecision)).scalars().all()
+
+    assert result["materialized_decision_count"] == 0
+    assert result["blocked_target_count"] == 1
+    assert decisions == []
+    assert result["blocked_targets"][0]["blockers"] == [
+        "paper_route_execution_capacity_contract_missing"
+    ]
+    assert (
+        result["blocked_targets"][0]["readiness"]["next_operator_action"]
+        == "repair_execution_capacity_contract"
+    )
+
+
+def test_materializer_rejects_notional_authoritative_target_when_capacity_not_ready(
+    db_session: Session,
+) -> None:
+    target = _hpairs_target(
+        paper_route_probe_symbol_quantities={},
+        target_symbol_quantities={},
+        symbol_quantities={},
+        target_quantity="",
+        target_notional="20",
+        paper_route_execution_capacity_contract={
+            "schema_version": "torghut.paper-route-execution-capacity-contract.v1",
+            "state": "blocked",
+            "target_notional": "20",
+            "effective_collection_notional_cap": "10",
+            "capacity_ratio_to_target": "0.5",
+            "blockers": ["paper_route_execution_capacity_below_target_notional"],
+        },
+    )
+
+    result = materialize_bounded_paper_route_target_plan(
+        db_session,
+        _plan(target),
+        generated_at=datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc),
+        bounded_notional_limit=Decimal("20"),
+    )
+
+    assert result["materialized_decision_count"] == 0
+    assert result["blocked_target_count"] == 1
+    assert result["blocked_targets"][0]["blockers"] == [
+        "paper_route_execution_capacity_below_target_notional",
+        "paper_route_execution_capacity_not_ready",
+    ]
+    assert (
+        result["blocked_targets"][0]["readiness"]["next_operator_action"]
+        == "repair_execution_capacity_contract"
+    )
 
 
 def test_materializer_preserves_explicit_quantities_without_runtime_sizing(


### PR DESCRIPTION
## Summary

- Adds a paper-route execution-capacity contract to target-plan output so notional-authoritative H-PAIRS targets expose effective collection notional, cap ratio, configured caps, symbol budgets, optional quote-derived broker quantities, and capacity blockers.
- Wires capacity blockers into bounded paper-route collection readiness, including per-order/per-symbol/strategy cap shortfalls and short-sale or broker quantity rounding failures.
- Makes materialization fail closed for notional-only targets that lack a `capacity_ready` contract, with the CLI and shared materialization library using the same blocker helper.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_target_plan.py tests/test_paper_route_evidence.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/paper_route_target_plan.py scripts/materialize_bounded_paper_route_targets.py tests/test_paper_route_evidence.py tests/test_paper_route_target_plan.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py app/trading/paper_route_target_plan.py scripts/materialize_bounded_paper_route_targets.py tests/test_paper_route_evidence.py tests/test_paper_route_target_plan.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen python -m py_compile app/trading/paper_route_evidence.py app/trading/paper_route_target_plan.py scripts/materialize_bounded_paper_route_targets.py tests/test_paper_route_evidence.py tests/test_paper_route_target_plan.py tests/test_materialize_bounded_paper_route_targets.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
