### PR TITLE
fix(torghut): stop failed cronjobs degrading app health

### DIFF
--- a/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
+++ b/argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml
@@ -11,10 +11,11 @@ spec:
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 1
       activeDeadlineSeconds: 300
       template:

--- a/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml
@@ -7,9 +7,10 @@ spec:
   schedule: "17 4 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 1800
       template:
         spec:
           restartPolicy: OnFailure

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -7,10 +7,11 @@ spec:
   schedule: "23 8,21 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 900
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 2
       activeDeadlineSeconds: 900
       template:

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -10,9 +10,10 @@ spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 0
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 1
       activeDeadlineSeconds: 900
       template:

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -10,10 +10,11 @@ spec:
   schedule: "13,43 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 1
       activeDeadlineSeconds: 900
       template:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -11,10 +11,11 @@ spec:
   timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 1
       activeDeadlineSeconds: 300
       template:

--- a/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
+++ b/argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml
@@ -10,10 +10,11 @@ spec:
   schedule: "*/6 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 0
       activeDeadlineSeconds: 900
       template:
@@ -103,10 +104,11 @@ spec:
   schedule: "21,51 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 300
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 1800
       backoffLimit: 0
       activeDeadlineSeconds: 900
       template:

--- a/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml
@@ -12,7 +12,7 @@ spec:
     - "5 5 * * 2-6"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 0
   startingDeadlineSeconds: 900
   workflowSpec:
     workflowTemplateRef:

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -68,6 +68,9 @@ const getAtPath = (root: unknown, selectorPath: Array<string | number>): JsonRec
 
 const parseManifest = (path: string): JsonRecord => YAML.parse(readFileSync(join(repoRoot, path), 'utf8')) as JsonRecord
 
+const parseManifestDocuments = (path: string): JsonRecord[] =>
+  YAML.parseAllDocuments(readFileSync(join(repoRoot, path), 'utf8')).map((document) => document.toJSON() as JsonRecord)
+
 const parameterValue = (manifest: JsonRecord, name: string): string => {
   const parameters = getAtPath(manifest, ['spec', 'arguments']).parameters
   if (!Array.isArray(parameters)) {
@@ -91,6 +94,37 @@ describe('Torghut manifest scheduling', () => {
         'kubernetes.io/arch': 'arm64',
       })
     }
+  })
+
+  it('prevents Torghut scheduled failures from lingering in Argo app health', () => {
+    const cronJobPaths = [
+      'argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml',
+      'argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml',
+      'argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml',
+      'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml',
+      'argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml',
+      'argocd/applications/torghut/paper-account-flatten-cronjob.yaml',
+      'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml',
+    ]
+
+    let checkedCronJobs = 0
+    for (const path of cronJobPaths) {
+      for (const manifest of parseManifestDocuments(path)) {
+        expect(manifest.kind, path).toBe('CronJob')
+        const spec = getAtPath(manifest, ['spec'])
+        const jobSpec = getAtPath(manifest, ['spec', 'jobTemplate', 'spec'])
+        expect(spec.failedJobsHistoryLimit, path).toBe(0)
+        expect(jobSpec.ttlSecondsAfterFinished, path).toBe(1800)
+        checkedCronJobs += 1
+      }
+    }
+    expect(checkedCronJobs).toBe(8)
+
+    const replayCronWorkflow = parseManifest(
+      'argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml',
+    )
+    expect(replayCronWorkflow.kind).toBe('CronWorkflow')
+    expect(getAtPath(replayCronWorkflow, ['spec']).failedJobsHistoryLimit).toBe(0)
   })
 
   it('keeps whitepaper autoresearch off the serving pod resource envelope', () => {

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1643,6 +1643,41 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(_params(hpairs).get("max_gross_exposure_pct_equity"), "10.0")
 
+    def test_torghut_scheduled_jobs_do_not_leave_failed_children_degrading_argo(
+        self,
+    ) -> None:
+        cronjob_paths = (
+            "argocd/applications/torghut/bounded-paper-route-target-materialization-cronjob.yaml",
+            "argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml",
+            "argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml",
+            "argocd/applications/torghut/execution-tca-refresh-cronjob.yaml",
+            "argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml",
+            "argocd/applications/torghut/paper-account-flatten-cronjob.yaml",
+            "argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml",
+        )
+        checked_cronjobs = 0
+        for relative_path in cronjob_paths:
+            for manifest in _load_yaml_mappings(relative_path):
+                self.assertEqual(manifest.get("kind"), "CronJob")
+                spec = cast(Mapping[str, object], manifest.get("spec", {}))
+                self.assertEqual(spec.get("failedJobsHistoryLimit"), 0)
+                job_spec = cast(
+                    Mapping[str, object],
+                    cast(Mapping[str, object], spec.get("jobTemplate", {})).get(
+                        "spec", {}
+                    ),
+                )
+                self.assertEqual(job_spec.get("ttlSecondsAfterFinished"), 1800)
+                checked_cronjobs += 1
+        self.assertEqual(checked_cronjobs, 8)
+
+        replay_cronworkflow = _load_yaml_mapping(
+            "argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml"
+        )
+        self.assertEqual(replay_cronworkflow.get("kind"), "CronWorkflow")
+        replay_spec = cast(Mapping[str, object], replay_cronworkflow.get("spec", {}))
+        self.assertEqual(replay_spec.get("failedJobsHistoryLimit"), 0)
+
     def test_tigerbeetle_journal_order_events_cronjob_covers_live_and_sim(
         self,
     ) -> None:
@@ -1716,7 +1751,8 @@ class TestLiveConfigManifestContract(TestCase):
             self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
             self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
             self.assertEqual(spec.get("successfulJobsHistoryLimit"), 2)
-            self.assertEqual(spec.get("failedJobsHistoryLimit"), 3)
+            self.assertEqual(spec.get("failedJobsHistoryLimit"), 0)
+            self.assertEqual(job_spec.get("ttlSecondsAfterFinished"), 1800)
             self.assertEqual(job_spec.get("activeDeadlineSeconds"), 900)
             self.assertEqual(job_spec.get("backoffLimit"), 0)
             template = cast(


### PR DESCRIPTION
## Summary

- Set Torghut CronJobs to retain zero failed child Jobs so old schedule failures do not keep the Argo application degraded.
- Added `ttlSecondsAfterFinished: 1800` to Torghut CronJob job templates to bound completed Job lifetime.
- Added Python and package-script manifest contract tests for the scheduled-job retention policy.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k scheduled_jobs_do_not_leave_failed_children`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts -t 'prevents Torghut scheduled failures from lingering in Argo app health'`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
