### PR TITLE
fix(torghut): automate zero-notional drift repair

### DIFF
--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -40,6 +40,7 @@ resources:
   - order-feed-source-window-repair-cronjob.yaml
   - empirical-artifacts-retention-cronjob.yaml
   - execution-tca-refresh-cronjob.yaml
+  - zero-notional-drift-repair-cronjob.yaml
   - paper-account-flatten-cronjob.yaml
   - whitepaper-autoresearch-workflowtemplate.yaml
   - whitepaper-autoresearch-replay-materialization-cronworkflow.yaml

--- a/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
+++ b/argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml
@@ -1,0 +1,74 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-zero-notional-drift-repair
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: zero-notional-drift-repair
+spec:
+  schedule: "*/10 9-16 * * 1-5"
+  timeZone: America/New_York
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 0
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 1800
+      backoffLimit: 0
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
+          containers:
+            - name: run-zero-notional-drift-repair
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:904409b0a8127e59381251485f2aeddaacf0b78045155579d4f5804ed5d5f39f
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+              env:
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  echo "stage=zero_notional_drift_repair service=torghut-sim started_at=$(date -Iseconds)"
+                  /opt/venv/bin/python scripts/run_zero_notional_repair.py \
+                    --service-url http://torghut-sim.torghut.svc.cluster.local \
+                    --action rerun_drift_checks_for_blocked_hypotheses \
+                    --execute \
+                    --drift-limit 1000 \
+                    --attempts 3 \
+                    --timeout-seconds 45 \
+                    --retry-backoff-seconds 5 \
+                    --allow-no-selected-repair \
+                    --allow-no-signal-blocked \
+                    --json
+                  echo "stage=zero_notional_drift_repair service=torghut started_at=$(date -Iseconds)"
+                  /opt/venv/bin/python scripts/run_zero_notional_repair.py \
+                    --service-url http://torghut.torghut.svc.cluster.local \
+                    --action rerun_drift_checks_for_blocked_hypotheses \
+                    --execute \
+                    --drift-limit 1000 \
+                    --attempts 3 \
+                    --timeout-seconds 45 \
+                    --retry-backoff-seconds 5 \
+                    --allow-no-selected-repair \
+                    --allow-no-signal-blocked \
+                    --json
+                  echo "stage=zero_notional_drift_repair completed_at=$(date -Iseconds)"

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -23,6 +23,10 @@ const torghutArm64ImageChecks: ManifestCheck[] = [
     selectorPath: ['spec', 'jobTemplate', 'spec', 'template', 'spec'],
   },
   {
+    path: 'argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml',
+    selectorPath: ['spec', 'jobTemplate', 'spec', 'template', 'spec'],
+  },
+  {
     path: 'argocd/applications/torghut/analysis-template-runtime-ready.yaml',
     selectorPath: ['spec', 'metrics', 0, 'provider', 'job', 'spec', 'template', 'spec'],
   },
@@ -102,6 +106,7 @@ describe('Torghut manifest scheduling', () => {
       'argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml',
       'argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml',
       'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml',
+      'argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml',
       'argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml',
       'argocd/applications/torghut/paper-account-flatten-cronjob.yaml',
       'argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml',
@@ -118,7 +123,7 @@ describe('Torghut manifest scheduling', () => {
         checkedCronJobs += 1
       }
     }
-    expect(checkedCronJobs).toBe(8)
+    expect(checkedCronJobs).toBe(9)
 
     const replayCronWorkflow = parseManifest(
       'argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml',

--- a/services/torghut/scripts/run_zero_notional_repair.py
+++ b/services/torghut/scripts/run_zero_notional_repair.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from typing import Any
+
+
+DEFAULT_ACTION = "rerun_drift_checks_for_blocked_hypotheses"
+ZERO_NOTIONAL_REPAIR_RECEIPT_SCHEMA_VERSION = (
+    "torghut.zero-notional-repair-execution-receipt.v1"
+)
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _strings(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value:
+        text = _text(item)
+        if text:
+            result.append(text)
+    return result
+
+
+def _is_zero(value: object) -> bool:
+    return _text(value, "0") in {"", "0", "0.0", "0.00", "0.0000"}
+
+
+def _bool_false(value: object) -> bool:
+    if isinstance(value, bool):
+        return not value
+    return _text(value).lower() in {"", "0", "false", "no", "off"}
+
+
+def _repair_url(
+    service_url: str, *, action: str, execute: bool, drift_limit: int
+) -> str:
+    base = service_url.rstrip("/")
+    query = urllib.parse.urlencode(
+        {
+            "action": action,
+            "execute": "true" if execute else "false",
+            "drift_limit": str(drift_limit),
+        }
+    )
+    return f"{base}/trading/profit-freshness/zero-notional-repair?{query}"
+
+
+def _post_repair(url: str, *, timeout_seconds: float) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        data=b"{}",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(  # noqa: S310 - in-cluster operator URL supplied by GitOps/CLI.
+        request,
+        timeout=max(timeout_seconds, 1.0),
+    ) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("zero_notional_repair_response_not_object")
+    return payload
+
+
+def _receipt_validation_errors(receipt: Mapping[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if (
+        _text(receipt.get("schema_version"))
+        != ZERO_NOTIONAL_REPAIR_RECEIPT_SCHEMA_VERSION
+    ):
+        errors.append("receipt_schema_version_mismatch")
+    if not _bool_false(receipt.get("order_submission_enabled")):
+        errors.append("receipt_order_submission_enabled")
+    if not _is_zero(receipt.get("paper_notional_limit")):
+        errors.append("receipt_paper_notional_nonzero")
+    if not _is_zero(receipt.get("live_notional_limit")):
+        errors.append("receipt_live_notional_nonzero")
+    safety = receipt.get("safety_invariants")
+    if not isinstance(safety, Mapping):
+        errors.append("receipt_safety_invariants_missing")
+    else:
+        if not _is_zero(safety.get("max_notional")):
+            errors.append("receipt_safety_max_notional_nonzero")
+        if safety.get("paper_live_capital_unchanged") is not True:
+            errors.append("receipt_capital_invariant_not_true")
+        if safety.get("order_submission_disabled") is not True:
+            errors.append("receipt_order_submission_invariant_not_true")
+    return errors
+
+
+def _accepted_blocked_state(
+    receipt: Mapping[str, Any],
+    *,
+    allow_no_selected_repair: bool,
+    allow_no_signal_blocked: bool,
+) -> bool:
+    state = _text(receipt.get("execution_state"))
+    blocked_reasons = _strings(receipt.get("blocked_reasons"))
+    if allow_no_selected_repair and state == "no_selected_repair":
+        return True
+    if (
+        allow_no_selected_repair
+        and blocked_reasons
+        and all(
+            reason.startswith("profit_freshness_frontier_matching_repair_missing:")
+            for reason in blocked_reasons
+        )
+    ):
+        return True
+    if (
+        allow_no_signal_blocked
+        and state == "runner_blocked"
+        and blocked_reasons
+        and all(
+            reason.startswith("drift_check_no_signals:") for reason in blocked_reasons
+        )
+    ):
+        return True
+    return False
+
+
+def _receipt_exit_code(
+    receipt: Mapping[str, Any],
+    *,
+    allow_no_selected_repair: bool,
+    allow_no_signal_blocked: bool,
+) -> tuple[int, list[str]]:
+    validation_errors = _receipt_validation_errors(receipt)
+    if validation_errors:
+        return 1, validation_errors
+
+    command_exit_code = int(receipt.get("command_exit_code") or 0)
+    execution_state = _text(receipt.get("execution_state"))
+    if execution_state == "executed" and command_exit_code == 0:
+        return 0, []
+    if _accepted_blocked_state(
+        receipt,
+        allow_no_selected_repair=allow_no_selected_repair,
+        allow_no_signal_blocked=allow_no_signal_blocked,
+    ):
+        return 0, []
+    return command_exit_code if command_exit_code else 1, []
+
+
+def run(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    url = _repair_url(
+        args.service_url,
+        action=args.action,
+        execute=bool(args.execute),
+        drift_limit=max(1, int(args.drift_limit)),
+    )
+    attempts = max(1, int(args.attempts))
+    attempt_errors: list[str] = []
+    for attempt in range(1, attempts + 1):
+        try:
+            receipt = _post_repair(url, timeout_seconds=float(args.timeout_seconds))
+            receipt["request_url"] = url
+            receipt["fetch_attempts"] = attempt
+            exit_code, validation_errors = _receipt_exit_code(
+                receipt,
+                allow_no_selected_repair=bool(args.allow_no_selected_repair),
+                allow_no_signal_blocked=bool(args.allow_no_signal_blocked),
+            )
+            if validation_errors:
+                receipt["validation_errors"] = validation_errors
+            return exit_code, receipt
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            attempt_errors.append(f"{type(exc).__name__}:{exc}")
+            if attempt < attempts:
+                time.sleep(max(0.0, float(args.retry_backoff_seconds)))
+                continue
+            return (
+                1,
+                {
+                    "schema_version": ZERO_NOTIONAL_REPAIR_RECEIPT_SCHEMA_VERSION,
+                    "execution_state": "request_failed",
+                    "command_exit_code": 1,
+                    "request_url": url,
+                    "fetch_attempts": attempt,
+                    "blocked_reasons": ["zero_notional_repair_request_failed"],
+                    "attempt_errors": attempt_errors,
+                    "order_submission_enabled": False,
+                    "paper_notional_limit": "0",
+                    "live_notional_limit": "0",
+                    "safety_invariants": {
+                        "max_notional": "0",
+                        "paper_live_capital_unchanged": True,
+                        "order_submission_disabled": True,
+                    },
+                },
+            )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a Torghut zero-notional repair endpoint and validate the receipt stays capital-safe."
+    )
+    parser.add_argument(
+        "--service-url",
+        required=True,
+        help="Torghut service base URL, for example http://torghut-sim.torghut.svc.cluster.local.",
+    )
+    parser.add_argument("--action", default=DEFAULT_ACTION)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--drift-limit", type=int, default=1000)
+    parser.add_argument("--attempts", type=int, default=3)
+    parser.add_argument("--timeout-seconds", type=float, default=45.0)
+    parser.add_argument("--retry-backoff-seconds", type=float, default=5.0)
+    parser.add_argument("--allow-no-selected-repair", action="store_true")
+    parser.add_argument("--allow-no-signal-blocked", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(list(argv if argv is not None else sys.argv[1:]))
+    exit_code, receipt = run(args)
+    if args.json:
+        print(json.dumps(receipt, sort_keys=True, default=str))
+    else:
+        print(
+            " ".join(
+                [
+                    f"execution_state={_text(receipt.get('execution_state'))}",
+                    f"command_exit_code={receipt.get('command_exit_code')}",
+                    f"fetch_attempts={receipt.get('fetch_attempts')}",
+                    f"blocked_reasons={','.join(_strings(receipt.get('blocked_reasons')))}",
+                ]
+            )
+        )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1242,6 +1242,84 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--apply", args)
         self.assertEqual(args.count("scripts/refresh_execution_tca_metrics.py"), 2)
 
+    def test_zero_notional_drift_repair_cronjob_runs_capital_safe_repair_endpoint(
+        self,
+    ) -> None:
+        spec, container = _load_cronjob_container(
+            "argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml"
+        )
+
+        self.assertEqual(spec.get("schedule"), "*/10 9-16 * * 1-5")
+        self.assertEqual(spec.get("timeZone"), "America/New_York")
+        self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
+        self.assertEqual(spec.get("failedJobsHistoryLimit"), 0)
+        self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
+        job_spec = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], spec.get("jobTemplate", {})).get("spec", {}),
+        )
+        template = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], job_spec.get("template", {})),
+        )
+        pod_spec = cast(Mapping[str, object], template.get("spec", {}))
+        self.assertEqual(job_spec.get("ttlSecondsAfterFinished"), 1800)
+        self.assertEqual(job_spec.get("backoffLimit"), 0)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 300)
+        self.assertEqual(pod_spec.get("restartPolicy"), "Never")
+        self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
+        self.assertEqual(
+            pod_spec.get("nodeSelector"),
+            {"kubernetes.io/arch": "arm64"},
+        )
+        self.assertIn(
+            "registry.ide-newton.ts.net/lab/torghut@sha256:",
+            str(container.get("image")),
+        )
+        resources = cast(Mapping[str, object], container.get("resources", {}))
+        self.assertEqual(
+            resources,
+            {
+                "requests": {
+                    "cpu": "100m",
+                    "memory": "256Mi",
+                    "ephemeral-storage": "128Mi",
+                },
+                "limits": {
+                    "cpu": "500m",
+                    "memory": "512Mi",
+                    "ephemeral-storage": "512Mi",
+                },
+            },
+        )
+        env = {
+            item.get("name"): item
+            for item in cast(list[Mapping[str, object]], container.get("env", []))
+        }
+        self.assertEqual(env["PYTHONUNBUFFERED"].get("value"), "1")
+
+        args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/run_zero_notional_repair.py", args)
+        self.assertEqual(args.count("scripts/run_zero_notional_repair.py"), 2)
+        self.assertLess(
+            args.index("service=torghut-sim"),
+            args.index("service=torghut started_at"),
+        )
+        self.assertIn(
+            "--service-url http://torghut-sim.torghut.svc.cluster.local", args
+        )
+        self.assertIn("--service-url http://torghut.torghut.svc.cluster.local", args)
+        self.assertIn("--action rerun_drift_checks_for_blocked_hypotheses", args)
+        self.assertEqual(args.count("--execute"), 2)
+        self.assertEqual(args.count("--drift-limit 1000"), 2)
+        self.assertEqual(args.count("--allow-no-selected-repair"), 2)
+        self.assertEqual(args.count("--allow-no-signal-blocked"), 2)
+        self.assertNotIn("--max-notional", args)
+        self.assertNotIn("--paper-notional", args)
+        self.assertNotIn("--live-notional", args)
+        self.assertNotIn("alpaca", args.lower())
+        self.assertNotIn("DB_DSN", args)
+
     def test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account(
         self,
     ) -> None:
@@ -1651,6 +1729,7 @@ class TestLiveConfigManifestContract(TestCase):
             "argocd/applications/torghut/empirical-artifacts-retention-cronjob.yaml",
             "argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml",
             "argocd/applications/torghut/execution-tca-refresh-cronjob.yaml",
+            "argocd/applications/torghut/zero-notional-drift-repair-cronjob.yaml",
             "argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml",
             "argocd/applications/torghut/paper-account-flatten-cronjob.yaml",
             "argocd/applications/torghut/tigerbeetle-journal-order-events-cronjob.yaml",
@@ -1669,7 +1748,7 @@ class TestLiveConfigManifestContract(TestCase):
                 )
                 self.assertEqual(job_spec.get("ttlSecondsAfterFinished"), 1800)
                 checked_cronjobs += 1
-        self.assertEqual(checked_cronjobs, 8)
+        self.assertEqual(checked_cronjobs, 9)
 
         replay_cronworkflow = _load_yaml_mapping(
             "argocd/applications/torghut/whitepaper-autoresearch-replay-materialization-cronworkflow.yaml"

--- a/services/torghut/tests/test_run_zero_notional_repair.py
+++ b/services/torghut/tests/test_run_zero_notional_repair.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+import io
+from unittest import TestCase
+from unittest.mock import patch
+
+from scripts import run_zero_notional_repair as script
+
+
+class _FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def _capital_safe_receipt(**overrides: object) -> dict[str, object]:
+    receipt: dict[str, object] = {
+        "schema_version": script.ZERO_NOTIONAL_REPAIR_RECEIPT_SCHEMA_VERSION,
+        "execution_state": "executed",
+        "command_exit_code": 0,
+        "blocked_reasons": [],
+        "order_submission_enabled": False,
+        "paper_notional_limit": "0",
+        "live_notional_limit": "0",
+        "safety_invariants": {
+            "max_notional": "0",
+            "paper_live_capital_unchanged": True,
+            "order_submission_disabled": True,
+        },
+    }
+    receipt.update(overrides)
+    return receipt
+
+
+class TestRunZeroNotionalRepair(TestCase):
+    def test_normalizers_handle_missing_and_non_boolean_values(self) -> None:
+        self.assertEqual(script._text(None, "fallback"), "fallback")
+        self.assertEqual(script._strings("not-a-list"), [])
+        self.assertTrue(script._bool_false("false"))
+
+    def test_run_posts_capital_safe_repair_request(self) -> None:
+        args = script.parse_args(
+            [
+                "--service-url",
+                "http://torghut-sim.torghut.svc.cluster.local/",
+                "--execute",
+                "--drift-limit",
+                "321",
+                "--json",
+            ]
+        )
+
+        with patch.object(
+            script.urllib.request,
+            "urlopen",
+            return_value=_FakeResponse(_capital_safe_receipt()),
+        ) as urlopen:
+            exit_code, receipt = script.run(args)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(receipt["execution_state"], "executed")
+        self.assertEqual(receipt["fetch_attempts"], 1)
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(request.data, b"{}")
+        self.assertEqual(request.get_header("Accept"), "application/json")
+        self.assertEqual(
+            request.full_url,
+            "http://torghut-sim.torghut.svc.cluster.local/trading/"
+            "profit-freshness/zero-notional-repair?"
+            "action=rerun_drift_checks_for_blocked_hypotheses"
+            "&execute=true&drift_limit=321",
+        )
+
+    def test_rejects_receipt_that_would_enable_order_submission(self) -> None:
+        args = script.parse_args(
+            [
+                "--service-url",
+                "http://torghut.torghut.svc.cluster.local",
+                "--execute",
+                "--json",
+            ]
+        )
+
+        with patch.object(
+            script.urllib.request,
+            "urlopen",
+            return_value=_FakeResponse(
+                _capital_safe_receipt(order_submission_enabled=True)
+            ),
+        ):
+            exit_code, receipt = script.run(args)
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("receipt_order_submission_enabled", receipt["validation_errors"])
+
+    def test_rejects_malformed_receipt_invariants(self) -> None:
+        errors = script._receipt_validation_errors(
+            {
+                "schema_version": "wrong",
+                "order_submission_enabled": "no",
+                "paper_notional_limit": "1",
+                "live_notional_limit": "2",
+            }
+        )
+
+        self.assertEqual(
+            errors,
+            [
+                "receipt_schema_version_mismatch",
+                "receipt_paper_notional_nonzero",
+                "receipt_live_notional_nonzero",
+                "receipt_safety_invariants_missing",
+            ],
+        )
+
+    def test_rejects_safety_invariant_drift(self) -> None:
+        errors = script._receipt_validation_errors(
+            _capital_safe_receipt(
+                safety_invariants={
+                    "max_notional": "100",
+                    "paper_live_capital_unchanged": False,
+                    "order_submission_disabled": False,
+                }
+            )
+        )
+
+        self.assertEqual(
+            errors,
+            [
+                "receipt_safety_max_notional_nonzero",
+                "receipt_capital_invariant_not_true",
+                "receipt_order_submission_invariant_not_true",
+            ],
+        )
+
+    def test_rejects_non_object_http_response(self) -> None:
+        with patch.object(
+            script.urllib.request,
+            "urlopen",
+            return_value=_FakeResponse(["not", "a", "receipt"]),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError, "zero_notional_repair_response_not_object"
+            ):
+                script._post_repair(
+                    "http://torghut/trading/profit-freshness/zero-notional-repair",
+                    timeout_seconds=0.1,
+                )
+
+    def test_accepts_missing_selected_repair_only_when_flagged(self) -> None:
+        receipt = _capital_safe_receipt(
+            execution_state="no_selected_repair",
+            command_exit_code=1,
+            blocked_reasons=[
+                "profit_freshness_frontier_matching_repair_missing:"
+                "rerun_drift_checks_for_blocked_hypotheses"
+            ],
+        )
+        strict_exit_code, _ = script._receipt_exit_code(
+            receipt,
+            allow_no_selected_repair=False,
+            allow_no_signal_blocked=False,
+        )
+        allowed_exit_code, _ = script._receipt_exit_code(
+            receipt,
+            allow_no_selected_repair=True,
+            allow_no_signal_blocked=False,
+        )
+
+        self.assertEqual(strict_exit_code, 1)
+        self.assertEqual(allowed_exit_code, 0)
+
+    def test_accepts_matching_frontier_missing_block_only_when_flagged(self) -> None:
+        receipt = _capital_safe_receipt(
+            execution_state="runner_blocked",
+            command_exit_code=1,
+            blocked_reasons=[
+                "profit_freshness_frontier_matching_repair_missing:"
+                "rerun_drift_checks_for_blocked_hypotheses"
+            ],
+        )
+
+        strict_exit_code, _ = script._receipt_exit_code(
+            receipt,
+            allow_no_selected_repair=False,
+            allow_no_signal_blocked=False,
+        )
+        allowed_exit_code, _ = script._receipt_exit_code(
+            receipt,
+            allow_no_selected_repair=True,
+            allow_no_signal_blocked=False,
+        )
+
+        self.assertEqual(strict_exit_code, 1)
+        self.assertEqual(allowed_exit_code, 0)
+
+    def test_accepts_no_signal_drift_block_only_when_flagged(self) -> None:
+        receipt = _capital_safe_receipt(
+            execution_state="runner_blocked",
+            command_exit_code=1,
+            blocked_reasons=["drift_check_no_signals:H-PAIRS-01"],
+        )
+        strict_exit_code, _ = script._receipt_exit_code(
+            receipt,
+            allow_no_selected_repair=False,
+            allow_no_signal_blocked=False,
+        )
+        allowed_exit_code, _ = script._receipt_exit_code(
+            receipt,
+            allow_no_selected_repair=False,
+            allow_no_signal_blocked=True,
+        )
+
+        self.assertEqual(strict_exit_code, 1)
+        self.assertEqual(allowed_exit_code, 0)
+
+    def test_retries_transient_request_failure(self) -> None:
+        args = script.parse_args(
+            [
+                "--service-url",
+                "http://torghut-sim.torghut.svc.cluster.local",
+                "--execute",
+                "--attempts",
+                "2",
+                "--retry-backoff-seconds",
+                "0",
+                "--json",
+            ]
+        )
+
+        with (
+            patch.object(
+                script.urllib.request,
+                "urlopen",
+                side_effect=[
+                    script.urllib.error.URLError("temporary"),
+                    _FakeResponse(_capital_safe_receipt()),
+                ],
+            ) as urlopen,
+            patch.object(script.time, "sleep") as sleep,
+        ):
+            exit_code, receipt = script.run(args)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(receipt["fetch_attempts"], 2)
+        self.assertEqual(urlopen.call_count, 2)
+        sleep.assert_called_once_with(0.0)
+
+    def test_returns_capital_safe_failure_payload_after_terminal_request_error(
+        self,
+    ) -> None:
+        args = script.parse_args(
+            [
+                "--service-url",
+                "http://torghut-sim.torghut.svc.cluster.local",
+                "--execute",
+                "--attempts",
+                "1",
+                "--json",
+            ]
+        )
+
+        with patch.object(
+            script.urllib.request,
+            "urlopen",
+            side_effect=script.urllib.error.URLError("down"),
+        ):
+            exit_code, receipt = script.run(args)
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(receipt["execution_state"], "request_failed")
+        self.assertEqual(receipt["fetch_attempts"], 1)
+        self.assertEqual(receipt["order_submission_enabled"], False)
+        self.assertEqual(receipt["paper_notional_limit"], "0")
+        self.assertEqual(receipt["live_notional_limit"], "0")
+        self.assertEqual(
+            receipt["blocked_reasons"], ["zero_notional_repair_request_failed"]
+        )
+
+    def test_main_can_print_json_and_operator_text(self) -> None:
+        json_stdout = io.StringIO()
+        text_stdout = io.StringIO()
+        receipt = _capital_safe_receipt(fetch_attempts=1)
+
+        with (
+            patch.object(script, "run", return_value=(0, receipt)),
+            patch("sys.stdout", json_stdout),
+        ):
+            json_exit_code = script.main(
+                ["--service-url", "http://torghut", "--execute", "--json"]
+            )
+
+        with (
+            patch.object(script, "run", return_value=(1, receipt)),
+            patch("sys.stdout", text_stdout),
+        ):
+            text_exit_code = script.main(["--service-url", "http://torghut"])
+
+        self.assertEqual(json_exit_code, 0)
+        self.assertEqual(
+            json.loads(json_stdout.getvalue())["execution_state"], "executed"
+        )
+        self.assertEqual(text_exit_code, 1)
+        self.assertIn("execution_state=executed", text_stdout.getvalue())
+        self.assertIn("blocked_reasons=", text_stdout.getvalue())


### PR DESCRIPTION
## Summary

- Added `scripts/run_zero_notional_repair.py` to POST the existing zero-notional repair endpoint and fail closed unless the receipt proves order submission is disabled, paper/live notional limits are zero, and safety invariants hold.
- Added the `torghut-zero-notional-drift-repair` CronJob to run `rerun_drift_checks_for_blocked_hypotheses` for sim first, then live, during weekday market hours without broker or database credentials.
- Added Python and TS manifest contract coverage so this repair job stays arm64-pinned, Argo-health safe, and unable to grow into a hidden notional or Alpaca submission path.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv lock --check`
- `uv run --frozen pytest tests/test_run_zero_notional_repair.py`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k "zero_notional_drift_repair or scheduled_jobs_do_not_leave_failed_children"`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen python -m compileall app scripts`
- `bun run lint:argocd`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen coverage run --branch -m pytest tests/test_run_zero_notional_repair.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen coverage xml --fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A - backend/GitOps change only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
