### PR TITLE
fix(torghut): target simulation privilege grants

### DIFF
--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -272,18 +272,87 @@ spec:
                       text('select quote_ident(:role)'),
                       {'role': runtime_role},
                   ).scalar_one()
-                  statements = [
-                      f'GRANT USAGE, CREATE ON SCHEMA public TO {quoted_role}',
-                      f'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {quoted_role}',
-                      f'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {quoted_role}',
-                      f'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO {quoted_role}',
-                      f'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO {quoted_role}',
-                      f'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO {quoted_role}',
-                      f'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO {quoted_role}',
-                  ]
-                  for statement in statements:
-                      connection.execute(text(statement))
-                  print(f'granted simulation runtime privileges to {runtime_role}')
+                  missing_relations = connection.execute(
+                      text(
+                          """
+                          SELECT c.oid::regclass::text AS object_name
+                          FROM pg_class c
+                          JOIN pg_namespace n ON n.oid = c.relnamespace
+                          WHERE n.nspname = 'public'
+                            AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+                            AND NOT (
+                              has_table_privilege(:runtime_role, c.oid, 'SELECT')
+                              AND has_table_privilege(:runtime_role, c.oid, 'INSERT')
+                              AND has_table_privilege(:runtime_role, c.oid, 'UPDATE')
+                              AND has_table_privilege(:runtime_role, c.oid, 'DELETE')
+                              AND has_table_privilege(:runtime_role, c.oid, 'TRUNCATE')
+                              AND has_table_privilege(:runtime_role, c.oid, 'REFERENCES')
+                              AND has_table_privilege(:runtime_role, c.oid, 'TRIGGER')
+                            )
+                          ORDER BY c.relkind, c.relname
+                          """
+                      ),
+                      {'runtime_role': runtime_role},
+                  ).scalars().all()
+                  missing_sequences = connection.execute(
+                      text(
+                          """
+                          SELECT c.oid::regclass::text AS object_name
+                          FROM pg_class c
+                          JOIN pg_namespace n ON n.oid = c.relnamespace
+                          WHERE n.nspname = 'public'
+                            AND c.relkind = 'S'
+                            AND NOT (
+                              has_sequence_privilege(:runtime_role, c.oid, 'USAGE')
+                              AND has_sequence_privilege(:runtime_role, c.oid, 'SELECT')
+                              AND has_sequence_privilege(:runtime_role, c.oid, 'UPDATE')
+                            )
+                          ORDER BY c.relname
+                          """
+                      ),
+                      {'runtime_role': runtime_role},
+                  ).scalars().all()
+                  missing_functions = connection.execute(
+                      text(
+                          """
+                          SELECT p.oid::regprocedure::text AS object_name
+                          FROM pg_proc p
+                          JOIN pg_namespace n ON n.oid = p.pronamespace
+                          WHERE n.nspname = 'public'
+                            AND NOT has_function_privilege(:runtime_role, p.oid, 'EXECUTE')
+                          ORDER BY p.proname, p.oid
+                          """
+                      ),
+                      {'runtime_role': runtime_role},
+                  ).scalars().all()
+
+                  connection.exec_driver_sql(f'GRANT USAGE, CREATE ON SCHEMA public TO {quoted_role}')
+                  for object_name in missing_relations:
+                      connection.exec_driver_sql(
+                          f'GRANT ALL PRIVILEGES ON TABLE {object_name} TO {quoted_role}'
+                      )
+                  for object_name in missing_sequences:
+                      connection.exec_driver_sql(
+                          f'GRANT ALL PRIVILEGES ON SEQUENCE {object_name} TO {quoted_role}'
+                      )
+                  for object_name in missing_functions:
+                      connection.exec_driver_sql(
+                          f'GRANT EXECUTE ON FUNCTION {object_name} TO {quoted_role}'
+                      )
+                  connection.exec_driver_sql(
+                      f'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO {quoted_role}'
+                  )
+                  connection.exec_driver_sql(
+                      f'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO {quoted_role}'
+                  )
+                  connection.exec_driver_sql(
+                      f'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO {quoted_role}'
+                  )
+                  print(
+                      'granted missing simulation runtime privileges to '
+                      f'{runtime_role}: relations={len(missing_relations)} '
+                      f'sequences={len(missing_sequences)} functions={len(missing_functions)}'
+                  )
               PY
           env:
             - name: DB_DSN

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -283,6 +283,15 @@ describe('update-manifests', () => {
     )
     expect(migrationManifest).toContain('DB_WAIT_DATABASE="${database}"')
     expect(migrationManifest).toContain('dsn = database_url(dsn, database)')
+    expect(migrationManifest).toContain('missing_relations = connection.execute')
+    expect(migrationManifest).toContain("has_table_privilege(:runtime_role, c.oid, 'SELECT')")
+    expect(migrationManifest).toContain("has_sequence_privilege(:runtime_role, c.oid, 'USAGE')")
+    expect(migrationManifest).toContain("has_function_privilege(:runtime_role, p.oid, 'EXECUTE')")
+    expect(migrationManifest).toContain('GRANT ALL PRIVILEGES ON TABLE {object_name} TO {quoted_role}')
+    expect(migrationManifest).toContain('granted missing simulation runtime privileges')
+    expect(migrationManifest).not.toContain('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public')
+    expect(migrationManifest).not.toContain('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public')
+    expect(migrationManifest).not.toContain('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public')
   })
 
   it('keeps the whitepaper semantic backfill hook on arm64 nodes', () => {

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -2185,8 +2185,27 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("autoresearch_portfolio_candidates", args)
         self.assertIn("public_table_exists", args)
         self.assertIn(upgrade_heads, args)
-        self.assertIn("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public", args)
-        self.assertIn("granted simulation runtime privileges", args)
+        self.assertIn("missing_relations = connection.execute", args)
+        self.assertIn("missing_sequences = connection.execute", args)
+        self.assertIn("missing_functions = connection.execute", args)
+        self.assertIn("has_table_privilege(:runtime_role, c.oid, 'SELECT')", args)
+        self.assertIn("has_sequence_privilege(:runtime_role, c.oid, 'USAGE')", args)
+        self.assertIn("has_function_privilege(:runtime_role, p.oid, 'EXECUTE')", args)
+        self.assertIn(
+            "GRANT ALL PRIVILEGES ON TABLE {object_name} TO {quoted_role}", args
+        )
+        self.assertIn(
+            "GRANT ALL PRIVILEGES ON SEQUENCE {object_name} TO {quoted_role}", args
+        )
+        self.assertIn("GRANT EXECUTE ON FUNCTION {object_name} TO {quoted_role}", args)
+        self.assertIn(
+            "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES",
+            args,
+        )
+        self.assertIn("granted missing simulation runtime privileges", args)
+        self.assertNotIn("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public", args)
+        self.assertNotIn("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public", args)
+        self.assertNotIn("GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public", args)
         self.assertLess(
             args.index("CREATE EXTENSION IF NOT EXISTS vector"),
             args.index("c.oid::regclass::text AS object_name"),
@@ -2205,7 +2224,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertLess(
             args.index(upgrade_heads),
-            args.index("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public"),
+            args.index("missing_relations = connection.execute"),
         )
 
     def test_profitability_sweep_universes_are_chip_only(self) -> None:


### PR DESCRIPTION
## Summary

- Replaces the Torghut sim migration hook's broad per-deploy schema grants with targeted missing-privilege grants for relations, sequences, and functions.
- Keeps schema/default privilege repair in place so new migration-created objects still become runtime-accessible.
- Adds manifest contract coverage so release automation cannot reintroduce broad schema-wide grant calls.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k migration_job_prepares_sim_database_before_sim_upgrade`
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts -t 'keeps the migration hook gated on database readiness'`
- `uv run --frozen ruff format tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py`
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py && uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/update-manifests.test.ts && git diff --check`
- `uv sync --frozen --extra dev`
- `bun run lint:argocd`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live read-only catalog probe against `torghut_sim_default`: targeted missing-privilege queries returned `0|0|0`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
